### PR TITLE
[FLINK-12051][runtime][tests] Wait for TaskExecutor to be started

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1152,7 +1152,7 @@ public class TaskExecutorTest extends TestLogger {
 			.setTaskStateManager(localStateStoresManager)
 			.build();
 
-		final TaskExecutor taskExecutor = new TaskExecutor(
+		final TestingTaskExecutor taskExecutor = new TestingTaskExecutor(
 			rpc,
 			taskManagerConfiguration,
 			haServices,
@@ -1165,6 +1165,7 @@ public class TaskExecutorTest extends TestLogger {
 
 		try {
 			taskExecutor.start();
+			taskExecutor.waitUntilStarted();
 
 			ArgumentCaptor<JobLeaderListener> jobLeaderListenerArgumentCaptor = ArgumentCaptor.forClass(JobLeaderListener.class);
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes an issue in the `TaskExecutorTest` where we did not wait for the `TaskExecutor` to finishing starting before verifying behavior. Since the introduction of `TaskExecutor#onStart` `TaskExecutor#start` only kicks off the asynchronous startup of the `TaskExecutor`, whereas previously this asynchronous was done within `start` itself.
