### PR TITLE
[FLINK-12064] [core, State Backends] RocksDBKeyedStateBackend snapshot uses incorrect key serializer if reconfigure happens during restore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackendBuilder.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 public abstract class AbstractKeyedStateBackendBuilder<K>
 	implements StateBackendBuilder<AbstractKeyedStateBackend, BackendBuildingException> {
 	protected final TaskKvStateRegistry kvStateRegistry;
-	protected final TypeSerializer<K> keySerializer;
 	protected final StateSerializerProvider<K> keySerializerProvider;
 	protected final ClassLoader userCodeClassLoader;
 	protected final int numberOfKeyGroups;
@@ -57,7 +56,6 @@ public abstract class AbstractKeyedStateBackendBuilder<K>
 		StreamCompressionDecorator keyGroupCompressionDecorator,
 		CloseableRegistry cancelStreamRegistry) {
 		this.kvStateRegistry = kvStateRegistry;
-		this.keySerializer = keySerializer;
 		this.keySerializerProvider = StateSerializerProvider.fromNewRegisteredSerializer(keySerializer);
 		this.userCodeClassLoader = userCodeClassLoader;
 		this.numberOfKeyGroups = numberOfKeyGroups;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -157,8 +157,6 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 				CustomVoidNamespaceSerializer.INSTANCE,
 				newAccessDescriptorAfterRestore);
 
-			snapshot.discardState();
-
 			// make sure that reading and writing each key state works with the new serializer
 			backend.setCurrentKey(1);
 			Assert.assertEquals(new TestType("foo", 1456), valueState.value());
@@ -171,6 +169,12 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			backend.setCurrentKey(3);
 			Assert.assertEquals(new TestType("hello", 189), valueState.value());
 			valueState.update(new TestType("newValue3", 444));
+
+			// do another snapshot to verify the snapshot logic after migration
+			snapshot = runSnapshot(
+				backend.snapshot(2L, 3L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry);
+			snapshot.discardState();
 		} finally {
 			backend.dispose();
 		}
@@ -266,8 +270,6 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 				CustomVoidNamespaceSerializer.INSTANCE,
 				newAccessDescriptorAfterRestore);
 
-			snapshot.discardState();
-
 			// make sure that reading and writing each key state works with the new serializer
 			backend.setCurrentKey(1);
 			Iterator<TestType> iterable1 = listState.get().iterator();
@@ -289,6 +291,13 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			Assert.assertEquals(new TestType("key-3", 2), iterable3.next());
 			Assert.assertFalse(iterable3.hasNext());
 			listState.add(new TestType("new-key-3", 777));
+
+			// do another snapshot to verify the snapshot logic after migration
+			snapshot = runSnapshot(
+				backend.snapshot(2L, 3L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry);
+			snapshot.discardState();
+
 		} finally {
 			backend.dispose();
 		}
@@ -405,6 +414,10 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			backend.setCurrentKey(new TestType("bar", 456));
 			Assert.assertEquals(5, valueState.value().intValue());
 
+			// do another snapshot to verify the snapshot logic after migration
+			snapshot = runSnapshot(
+				backend.snapshot(2L, 3L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry);
 			snapshot.discardState();
 		} finally {
 			backend.dispose();
@@ -493,6 +506,10 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			backend.setCurrentKey(5);
 			Assert.assertEquals(50, valueState.value().intValue());
 
+			// do another snapshot to verify the snapshot logic after migration
+			snapshot = runSnapshot(
+				backend.snapshot(2L, 3L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry);
 			snapshot.discardState();
 		} finally {
 			backend.dispose();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackendBuilder.java
@@ -72,7 +72,7 @@ public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
 		restoreOperation.restore();
 		return new MockKeyedStateBackend<>(
 			kvStateRegistry,
-			keySerializer,
+			keySerializerProvider.currentSchemaSerializer(),
 			userCodeClassLoader,
 			numberOfKeyGroups,
 			keyGroupRange,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -425,7 +425,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 		RocksDBSnapshotStrategyBase<K> savepointSnapshotStrategy = new RocksFullSnapshotStrategy<>(
 			db,
 			rocksDBResourceGuard,
-			keySerializer,
+			keySerializerProvider.currentSchemaSerializer(),
 			kvStateInformation,
 			keyGroupRange,
 			keyGroupPrefixBytes,
@@ -438,7 +438,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 			checkpointSnapshotStrategy = new RocksIncrementalSnapshotStrategy<>(
 				db,
 				rocksDBResourceGuard,
-				keySerializer,
+				keySerializerProvider.currentSchemaSerializer(),
 				kvStateInformation,
 				keyGroupRange,
 				keyGroupPrefixBytes,


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the issue of `RocksDBKeyedStateBackend` snapshot using incorrect key serializer if reconfigured during restore in `RocksDBKeyedStateBackendBuilder`, which is a regression caused by FLINK-10043. We also reenforce the UT cases to cover the issue scenario.


## Brief change log

Remove `keySerializer` from `AbstractKeyedStateBackendBuilder` and use `keySerializerProvider.currentSchemaSerializer()` instead in `RocksDBKeyedStateBackendBuilder`. For the test case part, perform an additional snapshot after state migration.


## Verifying this change

This change added tests and can be verified as follows:

* Reenforced `StateBackendMigrationTestBase`, adding an additional snapshot after state migration to verify the snapshot part.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (**yes**)
     * This change assures to use correct serializer in snapshot
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes**)
     * This change prevents possible corruption of snapshot data
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
