### PR TITLE
[FLINK-12050][Tests] BlockingShutdownTest fails on Java 9

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -256,7 +256,8 @@ public abstract class TestJvmProcess {
 
 		try {
 			Class<? extends Process> clazz = process.getClass();
-			if (clazz.getName().equals("java.lang.UNIXProcess")) {
+			if (clazz.getName().equals("java.lang.UNIXProcess")
+				|| clazz.getName().equals("java.lang.ProcessImpl")) {
 				Field pidField = clazz.getDeclaredField("pid");
 				pidField.setAccessible(true);
 				return pidField.getLong(process);


### PR DESCRIPTION

## What is the purpose of the change

Fix error in BlockingShutdownTest on Java 9.


## Brief change log

Add clazz.getName.equals("java.lang.ProcessImpl") in if condition.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
