### PR TITLE
[FLINK-12021] Deploy execution in topological sorted order

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -102,6 +102,13 @@ public class EmbeddedLeaderService {
 		}
 	}
 
+	@VisibleForTesting
+	public boolean isShutdown() {
+		synchronized (lock) {
+			return shutdown;
+		}
+	}
+
 	private void fatalError(Throwable error) {
 		LOG.error("Embedded leader election service encountered a fatal error. Shutting down service.", error);
 
@@ -171,7 +178,11 @@ public class EmbeddedLeaderService {
 				service.contender = contender;
 				service.running = true;
 
-				updateLeader();
+				updateLeader().whenComplete((aVoid, throwable) -> {
+					if (throwable != null) {
+						fatalError(throwable);
+					}
+				});
 			}
 			catch (Throwable t) {
 				fatalError(t);
@@ -210,7 +221,11 @@ public class EmbeddedLeaderService {
 					currentLeaderSessionId = null;
 				}
 
-				updateLeader();
+				updateLeader().whenComplete((aVoid, throwable) -> {
+					if (throwable != null) {
+						fatalError(throwable);
+					}
+				});
 			}
 			catch (Throwable t) {
 				fatalError(t);
@@ -280,11 +295,12 @@ public class EmbeddedLeaderService {
 
 				currentLeaderSessionId = leaderSessionId;
 				currentLeaderProposed = leaderService;
+				currentLeaderProposed.isLeader = true;
 
 				LOG.info("Proposing leadership to contender {} @ {}",
 						leaderService.contender, leaderService.contender.getAddress());
 
-				return execute(new GrantLeadershipCall(leaderService, leaderSessionId, LOG));
+				return execute(new GrantLeadershipCall(leaderService.contender, leaderSessionId, LOG));
 			}
 		} else {
 			return CompletableFuture.completedFuture(null);
@@ -373,7 +389,8 @@ public class EmbeddedLeaderService {
 				}
 
 				LOG.info("Revoking leadership of {}.", leaderService.contender);
-				CompletableFuture<Void> revokeLeadershipCallFuture = execute(new RevokeLeadershipCall(leaderService));
+				leaderService.isLeader = false;
+				CompletableFuture<Void> revokeLeadershipCallFuture = execute(new RevokeLeadershipCall(leaderService.contender));
 
 				CompletableFuture<Void> notifyAllListenersFuture = notifyAllListeners(null, null);
 
@@ -506,33 +523,28 @@ public class EmbeddedLeaderService {
 
 	private static class GrantLeadershipCall implements Runnable {
 
-		private final EmbeddedLeaderElectionService leaderElectionService;
+		private final LeaderContender contender;
 		private final UUID leaderSessionId;
 		private final Logger logger;
 
 		GrantLeadershipCall(
-				EmbeddedLeaderElectionService leaderElectionService,
+				LeaderContender contender,
 				UUID leaderSessionId,
 				Logger logger) {
 
-			this.leaderElectionService = checkNotNull(leaderElectionService);
+			this.contender = checkNotNull(contender);
 			this.leaderSessionId = checkNotNull(leaderSessionId);
 			this.logger = checkNotNull(logger);
 		}
 
 		@Override
 		public void run() {
-			leaderElectionService.isLeader = true;
-
-			final LeaderContender contender = leaderElectionService.contender;
-
 			try {
 				contender.grantLeadership(leaderSessionId);
 			}
 			catch (Throwable t) {
 				logger.warn("Error granting leadership to contender", t);
 				contender.handleError(t instanceof Exception ? (Exception) t : new Exception(t));
-				leaderElectionService.isLeader = false;
 			}
 		}
 	}
@@ -540,17 +552,15 @@ public class EmbeddedLeaderService {
 	private static class RevokeLeadershipCall implements Runnable {
 
 		@Nonnull
-		private final EmbeddedLeaderElectionService leaderElectionService;
+		private final LeaderContender contender;
 
-		RevokeLeadershipCall(@Nonnull EmbeddedLeaderElectionService leaderElectionService) {
-			this.leaderElectionService = leaderElectionService;
+		RevokeLeadershipCall(@Nonnull LeaderContender contender) {
+			this.contender = contender;
 		}
 
 		@Override
 		public void run() {
-			leaderElectionService.isLeader = false;
-
-			leaderElectionService.contender.revokeLeadership();
+			contender.revokeLeadership();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ConjunctFutureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ConjunctFutureTest.java
@@ -18,21 +18,27 @@
 
 package org.apache.flink.runtime.concurrent;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.FutureUtils.ConjunctFuture;
 import org.apache.flink.util.TestLogger;
 
-import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -40,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Tests for the {@link ConjunctFuture} and {@link FutureUtils.WaitingConjunctFuture}.
+ * Tests for the {@link ConjunctFuture} and its sub classes.
  */
 @RunWith(Parameterized.class)
 public class ConjunctFutureTest extends TestLogger {
@@ -193,23 +199,33 @@ public class ConjunctFutureTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that the conjunct future returns upon completion the collection of all future values.
+	 * Tests that the conjunct future returns upon completion the collection of all future values
+	 * in the same order in which the futures were inserted.
 	 */
 	@Test
-	public void testConjunctFutureValue() throws ExecutionException, InterruptedException {
-		java.util.concurrent.CompletableFuture<Integer> future1 = java.util.concurrent.CompletableFuture.completedFuture(1);
-		java.util.concurrent.CompletableFuture<Long> future2 = java.util.concurrent.CompletableFuture.completedFuture(2L);
-		java.util.concurrent.CompletableFuture<Double> future3 = new java.util.concurrent.CompletableFuture<>();
+	public void testConjunctFutureValue() throws Exception {
+		final int numberFutures = 10;
 
-		ConjunctFuture<Collection<Number>> result = FutureUtils.combineAll(Arrays.asList(future1, future2, future3));
+		final List<CompletableFuture<Integer>> futures = new ArrayList<>(numberFutures);
+		for (int i = 0; i < numberFutures; i++) {
+			futures.add(new CompletableFuture<>());
+		}
 
-		assertFalse(result.isDone());
+		ConjunctFuture<Collection<Number>> result = FutureUtils.combineAll(futures);
 
-		future3.complete(.1);
+		final List<Tuple2<Integer, CompletableFuture<Integer>>> shuffledFutures = IntStream.range(0, futures.size())
+			.mapToObj(index -> Tuple2.of(index, futures.get(index)))
+			.collect(Collectors.toList());
+		Collections.shuffle(shuffledFutures);
 
-		assertTrue(result.isDone());
+		for (Tuple2<Integer, CompletableFuture<Integer>> shuffledFuture : shuffledFutures) {
+			assertThat(result.isDone(), is(false));
+			shuffledFuture.f1.complete(shuffledFuture.f0);
+		}
 
-		assertThat(result.get(), IsIterableContainingInAnyOrder.<Number>containsInAnyOrder(1, 2L, .1));
+		assertThat(result.isDone(), is(true));
+
+		assertThat(result.get(), is(equalTo(IntStream.range(0, numberFutures).boxed().collect(Collectors.toList()))));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -318,7 +318,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
 		Tuple2<ExecutionGraph, Map<ExecutionAttemptID, Execution>> graphAndExecutions = setupExecution(v1, 1, v2, 1);
 		ExecutionGraph graph = graphAndExecutions.f0;
-		
+
 		// verify behavior for canceled executions
 		Execution execution1 = graphAndExecutions.f1.values().iterator().next();
 
@@ -326,15 +326,15 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		Map<String, Accumulator<?, ?>> accumulators = new HashMap<>();
 		accumulators.put("acc", new IntCounter(4));
 		AccumulatorSnapshot accumulatorSnapshot = new AccumulatorSnapshot(graph.getJobID(), execution1.getAttemptId(), accumulators);
-		
+
 		TaskExecutionState state = new TaskExecutionState(graph.getJobID(), execution1.getAttemptId(), ExecutionState.CANCELED, null, accumulatorSnapshot, ioMetrics);
-		
+
 		graph.updateState(state);
-		
+
 		assertEquals(ioMetrics, execution1.getIOMetrics());
 		assertNotNull(execution1.getUserAccumulators());
 		assertEquals(4, execution1.getUserAccumulators().get("acc").getLocalValue());
-		
+
 		// verify behavior for failed executions
 		Execution execution2 = graphAndExecutions.f1.values().iterator().next();
 
@@ -365,14 +365,14 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		JobVertex v2 = new JobVertex("v2", jid2);
 
 		Map<ExecutionAttemptID, Execution> executions = setupExecution(v1, 1, v2, 1).f1;
-		
+
 		IOMetrics ioMetrics = new IOMetrics(0, 0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, 0.0);
 		Map<String, Accumulator<?, ?>> accumulators = Collections.emptyMap();
 
 		Execution execution1 = executions.values().iterator().next();
 		execution1.cancel();
 		execution1.completeCancelling(accumulators, ioMetrics);
-		
+
 		assertEquals(ioMetrics, execution1.getIOMetrics());
 		assertEquals(accumulators, execution1.getUserAccumulators());
 
@@ -540,7 +540,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		checkJobOffloaded(eg);
 
 		eg.start(TestingComponentMainThreadExecutorServiceAdapter.forMainThread());
-		
+
 		eg.setQueuedSchedulingAllowed(false);
 
 		List<JobVertex> ordered = Arrays.asList(v1, v2);
@@ -668,19 +668,6 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			taskManagerLocation,
 			index,
 			new SimpleAckingTaskManagerGateway());
-	}
-
-	@SuppressWarnings("serial")
-	public static class FailingFinalizeJobVertex extends JobVertex {
-
-		public FailingFinalizeJobVertex(String name, JobVertexID id) {
-			super(name, id);
-		}
-
-		@Override
-		public void finalizeOnMaster(ClassLoader cl) throws Exception {
-			throw new Exception();
-		}
 	}
 
 	private ExecutionGraph createExecutionGraph(Configuration configuration) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingSlotProvider.java
@@ -38,7 +38,7 @@ import java.util.function.Function;
 /**
  * {@link SlotProvider} implementation for testing purposes.
  */
-public final class TestingSlotProvider implements SlotProvider {
+public class TestingSlotProvider implements SlotProvider {
 
 	private final ConcurrentMap<SlotRequestId, CompletableFuture<LogicalSlot>> slotFutures;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.nonha.embedded;
+
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for the {@link EmbeddedLeaderService}.
+ */
+public class EmbeddedLeaderServiceTest extends TestLogger {
+
+	/**
+	 * Tests that the {@link EmbeddedLeaderService} can handle a concurrent grant
+	 * leadership call and a shutdown.
+	 */
+	@Test
+	public void testConcurrentGrantLeadershipAndShutdown() throws Exception {
+		final EmbeddedLeaderService embeddedLeaderService = new EmbeddedLeaderService(TestingUtils.defaultExecutor());
+
+		try {
+			final LeaderElectionService leaderElectionService = embeddedLeaderService.createLeaderElectionService();
+
+			final TestingLeaderContender contender = new TestingLeaderContender();
+
+			leaderElectionService.start(contender);
+			leaderElectionService.stop();
+
+			try {
+				// check that no exception occurred
+				contender.getLeaderSessionFuture().get(10L, TimeUnit.MILLISECONDS);
+			} catch (TimeoutException ignored) {
+				// we haven't participated in the leader election
+			}
+
+			// the election service should still be running
+			Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
+		} finally {
+			embeddedLeaderService.shutdown();
+		}
+	}
+
+	/**
+	 * Tests that the {@link EmbeddedLeaderService} can handle a concurrent revoke
+	 * leadership call and a shutdown.
+	 */
+	@Test
+	public void testConcurrentRevokeLeadershipAndShutdown() throws Exception {
+		final EmbeddedLeaderService embeddedLeaderService = new EmbeddedLeaderService(TestingUtils.defaultExecutor());
+
+		try {
+			final LeaderElectionService leaderElectionService = embeddedLeaderService.createLeaderElectionService();
+
+			final TestingLeaderContender contender = new TestingLeaderContender();
+
+			leaderElectionService.start(contender);
+
+			// wait for the leadership
+			contender.getLeaderSessionFuture().get();
+
+			final CompletableFuture<Void> revokeLeadershipFuture = embeddedLeaderService.revokeLeadership();
+			leaderElectionService.stop();
+
+			try {
+				// check that no exception occurred
+				revokeLeadershipFuture.get(10L, TimeUnit.MILLISECONDS);
+			} catch (TimeoutException ignored) {
+				// the leader election service has been stopped before revoking could be executed
+			}
+
+			// the election service should still be running
+			Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
+		} finally {
+			embeddedLeaderService.shutdown();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingLeaderContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingLeaderContender.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.nonha.embedded;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.leaderelection.LeaderContender;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link LeaderContender} implementation for testing purposes.
+ */
+final class TestingLeaderContender implements LeaderContender {
+
+	private final Object lock = new Object();
+
+	private CompletableFuture<UUID> leaderSessionFuture;
+
+	TestingLeaderContender() {
+		leaderSessionFuture = new CompletableFuture<>();
+	}
+
+	@Override
+	public void grantLeadership(UUID leaderSessionID) {
+		synchronized (lock) {
+			if (!leaderSessionFuture.isCompletedExceptionally()) {
+				if (!leaderSessionFuture.complete(leaderSessionID)) {
+					leaderSessionFuture = CompletableFuture.completedFuture(leaderSessionID);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void revokeLeadership() {
+		synchronized (lock) {
+			if (leaderSessionFuture.isDone() && !leaderSessionFuture.isCompletedExceptionally()) {
+				leaderSessionFuture = new CompletableFuture<>();
+			}
+		}
+	}
+
+	@Override
+	public String getAddress() {
+		return "foobar";
+	}
+
+	@Override
+	public void handleError(Exception exception) {
+		synchronized (lock) {
+			if (!(leaderSessionFuture.isCompletedExceptionally() || leaderSessionFuture.completeExceptionally(exception))) {
+				leaderSessionFuture = FutureUtils.completedExceptionally(exception);
+			}
+		}
+	}
+
+	public void tryRethrowException() {
+		synchronized (lock) {
+			if (leaderSessionFuture.isCompletedExceptionally()) {
+				leaderSessionFuture.getNow(null);
+			}
+		}
+	}
+
+	CompletableFuture<UUID> getLeaderSessionFuture() {
+		synchronized (lock) {
+			return leaderSessionFuture;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/LocalTaskManagerLocation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/LocalTaskManagerLocation.java
@@ -30,6 +30,6 @@ public class LocalTaskManagerLocation extends TaskManagerLocation {
 	private static final long serialVersionUID = 2396142513336559461L;
 
 	public LocalTaskManagerLocation() {
-		super(ResourceID.generate(), InetAddress.getLoopbackAddress(), -1);
+		super(ResourceID.generate(), InetAddress.getLoopbackAddress(), 42);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Due to changes how the slot futures are completed and due to the fact that the
ResultConjunctFuture does not maintain the order in which the futures were specified,
it could happen that executions were not deployed in topological order. This commit
fixes this problem by changing the ResultConjunctFuture so that it maintains the order
of the specified futures in its result collection.

This also fixes a performance regression when deploying tasks since deploying tasks in non-topological order can lead to additional result partition lookups.

## Verifying this change

- Added `ExecutionGraphDeploymentTest#testExecutionGraphIsDeployedInTopologicalOrder` and `ConjunctFutureTest#testConjunctFutureCompletion`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
