### PR TITLE
[hotfix] Remove unused construction and IOMode from NetworkEnvironmentConfiguration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -284,12 +284,6 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_MEMORY_SEGMENT_SIZE_KEY = "taskmanager.memory.segment-size";
 
 	/**
-	 * The implementation to use for spillable/spilled intermediate results, which have both
-	 * synchronous and asynchronous implementations: "sync" or "async".
-	 */
-	public static final String TASK_MANAGER_NETWORK_DEFAULT_IO_MODE = "taskmanager.network.defaultIOMode";
-
-	/**
 	 * The config parameter defining the number of task slots of a task manager.
 	 *
 	 * @deprecated use {@link TaskManagerOptions#NUM_TASK_SLOTS} instead
@@ -1433,12 +1427,6 @@ public final class ConfigConstants {
 	 */
 	@Deprecated
 	public static final int DEFAULT_TASK_MANAGER_MEMORY_SEGMENT_SIZE = 32768;
-
-	/**
-	 * The implementation to use for spillable/spilled intermediate results, which have both
-	 * synchronous and asynchronous implementations: "sync" or "async".
-	 */
-	public static final String DEFAULT_TASK_MANAGER_NETWORK_DEFAULT_IO_MODE = "sync";
 
 	/**
 	 * Flag indicating whether to start a thread, which repeatedly logs the memory usage of the JVM.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -284,6 +284,12 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_MEMORY_SEGMENT_SIZE_KEY = "taskmanager.memory.segment-size";
 
 	/**
+	 * @deprecated Not used anymore
+	 */
+	@Deprecated
+	public static final String TASK_MANAGER_NETWORK_DEFAULT_IO_MODE = "taskmanager.network.defaultIOMode";
+
+	/**
 	 * The config parameter defining the number of task slots of a task manager.
 	 *
 	 * @deprecated use {@link TaskManagerOptions#NUM_TASK_SLOTS} instead
@@ -1427,6 +1433,12 @@ public final class ConfigConstants {
 	 */
 	@Deprecated
 	public static final int DEFAULT_TASK_MANAGER_MEMORY_SEGMENT_SIZE = 32768;
