### PR TITLE
[FLINK-12049][Tests] ClassLoaderUtilsTest fails on Java 9

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ClassLoaderUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ClassLoaderUtil.java
@@ -38,6 +38,9 @@ public final class ClassLoaderUtil {
 	 * 
 	 * <p>NOTE: This method makes a best effort to provide information about the classloader, and
 	 * never throws an exception.</p>
+	 *
+	 * <p>NOTE: Passing {@code ClassLoader.getSystemClassLoader()} on Java 9+ will not return
+	 * anything interesting.
 	 * 
 	 * @param loader The classloader to get the info string for.
 	 * @return The classloader information string.
@@ -102,6 +105,11 @@ public final class ClassLoaderUtil {
 				return "Cannot access classloader info due to an exception.\n"
 						+ ExceptionUtils.stringifyException(t);
 			}
+		}
+		else if (loader == ClassLoader.getSystemClassLoader()) {
+			// this branch is only reachable on Java9+
+			// where the system classloader is no longer a URLClassLoader
+			return "System ClassLoader";
 		}
 		else {
 			return "No user code ClassLoader";


### PR DESCRIPTION


## What is the purpose of the change

Fix error in ClassLoaderUtilsTest#testWithAppClassLoader on Java 9.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
