### PR TITLE
[FLINK-11959][table-runtime-blink] Introduce window operator for blink streaming runtime

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/AggsHandlerCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/AggsHandlerCodeGenerator.scala
@@ -31,10 +31,9 @@ import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.{AggregateFunction, DeclarativeAggregateFunction}
 import org.apache.flink.table.generated.{AggsHandleFunction, GeneratedAggsHandleFunction, GeneratedNamespaceAggsHandleFunction, NamespaceAggsHandleFunction}
 import org.apache.flink.table.plan.util.AggregateInfoList
-import org.apache.flink.table.runtime.functions.ExecutionContext
-
 import org.apache.calcite.rex.RexLiteral
 import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.table.runtime.context.ExecutionContext
 
 /**
   * A code generator for generating [[AggsHandleFunction]].

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/util/BaseRowTestUtil.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/util/BaseRowTestUtil.java
@@ -33,7 +33,7 @@ import java.util.TimeZone;
 /**
  * Utility for BaseRow.
  */
-public class BaseRowUtil {
+public class BaseRowTestUtil {
 
 	public static String baseRowToString(BaseRow value, BaseRowTypeInfo rowTypeInfo, TimeZone tz) {
 		return baseRowToString(value, rowTypeInfo, tz, true);

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/codegen/agg/AggsHandlerCodeGeneratorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/codegen/agg/AggsHandlerCodeGeneratorTest.scala
@@ -31,14 +31,13 @@ import org.apache.flink.table.dataview.DataViewSpec
 import org.apache.flink.table.functions.AvgAggFunction.{DoubleAvgAggFunction, IntegralAvgAggFunction}
 import org.apache.flink.table.generated.AggsHandleFunction
 import org.apache.flink.table.plan.util.{AggregateInfo, AggregateInfoList}
-import org.apache.flink.table.runtime.functions.ExecutionContext
-
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.tools.FrameworkConfig
 import org.junit.{Assert, Test}
 import org.powermock.api.mockito.PowerMockito.{mock, when}
-
 import java.lang
+
+import org.apache.flink.table.runtime.context.ExecutionContext
 
 class AggsHandlerCodeGeneratorTest {
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/BatchTestBase.scala
@@ -27,7 +27,6 @@ import org.apache.flink.table.api.java.{BatchTableEnvironment => JavaBatchTableE
 import org.apache.flink.table.api.scala.{BatchTableEnvironment => ScalaBatchTableEnv}
 import org.apache.flink.table.api.{SqlParserException, Table, TableConfig, TableConfigOptions, TableEnvironment, TableImpl}
 import org.apache.flink.table.plan.util.FlinkRelOptUtil
-import org.apache.flink.table.runtime.utils.BatchTestBase.PARALLELISM
 import org.apache.flink.table.util.DiffRepository
 import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.types.Row

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamTestSink.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamTestSink.scala
@@ -31,9 +31,9 @@ import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.table.api.{TableConfig, Types}
 import org.apache.flink.table.dataformat.BaseRow
-import org.apache.flink.table.sinks.{AppendStreamTableSink, BatchTableSink, TableSink}
+import org.apache.flink.table.sinks.{AppendStreamTableSink, BatchTableSink}
 import org.apache.flink.table.typeutils.BaseRowTypeInfo
-import org.apache.flink.table.util.BaseRowUtil
+import org.apache.flink.table.util.BaseRowTestUtil
 import org.apache.flink.types.Row
 
 import _root_.java.util.TimeZone
@@ -136,7 +136,7 @@ final class TestingAppendBaseRowSink(
   }
 
   def invoke(value: BaseRow): Unit = localResults +=
-    BaseRowUtil.baseRowToString(value, rowTypeInfo, tz)
+    BaseRowTestUtil.baseRowToString(value, rowTypeInfo, tz)
 
   def getAppendResults: List[String] = getResults
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/window/CountWindow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/window/CountWindow.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.window;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.MathUtils;
+
+import java.io.IOException;
+
+/**
+ * A {@link Window} that represents a count window. For each count window, we will assign a unique
+ * id. Thus this CountWindow can act as namespace part in state. We can attach data to each
+ * different CountWindow.
+ */
+public class CountWindow extends Window {
+
+	private final long id;
+
+	public CountWindow(long id) {
+		this.id = id;
+	}
+
+	/**
+	 * Gets the id (0-based) of the window.
+	 */
+	public long getId() {
+		return id;
+	}
+
+	@Override
+	public long maxTimestamp() {
+		return Long.MAX_VALUE;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		CountWindow window = (CountWindow) o;
+
+		return id == window.id;
+	}
+
+	@Override
+	public int hashCode() {
+		return MathUtils.longToIntWithBitMixing(id);
+	}
+
+	@Override
+	public String toString() {
+		return "CountWindow{" +
+			"id=" + id + '}';
+	}
+
+	@Override
+	public int compareTo(Window o) {
+		CountWindow that = (CountWindow) o;
+		return Long.compare(this.id, that.id);
+	}
+
+	// ------------------------------------------------------------------------
+	// Serializer
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The serializer used to write the CountWindow type.
+	 */
+	public static class Serializer extends TypeSerializerSingleton<CountWindow> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public boolean isImmutableType() {
+			return true;
+		}
+
+		@Override
+		public CountWindow createInstance() {
+			return null;
+		}
+
+		@Override
+		public CountWindow copy(CountWindow from) {
+			return from;
+		}
+
+		@Override
+		public CountWindow copy(CountWindow from, CountWindow reuse) {
+			return from;
+		}
+
+		@Override
+		public int getLength() {
+			return 0;
+		}
+
+		@Override
+		public void serialize(CountWindow record, DataOutputView target) throws IOException {
+			target.writeLong(record.id);
+		}
+
+		@Override
+		public CountWindow deserialize(DataInputView source) throws IOException {
+			return new CountWindow(source.readLong());
+		}
+
+		@Override
+		public CountWindow deserialize(CountWindow reuse, DataInputView source) throws IOException {
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			target.writeLong(source.readLong());
+		}
+
+
+		// ------------------------------------------------------------------------
+
+		@Override
+		public TypeSerializerSnapshot<CountWindow> snapshotConfiguration() {
+			return new CountWindow.Serializer.CountWindowSerializerSnapshot();
+		}
+
+		/**
+		 * Serializer configuration snapshot for compatibility and format evolution.
+		 */
+		@SuppressWarnings("WeakerAccess")
+		public static final class CountWindowSerializerSnapshot extends SimpleTypeSerializerSnapshot<CountWindow> {
+
+			public CountWindowSerializerSnapshot() {
+				super(CountWindow.Serializer::new);
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/window/TimeWindow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/window/TimeWindow.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.window;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+/**
+ * A {@link Window} that represents a time interval from {@code start} (inclusive) to
+ * {@code end} (exclusive).
+ */
+public class TimeWindow extends Window {
+
+	private final long start;
+	private final long end;
+
+	public TimeWindow(long start, long end) {
+		this.start = start;
+		this.end = end;
+	}
+
+	/**
+	 * Gets the starting timestamp of the window. This is the first timestamp that belongs
+	 * to this window.
+	 *
+	 * @return The starting timestamp of this window.
+	 */
+	public long getStart() {
+		return start;
+	}
+
+	/**
+	 * Gets the end timestamp of this window. The end timestamp is exclusive, meaning it
+	 * is the first timestamp that does not belong to this window any more.
+	 *
+	 * @return The exclusive end timestamp of this window.
+	 */
+	public long getEnd() {
+		return end;
+	}
+
+	/**
+	 * Gets the largest timestamp that still belongs to this window.
+	 *
+	 * <p>This timestamp is identical to {@code getEnd() - 1}.
+	 *
+	 * @return The largest timestamp that still belongs to this window.
+	 * @see #getEnd()
+	 */
+	@Override
+	public long maxTimestamp() {
+		return end - 1;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		TimeWindow window = (TimeWindow) o;
+
+		return end == window.end && start == window.start;
+	}
+
+	@Override
+	public int hashCode() {
+		// inspired from Apache BEAM
+		// The end values are themselves likely to be arithmetic sequence, which
+		// is a poor distribution to use for a hashtable, so we
+		// add a highly non-linear transformation.
+		return (int) (start + modInverse((int) (end << 1) + 1));
+	}
+
+	/**
+	 * Compute the inverse of (odd) x mod 2^32.
+	 */
+	private int modInverse(int x) {
+		// Cube gives inverse mod 2^4, as x^4 == 1 (mod 2^4) for all odd x.
+		int inverse = x * x * x;
+		// Newton iteration doubles correct bits at each step.
+		inverse *= 2 - x * inverse;
+		inverse *= 2 - x * inverse;
+		inverse *= 2 - x * inverse;
+		return inverse;
+	}
+
+	@Override
+	public String toString() {
+		return "TimeWindow{" +
+			"start=" + start +
+			", end=" + end +
+			'}';
+	}
+
+	/**
+	 * Returns {@code true} if this window intersects the given window.
+	 */
+	public boolean intersects(TimeWindow other) {
+		return this.start <= other.end && this.end >= other.start;
+	}
+
+	/**
+	 * Returns the minimal window covers both this window and the given window.
+	 */
+	public TimeWindow cover(TimeWindow other) {
+		return new TimeWindow(Math.min(start, other.start), Math.max(end, other.end));
+	}
+
+	@Override
+	public int compareTo(Window o) {
+		TimeWindow that = (TimeWindow) o;
+		if (this.start == that.start) {
+			return Long.compare(this.end, that.end);
+		} else {
+			return Long.compare(this.start, that.start);
+		}
+	}
+
+
+	// ------------------------------------------------------------------------
+	// Serializer
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The serializer used to write the TimeWindow type.
+	 */
+	public static class Serializer extends TypeSerializerSingleton<TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public boolean isImmutableType() {
+			return true;
+		}
+
+		@Override
+		public TimeWindow createInstance() {
+			return null;
+		}
+
+		@Override
+		public TimeWindow copy(TimeWindow from) {
+			return from;
+		}
+
+		@Override
+		public TimeWindow copy(TimeWindow from, TimeWindow reuse) {
+			return from;
+		}
+
+		@Override
+		public int getLength() {
+			return 0;
+		}
+
+		@Override
+		public void serialize(TimeWindow record, DataOutputView target) throws IOException {
+			target.writeLong(record.start);
+			target.writeLong(record.end);
+		}
+
+		@Override
+		public TimeWindow deserialize(DataInputView source) throws IOException {
+			long start = source.readLong();
+			long end = source.readLong();
+			return new TimeWindow(start, end);
+		}
+
+		@Override
+		public TimeWindow deserialize(TimeWindow reuse, DataInputView source) throws IOException {
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			target.writeLong(source.readLong());
+			target.writeLong(source.readLong());
+		}
+
+		// ------------------------------------------------------------------------
+
+		@Override
+		public TypeSerializerSnapshot<TimeWindow> snapshotConfiguration() {
+			return new TimeWindow.Serializer.TimeWindowSerializerSnapshot();
+		}
+
+		/**
+		 * Serializer configuration snapshot for compatibility and format evolution.
+		 */
+		@SuppressWarnings("WeakerAccess")
+		public static final class TimeWindowSerializerSnapshot extends SimpleTypeSerializerSnapshot<TimeWindow> {
+
+			public TimeWindowSerializerSnapshot() {
+				super(TimeWindow.Serializer::new);
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Method to get the window start for a timestamp.
+	 *
+	 * @param timestamp  epoch millisecond to get the window start.
+	 * @param offset     The offset which window start would be shifted by.
+	 * @param windowSize The size of the generated windows.
+	 * @return window start
+	 */
+	public static long getWindowStartWithOffset(long timestamp, long offset, long windowSize) {
+		return timestamp - (timestamp - offset + windowSize) % windowSize;
+	}
+
+	public static TimeWindow of(long start, long end) {
+		return new TimeWindow(start, end);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/window/Window.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/window/Window.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.window;
+
+
+/**
+ * A {@code Window} is a grouping of elements into finite buckets. Windows have a maximum timestamp
+ * which means that, at some point, all elements that go into one window will have arrived.
+ *
+ * <p>Subclasses should implement {@code equals()} and {@code hashCode()} so that logically
+ * same windows are treated the same.
+ */
+public abstract class Window implements Comparable<Window> {
+
+	/**
+	 * Gets the largest timestamp that still belongs to this window.
+	 *
+	 * @return The largest timestamp that still belongs to this window.
+	 */
+	public abstract long maxTimestamp();
+
+	public abstract int hashCode();
+
+	public abstract boolean equals(Object obj);
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/GenericRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/GenericRow.java
@@ -130,5 +130,12 @@ public final class GenericRow extends ObjectArrayRow {
 
 		return row;
 	}
+
+	public static GenericRow copyReference(GenericRow row) {
+		final GenericRow newRow = new GenericRow(row.fields.length);
+		System.arraycopy(row.fields, 0, newRow.fields, 0, row.fields.length);
+		newRow.setHeader(row.getHeader());
+		return newRow;
+	}
 }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ObjectArrayRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ObjectArrayRow.java
@@ -126,4 +126,16 @@ public abstract class ObjectArrayRow implements BaseRow {
 			return false;
 		}
 	}
+
+	public boolean equalsWithoutHeader(BaseRow o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || !(o instanceof ObjectArrayRow)) {
+			return false;
+		}
+
+		ObjectArrayRow row = (ObjectArrayRow) o;
+		return Arrays.equals(fields, row.fields);
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/util/BaseRowUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/util/BaseRowUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat.util;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
+import org.apache.flink.table.type.InternalType;
+
+/**
+ * Util for base row.
+ */
+public final class BaseRowUtil {
+
+	/**
+	 * Indicates the row as an accumulate message.
+	 */
+	public static final byte ACCUMULATE_MSG = 0;
+
+	/**
+	 * Indicates the row as a retraction message.
+	 */
+	public static final byte RETRACT_MSG = 1;
+
+	public static boolean isAccumulateMsg(BaseRow baseRow) {
+		return baseRow.getHeader() == ACCUMULATE_MSG;
+	}
+
+	public static BaseRow setAccumulate(BaseRow baseRow) {
+		baseRow.setHeader(ACCUMULATE_MSG);
+		return baseRow;
+	}
+
+	public static BaseRow setRetract(BaseRow baseRow) {
+		baseRow.setHeader(RETRACT_MSG);
+		return baseRow;
+	}
+
+	public static GenericRow toGenericRow(
+			BaseRow baseRow,
+			InternalType[] types) {
+		if (baseRow instanceof GenericRow) {
+			return (GenericRow) baseRow;
+		} else {
+			GenericRow row = new GenericRow(baseRow.getArity());
+			row.setHeader(baseRow.getHeader());
+			for (int i = 0; i < row.getArity(); i++) {
+				if (baseRow.isNullAt(i)) {
+					row.setField(i, null);
+				} else {
+					row.setField(i, TypeGetterSetters.get(baseRow, i, types[i]));
+				}
+			}
+			return row;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/AggsHandleFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/AggsHandleFunction.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.generated;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.runtime.functions.ExecutionContext;
+import org.apache.flink.table.runtime.context.ExecutionContext;
 
 /**
  * The base class for handling aggregate functions.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/GeneratedRecordEqualiser.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/GeneratedRecordEqualiser.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.generated;
+
+/**
+ * Describes a generated {@link RecordEqualiser}.
+ */
+public class GeneratedRecordEqualiser extends GeneratedClass<RecordEqualiser> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Creates a GeneratedRecordEqualiser.
+	 *
+	 * @param className  class name of the generated class.
+	 * @param code       code of the generated class.
+	 * @param references referenced objects of the generated class.
+	 */
+	public GeneratedRecordEqualiser(String className, String code, Object[] references) {
+		super(className, code, references);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/NamespaceAggsHandleFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/NamespaceAggsHandleFunction.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.generated;
 
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.runtime.functions.ExecutionContext;
+import org.apache.flink.table.runtime.context.ExecutionContext;
 
 /**
  * The base class for handling aggregate functions.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/RecordEqualiser.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/RecordEqualiser.java
@@ -16,34 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.functions;
+package org.apache.flink.table.generated;
 
-import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.dataformat.BaseRow;
 
+import java.io.Serializable;
+
 /**
- * A ExecutionContext contains information about the context in which functions are executed and
- * the APIs to create state.
+ * Record equaliser for BaseRow which can compare two BaseRows and returns whether they are equal.
  */
-public interface ExecutionContext {
-
-	// TODO add create state method.
+public interface RecordEqualiser extends Serializable {
 
 	/**
-	 * @return the key serializer of state key
+	 * Returns {@code true} if the rows are equal to each other
+	 * and {@code false} otherwise.
 	 */
-	<K> TypeSerializer<K> getKeySerializer();
+	boolean equals(BaseRow row1, BaseRow row2);
 
 	/**
-	 * @return key of the current processed element.
+	 * Returns {@code true} if the rows are equal to each other without header compare
+	 * and {@code false} otherwise.
 	 */
-	BaseRow currentKey();
-
-	/**
-	 * Sets current key.
-	 */
-	void setCurrentKey(BaseRow key);
-
-	RuntimeContext getRuntimeContext();
+	boolean equalsWithoutHeader(BaseRow row1, BaseRow row2);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/context/ExecutionContext.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/context/ExecutionContext.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.context;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.table.dataformat.BaseRow;
+
+/**
+ * A ExecutionContext contains information about the context in which functions are executed and
+ * the APIs to create state.
+ */
+public interface ExecutionContext {
+
+	// TODO add create state method.
+
+	/**
+	 * @return key of the current processed element.
+	 */
+	BaseRow currentKey();
+
+	/**
+	 * Sets current key.
+	 */
+	void setCurrentKey(BaseRow key);
+
+	RuntimeContext getRuntimeContext();
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/context/ExecutionContextImpl.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/context/ExecutionContextImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.context;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.util.Preconditions;
+
+
+/**
+ * Implementation of ExecutionContext.
+ */
+public final class ExecutionContextImpl implements ExecutionContext {
+
+	private final AbstractStreamOperator<?> operator;
+	private final RuntimeContext runtimeContext;
+
+	public ExecutionContextImpl(
+			AbstractStreamOperator<?> operator,
+			RuntimeContext runtimeContext) {
+		this.operator = operator;
+		this.runtimeContext = Preconditions.checkNotNull(runtimeContext);
+	}
+
+	@Override
+	public BaseRow currentKey() {
+		return (BaseRow) operator.getCurrentKey();
+	}
+
+	@Override
+	public void setCurrentKey(BaseRow key) {
+		operator.setCurrentKey(key);
+	}
+
+	@Override
+	public RuntimeContext getRuntimeContext() {
+		return runtimeContext;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/LRUMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/LRUMap.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An LRU cache, based on <code>LinkedHashMap</code>.
+ *
+ * <p>This cache has a fixed maximum number of elements (<code>cacheSize</code>).
+ * If the cache is full and another entry is added, the LRU (least recently
+ * used) entry is dropped.
+ *
+ * <p>Note: This class is not thread-safe.
+ */
+public class LRUMap<K, V> extends LinkedHashMap<K, V> {
+
+	private static final long serialVersionUID = 6148230381293590639L;
+
+	private final int cacheSize;
+	private final RemovalListener<K, V> removalListener;
+
+	public LRUMap(int cacheSize) {
+		this(cacheSize, null);
+	}
+
+	public LRUMap(int cacheSize, RemovalListener<K, V> removalListener) {
+		super((int) Math.ceil(cacheSize / 0.75) + 1, 0.75F, true);
+		this.cacheSize = cacheSize;
+		this.removalListener = removalListener;
+	}
+
+	protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+		if (size() > cacheSize) {
+			if (removalListener != null) {
+				removalListener.onRemoval(eldest);
+			}
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * An object that can receive a notification when an entry is removed from a LRUMap.
+	 * @param <K> the type of keys maintained by this map
+	 * @param <V> the type of mapped values
+	 */
+	public interface RemovalListener<K, V> {
+		void onRemoval(Map.Entry<K, V> eldest);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/WindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/WindowOperator.java
@@ -1,0 +1,704 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window;
+
+import org.apache.flink.api.common.state.MergingState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.internal.InternalMergingState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.JoinedRow;
+import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.table.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedRecordEqualiser;
+import org.apache.flink.table.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.context.ExecutionContextImpl;
+import org.apache.flink.table.runtime.window.assigners.MergingWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.PanedWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.window.internal.GeneralWindowProcessFunction;
+import org.apache.flink.table.runtime.window.internal.InternalWindowProcessFunction;
+import org.apache.flink.table.runtime.window.internal.MergingWindowProcessFunction;
+import org.apache.flink.table.runtime.window.internal.PanedWindowProcessFunction;
+import org.apache.flink.table.runtime.window.triggers.Trigger;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.typeutils.BaseRowSerializer;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Collection;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An operator that implements the logic for windowing based on a {@link WindowAssigner} and
+ * {@link Trigger}.
+ *
+ * <p>When an element arrives it gets assigned a key using a {@link KeySelector} and it gets
+ * assigned to zero or more windows using a {@link WindowAssigner}. Based on this, the element
+ * is put into panes. A pane is the bucket of elements that have the same key and same
+ * {@code Window}. An element can be in multiple panes if it was assigned to multiple windows by
+ * the
+ * {@code WindowAssigner}.
+ *
+ * <p>Each pane gets its own instance of the provided {@code Trigger}. This trigger determines when
+ * the contents of the pane should be processed to emit results. When a trigger fires,
+ * the given {@link org.apache.flink.table.generated.NamespaceAggsHandleFunction}
+ * is invoked to produce the results that are emitted for the pane to which the {@code Trigger}
+ * belongs.
+ *
+ * <p>The parameter types:
+ * {@code <IN>}: BaseRow
+ * {@code <OUT>}: JoinedRow(KEY, AGG_RESULT)
+ * {@code <KEY>}: GenericRow
+ * {@code <AGG_RESULT>}: GenericRow
+ * {@code <ACC>}: GenericRow
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+public class WindowOperator<K, W extends Window>
+		extends AbstractStreamOperator<BaseRow>
+		implements OneInputStreamOperator<BaseRow, BaseRow>, Triggerable<K, W> {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+	private static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
+	private static final String WATERMARK_LATENCY_METRIC_NAME = "watermarkLatency";
+
+	// ------------------------------------------------------------------------
+	// Configuration values and user functions
+	// ------------------------------------------------------------------------
+
+	private final WindowAssigner<W> windowAssigner;
+
+	private final Trigger<W> trigger;
+
+	/** For serializing the window in checkpoints. */
+	private final TypeSerializer<W> windowSerializer;
+
+	private final InternalType[] inputFieldTypes;
+
+	private final InternalType[] accumulatorTypes;
+
+	private final InternalType[] aggResultTypes;
+
+	private final InternalType[] windowPropertyTypes;
+
+	private final boolean sendRetraction;
+
+	private final int rowtimeIndex;
+
+	/**
+	 * The allowed lateness for elements. This is used for:
+	 * <ul>
+	 * <li>Deciding if an element should be dropped from a window due to lateness.
+	 * <li>Clearing the state of a window if the system time passes the
+	 * {@code window.maxTimestamp + allowedLateness} landmark.
+	 * </ul>
+	 */
+	private final long allowedLateness;
+
+	// --------------------------------------------------------------------------------
+
+	private NamespaceAggsHandleFunction<W> windowAggregator;
+	private GeneratedNamespaceAggsHandleFunction generatedWindowAggregator;
+
+	/**
+	 * The util to compare two BaseRow equals to each other.
+	 * As different BaseRow can't be equals directly, we use a code generated util to handle this.
+	 */
+	private RecordEqualiser equaliser;
+	private GeneratedRecordEqualiser generatedEqualiser;
+
+	// --------------------------------------------------------------------------------
+
+	private transient InternalWindowProcessFunction<K, W> windowFunction;
+
+	/** This is used for emitting elements with a given timestamp. */
+	private transient TimestampedCollector<BaseRow> collector;
+
+	/** Flag to prevent duplicate function.close() calls in close() and dispose(). */
+	private transient boolean functionsClosed = false;
+
+	private transient InternalTimerService<W> internalTimerService;
+
+	private transient InternalValueState<K, W, BaseRow> windowState;
+
+	private transient InternalValueState<K, W, BaseRow> previousState;
+
+	private transient TriggerContext triggerContext;
+
+	private transient JoinedRow reuseOutput;
+
+	// ------------------------------------------------------------------------
+	// Metrics
+	// ------------------------------------------------------------------------
+
+	private transient Counter numLateRecordsDropped;
+	private transient Meter lateRecordsDroppedRate;
+	private transient Gauge<Long> watermarkLatency;
+
+	WindowOperator(
+			NamespaceAggsHandleFunction<W> windowAggregator,
+			RecordEqualiser equaliser,
+			WindowAssigner<W> windowAssigner,
+			Trigger<W> trigger,
+			TypeSerializer<W> windowSerializer,
+			InternalType[] inputFieldTypes,
+			InternalType[] accumulatorTypes,
+			InternalType[] aggResultTypes,
+			InternalType[] windowPropertyTypes,
+			int rowtimeIndex,
+			boolean sendRetraction,
+			long allowedLateness) {
+		checkArgument(allowedLateness >= 0);
+		this.windowAggregator = checkNotNull(windowAggregator);
+		this.equaliser = checkNotNull(equaliser);
+		this.windowAssigner = checkNotNull(windowAssigner);
+		this.trigger = checkNotNull(trigger);
+		this.windowSerializer = checkNotNull(windowSerializer);
+		this.inputFieldTypes = checkNotNull(inputFieldTypes);
+		this.accumulatorTypes = checkNotNull(accumulatorTypes);
+		this.aggResultTypes = checkNotNull(aggResultTypes);
+		this.windowPropertyTypes = checkNotNull(windowPropertyTypes);
+		this.allowedLateness = allowedLateness;
+		this.sendRetraction = sendRetraction;
+
+		// rowtime index should >= 0 when in event time mode
+		checkArgument(!windowAssigner.isEventTime() || rowtimeIndex >= 0);
+		this.rowtimeIndex = rowtimeIndex;
+
+		setChainingStrategy(ChainingStrategy.ALWAYS);
+	}
+
+	WindowOperator(
+			GeneratedNamespaceAggsHandleFunction generatedWindowAggregator,
+			GeneratedRecordEqualiser generatedEqualiser,
+			WindowAssigner<W> windowAssigner,
+			Trigger<W> trigger,
+			TypeSerializer<W> windowSerializer,
+			InternalType[] inputFieldTypes,
+			InternalType[] accumulatorTypes,
+			InternalType[] aggResultTypes,
+			InternalType[] windowPropertyTypes,
+			int rowtimeIndex,
+			boolean sendRetraction,
+			long allowedLateness) {
+		checkArgument(allowedLateness >= 0);
+		this.generatedWindowAggregator = checkNotNull(generatedWindowAggregator);
+		this.generatedEqualiser = checkNotNull(generatedEqualiser);
+		this.windowAssigner = checkNotNull(windowAssigner);
+		this.trigger = checkNotNull(trigger);
+		this.windowSerializer = checkNotNull(windowSerializer);
+		this.inputFieldTypes = checkNotNull(inputFieldTypes);
+		this.accumulatorTypes = checkNotNull(accumulatorTypes);
+		this.aggResultTypes = checkNotNull(aggResultTypes);
+		this.windowPropertyTypes = checkNotNull(windowPropertyTypes);
+		this.allowedLateness = allowedLateness;
+		this.sendRetraction = sendRetraction;
+
+		// rowtime index should >= 0 when in event time mode
+		checkArgument(!windowAssigner.isEventTime() || rowtimeIndex >= 0);
+		this.rowtimeIndex = rowtimeIndex;
+
+		setChainingStrategy(ChainingStrategy.ALWAYS);
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		collector = new TimestampedCollector<>(output);
+		collector.eraseTimestamp();
+
+		internalTimerService = getInternalTimerService("window-timers", windowSerializer, this);
+
+		triggerContext = new TriggerContext();
+		triggerContext.open();
+
+		StateDescriptor<ValueState<BaseRow>, BaseRow> windowStateDescriptor = new ValueStateDescriptor<>(
+				"window-aggs",
+				new BaseRowSerializer(getExecutionConfig(), accumulatorTypes));
+		this.windowState = (InternalValueState<K, W, BaseRow>) getOrCreateKeyedState(windowSerializer, windowStateDescriptor);
+
+		if (sendRetraction) {
+			InternalType[] valueTypes = ArrayUtils.addAll(aggResultTypes, windowPropertyTypes);
+			StateDescriptor<ValueState<BaseRow>, BaseRow> previousStateDescriptor = new ValueStateDescriptor<>(
+					"previous-aggs",
+					new BaseRowSerializer(getExecutionConfig(), valueTypes));
+			this.previousState = (InternalValueState<K, W, BaseRow>) getOrCreateKeyedState(windowSerializer, previousStateDescriptor);
+		}
+
+		// compile aggregator
+		if (generatedWindowAggregator != null) {
+			this.windowAggregator = generatedWindowAggregator.newInstance(getRuntimeContext().getUserCodeClassLoader());
+
+		}
+		// compile equaliser
+		if (generatedEqualiser != null) {
+			this.equaliser = generatedEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
+		}
+
+		WindowContext windowContext = new WindowContext();
+		windowAggregator.open(new ExecutionContextImpl(this, getRuntimeContext()));
+
+		if (windowAssigner instanceof MergingWindowAssigner) {
+			this.windowFunction = new MergingWindowProcessFunction<>(
+					(MergingWindowAssigner<W>) windowAssigner,
+					windowAggregator,
+					windowSerializer,
+					allowedLateness);
+		} else if (windowAssigner instanceof PanedWindowAssigner) {
+			this.windowFunction = new PanedWindowProcessFunction<>(
+					(PanedWindowAssigner<W>) windowAssigner,
+					windowAggregator,
+					allowedLateness);
+		} else {
+			this.windowFunction = new GeneralWindowProcessFunction<>(
+					windowAssigner,
+					windowAggregator,
+					allowedLateness);
+		}
+		windowFunction.open(windowContext);
+
+		reuseOutput = new JoinedRow();
+
+		// metrics
+		this.numLateRecordsDropped = metrics.counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
+		this.lateRecordsDroppedRate = metrics.meter(
+				LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
+				new MeterView(numLateRecordsDropped, 60));
+		this.watermarkLatency = metrics.gauge(WATERMARK_LATENCY_METRIC_NAME, () -> {
+			long watermark = internalTimerService.currentWatermark();
+			if (watermark < 0) {
+				return 0L;
+			} else {
+				return internalTimerService.currentProcessingTime() - watermark;
+			}
+		});
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		collector = null;
+		triggerContext = null;
+		functionsClosed = true;
+		windowAggregator.close();
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		super.dispose();
+		collector = null;
+		triggerContext = null;
+		if (!functionsClosed) {
+			functionsClosed = true;
+			windowAggregator.close();
+		}
+	}
+
+	@Override
+	public void processElement(StreamRecord<BaseRow> record) throws Exception {
+		BaseRow inputRow = record.getValue();
+		long timestamp;
+		if (windowAssigner.isEventTime()) {
+			timestamp = inputRow.getLong(rowtimeIndex);
+		} else {
+			timestamp = internalTimerService.currentProcessingTime();
+		}
+
+		// the windows which the input row should be placed into
+		Collection<W> affectedWindows = windowFunction.assignStateNamespace(inputRow, timestamp);
+		boolean isElementDropped = true;
+		for (W window : affectedWindows) {
+			isElementDropped = false;
+
+			windowState.setCurrentNamespace(window);
+			BaseRow acc = windowState.value();
+			if (acc == null) {
+				acc = windowAggregator.createAccumulators();
+			}
+			windowAggregator.setAccumulators(window, acc);
+
+			if (BaseRowUtil.isAccumulateMsg(inputRow)) {
+				windowAggregator.accumulate(inputRow);
+			} else {
+				windowAggregator.retract(inputRow);
+			}
+			acc = windowAggregator.getAccumulators();
+			windowState.update(acc);
+		}
+
+		// the actual window which the input row is belongs to
+		Collection<W> actualWindows = windowFunction.assignActualWindows(inputRow, timestamp);
+		for (W window : actualWindows) {
+			isElementDropped = false;
+			triggerContext.window = window;
+			boolean triggerResult = triggerContext.onElement(inputRow, timestamp);
+			if (triggerResult) {
+				emitWindowResult(window);
+			}
+			// register a clean up timer for the window
+			registerCleanupTimer(window);
+		}
+
+		if (isElementDropped) {
+			// markEvent will increase numLateRecordsDropped
+			lateRecordsDroppedRate.markEvent();
+		}
+	}
+
+	@Override
+	public void onEventTime(InternalTimer<K, W> timer) throws Exception {
+		setCurrentKey(timer.getKey());
+
+		triggerContext.window = timer.getNamespace();
+		if (triggerContext.onEventTime(timer.getTimestamp())) {
+			// fire
+			emitWindowResult(triggerContext.window);
+		}
+
+		if (windowAssigner.isEventTime()) {
+			windowFunction.cleanWindowIfNeeded(triggerContext.window, timer.getTimestamp());
+		}
+	}
+
+	@Override
+	public void onProcessingTime(InternalTimer<K, W> timer) throws Exception {
+		setCurrentKey(timer.getKey());
+
+		triggerContext.window = timer.getNamespace();
+		if (triggerContext.onProcessingTime(timer.getTimestamp())) {
+			// fire
+			emitWindowResult(triggerContext.window);
+		}
+
+		if (!windowAssigner.isEventTime()) {
+			windowFunction.cleanWindowIfNeeded(triggerContext.window, timer.getTimestamp());
+		}
+	}
+
+	/**
+	 * Emits the window result of the given window.
+	 */
+	private void emitWindowResult(W window) throws Exception {
+		BaseRow aggResult = windowFunction.getWindowAggregationResult(window);
+		if (sendRetraction) {
+			previousState.setCurrentNamespace(window);
+			BaseRow previousAggResult = previousState.value();
+
+			// has emitted result for the window
+			if (previousAggResult != null) {
+				// current agg is not equal to the previous emitted, should emit retract
+				if (!equaliser.equalsWithoutHeader(aggResult, previousAggResult)) {
+					reuseOutput.replace((BaseRow) getCurrentKey(), previousAggResult);
+					BaseRowUtil.setRetract(reuseOutput);
+					// send retraction
+					collector.collect(reuseOutput);
+					// send accumulate
+					reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
+					BaseRowUtil.setAccumulate(reuseOutput);
+					collector.collect(reuseOutput);
+					// update previousState
+					previousState.update(aggResult);
+				}
+				// if the previous agg equals to the current agg, no need to send retract and accumulate
+			}
+			// the first fire for the window, only send accumulate
+			else {
+				// send accumulate
+				reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
+				BaseRowUtil.setAccumulate(reuseOutput);
+				collector.collect(reuseOutput);
+				// update previousState
+				previousState.update(aggResult);
+			}
+		} else {
+			reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
+			// no need to set header
+			collector.collect(reuseOutput);
+		}
+	}
+
+	/**
+	 * Registers a timer to cleanup the content of the window.
+	 *
+	 * @param window the window whose state to discard
+	 */
+	private void registerCleanupTimer(W window) {
+		long cleanupTime = cleanupTime(window);
+		if (cleanupTime == Long.MAX_VALUE) {
+			// don't set a GC timer for "end of time"
+			return;
+		}
+
+		if (windowAssigner.isEventTime()) {
+			triggerContext.registerEventTimeTimer(cleanupTime);
+		} else {
+			triggerContext.registerProcessingTimeTimer(cleanupTime);
+		}
+	}
+
+	/**
+	 * Returns the cleanup time for a window, which is
+	 * {@code window.maxTimestamp + allowedLateness}. In
+	 * case this leads to a value greated than {@link Long#MAX_VALUE}
+	 * then a cleanup time of {@link Long#MAX_VALUE} is
+	 * returned.
+	 *
+	 * @param window the window whose cleanup time we are computing.
+	 */
+	private long cleanupTime(W window) {
+		if (windowAssigner.isEventTime()) {
+			long cleanupTime = Math.max(0, window.maxTimestamp() + allowedLateness);
+			return cleanupTime >= window.maxTimestamp() ? cleanupTime : Long.MAX_VALUE;
+		} else {
+			return Math.max(0, window.maxTimestamp());
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private K currentKey() {
+		return (K) getCurrentKey();
+	}
+
+	// ------------------------------------------------------------------------------
+
+	/**
+	 * Context of window.
+	 */
+	private class WindowContext implements InternalWindowProcessFunction.Context<K, W> {
+
+		@Override
+		public <S extends State> S getPartitionedState(
+				StateDescriptor<S, ?> stateDescriptor) throws Exception {
+			requireNonNull(stateDescriptor, "The state properties must not be null");
+			return WindowOperator.this.getPartitionedState(stateDescriptor);
+		}
+
+		@Override
+		public K currentKey() {
+			return WindowOperator.this.currentKey();
+		}
+
+		@Override
+		public long currentProcessingTime() {
+			return internalTimerService.currentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return internalTimerService.currentWatermark();
+		}
+
+		@Override
+		public BaseRow getWindowAccumulators(W window) throws Exception {
+			windowState.setCurrentNamespace(window);
+			return windowState.value();
+		}
+
+		@Override
+		public void setWindowAccumulators(W window, BaseRow acc) throws Exception {
+			windowState.setCurrentNamespace(window);
+			windowState.update(acc);
+		}
+
+		@Override
+		public void clearWindowState(W window) throws Exception {
+			windowState.setCurrentNamespace(window);
+			windowState.clear();
+		}
+
+		@Override
+		public void clearPreviousState(W window) throws Exception {
+			if (previousState != null) {
+				previousState.setCurrentNamespace(window);
+				previousState.clear();
+			}
+		}
+
+		@Override
+		public void clearTrigger(W window) throws Exception {
+			triggerContext.window = window;
+			triggerContext.clear();
+		}
+
+		@Override
+		public void deleteCleanupTimer(W window) throws Exception {
+			long cleanupTime = cleanupTime(window);
+			if (cleanupTime == Long.MAX_VALUE) {
+				// no need to clean up because we didn't set one
+				return;
+			}
+			if (windowAssigner.isEventTime()) {
+				triggerContext.deleteEventTimeTimer(cleanupTime);
+			} else {
+				triggerContext.deleteProcessingTimeTimer(cleanupTime);
+			}
+		}
+
+		@Override
+		public void onMerge(W newWindow, Collection<W> mergedWindows) throws Exception {
+			triggerContext.window = newWindow;
+			triggerContext.mergedWindows = mergedWindows;
+			triggerContext.onMerge();
+		}
+	}
+
+	/**
+	 * {@code TriggerContext} is a utility for handling {@code Trigger} invocations. It can be
+	 * reused
+	 * by setting the {@code key} and {@code window} fields. No internal state must be kept in
+	 * the {@code TriggerContext}
+	 */
+	private class TriggerContext implements Trigger.OnMergeContext {
+
+		private W window;
+		private Collection<W> mergedWindows;
+
+		public void open() throws Exception {
+			trigger.open(this);
+		}
+
+		boolean onElement(BaseRow row, long timestamp) throws Exception {
+			return trigger.onElement(row, timestamp, window);
+		}
+
+		boolean onProcessingTime(long time) throws Exception {
+			return trigger.onProcessingTime(time, window);
+		}
+
+		boolean onEventTime(long time) throws Exception {
+			return trigger.onEventTime(time, window);
+		}
+
+		void onMerge() throws Exception {
+			trigger.onMerge(window, this);
+		}
+
+		@Override
+		public long getCurrentProcessingTime() {
+			return internalTimerService.currentProcessingTime();
+		}
+
+		@Override
+		public long getCurrentWatermark() {
+			return internalTimerService.currentWatermark();
+		}
+
+		@Override
+		public MetricGroup getMetricGroup() {
+			return WindowOperator.this.getMetricGroup();
+		}
+
+		@Override
+		public void registerProcessingTimeTimer(long time) {
+			internalTimerService.registerProcessingTimeTimer(window, time);
+		}
+
+		@Override
+		public void registerEventTimeTimer(long time) {
+			internalTimerService.registerEventTimeTimer(window, time);
+		}
+
+		@Override
+		public void deleteProcessingTimeTimer(long time) {
+			internalTimerService.deleteProcessingTimeTimer(window, time);
+		}
+
+		@Override
+		public void deleteEventTimeTimer(long time) {
+			internalTimerService.deleteEventTimeTimer(window, time);
+		}
+
+		public void clear() throws Exception {
+			trigger.clear(window);
+		}
+
+		@Override
+		public <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) {
+			try {
+				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateDescriptor);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not retrieve state", e);
+			}
+		}
+
+		@Override
+		public <S extends MergingState<?, ?>> void mergePartitionedState(
+				StateDescriptor<S, ?> stateDescriptor) {
+			if (mergedWindows != null && mergedWindows.size() > 0) {
+				try {
+					State state =
+							WindowOperator.this.getOrCreateKeyedState(
+									windowSerializer,
+									stateDescriptor);
+					if (state instanceof InternalMergingState) {
+						((InternalMergingState<K, W, ?, ?, ?>) state).mergeNamespaces(window, mergedWindows);
+					} else {
+						throw new IllegalArgumentException(
+								"The given state descriptor does not refer to a mergeable state (MergingState)");
+					}
+				}
+				catch (Exception e) {
+					throw new RuntimeException("Error while merging state.", e);
+				}
+			}
+		}
+	}
+
+
+	// ------------------------------------------------------------------------------
+	// Visible For Testing
+	// ------------------------------------------------------------------------------
+
+	protected Counter getNumLateRecordsDropped() {
+		return numLateRecordsDropped;
+	}
+
+	protected Gauge<Long> getWatermarkLatency() {
+		return watermarkLatency;
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/WindowOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/WindowOperatorBuilder.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.table.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedRecordEqualiser;
+import org.apache.flink.table.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.window.assigners.CountSlidingWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.CountTumblingWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.InternalTimeWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.SessionWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.SlidingWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.TumblingWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.window.triggers.ElementTriggers;
+import org.apache.flink.table.runtime.window.triggers.EventTimeTriggers;
+import org.apache.flink.table.runtime.window.triggers.ProcessingTimeTriggers;
+import org.apache.flink.table.runtime.window.triggers.Trigger;
+import org.apache.flink.table.type.InternalType;
+
+import java.time.Duration;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The {@link WindowOperatorBuilder} is used to build {@link WindowOperator} fluently.
+ *
+ * <pre>
+ * WindowOperatorBuilder
+ *   .builder(KeyedStream)
+ *   .tumble(Duration.ofMinutes(1))	// sliding(...), session(...)
+ *   .withEventTime()	// withProcessingTime()
+ *   .aggregate(AggregationsFunction, accTypes, windowTypes)
+ *   .withAllowedLateness(Duration.ZERO)
+ *   .withSendRetraction()
+ *   .build();
+ * </pre>
+ */
+public class WindowOperatorBuilder {
+	private InternalType[] inputFieldTypes;
+	private WindowAssigner<?> windowAssigner;
+	private Trigger<?> trigger;
+	private NamespaceAggsHandleFunction<?> aggregateFunction;
+	private GeneratedNamespaceAggsHandleFunction generatedAggregateFunction;
+	private RecordEqualiser equaliser;
+	private GeneratedRecordEqualiser generatedEqualiser;
+	private InternalType[] accumulatorTypes;
+	private InternalType[] aggResultTypes;
+	private InternalType[] windowPropertyTypes;
+	private long allowedLateness = 0L;
+	private boolean sendRetraction = false;
+	private int rowtimeIndex = -1;
+
+	public static WindowOperatorBuilder builder() {
+		return new WindowOperatorBuilder();
+	}
+
+	public WindowOperatorBuilder withInputFields(InternalType[] inputFieldTypes) {
+		this.inputFieldTypes = inputFieldTypes;
+		return this;
+	}
+
+	public WindowOperatorBuilder tumble(Duration size, long offset) {
+		checkArgument(windowAssigner == null);
+		this.windowAssigner = TumblingWindowAssigner.of(size)
+				.withOffset(Duration.ofMillis(-offset));
+		return this;
+	}
+
+	public WindowOperatorBuilder sliding(Duration size, Duration slide, long offset) {
+		checkArgument(windowAssigner == null);
+		this.windowAssigner = SlidingWindowAssigner.of(size, slide)
+				.withOffset(Duration.ofMillis(-offset));
+		return this;
+	}
+
+	public WindowOperatorBuilder session(Duration sessionGap) {
+		checkArgument(windowAssigner == null);
+		this.windowAssigner = SessionWindowAssigner.withGap(sessionGap);
+		return this;
+	}
+
+	public WindowOperatorBuilder countWindow(long size) {
+		checkArgument(windowAssigner == null);
+		checkArgument(trigger == null);
+		this.windowAssigner = CountTumblingWindowAssigner.of(size);
+		this.trigger = ElementTriggers.count(size);
+		return this;
+	}
+
+	public WindowOperatorBuilder countWindow(long size, long slide) {
+		checkArgument(windowAssigner == null);
+		checkArgument(trigger == null);
+		this.windowAssigner = CountSlidingWindowAssigner.of(size, slide);
+		this.trigger = ElementTriggers.count(size);
+		return this;
+	}
+
+	public WindowOperatorBuilder assigner(WindowAssigner<?> windowAssigner) {
+		checkArgument(this.windowAssigner == null);
+		checkNotNull(windowAssigner);
+		this.windowAssigner = windowAssigner;
+		return this;
+	}
+
+	public WindowOperatorBuilder triggering(Trigger<?> trigger) {
+		checkNotNull(trigger);
+		this.trigger = trigger;
+		return this;
+	}
+
+	public WindowOperatorBuilder withEventTime(int rowtimeIndex) {
+		checkNotNull(windowAssigner);
+		checkArgument(windowAssigner instanceof InternalTimeWindowAssigner);
+		InternalTimeWindowAssigner timeWindowAssigner = (InternalTimeWindowAssigner) windowAssigner;
+		this.windowAssigner = (WindowAssigner<?>) timeWindowAssigner.withEventTime();
+		this.rowtimeIndex = rowtimeIndex;
+		if (trigger == null) {
+			this.trigger = EventTimeTriggers.afterEndOfWindow();
+		}
+		return this;
+	}
+
+	public WindowOperatorBuilder withProcessingTime() {
+		checkNotNull(windowAssigner);
+		checkArgument(windowAssigner instanceof InternalTimeWindowAssigner);
+		InternalTimeWindowAssigner timeWindowAssigner = (InternalTimeWindowAssigner) windowAssigner;
+		this.windowAssigner = (WindowAssigner<?>) timeWindowAssigner.withProcessingTime();
+		if (trigger == null) {
+			this.trigger = ProcessingTimeTriggers.afterEndOfWindow();
+		}
+		return this;
+	}
+
+	public WindowOperatorBuilder withAllowedLateness(Duration allowedLateness) {
+		checkArgument(!allowedLateness.isNegative());
+		if (allowedLateness.toMillis() > 0) {
+			this.allowedLateness = allowedLateness.toMillis();
+			// allow late element, which means this window will send retractions
+			this.sendRetraction = true;
+		}
+		return this;
+	}
+
+	public WindowOperatorBuilder aggregate(
+			NamespaceAggsHandleFunction<?> aggregateFunction,
+			RecordEqualiser equaliser,
+			InternalType[] accumulatorTypes,
+			InternalType[] aggResultTypes,
+			InternalType[] windowPropertyTypes) {
+		ClosureCleaner.clean(aggregateFunction, true);
+		this.accumulatorTypes = accumulatorTypes;
+		this.aggResultTypes = aggResultTypes;
+		this.windowPropertyTypes = windowPropertyTypes;
+		this.aggregateFunction = checkNotNull(aggregateFunction);
+		this.equaliser = checkNotNull(equaliser);
+		return this;
+	}
+
+	public WindowOperatorBuilder aggregate(
+			GeneratedNamespaceAggsHandleFunction generatedAggregateFunction,
+			GeneratedRecordEqualiser generatedEqualiser,
+			InternalType[] accumulatorTypes,
+			InternalType[] aggResultTypes,
+			InternalType[] windowPropertyTypes) {
+		this.accumulatorTypes = accumulatorTypes;
+		this.aggResultTypes = aggResultTypes;
+		this.windowPropertyTypes = windowPropertyTypes;
+		this.generatedAggregateFunction = checkNotNull(generatedAggregateFunction);
+		this.generatedEqualiser = checkNotNull(generatedEqualiser);
+		return this;
+	}
+
+	public WindowOperatorBuilder withSendRetraction() {
+		this.sendRetraction = true;
+		return this;
+	}
+
+	public WindowOperator build() {
+		checkNotNull(trigger, "trigger is not set");
+		if (generatedAggregateFunction != null && generatedEqualiser != null) {
+			//noinspection unchecked
+			return new WindowOperator(
+					generatedAggregateFunction,
+					generatedEqualiser,
+					windowAssigner,
+					trigger,
+					windowAssigner.getWindowSerializer(new ExecutionConfig()),
+					inputFieldTypes,
+					accumulatorTypes,
+					aggResultTypes,
+					windowPropertyTypes,
+					rowtimeIndex,
+					sendRetraction,
+					allowedLateness);
+		} else {
+			//noinspection unchecked
+			return new WindowOperator(
+					aggregateFunction,
+					equaliser,
+					windowAssigner,
+					trigger,
+					windowAssigner.getWindowSerializer(new ExecutionConfig()),
+					inputFieldTypes,
+					accumulatorTypes,
+					aggResultTypes,
+					windowPropertyTypes,
+					rowtimeIndex,
+					sendRetraction,
+					allowedLateness);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/CountSlidingWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/CountSlidingWindowAssigner.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.window.CountWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.window.internal.InternalWindowProcessFunction;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link WindowAssigner} that windows elements into sliding windows based on the count number
+ * of the elements. Windows can possibly overlap.
+ */
+public class CountSlidingWindowAssigner extends WindowAssigner<CountWindow> {
+
+	private static final long serialVersionUID = 1923778575471995671L;
+	private final long windowSize;
+	private final long windowSlide;
+
+	private transient ValueState<Long> count;
+
+	private CountSlidingWindowAssigner(long windowSize, long windowSlide) {
+		if (windowSize <= 0 || windowSlide <= 0) {
+			throw new IllegalArgumentException(
+				"SlidingCountWindowAssigner parameters must satisfy slide > 0 and size > 0");
+		}
+		this.windowSize = windowSize;
+		this.windowSlide = windowSlide;
+	}
+
+	@Override
+	public void open(InternalWindowProcessFunction.Context<?, CountWindow> ctx) throws Exception {
+		String descriptorName = "slide-count-assigner";
+		ValueStateDescriptor<Long> countDescriptor = new ValueStateDescriptor<>(
+			descriptorName,
+			Types.LONG);
+		this.count = ctx.getPartitionedState(countDescriptor);
+	}
+
+	@Override
+	public Collection<CountWindow> assignWindows(BaseRow element, long timestamp) throws IOException {
+		Long countValue = count.value();
+		long currentCount = countValue == null ? 0L : countValue;
+		count.update(currentCount + 1);
+		long lastId = currentCount / windowSlide;
+		long lastStart = lastId * windowSlide;
+		long lastEnd = lastStart + windowSize - 1;
+		List<CountWindow> windows = new ArrayList<>();
+		while (lastId >= 0 && lastStart <= currentCount && currentCount <= lastEnd) {
+			if (lastStart <= currentCount && currentCount <= lastEnd) {
+				windows.add(new CountWindow(lastId));
+			}
+			lastId--;
+			lastStart -= windowSlide;
+			lastEnd -= windowSlide;
+		}
+		return windows;
+	}
+
+	@Override
+	public TypeSerializer<CountWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+		return new CountWindow.Serializer();
+	}
+
+	@Override
+	public boolean isEventTime() {
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "CountSlidingWindow(" + windowSize + ", " + windowSlide + ")";
+	}
+
+	public static CountSlidingWindowAssigner of(long windowSize, long windowSlide) {
+		return new CountSlidingWindowAssigner(windowSize, windowSlide);
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/CountTumblingWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/CountTumblingWindowAssigner.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.window.CountWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.window.internal.InternalWindowProcessFunction;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A {@link WindowAssigner} that windows elements into fixed-size windows
+ * based on the count number of the elements. Windows cannot overlap.
+ */
+public class CountTumblingWindowAssigner extends WindowAssigner<CountWindow> {
+	private static final long serialVersionUID = -3857633557257357800L;
+
+	private final long size;
+
+	private transient ValueState<Long> count;
+
+	private CountTumblingWindowAssigner(long size) {
+		this.size = size;
+	}
+
+	@Override
+	public void open(InternalWindowProcessFunction.Context<?, CountWindow> ctx) throws Exception {
+		String descriptorName = "tumble-count-assigner";
+		ValueStateDescriptor<Long> countDescriptor = new ValueStateDescriptor<>(
+			descriptorName,
+			Types.LONG);
+		this.count = ctx.getPartitionedState(countDescriptor);
+	}
+
+	@Override
+	public Collection<CountWindow> assignWindows(BaseRow element, long timestamp) throws IOException {
+		Long countValue = count.value();
+		long currentCount = countValue == null ? 0L : countValue;
+		long id = currentCount / size;
+		count.update(currentCount + 1);
+		return Collections.singleton(new CountWindow(id));
+	}
+
+	@Override
+	public TypeSerializer<CountWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+		return new CountWindow.Serializer();
+	}
+
+	@Override
+	public boolean isEventTime() {
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "CountTumblingWindow(" + size + ")";
+	}
+
+	public static CountTumblingWindowAssigner of(long size) {
+		return new CountTumblingWindowAssigner(size);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/InternalTimeWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/InternalTimeWindowAssigner.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+/**
+ * The internal time window assigner which has some useful methods.
+ */
+public interface InternalTimeWindowAssigner {
+
+	/**
+	 * @return an InternalTimeWindowAssigner which in event time mode.
+	 */
+	InternalTimeWindowAssigner withEventTime();
+
+	/**
+	 * @return an InternalTimeWindowAssigner which in processing time mode.
+	 */
+	InternalTimeWindowAssigner withProcessingTime();
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/MergingWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/MergingWindowAssigner.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.table.api.window.Window;
+
+import java.util.Collection;
+import java.util.NavigableSet;
+
+/**
+ * A {@code WindowAssigner} that can merge windows.
+ *
+ * @param <W> The type of {@code Window} that this assigner assigns.
+ */
+public abstract class MergingWindowAssigner<W extends Window> extends WindowAssigner<W> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Determines which windows (if any) should be merged.
+	 *
+	 * @param newWindow The new window
+	 * @param sortedWindows The sorted window candidates.
+	 * @param callback A callback that can be invoked to signal which windows should be merged.
+	 */
+	public abstract void mergeWindows(W newWindow, NavigableSet<W> sortedWindows, MergeCallback<W> callback);
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Callback to be used in {@link #mergeWindows(Window, NavigableSet, MergeCallback)} for specifying which
+	 * windows should be merged.
+	 */
+	public interface MergeCallback<W> {
+
+		/**
+		 * Specifies that the given windows should be merged into the result window.
+		 *
+		 * @param toBeMerged The list of windows that should be merged into one window.
+		 * @param mergeResult The resulting merged window.
+		 */
+		void merge(W mergeResult, Collection<W> toBeMerged);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/PanedWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/PanedWindowAssigner.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.table.api.window.Window;
+
+/**
+ * A {@code WindowAssigner} that window can be split into panes.
+ *
+ * @param <W> The type of {@code Window} that this assigner assigns.
+ */
+public abstract class PanedWindowAssigner<W extends Window> extends WindowAssigner<W> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Given the timestamp and element, returns the pane into which it should be placed.
+	 * @param element The element to which windows should be assigned.
+	 * @param timestamp The timestamp of the element when {@link #isEventTime()} returns true,
+	 *                  or the current system time when {@link #isEventTime()} returns false.
+	 */
+	public abstract W assignPane(Object element, long timestamp);
+
+	/**
+	 * Splits the given window into panes collection.
+	 * @param window the window to be split.
+	 * @return the panes iterable
+	 */
+	public abstract Iterable<W> splitIntoPanes(W window);
+
+	/**
+	 * Gets the last window which the pane belongs to.
+	 */
+	public abstract W getLastWindow(W pane);
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/SessionWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/SessionWindowAssigner.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.NavigableSet;
+
+
+/**
+ * A {@link WindowAssigner} that windows elements into sessions based on the timestamp.
+ * Windows cannot overlap.
+ */
+public class SessionWindowAssigner extends MergingWindowAssigner<TimeWindow> implements InternalTimeWindowAssigner {
+
+	private static final long serialVersionUID = -2595385378968688228L;
+
+	private final long sessionGap;
+
+	private final boolean isEventTime;
+
+	protected SessionWindowAssigner(long sessionGap, boolean isEventTime) {
+		if (sessionGap <= 0) {
+			throw new IllegalArgumentException("SessionWindowAssigner parameters must satisfy 0 < size");
+		}
+		this.sessionGap = sessionGap;
+		this.isEventTime = isEventTime;
+	}
+
+	@Override
+	public Collection<TimeWindow> assignWindows(BaseRow element, long timestamp) {
+		return Collections.singletonList(new TimeWindow(timestamp, timestamp + sessionGap));
+	}
+
+	@Override
+	public void mergeWindows(TimeWindow newWindow, NavigableSet<TimeWindow> sortedWindows, MergeCallback<TimeWindow> callback) {
+		TimeWindow ceiling = sortedWindows.ceiling(newWindow);
+		TimeWindow floor = sortedWindows.floor(newWindow);
+
+		Collection<TimeWindow> mergedWindows = new HashSet<>();
+		TimeWindow mergeResult = newWindow;
+		if (ceiling != null) {
+			mergeResult = mergeWindow(mergeResult, ceiling, mergedWindows);
+		}
+		if (floor != null) {
+			mergeResult = mergeWindow(mergeResult, floor, mergedWindows);
+		}
+		if (!mergedWindows.isEmpty()) {
+			// merge happens, add newWindow into the collection as well.
+			mergedWindows.add(newWindow);
+			callback.merge(mergeResult, mergedWindows);
+		}
+	}
+
+	/**
+	 * Merge curWindow and other, return a new window which covers curWindow and other
+	 * if they are overlapped. Otherwise, returns the curWindow itself.  */
+	private TimeWindow mergeWindow(TimeWindow curWindow, TimeWindow other, Collection<TimeWindow> mergedWindow) {
+		if (curWindow.intersects(other)) {
+			mergedWindow.add(other);
+			return curWindow.cover(other);
+		} else {
+			return curWindow;
+		}
+	}
+
+	@Override
+	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+		return new TimeWindow.Serializer();
+	}
+
+	@Override
+	public boolean isEventTime() {
+		return isEventTime;
+	}
+
+	@Override
+	public String toString() {
+		return "SessionWindow(" + sessionGap + ")";
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a new {@code SessionWindowAssigner} {@link WindowAssigner} that assigns
+	 * elements to sessions based on the timestamp.
+	 *
+	 * @param size The session timeout, i.e. the time gap between sessions
+	 * @return The policy.
+	 */
+	public static SessionWindowAssigner withGap(Duration size) {
+		return new SessionWindowAssigner(size.toMillis(), true);
+	}
+
+	public SessionWindowAssigner withEventTime() {
+		return new SessionWindowAssigner(sessionGap, true);
+	}
+
+	public SessionWindowAssigner withProcessingTime() {
+		return new SessionWindowAssigner(sessionGap, false);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/SlidingWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/SlidingWindowAssigner.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.util.IterableIterator;
+import org.apache.flink.util.MathUtils;
+
+import org.apache.commons.math3.util.ArithmeticUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A {@link WindowAssigner} that windows elements into sliding windows based on the timestamp of the
+ * elements. Windows can possibly overlap.
+ */
+public class SlidingWindowAssigner extends PanedWindowAssigner<TimeWindow> implements InternalTimeWindowAssigner {
+
+	private static final long serialVersionUID = 4895551155814656518L;
+
+	private final long size;
+
+	private final long slide;
+
+	private final long offset;
+
+	private final long paneSize;
+
+	private final int numPanesPerWindow;
+
+	private final boolean isEventTime;
+
+	protected SlidingWindowAssigner(long size, long slide, long offset, boolean isEventTime) {
+		if (size <= 0 || slide <= 0) {
+			throw new IllegalArgumentException(
+				"SlidingWindowAssigner parameters must satisfy slide > 0 and size > 0");
+		}
+
+		this.size = size;
+		this.slide = slide;
+		this.offset = offset;
+		this.isEventTime = isEventTime;
+		this.paneSize = ArithmeticUtils.gcd(size, slide);
+		this.numPanesPerWindow = MathUtils.checkedDownCast(size / paneSize);
+	}
+
+	@Override
+	public Collection<TimeWindow> assignWindows(BaseRow element, long timestamp) {
+		List<TimeWindow> windows = new ArrayList<>((int) (size / slide));
+		long lastStart = TimeWindow.getWindowStartWithOffset(timestamp, offset, slide);
+		for (long start = lastStart; start > timestamp - size; start -= slide) {
+			windows.add(new TimeWindow(start, start + size));
+		}
+		return windows;
+	}
+
+	@Override
+	public TimeWindow assignPane(Object element, long timestamp) {
+		long start = TimeWindow.getWindowStartWithOffset(timestamp, offset, paneSize);
+		return new TimeWindow(start, start + paneSize);
+	}
+
+	@Override
+	public Iterable<TimeWindow> splitIntoPanes(TimeWindow window) {
+		return new PanesIterable(window.getStart(), paneSize, numPanesPerWindow);
+	}
+
+	@Override
+	public TimeWindow getLastWindow(TimeWindow pane) {
+		long lastStart = TimeWindow.getWindowStartWithOffset(pane.getStart(), offset, slide);
+		return new TimeWindow(lastStart, lastStart + size);
+	}
+
+	@Override
+	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+		return new TimeWindow.Serializer();
+	}
+
+	@Override
+	public boolean isEventTime() {
+		return isEventTime;
+	}
+
+	@Override
+	public String toString() {
+		return "SlidingWindow(" + size + ", " + slide + ")";
+	}
+
+	private static class PanesIterable implements IterableIterator<TimeWindow> {
+
+		private final long paneSize;
+		private long paneStart;
+		private int numPanesRemaining;
+
+		PanesIterable(long paneStart, long paneSize, int numPanesPerWindow) {
+			this.paneStart = paneStart;
+			this.paneSize = paneSize;
+			this.numPanesRemaining = numPanesPerWindow;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return numPanesRemaining > 0;
+		}
+
+		@Override
+		public TimeWindow next() {
+			TimeWindow window = new TimeWindow(paneStart, paneStart + paneSize);
+			numPanesRemaining--;
+			paneStart += paneSize;
+			return window;
+		}
+
+		@Override
+		public Iterator<TimeWindow> iterator() {
+			return this;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a new {@code SlidingEventTimeWindows} {@link org.apache.flink.streaming.api.windowing.assigners.WindowAssigner} that assigns
+	 * elements to sliding time windows based on the element timestamp.
+	 *
+	 * @param size  The size of the generated windows.
+	 * @param slide The slide interval of the generated windows.
+	 * @return The time policy.
+	 */
+	public static SlidingWindowAssigner of(Duration size, Duration slide) {
+		return new SlidingWindowAssigner(size.toMillis(), slide.toMillis(), 0, true);
+	}
+
+	public SlidingWindowAssigner withOffset(Duration offset) {
+		return new SlidingWindowAssigner(size, slide, offset.toMillis(), isEventTime);
+	}
+
+	public SlidingWindowAssigner withEventTime() {
+		return new SlidingWindowAssigner(size, slide, offset, true);
+	}
+
+	public SlidingWindowAssigner withProcessingTime() {
+		return new SlidingWindowAssigner(size, slide, offset, false);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/TumblingWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/TumblingWindowAssigner.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A {@link WindowAssigner} that windows elements into fixed-size windows
+ * based on the timestamp of the elements. Windows cannot overlap.
+ */
+public class TumblingWindowAssigner extends WindowAssigner<TimeWindow> implements InternalTimeWindowAssigner {
+
+	private static final long serialVersionUID = -1671849072115929859L;
+	/**
+	 * Size of this window.
+	 */
+	private final long size;
+
+	/**
+	 * Offset of this window.  Windows start at time
+	 * N * size + offset, where 0 is the epoch.
+	 */
+	private final long offset;
+
+	private final boolean isEventTime;
+
+	protected TumblingWindowAssigner(long size, long offset, boolean isEventTime) {
+		if (size <= 0) {
+			throw new IllegalArgumentException
+				("TumblingWindowAssigner parameters must satisfy size > 0");
+		}
+		this.size = size;
+		this.offset = offset;
+		this.isEventTime = isEventTime;
+	}
+
+	@Override
+	public Collection<TimeWindow> assignWindows(BaseRow element, long timestamp) {
+		long start = TimeWindow.getWindowStartWithOffset(timestamp, offset, size);
+		return Collections.singletonList(new TimeWindow(start, start + size));
+	}
+
+	@Override
+	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+		return new TimeWindow.Serializer();
+	}
+
+	@Override
+	public boolean isEventTime() {
+		return isEventTime;
+	}
+
+	@Override
+	public String toString() {
+		return "TumblingWindow(" + size + ")";
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a new {@code TumblingWindowAssigner} {@link WindowAssigner} that assigns
+	 * elements to time windows based on the element timestamp.
+	 *
+	 * @param size The size of the generated windows.
+	 * @return The time policy.
+	 */
+	public static TumblingWindowAssigner of(Duration size) {
+		return new TumblingWindowAssigner(size.toMillis(), 0, true);
+	}
+
+	/**
+	 * Creates a new {@code TumblingWindowAssigner} {@link WindowAssigner} that assigns
+	 * elements to time windows based on the element timestamp and offset.
+	 *
+	 * <p>For example, if you want window a stream by hour,but window begins at the 15th minutes
+	 * of each hour, you can use {@code of(Time.hours(1),Time.minutes(15))},then you will get
+	 * time windows start at 0:15:00,1:15:00,2:15:00,etc.
+	 *
+	 * <p>Rather than that,if you are living in somewhere which is not using UTC±00:00 time,
+	 * such as China which is using UTC+08:00,and you want a time window with size of one day,
+	 * and window begins at every 00:00:00 of local time,you may use {@code of(Time.days(1),Time.hours(-8))}.
+	 * The parameter of offset is {@code Time.hours(-8))} since UTC+08:00 is 8 hours earlier than UTC time.
+	 *
+	 * @param offset The offset which window start would be shifted by.
+	 * @return The time policy.
+	 */
+	public TumblingWindowAssigner withOffset(Duration offset) {
+		return new TumblingWindowAssigner(size, offset.toMillis(), isEventTime);
+	}
+
+	public TumblingWindowAssigner withEventTime() {
+		return new TumblingWindowAssigner(size, offset, true);
+	}
+
+	public TumblingWindowAssigner withProcessingTime() {
+		return new TumblingWindowAssigner(size, offset, false);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/WindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/assigners/WindowAssigner.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.window.internal.InternalWindowProcessFunction;
+import org.apache.flink.table.runtime.window.triggers.Trigger;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+
+
+/**
+ * A {@code WindowAssigner} assigns zero or more {@link Window Windows} to an element.
+ *
+ * <p>In a window operation, elements are grouped by their key (if available) and by the windows to
+ * which it was assigned. The set of elements with the same key and window is called a pane.
+ * When a {@link Trigger} decides that a certain pane should fire the window to produce
+ * output elements for that pane.
+ *
+ * @param <W> The type of {@code Window} that this assigner assigns.
+ */
+public abstract class WindowAssigner<W extends Window> implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Initialization method for the function. It is called before the actual working methods.
+	 */
+	public void open(InternalWindowProcessFunction.Context<?, W> ctx) throws Exception {
+		// nothing to do
+	}
+
+	/**
+	 * Given the timestamp and element, returns the set of windows into which it
+	 * should be placed.
+	 *
+	 * @param element The element to which windows should be assigned.
+	 * @param timestamp The timestamp of the element when {@link #isEventTime()} returns true,
+	 *                  or the current system time when {@link #isEventTime()} returns false.
+	 */
+	public abstract Collection<W> assignWindows(BaseRow element, long timestamp) throws IOException;
+
+	/**
+	 * Returns a {@link TypeSerializer} for serializing windows that are assigned by
+	 * this {@code WindowAssigner}.
+	 */
+	public abstract TypeSerializer<W> getWindowSerializer(ExecutionConfig executionConfig);
+
+	/**
+	 * Returns {@code true} if elements are assigned to windows based on event time,
+	 * {@code false} otherwise.
+	 */
+	public abstract boolean isEventTime();
+
+	public abstract String toString();
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/GeneralWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/GeneralWindowProcessFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.internal;
+
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.window.assigners.WindowAssigner;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The general implementation of {@link InternalWindowProcessFunction}. The {@link WindowAssigner}
+ * should be a regular assigner without implement {@code PanedWindowAssigner} or {@code MergingWindowAssigner}.
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class GeneralWindowProcessFunction<K, W extends Window>
+	extends InternalWindowProcessFunction<K, W> {
+
+	private static final long serialVersionUID = 5992545519395844485L;
+
+	private List<W> reuseAffectedWindows;
+
+	public GeneralWindowProcessFunction(
+			WindowAssigner<W> windowAssigner,
+			NamespaceAggsHandleFunction<W> windowAggregator,
+			long allowedLateness) {
+		super(windowAssigner, windowAggregator, allowedLateness);
+	}
+
+	@Override
+	public Collection<W> assignStateNamespace(BaseRow inputRow, long timestamp) throws Exception {
+		Collection<W> elementWindows = windowAssigner.assignWindows(inputRow, timestamp);
+		reuseAffectedWindows = new ArrayList<>(elementWindows.size());
+		for (W window : elementWindows) {
+			if (!isWindowLate(window)) {
+				reuseAffectedWindows.add(window);
+			}
+		}
+		return reuseAffectedWindows;
+	}
+
+	@Override
+	public Collection<W> assignActualWindows(BaseRow inputRow, long timestamp) throws Exception {
+		// actual windows is equal to affected window, reuse it
+		return reuseAffectedWindows;
+	}
+
+	@Override
+	public BaseRow getWindowAggregationResult(W window) throws Exception {
+		BaseRow acc = ctx.getWindowAccumulators(window);
+		if (acc == null) {
+			acc = windowAggregator.createAccumulators();
+		}
+		windowAggregator.setAccumulators(window, acc);
+		return windowAggregator.getValue(window);
+	}
+
+	@Override
+	public void cleanWindowIfNeeded(W window, long time) throws Exception {
+		if (isCleanupTime(window, time)) {
+			ctx.clearWindowState(window);
+			ctx.clearPreviousState(window);
+			ctx.clearTrigger(window);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/InternalWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/InternalWindowProcessFunction.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.internal;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.window.triggers.Trigger;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+/**
+ * The internal interface for functions that process over grouped windows.
+ *
+ * @param <W> type of window
+ */
+public abstract class InternalWindowProcessFunction<K, W extends Window> implements Serializable {
+
+	private static final long serialVersionUID = 5191040787066951059L;
+
+	protected final WindowAssigner<W> windowAssigner;
+	protected final NamespaceAggsHandleFunction<W> windowAggregator;
+	protected final long allowedLateness;
+	protected Context<K, W> ctx;
+
+	protected InternalWindowProcessFunction(
+			WindowAssigner<W> windowAssigner,
+			NamespaceAggsHandleFunction<W> windowAggregator,
+			long allowedLateness) {
+		this.windowAssigner = windowAssigner;
+		this.windowAggregator = windowAggregator;
+		this.allowedLateness = allowedLateness;
+	}
+
+	/**
+	 * Initialization method for the function. It is called before the actual working methods.
+	 */
+	public void open(Context<K, W> ctx) throws Exception {
+		this.ctx = ctx;
+		this.windowAssigner.open(ctx);
+	}
+
+	/**
+	 * Assigns the input element into the state namespace which the input element should be
+	 * accumulated/retracted into.
+	 *
+	 * @param inputRow  the input element
+	 * @param timestamp the timestamp of the element or the processing time (depends on the type of
+	 *                  assigner)
+	 * @return the state namespace
+	 */
+	public abstract Collection<W> assignStateNamespace(BaseRow inputRow,
+			long timestamp) throws Exception;
+
+	/**
+	 * Assigns the input element into the actual windows which the {@link Trigger} should trigger
+	 * on.
+	 *
+	 * @param inputRow  the input element
+	 * @param timestamp the timestamp of the element or the processing time (depends on the type of
+	 *                  assigner)
+	 * @return the actual windows
+	 */
+	public abstract Collection<W> assignActualWindows(BaseRow inputRow,
+			long timestamp) throws Exception;
+
+	/**
+	 * Gets the aggregation result and window properties of the given window.
+	 *
+	 * @param window the window
+	 * @return the aggregation result and window properties
+	 */
+	public abstract BaseRow getWindowAggregationResult(W window) throws Exception;
+
+	/**
+	 * Cleans the given window if needed.
+	 *
+	 * @param window      the window to cleanup
+	 * @param currentTime the current timestamp
+	 */
+	public abstract void cleanWindowIfNeeded(W window, long currentTime) throws Exception;
+
+	/**
+	 * The tear-down method of the function. It is called after the last call to the main working
+	 * methods.
+	 */
+	public void close() throws Exception {
+
+	}
+
+	/**
+	 * Returns {@code true} if the given time is the cleanup time for the given window.
+	 */
+	protected final boolean isCleanupTime(W window, long time) {
+		return time == cleanupTime(window);
+	}
+
+	/**
+	 * Returns {@code true} if the watermark is after the end timestamp plus the allowed lateness
+	 * of the given window.
+	 */
+	protected boolean isWindowLate(W window) {
+		return (windowAssigner.isEventTime() && (cleanupTime(window) <= ctx.currentWatermark()));
+	}
+
+	/**
+	 * Returns the cleanup time for a window, which is
+	 * {@code window.maxTimestamp + allowedLateness}. In
+	 * case this leads to a value greated than {@link Long#MAX_VALUE}
+	 * then a cleanup time of {@link Long#MAX_VALUE} is
+	 * returned.
+	 *
+	 * @param window the window whose cleanup time we are computing.
+	 */
+	private long cleanupTime(W window) {
+		if (windowAssigner.isEventTime()) {
+			long cleanupTime = window.maxTimestamp() + allowedLateness;
+			return cleanupTime >= window.maxTimestamp() ? cleanupTime : Long.MAX_VALUE;
+		} else {
+			return window.maxTimestamp();
+		}
+	}
+
+
+	/**
+	 * Information available in an invocation of methods of {@link InternalWindowProcessFunction}.
+	 * @param <W>
+	 */
+	public interface Context<K, W extends Window> {
+
+		/**
+		 * Creates a partitioned state handle, using the state backend configured for this task.
+		 *
+		 * @throws IllegalStateException Thrown, if the key/value state was already initialized.
+		 * @throws Exception Thrown, if the state backend cannot create the key/value state.
+		 */
+		<S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception;
+
+		/**
+		 * @return current key of current processed element.
+		 */
+		K currentKey();
+
+		/**
+		 * Returns the current processing time.
+		 */
+		long currentProcessingTime();
+
+		/**
+		 * Returns the current event-time watermark.
+		 */
+		long currentWatermark();
+
+		/**
+		 * Gets the accumulators of the given window.
+		 */
+		BaseRow getWindowAccumulators(W window) throws Exception;
+
+		/**
+		 * Sets the accumulators of the given window.
+		 */
+		void setWindowAccumulators(W window, BaseRow acc) throws Exception;
+
+		/**
+		 * Clear window state of the given window.
+		 */
+		void clearWindowState(W window) throws Exception;
+
+		/**
+		 * Clear previous agg state (used for retraction) of the given window.
+		 */
+		void clearPreviousState(W window) throws Exception;
+
+		/**
+		 * Call {@link Trigger#clear(Window)}} on trigger.
+		 */
+		void clearTrigger(W window) throws Exception;
+
+		/**
+		 * Call {@link Trigger#onMerge(Window, Trigger.OnMergeContext)} on trigger.
+		 */
+		void onMerge(W newWindow, Collection<W> mergedWindows) throws Exception;
+
+		/**
+		 * Deletes the cleanup timer set for the contents of the provided window.
+		 */
+		void deleteCleanupTimer(W window) throws Exception;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/MergingWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/MergingWindowProcessFunction.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.internal;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.window.assigners.MergingWindowAssigner;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The implementation of {@link InternalWindowProcessFunction} for {@link MergingWindowAssigner}.
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class MergingWindowProcessFunction<K, W extends Window>
+	extends InternalWindowProcessFunction<K, W> {
+
+	private static final long serialVersionUID = -2866771637946397223L;
+
+	private final MergingWindowAssigner<W> windowAssigner;
+	private final TypeSerializer<W> windowSerializer;
+	private transient MergingWindowSet<W> mergingWindows;
+	private transient MergingFunctionImpl mergingFunction;
+
+	private List<W> reuseActualWindows;
+
+	public MergingWindowProcessFunction(
+			MergingWindowAssigner<W> windowAssigner,
+			NamespaceAggsHandleFunction<W> windowAggregator,
+			TypeSerializer<W> windowSerializer,
+			long allowedLateness) {
+		super(windowAssigner, windowAggregator, allowedLateness);
+		this.windowAssigner = windowAssigner;
+		this.windowSerializer = windowSerializer;
+	}
+
+	@Override
+	public void open(Context<K, W> ctx) throws Exception {
+		super.open(ctx);
+		MapStateDescriptor<W, W> mappingStateDescriptor = new MapStateDescriptor<>(
+			"session-window-mapping",
+			windowSerializer,
+			windowSerializer);
+		MapState<W, W> windowMapping = ctx.getPartitionedState(mappingStateDescriptor);
+		this.mergingWindows = new MergingWindowSet<>(windowAssigner, windowMapping);
+		this.mergingFunction = new MergingFunctionImpl();
+	}
+
+	@Override
+	public Collection<W> assignStateNamespace(BaseRow inputRow, long timestamp) throws Exception {
+		Collection<W> elementWindows = windowAssigner.assignWindows(inputRow, timestamp);
+		mergingWindows.initializeCache(ctx.currentKey());
+		reuseActualWindows = new ArrayList<>(1);
+		for (W window : elementWindows) {
+			// adding the new window might result in a merge, in that case the actualWindow
+			// is the merged window and we work with that. If we don't merge then
+			// actualWindow == window
+			W actualWindow = mergingWindows.addWindow(window, mergingFunction);
+
+			// drop if the window is already late
+			if (isWindowLate(actualWindow)) {
+				mergingWindows.retireWindow(actualWindow);
+			} else {
+				reuseActualWindows.add(actualWindow);
+			}
+		}
+		List<W> affectedWindows = new ArrayList<>(reuseActualWindows.size());
+		for (W actual : reuseActualWindows) {
+			affectedWindows.add(mergingWindows.getStateWindow(actual));
+		}
+		return affectedWindows;
+	}
+
+	@Override
+	public Collection<W> assignActualWindows(BaseRow inputRow, long timestamp) throws Exception {
+		// the actual windows is calculated in assignStateNamespace
+		return reuseActualWindows;
+	}
+
+	@Override
+	public BaseRow getWindowAggregationResult(W window) throws Exception {
+		W stateWindow = mergingWindows.getStateWindow(window);
+		BaseRow acc = ctx.getWindowAccumulators(stateWindow);
+		if (acc == null) {
+			acc = windowAggregator.createAccumulators();
+		}
+		windowAggregator.setAccumulators(stateWindow, acc);
+		return windowAggregator.getValue(window);
+	}
+
+	@Override
+	public void cleanWindowIfNeeded(W window, long currentTime) throws Exception {
+		if (isCleanupTime(window, currentTime)) {
+			ctx.clearTrigger(window);
+			W stateWindow = mergingWindows.getStateWindow(window);
+			ctx.clearWindowState(stateWindow);
+			// retire expired window
+			mergingWindows.initializeCache(ctx.currentKey());
+			mergingWindows.retireWindow(window);
+			// do not need to clear previous state, previous state is disabled in session window
+		}
+	}
+
+	private class MergingFunctionImpl implements MergingWindowSet.MergeFunction<W> {
+
+		@Override
+		public void merge(
+			W mergeResult,
+			Collection<W> mergedWindows,
+			W stateWindowResult,
+			Collection<W> stateWindowsToBeMerged) throws Exception {
+
+			if ((windowAssigner.isEventTime() && mergeResult.maxTimestamp() + allowedLateness <= ctx.currentWatermark())) {
+				throw new UnsupportedOperationException("The end timestamp of an " +
+					"event-time window cannot become earlier than the current watermark " +
+					"by merging. Current watermark: " + ctx.currentWatermark() +
+					" window: " + mergeResult);
+			} else if (!windowAssigner.isEventTime() && mergeResult.maxTimestamp() <= ctx.currentProcessingTime()) {
+				throw new UnsupportedOperationException("The end timestamp of a " +
+					"processing-time window cannot become earlier than the current processing time " +
+					"by merging. Current processing time: " + ctx.currentProcessingTime() +
+					" window: " + mergeResult);
+			}
+
+			ctx.onMerge(mergeResult, stateWindowsToBeMerged);
+
+			// clear registered timers
+			for (W m : mergedWindows) {
+				ctx.clearTrigger(m);
+				ctx.deleteCleanupTimer(m);
+			}
+
+			// merge the merged state windows into the newly resulting state window
+			if (!stateWindowsToBeMerged.isEmpty()) {
+				BaseRow targetAcc = ctx.getWindowAccumulators(stateWindowResult);
+				if (targetAcc == null) {
+					targetAcc = windowAggregator.createAccumulators();
+				}
+				windowAggregator.setAccumulators(stateWindowResult, targetAcc);
+				for (W w : stateWindowsToBeMerged) {
+					BaseRow acc = ctx.getWindowAccumulators(w);
+					if (acc != null) {
+						windowAggregator.merge(w, acc);
+					}
+					// clear merged window
+					ctx.clearWindowState(w);
+					ctx.clearPreviousState(w);
+				}
+				targetAcc = windowAggregator.getAccumulators();
+				ctx.setWindowAccumulators(stateWindowResult, targetAcc);
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/MergingWindowSet.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/MergingWindowSet.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.internal;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.runtime.util.LRUMap;
+import org.apache.flink.table.runtime.window.assigners.MergingWindowAssigner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * Utility for keeping track of merging {@link Window Windows} when using a
+ * {@link MergingWindowAssigner} in a {@code WindowOperator}.
+ *
+ * <p>When merging windows, we keep one of the original windows as the state window, i.e. the
+ * window that is used as namespace to store the window elements. Elements from the state
+ * windows of merged windows must be merged into this one state window. We keep
+ * a mapping from in-flight window to state window that can be queried using
+ * {@link #getStateWindow(Window)}.
+ *
+ * <p>A new window can be added to the set of in-flight windows using
+ * {@link #addWindow(Window, MergeFunction)}. This might merge other windows and the caller
+ * must react accordingly in the {@link MergeFunction#merge(Object, Collection, Object, Collection)}
+ * and adjust the outside view of windows and state.
+ *
+ * <p>Windows can be removed from the set of windows using {@link #retireWindow(Window)}.
+ *
+ * @param <W> The type of {@code Window} that this set is keeping track of.
+ */
+public class MergingWindowSet<W extends Window> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MergingWindowSet.class);
+
+	private static final int MAPPING_CACHE_SIZE = 10000;
+
+	/**
+	 * Mapping from window to the window that keeps the window state. When
+	 * we are incrementally merging windows starting from some window we keep that starting
+	 * window as the state window to prevent costly state juggling.
+	 */
+	private final MapState<W, W> mapping;
+
+	private final LRUMap<Object, TreeSet<W>> cachedSortedWindows;
+
+	private TreeSet<W> sortedWindows;
+
+	/**
+	 * Our window assigner.
+	 */
+	private final MergingWindowAssigner<W> windowAssigner;
+
+	/**
+	 * Restores a {@link MergingWindowSet} from the given state.
+	 */
+	public MergingWindowSet(MergingWindowAssigner<W> windowAssigner, MapState<W, W> mapping) {
+		this.windowAssigner = windowAssigner;
+		this.mapping = mapping;
+		this.cachedSortedWindows = new LRUMap<>(MAPPING_CACHE_SIZE);
+	}
+
+	/**
+	 * Set current key context of this window set.
+	 *
+	 * <p>Notes: {@code initializeCache(Object)} must be called before
+	 * {@link #addWindow(Window, MergeFunction)} and {@link #retireWindow(Window)}
+	 *
+	 * @param key the current access key
+	 */
+	public void initializeCache(Object key) throws Exception {
+		this.sortedWindows = cachedSortedWindows.get(key);
+		if (sortedWindows == null) {
+			this.sortedWindows = new TreeSet<>();
+			Iterator<Map.Entry<W, W>> keyValues = mapping.iterator();
+			if (keyValues != null) {
+				while (keyValues.hasNext()) {
+					Map.Entry<W, W> keyValue = keyValues.next();
+					this.sortedWindows.add(keyValue.getKey());
+				}
+			}
+			cachedSortedWindows.put(key, sortedWindows);
+		}
+	}
+
+	/**
+	 * Returns the state window for the given in-flight {@code Window}. The state window is the
+	 * {@code Window} in which we keep the actual state of a given in-flight window. Windows
+	 * might expand but we keep to original state window for keeping the elements of the window
+	 * to avoid costly state juggling.
+	 *
+	 * @param window The window for which to get the state window.
+	 */
+	public W getStateWindow(W window) throws Exception {
+		return mapping.get(window);
+	}
+
+	/**
+	 * Removes the given window from the set of in-flight windows.
+	 *
+	 * @param window The {@code Window} to remove.
+	 */
+	public void retireWindow(W window) throws Exception {
+		this.mapping.remove(window);
+		boolean removed = this.sortedWindows.remove(window);
+		if (!removed) {
+			throw new IllegalStateException("Window " + window + " is not in in-flight window set.");
+		}
+	}
+
+	/**
+	 * Adds a new {@code Window} to the set of in-flight windows. It might happen that this
+	 * triggers merging of previously in-flight windows. In that case, the provided
+	 * {@link MergeFunction} is called.
+	 *
+	 * <p>This returns the window that is the representative of the added window after adding.
+	 * This can either be the new window itself, if no merge occurred, or the newly merged
+	 * window. Adding an element to a window or calling trigger functions should only
+	 * happen on the returned representative. This way, we never have to deal with a new window
+	 * that is immediately swallowed up by another window.
+	 *
+	 * <p>If the new window is merged, the {@code MergeFunction} callback arguments also don't
+	 * contain the new window as part of the list of merged windows.
+	 *
+	 * @param newWindow     The new {@code Window} to add.
+	 * @param mergeFunction The callback to be invoked in case a merge occurs.
+	 * @return The {@code Window} that new new {@code Window} ended up in. This can also be the
+	 * the new {@code Window} itself in case no merge occurred.
+	 * @throws Exception
+	 */
+	public W addWindow(W newWindow, MergeFunction<W> mergeFunction) throws Exception {
+		MergeResultCollector collector = new MergeResultCollector();
+		windowAssigner.mergeWindows(newWindow, sortedWindows, collector);
+
+		W resultWindow = newWindow;
+		boolean isNewWindowMerged = false;
+
+		// perform the merge
+		for (Map.Entry<W, Collection<W>> c : collector.mergeResults.entrySet()) {
+			W mergeResult = c.getKey();
+			Collection<W> mergedWindows = c.getValue();
+
+			// if our new window is in the merged windows make the merge result the
+			// result window
+			if (mergedWindows.remove(newWindow)) {
+				isNewWindowMerged = true;
+				resultWindow = mergeResult;
+			}
+
+			// if our new window is the same as a pre-exising window, nothing to do
+			if (mergedWindows.isEmpty()) {
+				continue;
+			}
+
+			// pick any of the merged windows and choose that window's state window
+			// as the state window for the merge result
+			W mergedStateNamespace = this.mapping.get(mergedWindows.iterator().next());
+
+			// figure out the state windows that we are merging
+			List<W> mergedStateWindows = new ArrayList<>();
+			for (W mergedWindow : mergedWindows) {
+				W res = this.mapping.get(mergedWindow);
+				if (res != null) {
+					this.mapping.remove(mergedWindow);
+					this.sortedWindows.remove(mergedWindow);
+					// don't put the target state window into the merged windows
+					if (!res.equals(mergedStateNamespace)) {
+						mergedStateWindows.add(res);
+					}
+				}
+			}
+
+			this.mapping.put(mergeResult, mergedStateNamespace);
+			this.sortedWindows.add(mergeResult);
+
+			// don't merge the new window itself, it never had any state associated with it
+			// i.e. if we are only merging one pre-existing window into itself
+			// without extending the pre-exising window
+			if (!(mergedWindows.contains(mergeResult) && mergedWindows.size() == 1)) {
+				mergeFunction.merge(mergeResult,
+					mergedWindows,
+					mergedStateNamespace,
+					mergedStateWindows);
+			}
+		}
+
+		// the new window created a new, self-contained window without merging
+		if (collector.mergeResults.isEmpty() || (resultWindow.equals(newWindow) && !isNewWindowMerged)) {
+			this.mapping.put(resultWindow, resultWindow);
+			this.sortedWindows.add(resultWindow);
+		}
+
+		return resultWindow;
+	}
+
+	private class MergeResultCollector implements MergingWindowAssigner.MergeCallback<W> {
+
+		final Map<W, Collection<W>> mergeResults = new HashMap<>();
+
+		@Override
+		public void merge(W mergeResult, Collection<W> toBeMerged) {
+			LOG.debug("Merging {} into {}", toBeMerged, mergeResult);
+			mergeResults.put(mergeResult, toBeMerged);
+		}
+	}
+
+
+	/**
+	 * Callback for {@link #addWindow(Window, MergeFunction)}.
+	 *
+	 * @param <W>
+	 */
+	public interface MergeFunction<W> {
+
+		/**
+		 * This gets called when a merge occurs.
+		 *
+		 * @param mergeResult            The newly resulting merged {@code Window}.
+		 * @param mergedWindows          The merged {@code Window Windows}.
+		 * @param stateWindowResult      The state window of the merge result.
+		 * @param stateWindowsToBeMerged The merged state windows.
+		 * @throws Exception
+		 */
+		void merge(W mergeResult, Collection<W> mergedWindows, W stateWindowResult,
+				Collection<W> stateWindowsToBeMerged) throws Exception;
+	}
+
+	@Override
+	public String toString() {
+		return "MergingWindowSet{" +
+			"windows=" + mapping +
+			'}';
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/PanedWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/internal/PanedWindowProcessFunction.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.internal;
+
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.window.assigners.PanedWindowAssigner;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The implementation of {@link InternalWindowProcessFunction} for {@link PanedWindowAssigner}.
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class PanedWindowProcessFunction<K, W extends Window>
+	extends InternalWindowProcessFunction<K, W> {
+
+	private static final long serialVersionUID = 4259335376102569987L;
+
+	private final PanedWindowAssigner<W> windowAssigner;
+
+	public PanedWindowProcessFunction(
+			PanedWindowAssigner<W> windowAssigner,
+			NamespaceAggsHandleFunction<W> windowAggregator,
+			long allowedLateness) {
+		super(windowAssigner, windowAggregator, allowedLateness);
+		this.windowAssigner = windowAssigner;
+	}
+
+	@Override
+	public Collection<W> assignActualWindows(BaseRow inputRow, long timestamp) throws Exception {
+		Collection<W> elementWindows = windowAssigner.assignWindows(inputRow, timestamp);
+		List<W> actualWindows = new ArrayList<>(elementWindows.size());
+		for (W window : elementWindows) {
+			if (!isWindowLate(window)) {
+				actualWindows.add(window);
+			}
+		}
+		return actualWindows;
+	}
+
+	@Override
+	public Collection<W> assignStateNamespace(BaseRow inputRow, long timestamp) throws Exception {
+		W pane = windowAssigner.assignPane(inputRow, timestamp);
+		if (!isPaneLate(pane)) {
+			return Collections.singleton(pane);
+		} else {
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public BaseRow getWindowAggregationResult(W window) throws Exception {
+		Iterable<W> panes = windowAssigner.splitIntoPanes(window);
+		BaseRow acc = windowAggregator.createAccumulators();
+		// null namespace means use heap data views
+		windowAggregator.setAccumulators(null, acc);
+		for (W pane : panes) {
+			BaseRow paneAcc = ctx.getWindowAccumulators(pane);
+			if (paneAcc != null) {
+				windowAggregator.merge(pane, paneAcc);
+			}
+		}
+		return windowAggregator.getValue(window);
+	}
+
+	@Override
+	public void cleanWindowIfNeeded(W window, long currentTime) throws Exception {
+		if (isCleanupTime(window, currentTime)) {
+			Iterable<W> panes = windowAssigner.splitIntoPanes(window);
+			for (W pane : panes) {
+				W lastWindow = windowAssigner.getLastWindow(pane);
+				if (window.equals(lastWindow)) {
+					ctx.clearWindowState(pane);
+				}
+			}
+			ctx.clearTrigger(window);
+			ctx.clearPreviousState(window);
+		}
+	}
+
+	/** checks whether the pane is late (e.g. can be / has been cleanup) */
+	private boolean isPaneLate(W pane) {
+		// whether the pane is late depends on the last window which the pane is belongs to is late
+		return windowAssigner.isEventTime() && isWindowLate(windowAssigner.getLastWindow(pane));
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/triggers/ElementTriggers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/triggers/ElementTriggers.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.triggers;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.table.api.window.Window;
+
+/**
+ * A {@link Trigger} that fires at some point after a specified number of
+ * input elements have arrived.
+ */
+public class ElementTriggers {
+
+	/**
+	 * This class should never be instantiated.
+	 */
+	private ElementTriggers() {}
+
+	/**
+	 * Creates a new trigger that triggers on receiving of every element.
+	 */
+	public static <W extends Window> EveryElement<W> every() {
+		return new EveryElement<>();
+	}
+
+	/**
+	 * Creates a trigger that fires when the pane contains at lease {@code countElems} elements.
+	 */
+	public static <W extends Window> CountElement<W> count(long countElems) {
+		return new CountElement<>(countElems);
+	}
+
+	/**
+	 * A {@link Trigger} that triggers on every element.
+	 * @param <W> type of window
+	 */
+	public static final class EveryElement<W extends Window> extends Trigger<W> {
+
+		private static final long serialVersionUID = 3942805366646141029L;
+
+		@Override
+		public void open(TriggerContext ctx) throws Exception {
+			// do nothing
+		}
+
+		@Override
+		public boolean onElement(Object element, long timestamp, W window) throws Exception {
+			// trigger on every record
+			return true;
+		}
+
+		@Override
+		public boolean onProcessingTime(long time, W window) throws Exception {
+			return false;
+		}
+
+		@Override
+		public boolean onEventTime(long time, W window) throws Exception {
+			return false;
+		}
+
+		@Override
+		public void clear(W window) throws Exception {
+			// do nothing
+		}
+
+		@Override
+		public boolean canMerge() {
+			return true;
+		}
+
+		@Override
+		public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+			// do nothing
+		}
+
+		@Override
+		public String toString() {
+			return "Element.every()";
+		}
+	}
+
+	/**
+	 * A {@link Trigger} that fires at some point after a specified number of
+	 * input elements have arrived.
+	 */
+	public static final class CountElement<W extends Window> extends Trigger<W> {
+
+		private static final long serialVersionUID = -3823782971498746808L;
+
+		private final long countElems;
+		private final ReducingStateDescriptor<Long> countStateDesc;
+		private transient TriggerContext ctx;
+
+		CountElement(long countElems) {
+			this.countElems = countElems;
+			this.countStateDesc = new ReducingStateDescriptor<>(
+					"trigger-count-" + countElems, new Sum(), LongSerializer.INSTANCE);
+		}
+
+		@Override
+		public void open(TriggerContext ctx) throws Exception {
+			this.ctx = ctx;
+		}
+
+		@Override
+		public boolean onElement(Object element, long timestamp, W window) throws Exception {
+			ReducingState<Long> count = ctx.getPartitionedState(countStateDesc);
+			count.add(1L);
+			if (count.get() >= countElems) {
+				count.clear();
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public boolean onProcessingTime(long time, W window) throws Exception {
+			return false;
+		}
+
+		@Override
+		public boolean onEventTime(long time, W window) throws Exception {
+			return false;
+		}
+
+		@Override
+		public void clear(W window) throws Exception {
+			ctx.getPartitionedState(countStateDesc).clear();
+		}
+
+		@Override
+		public boolean canMerge() {
+			return true;
+		}
+
+		@Override
+		public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+			mergeContext.mergePartitionedState(countStateDesc);
+		}
+
+		@Override
+		public String toString() {
+			return "Element.count(" + countElems + ")";
+		}
+
+		private static class Sum implements ReduceFunction<Long> {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Long reduce(Long value1, Long value2) throws Exception {
+				return value1 + value2;
+			}
+
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/triggers/EventTimeTriggers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/triggers/EventTimeTriggers.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.triggers;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.api.window.Window;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link Trigger} that reacts to event-time timers.
+ * The behavior can be one of the following:
+ * <p><ul>
+ *      <li/> fire when the watermark passes the end of the window ({@link EventTimeTriggers#afterEndOfWindow()}),
+ * </ul></p>
+ * In the first case, the trigger can also specify an <tt>early</tt> and a <tt>late</tt> trigger.
+ * The <tt>early trigger</tt> will be responsible for specifying when the trigger should fire in the period
+ * between the beginning of the window and the time when the watermark passes the end of the window.
+ * The <tt>late trigger</tt> takes over after the watermark passes the end of the window, and specifies when
+ * the trigger should fire in the period between the <tt>endOfWindow</tt> and <tt>endOfWindow + allowedLateness</tt>.
+ */
+public class EventTimeTriggers {
+
+	private static final String TO_STRING = "EventTime.afterEndOfWindow()";
+
+	/**
+	 * This class should never be instantiated.
+	 */
+	private EventTimeTriggers() {}
+
+	/**
+	 * Creates a trigger that fires when the watermark passes the end of the window.
+	 */
+	public static <W extends Window> AfterEndOfWindow<W> afterEndOfWindow() {
+		return new AfterEndOfWindow<>();
+	}
+
+	/**
+	 * A {@link Trigger} that fires once the watermark passes the end of the window
+	 * to which a pane belongs.
+	 *
+	 * @see org.apache.flink.streaming.api.watermark.Watermark
+	 */
+	public static final class AfterEndOfWindow<W extends Window> extends Trigger<W> {
+
+		private static final long serialVersionUID = -6379468077823588591L;
+
+		/**
+		 * Creates a new {@code Trigger} like the this, except that it fires repeatedly whenever
+		 * the given {@code Trigger} fires before the watermark has passed the end of the window.
+		 */
+		public AfterEndOfWindowNoLate<W> withEarlyFirings(Trigger<W> earlyFirings) {
+			checkNotNull(earlyFirings);
+			return new AfterEndOfWindowNoLate<>(earlyFirings);
+		}
+
+		/**
+		 * Creates a new {@code Trigger} like the this, except that it fires repeatedly whenever
+		 * the given {@code Trigger} fires after the watermark has passed the end of the window.
+		 */
+		public Trigger<W> withLateFirings(Trigger<W> lateFirings) {
+			checkNotNull(lateFirings);
+			if (lateFirings instanceof ElementTriggers.EveryElement) {
+				// every-element late firing can be ignored
+				return this;
+			} else {
+				return new AfterEndOfWindowEarlyAndLate<>(null, lateFirings);
+			}
+		}
+
+		private TriggerContext ctx;
+
+		@Override
+		public void open(TriggerContext ctx) throws Exception {
+			this.ctx = ctx;
+		}
+
+		@Override
+		public boolean onElement(Object element, long timestamp, W window) throws Exception {
+			if (window.maxTimestamp() <= ctx.getCurrentWatermark()) {
+				// if the watermark is already past the window fire immediately
+				return true;
+			} else {
+				ctx.registerEventTimeTimer(window.maxTimestamp());
+				return false;
+			}
+		}
+
+		@Override
+		public boolean onProcessingTime(long time, W window) throws Exception {
+			return false;
+		}
+
+		@Override
+		public boolean onEventTime(long time, W window) throws Exception {
+			return time == window.maxTimestamp();
+		}
+
+		@Override
+		public void clear(W window) throws Exception {
+			ctx.deleteEventTimeTimer(window.maxTimestamp());
+		}
+
+		@Override
+		public boolean canMerge() {
+			return true;
+		}
+
+		@Override
+		public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+			ctx.registerEventTimeTimer(window.maxTimestamp());
+		}
+
+		@Override
+		public String toString() {
+			return TO_STRING;
+		}
+	}
+
+	/**
+	 * A composite {@link Trigger} that consist of AfterEndOfWindow and a early trigger and late trigger.
+	 */
+	public static final class AfterEndOfWindowEarlyAndLate<W extends Window> extends Trigger<W> {
+
+		private static final long serialVersionUID = -800582945577030338L;
+
+		private final Trigger<W> earlyTrigger;
+		private final Trigger<W> lateTrigger;
+		private final ValueStateDescriptor<Boolean> hasFiredOnTimeStateDesc;
+
+		private transient TriggerContext ctx;
+
+		AfterEndOfWindowEarlyAndLate(Trigger<W> earlyTrigger, Trigger<W> lateTrigger) {
+			this.earlyTrigger = earlyTrigger;
+			this.lateTrigger = lateTrigger;
+			this.hasFiredOnTimeStateDesc = new ValueStateDescriptor<>("eventTime-afterEOW", Types.BOOLEAN);
+		}
+
+		@Override
+		public void open(TriggerContext ctx) throws Exception {
+			this.ctx = ctx;
+			if (earlyTrigger != null) {
+				earlyTrigger.open(ctx);
+			}
+			if (lateTrigger != null) {
+				lateTrigger.open(ctx);
+			}
+		}
+
+		@Override
+		public boolean onElement(Object element, long timestamp, W window) throws Exception {
+			Boolean hasFired = ctx.getPartitionedState(hasFiredOnTimeStateDesc).value();
+			if (hasFired != null && hasFired) {
+				// this is to cover the case where we recover from a failure and the watermark
+				// is Long.MIN_VALUE but the window is already in the late phase.
+				return lateTrigger != null && lateTrigger.onElement(element, timestamp, window);
+			} else {
+				if (window.maxTimestamp() <= ctx.getCurrentWatermark()) {
+					// we are in the late phase
+
+					// if there is no late trigger then we fire on every late element
+					// This also covers the case of recovery after a failure
+					// where the currentWatermark will be Long.MIN_VALUE
+					return true;
+				} else {
+					// we are in the early phase
+					ctx.registerEventTimeTimer(window.maxTimestamp());
+					return earlyTrigger != null && earlyTrigger.onElement(element, timestamp, window);
+				}
+			}
+		}
+
+		@Override
+		public boolean onProcessingTime(long time, W window) throws Exception {
+			Boolean hasFired = ctx.getPartitionedState(hasFiredOnTimeStateDesc).value();
+			if (hasFired != null && hasFired) {
+				// late fire
+				return lateTrigger != null && lateTrigger.onProcessingTime(time, window);
+			} else {
+				// early fire
+				return earlyTrigger != null && earlyTrigger.onProcessingTime(time, window);
+			}
+		}
+
+		@Override
+		public boolean onEventTime(long time, W window) throws Exception {
+			ValueState<Boolean> hasFiredState = ctx.getPartitionedState(hasFiredOnTimeStateDesc);
+			Boolean hasFired = hasFiredState.value();
+			if (hasFired != null && hasFired) {
+				// late fire
+				return lateTrigger != null && lateTrigger.onEventTime(time, window);
+			} else {
+				if (time == window.maxTimestamp()) {
+					// fire on time and update state
+					hasFiredState.update(true);
+					return true;
+				} else {
+					// early fire
+					return earlyTrigger != null && earlyTrigger.onEventTime(time, window);
+				}
+			}
+		}
+
+		@Override
+		public boolean canMerge() {
+			return (earlyTrigger == null || earlyTrigger.canMerge()) &&
+				(lateTrigger == null || lateTrigger.canMerge());
+		}
+
+		@Override
+		public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+			if (earlyTrigger != null) {
+				earlyTrigger.onMerge(window, mergeContext);
+			}
+			if (lateTrigger != null) {
+				lateTrigger.onMerge(window, mergeContext);
+			}
+
+			// we assume that the new merged window has not fired yet its on-time timer.
+			ctx.getPartitionedState(hasFiredOnTimeStateDesc).update(false);
+
+			ctx.registerEventTimeTimer(window.maxTimestamp());
+		}
+
+		@Override
+		public void clear(W window) throws Exception {
+			if (earlyTrigger != null) {
+				earlyTrigger.clear(window);
+			}
+			if (lateTrigger != null) {
+				lateTrigger.clear(window);
+			}
+			ctx.deleteEventTimeTimer(window.maxTimestamp());
+			ctx.getPartitionedState(hasFiredOnTimeStateDesc).clear();
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder builder = new StringBuilder(TO_STRING);
+			if (earlyTrigger != null) {
+				builder
+					.append(".withEarlyFirings(")
+					.append(earlyTrigger)
+					.append(")");
+			}
+			if (lateTrigger != null) {
+				builder
+					.append(".withLateFirings(")
+					.append(lateTrigger)
+					.append(")");
+			}
+			return builder.toString();
+		}
+	}
+
+	/**
+	 * A composite {@link Trigger} that consist of AfterEndOfWindow and a late trigger.
+	 */
+	public static final class AfterEndOfWindowNoLate<W extends Window> extends Trigger<W> {
+
+		private static final long serialVersionUID = -4334481808648361926L;
+
+		/**
+		 * Creates a new {@code Trigger} like the this, except that it fires repeatedly whenever
+		 * the given {@code Trigger} fires after the watermark has passed the end of the window.
+		 */
+		public Trigger<W> withLateFirings(Trigger<W> lateFirings) {
+			checkNotNull(lateFirings);
+			if (lateFirings instanceof ElementTriggers.EveryElement) {
+				// every-element late firing can be ignored
+				return this;
+			} else {
+				return new AfterEndOfWindowEarlyAndLate<>(earlyTrigger, lateFirings);
+			}
+		}
+
+		// early trigger is always not null
+		private final Trigger<W> earlyTrigger;
+		private TriggerContext ctx;
+
+		private AfterEndOfWindowNoLate(Trigger<W> earlyTrigger) {
+			checkNotNull(earlyTrigger);
+			this.earlyTrigger = earlyTrigger;
+		}
+
+		@Override
+		public void open(TriggerContext ctx) throws Exception {
+			this.ctx = ctx;
+			earlyTrigger.open(ctx);
+		}
+
+		@Override
+		public boolean onElement(Object element, long timestamp, W window) throws Exception {
+			if (window.maxTimestamp() <= ctx.getCurrentWatermark()) {
+				// the on-time firing
+				return true;
+			} else {
+				// this is an early element so register the timer and let the early trigger decide
+				ctx.registerEventTimeTimer(window.maxTimestamp());
+				return earlyTrigger.onElement(element, timestamp, window);
+			}
+		}
+
+		@Override
+		public boolean onProcessingTime(long time, W window) throws Exception {
+			return earlyTrigger.onProcessingTime(time, window);
+		}
+
+		@Override
+		public boolean onEventTime(long time, W window) throws Exception {
+			return time == window.maxTimestamp() || earlyTrigger.onEventTime(time, window);
+		}
+
+		@Override
+		public boolean canMerge() {
+			return earlyTrigger.canMerge();
+		}
+
+		@Override
+		public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+			ctx.registerEventTimeTimer(window.maxTimestamp());
+			earlyTrigger.onMerge(window, mergeContext);
+		}
+
+		@Override
+		public void clear(W window) throws Exception {
+			ctx.deleteEventTimeTimer(window.maxTimestamp());
+			earlyTrigger.clear(window);
+		}
+
+		@Override
+		public String toString() {
+			return TO_STRING + ".withEarlyFirings(" + earlyTrigger + ")";
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/triggers/ProcessingTimeTriggers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/triggers/ProcessingTimeTriggers.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.triggers;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.table.api.window.Window;
+
+import java.time.Duration;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link Trigger} that reacts to processing-time timers.
+ * The behavior can be one of the following:
+ * <p><ul>
+ *     <li> fire when the processing time passes the end of the
+ *          window ({@link ProcessingTimeTriggers#afterEndOfWindow()}),
+ *     <li> fire when the processing time advances by a certain interval
+ *          after reception of the first element after the last firing for
+ *          a given window ({@link ProcessingTimeTriggers#every(Duration)}).
+ * </ul></p>
+ * In the first case, the trigger can also specify an <tt>early</tt> trigger.
+ * The <tt>early trigger</tt> will be responsible for specifying when the trigger should fire in the period
+ * between the beginning of the window and the time when the processing time passes the end of the window.
+ */
+public class ProcessingTimeTriggers {
+
+	private static final String TO_STRING = "ProcessingTime.afterEndOfWindow()";
+
+	/**
+	 * This class should never be instantiated.
+	 */
+	private ProcessingTimeTriggers() {}
+
+	/**
+	 * Creates a trigger that fires when the processing time passes the end of the window.
+	 */
+	public static <W extends Window> AfterEndOfWindow<W> afterEndOfWindow() {
+		return new AfterEndOfWindow<>();
+	}
+
+	/**
+	 * Creates a trigger that fires by a certain interval after reception of the first element.
+	 * @param time the certain interval
+	 */
+	public static <W extends Window> AfterFirstElementPeriodic<W> every(Duration time) {
+		return new AfterFirstElementPeriodic<>(time.toMillis());
+	}
+
+	/**
+	 * Trigger every a given interval, the first trigger time is interval
+	 * after the first element in the pane.
+	 *
+	 * @param <W> type of window
+	 */
+	public static final class AfterFirstElementPeriodic<W extends Window> extends Trigger<W> {
+
+		private static final long serialVersionUID = -4710472821577125673L;
+
+		private final long interval;
+		private final ReducingStateDescriptor<Long> nextFiringStateDesc;
+
+		private transient TriggerContext ctx;
+
+		AfterFirstElementPeriodic(long interval) {
+			checkArgument(interval > 0);
+			this.interval = interval;
+			this.nextFiringStateDesc = new ReducingStateDescriptor<>(
+					"processingTime-every-" + interval, new Min(), LongSerializer.INSTANCE);
+		}
+
+		@Override
+		public void open(TriggerContext ctx) throws Exception {
+			this.ctx = ctx;
+		}
+
+		@Override
+		public boolean onElement(Object element, long timestamp, W window) throws Exception {
+			ReducingState<Long> nextFiring = ctx.getPartitionedState(nextFiringStateDesc);
+			if (nextFiring.get() == null) {
+				long nextTimer = ctx.getCurrentProcessingTime() + interval;
+				ctx.registerProcessingTimeTimer(nextTimer);
+				nextFiring.add(nextTimer);
+			}
+			return false;
+		}
+
+		@Override
+		public boolean onProcessingTime(long time, W window) throws Exception {
+			ReducingState<Long> nextFiring = ctx.getPartitionedState(nextFiringStateDesc);
+			Long timer = nextFiring.get();
+			if (timer != null && timer == time) {
+				long newTimer = time + interval;
+				ctx.registerProcessingTimeTimer(newTimer);
+				nextFiring.clear();
+				nextFiring.add(newTimer);
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public boolean onEventTime(long time, W window) throws Exception {
+			return false;
+		}
+
+		@Override
+		public boolean canMerge() {
+			return true;
+		}
+
+		@Override
+		public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+			mergeContext.mergePartitionedState(nextFiringStateDesc);
+
+			// after merge, the merged state will be stored in current window
+			Long nextTimer = ctx.getPartitionedState(nextFiringStateDesc).get();
+			if (nextTimer != null) {
+				ctx.registerProcessingTimeTimer(nextTimer);
+			}
+		}
+
+		@Override
+		public void clear(W window) throws Exception {
+			ReducingState<Long> nextFiring = ctx.getPartitionedState(nextFiringStateDesc);
+			Long timer = nextFiring.get();
+			if (timer != null) {
+				ctx.deleteProcessingTimeTimer(timer);
+				nextFiring.clear();
+			}
+		}
+
+		@Override
+		public String toString() {
+			return "ProcessingTime.every(" + interval + ")";
+		}
+
+		private static class Min implements ReduceFunction<Long> {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Long reduce(Long value1, Long value2) throws Exception {
+				return Math.min(value1, value2);
+			}
+
+		}
+	}
+
+	/**
+	 * A {@link Trigger} that fires once the current system time passes the end of the window
+	 * to which a pane belongs.
+	 */
+	public static final class AfterEndOfWindow<W extends Window> extends Trigger<W> {
+		private static final long serialVersionUID = 2369815941792574642L;
+
+		/**
+		 * Creates a new {@code Trigger} like the this, except that it fires repeatedly whenever
+		 * the given {@code Trigger} fires before the processing time has passed the end of the window.
+		 */
+		public AfterEndOfWindowNoLate<W> withEarlyFirings(Trigger<W> earlyFirings) {
+			checkNotNull(earlyFirings);
+			return new AfterEndOfWindowNoLate<>(earlyFirings);
+		}
+
+		private TriggerContext ctx;
+
+		@Override
+		public void open(TriggerContext ctx) throws Exception {
+			this.ctx = ctx;
+		}
+
+		@Override
+		public boolean onElement(Object element, long timestamp, W window) throws Exception {
+			ctx.registerProcessingTimeTimer(window.maxTimestamp());
+			return false;
+		}
+
+		@Override
+		public boolean onProcessingTime(long time, W window) throws Exception {
+			return time == window.maxTimestamp();
+		}
+
+		@Override
+		public boolean onEventTime(long time, W window) throws Exception {
+			return false;
+		}
+
+		@Override
+		public void clear(W window) throws Exception {
+			ctx.deleteProcessingTimeTimer(window.maxTimestamp());
+		}
+
+		@Override
+		public boolean canMerge() {
+			return true;
+		}
+
+		@Override
+		public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+			ctx.registerProcessingTimeTimer(window.maxTimestamp());
+		}
+
+		@Override
+		public String toString() {
+			return TO_STRING;
+		}
+	}
+
+	/**
+	 * A composite {@link Trigger} that consist of AfterEndOfWindow and a early trigger.
+	 */
+	public static final class AfterEndOfWindowNoLate<W extends Window> extends Trigger<W> {
+
+		private static final long serialVersionUID = 2310050856564792734L;
+
+		// early trigger is always not null
+		private final Trigger<W> earlyTrigger;
+		private TriggerContext ctx;
+
+		AfterEndOfWindowNoLate(Trigger<W> earlyTrigger) {
+			checkNotNull(earlyTrigger);
+			this.earlyTrigger = earlyTrigger;
+		}
+
+		@Override
+		public void open(TriggerContext ctx) throws Exception {
+			this.ctx = ctx;
+			earlyTrigger.open(ctx);
+		}
+
+		@Override
+		public boolean onElement(Object element, long timestamp, W window) throws Exception {
+			ctx.registerProcessingTimeTimer(window.maxTimestamp());
+			return earlyTrigger.onElement(element, timestamp, window);
+		}
+
+		@Override
+		public boolean onProcessingTime(long time, W window) throws Exception {
+			return time == window.maxTimestamp() || earlyTrigger.onProcessingTime(time, window);
+		}
+
+		@Override
+		public boolean onEventTime(long time, W window) throws Exception {
+			return earlyTrigger.onEventTime(time, window);
+		}
+
+		@Override
+		public boolean canMerge() {
+			return earlyTrigger.canMerge();
+		}
+
+		@Override
+		public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+			ctx.registerProcessingTimeTimer(window.maxTimestamp());
+			earlyTrigger.onMerge(window, mergeContext);
+		}
+
+		@Override
+		public void clear(W window) throws Exception {
+			ctx.deleteProcessingTimeTimer(window.maxTimestamp());
+			earlyTrigger.clear(window);
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder builder = new StringBuilder(TO_STRING);
+			if (earlyTrigger != null) {
+				builder
+					.append(".withEarlyFirings(")
+					.append(earlyTrigger)
+					.append(")");
+			}
+			return builder.toString();
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/triggers/Trigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/triggers/Trigger.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.triggers;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.MergingState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.runtime.window.assigners.WindowAssigner;
+
+import java.io.Serializable;
+
+/**
+ * A {@code Trigger} determines when a pane of a window should be evaluated to emit the
+ * results for that part of the window.
+ *
+ * <p>A pane is the bucket of elements that have the same key and same {@link Window}.
+ * An element can be in multiple panes if it was assigned to multiple windows by the
+ * {@link WindowAssigner}. These panes all have their own instance of the {@code Trigger}.
+ *
+ * <p>Triggers must not maintain state internally since they can be re-created or reused for
+ * different keys. All necessary state should be persisted using the state abstraction
+ * available on the {@link TriggerContext}.
+ *
+ * @param <W> The type of {@link Window Windows} on which this {@code Trigger} can operate.
+ */
+public abstract class Trigger<W extends Window> implements Serializable {
+
+	private static final long serialVersionUID = -4104633972991191369L;
+
+	/**
+	 * Initialization method for the trigger. Creates states in this method.
+	 * @param ctx A context object that can be used to get states.
+	 */
+	public abstract void open(TriggerContext ctx) throws Exception;
+
+	/**
+	 * Called for every element that gets added to a pane. The result of this will determine
+	 * whether the pane is evaluated to emit results.
+	 *
+	 * @param element The element that arrived.
+	 * @param timestamp The timestamp of the element that arrived.
+	 * @param window The window to which the element is being added.
+	 * @return true for firing the window, false for no action
+	 */
+	public abstract boolean onElement(Object element, long timestamp, W window) throws Exception;
+
+	/**
+	 * Called when a processing-time timer that was set using the trigger context fires.
+	 *
+	 * <p>Note: This method is not called in case the window does not contain any elements. Thus,
+	 * if you return {@code PURGE} from a trigger method and you expect to do cleanup in a future
+	 * invocation of a timer callback it might be wise to clean any state that you would clean
+	 * in the timer callback.
+	 *
+	 * @param time The timestamp at which the timer fired.
+	 * @param window The window for which the timer fired.
+	 * @return true for firing the window, false for no action
+	 */
+	public abstract boolean onProcessingTime(long time, W window) throws Exception;
+
+	/**
+	 * Called when an event-time timer that was set using the trigger context fires.
+	 *
+	 * <p>Note: This method is not called in case the window does not contain any elements. Thus,
+	 * if you return {@code PURGE} from a trigger method and you expect to do cleanup in a future
+	 * invocation of a timer callback it might be wise to clean any state that you would clean
+	 * in the timer callback.
+	 *
+	 * @param time The timestamp at which the timer fired.
+	 * @param window The window for which the timer fired.
+	 * @return true for firing the window, false for no action
+	 */
+	public abstract boolean onEventTime(long time, W window) throws Exception;
+
+	/**
+	 * Returns true if this trigger supports merging of trigger state and can therefore.
+	 *
+	 * <p>If this returns {@code true} you must properly implement
+	 * {@link #onMerge(Window, OnMergeContext)}
+	 */
+	public boolean canMerge() {
+		return false;
+	}
+
+	/**
+	 * Called when several windows have been merged into one window by the
+	 * {@link org.apache.flink.streaming.api.windowing.assigners.WindowAssigner}.
+	 *
+	 * @param window The new window that results from the merge.
+	 */
+	public void onMerge(W window, OnMergeContext mergeContext) throws Exception {
+		throw new UnsupportedOperationException("This trigger does not support merging.");
+	}
+
+	/**
+	 * Clears any state that the trigger might still hold for the given window. This is called
+	 * when a window is purged. Timers set using {@link TriggerContext#registerEventTimeTimer(long)}
+	 * and {@link TriggerContext#registerProcessingTimeTimer(long)} should be deleted here as
+	 * well as state acquired using {@code TriggerContext#getPartitionedState(StateDescriptor)}.
+	 */
+	public abstract void clear(W window) throws Exception;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A context object that is given to {@link Trigger} methods to allow them to register timer
+	 * callbacks and deal with state.
+	 */
+	public interface TriggerContext {
+
+		/**
+		 * Returns the current processing time.
+		 */
+		long getCurrentProcessingTime();
+
+		/**
+		 * Returns the metric group for this {@link Trigger}. This is the same metric
+		 * group that would be returned from {@link RuntimeContext#getMetricGroup()} in a user
+		 * function.
+		 *
+		 * <p>You must not call methods that create metric objects
+		 * (such as {@link MetricGroup#counter(int)} multiple times but instead call once
+		 * and store the metric object in a field.
+		 */
+		MetricGroup getMetricGroup();
+
+		/**
+		 * Returns the current watermark time.
+		 */
+		long getCurrentWatermark();
+
+		/**
+		 * Register a system time callback. When the current system time passes the specified
+		 * time {@link Trigger#onProcessingTime(long, Window)} is called with the time specified here.
+		 *
+		 * @param time The time at which to invoke {@link Trigger#onProcessingTime(long, Window)}
+		 */
+		void registerProcessingTimeTimer(long time);
+
+		/**
+		 * Register an event-time callback. When the current watermark passes the specified
+		 * time {@link Trigger#onEventTime(long, Window)} is called with the time specified here.
+		 *
+		 * @param time The watermark at which to invoke {@link Trigger#onEventTime(long, Window)}
+		 * @see org.apache.flink.streaming.api.watermark.Watermark
+		 */
+		void registerEventTimeTimer(long time);
+
+		/**
+		 * Delete the processing time trigger for the given time.
+		 */
+		void deleteProcessingTimeTimer(long time);
+
+		/**
+		 * Delete the event-time trigger for the given time.
+		 */
+		void deleteEventTimeTimer(long time);
+
+		/**
+		 * Retrieves a {@link State} object that can be used to interact with
+		 * fault-tolerant state that is scoped to the window and key of the current
+		 * trigger invocation.
+		 *
+		 * @param stateDescriptor The StateDescriptor that contains the name and type of the
+		 *                        state that is being accessed.
+		 * @param <S>             The type of the state.
+		 * @return The partitioned state object.
+		 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+		 *                                       function (function is not part os a KeyedStream).
+		 */
+		<S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor);
+	}
+
+	/**
+	 * Extension of {@link TriggerContext} that is given to
+	 * {@link Trigger#onMerge(Window, OnMergeContext)}.
+	 */
+	public interface OnMergeContext extends TriggerContext {
+		<S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S, ?> stateDescriptor);
+	}
+}
+

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/BaseRowHarnessAssertor.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/BaseRowHarnessAssertor.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.TypeConverters;
+
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Utils for working with the various window test harnesses.
+ */
+public class BaseRowHarnessAssertor {
+
+	private final TypeInformation[] typeInfos;
+	private final Comparator<GenericRow> comparator;
+
+	public BaseRowHarnessAssertor(TypeInformation[] typeInfos, Comparator<GenericRow> comparator) {
+		this.typeInfos = typeInfos;
+		this.comparator = comparator;
+	}
+
+	/**
+	 * Compare the two queues containing operator/task output by converting them to an array first.
+	 */
+	public void assertOutputEqualsSorted(
+		String message,
+		Collection<Object> expected,
+		Collection<Object> actual) {
+
+		assertEquals(expected.size(), actual.size());
+
+		// first, compare only watermarks, their position should be deterministic
+		Iterator<Object> exIt = expected.iterator();
+		Iterator<Object> actIt = actual.iterator();
+		while (exIt.hasNext()) {
+			Object nextEx = exIt.next();
+			Object nextAct = actIt.next();
+			if (nextEx instanceof Watermark) {
+				assertEquals(nextEx, nextAct);
+			}
+		}
+
+		List<GenericRow> expectedRecords = new ArrayList<>();
+		List<GenericRow> actualRecords = new ArrayList<>();
+
+		for (Object ex : expected) {
+			if (ex instanceof StreamRecord) {
+				expectedRecords.add((GenericRow) ((StreamRecord) ex).getValue());
+			}
+		}
+
+		for (Object act : actual) {
+			if (act instanceof StreamRecord) {
+				BaseRow actualOutput = (BaseRow) ((StreamRecord) act).getValue();
+				// joined row can't equals to generic row, so cast joined row to generic row first
+				GenericRow actualRow = BaseRowUtil.toGenericRow(
+						actualOutput,
+						Arrays.stream(typeInfos)
+								.map(TypeConverters::createInternalTypeFromTypeInfo)
+								.toArray(InternalType[]::new));
+				actualRecords.add(actualRow);
+			}
+		}
+
+		GenericRow[] sortedExpected = expectedRecords.toArray(new GenericRow[expectedRecords.size()]);
+		GenericRow[] sortedActual = actualRecords.toArray(new GenericRow[actualRecords.size()]);
+
+		Arrays.sort(sortedExpected, comparator);
+		Arrays.sort(sortedActual, comparator);
+
+		Assert.assertArrayEquals(message, sortedExpected, sortedActual);
+	}
+
+	private static class StringComparator implements Comparator<GenericRow> {
+		@Override
+		public int compare(GenericRow o1, GenericRow o2) {
+			return o1.toString().compareTo(o2.toString());
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/BinaryRowKeySelector.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/BinaryRowKeySelector.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryRowWriter;
+import org.apache.flink.table.dataformat.BinaryWriter;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.typeutils.BaseRowTypeInfo;
+
+/**
+ * A utility class which will extract key from BaseRow.
+ */
+public class BinaryRowKeySelector implements KeySelector<BaseRow, BaseRow>, ResultTypeQueryable<BaseRow> {
+
+	private final int[] keyFields;
+	private final InternalType[] inputFieldTypes;
+	private final InternalType[] keyFieldTypes;
+
+	public BinaryRowKeySelector(int[] keyFields, InternalType[] inputFieldTypes) {
+		this.keyFields = keyFields;
+		this.inputFieldTypes = inputFieldTypes;
+		this.keyFieldTypes = new InternalType[keyFields.length];
+		for (int i = 0; i < keyFields.length; ++i) {
+			keyFieldTypes[i] = inputFieldTypes[keyFields[i]];
+		}
+	}
+
+	@Override
+	public BaseRow getKey(BaseRow value) throws Exception {
+		BinaryRow ret = new BinaryRow(keyFields.length);
+		BinaryRowWriter writer = new BinaryRowWriter(ret);
+		for (int i = 0; i < keyFields.length; i++) {
+			if (value.isNullAt(i)) {
+				writer.setNullAt(i);
+			} else {
+				BinaryWriter.write(
+						writer,
+						i,
+						TypeGetterSetters.get(value, keyFields[i], inputFieldTypes[keyFields[i]]),
+						inputFieldTypes[keyFields[i]]);
+			}
+		}
+		writer.complete();
+		return ret;
+	}
+
+	@Override
+	public TypeInformation<BaseRow> getProducedType() {
+		return new BaseRowTypeInfo(keyFieldTypes);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/MergingWindowSetTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/MergingWindowSetTest.java
@@ -1,0 +1,597 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.window.assigners.MergingWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.SessionWindowAssigner;
+import org.apache.flink.table.runtime.window.internal.MergingWindowSet;
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for verifying that {@link MergingWindowSet} correctly merges windows in various situations
+ * and that the merge callback is called with the correct sets of windows.
+ */
+public class MergingWindowSetTest {
+
+	/**
+	 * This test uses a special (misbehaving) {@code MergingWindowAssigner} that produces cases
+	 * where windows that don't overlap with the newly added window are being merged. We verify
+	 * that the merging window set is nevertheless correct and contains all added windows.
+	 */
+	@Test
+	public void testNonEagerMerging() throws Exception {
+		MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
+
+		MergingWindowSet<TimeWindow> windowSet =
+				new MergingWindowSet<>(new NonEagerlyMergingWindowAssigner(3000), mockState);
+		windowSet.initializeCache("key1");
+
+		TestingMergeFunction mergeFunction = new TestingMergeFunction();
+
+		TimeWindow result;
+
+		mergeFunction.reset();
+		result = windowSet.addWindow(new TimeWindow(0, 2), mergeFunction);
+		assertNotNull(windowSet.getStateWindow(result));
+
+		mergeFunction.reset();
+		result = windowSet.addWindow(new TimeWindow(2, 5), mergeFunction);
+		assertNotNull(windowSet.getStateWindow(result));
+
+		mergeFunction.reset();
+		result = windowSet.addWindow(new TimeWindow(1, 2), mergeFunction);
+		assertNotNull(windowSet.getStateWindow(result));
+
+		mergeFunction.reset();
+		result = windowSet.addWindow(new TimeWindow(10, 12), mergeFunction);
+		assertNotNull(windowSet.getStateWindow(result));
+	}
+
+	@Test
+	public void testIncrementalMerging() throws Exception {
+		MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
+
+		MergingWindowSet<TimeWindow> windowSet =
+				new MergingWindowSet<>(SessionWindowAssigner.withGap(Duration.ofMillis(3)), mockState);
+		windowSet.initializeCache("key1");
+
+		TestingMergeFunction mergeFunction = new TestingMergeFunction();
+
+		// add initial window
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 4), windowSet.addWindow(new TimeWindow(0, 4), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		assertTrue(windowSet.getStateWindow(new TimeWindow(0, 4)).equals(new TimeWindow(0, 4)));
+
+		// add some more windows
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 4), windowSet.addWindow(new TimeWindow(0, 4), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 5), windowSet.addWindow(new TimeWindow(3, 5), mergeFunction));
+		assertTrue(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(0, 5), mergeFunction.mergeTarget());
+		assertEquals(new TimeWindow(0, 4), mergeFunction.stateWindow());
+		assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(0, 4)));
+		assertTrue(mergeFunction.mergedStateWindows().isEmpty());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(4, 6), mergeFunction));
+		assertTrue(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(0, 6), mergeFunction.mergeTarget());
+		assertEquals(new TimeWindow(0, 4), mergeFunction.stateWindow());
+		assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(0, 5)));
+		assertTrue(mergeFunction.mergedStateWindows().isEmpty());
+
+		assertEquals(new TimeWindow(0, 4), windowSet.getStateWindow(new TimeWindow(0, 6)));
+
+		// add some windows that falls into the already merged region
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(1, 4), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(0, 4), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(3, 5), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(4, 6), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		assertEquals(new TimeWindow(0, 4), windowSet.getStateWindow(new TimeWindow(0, 6)));
+
+		// add some more windows that don't merge with the first bunch
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(11, 14), windowSet.addWindow(new TimeWindow(11, 14), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		assertEquals(new TimeWindow(0, 4), windowSet.getStateWindow(new TimeWindow(0, 6)));
+
+		assertEquals(new TimeWindow(11, 14), windowSet.getStateWindow(new TimeWindow(11, 14)));
+
+		// add some more windows that merge with the second bunch
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(10, 14), windowSet.addWindow(new TimeWindow(10, 13), mergeFunction));
+		assertTrue(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(10, 14), mergeFunction.mergeTarget());
+		assertEquals(new TimeWindow(11, 14), mergeFunction.stateWindow());
+		assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(11, 14)));
+		assertTrue(mergeFunction.mergedStateWindows().isEmpty());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(10, 15), windowSet.addWindow(new TimeWindow(12, 15), mergeFunction));
+		assertTrue(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(10, 15), mergeFunction.mergeTarget());
+		assertEquals(new TimeWindow(11, 14), mergeFunction.stateWindow());
+		assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(10, 14)));
+		assertTrue(mergeFunction.mergedStateWindows().isEmpty());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(10, 15), windowSet.addWindow(new TimeWindow(11, 14), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		assertEquals(new TimeWindow(0, 4), windowSet.getStateWindow(new TimeWindow(0, 6)));
+
+		assertEquals(new TimeWindow(11, 14), windowSet.getStateWindow(new TimeWindow(10, 15)));
+
+		// retire the first batch of windows
+		windowSet.retireWindow(new TimeWindow(0, 6));
+
+		assertTrue(windowSet.getStateWindow(new TimeWindow(0, 6)) == null);
+
+		assertTrue(windowSet.getStateWindow(new TimeWindow(10, 15)).equals(new TimeWindow(11, 14)));
+	}
+
+	@Test
+	public void testLateMerging() throws Exception {
+		MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
+
+		MergingWindowSet<TimeWindow> windowSet =
+				new MergingWindowSet<>(SessionWindowAssigner.withGap(Duration.ofMillis(3)), mockState);
+		windowSet.initializeCache("key1");
+
+		TestingMergeFunction mergeFunction = new TestingMergeFunction();
+
+		// add several non-overlapping initial windoww
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 3), windowSet.addWindow(new TimeWindow(0, 3), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(0, 3), windowSet.getStateWindow(new TimeWindow(0, 3)));
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(5, 8), windowSet.addWindow(new TimeWindow(5, 8), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(5, 8), windowSet.getStateWindow(new TimeWindow(5, 8)));
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(10, 13), windowSet.addWindow(new TimeWindow(10, 13), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(10, 13), windowSet.getStateWindow(new TimeWindow(10, 13)));
+
+		// add a window that merges the later two windows
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(8, 10), mergeFunction));
+		assertTrue(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(5, 13), mergeFunction.mergeTarget());
+		assertThat(mergeFunction.stateWindow(), anyOf(Is.is(new TimeWindow(5, 8)), Is.is(new TimeWindow(10, 13))));
+		assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(5, 8), new TimeWindow(10, 13)));
+		assertThat(mergeFunction.mergedStateWindows(), anyOf(
+				containsInAnyOrder(new TimeWindow(10, 13)),
+				containsInAnyOrder(new TimeWindow(5, 8))));
+		assertThat(mergeFunction.mergedStateWindows(), not(hasItem(mergeFunction.mergeTarget())));
+
+		assertEquals(new TimeWindow(0, 3), windowSet.getStateWindow(new TimeWindow(0, 3)));
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(5, 8), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(8, 10), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(10, 13), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+
+		assertThat(windowSet.getStateWindow(new TimeWindow(5, 13)), anyOf(Is.is(new TimeWindow(5, 8)), Is.is(new TimeWindow(10, 13))));
+
+		// add a window that merges all of them together
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 13), windowSet.addWindow(new TimeWindow(3, 5), mergeFunction));
+		assertTrue(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(0, 13), mergeFunction.mergeTarget());
+		assertThat(
+				mergeFunction.stateWindow(),
+				anyOf(Is.is(new TimeWindow(0, 3)), Is.is(new TimeWindow(5, 8)), Is.is(new TimeWindow(10, 13))));
+		assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(0, 3), new TimeWindow(5, 13)));
+		assertThat(mergeFunction.mergedStateWindows(), anyOf(
+				containsInAnyOrder(new TimeWindow(0, 3)),
+				containsInAnyOrder(new TimeWindow(5, 8)),
+				containsInAnyOrder(new TimeWindow(10, 13))));
+		assertThat(mergeFunction.mergedStateWindows(), not(hasItem(mergeFunction.mergeTarget())));
+
+		assertThat(
+				windowSet.getStateWindow(new TimeWindow(0, 13)),
+				anyOf(Is.is(new TimeWindow(0, 3)), Is.is(new TimeWindow(5, 8)), Is.is(new TimeWindow(10, 13))));
+	}
+
+
+	/**
+	 * Test merging of a large new window that covers one existing windows.
+	 */
+	@Test
+	public void testMergeLargeWindowCoveringSingleWindow() throws Exception {
+		MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
+
+		MergingWindowSet<TimeWindow> windowSet =
+				new MergingWindowSet<>(SessionWindowAssigner.withGap(Duration.ofMillis(3)), mockState);
+		windowSet.initializeCache("key1");
+
+		TestingMergeFunction mergeFunction = new TestingMergeFunction();
+
+		// add an initial small window
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(1, 2), windowSet.addWindow(new TimeWindow(1, 2), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(1, 2)));
+
+		// add a new window that completely covers the existing window
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(0, 3), windowSet.addWindow(new TimeWindow(0, 3), mergeFunction));
+		assertTrue(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(0, 3)));
+	}
+
+	/**
+	 * Test adding a new window that is identical to an existing window. This should not cause
+	 * a merge.
+	 */
+	@Test
+	public void testAddingIdenticalWindows() throws Exception {
+		MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
+
+		MergingWindowSet<TimeWindow> windowSet =
+				new MergingWindowSet<>(SessionWindowAssigner.withGap(Duration.ofMillis(3)), mockState);
+		windowSet.initializeCache("key1");
+
+		TestingMergeFunction mergeFunction = new TestingMergeFunction();
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(1, 2), windowSet.addWindow(new TimeWindow(1, 2), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(1, 2)));
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(1, 2), windowSet.addWindow(new TimeWindow(1, 2), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(1, 2)));
+	}
+
+
+	/**
+	 * Test merging of a large new window that covers multiple existing windows.
+	 */
+	@Test
+	public void testMergeLargeWindowCoveringMultipleWindows() throws Exception {
+		MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
+
+		MergingWindowSet<TimeWindow> windowSet =
+				new MergingWindowSet<>(SessionWindowAssigner.withGap(Duration.ofMillis(3)), mockState);
+		windowSet.initializeCache("key1");
+
+		TestingMergeFunction mergeFunction = new TestingMergeFunction();
+
+		// add several non-overlapping initial windoww
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(1, 3), windowSet.addWindow(new TimeWindow(1, 3), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(1, 3), windowSet.getStateWindow(new TimeWindow(1, 3)));
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(5, 8), windowSet.addWindow(new TimeWindow(5, 8), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(5, 8), windowSet.getStateWindow(new TimeWindow(5, 8)));
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(10, 13), windowSet.addWindow(new TimeWindow(10, 13), mergeFunction));
+		assertFalse(mergeFunction.hasMerged());
+		assertEquals(new TimeWindow(10, 13), windowSet.getStateWindow(new TimeWindow(10, 13)));
+
+		// add a new window that completely covers the existing windows
+
+		mergeFunction.reset();
+		assertEquals(new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(5, 13), mergeFunction));
+		assertTrue(mergeFunction.hasMerged());
+		assertThat(mergeFunction.mergedStateWindows(), anyOf(
+				containsInAnyOrder(new TimeWindow(5, 8)),
+				containsInAnyOrder(new TimeWindow(10, 13))));
+		assertThat(
+				windowSet.getStateWindow(new TimeWindow(5, 13)),
+				anyOf(Is.is(new TimeWindow(5, 8)), Is.is(new TimeWindow(10, 13))));
+	}
+
+	// ---------------------------------------------------------------------------------------
+
+	private static class MockMapState<K, V> implements MapState<K, V> {
+
+		private final Map<K, V> map = new HashMap<>();
+
+		@Override
+		public V get(K k) throws Exception {
+			return map.get(k);
+		}
+
+		@Override
+		public void put(K k, V v) throws Exception {
+			map.put(k, v);
+		}
+
+		@Override
+		public void putAll(Map<K, V> map) throws Exception {
+			this.map.putAll(map);
+		}
+
+		@Override
+		public void remove(K k) throws Exception {
+			map.remove(k);
+		}
+
+		@Override
+		public boolean contains(K k) throws Exception {
+			return map.containsKey(k);
+		}
+
+		@Override
+		public Iterable<Map.Entry<K, V>> entries() throws Exception {
+			return map.entrySet();
+		}
+
+		@Override
+		public Iterable<K> keys() throws Exception {
+			return map.keySet();
+		}
+
+		@Override
+		public Iterable<V> values() throws Exception {
+			return map.values();
+		}
+
+		@Override
+		public Iterator<Map.Entry<K, V>> iterator() throws Exception {
+			return map.entrySet().iterator();
+		}
+
+		@Override
+		public void clear() {
+			map.clear();
+		}
+	}
+
+	private static class TestingMergeFunction implements MergingWindowSet.MergeFunction<TimeWindow> {
+		private TimeWindow target = null;
+		private Collection<TimeWindow> sources = null;
+
+		private TimeWindow stateWindow = null;
+		private Collection<TimeWindow> mergedStateWindows = null;
+
+		public void reset() {
+			target = null;
+			sources = null;
+			stateWindow = null;
+			mergedStateWindows = null;
+		}
+
+		public boolean hasMerged() {
+			return target != null;
+		}
+
+		public TimeWindow mergeTarget() {
+			return target;
+		}
+
+		public Collection<TimeWindow> mergeSources() {
+			return sources;
+		}
+
+		public TimeWindow stateWindow() {
+			return stateWindow;
+		}
+
+		public Collection<TimeWindow> mergedStateWindows() {
+			return mergedStateWindows;
+		}
+
+		@Override
+		public void merge(
+				TimeWindow mergeResult,
+				Collection<TimeWindow> mergedWindows,
+				TimeWindow stateWindowResult,
+				Collection<TimeWindow> mergedStateWindows) throws Exception {
+
+			if (target != null) {
+				fail("More than one merge for adding a Window should not occur.");
+			}
+			this.stateWindow = stateWindowResult;
+			this.target = mergeResult;
+			this.mergedStateWindows = mergedStateWindows;
+			this.sources = mergedWindows;
+		}
+	}
+
+	/**
+	 * A special {@link MergingWindowAssigner} that let's windows get larger which leads to windows
+	 * being merged lazily.
+	 */
+	static class NonEagerlyMergingWindowAssigner extends MergingWindowAssigner<TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		protected long sessionTimeout;
+
+		public NonEagerlyMergingWindowAssigner(long sessionTimeout) {
+			this.sessionTimeout = sessionTimeout;
+		}
+
+		@Override
+		public Collection<TimeWindow> assignWindows(BaseRow element, long timestamp) {
+			return Collections.singletonList(new TimeWindow(timestamp, timestamp + sessionTimeout));
+		}
+
+		@Override
+		public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+			return null;
+		}
+
+		@Override
+		public boolean isEventTime() {
+			return true;
+		}
+
+		/**
+		 * Merge overlapping {@link TimeWindow}s.
+		 */
+		@Override
+		public void mergeWindows(TimeWindow newWindow, NavigableSet<TimeWindow> sortedWindows,
+				MergeCallback<TimeWindow> callback) {
+			TreeSet<TimeWindow> treeWindows = new TreeSet<>();
+			treeWindows.add(newWindow);
+			treeWindows.addAll(sortedWindows);
+
+			TimeWindow earliestStart = treeWindows.first();
+
+			List<TimeWindow> associatedWindows = new ArrayList<>();
+
+			for (TimeWindow win : treeWindows) {
+				if (win.getStart() < earliestStart.getEnd() && win.getStart() >= earliestStart.getStart()) {
+					associatedWindows.add(win);
+				}
+			}
+
+			TimeWindow target = new TimeWindow(earliestStart.getStart(), earliestStart.getEnd() + 1);
+
+			if (associatedWindows.size() > 1) {
+				callback.merge(target, associatedWindows);
+			}
+		}
+
+		@Override
+		public String toString() {
+			return "NonEagerlyMergingWindows";
+		}
+	}
+
+	private static class HeapMapState<UK, UV> implements MapState<UK, UV> {
+
+		private final Map<UK, UV> internalMap;
+
+		HeapMapState() {
+			internalMap = new HashMap<>();
+		}
+
+		@Override
+		public UV get(UK key) throws Exception {
+			return internalMap.get(key);
+		}
+
+		@Override
+		public void put(UK key, UV value) throws Exception {
+			internalMap.put(key, value);
+		}
+
+		@Override
+		public void putAll(Map<UK, UV> map) throws Exception {
+			internalMap.putAll(map);
+		}
+
+		@Override
+		public void remove(UK key) throws Exception {
+			internalMap.remove(key);
+		}
+
+		@Override
+		public boolean contains(UK key) throws Exception {
+			return internalMap.containsKey(key);
+		}
+
+		@Override
+		public Iterable<Map.Entry<UK, UV>> entries() throws Exception {
+			return internalMap.entrySet();
+		}
+
+		@Override
+		public Iterable<UK> keys() throws Exception {
+			return internalMap.keySet();
+		}
+
+		@Override
+		public Iterable<UV> values() throws Exception {
+			return internalMap.values();
+		}
+
+		@Override
+		public Iterator<Map.Entry<UK, UV>> iterator() throws Exception {
+			return internalMap.entrySet().iterator();
+		}
+
+		@Override
+		public void clear() {
+			internalMap.clear();
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/WindowOperatorContractTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/WindowOperatorContractTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.util.BinaryRowKeySelector;
+import org.apache.flink.table.runtime.window.assigners.MergingWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.window.triggers.Trigger;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.InternalTypes;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.flink.table.runtime.window.WindowTestUtils.baserow;
+import static org.apache.flink.table.runtime.window.WindowTestUtils.record;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * These tests verify that {@link WindowOperator} correctly interacts with the other windowing
+ * components: {@link WindowAssigner}, {@link Trigger}, AggsHandleFunction and window state.
+ *
+ * <p>These tests document the implicit contract that exists between the windowing components.
+ */
+public class WindowOperatorContractTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testAssignerIsInvokedOncePerElement() throws Exception {
+		WindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+		NamespaceAggsHandleFunction<TimeWindow> mockAggregate = mockAggsHandleFunction();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, mockAggregate, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(any(), anyLong()))
+				.thenReturn(Collections.singletonList(new TimeWindow(0, 0)));
+
+		testHarness.processElement(record("String", 1, 0L));
+
+		verify(mockAssigner, times(1)).assignWindows(eq(baserow("String", 1, 0L)), eq(0L));
+
+		testHarness.processElement(record("String", 1, 0L));
+
+		verify(mockAssigner, times(2)).assignWindows(eq(baserow("String", 1, 0L)), eq(0L));
+	}
+
+	@Test
+	public void testAssignerWithMultipleWindows() throws Exception {
+		WindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+		NamespaceAggsHandleFunction<TimeWindow> mockAggregate = mockAggsHandleFunction();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, mockAggregate, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(any(), anyLong()))
+				.thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
+
+		shouldFireOnElement(mockTrigger);
+
+		testHarness.processElement(record("String", 1, 0L));
+
+		verify(mockAggregate, times(2)).getValue(anyTimeWindow());
+		verify(mockAggregate, times(1)).getValue(eq(new TimeWindow(0, 2)));
+		verify(mockAggregate, times(1)).getValue(eq(new TimeWindow(2, 4)));
+	}
+
+	@Test
+	public void testOnElementCalledPerWindow() throws Exception {
+
+		WindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+		NamespaceAggsHandleFunction<TimeWindow> mockAggregate = mockAggsHandleFunction();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, mockAggregate, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(anyGenericRow(), anyLong()))
+				.thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
+
+		testHarness.processElement(record("String", 42, 1L));
+
+		verify(mockTrigger).onElement(eq(baserow("String", 42, 1L)), eq(1L), eq(new TimeWindow(2, 4)));
+		verify(mockTrigger).onElement(eq(baserow("String", 42, 1L)), eq(1L), eq(new TimeWindow(0, 2)));
+		verify(mockTrigger, times(2)).onElement(any(), anyLong(), anyTimeWindow());
+	}
+
+	@Test
+	public void testMergeWindowsIsCalled() throws Exception {
+		MergingWindowAssigner<TimeWindow> mockAssigner = mockMergingAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+		NamespaceAggsHandleFunction<TimeWindow> mockAggregate = mockAggsHandleFunction();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, mockAggregate, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(anyGenericRow(), anyLong()))
+				.thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
+
+		assertEquals(0, testHarness.getOutput().size());
+
+		testHarness.processElement(record("String", 42, 0L));
+
+		verify(mockAssigner).mergeWindows(eq(new TimeWindow(2, 4)), any(), anyMergeCallback());
+		verify(mockAssigner).mergeWindows(eq(new TimeWindow(0, 2)), any(), anyMergeCallback());
+		verify(mockAssigner, times(2)).mergeWindows(anyTimeWindow(), any(), anyMergeCallback());
+	}
+
+	// ------------------------------------------------------------------------------------------
+
+	@SuppressWarnings("unchecked")
+	private <W extends Window> KeyedOneInputStreamOperatorTestHarness<BaseRow, BaseRow, BaseRow> createWindowOperator(
+			WindowAssigner<W> assigner,
+			Trigger<W> trigger,
+			NamespaceAggsHandleFunction<W> aggregationsFunction,
+			long allowedLateness) throws Exception {
+
+		InternalType[] inputTypes = new InternalType[]{InternalTypes.STRING, InternalTypes.INT};
+		BinaryRowKeySelector keySelector = new BinaryRowKeySelector(new int[]{0}, inputTypes);
+		TypeInformation<BaseRow> keyType = keySelector.getProducedType();
+		InternalType[] accTypes = new InternalType[]{InternalTypes.LONG, InternalTypes.LONG};
+		InternalType[] windowTypes = new InternalType[]{InternalTypes.LONG, InternalTypes.LONG};
+		InternalType[] outputTypeWithoutKeys = new InternalType[]{
+				InternalTypes.LONG, InternalTypes.LONG, InternalTypes.LONG, InternalTypes.LONG};
+
+		boolean sendRetraction = allowedLateness > 0;
+
+		WindowOperator operator = new WindowOperator(
+				aggregationsFunction,
+				mock(RecordEqualiser.class),
+				assigner,
+				trigger,
+				assigner.getWindowSerializer(new ExecutionConfig()),
+				inputTypes,
+				outputTypeWithoutKeys,
+				accTypes,
+				windowTypes,
+				2,
+				sendRetraction,
+				allowedLateness);
+
+		return new KeyedOneInputStreamOperatorTestHarness<BaseRow, BaseRow, BaseRow>(
+				operator, keySelector, keyType);
+	}
+
+	private static <W extends Window> NamespaceAggsHandleFunction<W> mockAggsHandleFunction() throws Exception {
+		return mock(NamespaceAggsHandleFunction.class);
+	}
+
+	private <W extends Window> Trigger<W> mockTrigger() throws Exception {
+		@SuppressWarnings("unchecked")
+		Trigger<W> mockTrigger = mock(Trigger.class);
+
+		when(mockTrigger.onElement(Matchers.<BaseRow>any(), anyLong(), Matchers.any())).thenReturn(false);
+		when(mockTrigger.onEventTime(anyLong(), Matchers.any())).thenReturn(false);
+		when(mockTrigger.onProcessingTime(anyLong(), Matchers.any())).thenReturn(false);
+
+		return mockTrigger;
+	}
+
+	private static TimeWindow anyTimeWindow() {
+		return Mockito.any();
+	}
+
+	private static GenericRow anyGenericRow() {
+		return Mockito.any();
+	}
+
+	private static WindowAssigner<TimeWindow> mockTimeWindowAssigner() throws Exception {
+		@SuppressWarnings("unchecked")
+		WindowAssigner<TimeWindow> mockAssigner = mock(WindowAssigner.class);
+
+		when(mockAssigner.getWindowSerializer(Mockito.any())).thenReturn(new TimeWindow.Serializer());
+		when(mockAssigner.isEventTime()).thenReturn(true);
+
+		return mockAssigner;
+	}
+
+	private static MergingWindowAssigner<TimeWindow> mockMergingAssigner() throws Exception {
+		@SuppressWarnings("unchecked")
+		MergingWindowAssigner<TimeWindow> mockAssigner = mock(MergingWindowAssigner.class);
+
+		when(mockAssigner.getWindowSerializer(Mockito.any())).thenReturn(new TimeWindow.Serializer());
+		when(mockAssigner.isEventTime()).thenReturn(true);
+
+		return mockAssigner;
+	}
+
+	private static MergingWindowAssigner.MergeCallback<TimeWindow> anyMergeCallback() {
+		return Mockito.any();
+	}
+
+	// ------------------------------------------------------------------------------------
+
+	private static <T> void shouldFireOnElement(Trigger<TimeWindow> mockTrigger) throws Exception {
+		when(mockTrigger.onElement(Matchers.<T>anyObject(), anyLong(), anyTimeWindow()))
+				.thenReturn(true);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/WindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/WindowOperatorTest.java
@@ -1,0 +1,1350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.window.CountWindow;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.api.window.Window;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.table.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
+import org.apache.flink.table.runtime.util.BinaryRowKeySelector;
+import org.apache.flink.table.runtime.window.assigners.SessionWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.TumblingWindowAssigner;
+import org.apache.flink.table.runtime.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.window.triggers.ElementTriggers;
+import org.apache.flink.table.runtime.window.triggers.EventTimeTriggers;
+import org.apache.flink.table.runtime.window.triggers.ProcessingTimeTriggers;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.InternalTypes;
+import org.apache.flink.table.typeutils.BaseRowTypeInfo;
+
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.table.dataformat.BinaryString.fromString;
+import static org.apache.flink.table.runtime.window.WindowTestUtils.record;
+import static org.apache.flink.table.runtime.window.WindowTestUtils.retractRecord;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link WindowOperator}.
+ */
+public class WindowOperatorTest {
+
+	// For counting if close() is called the correct number of times on the SumReducer
+	private static AtomicInteger closeCalled = new AtomicInteger(0);
+
+	private InternalType[] inputFieldTypes = new InternalType[]{
+			InternalTypes.STRING,
+			InternalTypes.INT,
+			InternalTypes.LONG};
+
+	private BaseRowTypeInfo outputType = new BaseRowTypeInfo(
+			InternalTypes.STRING,
+			InternalTypes.LONG,
+			InternalTypes.LONG,
+			InternalTypes.LONG,
+			InternalTypes.LONG,
+			InternalTypes.LONG);
+
+	private InternalType[] aggResultTypes = new InternalType[]{InternalTypes.LONG, InternalTypes.LONG};
+	private InternalType[] accTypes = new InternalType[]{InternalTypes.LONG, InternalTypes.LONG};
+	private InternalType[] windowTypes = new InternalType[]{InternalTypes.LONG, InternalTypes.LONG, InternalTypes.LONG};
+	private GenericRowEqualiser equaliser = new GenericRowEqualiser(accTypes, windowTypes);
+	private BinaryRowKeySelector keySelector = new BinaryRowKeySelector(new int[]{0}, inputFieldTypes);
+	private TypeInformation<BaseRow> keyType = keySelector.getProducedType();
+	private BaseRowHarnessAssertor assertor = new BaseRowHarnessAssertor(
+			outputType.getFieldTypes(),
+			new GenericRowResultSortComparator());
+
+	@Test
+	public void testEventTimeSlidingWindows() throws Exception {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.sliding(Duration.ofSeconds(3), Duration.ofSeconds(1), 0)
+				.withEventTime(2)
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		testHarness.open();
+
+		// process elements
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		// add elements out-of-order
+		testHarness.processElement(record("key2", 1, 3999L));
+		testHarness.processElement(record("key2", 1, 3000L));
+
+		testHarness.processElement(record("key1", 1, 20L));
+		testHarness.processElement(record("key1", 1, 0L));
+		testHarness.processElement(record("key1", 1, 999L));
+
+		testHarness.processElement(record("key2", 1, 1998L));
+		testHarness.processElement(record("key2", 1, 1999L));
+		testHarness.processElement(record("key2", 1, 1000L));
+
+		testHarness.processWatermark(new Watermark(999));
+		expectedOutputOutput.add(record("key1", 3L, 3L, -2000L, 1000L, 999L));
+		expectedOutputOutput.add(new Watermark(999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(1999));
+		expectedOutputOutput.add(record("key1", 3L, 3L, -1000L, 2000L, 1999L));
+		expectedOutputOutput.add(record("key2", 3L, 3L, -1000L, 2000L, 1999L));
+		expectedOutputOutput.add(new Watermark(1999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(2999));
+		expectedOutputOutput.add(record("key1", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(new Watermark(2999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutputOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processWatermark(new Watermark(3999));
+		expectedOutputOutput.add(record("key2", 5L, 5L, 1000L, 4000L, 3999L));
+		expectedOutputOutput.add(new Watermark(3999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(4999));
+		expectedOutputOutput.add(record("key2", 2L, 2L, 2000L, 5000L, 4999L));
+		expectedOutputOutput.add(new Watermark(4999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(5999));
+		expectedOutputOutput.add(record("key2", 2L, 2L, 3000L, 6000L, 5999L));
+		expectedOutputOutput.add(new Watermark(5999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// those don't have any effect...
+		testHarness.processWatermark(new Watermark(6999));
+		testHarness.processWatermark(new Watermark(7999));
+		expectedOutputOutput.add(new Watermark(6999));
+		expectedOutputOutput.add(new Watermark(7999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		// we close once in the rest...
+		assertEquals("Close was not called.", 2, closeCalled.get());
+	}
+
+	@Test
+	public void testProcessingTimeSlidingWindows() throws Throwable {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.sliding(Duration.ofSeconds(3), Duration.ofSeconds(1), 0)
+				.withProcessingTime()
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// timestamp is ignored in processing time
+		testHarness.setProcessingTime(3);
+		testHarness.processElement(record("key2", 1, Long.MAX_VALUE));
+
+		testHarness.setProcessingTime(1000);
+
+		expectedOutputOutput.add(record("key2", 1L, 1L, -2000L, 1000L, 999L));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key2", 1, Long.MAX_VALUE));
+		testHarness.processElement(record("key2", 1, Long.MAX_VALUE));
+
+		testHarness.setProcessingTime(2000);
+
+		expectedOutputOutput.add(record("key2", 3L, 3L, -1000L, 2000L, 1999L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key1", 1, Long.MAX_VALUE));
+		testHarness.processElement(record("key1", 1, Long.MAX_VALUE));
+
+		testHarness.setProcessingTime(3000);
+
+		expectedOutputOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(record("key1", 2L, 2L, 0L, 3000L, 2999L));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key1", 1, Long.MAX_VALUE));
+		testHarness.processElement(record("key1", 1, Long.MAX_VALUE));
+		testHarness.processElement(record("key1", 1, Long.MAX_VALUE));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutputOutput.add(record("key2", 2L, 2L, 1000L, 4000L, 3999L));
+		expectedOutputOutput.add(record("key1", 5L, 5L, 1000L, 4000L, 3999L));
+		expectedOutputOutput.add(record("key1", 5L, 5L, 2000L, 5000L, 4999L));
+		expectedOutputOutput.add(record("key1", 3L, 3L, 3000L, 6000L, 5999L));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testEventTimeTumblingWindows() throws Exception {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.tumble(Duration.ofSeconds(3), 0)
+				.withEventTime(2)
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement(record("key2", 1, 3999L));
+		testHarness.processElement(record("key2", 1, 3000L));
+
+		testHarness.processElement(record("key1", 1, 20L));
+		testHarness.processElement(record("key1", 1, 0L));
+		testHarness.processElement(record("key1", 1, 999L));
+
+		testHarness.processElement(record("key2", 1, 1998L));
+		testHarness.processElement(record("key2", 1, 1999L));
+		testHarness.processElement(record("key2", 1, 1000L));
+
+		testHarness.processWatermark(new Watermark(999));
+		expectedOutputOutput.add(new Watermark(999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(1999));
+		expectedOutputOutput.add(new Watermark(1999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutputOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processWatermark(new Watermark(2999));
+		expectedOutputOutput.add(record("key1", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(new Watermark(2999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(3999));
+		expectedOutputOutput.add(new Watermark(3999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(4999));
+		expectedOutputOutput.add(new Watermark(4999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(5999));
+		expectedOutputOutput.add(record("key2", 2L, 2L, 3000L, 6000L, 5999L));
+		expectedOutputOutput.add(new Watermark(5999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// those don't have any effect...
+		testHarness.processWatermark(new Watermark(6999));
+		testHarness.processWatermark(new Watermark(7999));
+		expectedOutputOutput.add(new Watermark(6999));
+		expectedOutputOutput.add(new Watermark(7999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		// we close once in the rest...
+		assertEquals("Close was not called.", 2, closeCalled.get());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testEventTimeTumblingWindowsWithEarlyFiring() throws Exception {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.tumble(Duration.ofSeconds(3), 0)
+				.withEventTime(2)
+				.triggering(
+						EventTimeTriggers
+								.afterEndOfWindow()
+								.withEarlyFirings(ProcessingTimeTriggers.every(Duration.ofSeconds(1))))
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.withSendRetraction()
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+		testHarness.setProcessingTime(0L);
+
+		// add elements out-of-order
+		testHarness.processElement(record("key2", 1, 3999L));
+		testHarness.processElement(record("key2", 1, 3000L));
+
+		testHarness.setProcessingTime(1L);
+		testHarness.processElement(record("key1", 1, 20L));
+		testHarness.processElement(record("key1", 1, 0L));
+		testHarness.processElement(record("key1", 1, 999L));
+
+		testHarness.processElement(record("key2", 1, 1998L));
+		testHarness.processElement(record("key2", 1, 1999L));
+		testHarness.processElement(record("key2", 1, 1000L));
+
+		testHarness.setProcessingTime(1000);
+		expectedOutputOutput.add(record("key2", 2L, 2L, 3000L, 6000L, 5999L));
+		testHarness.processWatermark(new Watermark(999));
+		expectedOutputOutput.add(new Watermark(999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(1001);
+		expectedOutputOutput.add(record("key1", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
+
+		testHarness.processWatermark(new Watermark(1999));
+		testHarness.setProcessingTime(2001);
+		expectedOutputOutput.add(new Watermark(1999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutputOutput.clear();
+
+		// new a testHarness
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.setProcessingTime(3001);
+		testHarness.processWatermark(new Watermark(2999));
+		// on time fire key1 & key2 [0 ~ 3000) window, but because of early firing, on time result is ignored
+		expectedOutputOutput.add(new Watermark(2999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key2", 1, 4999L));
+		testHarness.processWatermark(new Watermark(3999));
+		testHarness.setProcessingTime(4001);
+		expectedOutputOutput.add(new Watermark(3999));
+		expectedOutputOutput.add(retractRecord("key2", 2L, 2L, 3000L, 6000L, 5999L));
+		expectedOutputOutput.add(record("key2", 3L, 3L, 3000L, 6000L, 5999L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// late arrival
+		testHarness.processElement(record("key2", 1, 2001L));
+		testHarness.processElement(record("key1", 1, 2030L));
+		// drop late elements
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(5100);
+		testHarness.processElement(record("key2", 1, 5122L));
+		testHarness.processWatermark(new Watermark(4999));
+		expectedOutputOutput.add(new Watermark(4999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(5999));
+		expectedOutputOutput.add(retractRecord("key2", 3L, 3L, 3000L, 6000L, 5999L));
+		expectedOutputOutput.add(record("key2", 4L, 4L, 3000L, 6000L, 5999L));
+		expectedOutputOutput.add(new Watermark(5999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(6001);
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// those don't have any effect...
+		testHarness.processWatermark(new Watermark(6999));
+		testHarness.processWatermark(new Watermark(7999));
+		expectedOutputOutput.add(new Watermark(6999));
+		expectedOutputOutput.add(new Watermark(7999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// late arrival, drop
+		testHarness.processElement(record("key2", 1, 2877L));
+		testHarness.processElement(record("key1", 1, 2899L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		// we close once in the rest...
+		assertEquals("Close was not called.", 2, closeCalled.get());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testEventTimeTumblingWindowsWithEarlyAndLateFirings() throws Exception {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.tumble(Duration.ofSeconds(3), 0)
+				.withEventTime(2)
+				.triggering(
+						EventTimeTriggers
+								.afterEndOfWindow()
+								.withEarlyFirings(ProcessingTimeTriggers.every(Duration.ofSeconds(1)))
+								.withLateFirings(ElementTriggers.every()))
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.withAllowedLateness(Duration.ofSeconds(3))
+				.withSendRetraction()
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+		testHarness.setProcessingTime(0L);
+
+		// add elements out-of-order
+		testHarness.processElement(record("key2", 1, 3999L));
+		testHarness.processElement(record("key2", 1, 3000L));
+
+		testHarness.setProcessingTime(1L);
+		testHarness.processElement(record("key1", 1, 20L));
+		testHarness.processElement(record("key1", 1, 0L));
+		testHarness.processElement(record("key1", 1, 999L));
+
+		testHarness.processElement(record("key2", 1, 1998L));
+		testHarness.processElement(record("key2", 1, 1999L));
+		testHarness.processElement(record("key2", 1, 1000L));
+
+		testHarness.setProcessingTime(1000);
+		expectedOutputOutput.add(record("key2", 2L, 2L, 3000L, 6000L, 5999L));
+		testHarness.processWatermark(new Watermark(999));
+		expectedOutputOutput.add(new Watermark(999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(1001);
+		expectedOutputOutput.add(record("key1", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
+
+		testHarness.processWatermark(new Watermark(1999));
+		testHarness.setProcessingTime(2001);
+		expectedOutputOutput.add(new Watermark(1999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutputOutput.clear();
+
+		// new a testHarness
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.setProcessingTime(3001);
+		testHarness.processWatermark(new Watermark(2999));
+		// on time fire key1 & key2 [0 ~ 3000) window, but because of early firing, on time result is ignored
+		expectedOutputOutput.add(new Watermark(2999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key2", 1, 4999L));
+		testHarness.processWatermark(new Watermark(3999));
+		testHarness.setProcessingTime(4001);
+		expectedOutputOutput.add(new Watermark(3999));
+		expectedOutputOutput.add(retractRecord("key2", 2L, 2L, 3000L, 6000L, 5999L));
+		expectedOutputOutput.add(record("key2", 3L, 3L, 3000L, 6000L, 5999L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// late arrival
+		testHarness.processElement(record("key2", 1, 2001L));
+		expectedOutputOutput.add(retractRecord("key2", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(record("key2", 4L, 4L, 0L, 3000L, 2999L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// late arrival
+		testHarness.processElement(record("key1", 1, 2030L));
+		expectedOutputOutput.add(retractRecord("key1", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(record("key1", 4L, 4L, 0L, 3000L, 2999L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(5100);
+		testHarness.processElement(record("key2", 1, 5122L));
+		testHarness.processWatermark(new Watermark(4999));
+		expectedOutputOutput.add(new Watermark(4999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processWatermark(new Watermark(5999));
+		expectedOutputOutput.add(retractRecord("key2", 3L, 3L, 3000L, 6000L, 5999L));
+		expectedOutputOutput.add(record("key2", 4L, 4L, 3000L, 6000L, 5999L));
+		expectedOutputOutput.add(new Watermark(5999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(6001);
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// those don't have any effect...
+		testHarness.processWatermark(new Watermark(6999));
+		testHarness.processWatermark(new Watermark(7999));
+		expectedOutputOutput.add(new Watermark(6999));
+		expectedOutputOutput.add(new Watermark(7999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// late arrival, but too late, drop
+		testHarness.processElement(record("key2", 1, 2877L));
+		testHarness.processElement(record("key1", 1, 2899L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		// we close once in the rest...
+		assertEquals("Close was not called.", 2, closeCalled.get());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testProcessingTimeTumblingWindows() throws Exception {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.tumble(Duration.ofSeconds(3), 0)
+				.withProcessingTime()
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.setProcessingTime(3);
+
+		// timestamp is ignored in processing time
+		testHarness.processElement(record("key2", 1, Long.MAX_VALUE));
+		testHarness.processElement(record("key2", 1, 7000L));
+		testHarness.processElement(record("key2", 1, 7000L));
+
+		testHarness.processElement(record("key1", 1, 7000L));
+		testHarness.processElement(record("key1", 1, 7000L));
+
+		testHarness.setProcessingTime(5000);
+
+		expectedOutputOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(record("key1", 2L, 2L, 0L, 3000L, 2999L));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key1", 1, 7000L));
+		testHarness.processElement(record("key1", 1, 7000L));
+		testHarness.processElement(record("key1", 1, 7000L));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutputOutput.add(record("key1", 3L, 3L, 3000L, 6000L, 5999L));
+
+		assertEquals(0L, operator.getWatermarkLatency().getValue());
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testEventTimeSessionWindows() throws Exception {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.session(Duration.ofSeconds(3))
+				.withEventTime(2)
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement(record("key2", 1, 0L));
+		testHarness.processElement(record("key2", 2, 1000L));
+		testHarness.processElement(record("key2", 3, 2500L));
+
+		testHarness.processElement(record("key1", 1, 10L));
+		testHarness.processElement(record("key1", 2, 1000L));
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshotV2 = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutputOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshotV2);
+		testHarness.open();
+
+		assertEquals(0L, operator.getWatermarkLatency().getValue());
+
+		testHarness.processElement(record("key1", 3, 2500L));
+
+		testHarness.processElement(record("key2", 4, 5501L));
+		testHarness.processElement(record("key2", 5, 6000L));
+		testHarness.processElement(record("key2", 5, 6000L));
+		testHarness.processElement(record("key2", 6, 6050L));
+
+		testHarness.processWatermark(new Watermark(12000));
+
+		expectedOutputOutput.add(record("key1", 6L, 3L, 10L, 5500L, 5499L));
+		expectedOutputOutput.add(record("key2", 6L, 3L, 0L, 5500L, 5499L));
+
+		expectedOutputOutput.add(record("key2", 20L, 4L, 5501L, 9050L, 9049L));
+		expectedOutputOutput.add(new Watermark(12000));
+
+		// add a late data
+		testHarness.processElement(record("key1", 3, 4000L));
+		testHarness.processElement(record("key2", 10, 15000L));
+		testHarness.processElement(record("key2", 20, 15000L));
+
+		testHarness.processWatermark(new Watermark(17999));
+
+		expectedOutputOutput.add(record("key2", 30L, 2L, 15000L, 18000L, 17999L));
+		expectedOutputOutput.add(new Watermark(17999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(18000);
+		assertEquals(1L, operator.getWatermarkLatency().getValue());
+
+		testHarness.close();
+
+		// we close once in the rest...
+		assertEquals("Close was not called.", 2, closeCalled.get());
+		assertEquals(1, operator.getNumLateRecordsDropped().getCount());
+	}
+
+	@Test
+	public void testProcessingTimeSessionWindows() throws Throwable {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.session(Duration.ofSeconds(3))
+				.withProcessingTime()
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		BaseRowHarnessAssertor assertor = new BaseRowHarnessAssertor(
+				outputType.getFieldTypes(), new GenericRowResultSortComparator());
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// timestamp is ignored in processing time
+		testHarness.setProcessingTime(3);
+		testHarness.processElement(record("key2", 1, 1L));
+
+		testHarness.setProcessingTime(1000);
+		testHarness.processElement(record("key2", 1, 1002L));
+
+		testHarness.setProcessingTime(5000);
+
+		expectedOutputOutput.add(record("key2", 2L, 2L, 3L, 4000L, 3999L));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key2", 1, 5000L));
+		testHarness.processElement(record("key2", 1, 5000L));
+		testHarness.processElement(record("key1", 1, 5000L));
+		testHarness.processElement(record("key1", 1, 5000L));
+		testHarness.processElement(record("key1", 1, 5000L));
+
+		testHarness.setProcessingTime(10000);
+
+		expectedOutputOutput.add(record("key2", 2L, 2L, 5000L, 8000L, 7999L));
+		expectedOutputOutput.add(record("key1", 3L, 3L, 5000L, 8000L, 7999L));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	/**
+	 * This tests a custom Session window assigner that assigns some elements to "point windows",
+	 * windows that have the same timestamp for start and end.
+	 *
+	 * <p>In this test, elements that have 33 as the second tuple field will be put into a point
+	 * window.
+	 */
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testPointSessions() throws Exception {
+		closeCalled.set(0);
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.assigner(new PointSessionWindowAssigner(3000))
+				.withEventTime(2)
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement(record("key2", 1, 0L));
+		testHarness.processElement(record("key2", 33, 1000L));
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processElement(record("key2", 33, 2500L));
+
+		testHarness.processElement(record("key1", 1, 10L));
+		testHarness.processElement(record("key1", 2, 1000L));
+		testHarness.processElement(record("key1", 33, 2500L));
+
+		testHarness.processWatermark(new Watermark(12000));
+
+		expectedOutputOutput.add(record("key1", 36L, 3L, 10L, 4000L, 3999L));
+		expectedOutputOutput.add(record("key2", 67L, 3L, 0L, 3000L, 2999L));
+		expectedOutputOutput.add(new Watermark(12000));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		// we close once in the rest...
+		assertEquals("Close was not called.", 2, closeCalled.get());
+	}
+
+	@Test
+	public void testLateness() throws Exception {
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.tumble(Duration.ofSeconds(2), 0)
+				.withEventTime(2)
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.withAllowedLateness(Duration.ofMillis(500))
+				.withSendRetraction()
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(record("key2", 1, 500L));
+		testHarness.processWatermark(new Watermark(1500));
+
+		expectedOutput.add(new Watermark(1500));
+
+		testHarness.processElement(record("key2", 1, 1300L));
+		testHarness.processWatermark(new Watermark(2300));
+
+		GenericRow key2Result = GenericRow.of(fromString("key2"), 2L, 2L, 0L, 2000L, 1999L);
+		expectedOutput.add(new StreamRecord<>(key2Result));
+		expectedOutput.add(new Watermark(2300));
+
+		// this will not be dropped because window.maxTimestamp() + allowedLateness > currentWatermark
+		testHarness.processElement(record("key2", 1, 1997L));
+		testHarness.processWatermark(new Watermark(6000));
+
+		// this is 1 and not 3 because the trigger fires and purges
+		BaseRow key2Retract = BaseRowUtil.setRetract(GenericRow.copyReference(key2Result));
+		expectedOutput.add(new StreamRecord<>(key2Retract));
+		expectedOutput.add(record("key2", 3L, 3L, 0L, 2000L, 1999L));
+		expectedOutput.add(new Watermark(6000));
+
+		// this will be dropped because window.maxTimestamp() + allowedLateness < currentWatermark
+		testHarness.processElement(record("key2", 1, 1998L));
+		testHarness.processWatermark(new Watermark(7000));
+
+		expectedOutput.add(new Watermark(7000));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		assertEquals(1, operator.getNumLateRecordsDropped().getCount());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testCleanupTimeOverflow() throws Exception {
+		long windowSize = 1000;
+		long lateness = 2000;
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.tumble(Duration.ofMillis(windowSize), 0)
+				.withEventTime(2)
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.withAllowedLateness(Duration.ofMillis(lateness))
+				.withSendRetraction()
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
+				new KeyedOneInputStreamOperatorTestHarness<BaseRow, BaseRow, BaseRow>(
+						operator, keySelector, keyType);
+
+		testHarness.open();
+
+		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+
+		WindowAssigner<TimeWindow> windowAssigner = TumblingWindowAssigner.of(Duration.ofMillis(windowSize));
+		long timestamp = Long.MAX_VALUE - 1750;
+		Collection<TimeWindow> windows = windowAssigner.assignWindows(GenericRow.of(fromString("key2"), 1), timestamp);
+		TimeWindow window = windows.iterator().next();
+
+		testHarness.processElement(record("key2", 1, timestamp));
+
+		// the garbage collection timer would wrap-around
+		assertTrue(window.maxTimestamp() + lateness < window.maxTimestamp());
+
+		// and it would prematurely fire with watermark (Long.MAX_VALUE - 1500)
+		assertTrue(window.maxTimestamp() + lateness < Long.MAX_VALUE - 1500);
+
+		// if we don't correctly prevent wrap-around in the garbage collection
+		// timers this watermark will clean our window state for the just-added
+		// element/window
+		testHarness.processWatermark(new Watermark(Long.MAX_VALUE - 1500));
+
+		// this watermark is before the end timestamp of our only window
+		assertTrue(Long.MAX_VALUE - 1500 < window.maxTimestamp());
+		assertTrue(window.maxTimestamp() < Long.MAX_VALUE);
+
+		// push in a watermark that will trigger computation of our window
+		testHarness.processWatermark(new Watermark(window.maxTimestamp()));
+
+		expected.add(new Watermark(Long.MAX_VALUE - 1500));
+		expected.add(record("key2", 1L, 1L, window.getStart(), window.getEnd(), window.maxTimestamp()));
+		expected.add(new Watermark(window.maxTimestamp()));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	@Test
+	public void testCleanupTimerWithEmptyReduceStateForTumblingWindows() throws Exception {
+		final int windowSize = 2;
+		final long lateness = 1;
+
+		WindowOperator operator = WindowOperatorBuilder
+				.builder()
+				.withInputFields(inputFieldTypes)
+				.tumble(Duration.ofSeconds(windowSize), 0)
+				.withEventTime(2)
+				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.withAllowedLateness(Duration.ofMillis(lateness))
+				.withSendRetraction()
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		testHarness.open();
+
+		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+
+		// normal element
+		testHarness.processElement(record("key2", 1, 1000L));
+		testHarness.processWatermark(new Watermark(1599));
+		testHarness.processWatermark(new Watermark(1999));
+		testHarness.processWatermark(new Watermark(2000));
+		testHarness.processWatermark(new Watermark(5000));
+
+		expected.add(new Watermark(1599));
+		expected.add(record("key2", 1L, 1L, 0L, 2000L, 1999L));
+		expected.add(new Watermark(1999)); // here it fires and purges
+		expected.add(new Watermark(2000)); // here is the cleanup timer
+		expected.add(new Watermark(5000));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	@Test
+	public void testTumblingCountWindow() throws Exception {
+		closeCalled.set(0);
+		final int windowSize = 3;
+		InternalType[] windowTypes = new InternalType[]{InternalTypes.LONG};
+
+		WindowOperator operator = WindowOperatorBuilder.builder()
+				.withInputFields(inputFieldTypes)
+				.countWindow(windowSize)
+				.aggregate(new SumAndCountAggCountWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(record("key2", 1, 0L));
+		testHarness.processElement(record("key2", 2, 1000L));
+		testHarness.processElement(record("key2", 3, 2500L));
+		testHarness.processElement(record("key1", 1, 10L));
+		testHarness.processElement(record("key1", 2, 1000L));
+
+		testHarness.processWatermark(new Watermark(12000));
+		testHarness.setProcessingTime(12000L);
+		expectedOutputOutput.add(record("key2", 6L, 3L, 0L));
+		expectedOutputOutput.add(new Watermark(12000));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshotV2 = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutputOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshotV2);
+		testHarness.open();
+
+		testHarness.processElement(record("key1", 2, 2500L));
+		expectedOutputOutput.add(record("key1", 5L, 3L, 0L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key2", 4, 5501L));
+		testHarness.processElement(record("key2", 5, 6000L));
+		testHarness.processElement(record("key2", 5, 6000L));
+		testHarness.processElement(record("key2", 6, 6050L));
+
+		expectedOutputOutput.add(record("key2", 14L, 3L, 1L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key1", 3, 4000L));
+		testHarness.processElement(record("key2", 10, 15000L));
+		testHarness.processElement(record("key2", 20, 15000L));
+		expectedOutputOutput.add(record("key2", 36L, 3L, 2L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key1", 2, 2500L));
+		testHarness.processElement(record("key1", 2, 2500L));
+		expectedOutputOutput.add(record("key1", 7L, 3L, 1L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		// we close once in the rest...
+		assertEquals("Close was not called.", 2, closeCalled.get());
+	}
+
+	@Test
+	public void testSlidingCountWindow() throws Exception {
+		closeCalled.set(0);
+		final int windowSize = 5;
+		final int windowSlide = 3;
+		InternalType[] windowTypes = new InternalType[]{InternalTypes.LONG};
+
+		WindowOperator operator = WindowOperatorBuilder.builder()
+				.withInputFields(inputFieldTypes)
+				.countWindow(windowSize, windowSlide)
+				.aggregate(new SumAndCountAggCountWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.build();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutputOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(record("key2", 1, 0L));
+		testHarness.processElement(record("key2", 2, 1000L));
+		testHarness.processElement(record("key2", 3, 2500L));
+		testHarness.processElement(record("key2", 4, 2500L));
+		testHarness.processElement(record("key2", 5, 2500L));
+		testHarness.processElement(record("key1", 1, 10L));
+		testHarness.processElement(record("key1", 2, 1000L));
+
+		testHarness.processWatermark(new Watermark(12000));
+		testHarness.setProcessingTime(12000L);
+		expectedOutputOutput.add(record("key2", 15L, 5L, 0L));
+		expectedOutputOutput.add(new Watermark(12000));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshotV2 = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutputOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshotV2);
+		testHarness.open();
+
+		testHarness.processElement(record("key1", 3, 2500L));
+		testHarness.processElement(record("key1", 4, 2500L));
+		testHarness.processElement(record("key1", 5, 2500L));
+		expectedOutputOutput.add(record("key1", 15L, 5L, 0L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key2", 6, 6000L));
+		testHarness.processElement(record("key2", 7, 6000L));
+		testHarness.processElement(record("key2", 8, 6050L));
+		testHarness.processElement(record("key2", 9, 6050L));
+		expectedOutputOutput.add(record("key2", 30L, 5L, 1L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.processElement(record("key1", 6, 4000L));
+		testHarness.processElement(record("key1", 7, 4000L));
+		testHarness.processElement(record("key1", 8, 4000L));
+		testHarness.processElement(record("key2", 10, 15000L));
+		testHarness.processElement(record("key2", 11, 15000L));
+		expectedOutputOutput.add(record("key1", 30L, 5L, 1L));
+		expectedOutputOutput.add(record("key2", 45L, 5L, 2L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutputOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		// we close once in the rest...
+		assertEquals("Close was not called.", 2, closeCalled.get());
+	}
+
+	// --------------------------------------------------------------------------------
+
+	private static class PointSessionWindowAssigner extends SessionWindowAssigner {
+		private static final long serialVersionUID = 1L;
+
+		private final long sessionTimeout;
+
+		private PointSessionWindowAssigner(long sessionTimeout) {
+			super(sessionTimeout, true);
+			this.sessionTimeout = sessionTimeout;
+		}
+
+		private PointSessionWindowAssigner(long sessionTimeout, boolean isEventTime) {
+			super(sessionTimeout, isEventTime);
+			this.sessionTimeout = sessionTimeout;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public Collection<TimeWindow> assignWindows(BaseRow element, long timestamp) {
+			int second = element.getInt(1);
+			if (second == 33) {
+				return Collections.singletonList(new TimeWindow(timestamp, timestamp));
+			}
+			return Collections.singletonList(new TimeWindow(timestamp, timestamp + sessionTimeout));
+		}
+
+		@Override
+		public SessionWindowAssigner withEventTime() {
+			return new PointSessionWindowAssigner(sessionTimeout, true);
+		}
+
+		@Override
+		public SessionWindowAssigner withProcessingTime() {
+			return new PointSessionWindowAssigner(sessionTimeout, false);
+		}
+	}
+
+	// schema: String, Long, Long, Long, Long
+	private static class GenericRowResultSortComparator implements Comparator<GenericRow>, Serializable {
+
+		private static final long serialVersionUID = -4988371592272863772L;
+
+		@Override
+		public int compare(GenericRow row1, GenericRow row2) {
+			String key1 = row1.getString(0).toString();
+			String key2 = row2.getString(0).toString();
+			return key1.compareTo(key2);
+		}
+	}
+
+	// sum, count, window_start, window_end
+	private static class SumAndCountAggTimeWindow extends SumAndCountAgg<TimeWindow> {
+
+		private static final long serialVersionUID = 2062031590687738047L;
+
+		@Override
+		public BaseRow getValue(TimeWindow namespace) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			GenericRow row = new GenericRow(5);
+			if (!sumIsNull) {
+				row.setField(0, sum);
+			}
+			if (!countIsNull) {
+				row.setField(1, count);
+			}
+			row.setField(2, namespace.getStart());
+			row.setField(3, namespace.getEnd());
+			row.setField(4, namespace.maxTimestamp());
+			return row;
+		}
+	}
+
+	// sum, count, window_id
+	private static class SumAndCountAggCountWindow extends SumAndCountAgg<CountWindow> {
+
+		private static final long serialVersionUID = -2634639678371135643L;
+
+		@Override
+		public BaseRow getValue(CountWindow namespace) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			GenericRow row = new GenericRow(3);
+			if (!sumIsNull) {
+				row.setField(0, sum);
+			}
+			if (!countIsNull) {
+				row.setField(1, count);
+			}
+			row.setField(2, namespace.getId());
+			return row;
+		}
+	}
+
+	private static class SumAndCountAgg<W extends Window> implements NamespaceAggsHandleFunction<W> {
+
+		private static final long serialVersionUID = 2822222597580664436L;
+
+		protected boolean openCalled = false;
+
+		long sum;
+		boolean sumIsNull;
+		long count;
+		boolean countIsNull;
+
+		@Override
+		public void open(ExecutionContext ctx) throws Exception {
+			openCalled = true;
+		}
+
+		@Override
+		public void setAccumulators(W namespace, BaseRow acc) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			sumIsNull = acc.isNullAt(0);
+			if (!sumIsNull) {
+				sum = acc.getLong(0);
+			}
+
+			countIsNull = acc.isNullAt(1);
+			if (!countIsNull) {
+				count = acc.getLong(1);
+			}
+		}
+
+		@Override
+		public void accumulate(BaseRow inputRow) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			boolean inputIsNull = inputRow.isNullAt(1);
+			if (!inputIsNull) {
+				sum += inputRow.getInt(1);
+				count += 1;
+			}
+		}
+
+		@Override
+		public void retract(BaseRow inputRow) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			boolean inputIsNull = inputRow.isNullAt(1);
+			if (!inputIsNull) {
+				sum -= inputRow.getInt(1);
+				count -= 1;
+			}
+		}
+
+		@Override
+		public void merge(W w, BaseRow otherAcc) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			boolean sumIsNull2 = otherAcc.isNullAt(0);
+			if (!sumIsNull2) {
+				sum += otherAcc.getLong(0);
+			}
+			boolean countIsNull2 = otherAcc.isNullAt(1);
+			if (!countIsNull2) {
+				count += otherAcc.getLong(1);
+			}
+		}
+
+		@Override
+		public BaseRow createAccumulators() {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			GenericRow acc = new GenericRow(2);
+			acc.setField(0, 0L);
+			acc.setField(1, 0L);
+			return acc;
+		}
+
+		@Override
+		public BaseRow getAccumulators() throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			GenericRow row = new GenericRow(2);
+			if (!sumIsNull) {
+				row.setField(0, sum);
+			}
+			if (!countIsNull) {
+				row.setField(1, count);
+			}
+			return row;
+		}
+
+		@Override
+		public BaseRow getValue(W namespace) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			GenericRow row = new GenericRow(2);
+			if (!sumIsNull) {
+				row.setField(0, sum);
+			}
+			if (!countIsNull) {
+				row.setField(1, count);
+			}
+			return row;
+		}
+
+		@Override
+		public void cleanup(W window) {
+
+		}
+
+		@Override
+		public void close() {
+			closeCalled.incrementAndGet();
+		}
+	}
+
+	private static class GenericRowEqualiser implements RecordEqualiser {
+
+		private final InternalType[] fieldTypes;
+
+		GenericRowEqualiser(InternalType[] aggResultTypes, InternalType[] windowTypes) {
+			int size = aggResultTypes.length + windowTypes.length;
+			this.fieldTypes = new InternalType[size];
+			for (int i = 0; i < size; i++) {
+				if (i < aggResultTypes.length) {
+					fieldTypes[i] = aggResultTypes[i];
+				} else {
+					fieldTypes[i] = windowTypes[i - aggResultTypes.length];
+				}
+			}
+		}
+
+		@Override
+		public boolean equals(BaseRow row1, BaseRow row2) {
+			GenericRow left = BaseRowUtil.toGenericRow(row1, fieldTypes);
+			GenericRow right = BaseRowUtil.toGenericRow(row2, fieldTypes);
+			return left.equals(right);
+		}
+
+		@Override
+		public boolean equalsWithoutHeader(BaseRow row1, BaseRow row2) {
+			GenericRow left = BaseRowUtil.toGenericRow(row1, fieldTypes);
+			GenericRow right = BaseRowUtil.toGenericRow(row2, fieldTypes);
+			return left.equalsWithoutHeader(right);
+		}
+	}
+
+	private OneInputStreamOperatorTestHarness<BaseRow, BaseRow> createTestHarness(
+			WindowOperator operator)
+			throws Exception {
+		return new KeyedOneInputStreamOperatorTestHarness<BaseRow, BaseRow, BaseRow>(
+				operator, keySelector, keyType);
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/WindowTestUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/WindowTestUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window;
+
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.util.BaseRowUtil;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import static org.apache.flink.table.dataformat.BinaryString.fromString;
+
+/**
+ * Utilities that are useful for working with Window tests.
+ */
+public interface WindowTestUtils {
+
+	static Matcher<TimeWindow> timeWindow(long start, long end) {
+		return Matchers.equalTo(new TimeWindow(start, end));
+	}
+
+	static StreamRecord<BaseRow> record(String key, Object... fields) {
+		return new StreamRecord<>(baserow(key, fields));
+	}
+
+	static StreamRecord<BaseRow> retractRecord(String key, Object... fields) {
+		BaseRow row = baserow(key, fields);
+		BaseRowUtil.setRetract(row);
+		return new StreamRecord<>(row);
+	}
+
+	static BaseRow baserow(String key, Object... fields) {
+		Object[] objects = new Object[fields.length + 1];
+		objects[0] = fromString(key);
+		System.arraycopy(fields, 0, objects, 1, fields.length);
+		return GenericRow.of(objects);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/assigners/SessionWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/assigners/SessionWindowAssignerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.TreeSet;
+
+import static org.apache.flink.table.runtime.window.WindowTestUtils.timeWindow;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link SessionWindowAssigner}.
+ */
+public class SessionWindowAssignerTest {
+
+	private static final BaseRow ELEMENT = GenericRow.of("String");
+
+	@Test
+	public void testWindowAssignment() {
+		final int sessionGap = 5000;
+
+		SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(sessionGap));
+
+		assertThat(assigner.assignWindows(ELEMENT, 0L), contains(timeWindow(0, sessionGap)));
+		assertThat(assigner.assignWindows(ELEMENT, 4999L), contains(timeWindow(4999, 4999 + sessionGap)));
+		assertThat(assigner.assignWindows(ELEMENT, 5000L), contains(timeWindow(5000, 5000 + sessionGap)));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testMergeEmptyWindow() {
+		MergingWindowAssigner.MergeCallback callback = mock(MergingWindowAssigner.MergeCallback.class);
+		SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
+
+		assigner.mergeWindows(TimeWindow.of(0, 1), new TreeSet<>(), callback);
+
+		verify(callback, never()).merge(anyObject(), Matchers.anyCollection());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testMergeSingleWindow() {
+		MergingWindowAssigner.MergeCallback callback = mock(MergingWindowAssigner.MergeCallback.class);
+		SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
+
+		TreeSet<TimeWindow> sortedWindows = new TreeSet<>();
+		sortedWindows.add(TimeWindow.of(6000, 6001));
+		assigner.mergeWindows(TimeWindow.of(0, 1), sortedWindows, callback);
+
+		verify(callback, never()).merge(anyObject(), anyCollection());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testMergeConsecutiveWindows() {
+		MergingWindowAssigner.MergeCallback callback = mock(MergingWindowAssigner.MergeCallback.class);
+		SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
+
+		TreeSet<TimeWindow> sortedWindows = new TreeSet<>();
+		sortedWindows.addAll(Arrays.asList(
+				new TimeWindow(0, 1),
+				new TimeWindow(2, 3),
+				new TimeWindow(4, 5),
+				new TimeWindow(7, 8)));
+		assigner.mergeWindows(new TimeWindow(1, 2), sortedWindows, callback);
+
+		verify(callback, times(1)).merge(
+				eq(new TimeWindow(0, 3)),
+				argThat((ArgumentMatcher<Collection<TimeWindow>>) timeWindows ->
+						containsInAnyOrder(
+								new TimeWindow(0, 1),
+								new TimeWindow(1, 2),
+								new TimeWindow(2, 3)).matches(timeWindows)));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testMergeCoveringWindow() {
+		MergingWindowAssigner.MergeCallback callback = mock(MergingWindowAssigner.MergeCallback.class);
+		SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
+
+		TreeSet<TimeWindow> sortedWindows = new TreeSet<>();
+		sortedWindows.addAll(Arrays.asList(
+				new TimeWindow(1, 4),
+				new TimeWindow(5, 7),
+				new TimeWindow(9, 10)));
+		assigner.mergeWindows(new TimeWindow(3, 6), sortedWindows, callback);
+
+		verify(callback, times(1)).merge(
+				eq(new TimeWindow(1, 7)),
+				argThat((ArgumentMatcher<Collection<TimeWindow>>) timeWindows ->
+						containsInAnyOrder(
+								new TimeWindow(1, 4),
+								new TimeWindow(5, 7),
+								new TimeWindow(3, 6)).matches(timeWindows)));
+	}
+
+	@Test
+	public void testProperties() {
+		SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
+
+		assertTrue(assigner.isEventTime());
+		assertEquals(new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
+
+		assertTrue(assigner.withEventTime().isEventTime());
+		assertFalse(assigner.withProcessingTime().isEventTime());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/assigners/SlidingWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/assigners/SlidingWindowAssignerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.Duration;
+
+import static org.apache.flink.table.runtime.window.WindowTestUtils.timeWindow;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link SlidingWindowAssigner}.
+ */
+public class SlidingWindowAssignerTest {
+
+	private static final BaseRow ELEMENT = GenericRow.of("String");
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testWindowAssignment() {
+		SlidingWindowAssigner assigner = SlidingWindowAssigner.of(Duration.ofMillis(5000), Duration.ofMillis(1000));
+
+		assertThat(
+			assigner.assignWindows(ELEMENT, 0L),
+			containsInAnyOrder(
+				timeWindow(-4000, 1000),
+				timeWindow(-3000, 2000),
+				timeWindow(-2000, 3000),
+				timeWindow(-1000, 4000),
+				timeWindow(0, 5000)));
+		assertThat(
+			assigner.assignWindows(ELEMENT, 4999L),
+			containsInAnyOrder(
+				timeWindow(0, 5000),
+				timeWindow(1000, 6000),
+				timeWindow(2000, 7000),
+				timeWindow(3000, 8000),
+				timeWindow(4000, 9000)));
+		assertThat(
+			assigner.assignWindows(ELEMENT, 5000L),
+			containsInAnyOrder(
+				timeWindow(1000, 6000),
+				timeWindow(2000, 7000),
+				timeWindow(3000, 8000),
+				timeWindow(4000, 9000),
+				timeWindow(5000, 10000)));
+
+		// test pane
+		assertEquals(assigner.assignPane(ELEMENT, 0L), new TimeWindow(0, 1000));
+		assertEquals(assigner.assignPane(ELEMENT, 4999L), new TimeWindow(4000, 5000));
+		assertEquals(assigner.assignPane(ELEMENT, 5000L), new TimeWindow(5000, 6000));
+
+		assertThat(
+			assigner.splitIntoPanes(new TimeWindow(0, 5000)),
+			contains(
+				timeWindow(0, 1000),
+				timeWindow(1000, 2000),
+				timeWindow(2000, 3000),
+				timeWindow(3000, 4000),
+				timeWindow(4000, 5000)));
+
+		assertThat(
+			assigner.splitIntoPanes(new TimeWindow(3000, 8000)),
+			contains(
+				timeWindow(3000, 4000),
+				timeWindow(4000, 5000),
+				timeWindow(5000, 6000),
+				timeWindow(6000, 7000),
+				timeWindow(7000, 8000)));
+
+		assertEquals(assigner.getLastWindow(new TimeWindow(4000, 5000)), new TimeWindow(4000, 9000));
+		assertEquals(assigner.getLastWindow(new TimeWindow(2000, 3000)), new TimeWindow(2000, 7000));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testWindowAssignmentWithOffset() {
+		SlidingWindowAssigner assigner = SlidingWindowAssigner
+			.of(Duration.ofMillis(5000), Duration.ofMillis(1000))
+			.withOffset(Duration.ofMillis(100));
+
+		assertThat(
+			assigner.assignWindows(ELEMENT, 100L),
+				containsInAnyOrder(
+				timeWindow(-3900, 1100),
+				timeWindow(-2900, 2100),
+				timeWindow(-1900, 3100),
+				timeWindow(-900, 4100),
+				timeWindow(100, 5100)));
+		assertThat(
+			assigner.assignWindows(ELEMENT, 5099L),
+			containsInAnyOrder(
+				timeWindow(100, 5100),
+				timeWindow(1100, 6100),
+				timeWindow(2100, 7100),
+				timeWindow(3100, 8100),
+				timeWindow(4100, 9100)));
+		assertThat(
+			assigner.assignWindows(ELEMENT, 5100L),
+			containsInAnyOrder(
+				timeWindow(1100, 6100),
+				timeWindow(2100, 7100),
+				timeWindow(3100, 8100),
+				timeWindow(4100, 9100),
+				timeWindow(5100, 10100)));
+
+		// test pane
+		assertEquals(assigner.assignPane(ELEMENT, 100L), new TimeWindow(100, 1100));
+		assertEquals(assigner.assignPane(ELEMENT, 5099L), new TimeWindow(4100, 5100));
+		assertEquals(assigner.assignPane(ELEMENT, 5100L), new TimeWindow(5100, 6100));
+
+		assertThat(
+			assigner.splitIntoPanes(new TimeWindow(1100, 6100)),
+			contains(
+				timeWindow(1100, 2100),
+				timeWindow(2100, 3100),
+				timeWindow(3100, 4100),
+				timeWindow(4100, 5100),
+				timeWindow(5100, 6100)));
+
+		assertThat(
+			assigner.splitIntoPanes(new TimeWindow(3100, 8100)),
+			contains(
+				timeWindow(3100, 4100),
+				timeWindow(4100, 5100),
+				timeWindow(5100, 6100),
+				timeWindow(6100, 7100),
+				timeWindow(7100, 8100)));
+
+		assertEquals(assigner.getLastWindow(new TimeWindow(4100, 5100)), new TimeWindow(4100, 9100));
+		assertEquals(assigner.getLastWindow(new TimeWindow(2100, 3100)), new TimeWindow(2100, 7100));
+	}
+
+	@Test
+	public void testInvalidParameters() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("slide > 0 and size > 0");
+		SlidingWindowAssigner.of(Duration.ofSeconds(-2), Duration.ofSeconds(1));
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("slide > 0 and size > 0");
+		SlidingWindowAssigner.of(Duration.ofSeconds(2), Duration.ofSeconds(-1));
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("slide > 0 and size > 0");
+		SlidingWindowAssigner.of(Duration.ofSeconds(20), Duration.ofSeconds(10)).withOffset(Duration.ofSeconds(-1));
+	}
+
+	@Test
+	public void testProperties() {
+		SlidingWindowAssigner assigner = SlidingWindowAssigner.of(Duration.ofMillis(5000), Duration.ofMillis(1000));
+
+		assertTrue(assigner.isEventTime());
+		assertEquals(new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
+
+		assertTrue(assigner.withEventTime().isEventTime());
+		assertFalse(assigner.withProcessingTime().isEventTime());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/assigners/TumblingWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/assigners/TumblingWindowAssignerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.Duration;
+
+import static org.apache.flink.table.runtime.window.WindowTestUtils.timeWindow;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link TumblingWindowAssigner}.
+ */
+public class TumblingWindowAssignerTest {
+
+	private static final BaseRow ELEMENT = GenericRow.of("String");
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testWindowAssignment() {
+		TumblingWindowAssigner assigner = TumblingWindowAssigner.of(Duration.ofMillis(5000));
+
+		assertThat(assigner.assignWindows(ELEMENT, 0L), contains(timeWindow(0, 5000)));
+		assertThat(assigner.assignWindows(ELEMENT, 4999L), contains(timeWindow(0, 5000)));
+		assertThat(assigner.assignWindows(ELEMENT, 5000L), contains(timeWindow(5000, 10000)));
+	}
+
+	@Test
+	public void testWindowAssignmentWithOffset() {
+		TumblingWindowAssigner assigner = TumblingWindowAssigner
+				.of(Duration.ofMillis(5000))
+				.withOffset(Duration.ofMillis(100));
+
+		assertThat(assigner.assignWindows(ELEMENT, 100L), contains(timeWindow(100, 5100)));
+		assertThat(assigner.assignWindows(ELEMENT, 5099L), contains(timeWindow(100, 5100)));
+		assertThat(assigner.assignWindows(ELEMENT, 5100L), contains(timeWindow(5100, 10100)));
+	}
+
+	@Test
+	public void testInvalidParameters() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("size > 0");
+		TumblingWindowAssigner.of(Duration.ofSeconds(-1));
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("size > 0");
+		TumblingWindowAssigner.of(Duration.ofSeconds(10)).withOffset(Duration.ofSeconds(20));
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("size > 0");
+		TumblingWindowAssigner.of(Duration.ofSeconds(10)).withOffset(Duration.ofSeconds(-1));
+	}
+
+	@Test
+	public void testProperties() {
+		TumblingWindowAssigner assigner = TumblingWindowAssigner.of(Duration.ofMillis(5000));
+
+		assertTrue(assigner.isEventTime());
+		assertEquals(new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
+
+		assertTrue(assigner.withEventTime().isEventTime());
+		assertFalse(assigner.withProcessingTime().isEventTime());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/triggers/TriggersTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/triggers/TriggersTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.triggers;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for triggers.
+ */
+public class TriggersTest {
+
+	@Test
+	public void testEventTime() {
+		Trigger<?> trigger;
+		String expected;
+
+		trigger = EventTimeTriggers
+				.afterEndOfWindow()
+				.withEarlyFirings(ElementTriggers.every())
+				.withLateFirings(ProcessingTimeTriggers.every(Duration.ofSeconds(1)));
+		expected = "EventTime.afterEndOfWindow()" +
+				".withEarlyFirings(Element.every())" +
+				".withLateFirings(ProcessingTime.every(1000))";
+		assertEquals(expected, trigger.toString());
+		assertTrue(trigger instanceof EventTimeTriggers.AfterEndOfWindowEarlyAndLate);
+
+		trigger = EventTimeTriggers
+				.afterEndOfWindow()
+				.withEarlyFirings(ProcessingTimeTriggers.every(Duration.ofSeconds(1)))
+				.withLateFirings(ElementTriggers.every());
+		expected = "EventTime.afterEndOfWindow().withEarlyFirings(ProcessingTime.every(1000))";
+		assertEquals(expected, trigger.toString());
+		assertTrue(trigger instanceof EventTimeTriggers.AfterEndOfWindowNoLate);
+
+		// only periodic early trigger
+		trigger = EventTimeTriggers
+				.afterEndOfWindow()
+				.withEarlyFirings(ProcessingTimeTriggers.every(Duration.ofSeconds(1)));
+		expected = "EventTime.afterEndOfWindow().withEarlyFirings(ProcessingTime.every(1000))";
+		assertEquals(expected, trigger.toString());
+		//noinspection ConstantConditions
+		assertTrue(trigger instanceof EventTimeTriggers.AfterEndOfWindowNoLate);
+
+		// only Element.every() early trigger
+		trigger = EventTimeTriggers
+				.afterEndOfWindow()
+				.withEarlyFirings(ElementTriggers.every());
+		expected = "EventTime.afterEndOfWindow().withEarlyFirings(Element.every())";
+		assertEquals(expected, trigger.toString());
+		//noinspection ConstantConditions
+		assertTrue(trigger instanceof EventTimeTriggers.AfterEndOfWindowNoLate);
+
+		// only periodic late trigger
+		trigger = EventTimeTriggers
+				.afterEndOfWindow()
+				.withLateFirings(ProcessingTimeTriggers.every(Duration.ofMillis(1)));
+		expected = "EventTime.afterEndOfWindow().withLateFirings(ProcessingTime.every(1))";
+		assertEquals(expected, trigger.toString());
+		assertTrue(trigger instanceof EventTimeTriggers.AfterEndOfWindowEarlyAndLate);
+
+		// only Element.every() late trigger
+		trigger = EventTimeTriggers
+				.afterEndOfWindow()
+				.withLateFirings(ElementTriggers.every());
+		expected = "EventTime.afterEndOfWindow()";
+		assertEquals(expected, trigger.toString());
+		assertTrue(trigger instanceof EventTimeTriggers.AfterEndOfWindow);
+	}
+
+	@Test
+	public void testProcessingTime() {
+		Trigger<?> trigger;
+		String expected;
+
+		trigger = ProcessingTimeTriggers
+				.afterEndOfWindow();
+		expected = "ProcessingTime.afterEndOfWindow()";
+		assertEquals(expected, trigger.toString());
+		//noinspection ConstantConditions
+		assertTrue(trigger instanceof ProcessingTimeTriggers.AfterEndOfWindow);
+
+		trigger = ProcessingTimeTriggers
+				.afterEndOfWindow()
+				.withEarlyFirings(ElementTriggers.every());
+		expected = "ProcessingTime.afterEndOfWindow().withEarlyFirings(Element.every())";
+		assertEquals(expected, trigger.toString());
+		//noinspection ConstantConditions
+		assertTrue(trigger instanceof ProcessingTimeTriggers.AfterEndOfWindowNoLate);
+
+		trigger = ProcessingTimeTriggers
+				.afterEndOfWindow()
+				.withEarlyFirings(ProcessingTimeTriggers.every(Duration.ofSeconds(1)));
+		expected = "ProcessingTime.afterEndOfWindow().withEarlyFirings(ProcessingTime.every(1000))";
+		assertEquals(expected, trigger.toString());
+		//noinspection ConstantConditions
+		assertTrue(trigger instanceof ProcessingTimeTriggers.AfterEndOfWindowNoLate);
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

introduced a new window operator in blink streaming runtime, the differences between blink's window operator and the one used in DataStream API are:

  - The blink's window operator is mainly used by window aggregate. It work closely with SQL's aggregate function, hence we didn't provide the flexibility to apply arbitrary `WindowFunction` like DataStream did. Instead, we only need to save the intermediate accumulate state for aggregate functions. There is no need for us to save original input rows into state, which will be much more efficient.
  - This new window operator can deal with retract messages.
  - We did some pane based optimization within sliding window operator, similar with FLINK-7001. 

## Brief change log

  - introduced WindowOperator to table-runtime-blink

## Verifying this change

This change added some tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