+
+	/**
+	 * @deprecated Not used anymore
+	 */
+	@Deprecated
+	public static final String DEFAULT_TASK_MANAGER_NETWORK_DEFAULT_IO_MODE = "sync";
 
 	/**
 	 * Flag indicating whether to start a thread, which repeatedly logs the memory usage of the JVM.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
@@ -36,22 +36,6 @@ import java.util.concurrent.LinkedBlockingQueue;
  * The facade for the provided I/O manager services.
  */
 public abstract class IOManager {
-
-	public enum IOMode {
-
-		SYNC(true), ASYNC(false);
-
-		private final boolean isSynchronous;
-
-		IOMode(boolean isSynchronous) {
-			this.isSynchronous = isSynchronous;
-		}
-
-		public boolean isSynchronous() {
-			return isSynchronous;
-		}
-	}
-
 	/** Logging */
 	protected static final Logger LOG = LoggerFactory.getLogger(IOManager.class);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -29,7 +29,6 @@ import org.apache.flink.configuration.QueryableStateOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
@@ -384,13 +383,6 @@ public class TaskManagerServicesConfiguration {
 			ConfigConstants.TASK_MANAGER_NETWORK_DEFAULT_IO_MODE,
 			ConfigConstants.DEFAULT_TASK_MANAGER_NETWORK_DEFAULT_IO_MODE);
 
-		final IOManager.IOMode ioMode;
-		if (syncOrAsync.equals("async")) {
-			ioMode = IOManager.IOMode.ASYNC;
-		} else {
-			ioMode = IOManager.IOMode.SYNC;
-		}
-
 		int initialRequestBackoff = configuration.getInteger(
 			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL);
 		int maxRequestBackoff = configuration.getInteger(
@@ -406,7 +398,6 @@ public class TaskManagerServicesConfiguration {
 			networkBufMin,
 			networkBufMax,
 			pageSize,
-			ioMode,
 			initialRequestBackoff,
 			maxRequestBackoff,
 			buffersPerChannel,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.CheckpointingOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -377,11 +376,6 @@ public class TaskManagerServicesConfiguration {
 		} else {
 			nettyConfig = null;
 		}
-
-		// Default spill I/O mode for intermediate results
-		final String syncOrAsync = configuration.getString(
-			ConfigConstants.TASK_MANAGER_NETWORK_DEFAULT_IO_MODE,
-			ConfigConstants.DEFAULT_TASK_MANAGER_NETWORK_DEFAULT_IO_MODE);
 
 		int initialRequestBackoff = configuration.getInteger(
 			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.taskmanager;
 
-import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 
 import javax.annotation.Nullable;
@@ -36,8 +35,6 @@ public class NetworkEnvironmentConfiguration {
 
 	private final int networkBufferSize;
 
-	private final IOMode ioMode;
-
 	private final int partitionRequestInitialBackoff;
 
 	private final int partitionRequestMaxBackoff;
@@ -48,34 +45,11 @@ public class NetworkEnvironmentConfiguration {
 
 	private final NettyConfig nettyConfig;
 
-	/**
-	 * Constructor for a setup with purely local communication (no netty).
-	 */
 	public NetworkEnvironmentConfiguration(
 			float networkBufFraction,
 			long networkBufMin,
 			long networkBufMax,
 			int networkBufferSize,
-			IOMode ioMode,
-			int partitionRequestInitialBackoff,
-			int partitionRequestMaxBackoff,
-			int networkBuffersPerChannel,
-			int floatingNetworkBuffersPerGate) {
-
-		this(networkBufFraction, networkBufMin, networkBufMax, networkBufferSize,
-				ioMode,
-				partitionRequestInitialBackoff, partitionRequestMaxBackoff,
-				networkBuffersPerChannel, floatingNetworkBuffersPerGate,
-				null);
-		
-	}
-
-	public NetworkEnvironmentConfiguration(
-			float networkBufFraction,
-			long networkBufMin,
-			long networkBufMax,
-			int networkBufferSize,
-			IOMode ioMode,
 			int partitionRequestInitialBackoff,
 			int partitionRequestMaxBackoff,
 			int networkBuffersPerChannel,
@@ -86,7 +60,6 @@ public class NetworkEnvironmentConfiguration {
 		this.networkBufMin = networkBufMin;
 		this.networkBufMax = networkBufMax;
 		this.networkBufferSize = networkBufferSize;
-		this.ioMode = ioMode;
 		this.partitionRequestInitialBackoff = partitionRequestInitialBackoff;
 		this.partitionRequestMaxBackoff = partitionRequestMaxBackoff;
 		this.networkBuffersPerChannel = networkBuffersPerChannel;
@@ -110,10 +83,6 @@ public class NetworkEnvironmentConfiguration {
 
 	public int networkBufferSize() {
 		return networkBufferSize;
-	}
-
-	public IOMode ioMode() {
-		return ioMode;
 	}
 
 	public int partitionRequestInitialBackoff() {
@@ -142,7 +111,6 @@ public class NetworkEnvironmentConfiguration {
 	public int hashCode() {
 		int result = 1;
 		result = 31 * result + networkBufferSize;
-		result = 31 * result + ioMode.hashCode();
 		result = 31 * result + partitionRequestInitialBackoff;
 		result = 31 * result + partitionRequestMaxBackoff;
 		result = 31 * result + networkBuffersPerChannel;
@@ -170,7 +138,6 @@ public class NetworkEnvironmentConfiguration {
 					this.partitionRequestMaxBackoff == that.partitionRequestMaxBackoff &&
 					this.networkBuffersPerChannel == that.networkBuffersPerChannel &&
 					this.floatingNetworkBuffersPerGate == that.floatingNetworkBuffersPerGate &&
-					this.ioMode == that.ioMode && 
 					(nettyConfig != null ? nettyConfig.equals(that.nettyConfig) : that.nettyConfig == null);
 		}
 	}
@@ -182,7 +149,6 @@ public class NetworkEnvironmentConfiguration {
 				", networkBufMin=" + networkBufMin +
 				", networkBufMax=" + networkBufMax +
 				", networkBufferSize=" + networkBufferSize +
-				", ioMode=" + ioMode +
 				", partitionRequestInitialBackoff=" + partitionRequestInitialBackoff +
 				", partitionRequestMaxBackoff=" + partitionRequestMaxBackoff +
 				", networkBuffersPerChannel=" + networkBuffersPerChannel +

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
@@ -91,7 +91,6 @@ public class NetworkBufferCalculationTest extends TestLogger {
 			networkBufMin,
 			networkBufMax,
 			checkedDownCast(MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes()),
-			null,
 			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL.defaultValue(),
 			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_MAX.defaultValue(),
 			TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue(),


### PR DESCRIPTION
## What is the purpose of the change

*Remove unused construction and `IOMode` from `NetworkEnvironmentConfiguration`*

## Brief change log

  - *Remove unused construction from `NetworkEnvironmentConfiguration`*
  - *Remove unused `IOMode` field from `NetworkEnvironmentConfiguration`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)