### PR TITLE
[FLINK-12041][table-runtime-blink] Introduce ResettableExternalBuffer to blink batch

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
@@ -398,6 +398,12 @@ public final class BinaryRow extends BinaryFormat implements BaseRow {
 		return reuse;
 	}
 
+	public void clear() {
+		segments = null;
+		offset = 0;
+		sizeInBytes = 0;
+	}
+
 	@Override
 	public int hashCode() {
 		return SegmentsUtil.hashByWords(segments, offset, sizeInBytes);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.util.BinaryRowUtil;
 import org.apache.flink.table.generated.JoinCondition;
 import org.apache.flink.table.generated.Projection;
+import org.apache.flink.table.runtime.io.BinaryRowChannelInputViewIterator;
 import org.apache.flink.table.runtime.io.ChannelWithMeta;
 import org.apache.flink.table.runtime.join.HashJoinType;
 import org.apache.flink.table.runtime.join.NullAwareJoinHelper;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/io/BinaryRowChannelInputViewIterator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/io/BinaryRowChannelInputViewIterator.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.hashtable;
+package org.apache.flink.table.runtime.io;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.ChannelReaderInputView;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableBuffer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.	See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Resettable buffer that add {@link BaseRow} and return {@link BinaryRow} iterator.
+ *
+ * <p>Instructions:
+ * 1.{@link #reset()}
+ * 2.multi {@link #add(BaseRow)}
+ * 3.{@link #complete()}
+ * 4.multi {@link #newIterator()}
+ * repeat the above steps or {@link #close()}.
+ */
+public interface ResettableBuffer extends Closeable {
+
+	/**
+	 * Re-initialize the buffer state.
+	 */
+	void reset();
+
+	/**
+	 * Appends the specified row to the end of this buffer.
+	 */
+	void add(BaseRow row) throws IOException;
+
+	/**
+	 * Finally, complete add.
+	 */
+	void complete();
+
+	/**
+	 * Get a new iterator starting from first row.
+	 */
+	ResettableIterator newIterator();
+
+	/**
+	 * Get a new iterator starting from the `beginRow`-th row. `beginRow` is 0-indexed.
+	 */
+	ResettableIterator newIterator(int beginRow);
+
+	/**
+	 * Row iterator that can be reset.
+	 */
+	interface ResettableIterator extends RowIterator<BinaryRow>, Closeable {
+
+		/**
+		 * Re-initialize the iterator, start from begin row.
+		 */
+		void reset() throws IOException;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableExternalBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableExternalBuffer.java
@@ -1,0 +1,715 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.	See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.disk.RandomAccessInputView;
+import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
+import org.apache.flink.runtime.io.disk.iomanager.BlockChannelReader;
+import org.apache.flink.runtime.io.disk.iomanager.BlockChannelWriter;
+import org.apache.flink.runtime.io.disk.iomanager.ChannelReaderInputView;
+import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
+import org.apache.flink.runtime.io.disk.iomanager.HeaderlessChannelReaderInputView;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.memory.ListMemorySegmentSource;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.runtime.io.BinaryRowChannelInputViewIterator;
+import org.apache.flink.table.runtime.io.ChannelWithMeta;
+import org.apache.flink.table.typeutils.AbstractRowSerializer;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.MutableObjectIterator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A resettable external buffer for binary row. It stores records in memory and spill to disk
+ * when memory is not enough. When the spill is completed, the records are written to memory again.
+ * The returned iterator reads the data in write order (read spilled records first). It supports
+ * infinite length. It can open multiple Iterators. It support new iterator with beginRow.
+ *
+ * <p>Instructions:
+ * 1.{@link #reset()}
+ * 2.multi {@link #add(BaseRow)}
+ * 3.{@link #complete()}
+ * 4.multi {@link #newIterator()}
+ * repeat the above steps or {@link #close()}.
+ *
+ * <p>NOTE: Not supports reading while writing. In the face of concurrent modification, the
+ * iterator fails quickly and cleanly, rather than risking arbitrary, non-deterministic behavior
+ * at an undetermined time in the future.
+ */
+public class ResettableExternalBuffer implements Closeable {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ResettableExternalBuffer.class);
+
+	// We will only read one spilled file at the same time.
+	private static final int READ_BUFFER = 2;
+
+	private final MemoryManager memoryManager;
+	private final IOManager ioManager;
+	private final List<MemorySegment> memory;
+	private final BinaryRowSerializer binaryRowSerializer;
+	private final InMemoryBuffer inMemoryBuffer;
+	private long spillSize;
+
+	// The size of each segment
+	private int segmentSize;
+
+	// The length of each row, if each row is of fixed length
+	private long rowLength;
+	// If each row is of fixed length
+	private boolean isRowAllInFixedPart;
+
+	private final List<ChannelWithMeta> spilledChannelIDs;
+	private final List<Integer> spilledChannelRowOffsets;
+	private int numRows;
+
+	// Number of iterators currently opened
+	private int iterOpenedCount;
+
+	// Times of reset() called. Used to check validity of iterators.
+	private int externalBufferVersion;
+
+	private boolean addCompleted;
+
+	public ResettableExternalBuffer(
+		MemoryManager memoryManager,
+		IOManager ioManager,
+		List<MemorySegment> memory,
+		AbstractRowSerializer serializer,
+		boolean isRowAllInFixedPart) {
+		this.memoryManager = memoryManager;
+		this.ioManager = ioManager;
+		this.memory = memory;
+
+		this.binaryRowSerializer = serializer instanceof BinaryRowSerializer ?
+				(BinaryRowSerializer) serializer.duplicate() :
+				new BinaryRowSerializer(serializer.getArity());
+
+		this.inMemoryBuffer = new InMemoryBuffer(serializer);
+
+		this.spilledChannelIDs = new ArrayList<>();
+		this.spillSize = 0;
+
+		this.segmentSize = memory.get(0).size();
+
+		this.spilledChannelRowOffsets = new ArrayList<>();
+		this.numRows = 0;
+
+		this.iterOpenedCount = 0;
+		this.externalBufferVersion = 0;
+
+		this.isRowAllInFixedPart = isRowAllInFixedPart;
+		this.rowLength = isRowAllInFixedPart ? binaryRowSerializer.getSerializedRowFixedPartLength() : -1;
+		this.addCompleted = false;
+	}
+
+	/**
+	 * Re-initialize the buffer state.
+	 */
+	public void reset() {
+		clearChannels();
+		inMemoryBuffer.reset();
+		numRows = 0;
+		externalBufferVersion++;
+		addCompleted = false;
+	}
+
+	/**
+	 * Appends the specified row to the end of this buffer.
+	 */
+	public void add(BaseRow row) throws IOException {
+		checkState(!addCompleted, "This buffer has add completed.");
+		if (!inMemoryBuffer.write(row)) {
+			// Check if record is too big.
+			if (inMemoryBuffer.getCurrentDataBufferOffset() == 0) {
+				throwTooBigException(row);
+			}
+			spill();
+			if (!inMemoryBuffer.write(row)) {
+				throwTooBigException(row);
+			}
+		}
+
+		numRows++;
+	}
+
+	/**
+	 * Finally, complete add.
+	 */
+	public void complete() {
+		addCompleted = true;
+	}
+
+	public BufferIterator newIterator() {
+		return newIterator(0);
+	}
+
+	/**
+	 * Get a new iterator starting from the `beginRow`-th row. `beginRow` is 0-indexed.
+	 */
+	public BufferIterator newIterator(int beginRow) {
+		checkState(addCompleted, "This buffer has not add completed.");
+		checkArgument(beginRow >= 0, "`beginRow` can't be negative!");
+		iterOpenedCount++;
+		return new BufferIterator(beginRow);
+	}
+
+	/**
+	 * Delete all files and release the memory.
+	 */
+	@Override
+	public void close() {
+		clearChannels();
+		memoryManager.release(memory);
+		inMemoryBuffer.close();
+	}
+
+	private void throwTooBigException(BaseRow row) throws IOException {
+		int rowSize = InstantiationUtil.serializeToByteArray(inMemoryBuffer.serializer, row).length;
+		throw new IOException("Record is too big, it can't be added to a empty InMemoryBuffer! " +
+				"Record size: " + rowSize + ", Buffer: " + memorySize());
+	}
+
+	private void spill() throws IOException {
+		FileIOChannel.ID channel = ioManager.createChannel();
+
+		final BlockChannelWriter<MemorySegment> writer = this.ioManager.createBlockChannelWriter(channel);
+		int numRecordBuffers = inMemoryBuffer.getNumRecordBuffers();
+		ArrayList<MemorySegment> segments = inMemoryBuffer.getRecordBufferSegments();
+		try {
+			// spill in memory buffer in zero-copy.
+			for (int i = 0; i < numRecordBuffers; i++) {
+				writer.writeBlock(segments.get(i));
+			}
+			LOG.info("here spill the reset buffer data with {} bytes", writer.getSize());
+			writer.close();
+		} catch (IOException e) {
+			writer.closeAndDelete();
+			throw e;
+		}
+
+		spillSize += numRecordBuffers * segmentSize;
+		spilledChannelIDs.add(new ChannelWithMeta(
+			channel,
+			inMemoryBuffer.getNumRecordBuffers(),
+			inMemoryBuffer.getNumBytesInLastBuffer()));
+		this.spilledChannelRowOffsets.add(numRows);
+
+		inMemoryBuffer.reset();
+	}
+
+	public int size() {
+		return numRows;
+	}
+
+	private int memorySize() {
+		return memory.size() * segmentSize;
+	}
+
+	public long getUsedMemoryInBytes() {
+		return memorySize() + iterOpenedCount * READ_BUFFER * segmentSize;
+	}
+
+	public int getNumSpillFiles() {
+		return spilledChannelIDs.size();
+	}
+
+	public long getSpillInBytes() {
+		return spillSize;
+	}
+
+	private void clearChannels() {
+		for (ChannelWithMeta meta : spilledChannelIDs) {
+			final File f = new File(meta.getChannel().getPath());
+			if (f.exists()) {
+				f.delete();
+			}
+		}
+		spilledChannelIDs.clear();
+		spillSize = 0;
+
+		spilledChannelRowOffsets.clear();
+	}
+
+	/**
+	 * Iterator of external buffer.
+	 */
+	public class BufferIterator implements Closeable {
+
+		MutableObjectIterator<BinaryRow> currentIterator;
+
+		// memory for file reader to store read result
+		List<MemorySegment> freeMemory = null;
+		BlockChannelReader<MemorySegment> fileReader;
+		int currentChannelID = -1;
+
+		BinaryRow reuse = binaryRowSerializer.createInstance();
+		BinaryRow row;
+		int beginRow;
+		int nextRow;
+
+		// reuse in memory buffer iterator to reduce initialization cost.
+		InMemoryBuffer.InMemoryBufferIterator reusableMemoryIterator;
+
+		// value of resetCount of buffer when this iterator is created.
+		// used to check validity.
+		int versionSnapshot;
+		// if this iterator is closed
+		boolean closed;
+
+		private BufferIterator(int beginRow) {
+			this.beginRow = Math.min(beginRow, numRows);
+			this.nextRow = this.beginRow;
+
+			this.versionSnapshot = externalBufferVersion;
+			this.closed = false;
+		}
+
+		private void checkValidity() {
+			if (closed) {
+				throw new RuntimeException("This iterator is closed!");
+			} else if (this.versionSnapshot != externalBufferVersion) {
+				throw new RuntimeException("This iterator is no longer valid!");
+			}
+		}
+
+		public void reset() throws IOException {
+			checkValidity();
+			resetImpl();
+		}
+
+		private void resetImpl() throws IOException {
+			closeCurrentFileReader();
+
+			nextRow = beginRow;
+			currentChannelID = -1;
+			currentIterator = null;
+
+			row = null;
+			reuse.clear();
+		}
+
+		@Override
+		public void close() {
+			if (closed) {
+				return;
+			}
+
+			try {
+				resetImpl();
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+
+			if (freeMemory != null) {
+				freeMemory.clear();
+			}
+			if (reusableMemoryIterator != null) {
+				reusableMemoryIterator.close();
+			}
+
+			closed = true;
+			iterOpenedCount--;
+		}
+
+		public boolean hasNext() {
+			return nextRow < numRows;
+		}
+
+		public int getBeginRow() {
+			return beginRow;
+		}
+
+		public boolean advanceNext() {
+			checkValidity();
+
+			try {
+				updateIteratorIfNeeded();
+
+				// get from curr iterator or new iterator.
+				while (true) {
+					if (currentIterator != null &&
+						(row = currentIterator.next(reuse)) != null) {
+						this.nextRow++;
+						return true;
+					} else {
+						if (!nextIterator()) {
+							return false;
+						}
+					}
+				}
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		private boolean nextIterator() throws IOException {
+			if (currentChannelID == -1) {
+				// First call to next iterator. Fetch iterator according to beginRow.
+				if (isRowAllInFixedPart) {
+					gotoAllInFixedPartRow(beginRow);
+				} else {
+					gotoVariableLengthRow(beginRow);
+				}
+			} else if (currentChannelID == Integer.MAX_VALUE) {
+				// The last one is in memory, so the end.
+				return false;
+			} else if (currentChannelID < spilledChannelIDs.size() - 1) {
+				// Next spilled iterator.
+				nextSpilledIterator();
+			} else {
+				// It is the last iterator.
+				newMemoryIterator();
+			}
+			return true;
+		}
+
+		private boolean iteratorNeedsUpdate() {
+			int size = spilledChannelRowOffsets.size();
+			return size > 0
+				&& currentChannelID == Integer.MAX_VALUE
+				&& nextRow <= spilledChannelRowOffsets.get(size - 1);
+		}
+
+		private void updateIteratorIfNeeded() throws IOException {
+			if (iteratorNeedsUpdate()) {
+				reuse.clear();
+				reusableMemoryIterator = null;
+
+				if (isRowAllInFixedPart) {
+					gotoAllInFixedPartRow(nextRow);
+				} else {
+					gotoVariableLengthRow(nextRow);
+				}
+			}
+		}
+
+		public BinaryRow getRow() {
+			return row;
+		}
+
+		private void closeCurrentFileReader() throws IOException {
+			if (fileReader != null) {
+				fileReader.close();
+				fileReader = null;
+			}
+		}
+
+		private void gotoAllInFixedPartRow(int beginRow) throws IOException {
+			// Find which channel contains the row.
+			int beginChannel = upperBound(beginRow, spilledChannelRowOffsets);
+			// Find the row number in its own channel (0-indexed).
+			int beginRowInChannel = getBeginIndexInChannel(beginRow, beginChannel);
+			if (beginRow == numRows) {
+				// Row number out of range! Should return an "empty" iterator.
+				newMemoryIterator(beginRowInChannel, inMemoryBuffer.getCurrentDataBufferOffset());
+				return;
+			}
+
+			// Fixed length. Calculate offset directly.
+			long numRecordsInSegment = segmentSize / rowLength;
+			long offset =
+				(beginRowInChannel / numRecordsInSegment) * segmentSize +
+					(beginRowInChannel % numRecordsInSegment) * rowLength;
+
+			if (beginChannel < spilledChannelRowOffsets.size()) {
+				// Data on disk
+				newSpilledIterator(beginChannel, offset);
+			} else {
+				// Data in memory
+				newMemoryIterator(beginRowInChannel, offset);
+			}
+		}
+
+		private void gotoVariableLengthRow(int beginRow) throws IOException {
+			// Find which channel contains the row.
+			int beginChannel = upperBound(beginRow, spilledChannelRowOffsets);
+			// Find the row number in its own channel (0-indexed).
+			int beginRowInChannel = getBeginIndexInChannel(beginRow, beginChannel);
+			if (beginRow == numRows) {
+				// Row number out of range! Should return an "empty" iterator.
+				newMemoryIterator(beginRowInChannel, inMemoryBuffer.getCurrentDataBufferOffset());
+				return;
+			}
+
+			if (beginChannel < spilledChannelRowOffsets.size()) {
+				// Data on disk
+				newSpilledIterator(beginChannel);
+			} else {
+				// Data in memory
+				newMemoryIterator();
+			}
+
+			nextRow -= beginRowInChannel;
+			for (int i = 0; i < beginRowInChannel; i++) {
+				advanceNext();
+			}
+		}
+
+		private void nextSpilledIterator() throws IOException {
+			newSpilledIterator(currentChannelID + 1);
+		}
+
+		private void newSpilledIterator(int channelID) throws IOException {
+			newSpilledIterator(channelID, 0);
+		}
+
+		private void newSpilledIterator(int channelID, long offset) throws IOException {
+			ChannelWithMeta channel = spilledChannelIDs.get(channelID);
+			currentChannelID = channelID;
+
+			// close current reader first.
+			closeCurrentFileReader();
+
+			// calculate segment number
+			int segmentNum = (int) (offset / segmentSize);
+			long seekPosition = segmentNum * segmentSize;
+
+			// new reader.
+			this.fileReader = ioManager.createBlockChannelReader(channel.getChannel());
+			if (offset > 0) {
+				// seek to the beginning of that segment
+				fileReader.seekToPosition(seekPosition);
+			}
+			ChannelReaderInputView inView = new HeaderlessChannelReaderInputView(
+				fileReader, getReadMemory(), channel.getBlockCount() - segmentNum,
+				channel.getNumBytesInLastBlock(), false, offset - seekPosition
+			);
+			this.currentIterator = new BinaryRowChannelInputViewIterator(inView, binaryRowSerializer);
+		}
+
+		private void newMemoryIterator() throws IOException {
+			newMemoryIterator(0, 0);
+		}
+
+		private void newMemoryIterator(int beginRow, long offset) throws IOException {
+			currentChannelID = Integer.MAX_VALUE;
+			// close curr reader first.
+			closeCurrentFileReader();
+
+			if (reusableMemoryIterator == null) {
+				reusableMemoryIterator = inMemoryBuffer.newIterator(beginRow, offset);
+			} else {
+				reusableMemoryIterator.reset(inMemoryBuffer.recordCount, offset);
+			}
+			this.currentIterator = reusableMemoryIterator;
+		}
+
+		private int getBeginIndexInChannel(int beginRow, int beginChannel) {
+			if (beginChannel > 0) {
+				return beginRow - spilledChannelRowOffsets.get(beginChannel - 1);
+			} else {
+				return beginRow;
+			}
+		}
+
+		private List<MemorySegment> getReadMemory() {
+			if (freeMemory == null) {
+				freeMemory = new ArrayList<>();
+				for (int i = 0; i < READ_BUFFER; i++) {
+					freeMemory.add(MemorySegmentFactory.allocateUnpooledSegment(segmentSize));
+				}
+			}
+			return freeMemory;
+		}
+
+		// Find the index of the first element which is strictly greater than `goal` in `list`.
+		// `list` must be sorted.
+		// If every element in `list` is not larger than `goal`, return `list.size()`.
+		private int upperBound(int goal, List<Integer> list) {
+			if (list.size() == 0) {
+				return 0;
+			}
+			if (list.get(list.size() - 1) <= goal) {
+				return list.size();
+			}
+
+			// Binary search
+			int head = 0;
+			int tail = list.size() - 1;
+			int mid;
+			while (head < tail) {
+				mid = (head + tail) / 2;
+				if (list.get(mid) <= goal) {
+					head = mid + 1;
+				} else {
+					tail = mid;
+				}
+			}
+			return head;
+		}
+	}
+
+	@VisibleForTesting
+	List<ChannelWithMeta> getSpillChannels() {
+		return spilledChannelIDs;
+	}
+
+	/**
+	 * In memory buffer that stores records to memorySegments, returns a iterator that map from memory.
+	 */
+	private class InMemoryBuffer implements Closeable {
+
+		private final int segmentSize;
+		private final ArrayList<MemorySegment> freeMemory;
+		private final AbstractRowSerializer serializer;
+		private final ArrayList<MemorySegment> recordBufferSegments;
+		private final SimpleCollectingOutputView recordCollector;
+
+		// Can't use recordCollector.getCurrentOffset(), maybe the offset of recordCollector is
+		// disrupted by the attempt of record writing.
+		private long currentDataBufferOffset;
+		private int numBytesInLastBuffer;
+
+		private int recordCount;
+
+		private InMemoryBuffer(AbstractRowSerializer serializer) {
+			this.segmentSize = memory.get(0).size();
+			this.freeMemory = new ArrayList<>(memory);
+			// serializer has states, so we must duplicate
+			this.serializer = (AbstractRowSerializer) serializer.duplicate();
+			this.recordBufferSegments = new ArrayList<>(memory.size());
+			this.recordCollector = new SimpleCollectingOutputView(this.recordBufferSegments,
+					new ListMemorySegmentSource(this.freeMemory), this.segmentSize);
+			this.recordCount = 0;
+		}
+
+		private void reset() {
+			this.currentDataBufferOffset = 0;
+			this.recordCount = 0;
+
+			// reset free and record segments.
+			this.freeMemory.addAll(this.recordBufferSegments);
+			this.recordBufferSegments.clear();
+
+			this.recordCollector.reset();
+		}
+
+		@Override
+		public void close() {
+			this.freeMemory.clear();
+			this.recordBufferSegments.clear();
+		}
+
+		public boolean write(BaseRow row) throws IOException {
+			try {
+				this.serializer.serializeToPages(row, this.recordCollector);
+				currentDataBufferOffset = this.recordCollector.getCurrentOffset();
+				numBytesInLastBuffer = this.recordCollector.getCurrentPositionInSegment();
+				recordCount++;
+				return true;
+			} catch (EOFException e) {
+				return false;
+			}
+		}
+
+		private ArrayList<MemorySegment> getRecordBufferSegments() {
+			return recordBufferSegments;
+		}
+
+		private long getCurrentDataBufferOffset() {
+			return currentDataBufferOffset;
+		}
+
+		private int getNumRecordBuffers() {
+			int result = (int) (currentDataBufferOffset / segmentSize);
+			long mod = currentDataBufferOffset % segmentSize;
+			if (mod != 0) {
+				result += 1;
+			}
+			return result;
+		}
+
+		private int getNumBytesInLastBuffer() {
+			return numBytesInLastBuffer;
+		}
+
+		private InMemoryBufferIterator newIterator(int beginRow, long offset) {
+			checkArgument(offset >= 0, "`offset` can't be negative!");
+
+			RandomAccessInputView recordBuffer = new RandomAccessInputView(
+					this.recordBufferSegments, this.segmentSize, numBytesInLastBuffer);
+			return new InMemoryBufferIterator(recordCount, beginRow, offset, recordBuffer);
+		}
+
+		/**
+		 * Iterator of in memory buffer.
+		 */
+		public class InMemoryBufferIterator implements MutableObjectIterator<BinaryRow>, Closeable {
+			private final int beginRow;
+			private int nextRow;
+			private RandomAccessInputView recordBuffer;
+			private int expectedRecordCount;
+
+			private InMemoryBufferIterator(int expectedRecordCount, int beginRow, long offset, RandomAccessInputView recordBuffer) {
+				this.beginRow = beginRow;
+				this.recordBuffer = recordBuffer;
+				reset(expectedRecordCount, offset);
+			}
+
+			public void reset(int expectedRecordCount, long offset) {
+				this.nextRow = beginRow;
+				this.expectedRecordCount = expectedRecordCount;
+				recordBuffer.setReadPosition(offset);
+			}
+
+			@Override
+			public BinaryRow next(BinaryRow reuse) throws IOException {
+				try {
+					if (expectedRecordCount != recordCount) {
+						throw new ConcurrentModificationException();
+					}
+					if (nextRow >= recordCount) {
+						return null;
+					}
+					nextRow++;
+					return (BinaryRow) serializer.mapFromPages(reuse, recordBuffer);
+				} catch (EOFException e) {
+					return null;
+				}
+			}
+
+			@Override
+			public BinaryRow next() throws IOException {
+				throw new RuntimeException("Not support!");
+			}
+
+			@Override
+			public void close() {
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableExternalBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableExternalBuffer.java
@@ -63,7 +63,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * iterator fails quickly and cleanly, rather than risking arbitrary, non-deterministic behavior
  * at an undetermined time in the future.
  */
-public class ResettableExternalBuffer implements ResettableBuffer {
+public class ResettableExternalBuffer implements ResettableRowBuffer {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ResettableExternalBuffer.class);
 
@@ -253,7 +253,7 @@ public class ResettableExternalBuffer implements ResettableBuffer {
 	/**
 	 * Iterator of external buffer.
 	 */
-	public class BufferIterator implements ResettableBuffer.ResettableIterator {
+	public class BufferIterator implements ResettableRowBuffer.ResettableIterator {
 
 		MutableObjectIterator<BinaryRow> currentIterator;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableRowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableRowBuffer.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * 4.multi {@link #newIterator()}
  * repeat the above steps or {@link #close()}.
  */
-public interface ResettableBuffer extends Closeable {
+public interface ResettableRowBuffer extends Closeable {
 
 	/**
 	 * Re-initialize the buffer state.

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/ResettableExternalBufferTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/ResettableExternalBufferTest.java
@@ -1,0 +1,945 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.	See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryRowWriter;
+import org.apache.flink.table.dataformat.BinaryString;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static org.apache.flink.runtime.memory.MemoryManager.DEFAULT_PAGE_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link ResettableExternalBuffer}.
+ */
+public class ResettableExternalBufferTest {
+
+	private static final int MEMORY_SIZE = 1024 * DEFAULT_PAGE_SIZE;
+
+	private MemoryManager memManager;
+	private IOManager ioManager;
+	private Random random;
+	private BinaryRowSerializer serializer;
+	private BinaryRowSerializer multiColumnFixedLengthSerializer;
+	private BinaryRowSerializer multiColumnVariableLengthSerializer;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Before
+	public void before() {
+		this.memManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.ioManager = new IOManagerAsync();
+		this.random = new Random();
+		this.serializer = new BinaryRowSerializer(1);
+		this.multiColumnFixedLengthSerializer = new BinaryRowSerializer(3);
+		this.multiColumnVariableLengthSerializer = new BinaryRowSerializer(5);
+	}
+
+	private ResettableExternalBuffer newBuffer(long memorySize) throws MemoryAllocationException {
+		return newBuffer(memorySize, this.serializer, true);
+	}
+
+	private ResettableExternalBuffer newBuffer(long memorySize,
+			BinaryRowSerializer serializer, boolean isRowAllInFixedPart) throws MemoryAllocationException {
+		return new ResettableExternalBuffer(
+				memManager, ioManager,
+				memManager.allocatePages(this, (int) (memorySize / memManager.getPageSize())),
+				serializer, isRowAllInFixedPart);
+	}
+
+	@Test
+	public void testLess() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 100;
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertEquals(buffer.getSpillChannels().size(), 0);
+
+		// repeat read
+		assertBuffer(expected, buffer);
+		buffer.newIterator();
+		assertBuffer(expected, buffer);
+
+		buffer.close();
+	}
+
+	@Test
+	public void testSpill() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 5000; // 16 * 5000
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertTrue(buffer.getSpillChannels().size() > 0);
+
+		// repeat read
+		assertBuffer(expected, buffer);
+		buffer.newIterator();
+		assertBuffer(expected, buffer);
+
+		buffer.close();
+	}
+
+	@Test
+	public void testBufferReset() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		// less
+		insertMulti(buffer, 10);
+		buffer.reset();
+		assertEquals(buffer.size(), 0);
+
+		// not spill
+		List<Long> expected = insertMulti(buffer, 100);
+		assertEquals(buffer.size(), 100);
+		assertBuffer(expected, buffer);
+		buffer.reset();
+
+		// spill
+		expected = insertMulti(buffer, 2500);
+		assertEquals(buffer.size(), 2500);
+		assertBuffer(expected, buffer);
+
+		buffer.close();
+	}
+
+	@Test
+	public void testBufferResetWithSpill() throws Exception {
+		int inMemoryThreshold = 20;
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		// spill
+		List<Long> expected = insertMulti(buffer, 2500);
+		assertEquals(buffer.size(), 2500);
+		assertBuffer(expected, buffer);
+		buffer.reset();
+
+		// spill, but not read the values
+		insertMulti(buffer, 2500);
+		buffer.newIterator();
+		assertEquals(buffer.size(), 2500);
+		buffer.reset();
+
+		// not spill
+		expected = insertMulti(buffer, inMemoryThreshold / 2);
+		assertBuffer(expected, buffer);
+		buffer.reset();
+		assertEquals(buffer.size(), 0);
+
+		// less
+		expected = insertMulti(buffer, 100);
+		assertEquals(buffer.size(), 100);
+		assertBuffer(expected, buffer);
+		buffer.reset();
+
+		buffer.close();
+	}
+
+	@Test
+	public void testHugeRecord() throws Exception {
+		thrown.expect(IOException.class);
+		try (ResettableExternalBuffer buffer = new ResettableExternalBuffer(
+				memManager, ioManager,
+				memManager.allocatePages(this, 3 * DEFAULT_PAGE_SIZE / memManager.getPageSize()),
+				new BinaryRowSerializer(1),
+				false)) {
+			writeHuge(buffer, 10);
+			writeHuge(buffer, 50000);
+		}
+	}
+
+	@Test
+	public void testRandomAccessLess() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 100;
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertEquals(buffer.getSpillChannels().size(), 0);
+
+		// repeat random access
+		List<Integer> beginPos = new ArrayList<>();
+		for (int i = 0; i < buffer.size(); i++) {
+			beginPos.add(i);
+		}
+		Collections.shuffle(beginPos);
+		for (int i = 0; i < buffer.size(); i++) {
+			assertRandomAccess(expected, buffer, beginPos.get(i));
+		}
+
+		buffer.close();
+	}
+
+	@Test
+	public void testRandomAccessSpill() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 5000;
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertTrue(buffer.getSpillChannels().size() > 0);
+
+		// repeat random access
+		List<Integer> beginPos = new ArrayList<>();
+		for (int i = 0; i < buffer.size(); i++) {
+			beginPos.add(i);
+		}
+		Collections.shuffle(beginPos);
+		for (int i = 0; i < buffer.size(); i++) {
+			assertRandomAccess(expected, buffer, beginPos.get(i));
+		}
+
+		buffer.close();
+	}
+
+	@Test
+	public void testBufferResetWithSpillAndRandomAccess() throws Exception {
+		final int tries = 100;
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		// spill, random access and reset twice
+		List<Long> expected;
+		for (int i = 0; i < 2; i++) {
+			expected = insertMulti(buffer, 2500);
+			assertEquals(buffer.size(), 2500);
+			for (int j = 0; j < tries; j++) {
+				assertRandomAccess(expected, buffer);
+			}
+			buffer.reset();
+		}
+
+		// spill, but not read the values
+		insertMulti(buffer, 2500);
+		buffer.newIterator();
+		assertEquals(buffer.size(), 2500);
+		buffer.reset();
+
+		// not spill
+		expected = insertMulti(buffer, 10);
+		for (int i = 0; i < tries; i++) {
+			assertRandomAccess(expected, buffer);
+		}
+		buffer.reset();
+		assertEquals(buffer.size(), 0);
+
+		// less
+		expected = insertMulti(buffer, 100);
+		assertEquals(buffer.size(), 100);
+		for (int i = 0; i < tries; i++) {
+			assertRandomAccess(expected, buffer);
+		}
+		buffer.reset();
+
+		buffer.close();
+	}
+
+	@Test
+	public void testMultiColumnFixedLengthRandomAccessLess() throws Exception {
+		testMultiColumnRandomAccessLess(multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
+	}
+
+	@Test
+	public void testMultiColumnFixedLengthRandomAccessSpill() throws Exception {
+		testMultiColumnRandomAccessSpill(multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
+	}
+
+	@Test
+	public void testBufferResetWithSpillAndMultiColumnFixedLengthRandomAccess() throws Exception {
+		testBufferResetWithSpillAndMultiColumnRandomAccess(multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
+	}
+
+	@Test
+	public void testMultiColumnVariableLengthRandomAccessLess() throws Exception {
+		testMultiColumnRandomAccessLess(multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
+	}
+
+	@Test
+	public void testMultiColumnVariableLengthRandomAccessSpill() throws Exception {
+		testMultiColumnRandomAccessSpill(multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
+	}
+
+	@Test
+	public void testBufferResetWithSpillAndMultiColumnVariableLengthRandomAccess() throws Exception {
+		testBufferResetWithSpillAndMultiColumnRandomAccess(multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
+	}
+
+	@Test
+	public void testIteratorOnFixedLengthEmptyBuffer() throws Exception {
+		testIteratorOnMultiColumnEmptyBuffer(multiColumnFixedLengthSerializer, true);
+	}
+
+	@Test
+	public void testFixedLengthRandomAccessOutOfRange() throws Exception {
+		testRandomAccessOutOfRange(multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
+	}
+
+	@Test
+	public void testIteratorOnVariableLengthEmptyBuffer() throws Exception {
+		testIteratorOnMultiColumnEmptyBuffer(multiColumnVariableLengthSerializer, false);
+	}
+
+	@Test
+	public void testVariableLengthRandomAccessOutOfRange() throws Exception {
+		testRandomAccessOutOfRange(multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
+	}
+
+	@Test
+	public void testIteratorReset() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 100;
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertEquals(buffer.getSpillChannels().size(), 0);
+
+		// reset and read
+		ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator();
+		assertBuffer(expected, iterator);
+		iterator.reset();
+		assertBuffer(expected, iterator);
+		iterator.close();
+
+		buffer.close();
+	}
+
+	@Test
+	public void testIteratorResetWithSpill() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 5000; // 16 * 5000
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertTrue(buffer.getSpillChannels().size() > 0);
+
+		// reset and read
+		ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator();
+		assertBuffer(expected, iterator);
+		iterator.reset();
+		assertBuffer(expected, iterator);
+		iterator.close();
+
+		buffer.close();
+	}
+
+	@Test
+	public void testIteratorResetWithRandomAccess() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 100;
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertEquals(buffer.getSpillChannels().size(), 0);
+
+		// repeat random access
+		List<Integer> beginPos = new ArrayList<>();
+		for (int i = 0; i < buffer.size(); i++) {
+			beginPos.add(i);
+		}
+		Collections.shuffle(beginPos);
+		for (int i = 0; i < buffer.size(); i++) {
+			int begin = beginPos.get(i);
+			ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator(begin);
+			assertRandomAccess(expected, iterator, begin);
+			iterator.reset();
+			assertRandomAccess(expected, iterator, begin);
+			iterator.close();
+		}
+
+		buffer.close();
+	}
+
+	@Test
+	public void testIteratorResetWithRandomAccessSpill() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 5000;
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertTrue(buffer.getSpillChannels().size() > 0);
+
+		// repeat random access
+		List<Integer> beginPos = new ArrayList<>();
+		for (int i = 0; i < buffer.size(); i++) {
+			beginPos.add(i);
+		}
+		Collections.shuffle(beginPos);
+		for (int i = 0; i < buffer.size(); i++) {
+			int begin = beginPos.get(i);
+			ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator(begin);
+			assertRandomAccess(expected, iterator, begin);
+			iterator.reset();
+			assertRandomAccess(expected, iterator, begin);
+			iterator.close();
+		}
+
+		buffer.close();
+	}
+
+	@Test
+	public void testMultipleIteratorsLess() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 100;
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertEquals(buffer.getSpillChannels().size(), 0);
+
+		// repeat random access
+		List<Integer> beginPos = new ArrayList<>();
+		for (int i = 0; i < buffer.size(); i++) {
+			beginPos.add(i);
+		}
+		Collections.shuffle(beginPos);
+		for (int i = 0; i < buffer.size(); i++) {
+			int beginIdx = beginPos.get(i);
+			ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator(beginIdx);
+			assertRandomAccess(expected, iterator, beginIdx);
+			if (i % 3 == 0) {
+				iterator.close();
+			}
+		}
+
+		buffer.close();
+	}
+
+	@Test
+	public void testMultipleIteratorsSpill() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 5000;
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertTrue(buffer.getSpillChannels().size() > 0);
+
+		// repeat random access
+		List<Integer> beginPos = new ArrayList<>();
+		for (int i = 0; i < buffer.size(); i++) {
+			beginPos.add(i);
+		}
+		Collections.shuffle(beginPos);
+		for (int i = 0; i < buffer.size(); i++) {
+			int beginIdx = beginPos.get(i);
+			ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator(beginIdx);
+			assertRandomAccess(expected, iterator, beginIdx);
+			if (i % 3 == 0) {
+				iterator.close();
+			}
+		}
+
+		buffer.close();
+	}
+
+	@Test
+	public void testMultipleIteratorsWithIteratorReset() throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
+
+		int number = 5000; // 16 * 5000
+		List<Long> expected = insertMulti(buffer, number);
+		assertEquals(buffer.size(), number);
+		assertBuffer(expected, buffer);
+		assertTrue(buffer.getSpillChannels().size() > 0);
+
+		// reset and read
+		ResettableExternalBuffer.BufferIterator iterator1 = buffer.newIterator();
+		assertBuffer(expected, iterator1);
+		iterator1.reset();
+		assertBuffer(expected, iterator1);
+
+		ResettableExternalBuffer.BufferIterator iterator2 = buffer.newIterator();
+		assertBuffer(expected, iterator2);
+		iterator2.reset();
+		assertBuffer(expected, iterator2);
+
+		iterator1.reset();
+		assertBuffer(expected, iterator1);
+		iterator2.reset();
+		assertBuffer(expected, iterator2);
+
+		iterator1.close();
+
+		iterator2.reset();
+		assertBuffer(expected, iterator2);
+		iterator2.close();
+
+		buffer.close();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testUpdateIteratorFixedLengthLess() throws Exception {
+		testUpdateIteratorLess(multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testUpdateIteratorFixedLengthSpill() throws Exception {
+		testUpdateIteratorSpill(multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testUpdateIteratorVariableLengthLess() throws Exception {
+		testUpdateIteratorLess(multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testUpdateIteratorVariableLengthSpill() throws Exception {
+		testUpdateIteratorSpill(multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
+	}
+
+	private <T extends RowData> void testMultiColumnRandomAccessLess(
+			BinaryRowSerializer serializer, Class<T> clazz, boolean isRowAllInFixedPart) throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2, serializer, isRowAllInFixedPart);
+
+		int number = 30;
+		List<RowData> expected = insertMultiColumn(buffer, number, clazz);
+		assertEquals(buffer.size(), number);
+		assertEquals(buffer.getSpillChannels().size(), 0);
+
+		// repeat random access
+		List<Integer> beginPos = new ArrayList<>();
+		for (int i = 0; i < buffer.size(); i++) {
+			beginPos.add(i);
+		}
+		Collections.shuffle(beginPos);
+		for (int i = 0; i < buffer.size(); i++) {
+			assertMultiColumnRandomAccess(expected, buffer, beginPos.get(i));
+		}
+
+		buffer.close();
+	}
+
+	private <T extends RowData> void testMultiColumnRandomAccessSpill(
+			BinaryRowSerializer serializer, Class<T> clazz, boolean isRowAllInFixedPart) throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2, serializer, isRowAllInFixedPart);
+
+		int number = 4000;
+		List<RowData> expected = insertMultiColumn(buffer, number, clazz);
+		assertEquals(buffer.size(), number);
+		assertTrue(buffer.getSpillChannels().size() > 0);
+
+		// repeat random access
+		List<Integer> beginPos = new ArrayList<>();
+		for (int i = 0; i < buffer.size(); i++) {
+			beginPos.add(i);
+		}
+		Collections.shuffle(beginPos);
+		for (int i = 0; i < buffer.size(); i++) {
+			assertMultiColumnRandomAccess(expected, buffer, beginPos.get(i));
+		}
+
+		buffer.close();
+	}
+
+	private <T extends RowData> void testBufferResetWithSpillAndMultiColumnRandomAccess(
+			BinaryRowSerializer serializer, Class<T> clazz, boolean isRowAllInFixedPart) throws Exception {
+		final int tries = 100;
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2, serializer, isRowAllInFixedPart);
+
+		// spill, random access and reset twice
+		List<RowData> expected;
+		for (int i = 0; i < 2; i++) {
+			expected = insertMultiColumn(buffer, 1500, clazz);
+			assertEquals(buffer.size(), 1500);
+			for (int j = 0; j < tries; j++) {
+				assertMultiColumnRandomAccess(expected, buffer);
+			}
+			buffer.reset();
+		}
+
+		// spill, but not read the values
+		insertMultiColumn(buffer, 1500, clazz);
+		buffer.newIterator();
+		assertEquals(buffer.size(), 1500);
+		buffer.reset();
+
+		// not spill
+		expected = insertMultiColumn(buffer, 10, clazz);
+		for (int i = 0; i < tries; i++) {
+			assertMultiColumnRandomAccess(expected, buffer);
+		}
+		buffer.reset();
+		assertEquals(buffer.size(), 0);
+
+		// less
+		expected = insertMultiColumn(buffer, 30, clazz);
+		assertEquals(buffer.size(), 30);
+		for (int i = 0; i < tries; i++) {
+			assertMultiColumnRandomAccess(expected, buffer);
+		}
+		buffer.reset();
+
+		buffer.close();
+	}
+
+	private void testIteratorOnMultiColumnEmptyBuffer(
+			BinaryRowSerializer serializer, boolean isRowAllInFixedPart) throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2, serializer, isRowAllInFixedPart);
+
+		ResettableExternalBuffer.BufferIterator iterator;
+		buffer.complete();
+		iterator = buffer.newIterator(0);
+		assertFalse(iterator.advanceNext());
+		iterator = buffer.newIterator(random.nextInt(Integer.MAX_VALUE));
+		assertFalse(iterator.advanceNext());
+
+		buffer.close();
+	}
+
+	private <T extends RowData> void testRandomAccessOutOfRange(
+			BinaryRowSerializer serializer, Class<T> clazz, boolean isRowAllInFixedPart) throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2, serializer, isRowAllInFixedPart);
+
+		int number = 100;
+		List<RowData> expected = insertMultiColumn(buffer, number, clazz);
+		assertEquals(buffer.size(), number);
+		assertMultiColumnRandomAccess(expected, buffer, 0);
+
+		ResettableExternalBuffer.BufferIterator iterator;
+		iterator = buffer.newIterator(number);
+		assertFalse(iterator.advanceNext());
+		iterator = buffer.newIterator(number + random.nextInt(Integer.MAX_VALUE));
+		assertFalse(iterator.advanceNext());
+		iterator = buffer.newIterator(random.nextInt(number));
+		assertTrue(iterator.advanceNext());
+
+		buffer.close();
+	}
+
+	private <T extends RowData> void testUpdateIteratorLess(
+			BinaryRowSerializer serializer, Class<T> clazz, boolean isRowAllInFixedPart) throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2, serializer, isRowAllInFixedPart);
+
+		int number = 20;
+		int iters = 3;
+
+		List<RowData> expected = new ArrayList<>();
+		List<ResettableExternalBuffer.BufferIterator> iterators = new ArrayList<>();
+
+		for (int i = 0; i < iters; i++) {
+			iterators.add(buffer.newIterator());
+		}
+
+		for (int i = 0; i < number; i++) {
+			RowData data = clazz.newInstance();
+			data.insertIntoBuffer(buffer);
+			expected.add(data);
+
+			for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+				assertTrue(iterator.advanceNext());
+				BinaryRow row = iterator.getRow();
+				data.checkSame(row);
+
+				assertFalse(iterator.advanceNext());
+			}
+		}
+
+		for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+			iterator.reset();
+		}
+
+		for (int i = 0; i < number; i++) {
+			for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+				assertTrue(iterator.advanceNext());
+				BinaryRow row = iterator.getRow();
+				expected.get(i).checkSame(row);
+			}
+		}
+
+		for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+			iterator.close();
+		}
+
+		assertMultiColumnRandomAccess(expected, buffer);
+
+		buffer.close();
+	}
+
+	private <T extends RowData> void testUpdateIteratorSpill(
+			BinaryRowSerializer serializer, Class<T> clazz, boolean isRowAllInFixedPart) throws Exception {
+		ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2, serializer, isRowAllInFixedPart);
+
+		int number = 100;
+		int step = 20;
+		int iters = 3;
+
+		List<RowData> expected = new ArrayList<>();
+		List<RowData> smallExpected = new ArrayList<>();
+		List<ResettableExternalBuffer.BufferIterator> iterators = new ArrayList<>();
+
+		for (int i = 0; i < iters; i++) {
+			iterators.add(buffer.newIterator());
+		}
+
+		for (int i = 0; i < number; i++) {
+			smallExpected.clear();
+			for (int j = 0; j < step; j++) {
+				RowData data = clazz.newInstance();
+				data.insertIntoBuffer(buffer);
+				expected.add(data);
+				smallExpected.add(data);
+			}
+
+			for (int j = 0; j < step; j++) {
+				for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+					assertTrue(iterator.advanceNext());
+					BinaryRow row = iterator.getRow();
+					smallExpected.get(j).checkSame(row);
+				}
+			}
+			for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+				assertFalse(iterator.advanceNext());
+			}
+		}
+
+		for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+			iterator.reset();
+		}
+
+		for (int i = 0; i < number * step; i++) {
+			for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+				assertTrue(iterator.advanceNext());
+				BinaryRow row = iterator.getRow();
+				expected.get(i).checkSame(row);
+			}
+		}
+
+		for (ResettableExternalBuffer.BufferIterator iterator : iterators) {
+			iterator.close();
+		}
+
+		assertMultiColumnRandomAccess(expected, buffer);
+
+		buffer.close();
+	}
+
+	private void writeHuge(ResettableExternalBuffer buffer, int size) throws IOException {
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.reset();
+		writer.writeString(0, BinaryString.fromString(RandomStringUtils.random(size)));
+		writer.complete();
+		buffer.add(row);
+	}
+
+	private void assertBuffer(List<Long> expected, ResettableExternalBuffer buffer) {
+		ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator();
+		assertBuffer(expected, iterator);
+		iterator.close();
+	}
+
+	private void assertBuffer(
+			List<Long> expected, ResettableExternalBuffer.BufferIterator iterator
+	) {
+		List<Long> values = new ArrayList<>();
+		while (iterator.advanceNext()) {
+			values.add(iterator.getRow().getLong(0));
+		}
+		assertEquals(expected, values);
+	}
+
+	private List<Long> insertMulti(ResettableExternalBuffer buffer, int cnt) throws IOException {
+		ArrayList<Long> expected = new ArrayList<>(cnt);
+		insertMulti(buffer, cnt, expected);
+		buffer.complete();
+		return expected;
+	}
+
+	private void insertMulti(ResettableExternalBuffer buffer, int cnt,
+			List<Long> expected) throws IOException {
+		for (int i = 0; i < cnt; i++) {
+			expected.add(randomInsert(buffer));
+		}
+	}
+
+	private long randomInsert(ResettableExternalBuffer buffer) throws IOException {
+		long l = random.nextLong();
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.reset();
+		writer.writeLong(0, l);
+		writer.complete();
+		buffer.add(row);
+		return l;
+	}
+
+	private void assertRandomAccess(List<Long> expected, ResettableExternalBuffer buffer) {
+		int begin = random.nextInt(buffer.size());
+		assertRandomAccess(expected, buffer, begin);
+	}
+
+	private void assertRandomAccess(List<Long> expected, ResettableExternalBuffer buffer,
+			int begin) {
+		ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator(begin);
+		assertRandomAccess(expected, iterator, begin);
+		iterator.close();
+	}
+
+	private void assertRandomAccess(List<Long> expected,
+			ResettableExternalBuffer.BufferIterator iterator, int begin) {
+		List<Long> values = new ArrayList<>();
+		while (iterator.advanceNext()) {
+			values.add(iterator.getRow().getLong(0));
+		}
+		assertEquals(expected.subList(begin, expected.size()), values);
+	}
+
+	private <T extends RowData> List<RowData> insertMultiColumn(
+			ResettableExternalBuffer buffer, int cnt, Class<T> clazz)
+			throws IOException, IllegalAccessException, InstantiationException {
+		ArrayList<RowData> expected = new ArrayList<>(cnt);
+		insertMultiColumn(buffer, cnt, expected, clazz);
+		buffer.complete();
+		return expected;
+	}
+
+	private <T extends RowData> void insertMultiColumn(
+			ResettableExternalBuffer buffer, int cnt, List<RowData> expected, Class<T> clazz)
+			throws IOException, IllegalAccessException, InstantiationException {
+		for (int i = 0; i < cnt; i++) {
+			RowData data = clazz.newInstance();
+			data.insertIntoBuffer(buffer);
+			expected.add(data);
+		}
+		buffer.complete();
+	}
+
+	private void assertMultiColumnRandomAccess(List<RowData> expected,
+			ResettableExternalBuffer buffer) {
+		int begin = random.nextInt(buffer.size());
+		assertMultiColumnRandomAccess(expected, buffer, begin);
+	}
+
+	private void assertMultiColumnRandomAccess(List<RowData> expected,
+			ResettableExternalBuffer buffer, int begin) {
+		ResettableExternalBuffer.BufferIterator iterator = buffer.newIterator(begin);
+		for (int i = begin; i < buffer.size(); i++) {
+			assertTrue(iterator.advanceNext());
+			expected.get(i).checkSame(iterator.getRow());
+		}
+	}
+
+	private interface RowData {
+		void insertIntoBuffer(ResettableExternalBuffer buffer) throws IOException;
+
+		void checkSame(BinaryRow row);
+	}
+
+	private static class FixedLengthRowData implements RowData {
+		private boolean col0;
+		private long col1;
+		private int col2;
+		private Random random;
+
+		FixedLengthRowData() {
+			random = new Random();
+			col0 = random.nextBoolean();
+			col1 = random.nextLong();
+			col2 = random.nextInt();
+		}
+
+		@Override
+		public void insertIntoBuffer(ResettableExternalBuffer buffer) throws IOException {
+			BinaryRow row = new BinaryRow(3);
+			BinaryRowWriter writer = new BinaryRowWriter(row);
+			writer.reset();
+			writer.writeBoolean(0, col0);
+			writer.writeLong(1, col1);
+			writer.writeInt(2, col2);
+			writer.complete();
+			buffer.add(row);
+		}
+
+		@Override
+		public void checkSame(BinaryRow row) {
+			assertEquals(col0, row.getBoolean(0));
+			assertEquals(col1, row.getLong(1));
+			assertEquals(col2, row.getInt(2));
+		}
+	}
+
+	private static class VariableLengthRowData implements RowData {
+		private boolean col0;
+		private long col1;
+		private BinaryString col2;
+		private int col3;
+		private BinaryString col4;
+		private Random random;
+
+		public VariableLengthRowData() {
+			random = new Random();
+			col0 = random.nextBoolean();
+			col1 = random.nextLong();
+			col2 = BinaryString.fromString(RandomStringUtils.random(random.nextInt(50) + 1));
+			col3 = random.nextInt();
+			col4 = BinaryString.fromString(RandomStringUtils.random(random.nextInt(50) + 1));
+		}
+
+		@Override
+		public void insertIntoBuffer(ResettableExternalBuffer buffer) throws IOException {
+			BinaryRow row = new BinaryRow(5);
+			BinaryRowWriter writer = new BinaryRowWriter(row);
+			writer.reset();
+			writer.writeBoolean(0, col0);
+			writer.writeLong(1, col1);
+			writer.writeString(2, col2);
+			writer.writeInt(3, col3);
+			writer.writeString(4, col4);
+			writer.complete();
+			buffer.add(row);
+		}
+
+		@Override
+		public void checkSame(BinaryRow row) {
+			assertEquals(col0, row.getBoolean(0));
+			assertEquals(col1, row.getLong(1));
+			assertEquals(col2, row.getString(2));
+			assertEquals(col3, row.getInt(3));
+			assertEquals(col4, row.getString(4));
+		}
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce ResettableExternalBuffer:
A resettable external buffer for binary row. It stores records in memory and spill to disk when memory is not enough. When the spill is completed, the records are written to memory again. The returned iterator reads the data in write order (read spilled records first).
1.It supports infinite length.
2.It can open multiple Iterators.
3.It support new iterator with beginRow.

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
