### PR TITLE
[FLINK-12045] [core, State Backends] Support force migration between incompatible state schemas/serializers

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -98,6 +98,9 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	@Nonnull
 	private StateTtlConfig ttlConfig = StateTtlConfig.DISABLED;
 
+	/** Whether do force migration when state serializer compatibility is unknown. */
+	private boolean forceMigrationIfSchemaCompatibilityUnknown = false;
+
 	/** The default value returned by the state when no other value is bound to a key. */
 	@Nullable
 	protected transient T defaultValue;
@@ -290,6 +293,14 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 			// we can drop the type info now, no longer needed
 			typeInfo  = null;
 		}
+	}
+
+	public void setForceMigrationIfSchemaCompatibilityUnknown(boolean forceMigrationIfSchemaCompatibilityUnknown) {
+		this.forceMigrationIfSchemaCompatibilityUnknown = forceMigrationIfSchemaCompatibilityUnknown;
+	}
+
+	public boolean isForceMigrationIfSchemaCompatibilityUnknown() {
+		return forceMigrationIfSchemaCompatibilityUnknown;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -361,4 +361,12 @@ public abstract class AbstractKeyedStateBackend<K> implements
 		return false;
 	}
 
+	/**
+	 * Returns the meta info of the state.
+	 *
+	 * @param stateName name of the state.
+	 * @return meta info of the state.
+	 */
+	@VisibleForTesting
+	public abstract RegisteredKeyValueStateBackendMetaInfo getRegisteredStateMetaInfo(String stateName);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -28,7 +28,6 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.state.Keyed;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.PriorityComparable;
 import org.apache.flink.runtime.state.PriorityComparator;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
@@ -159,6 +160,11 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@Override
 	public boolean requiresLegacySynchronousTimerSnapshots() {
 		return false;
+	}
+
+	@Override
+	public RegisteredKeyValueStateBackendMetaInfo getRegisteredStateMetaInfo(String stateName) {
+		return null;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
@@ -194,6 +194,13 @@ public class TestType implements HeapPriorityQueueElement, PriorityComparable<Te
 		}
 	}
 
+	/**
+	 * A serializer whose compatibility is marked as unknown but actually compatible after migration,
+	 * to test force migration.
+	 */
+	public static class TestTypeSerializerForForceMigration extends V2TestTypeSerializer {
+	}
+
 	public static abstract class TestTypeSerializerBase extends TypeSerializer<TestType> {
 
 		private static final long serialVersionUID = 256299937766275871L;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/V1TestTypeSerializerSnapshot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/V1TestTypeSerializerSnapshot.java
@@ -40,6 +40,8 @@ public class V1TestTypeSerializerSnapshot implements TypeSerializerSnapshot<Test
 	public TypeSerializerSchemaCompatibility<TestType> resolveSchemaCompatibility(TypeSerializer<TestType> newSerializer) {
 		if (newSerializer instanceof TestType.V1TestTypeSerializer) {
 			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else if (newSerializer instanceof TestType.TestTypeSerializerForForceMigration) {
+			return TypeSerializerSchemaCompatibility.unknown();
 		} else if (newSerializer instanceof TestType.V2TestTypeSerializer) {
 			return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
 		} else if (newSerializer instanceof TestType.ReconfigurationRequiringTestTypeSerializer) {


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for state schema force migration between incompatible serializers, and is a feature designed for advanced users.

## Brief change log

* Add a `forceMigrationIfSchemaIncompatible` field in `StateDescriptor`
* Allow state migration even if serializer compatible check returns `INCOMPATIBLE` when `forceMigrationIfSchemaIncompatible` set to true, in both rocksdb and heap backend


## Verifying this change

This change added tests and can be verified as follows:
* Added a `testForceMigration` case in `StateBackendMigrationTestBase`
* Added check to assert new serializer is registered after state migration in `StateBackendMigrationTestBase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes**)
     - Added a `forceMigrationIfSchemaIncompatible` field and setter/getter methods in `StateDescriptor`
  - The serializers: (**yes**)
     - Allows incompatible serializers to do state migration if user set to
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**not documented**)
     * Plan to document the usage of force migration in a separate PR after verified
