### PR TITLE
[FLINK-12054][Tests] HBaseConnectorITCase fails on Java 9

### DIFF
--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseTestingClusterAutostarter.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseTestingClusterAutostarter.java
@@ -211,8 +211,10 @@ public class HBaseTestingClusterAutostarter extends TestLogger implements Serial
 
 	private static void addDirectoryToClassPath(File directory) {
 		try {
-			URLClassLoader classLoader = new URLClassLoader(new URL[]{directory.toURI().toURL()});
-			if (!(classLoader instanceof URLClassLoader)) {
+			// Get the classloader actually used by HBaseConfiguration
+			ClassLoader classLoader = HBaseConfiguration.create().getClassLoader();
+			URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{directory.toURI().toURL()}, classLoader);
+			if (!(urlClassLoader instanceof URLClassLoader)) {
 				fail("We should get a URLClassLoader");
 			}
 
@@ -221,7 +223,7 @@ public class HBaseTestingClusterAutostarter extends TestLogger implements Serial
 			method.setAccessible(true);
 
 			// Add the directory where we put the hbase-site.xml to the classpath
-			method.invoke(classLoader, directory.toURI().toURL());
+			method.invoke(urlClassLoader, directory.toURI().toURL());
 		} catch (MalformedURLException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 			fail("Unable to add " + directory + " to classpath because of this exception: " + e.getMessage());
 		}

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseTestingClusterAutostarter.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseTestingClusterAutostarter.java
@@ -211,8 +211,7 @@ public class HBaseTestingClusterAutostarter extends TestLogger implements Serial
 
 	private static void addDirectoryToClassPath(File directory) {
 		try {
-			// Get the classloader actually used by HBaseConfiguration
-			ClassLoader classLoader = HBaseConfiguration.create().getClassLoader();
+			URLClassLoader classLoader = new URLClassLoader(new URL[]{directory.toURI().toURL()});
 			if (!(classLoader instanceof URLClassLoader)) {
 				fail("We should get a URLClassLoader");
 			}


### PR DESCRIPTION


## What is the purpose of the change

Fix the error in HBaseConnectorITCase on Java 9.

## Brief change log

Create a new URLClassLoader with directory.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
