### PR TITLE
[FLINK-12042][StateBackends] Fix RocksDBStateBackend's mistaken usage of default filesystem

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotDirectory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotDirectory.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.fs.Path;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -154,11 +155,11 @@ public abstract class SnapshotDirectory {
 	}
 
 	/**
-	 * Creates a temporary snapshot directory for the given path. This will always return "null" as result of
+	 * Creates a local temporary snapshot directory for the given path. This will always return "null" as result of
 	 * {@link #completeSnapshotAndGetHandle()} and always attempt to delete the underlying directory in
 	 * {@link #cleanup()}.
 	 */
-	public static SnapshotDirectory temporary(@Nonnull Path directory) throws IOException {
+	public static SnapshotDirectory temporary(@Nonnull File directory) throws IOException {
 		return new TemporarySnapshotDirectory(directory);
 	}
 
@@ -172,8 +173,8 @@ public abstract class SnapshotDirectory {
 
 	private static class TemporarySnapshotDirectory extends SnapshotDirectory {
 
-		TemporarySnapshotDirectory(@Nonnull Path directory) throws IOException {
-			super(directory, FileSystem.getLocalFileSystem());
+		TemporarySnapshotDirectory(@Nonnull File directory) throws IOException {
+			super(new Path(directory.toURI()), FileSystem.getLocalFileSystem());
 		}
 
 		@Override
@@ -185,7 +186,7 @@ public abstract class SnapshotDirectory {
 	private static class PermanentSnapshotDirectory extends SnapshotDirectory {
 
 		PermanentSnapshotDirectory(@Nonnull Path directory) throws IOException {
-			super(directory, FileSystem.getLocalFileSystem());
+			super(directory);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotDirectory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotDirectory.java
@@ -173,7 +173,7 @@ public abstract class SnapshotDirectory {
 	private static class TemporarySnapshotDirectory extends SnapshotDirectory {
 
 		TemporarySnapshotDirectory(@Nonnull Path directory) throws IOException {
-			super(directory);
+			super(directory, FileSystem.getLocalFileSystem());
 		}
 
 		@Override
@@ -185,7 +185,7 @@ public abstract class SnapshotDirectory {
 	private static class PermanentSnapshotDirectory extends SnapshotDirectory {
 
 		PermanentSnapshotDirectory(@Nonnull Path directory) throws IOException {
-			super(directory);
+			super(directory, FileSystem.getLocalFileSystem());
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SnapshotDirectoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SnapshotDirectoryTest.java
@@ -95,8 +95,7 @@ public class SnapshotDirectoryTest extends TestLogger {
 		FileSystem.initialize(configuration);
 		File folderB = new File(folderRoot, String.valueOf(UUID.randomUUID()));
 		// only pass the path and leave the scheme missing
-		Path pathB = new Path(folderB.getAbsolutePath());
-		SnapshotDirectory snapshotDirectoryB = SnapshotDirectory.temporary(pathB);
+		SnapshotDirectory snapshotDirectoryB = SnapshotDirectory.temporary(folderB);
 		Assert.assertTrue(snapshotDirectoryB.getFileSystem().equals(FileSystem.getLocalFileSystem()));
 		Assert.assertFalse(snapshotDirectoryB.exists());
 		Assert.assertTrue(folderB.mkdirs());
@@ -213,8 +212,7 @@ public class SnapshotDirectoryTest extends TestLogger {
 		File folderRoot = temporaryFolder.getRoot();
 		File folder = new File(folderRoot, String.valueOf(UUID.randomUUID()));
 		Assert.assertTrue(folder.mkdirs());
-		Path folderPath = new Path(folder.toURI());
-		SnapshotDirectory tmpSnapshotDirectory = SnapshotDirectory.temporary(folderPath);
+		SnapshotDirectory tmpSnapshotDirectory = SnapshotDirectory.temporary(folder);
 		// temporary snapshot directories should not return a handle, because they will be deleted.
 		Assert.assertNull(tmpSnapshotDirectory.completeSnapshotAndGetHandle());
 		// check that the directory is deleted even after we called #completeSnapshotAndGetHandle.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SnapshotDirectoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SnapshotDirectoryTest.java
@@ -89,7 +89,7 @@ public class SnapshotDirectoryTest extends TestLogger {
 		Assert.assertTrue(folderA.delete());
 		Assert.assertFalse(snapshotDirectoryA.exists());
 
-		// ensure that snapshot directory will always use the local file system not the default file system
+		// ensure that snapshot directory will always use the local file system instead of the default file system
 		Configuration configuration = new Configuration();
 		configuration.setString(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "nonexistfs:///");
 		FileSystem.initialize(configuration);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SnapshotDirectoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SnapshotDirectoryTest.java
@@ -98,6 +98,11 @@ public class SnapshotDirectoryTest extends TestLogger {
 		Path pathB = new Path(folderB.getAbsolutePath());
 		SnapshotDirectory snapshotDirectoryB = SnapshotDirectory.temporary(pathB);
 		Assert.assertTrue(snapshotDirectoryB.getFileSystem().equals(FileSystem.getLocalFileSystem()));
+		Assert.assertFalse(snapshotDirectoryB.exists());
+		Assert.assertTrue(folderB.mkdirs());
+		Assert.assertTrue(snapshotDirectoryB.exists());
+		Assert.assertTrue(folderB.delete());
+		Assert.assertFalse(snapshotDirectoryB.exists());
 		// restore the FileSystem configuration
 		FileSystem.initialize(new Configuration());
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -210,8 +210,7 @@ public class RocksIncrementalSnapshotStrategy<K> extends RocksDBSnapshotStrategy
 		} else {
 			// create a "temporary" snapshot directory because local recovery is inactive.
 			File snapshotDir = new File(instanceBasePath, "chk-" + checkpointId);
-			Path path = new Path(snapshotDir.toURI());
-			return SnapshotDirectory.temporary(path);
+			return SnapshotDirectory.temporary(snapshotDir);
 		}
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -209,7 +209,8 @@ public class RocksIncrementalSnapshotStrategy<K> extends RocksDBSnapshotStrategy
 			}
 		} else {
 			// create a "temporary" snapshot directory because local recovery is inactive.
-			Path path = new Path(instanceBasePath.getAbsolutePath(), "chk-" + checkpointId);
+			File snapshotDir = new File(instanceBasePath, "chk-" + checkpointId);
+			Path path = new Path(snapshotDir.toURI());
 			return SnapshotDirectory.temporary(path);
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

The scheme of SnapshotDirectory is not specified when RocksDBStateBackend is performing incremental checkpoints with local recovery disabled, and this will lead to IllegalStateException (for 1.6.4) when the async task tries to check the file existence using the default system, if `fs.default-scheme` is specified to filesystems other than local filesystem.

We should always stick to local directories for snapshot no matter what `fs.default-scheme` is set to.

## Brief change log

- *Use URI instead of the absolute path of local path to initialize SnapshotDirectory*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
