### PR TITLE
[FLINK-12043][core] Process unreadble NPE without any hint

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparator.java
@@ -22,6 +22,7 @@ import static java.lang.Math.min;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.base.BooleanComparator;
+import org.apache.flink.util.Preconditions;
 
 @Internal
 public class BooleanPrimitiveArrayComparator extends PrimitiveArrayComparator<boolean[], BooleanComparator> {
@@ -40,6 +41,8 @@ public class BooleanPrimitiveArrayComparator extends PrimitiveArrayComparator<bo
 
 	@Override
 	public int compare(boolean[] first, boolean[] second) {
+		Preconditions.checkNotNull(first, "The first array must not be null");
+		Preconditions.checkNotNull(second, "The second array must not be null");
 		for (int x = 0; x < min(first.length, second.length); x++) {
 			int cmp = (second[x] == first[x] ? 0 : (first[x] ? 1 : -1));
 			if (cmp != 0) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A serializer for boolean arrays.
@@ -51,6 +52,7 @@ public final class BooleanPrimitiveArraySerializer extends TypeSerializerSinglet
 
 	@Override
 	public boolean[] copy(boolean[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		boolean[] copy = new boolean[from.length];
 		System.arraycopy(from, 0, copy, 0, from.length);
 		return copy;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparator.java
@@ -22,6 +22,7 @@ import static java.lang.Math.min;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.base.ByteComparator;
+import org.apache.flink.util.Preconditions;
 
 @Internal
 public class BytePrimitiveArrayComparator extends PrimitiveArrayComparator<byte[], ByteComparator> {
@@ -40,6 +41,8 @@ public class BytePrimitiveArrayComparator extends PrimitiveArrayComparator<byte[
 
 	@Override
 	public int compare(byte[] first, byte[] second) {
+		Preconditions.checkNotNull(first, "The first array must not be null");
+		Preconditions.checkNotNull(second, "The second array must not be null");
 		for (int x = 0; x < min(first.length, second.length); x++) {
 			int cmp = first[x] - second[x];
 			if (cmp != 0) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A serializer for byte arrays.
@@ -51,6 +52,7 @@ public final class BytePrimitiveArraySerializer extends TypeSerializerSingleton<
 
 	@Override
 	public byte[] copy(byte[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		byte[] copy = new byte[from.length];
 		System.arraycopy(from, 0, copy, 0, from.length);
 		return copy;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparator.java
@@ -22,6 +22,7 @@ import static java.lang.Math.min;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.base.CharComparator;
+import org.apache.flink.util.Preconditions;
 
 @Internal
 public class CharPrimitiveArrayComparator extends PrimitiveArrayComparator<char[], CharComparator> {
@@ -40,6 +41,8 @@ public class CharPrimitiveArrayComparator extends PrimitiveArrayComparator<char[
 
 	@Override
 	public int compare(char[] first, char[] second) {
+		Preconditions.checkNotNull(first, "The first array must not be null");
+		Preconditions.checkNotNull(second, "The second array must not be null");
 		for (int x = 0; x < min(first.length, second.length); x++) {
 			int cmp = first[x] - second[x];
 			if (cmp != 0) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A serializer for char arrays.
@@ -51,6 +52,7 @@ public final class CharPrimitiveArraySerializer extends TypeSerializerSingleton<
 
 	@Override
 	public char[] copy(char[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		char[] copy = new char[from.length];
 		System.arraycopy(from, 0, copy, 0, from.length);
 		return copy;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparator.java
@@ -22,6 +22,7 @@ import static java.lang.Math.min;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.base.DoubleComparator;
+import org.apache.flink.util.Preconditions;
 
 @Internal
 public class DoublePrimitiveArrayComparator extends PrimitiveArrayComparator<double[], DoubleComparator> {
@@ -41,6 +42,8 @@ public class DoublePrimitiveArrayComparator extends PrimitiveArrayComparator<dou
 
 	@Override
 	public int compare(double[] first, double[] second) {
+		Preconditions.checkNotNull(first, "The first array must not be null");
+		Preconditions.checkNotNull(second, "The second array must not be null");
 		for (int x = 0; x < min(first.length, second.length); x++) {
 			int cmp = Double.compare(first[x], second[x]);
 			if (cmp != 0) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A serializer for double arrays.
@@ -51,6 +52,7 @@ public final class DoublePrimitiveArraySerializer extends TypeSerializerSingleto
 	
 	@Override
 	public double[] copy(double[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		double[] copy = new double[from.length];
 		System.arraycopy(from, 0, copy, 0, from.length);
 		return copy;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparator.java
@@ -22,6 +22,7 @@ import static java.lang.Math.min;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.base.FloatComparator;
+import org.apache.flink.util.Preconditions;
 
 @Internal
 public class FloatPrimitiveArrayComparator extends PrimitiveArrayComparator<float[], FloatComparator> {
@@ -40,6 +41,8 @@ public class FloatPrimitiveArrayComparator extends PrimitiveArrayComparator<floa
 
 	@Override
 	public int compare(float[] first, float[] second) {
+		Preconditions.checkNotNull(first, "The first array must not be null");
+		Preconditions.checkNotNull(second, "The second array must not be null");
 		for (int x = 0; x < min(first.length, second.length); x++) {
 			int cmp = Float.compare(first[x], second[x]);
 			if (cmp != 0) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A serializer for float arrays.
@@ -51,6 +52,7 @@ public final class FloatPrimitiveArraySerializer extends TypeSerializerSingleton
 
 	@Override
 	public float[] copy(float[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		float[] copy = new float[from.length];
 		System.arraycopy(from, 0, copy, 0, from.length);
 		return copy;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparator.java
@@ -22,6 +22,7 @@ import static java.lang.Math.min;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.base.IntComparator;
+import org.apache.flink.util.Preconditions;
 
 @Internal
 public class IntPrimitiveArrayComparator extends PrimitiveArrayComparator<int[], IntComparator> {
@@ -40,6 +41,8 @@ public class IntPrimitiveArrayComparator extends PrimitiveArrayComparator<int[],
 
 	@Override
 	public int compare(int[] first, int[] second) {
+		Preconditions.checkNotNull(first, "The first array must not be null");
+		Preconditions.checkNotNull(second, "The second array must not be null");
 		for (int x = 0; x < min(first.length, second.length); x++) {
 			int cmp = first[x] - second[x];
 			if (cmp != 0) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A serializer for int arrays.
@@ -51,6 +52,7 @@ public class IntPrimitiveArraySerializer extends TypeSerializerSingleton<int[]>{
 
 	@Override
 	public int[] copy(int[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		int[] copy = new int[from.length];
 		System.arraycopy(from, 0, copy, 0, from.length);
 		return copy;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparator.java
@@ -22,6 +22,7 @@ import static java.lang.Math.min;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.base.LongComparator;
+import org.apache.flink.util.Preconditions;
 
 @Internal
 public class LongPrimitiveArrayComparator extends PrimitiveArrayComparator<long[], LongComparator> {
@@ -40,6 +41,8 @@ public class LongPrimitiveArrayComparator extends PrimitiveArrayComparator<long[
 
 	@Override
 	public int compare(long[] first, long[] second) {
+		Preconditions.checkNotNull(first, "The first array must not be null");
+		Preconditions.checkNotNull(second, "The second array must not be null");
 		for (int x = 0; x < min(first.length, second.length); x++) {
 			int cmp = first[x] < second[x] ? -1 : (first[x] == second[x] ? 0 : 1);
 			if (cmp != 0) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A serializer for long arrays.
@@ -51,6 +52,7 @@ public final class LongPrimitiveArraySerializer extends TypeSerializerSingleton<
 
 	@Override
 	public long[] copy(long[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		long[] result = new long[from.length];
 		System.arraycopy(from, 0, result, 0, from.length);
 		return result;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparator.java
@@ -22,6 +22,7 @@ import static java.lang.Math.min;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.base.ShortComparator;
+import org.apache.flink.util.Preconditions;
 
 @Internal
 public class ShortPrimitiveArrayComparator extends PrimitiveArrayComparator<short[], ShortComparator> {
@@ -40,6 +41,8 @@ public class ShortPrimitiveArrayComparator extends PrimitiveArrayComparator<shor
 
 	@Override
 	public int compare(short[] first, short[] second) {
+		Preconditions.checkNotNull(first, "The first array must not be null");
+		Preconditions.checkNotNull(second, "The second array must not be null");
 		for (int x = 0; x < min(first.length, second.length); x++) {
 			int cmp = first[x] - second[x];
 			if (cmp != 0) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A serializer for short arrays.
@@ -51,6 +52,7 @@ public final class ShortPrimitiveArraySerializer extends TypeSerializerSingleton
 
 	@Override
 	public short[] copy(short[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		short[] copy = new short[from.length];
 		System.arraycopy(from, 0, copy, 0, from.length);
 		return copy;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializer.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.StringValue;
+import org.apache.flink.util.Preconditions;
 
 
 /**
@@ -53,6 +54,7 @@ public final class StringArraySerializer extends TypeSerializerSingleton<String[
 
 	@Override
 	public String[] copy(String[] from) {
+		Preconditions.checkNotNull(from, "The from array must not be null.");
 		String[] target = new String[from.length];
 		System.arraycopy(from, 0, target, 0, from.length);
 		return target;


### PR DESCRIPTION
## What is the purpose of the change
This pr process the array NullPointerException in package "org.apache.flink.api.common.typeutils.base.array"  in  serializer and comparator class.

## Brief change log
  - serializer's `copy(boolean[] from)` method throws IllegalArgumentException explicitly 
  - comparator's `compare(boolean[] first, boolean[] second)` method throws IllegalArgumentException explicitly 
 
## Verifying this change
This change is already covered by existing tests in typeutils test of core module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes /** no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes /** no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
