### PR TITLE
[FLINK-12066] [State Backends] Remove StateSerializerProvider field in keyed state backends

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -53,8 +53,8 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	Closeable,
 	CheckpointListener {
 
-	/** {@link StateSerializerProvider} for our key serializer. */
-	protected final StateSerializerProvider<K> keySerializerProvider;
+	/** The key serializer. */
+	protected final TypeSerializer<K> keySerializer;
 
 	/** Listeners to changes of ({@link #keyContext}). */
 	private final ArrayList<KeySelectionListener<K>> keySelectionListeners;
@@ -102,7 +102,7 @@ public abstract class AbstractKeyedStateBackend<K> implements
 		InternalKeyContext<K> keyContext) {
 		this(
 			kvStateRegistry,
-			StateSerializerProvider.fromNewRegisteredSerializer(keySerializer),
+			keySerializer,
 			userCodeClassLoader,
 			executionConfig,
 			ttlTimeProvider,
@@ -114,7 +114,7 @@ public abstract class AbstractKeyedStateBackend<K> implements
 
 	public AbstractKeyedStateBackend(
 		TaskKvStateRegistry kvStateRegistry,
-		StateSerializerProvider<K> keySerializerProvider,
+		TypeSerializer<K> keySerializer,
 		ClassLoader userCodeClassLoader,
 		ExecutionConfig executionConfig,
 		TtlTimeProvider ttlTimeProvider,
@@ -128,7 +128,7 @@ public abstract class AbstractKeyedStateBackend<K> implements
 		Preconditions.checkArgument(numberOfKeyGroups >= keyGroupRange.getNumberOfKeyGroups(), "The total number of key groups must be at least the number in the key group range assigned to this backend");
 
 		this.kvStateRegistry = kvStateRegistry;
-		this.keySerializerProvider = keySerializerProvider;
+		this.keySerializer = keySerializer;
 		this.userCodeClassLoader = Preconditions.checkNotNull(userCodeClassLoader);
 		this.cancelStreamRegistry = cancelStreamRegistry;
 		this.keyValueStatesByName = new HashMap<>();
@@ -197,7 +197,7 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	 */
 	@Override
 	public TypeSerializer<K> getKeySerializer() {
-		return keySerializerProvider.currentSchemaSerializer();
+		return keySerializer;
 	}
 
 	/**
@@ -268,7 +268,7 @@ public abstract class AbstractKeyedStateBackend<K> implements
 			final TypeSerializer<N> namespaceSerializer,
 			StateDescriptor<S, V> stateDescriptor) throws Exception {
 		checkNotNull(namespaceSerializer, "Namespace serializer");
-		checkNotNull(keySerializerProvider, "State key serializer has not been configured in the config. " +
+		checkNotNull(keySerializer, "State key serializer has not been configured in the config. " +
 				"This operation cannot use partitioned state.");
 
 		InternalKvState<K, ?, ?> kvState = keyValueStatesByName.get(stateDescriptor.getName());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -46,7 +46,6 @@ import org.apache.flink.runtime.state.PriorityComparable;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.SnapshotResult;
-import org.apache.flink.runtime.state.StateSerializerProvider;
 import org.apache.flink.runtime.state.StateSnapshotRestore;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.StateSnapshotTransformers;
@@ -114,7 +113,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	public HeapKeyedStateBackend(
 		TaskKvStateRegistry kvStateRegistry,
-		StateSerializerProvider<K> keySerializerProvider,
+		TypeSerializer<K> keySerializer,
 		ClassLoader userCodeClassLoader,
 		ExecutionConfig executionConfig,
 		TtlTimeProvider ttlTimeProvider,
@@ -128,7 +127,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		InternalKeyContext<K> keyContext) {
 		super(
 			kvStateRegistry,
-			keySerializerProvider,
+			keySerializer,
 			userCodeClassLoader,
 			executionConfig,
 			ttlTimeProvider,
@@ -240,7 +239,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				newStateSerializer,
 				snapshotTransformFactory);
 
-			stateTable = snapshotStrategy.newStateTable(keyContext, newMetaInfo, keySerializerProvider.currentSchemaSerializer());
+			stateTable = snapshotStrategy.newStateTable(keyContext, newMetaInfo, keySerializer);
 			registeredKVStates.put(stateDesc.getName(), stateTable);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
@@ -117,7 +117,7 @@ public class HeapKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
 		}
 		return new HeapKeyedStateBackend<>(
 			kvStateRegistry,
-			keySerializerProvider,
+			keySerializerProvider.currentSchemaSerializer(),
 			userCodeClassLoader,
 			executionConfig,
 			ttlTimeProvider,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -49,7 +49,6 @@ import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.SnapshotResult;
-import org.apache.flink.runtime.state.StateSerializerProvider;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
@@ -200,7 +199,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		DBOptions dbOptions,
 		Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
 		TaskKvStateRegistry kvStateRegistry,
-		StateSerializerProvider<K> keySerializerProvider,
+		TypeSerializer<K> keySerializer,
 		ExecutionConfig executionConfig,
 		TtlTimeProvider ttlTimeProvider,
 		RocksDB db,
@@ -221,7 +220,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		super(
 			kvStateRegistry,
-			keySerializerProvider,
+			keySerializer,
 			userCodeClassLoader,
 			executionConfig,
 			ttlTimeProvider,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -335,7 +335,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 			this.dbOptions,
 			columnFamilyOptionsFactory,
 			this.kvStateRegistry,
-			this.keySerializerProvider,
+			this.keySerializerProvider.currentSchemaSerializer(),
 			this.executionConfig,
 			this.ttlTimeProvider,
 			db,


### PR DESCRIPTION
## What is the purpose of the change

This PR removes the {{StateSerializerProvider}} field in rocksdb and heap keyed backends, as per [discussed](https://github.com/apache/flink/pull/7674#discussion_r257630962) and planed in previous review of FLINK-10043

## Brief change log

* Removed {{StateSerializerProvider}} field from keyed backends
* Introduced a new {{HeapInternalKeyContext}} which allows restore to happen before backend construction in heap backend builder.


## Verifying this change

This change is already covered by existing tests, such as:

* All tests under `org.apache.flink.runtime.state` package
* All tests under `org.apache.flink.runtime.state.heap` package

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
