### PR TITLE
[FLINK-12067][network] Refactor the constructor of NetworkEnvironment

### DIFF
--- a/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 
@@ -69,8 +70,8 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that {@link TaskManagerServices#calculateNetworkBufferMemory(long, Configuration)} has the same
-	 * result as the shell script.
+	 * Tests that {@link NetworkEnvironmentConfiguration#calculateNetworkBufferMemory(long, Configuration)}
+	 * has the same result as the shell script.
 	 */
 	@Test
 	public void compareNetworkBufShellScriptWithJava() throws Exception {
@@ -200,7 +201,7 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 			Configuration config = getConfig(javaMemMB, useOffHeap, frac, min, max, managedMemSize, managedMemFrac);
 			long totalJavaMemorySize = ((long) javaMemMB) << 20; // megabytes to bytes
 			final int networkBufMB =
-				(int) (TaskManagerServices.calculateNetworkBufferMemory(totalJavaMemorySize, config) >> 20);
+				(int) (NetworkEnvironmentConfiguration.calculateNetworkBufferMemory(totalJavaMemorySize, config) >> 20);
 			// max (exclusive): total - netbuf
 			managedMemSize = Math.min(javaMemMB - networkBufMB - 1, ran.nextInt(Integer.MAX_VALUE));
 		} else {
@@ -226,7 +227,8 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 
 		final long totalJavaMemorySizeMB = config.getLong(KEY_TASKM_MEM_SIZE, 0L);
 
-		long javaNetworkBufMem = TaskManagerServices.calculateNetworkBufferMemory(totalJavaMemorySizeMB << 20, config);
+		long javaNetworkBufMem = NetworkEnvironmentConfiguration.calculateNetworkBufferMemory(
+			totalJavaMemorySizeMB << 20, config);
 
 		String[] command = {"src/test/bin/calcTMNetBufMem.sh",
 			totalJavaMemorySizeMB + "m",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -70,7 +70,7 @@ public class NetworkEnvironment {
 
 		NettyConfig nettyConfig = config.nettyConfig();
 		if (nettyConfig != null) {
-			this.connectionManager = new NettyConnectionManager(nettyConfig);
+			this.connectionManager = new NettyConnectionManager(nettyConfig, config.isCreditBased());
 		} else {
 			this.connectionManager = new LocalConnectionManager();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -22,10 +22,13 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyConfig;
+import org.apache.flink.runtime.io.network.netty.NettyConnectionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
@@ -48,6 +51,8 @@ public class NetworkEnvironment {
 
 	private final Object lock = new Object();
 
+	private final NetworkEnvironmentConfiguration config;
+
 	private final NetworkBufferPool networkBufferPool;
 
 	private final ConnectionManager connectionManager;
@@ -56,64 +61,25 @@ public class NetworkEnvironment {
 
 	private final TaskEventPublisher taskEventPublisher;
 
-	private final int partitionRequestInitialBackoff;
-
-	private final int partitionRequestMaxBackoff;
-
-	/** Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel). */
-	private final int networkBuffersPerChannel;
-
-	/** Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). */
-	private final int extraNetworkBuffersPerGate;
-
-	private final boolean enableCreditBased;
-
 	private boolean isShutdown;
 
-	public NetworkEnvironment(
-		int numBuffers,
-		int memorySegmentSize,
-		int partitionRequestInitialBackoff,
-		int partitionRequestMaxBackoff,
-		int networkBuffersPerChannel,
-		int extraNetworkBuffersPerGate,
-		boolean enableCreditBased) {
-		this(
-			new NetworkBufferPool(numBuffers, memorySegmentSize),
-			new LocalConnectionManager(),
-			new ResultPartitionManager(),
-			new TaskEventDispatcher(),
-			partitionRequestInitialBackoff,
-			partitionRequestMaxBackoff,
-			networkBuffersPerChannel,
-			extraNetworkBuffersPerGate,
-			enableCreditBased);
-	}
+	public NetworkEnvironment(NetworkEnvironmentConfiguration config, TaskEventPublisher taskEventPublisher) {
+		this.config = checkNotNull(config);
 
-	public NetworkEnvironment(
-			NetworkBufferPool networkBufferPool,
-			ConnectionManager connectionManager,
-			ResultPartitionManager resultPartitionManager,
-			TaskEventPublisher taskEventPublisher,
-			int partitionRequestInitialBackoff,
-			int partitionRequestMaxBackoff,
-			int networkBuffersPerChannel,
-			int extraNetworkBuffersPerGate,
-			boolean enableCreditBased) {
+		this.networkBufferPool = new NetworkBufferPool(config.numNetworkBuffers(), config.networkBufferSize());
 
-		this.networkBufferPool = checkNotNull(networkBufferPool);
-		this.connectionManager = checkNotNull(connectionManager);
-		this.resultPartitionManager = checkNotNull(resultPartitionManager);
+		NettyConfig nettyConfig = config.nettyConfig();
+		if (nettyConfig != null) {
+			this.connectionManager = new NettyConnectionManager(nettyConfig);
+		} else {
+			this.connectionManager = new LocalConnectionManager();
+		}
+
+		this.resultPartitionManager = new ResultPartitionManager();
+
 		this.taskEventPublisher = checkNotNull(taskEventPublisher);
 
-		this.partitionRequestInitialBackoff = partitionRequestInitialBackoff;
-		this.partitionRequestMaxBackoff = partitionRequestMaxBackoff;
-
 		isShutdown = false;
-		this.networkBuffersPerChannel = networkBuffersPerChannel;
-		this.extraNetworkBuffersPerGate = extraNetworkBuffersPerGate;
-
-		this.enableCreditBased = enableCreditBased;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -132,16 +98,8 @@ public class NetworkEnvironment {
 		return networkBufferPool;
 	}
 
-	public int getPartitionRequestInitialBackoff() {
-		return partitionRequestInitialBackoff;
-	}
-
-	public int getPartitionRequestMaxBackoff() {
-		return partitionRequestMaxBackoff;
-	}
-
-	public boolean isCreditBased() {
-		return enableCreditBased;
+	public NetworkEnvironmentConfiguration getConfiguration() {
+		return config;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -174,8 +132,8 @@ public class NetworkEnvironment {
 
 		try {
 			int maxNumberOfMemorySegments = partition.getPartitionType().isBounded() ?
-				partition.getNumberOfSubpartitions() * networkBuffersPerChannel +
-					extraNetworkBuffersPerGate : Integer.MAX_VALUE;
+				partition.getNumberOfSubpartitions() * config.networkBuffersPerChannel() +
+					config.floatingNetworkBuffersPerGate() : Integer.MAX_VALUE;
 			// If the partition type is back pressure-free, we register with the buffer pool for
 			// callbacks to release memory.
 			bufferPool = networkBufferPool.createBufferPool(partition.getNumberOfSubpartitions(),
@@ -203,17 +161,17 @@ public class NetworkEnvironment {
 		BufferPool bufferPool = null;
 		int maxNumberOfMemorySegments;
 		try {
-			if (enableCreditBased) {
+			if (config.isCreditBased()) {
 				maxNumberOfMemorySegments = gate.getConsumedPartitionType().isBounded() ?
-					extraNetworkBuffersPerGate : Integer.MAX_VALUE;
+					config.floatingNetworkBuffersPerGate() : Integer.MAX_VALUE;
 
 				// assign exclusive buffers to input channels directly and use the rest for floating buffers
-				gate.assignExclusiveSegments(networkBufferPool, networkBuffersPerChannel);
+				gate.assignExclusiveSegments(networkBufferPool, config.networkBuffersPerChannel());
 				bufferPool = networkBufferPool.createBufferPool(0, maxNumberOfMemorySegments);
 			} else {
 				maxNumberOfMemorySegments = gate.getConsumedPartitionType().isBounded() ?
-					gate.getNumberOfInputChannels() * networkBuffersPerChannel +
-						extraNetworkBuffersPerGate : Integer.MAX_VALUE;
+					gate.getNumberOfInputChannels() * config.networkBuffersPerChannel() +
+						config.floatingNetworkBuffersPerGate() : Integer.MAX_VALUE;
 
 				bufferPool = networkBufferPool.createBufferPool(gate.getNumberOfInputChannels(),
 					maxNumberOfMemorySegments);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -208,10 +208,6 @@ public class NettyConfig {
 			&& SSLUtils.isInternalSSLEnabled(config);
 	}
 
-	public boolean isCreditBasedEnabled() {
-		return config.getBoolean(TaskManagerOptions.NETWORK_CREDIT_MODEL);
-	}
-
 	public Configuration getConfig() {
 		return config;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -35,20 +35,21 @@ public class NettyConnectionManager implements ConnectionManager {
 
 	private final PartitionRequestClientFactory partitionRequestClientFactory;
 
-	public NettyConnectionManager(NettyConfig nettyConfig) {
+	private final boolean isCreditBased;
+
+	public NettyConnectionManager(NettyConfig nettyConfig, boolean isCreditBased) {
 		this.server = new NettyServer(nettyConfig);
 		this.client = new NettyClient(nettyConfig);
 		this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas());
 
 		this.partitionRequestClientFactory = new PartitionRequestClientFactory(client);
+
+		this.isCreditBased = isCreditBased;
 	}
 
 	@Override
 	public void start(ResultPartitionProvider partitionProvider, TaskEventPublisher taskEventPublisher) throws IOException {
-		NettyProtocol partitionRequestProtocol = new NettyProtocol(
-			partitionProvider,
-			taskEventPublisher,
-			client.getConfig().isCreditBasedEnabled());
+		NettyProtocol partitionRequestProtocol = new NettyProtocol(partitionProvider, taskEventPublisher, isCreditBased);
 
 		client.init(partitionRequestProtocol, bufferPool);
 		server.init(partitionRequestProtocol, bufferPool);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.TaskActions;
 
 import org.slf4j.Logger;
@@ -678,9 +679,11 @@ public class SingleInputGate implements InputGate {
 
 		final InputChannelDeploymentDescriptor[] icdd = checkNotNull(igdd.getInputChannelDeploymentDescriptors());
 
+		final NetworkEnvironmentConfiguration networkConfig = networkEnvironment.getConfiguration();
+
 		final SingleInputGate inputGate = new SingleInputGate(
 			owningTaskName, jobId, consumedResultId, consumedPartitionType, consumedSubpartitionIndex,
-			icdd.length, taskActions, metrics, networkEnvironment.getConfiguration().isCreditBased());
+			icdd.length, taskActions, metrics, networkConfig.isCreditBased());
 
 		// Create the input channels. There is one input channel for each consumed partition.
 		final InputChannel[] inputChannels = new InputChannel[icdd.length];
@@ -697,8 +700,8 @@ public class SingleInputGate implements InputGate {
 				inputChannels[i] = new LocalInputChannel(inputGate, i, partitionId,
 					networkEnvironment.getResultPartitionManager(),
 					taskEventPublisher,
-					networkEnvironment.getConfiguration().partitionRequestInitialBackoff(),
-					networkEnvironment.getConfiguration().partitionRequestMaxBackoff(),
+					networkConfig.partitionRequestInitialBackoff(),
+					networkConfig.partitionRequestMaxBackoff(),
 					metrics
 				);
 
@@ -708,8 +711,8 @@ public class SingleInputGate implements InputGate {
 				inputChannels[i] = new RemoteInputChannel(inputGate, i, partitionId,
 					partitionLocation.getConnectionId(),
 					networkEnvironment.getConnectionManager(),
-					networkEnvironment.getConfiguration().partitionRequestInitialBackoff(),
-					networkEnvironment.getConfiguration().partitionRequestMaxBackoff(),
+					networkConfig.partitionRequestInitialBackoff(),
+					networkConfig.partitionRequestMaxBackoff(),
 					metrics
 				);
 
@@ -720,8 +723,8 @@ public class SingleInputGate implements InputGate {
 					networkEnvironment.getResultPartitionManager(),
 					taskEventPublisher,
 					networkEnvironment.getConnectionManager(),
-					networkEnvironment.getConfiguration().partitionRequestInitialBackoff(),
-					networkEnvironment.getConfiguration().partitionRequestMaxBackoff(),
+					networkConfig.partitionRequestInitialBackoff(),
+					networkConfig.partitionRequestMaxBackoff(),
 					metrics
 				);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -680,7 +680,7 @@ public class SingleInputGate implements InputGate {
 
 		final SingleInputGate inputGate = new SingleInputGate(
 			owningTaskName, jobId, consumedResultId, consumedPartitionType, consumedSubpartitionIndex,
-			icdd.length, taskActions, metrics, networkEnvironment.isCreditBased());
+			icdd.length, taskActions, metrics, networkEnvironment.getConfiguration().isCreditBased());
 
 		// Create the input channels. There is one input channel for each consumed partition.
 		final InputChannel[] inputChannels = new InputChannel[icdd.length];
@@ -697,8 +697,8 @@ public class SingleInputGate implements InputGate {
 				inputChannels[i] = new LocalInputChannel(inputGate, i, partitionId,
 					networkEnvironment.getResultPartitionManager(),
 					taskEventPublisher,
-					networkEnvironment.getPartitionRequestInitialBackoff(),
-					networkEnvironment.getPartitionRequestMaxBackoff(),
+					networkEnvironment.getConfiguration().partitionRequestInitialBackoff(),
+					networkEnvironment.getConfiguration().partitionRequestMaxBackoff(),
 					metrics
 				);
 
@@ -708,8 +708,8 @@ public class SingleInputGate implements InputGate {
 				inputChannels[i] = new RemoteInputChannel(inputGate, i, partitionId,
 					partitionLocation.getConnectionId(),
 					networkEnvironment.getConnectionManager(),
-					networkEnvironment.getPartitionRequestInitialBackoff(),
-					networkEnvironment.getPartitionRequestMaxBackoff(),
+					networkEnvironment.getConfiguration().partitionRequestInitialBackoff(),
+					networkEnvironment.getConfiguration().partitionRequestMaxBackoff(),
 					metrics
 				);
 
@@ -720,8 +720,8 @@ public class SingleInputGate implements InputGate {
 					networkEnvironment.getResultPartitionManager(),
 					taskEventPublisher,
 					networkEnvironment.getConnectionManager(),
-					networkEnvironment.getPartitionRequestInitialBackoff(),
-					networkEnvironment.getPartitionRequestMaxBackoff(),
+					networkEnvironment.getConfiguration().partitionRequestInitialBackoff(),
+					networkEnvironment.getConfiguration().partitionRequestMaxBackoff(),
 					metrics
 				);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/QueryableStateConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/QueryableStateConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.QueryableStateOptions;
 import org.apache.flink.util.NetUtils;
 
@@ -136,5 +137,33 @@ public class QueryableStateConfiguration {
 		final Iterator<Integer> proxyPorts = NetUtils.getPortRangeFromString(QueryableStateOptions.PROXY_PORT_RANGE.defaultValue());
 		final Iterator<Integer> serverPorts = NetUtils.getPortRangeFromString(QueryableStateOptions.SERVER_PORT_RANGE.defaultValue());
 		return new QueryableStateConfiguration(proxyPorts, serverPorts, 0, 0, 0, 0);
+	}
+
+	/**
+	 * Creates the {@link QueryableStateConfiguration} from the given Configuration.
+	 */
+	public static QueryableStateConfiguration fromConfiguration(Configuration config) {
+		if (!config.getBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER)) {
+			return null;
+		}
+
+		final Iterator<Integer> proxyPorts = NetUtils.getPortRangeFromString(
+			config.getString(QueryableStateOptions.PROXY_PORT_RANGE));
+		final Iterator<Integer> serverPorts = NetUtils.getPortRangeFromString(
+			config.getString(QueryableStateOptions.SERVER_PORT_RANGE));
+
+		final int numProxyServerNetworkThreads = config.getInteger(QueryableStateOptions.PROXY_NETWORK_THREADS);
+		final int numProxyServerQueryThreads = config.getInteger(QueryableStateOptions.PROXY_ASYNC_QUERY_THREADS);
+
+		final int numStateServerNetworkThreads = config.getInteger(QueryableStateOptions.SERVER_NETWORK_THREADS);
+		final int numStateServerQueryThreads = config.getInteger(QueryableStateOptions.SERVER_ASYNC_QUERY_THREADS);
+
+		return new QueryableStateConfiguration(
+			proxyPorts,
+			serverPorts,
+			numProxyServerNetworkThreads,
+			numProxyServerQueryThreads,
+			numStateServerNetworkThreads,
+			numStateServerQueryThreads);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -353,6 +353,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		TaskManagerServicesConfiguration taskManagerServicesConfiguration =
 			TaskManagerServicesConfiguration.fromConfiguration(
 				configuration,
+				EnvironmentInformation.getMaxJvmHeapMemory(),
 				remoteAddress,
 				localCommunicationOnly);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -30,20 +30,12 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
-import org.apache.flink.runtime.io.network.ConnectionManager;
-import org.apache.flink.runtime.io.network.LocalConnectionManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
-import org.apache.flink.runtime.io.network.TaskEventPublisher;
-import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.io.network.netty.NettyConfig;
-import org.apache.flink.runtime.io.network.netty.NettyConnectionManager;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
-import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -247,8 +239,8 @@ public class TaskManagerServices {
 
 		final TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 
-		final NetworkEnvironment network = createNetworkEnvironment(
-			taskManagerServicesConfiguration, maxJvmHeapMemory, taskEventDispatcher);
+		final NetworkEnvironment network = new NetworkEnvironment(
+			taskManagerServicesConfiguration.getNetworkConfig(), taskEventDispatcher);
 		network.start();
 
 		final KvStateService kvStateService = KvStateService.fromConfiguration(taskManagerServicesConfiguration);
@@ -401,60 +393,6 @@ public class TaskManagerServices {
 	}
 
 	/**
-	 * Creates the {@link NetworkEnvironment} from the given {@link TaskManagerServicesConfiguration}.
-	 *
-	 * @param taskManagerServicesConfiguration to construct the network environment from
-	 * @param maxJvmHeapMemory the maximum JVM heap size
-	 * @return Network environment
-	 * @throws IOException
-	 */
-	private static NetworkEnvironment createNetworkEnvironment(
-			TaskManagerServicesConfiguration taskManagerServicesConfiguration,
-			long maxJvmHeapMemory,
-			TaskEventPublisher taskEventPublisher) {
-
-		NetworkEnvironmentConfiguration networkEnvironmentConfiguration = taskManagerServicesConfiguration.getNetworkConfig();
-
-		final long networkBuf = calculateNetworkBufferMemory(taskManagerServicesConfiguration, maxJvmHeapMemory);
-		int segmentSize = networkEnvironmentConfiguration.networkBufferSize();
-
-		// tolerate offcuts between intended and allocated memory due to segmentation (will be available to the user-space memory)
-		final long numNetBuffersLong = networkBuf / segmentSize;
-		if (numNetBuffersLong > Integer.MAX_VALUE) {
-			throw new IllegalArgumentException("The given number of memory bytes (" + networkBuf
-				+ ") corresponds to more than MAX_INT pages.");
-		}
-
-		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
-			(int) numNetBuffersLong,
-			segmentSize);
-
-		ConnectionManager connectionManager;
-		boolean enableCreditBased = false;
-		NettyConfig nettyConfig = networkEnvironmentConfiguration.nettyConfig();
-		if (nettyConfig != null) {
-			connectionManager = new NettyConnectionManager(nettyConfig);
-			enableCreditBased = nettyConfig.isCreditBasedEnabled();
-		} else {
-			connectionManager = new LocalConnectionManager();
-		}
-
-		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
-
-		// we start the network first, to make sure it can allocate its buffers first
-		return new NetworkEnvironment(
-			networkBufferPool,
-			connectionManager,
-			resultPartitionManager,
-			taskEventPublisher,
-			networkEnvironmentConfiguration.partitionRequestInitialBackoff(),
-			networkEnvironmentConfiguration.partitionRequestMaxBackoff(),
-			networkEnvironmentConfiguration.networkBuffersPerChannel(),
-			networkEnvironmentConfiguration.floatingNetworkBuffersPerGate(),
-			enableCreditBased);
-	}
-
-	/**
 	 * Calculates the amount of memory used for network buffers based on the total memory to use and
 	 * the according configuration parameters.
 	 *
@@ -527,90 +465,6 @@ public class TaskManagerServices {
 					"Network buffer memory size too small: " + networkBufBytes + " < " +
 						segmentSize + " (" + TaskManagerOptions.MEMORY_SEGMENT_SIZE.key() + ")");
 		}
-
-		return networkBufBytes;
-	}
-
-	/**
-	 * Calculates the amount of memory used for network buffers inside the current JVM instance
-	 * based on the available heap or the max heap size and the according configuration parameters.
-	 *
-	 * <p>For containers or when started via scripts, if started with a memory limit and set to use
-	 * off-heap memory, the maximum heap size for the JVM is adjusted accordingly and we are able
-	 * to extract the intended values from this.
-	 *
-	 * <p>The following configuration parameters are involved:
-	 * <ul>
-	 *  <li>{@link TaskManagerOptions#MANAGED_MEMORY_FRACTION},</li>
-	 *  <li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION},</li>
-	 * 	<li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN},</li>
-	 * 	<li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}, and</li>
-	 *  <li>{@link TaskManagerOptions#NETWORK_NUM_BUFFERS} (fallback if the ones above do not exist)</li>
-	 * </ul>.
-	 *
-	 * @param tmConfig task manager services configuration object
-	 * @param maxJvmHeapMemory the maximum JVM heap size
-	 *
-	 * @return memory to use for network buffers (in bytes)
-	 */
-	public static long calculateNetworkBufferMemory(TaskManagerServicesConfiguration tmConfig, long maxJvmHeapMemory) {
-		final NetworkEnvironmentConfiguration networkConfig = tmConfig.getNetworkConfig();
-
-		final float networkBufFraction = networkConfig.networkBufFraction();
-		final long networkBufMin = networkConfig.networkBufMin();
-		final long networkBufMax = networkConfig.networkBufMax();
-
-		if (networkBufMin == networkBufMax) {
-			// fixed network buffer pool size
-			return networkBufMin;
-		}
-
-		// relative network buffer pool size using the fraction...
-
-		// The maximum heap memory has been adjusted as in
-		// calculateHeapSizeMB(long totalJavaMemorySizeMB, Configuration config))
-		// and we need to invert these calculations.
-
-		final MemoryType memType = tmConfig.getMemoryType();
-
-		final long jvmHeapNoNet;
-		if (memType == MemoryType.HEAP) {
-			jvmHeapNoNet = maxJvmHeapMemory;
-		} else if (memType == MemoryType.OFF_HEAP) {
-
-			// check if a value has been configured
-			long configuredMemory = tmConfig.getConfiguredMemory() << 20; // megabytes to bytes
-
-			if (configuredMemory > 0) {
-				// The maximum heap memory has been adjusted according to configuredMemory, i.e.
-				// maxJvmHeap = jvmHeapNoNet - configuredMemory
-
-				jvmHeapNoNet = maxJvmHeapMemory + configuredMemory;
-			} else {
-				// The maximum heap memory has been adjusted according to the fraction, i.e.
-				// maxJvmHeap = jvmHeapNoNet - jvmHeapNoNet * managedFraction = jvmHeapNoNet * (1 - managedFraction)
-
-				final float managedFraction = tmConfig.getMemoryFraction();
-				jvmHeapNoNet = (long) (maxJvmHeapMemory / (1.0 - managedFraction));
-			}
-		} else {
-			throw new RuntimeException("No supported memory type detected.");
-		}
-
-		// finally extract the network buffer memory size again from:
-		// jvmHeapNoNet = jvmHeap - networkBufBytes
-		//              = jvmHeap - Math.min(networkBufMax, Math.max(networkBufMin, jvmHeap * netFraction)
-		final long networkBufBytes = Math.min(networkBufMax, Math.max(networkBufMin,
-			(long) (jvmHeapNoNet / (1.0 - networkBufFraction) * networkBufFraction)));
-
-		TaskManagerServicesConfiguration
-			.checkConfigParameter(networkBufBytes < maxJvmHeapMemory,
-				"(" + networkBufFraction + ", " + networkBufMin + ", " + networkBufMax + ")",
-				"(" + TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key() + ", " +
-					TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.key() + ", " +
-					TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key() + ")",
-				"Network buffer memory size too large: " + networkBufBytes + " >= " +
-					maxJvmHeapMemory + "(maximum JVM heap size)");
 
 		return networkBufBytes;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -138,6 +138,7 @@ public class TaskManagerServicesConfiguration {
 		return networkConfig;
 	}
 
+	@Nullable
 	QueryableStateConfiguration getQueryableStateConfig() {
 		return queryableStateConfig;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -18,36 +18,22 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
-import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.QueryableStateOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.io.network.netty.NettyConfig;
-import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
-import org.apache.flink.util.MathUtils;
-import org.apache.flink.util.NetUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 
 import javax.annotation.Nullable;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.Iterator;
 import java.util.Optional;
 
-import static org.apache.flink.configuration.MemorySize.MemoryUnit.MEGA_BYTES;
-import static org.apache.flink.util.MathUtils.checkedDownCast;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -56,7 +42,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * the io manager and the metric registry.
  */
 public class TaskManagerServicesConfiguration {
-	private static final Logger LOG = LoggerFactory.getLogger(TaskManagerServicesConfiguration.class);
 
 	private final InetAddress taskManagerAddress;
 
@@ -133,7 +118,7 @@ public class TaskManagerServicesConfiguration {
 	//  Getter/Setter
 	// --------------------------------------------------------------------------------------------
 
-	public InetAddress getTaskManagerAddress() {
+	InetAddress getTaskManagerAddress() {
 		return taskManagerAddress;
 	}
 
@@ -141,11 +126,11 @@ public class TaskManagerServicesConfiguration {
 		return tmpDirPaths;
 	}
 
-	public String[] getLocalRecoveryStateRootDirectories() {
+	String[] getLocalRecoveryStateRootDirectories() {
 		return localRecoveryStateRootDirectories;
 	}
 
-	public boolean isLocalRecoveryEnabled() {
+	boolean isLocalRecoveryEnabled() {
 		return localRecoveryEnabled;
 	}
 
@@ -153,7 +138,7 @@ public class TaskManagerServicesConfiguration {
 		return networkConfig;
 	}
 
-	public QueryableStateConfiguration getQueryableStateConfig() {
+	QueryableStateConfiguration getQueryableStateConfig() {
 		return queryableStateConfig;
 	}
 
@@ -170,7 +155,7 @@ public class TaskManagerServicesConfiguration {
 	 *
 	 * @return on-heap or off-heap memory
 	 */
-	public MemoryType getMemoryType() {
+	MemoryType getMemoryType() {
 		return memoryType;
 	}
 
@@ -181,15 +166,15 @@ public class TaskManagerServicesConfiguration {
 	 *
 	 * @see TaskManagerOptions#MANAGED_MEMORY_SIZE
 	 */
-	public long getConfiguredMemory() {
+	long getConfiguredMemory() {
 		return configuredMemory;
 	}
 
-	public boolean isPreAllocateMemory() {
+	boolean isPreAllocateMemory() {
 		return preAllocateMemory;
 	}
 
-	public long getTimerServiceShutdownTimeout() {
+	long getTimerServiceShutdownTimeout() {
 		return timerServiceShutdownTimeout;
 	}
 
@@ -197,7 +182,7 @@ public class TaskManagerServicesConfiguration {
 		return systemResourceMetricsProbingInterval;
 	}
 
-	public RetryingRegistrationConfiguration getRetryingRegistrationConfiguration() {
+	RetryingRegistrationConfiguration getRetryingRegistrationConfiguration() {
 		return retryingRegistrationConfiguration;
 	}
 
@@ -221,13 +206,6 @@ public class TaskManagerServicesConfiguration {
 			long maxJvmHeapMemory,
 			InetAddress remoteAddress,
 			boolean localCommunication) {
-
-		// we need this because many configs have been written with a "-1" entry
-		int slots = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
-		if (slots == -1) {
-			slots = 1;
-		}
-
 		final String[] tmpDirs = ConfigurationUtils.parseTempDirectories(configuration);
 		String[] localStateRootDir = ConfigurationUtils.parseLocalStateDirectories(configuration);
 		if (localStateRootDir.length == 0) {
@@ -237,14 +215,13 @@ public class TaskManagerServicesConfiguration {
 
 		boolean localRecoveryMode = configuration.getBoolean(CheckpointingOptions.LOCAL_RECOVERY);
 
-		final NetworkEnvironmentConfiguration networkConfig = parseNetworkEnvironmentConfiguration(
+		final NetworkEnvironmentConfiguration networkConfig = NetworkEnvironmentConfiguration.fromConfiguration(
 			configuration,
 			maxJvmHeapMemory,
 			localCommunication,
-			remoteAddress,
-			slots);
+			remoteAddress);
 
-		final QueryableStateConfiguration queryableStateConfig = parseQueryableStateConfiguration(configuration);
+		final QueryableStateConfiguration queryableStateConfig = QueryableStateConfiguration.fromConfiguration(configuration);
 
 		boolean preAllocateMemory = configuration.getBoolean(TaskManagerOptions.MANAGED_MEMORY_PRE_ALLOCATE);
 
@@ -259,359 +236,13 @@ public class TaskManagerServicesConfiguration {
 			localRecoveryMode,
 			networkConfig,
 			queryableStateConfig,
-			slots,
-			getManagedMemorySize(configuration),
-			getMemoryType(configuration),
+			ConfigurationParserUtils.getSlot(configuration),
+			ConfigurationParserUtils.getManagedMemorySize(configuration),
+			ConfigurationParserUtils.getMemoryType(configuration),
 			preAllocateMemory,
-			getManagedMemoryFraction(configuration),
+			ConfigurationParserUtils.getManagedMemoryFraction(configuration),
 			timerServiceShutdownTimeout,
 			retryingRegistrationConfiguration,
 			ConfigurationUtils.getSystemResourceMetricsProbingInterval(configuration));
-	}
-
-	// --------------------------------------------------------------------------
-	//  Parsing and checking the TaskManager Configuration
-	// --------------------------------------------------------------------------
-
-	/**
-	 * Creates the {@link NetworkEnvironmentConfiguration} from the given {@link Configuration}.
-	 *
-	 * @param configuration to create the network environment configuration from
-	 * @param maxJvmHeapMemory The maximum JVM heap size, in bytes
-	 * @param localTaskManagerCommunication true if task manager communication is local
-	 * @param taskManagerAddress address of the task manager
-	 * @param slots to start the task manager with
-	 * @return Network environment configuration
-	 */
-	@SuppressWarnings("deprecation")
-	private static NetworkEnvironmentConfiguration parseNetworkEnvironmentConfiguration(
-		Configuration configuration,
-		long maxJvmHeapMemory,
-		boolean localTaskManagerCommunication,
-		InetAddress taskManagerAddress,
-		int slots) {
-
-		// ----> hosts / ports for communication and data exchange
-
-		int dataport = configuration.getInteger(TaskManagerOptions.DATA_PORT);
-		checkConfigParameter(dataport >= 0, dataport, TaskManagerOptions.DATA_PORT.key(),
-			"Leave config parameter empty or use 0 to let the system choose a port automatically.");
-
-		checkConfigParameter(slots >= 1, slots, TaskManagerOptions.NUM_TASK_SLOTS.key(),
-			"Number of task slots must be at least one.");
-
-		final int pageSize = getPageSize(configuration);
-
-		final int numNetworkBuffers;
-		if (!hasNewNetworkBufConf(configuration)) {
-			// fallback: number of network buffers
-			numNetworkBuffers = configuration.getInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS);
-
-			checkNetworkConfigOld(numNetworkBuffers);
-		} else {
-			if (configuration.contains(TaskManagerOptions.NETWORK_NUM_BUFFERS)) {
-				LOG.info("Ignoring old (but still present) network buffer configuration via {}.",
-					TaskManagerOptions.NETWORK_NUM_BUFFERS.key());
-			}
-
-			final long networkMemorySize = calculateNetworkBufferMemory(configuration, maxJvmHeapMemory);
-
-			// tolerate offcuts between intended and allocated memory due to segmentation (will be available to the user-space memory)
-			long numNetworkBuffersLong = networkMemorySize / pageSize;
-			if (numNetworkBuffersLong > Integer.MAX_VALUE) {
-				throw new IllegalArgumentException("The given number of memory bytes (" + networkMemorySize
-					+ ") corresponds to more than MAX_INT pages.");
-			}
-			numNetworkBuffers = (int) numNetworkBuffersLong;
-		}
-
-		final NettyConfig nettyConfig;
-		if (!localTaskManagerCommunication) {
-			final InetSocketAddress taskManagerInetSocketAddress = new InetSocketAddress(taskManagerAddress, dataport);
-
-			nettyConfig = new NettyConfig(taskManagerInetSocketAddress.getAddress(),
-				taskManagerInetSocketAddress.getPort(), pageSize, slots, configuration);
-		} else {
-			nettyConfig = null;
-		}
-
-		int initialRequestBackoff = configuration.getInteger(TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL);
-		int maxRequestBackoff = configuration.getInteger(TaskManagerOptions.NETWORK_REQUEST_BACKOFF_MAX);
-
-		int buffersPerChannel = configuration.getInteger(TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL);
-		int extraBuffersPerGate = configuration.getInteger(TaskManagerOptions.NETWORK_EXTRA_BUFFERS_PER_GATE);
-
-		boolean isCreditBased = configuration.getBoolean(TaskManagerOptions.NETWORK_CREDIT_MODEL);
-
-		return new NetworkEnvironmentConfiguration(
-			numNetworkBuffers,
-			pageSize,
-			initialRequestBackoff,
-			maxRequestBackoff,
-			buffersPerChannel,
-			extraBuffersPerGate,
-			isCreditBased,
-			nettyConfig);
-	}
-
-	/**
-	 * Calculates the amount of memory used for network buffers inside the current JVM instance
-	 * based on the available heap or the max heap size and the according configuration parameters.
-	 *
-	 * <p>For containers or when started via scripts, if started with a memory limit and set to use
-	 * off-heap memory, the maximum heap size for the JVM is adjusted accordingly and we are able
-	 * to extract the intended values from this.
-	 *
-	 * <p>The following configuration parameters are involved:
-	 * <ul>
-	 *  <li>{@link TaskManagerOptions#MANAGED_MEMORY_FRACTION},</li>
-	 *  <li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION},</li>
-	 * 	<li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN},</li>
-	 * 	<li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}, and</li>
-	 *  <li>{@link TaskManagerOptions#NETWORK_NUM_BUFFERS} (fallback if the ones above do not exist)</li>
-	 * </ul>.
-	 *
-	 * @param configuration configuration object
-	 * @param maxJvmHeapMemory the maximum JVM heap size
-	 *
-	 * @return memory to use for network buffers (in bytes)
-	 */
-	@VisibleForTesting
-	static long calculateNetworkBufferMemory(Configuration configuration, long maxJvmHeapMemory) {
-		// The maximum heap memory has been adjusted as in TaskManagerServices#calculateHeapSizeMB
-		// and we need to invert these calculations.
-		final long jvmHeapNoNet;
-		final MemoryType memoryType = getMemoryType(configuration);
-		if (memoryType == MemoryType.HEAP) {
-			jvmHeapNoNet = maxJvmHeapMemory;
-		} else if (memoryType == MemoryType.OFF_HEAP) {
-			long configuredMemory = getManagedMemorySize(configuration) << 20; // megabytes to bytes
-			if (configuredMemory > 0) {
-				// The maximum heap memory has been adjusted according to configuredMemory, i.e.
-				// maxJvmHeap = jvmHeapNoNet - configuredMemory
-				jvmHeapNoNet = maxJvmHeapMemory + configuredMemory;
-			} else {
-				// The maximum heap memory has been adjusted according to the fraction, i.e.
-				// maxJvmHeap = jvmHeapNoNet - jvmHeapNoNet * managedFraction = jvmHeapNoNet * (1 - managedFraction)
-				jvmHeapNoNet = (long) (maxJvmHeapMemory / (1.0 - getManagedMemoryFraction(configuration)));
-			}
-		} else {
-			throw new RuntimeException("No supported memory type detected.");
-		}
-
-		float networkBufFraction = configuration.getFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION);
-		long networkBufMin = MemorySize.parse(configuration.getString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN)).getBytes();
-		long networkBufMax = MemorySize.parse(configuration.getString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX)).getBytes();
-		checkNetworkBufferConfig(getPageSize(configuration), networkBufFraction, networkBufMin, networkBufMax);
-
-		// finally extract the network buffer memory size again from:
-		// jvmHeapNoNet = jvmHeap - networkBufBytes
-		//              = jvmHeap - Math.min(networkBufMax, Math.max(networkBufMin, jvmHeap * netFraction)
-		long networkMemorySize = Math.min(networkBufMax, Math.max(networkBufMin,
-			(long) (jvmHeapNoNet / (1.0 - networkBufFraction) * networkBufFraction)));
-
-		TaskManagerServicesConfiguration.checkConfigParameter(networkMemorySize < maxJvmHeapMemory,
-			"(" + networkBufFraction + ", " + networkBufMin + ", " + networkBufMax + ")",
-			"(" + TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key() + ", " +
-				TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.key() + ", " +
-				TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key() + ")",
-			"Network buffer memory size too large: " + networkMemorySize + " >= " +
-				maxJvmHeapMemory + "(maximum JVM heap size)");
-
-		return networkMemorySize;
-	}
-
-	/**
-	 * Validates the (old) network buffer configuration.
-	 *
-	 * @param numNetworkBuffers		number of buffers used in the network stack
-	 *
-	 * @throws IllegalConfigurationException if the condition does not hold
-	 */
-	@SuppressWarnings("deprecation")
-	protected static void checkNetworkConfigOld(final int numNetworkBuffers) {
-		checkConfigParameter(numNetworkBuffers > 0, numNetworkBuffers,
-			TaskManagerOptions.NETWORK_NUM_BUFFERS.key(),
-			"Must have at least one network buffer");
-	}
-
-	/**
-	 * Validates the (new) network buffer configuration.
-	 *
-	 * @param pageSize 				size of memory buffers
-	 * @param networkBufFraction	fraction of JVM memory to use for network buffers
-	 * @param networkBufMin 		minimum memory size for network buffers (in bytes)
-	 * @param networkBufMax 		maximum memory size for network buffers (in bytes)
-	 *
-	 * @throws IllegalConfigurationException if the condition does not hold
-	 */
-	protected static void checkNetworkBufferConfig(
-			final int pageSize, final float networkBufFraction, final long networkBufMin,
-			final long networkBufMax) throws IllegalConfigurationException {
-
-		checkConfigParameter(networkBufFraction > 0.0f && networkBufFraction < 1.0f, networkBufFraction,
-			TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key(),
-			"Network buffer memory fraction of the free memory must be between 0.0 and 1.0");
-
-		checkConfigParameter(networkBufMin >= pageSize, networkBufMin,
-			TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.key(),
-			"Minimum memory for network buffers must allow at least one network " +
-				"buffer with respect to the memory segment size");
-
-		checkConfigParameter(networkBufMax >= pageSize, networkBufMax,
-			TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key(),
-			"Maximum memory for network buffers must allow at least one network " +
-				"buffer with respect to the memory segment size");
-
-		checkConfigParameter(networkBufMax >= networkBufMin, networkBufMax,
-			TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key(),
-			"Maximum memory for network buffers must not be smaller than minimum memory (" +
-				TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key() + ": " + networkBufMin + ")");
-	}
-
-	/**
-	 * Returns whether the new network buffer memory configuration is present in the configuration
-	 * object, i.e. at least one new parameter is given or the old one is not present.
-	 *
-	 * @param config configuration object
-	 * @return <tt>true</tt> if the new configuration method is used, <tt>false</tt> otherwise
-	 */
-	@SuppressWarnings("deprecation")
-	public static boolean hasNewNetworkBufConf(final Configuration config) {
-		return config.contains(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION) ||
-			config.contains(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN) ||
-			config.contains(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX) ||
-			!config.contains(TaskManagerOptions.NETWORK_NUM_BUFFERS);
-	}
-
-	/**
-	 * Creates the {@link QueryableStateConfiguration} from the given Configuration.
-	 */
-	private static QueryableStateConfiguration parseQueryableStateConfiguration(Configuration config) {
-		if (!config.getBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER)) {
-			return null;
-		}
-
-		final Iterator<Integer> proxyPorts = NetUtils.getPortRangeFromString(
-				config.getString(QueryableStateOptions.PROXY_PORT_RANGE));
-		final Iterator<Integer> serverPorts = NetUtils.getPortRangeFromString(
-				config.getString(QueryableStateOptions.SERVER_PORT_RANGE));
-
-		final int numProxyServerNetworkThreads = config.getInteger(QueryableStateOptions.PROXY_NETWORK_THREADS);
-		final int numProxyServerQueryThreads = config.getInteger(QueryableStateOptions.PROXY_ASYNC_QUERY_THREADS);
-
-		final int numStateServerNetworkThreads = config.getInteger(QueryableStateOptions.SERVER_NETWORK_THREADS);
-		final int numStateServerQueryThreads = config.getInteger(QueryableStateOptions.SERVER_ASYNC_QUERY_THREADS);
-
-		return new QueryableStateConfiguration(
-				proxyPorts,
-				serverPorts,
-				numProxyServerNetworkThreads,
-				numProxyServerQueryThreads,
-				numStateServerNetworkThreads,
-				numStateServerQueryThreads);
-	}
-
-	/**
-	 * Validates a condition for a config parameter and displays a standard exception, if the
-	 * the condition does not hold.
-	 *
-	 * @param condition             The condition that must hold. If the condition is false, an exception is thrown.
-	 * @param parameter         The parameter value. Will be shown in the exception message.
-	 * @param name              The name of the config parameter. Will be shown in the exception message.
-	 * @param errorMessage  The optional custom error message to append to the exception message.
-	 *
-	 * @throws IllegalConfigurationException if the condition does not hold
-	 */
-	static void checkConfigParameter(boolean condition, Object parameter, String name, String errorMessage)
-			throws IllegalConfigurationException {
-		if (!condition) {
-			throw new IllegalConfigurationException("Invalid configuration value for " +
-					name + " : " + parameter + " - " + errorMessage);
-		}
-	}
-
-	/**
-	 * Parses the configuration to get the managed memory size and validates the value.
-	 *
-	 * @param configuration configuration object
-	 * @return managed memory size (in megabytes)
-	 */
-	private static long getManagedMemorySize(Configuration configuration) {
-		long managedMemorySize;
-		String managedMemorySizeDefaultVal = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue();
-		if (!configuration.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE).equals(managedMemorySizeDefaultVal)) {
-			try {
-				managedMemorySize = MemorySize.parse(configuration.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE), MEGA_BYTES).getMebiBytes();
-			} catch (IllegalArgumentException e) {
-				throw new IllegalConfigurationException("Could not read " + TaskManagerOptions.MANAGED_MEMORY_SIZE.key(), e);
-			}
-		} else {
-			managedMemorySize = Long.valueOf(managedMemorySizeDefaultVal);
-		}
-
-		checkConfigParameter(
-			configuration.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE).equals(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()) ||
-				managedMemorySize > 0, managedMemorySize,
-			TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
-			"MemoryManager needs at least one MB of memory. " +
-				"If you leave this config parameter empty, the system automatically pick a fraction of the available memory.");
-
-		return managedMemorySize;
-	}
-
-	/**
-	 * Parses the configuration to get the fraction of managed memory and validates the value.
-	 *
-	 * @param configuration configuration object
-	 * @return fraction of managed memory
-	 */
-	private static float getManagedMemoryFraction(Configuration configuration) {
-		float managedMemoryFraction = configuration.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION);
-
-		checkConfigParameter(managedMemoryFraction > 0.0f && managedMemoryFraction < 1.0f, managedMemoryFraction,
-			TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(),
-			"MemoryManager fraction of the free memory must be between 0.0 and 1.0");
-
-		return managedMemoryFraction;
-	}
-
-	/**
-	 * Parses the configuration to get the type of memory.
-	 *
-	 * @param configuration configuration object
-	 * @return type of memory
-	 */
-	private static MemoryType getMemoryType(Configuration configuration) {
-		// check whether we use heap or off-heap memory
-		final MemoryType memType;
-		if (configuration.getBoolean(TaskManagerOptions.MEMORY_OFF_HEAP)) {
-			memType = MemoryType.OFF_HEAP;
-		} else {
-			memType = MemoryType.HEAP;
-		}
-		return memType;
-	}
-
-	/**
-	 * Parses the configuration to get the page size and validates the value.
-	 *
-	 * @param configuration configuration object
-	 * @return size of memory segment
-	 */
-	private static int getPageSize(Configuration configuration) {
-		final int pageSize = checkedDownCast(MemorySize.parse(
-			configuration.getString(TaskManagerOptions.MEMORY_SEGMENT_SIZE)).getBytes());
-
-		// check page size of for minimum size
-		checkConfigParameter(pageSize >= MemoryManager.MIN_PAGE_SIZE, pageSize,
-			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
-			"Minimum memory segment size is " + MemoryManager.MIN_PAGE_SIZE);
-		// check page size for power of two
-		checkConfigParameter(MathUtils.isPowerOf2(pageSize), pageSize,
-			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
-			"Memory segment size must be a power of 2.");
-
-		return pageSize;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
@@ -27,11 +27,7 @@ import javax.annotation.Nullable;
  */
 public class NetworkEnvironmentConfiguration {
 
-	private final float networkBufFraction;
-
-	private final long networkBufMin;
-
-	private final long networkBufMax;
+	private final int numNetworkBuffers;
 
 	private final int networkBufferSize;
 
@@ -43,42 +39,34 @@ public class NetworkEnvironmentConfiguration {
 
 	private final int floatingNetworkBuffersPerGate;
 
+	private final boolean isCreditBased;
+
 	private final NettyConfig nettyConfig;
 
 	public NetworkEnvironmentConfiguration(
-			float networkBufFraction,
-			long networkBufMin,
-			long networkBufMax,
+			int numNetworkBuffers,
 			int networkBufferSize,
 			int partitionRequestInitialBackoff,
 			int partitionRequestMaxBackoff,
 			int networkBuffersPerChannel,
 			int floatingNetworkBuffersPerGate,
+			boolean isCreditBased,
 			@Nullable NettyConfig nettyConfig) {
 
-		this.networkBufFraction = networkBufFraction;
-		this.networkBufMin = networkBufMin;
-		this.networkBufMax = networkBufMax;
+		this.numNetworkBuffers = numNetworkBuffers;
 		this.networkBufferSize = networkBufferSize;
 		this.partitionRequestInitialBackoff = partitionRequestInitialBackoff;
 		this.partitionRequestMaxBackoff = partitionRequestMaxBackoff;
 		this.networkBuffersPerChannel = networkBuffersPerChannel;
 		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
+		this.isCreditBased = isCreditBased;
 		this.nettyConfig = nettyConfig;
 	}
 
 	// ------------------------------------------------------------------------
 
-	public float networkBufFraction() {
-		return networkBufFraction;
-	}
-
-	public long networkBufMin() {
-		return networkBufMin;
-	}
-
-	public long networkBufMax() {
-		return networkBufMax;
+	public int numNetworkBuffers() {
+		return numNetworkBuffers;
 	}
 
 	public int networkBufferSize() {
@@ -105,6 +93,10 @@ public class NetworkEnvironmentConfiguration {
 		return nettyConfig;
 	}
 
+	public boolean isCreditBased() {
+		return isCreditBased;
+	}
+
 	// ------------------------------------------------------------------------
 
 	@Override
@@ -115,6 +107,7 @@ public class NetworkEnvironmentConfiguration {
 		result = 31 * result + partitionRequestMaxBackoff;
 		result = 31 * result + networkBuffersPerChannel;
 		result = 31 * result + floatingNetworkBuffersPerGate;
+		result = 31 * result + (isCreditBased ? 1 : 0);
 		result = 31 * result + (nettyConfig != null ? nettyConfig.hashCode() : 0);
 		return result;
 	}
@@ -130,14 +123,13 @@ public class NetworkEnvironmentConfiguration {
 		else {
 			final NetworkEnvironmentConfiguration that = (NetworkEnvironmentConfiguration) obj;
 
-			return this.networkBufFraction == that.networkBufFraction &&
-					this.networkBufMin == that.networkBufMin &&
-					this.networkBufMax == that.networkBufMax &&
+			return this.numNetworkBuffers == that.numNetworkBuffers &&
 					this.networkBufferSize == that.networkBufferSize &&
 					this.partitionRequestInitialBackoff == that.partitionRequestInitialBackoff &&
 					this.partitionRequestMaxBackoff == that.partitionRequestMaxBackoff &&
 					this.networkBuffersPerChannel == that.networkBuffersPerChannel &&
 					this.floatingNetworkBuffersPerGate == that.floatingNetworkBuffersPerGate &&
+					this.isCreditBased == that.isCreditBased &&
 					(nettyConfig != null ? nettyConfig.equals(that.nettyConfig) : that.nettyConfig == null);
 		}
 	}
@@ -145,14 +137,13 @@ public class NetworkEnvironmentConfiguration {
 	@Override
 	public String toString() {
 		return "NetworkEnvironmentConfiguration{" +
-				"networkBufFraction=" + networkBufFraction +
-				", networkBufMin=" + networkBufMin +
-				", networkBufMax=" + networkBufMax +
+				", numNetworkBuffers=" + numNetworkBuffers +
 				", networkBufferSize=" + networkBufferSize +
 				", partitionRequestInitialBackoff=" + partitionRequestInitialBackoff +
 				", partitionRequestMaxBackoff=" + partitionRequestMaxBackoff +
 				", networkBuffersPerChannel=" + networkBuffersPerChannel +
 				", floatingNetworkBuffersPerGate=" + floatingNetworkBuffersPerGate +
+				", isCreditBased=" + isCreditBased +
 				", nettyConfig=" + nettyConfig +
 				'}';
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
@@ -27,8 +27,8 @@ import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
-
 import org.apache.flink.util.MathUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +128,6 @@ public class NetworkEnvironmentConfiguration {
 	 * @param taskManagerAddress identifying the IP address under which the TaskManager will be accessible
 	 * @return NetworkEnvironmentConfiguration
 	 */
-	@Deprecated
 	public static NetworkEnvironmentConfiguration fromConfiguration(
 		Configuration configuration,
 		long maxJvmHeapMemory,
@@ -254,10 +253,6 @@ public class NetworkEnvironmentConfiguration {
 				networkBufBytes, TaskManagerOptions.NETWORK_NUM_BUFFERS.key(),
 				"Network buffer memory size too large: " + networkBufBytes + " >= " +
 					totalJavaMemorySize + " (total JVM memory size)");
-			ConfigurationParserUtils.checkConfigParameter(networkBufBytes >= segmentSize,
-				networkBufBytes, TaskManagerOptions.NETWORK_NUM_BUFFERS.key(),
-				"Network buffer memory size too small: " + networkBufBytes + " < " +
-					segmentSize + " (" + TaskManagerOptions.MEMORY_SEGMENT_SIZE.key() + ")");
 		}
 
 		return networkBufBytes;
@@ -396,6 +391,7 @@ public class NetworkEnvironmentConfiguration {
 	 * @param maxJvmHeapMemory the maximum JVM heap size (in bytes)
 	 * @return the number of network buffers
 	 */
+	@SuppressWarnings("deprecation")
 	private static int calculateNumberOfNetworkBuffers(Configuration configuration, long maxJvmHeapMemory) {
 		final int numberOfNetworkBuffers;
 		if (!hasNewNetworkConfig(configuration)) {
@@ -424,14 +420,13 @@ public class NetworkEnvironmentConfiguration {
 	}
 
 	/**
-	 * Parses the configuration to wrapper related components into netty configuration which might be null if
-	 * communication is in the same task manager.
+	 * Generates {@link NettyConfig} from Flink {@link Configuration}.
 	 *
 	 * @param configuration configuration object
 	 * @param localTaskManagerCommunication true, to skip initializing the network stack
 	 * @param taskManagerAddress identifying the IP address under which the TaskManager will be accessible
 	 * @param dataport data port for communication and data exchange
-	 * @return the netty configuration
+	 * @return the netty configuration or {@code null} if communication is in the same task manager
 	 */
 	@Nullable
 	private static NettyConfig createNettyConfig(
@@ -459,7 +454,7 @@ public class NetworkEnvironmentConfiguration {
 	 * @param configuration configuration object
 	 * @return size of memory segment
 	 */
-	private static int getPageSize(Configuration configuration) {
+	public static int getPageSize(Configuration configuration) {
 		final int pageSize = checkedDownCast(MemorySize.parse(
 			configuration.getString(TaskManagerOptions.MEMORY_SEGMENT_SIZE)).getBytes());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
@@ -293,13 +293,6 @@ public class NetworkEnvironmentConfiguration {
 				TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key() + ")",
 			"Network buffer memory size too large: " + networkBufBytes + " >= " +
 				maxJvmHeapMemory + " (maximum JVM memory size)");
-		ConfigurationParserUtils.checkConfigParameter(networkBufBytes >= pageSize,
-			"(" + networkBufFraction + ", " + networkBufMin + ", " + networkBufMax + ")",
-			"(" + TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key() + ", " +
-				TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.key() + ", " +
-				TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key() + ")",
-			"Network buffer memory size too small: " + networkBufBytes + " < " +
-				pageSize + " (" + TaskManagerOptions.MEMORY_SEGMENT_SIZE.key() + ")");
 
 		return networkBufBytes;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
@@ -148,7 +148,7 @@ public class NetworkEnvironmentConfiguration {
 		int buffersPerChannel = configuration.getInteger(TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL);
 		int extraBuffersPerGate = configuration.getInteger(TaskManagerOptions.NETWORK_EXTRA_BUFFERS_PER_GATE);
 
-		boolean isCreditBased = configuration.getBoolean(TaskManagerOptions.NETWORK_CREDIT_MODEL);
+		boolean isCreditBased = nettyConfig != null && configuration.getBoolean(TaskManagerOptions.NETWORK_CREDIT_MODEL);
 
 		return new NetworkEnvironmentConfiguration(
 			numberOfNetworkBuffers,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfigurationBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfigurationBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+import org.apache.flink.runtime.io.network.netty.NettyConfig;
+
+/**
+ * Builder for the {@link NetworkEnvironmentConfiguration}.
+ */
+public class NetworkEnvironmentConfigurationBuilder {
+
+	private int numNetworkBuffers = 1024;
+
+	private int networkBufferSize = 32 * 1024;
+
+	private int partitionRequestInitialBackoff = 0;
+
+	private int partitionRequestMaxBackoff = 0;
+
+	private int networkBuffersPerChannel = 2;
+
+	private int floatingNetworkBuffersPerGate = 8;
+
+	private boolean isCreditBased = true;
+
+	private NettyConfig nettyConfig;
+
+	public NetworkEnvironmentConfigurationBuilder setNumNetworkBuffers(int numNetworkBuffers) {
+		this.numNetworkBuffers = numNetworkBuffers;
+		return this;
+	}
+
+	public NetworkEnvironmentConfigurationBuilder setNetworkBufferSize(int networkBufferSize) {
+		this.networkBufferSize = networkBufferSize;
+		return this;
+	}
+
+	public NetworkEnvironmentConfigurationBuilder setPartitionRequestInitialBackoff(int partitionRequestInitialBackoff) {
+		this.partitionRequestInitialBackoff = partitionRequestInitialBackoff;
+		return this;
+	}
+
+	public NetworkEnvironmentConfigurationBuilder setPartitionRequestMaxBackoff(int partitionRequestMaxBackoff) {
+		this.partitionRequestMaxBackoff = partitionRequestMaxBackoff;
+		return this;
+	}
+
+	public NetworkEnvironmentConfigurationBuilder setNetworkBuffersPerChannel(int networkBuffersPerChannel) {
+		this.networkBuffersPerChannel = networkBuffersPerChannel;
+		return this;
+	}
+
+	public NetworkEnvironmentConfigurationBuilder setFloatingNetworkBuffersPerGate(int floatingNetworkBuffersPerGate) {
+		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
+		return this;
+	}
+
+	public NetworkEnvironmentConfigurationBuilder setIsCreditBased(boolean isCreditBased) {
+		this.isCreditBased = isCreditBased;
+		return this;
+	}
+
+	public NetworkEnvironmentConfigurationBuilder setNettyConfig(NettyConfig nettyConfig) {
+		this.nettyConfig = nettyConfig;
+		return this;
+	}
+
+	public NetworkEnvironmentConfiguration build() {
+		return new NetworkEnvironmentConfiguration(
+			numNetworkBuffers,
+			networkBufferSize,
+			partitionRequestInitialBackoff,
+			partitionRequestMaxBackoff,
+			networkBuffersPerChannel,
+			floatingNetworkBuffersPerGate,
+			isCreditBased,
+			nettyConfig);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.util.MathUtils;
+
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.MEGA_BYTES;
+import static org.apache.flink.util.MathUtils.checkedDownCast;
+
+/**
+ * Utility class to extract related parameters from {@link Configuration} and to
+ * sanity check them.
+ */
+public class ConfigurationParserUtils {
+
+	/**
+	 * Parses the configuration to get the managed memory size and validates the value.
+	 *
+	 * @param configuration configuration object
+	 * @return managed memory size (in megabytes)
+	 */
+	public static long getManagedMemorySize(Configuration configuration) {
+		long managedMemorySize;
+		String managedMemorySizeDefaultVal = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue();
+		if (!configuration.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE).equals(managedMemorySizeDefaultVal)) {
+			try {
+				managedMemorySize = MemorySize.parse(
+					configuration.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE), MEGA_BYTES).getMebiBytes();
+			} catch (IllegalArgumentException e) {
+				throw new IllegalConfigurationException("Could not read " + TaskManagerOptions.MANAGED_MEMORY_SIZE.key(), e);
+			}
+		} else {
+			managedMemorySize = Long.valueOf(managedMemorySizeDefaultVal);
+		}
+
+		checkConfigParameter(configuration.getString(
+			TaskManagerOptions.MANAGED_MEMORY_SIZE).equals(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()) || managedMemorySize > 0,
+			managedMemorySize, TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
+			"MemoryManager needs at least one MB of memory. " +
+				"If you leave this config parameter empty, the system automatically pick a fraction of the available memory.");
+
+		return managedMemorySize;
+	}
+
+	/**
+	 * Parses the configuration to get the fraction of managed memory and validates the value.
+	 *
+	 * @param configuration configuration object
+	 * @return fraction of managed memory
+	 */
+	public static float getManagedMemoryFraction(Configuration configuration) {
+		float managedMemoryFraction = configuration.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION);
+
+		checkConfigParameter(managedMemoryFraction > 0.0f && managedMemoryFraction < 1.0f, managedMemoryFraction,
+			TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(),
+			"MemoryManager fraction of the free memory must be between 0.0 and 1.0");
+
+		return managedMemoryFraction;
+	}
+
+	/**
+	 * Parses the configuration to get the type of memory.
+	 *
+	 * @param configuration configuration object
+	 * @return type of memory
+	 */
+	public static MemoryType getMemoryType(Configuration configuration) {
+		// check whether we use heap or off-heap memory
+		final MemoryType memType;
+		if (configuration.getBoolean(TaskManagerOptions.MEMORY_OFF_HEAP)) {
+			memType = MemoryType.OFF_HEAP;
+		} else {
+			memType = MemoryType.HEAP;
+		}
+		return memType;
+	}
+
+	/**
+	 * Parses the configuration to get the page size and validates the value.
+	 *
+	 * @param configuration configuration object
+	 * @return size of memory segment
+	 */
+	public static int getPageSize(Configuration configuration) {
+		final int pageSize = checkedDownCast(MemorySize.parse(
+			configuration.getString(TaskManagerOptions.MEMORY_SEGMENT_SIZE)).getBytes());
+
+		// check page size of for minimum size
+		checkConfigParameter(pageSize >= MemoryManager.MIN_PAGE_SIZE, pageSize,
+			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
+			"Minimum memory segment size is " + MemoryManager.MIN_PAGE_SIZE);
+		// check page size for power of two
+		checkConfigParameter(MathUtils.isPowerOf2(pageSize), pageSize,
+			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
+			"Memory segment size must be a power of 2.");
+
+		return pageSize;
+	}
+
+	/**
+	 * Parses the configuration to get the number of slots and validates the value.
+	 *
+	 * @param configuration configuration object
+	 * @return the number of slots in task manager
+	 */
+	public static int getSlot(Configuration configuration) {
+		int slots = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
+		// we need this because many configs have been written with a "-1" entry
+		if (slots == -1) {
+			slots = 1;
+		}
+
+		ConfigurationParserUtils.checkConfigParameter(slots >= 1, slots, TaskManagerOptions.NUM_TASK_SLOTS.key(),
+			"Number of task slots must be at least one.");
+
+		return slots;
+	}
+
+	/**
+	 * Validates a condition for a config parameter and displays a standard exception, if the
+	 * the condition does not hold.
+	 *
+	 * @param condition             The condition that must hold. If the condition is false, an exception is thrown.
+	 * @param parameter         The parameter value. Will be shown in the exception message.
+	 * @param name              The name of the config parameter. Will be shown in the exception message.
+	 * @param errorMessage  The optional custom error message to append to the exception message.
+	 *
+	 * @throws IllegalConfigurationException if the condition does not hold
+	 */
+	public static void checkConfigParameter(boolean condition, Object parameter, String name, String errorMessage)
+		throws IllegalConfigurationException {
+		if (!condition) {
+			throw new IllegalConfigurationException("Invalid configuration value for " +
+				name + " : " + parameter + " - " + errorMessage);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
@@ -23,11 +23,8 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
-import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.util.MathUtils;
 
 import static org.apache.flink.configuration.MemorySize.MemoryUnit.MEGA_BYTES;
-import static org.apache.flink.util.MathUtils.checkedDownCast;
 
 /**
  * Utility class to extract related parameters from {@link Configuration} and to
@@ -95,28 +92,6 @@ public class ConfigurationParserUtils {
 			memType = MemoryType.HEAP;
 		}
 		return memType;
-	}
-
-	/**
-	 * Parses the configuration to get the page size and validates the value.
-	 *
-	 * @param configuration configuration object
-	 * @return size of memory segment
-	 */
-	public static int getPageSize(Configuration configuration) {
-		final int pageSize = checkedDownCast(MemorySize.parse(
-			configuration.getString(TaskManagerOptions.MEMORY_SEGMENT_SIZE)).getBytes());
-
-		// check page size of for minimum size
-		checkConfigParameter(pageSize >= MemoryManager.MIN_PAGE_SIZE, pageSize,
-			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
-			"Minimum memory segment size is " + MemoryManager.MIN_PAGE_SIZE);
-		// check page size for power of two
-		checkConfigParameter(MathUtils.isPowerOf2(pageSize), pageSize,
-			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
-			"Memory segment size must be a power of 2.");
-
-		return pageSize;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParametersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParametersTest.java
@@ -21,11 +21,12 @@ package org.apache.flink.runtime.clusterframework;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
 import static org.apache.flink.configuration.TaskManagerOptions.MEMORY_OFF_HEAP;
-import static org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateNetworkBufferMemory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -51,10 +52,9 @@ public class ContaineredTaskManagerParametersTest extends TestLogger {
 			ConfigConstants.DEFAULT_YARN_HEAP_CUTOFF);
 
 		long cutoff = Math.max((long) (CONTAINER_MEMORY * memoryCutoffRatio), minCutoff);
-		final long networkBufMB =
-			calculateNetworkBufferMemory(
-				(CONTAINER_MEMORY - cutoff) << 20, // megabytes to bytes
-				conf) >> 20; // bytes to megabytes
+		final long networkBufMB = NetworkEnvironmentConfiguration.calculateNetworkBufferMemory(
+			(CONTAINER_MEMORY - cutoff) << 20, // megabytes to bytes
+			conf) >> 20; // bytes to megabytes
 		assertEquals(networkBufMB + cutoff, params.taskManagerDirectMemoryLimitMB());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfigurationBuilder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.runtime.taskmanager.Task;
 
@@ -56,9 +57,6 @@ import static org.powermock.api.mockito.PowerMockito.spy;
  */
 @RunWith(Parameterized.class)
 public class NetworkEnvironmentTest {
-	private static final int numBuffers = 1024;
-
-	private static final int memorySegmentSize = 128;
 
 	@Parameterized.Parameter
 	public boolean enableCreditBasedFlowControl;
@@ -77,8 +75,9 @@ public class NetworkEnvironmentTest {
 	 */
 	@Test
 	public void testRegisterTaskUsesBoundedBuffers() throws Exception {
-		final NetworkEnvironment network = new NetworkEnvironment(
-			numBuffers, memorySegmentSize, 0, 0, 2, 8, enableCreditBasedFlowControl);
+		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build());
 
 		// result partitions
 		ResultPartition rp1 = createResultPartition(ResultPartitionType.PIPELINED, 2);
@@ -182,7 +181,10 @@ public class NetworkEnvironmentTest {
 
 	private void testRegisterTaskWithLimitedBuffers(int bufferPoolSize) throws Exception {
 		final NetworkEnvironment network = new NetworkEnvironment(
-			bufferPoolSize, memorySegmentSize, 0, 0, 2, 8, enableCreditBasedFlowControl);
+			new NetworkEnvironmentConfigurationBuilder()
+				.setNumNetworkBuffers(bufferPoolSize)
+				.setIsCreditBased(enableCreditBasedFlowControl)
+				.build());
 
 		final ConnectionManager connManager = createDummyConnectionManager();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -77,7 +77,8 @@ public class NetworkEnvironmentTest {
 	public void testRegisterTaskUsesBoundedBuffers() throws Exception {
 		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
 			.setIsCreditBased(enableCreditBasedFlowControl)
-			.build());
+			.build(),
+			new TaskEventDispatcher());
 
 		// result partitions
 		ResultPartition rp1 = createResultPartition(ResultPartitionType.PIPELINED, 2);
@@ -180,11 +181,11 @@ public class NetworkEnvironmentTest {
 	}
 
 	private void testRegisterTaskWithLimitedBuffers(int bufferPoolSize) throws Exception {
-		final NetworkEnvironment network = new NetworkEnvironment(
-			new NetworkEnvironmentConfigurationBuilder()
-				.setNumNetworkBuffers(bufferPoolSize)
-				.setIsCreditBased(enableCreditBasedFlowControl)
-				.build());
+		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
+			.setNumNetworkBuffers(bufferPoolSize)
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build(),
+			new TaskEventDispatcher());
 
 		final ConnectionManager connManager = createDummyConnectionManager();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -57,7 +57,7 @@ public class NettyConnectionManagerTest {
 				numberOfSlots,
 				new Configuration());
 
-		NettyConnectionManager connectionManager = new NettyConnectionManager(config);
+		NettyConnectionManager connectionManager = new NettyConnectionManager(config, true);
 
 		connectionManager.start(
 				mock(ResultPartitionProvider.class),
@@ -125,7 +125,7 @@ public class NettyConnectionManagerTest {
 				1337,
 				flinkConfig);
 
-		NettyConnectionManager connectionManager = new NettyConnectionManager(config);
+		NettyConnectionManager connectionManager = new NettyConnectionManager(config, true);
 
 		connectionManager.start(
 				mock(ResultPartitionProvider.class),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfigurationBuilder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.runtime.taskmanager.TaskActions;
 
@@ -226,7 +227,9 @@ public class ResultPartitionTest {
 	 */
 	private void testReleaseMemory(final ResultPartitionType resultPartitionType) throws Exception {
 		final int numAllBuffers = 10;
-		final NetworkEnvironment network = new NetworkEnvironment(numAllBuffers, 128, 0, 0, 2, 8, true);
+		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
+			.setNumNetworkBuffers(numAllBuffers)
+			.build());
 		final ResultPartitionConsumableNotifier notifier = new NoOpResultPartitionConsumableNotifier();
 		final ResultPartition resultPartition = createPartition(notifier, resultPartitionType, false);
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
@@ -228,8 +229,8 @@ public class ResultPartitionTest {
 	private void testReleaseMemory(final ResultPartitionType resultPartitionType) throws Exception {
 		final int numAllBuffers = 10;
 		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
-			.setNumNetworkBuffers(numAllBuffers)
-			.build());
+			.setNumNetworkBuffers(numAllBuffers).build(),
+			new TaskEventDispatcher());
 		final ResultPartitionConsumableNotifier notifier = new NoOpResultPartitionConsumableNotifier();
 		final ResultPartition resultPartition = createPartition(notifier, resultPartitionType, false);
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.io.network.util.TestTaskEvent;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfigurationBuilder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 
 import org.junit.Test;
@@ -341,8 +342,11 @@ public class SingleInputGateTest {
 		int initialBackoff = 137;
 		int maxBackoff = 1001;
 
-		final NetworkEnvironment netEnv = new NetworkEnvironment(
-			100, 32, initialBackoff, maxBackoff, 2, 8, enableCreditBasedFlowControl);
+		final NetworkEnvironment netEnv = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
+			.setPartitionRequestInitialBackoff(initialBackoff)
+			.setPartitionRequestMaxBackoff(maxBackoff)
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build());
 
 		SingleInputGate gate = SingleInputGate.create(
 			"TestTask",
@@ -402,8 +406,9 @@ public class SingleInputGateTest {
 		final SingleInputGate inputGate = createInputGate(1, ResultPartitionType.PIPELINED_BOUNDED);
 		int buffersPerChannel = 2;
 		int extraNetworkBuffersPerGate = 8;
-		final NetworkEnvironment network = new NetworkEnvironment(
-			100, 32, 0, 0, buffersPerChannel, extraNetworkBuffersPerGate, enableCreditBasedFlowControl);
+		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build());
 
 		try {
 			final ResultPartitionID resultPartitionId = new ResultPartitionID();
@@ -441,8 +446,9 @@ public class SingleInputGateTest {
 		final SingleInputGate inputGate = createInputGate(1, ResultPartitionType.PIPELINED_BOUNDED);
 		int buffersPerChannel = 2;
 		int extraNetworkBuffersPerGate = 8;
-		final NetworkEnvironment network = new NetworkEnvironment(
-			100, 32, 0, 0, buffersPerChannel, extraNetworkBuffersPerGate, enableCreditBasedFlowControl);
+		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build());
 
 		try {
 			final ResultPartitionID resultPartitionId = new ResultPartitionID();
@@ -492,9 +498,9 @@ public class SingleInputGateTest {
 	@Test
 	public void testUpdateUnknownInputChannel() throws Exception {
 		final SingleInputGate inputGate = createInputGate(2);
-		int buffersPerChannel = 2;
-		final NetworkEnvironment network = new NetworkEnvironment(
-			100, 32, 0, 0, buffersPerChannel, 8, enableCreditBasedFlowControl);
+		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build());
 
 		try {
 			final ResultPartitionID localResultPartitionId = new ResultPartitionID();
@@ -586,8 +592,8 @@ public class SingleInputGateTest {
 			network.getResultPartitionManager(),
 			new TaskEventDispatcher(),
 			network.getConnectionManager(),
-			network.getPartitionRequestInitialBackoff(),
-			network.getPartitionRequestMaxBackoff(),
+			network.getConfiguration().partitionRequestInitialBackoff(),
+			network.getConfiguration().partitionRequestMaxBackoff(),
 			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup()
 		);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -346,7 +346,8 @@ public class SingleInputGateTest {
 			.setPartitionRequestInitialBackoff(initialBackoff)
 			.setPartitionRequestMaxBackoff(maxBackoff)
 			.setIsCreditBased(enableCreditBasedFlowControl)
-			.build());
+			.build(),
+			new TaskEventDispatcher());
 
 		SingleInputGate gate = SingleInputGate.create(
 			"TestTask",
@@ -406,9 +407,7 @@ public class SingleInputGateTest {
 		final SingleInputGate inputGate = createInputGate(1, ResultPartitionType.PIPELINED_BOUNDED);
 		int buffersPerChannel = 2;
 		int extraNetworkBuffersPerGate = 8;
-		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
-			.setIsCreditBased(enableCreditBasedFlowControl)
-			.build());
+		final NetworkEnvironment network = createNetworkEnvironment();
 
 		try {
 			final ResultPartitionID resultPartitionId = new ResultPartitionID();
@@ -446,9 +445,7 @@ public class SingleInputGateTest {
 		final SingleInputGate inputGate = createInputGate(1, ResultPartitionType.PIPELINED_BOUNDED);
 		int buffersPerChannel = 2;
 		int extraNetworkBuffersPerGate = 8;
-		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
-			.setIsCreditBased(enableCreditBasedFlowControl)
-			.build());
+		final NetworkEnvironment network = createNetworkEnvironment();
 
 		try {
 			final ResultPartitionID resultPartitionId = new ResultPartitionID();
@@ -498,9 +495,7 @@ public class SingleInputGateTest {
 	@Test
 	public void testUpdateUnknownInputChannel() throws Exception {
 		final SingleInputGate inputGate = createInputGate(2);
-		final NetworkEnvironment network = new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
-			.setIsCreditBased(enableCreditBasedFlowControl)
-			.build());
+		final NetworkEnvironment network = createNetworkEnvironment();
 
 		try {
 			final ResultPartitionID localResultPartitionId = new ResultPartitionID();
@@ -608,6 +603,13 @@ public class SingleInputGateTest {
 			createUnknownInputChannel(network, inputGate, partitionId, channelIndex)
 				.toRemoteInputChannel(connectionId);
 		inputGate.setInputChannel(partitionId.getPartitionId(), remote);
+	}
+
+	private NetworkEnvironment createNetworkEnvironment() {
+		return new NetworkEnvironment(new NetworkEnvironmentConfigurationBuilder()
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build(),
+			new TaskEventDispatcher());
 	}
 
 	static void verifyBufferOrEvent(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -43,7 +43,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 	@ClassRule
 	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-	private static final long MEM_SIZE_PARAM = 128L*1024*1024;
+	private static final long MEM_SIZE_PARAM = 128L * 1024 * 1024;
 
 	/**
 	 * This tests that the creation of {@link TaskManagerServices} correctly creates the local state root directory
@@ -67,7 +67,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 		final ResourceID tmResourceID = ResourceID.generate();
 
 		TaskManagerServicesConfiguration taskManagerServicesConfiguration =
-			TaskManagerServicesConfiguration.fromConfiguration(config, InetAddress.getLocalHost(), true);
+			TaskManagerServicesConfiguration.fromConfiguration(config, MEM_SIZE_PARAM, InetAddress.getLocalHost(), true);
 
 		TaskManagerServices taskManagerServices = TaskManagerServices.fromConfiguration(
 			taskManagerServicesConfiguration,
@@ -108,7 +108,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 		final ResourceID tmResourceID = ResourceID.generate();
 
 		TaskManagerServicesConfiguration taskManagerServicesConfiguration =
-			TaskManagerServicesConfiguration.fromConfiguration(config, InetAddress.getLocalHost(), true);
+			TaskManagerServicesConfiguration.fromConfiguration(config, MEM_SIZE_PARAM, InetAddress.getLocalHost(), true);
 
 		TaskManagerServices taskManagerServices = TaskManagerServices.fromConfiguration(
 			taskManagerServicesConfiguration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -32,8 +33,8 @@ import static org.junit.Assert.assertEquals;
 public class NetworkBufferCalculationTest extends TestLogger {
 
 	/**
-	 * Test for {@link TaskManagerServicesConfiguration#calculateNetworkBufferMemory(Configuration, long)}
-	 * using the same (manual) test cases as in {@link TaskManagerServicesTest#calculateHeapSizeMB()}.
+	 * Test for {@link NetworkEnvironmentConfiguration#calculateNewNetworkBufferMemory(Configuration, long)}
+	 * using the same (manual) test cases as in {@link NetworkEnvironmentConfigurationTest#calculateHeapSizeMB()}.
 	 */
 	@Test
 	public void calculateNetworkBufFromHeapSize() {
@@ -44,23 +45,23 @@ public class NetworkBufferCalculationTest extends TestLogger {
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.1f, 60L << 20, 1L << 30, false);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
-			TaskManagerServicesConfiguration.calculateNetworkBufferMemory(config, 900L << 20)); // 900MB
+			NetworkEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 900L << 20)); // 900MB
 
 		config = getConfig(
 			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.2f, 60L << 20, 1L << 30, false);
 		assertEquals((200L << 20) + 3 /* slightly too many due to floating point imprecision */,
-			TaskManagerServicesConfiguration.calculateNetworkBufferMemory(config, 800L << 20)); // 800MB
+			NetworkEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 800L << 20)); // 800MB
 
 		config = getConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.1f, 60L << 20, 1L << 30, true);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
-			TaskManagerServicesConfiguration.calculateNetworkBufferMemory(config, 890L << 20)); // 890MB
+			NetworkEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 890L << 20)); // 890MB
 
 		config = getConfig(0, 0.1f, 0.1f, 60L << 20, 1L << 30, true);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
-			TaskManagerServicesConfiguration.calculateNetworkBufferMemory(config, 810L << 20)); // 810MB
+			NetworkEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 810L << 20)); // 810MB
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -57,6 +57,7 @@ import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
 import org.apache.flink.runtime.io.network.partition.NoOpResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -263,7 +264,7 @@ public class TaskExecutorTest extends TestLogger {
 			false);
 
 		final NetworkEnvironment networkEnvironment = new NetworkEnvironment(
-			new NetworkEnvironmentConfigurationBuilder().build());
+			new NetworkEnvironmentConfigurationBuilder().build(), new TaskEventDispatcher());
 		networkEnvironment.start();
 
 		final KvStateService kvStateService = new KvStateService(new KvStateRegistry(), null, null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -89,6 +89,7 @@ import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfigurationBuilder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -262,13 +263,7 @@ public class TaskExecutorTest extends TestLogger {
 			false);
 
 		final NetworkEnvironment networkEnvironment = new NetworkEnvironment(
-			1,
-			1,
-			0,
-			0,
-			2,
-			8,
-			true);
+			new NetworkEnvironmentConfigurationBuilder().build());
 		networkEnvironment.start();
 
 		final KvStateService kvStateService = new KvStateService(new KvStateRegistry(), null, null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfigurationTest.java
@@ -26,67 +26,17 @@ import org.junit.Test;
 
 import java.net.InetAddress;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Unit test for {@link TaskManagerServicesConfiguration}.
  */
 public class TaskManagerServicesConfigurationTest extends TestLogger {
-	/**
-	 * Verifies that {@link TaskManagerServicesConfiguration#hasNewNetworkBufConf(Configuration)}
-	 * returns the correct result for old configurations via
-	 * {@link TaskManagerOptions#NETWORK_NUM_BUFFERS}.
-	 */
-	@SuppressWarnings("deprecation")
-	@Test
-	public void hasNewNetworkBufConfOld() throws Exception {
-		Configuration config = new Configuration();
-		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 1);
 
-		assertFalse(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-	}
+	private static final long MEM_SIZE_PARAM = 128L * 1024 * 1024;
 
 	/**
-	 * Verifies that {@link TaskManagerServicesConfiguration#hasNewNetworkBufConf(Configuration)}
-	 * returns the correct result for new configurations via
-	 * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION},
-	 * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN} and {@link
-	 * TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}.
-	 */
-	@Test
-	public void hasNewNetworkBufConfNew() throws Exception {
-		Configuration config = new Configuration();
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-
-		// fully defined:
-		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, "1024");
-		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, "2048");
-
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-
-		// partly defined:
-		config = new Configuration();
-		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, "1024");
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-
-		config = new Configuration();
-		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, "1024");
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-
-		config = new Configuration();
-		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, "1024");
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, "1024");
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-	}
-
-	/**
-	 * Verifies that {@link TaskManagerServicesConfiguration#hasNewNetworkBufConf(Configuration)}
+	 * Verifies that {@link TaskManagerServicesConfiguration#fromConfiguration(Configuration, long, InetAddress, boolean)}
 	 * returns the correct result for new configurations via
 	 * {@link TaskManagerOptions#NETWORK_REQUEST_BACKOFF_INITIAL},
 	 * {@link TaskManagerOptions#NETWORK_REQUEST_BACKOFF_MAX},
@@ -104,39 +54,11 @@ public class TaskManagerServicesConfigurationTest extends TestLogger {
 		config.setInteger(TaskManagerOptions.NETWORK_EXTRA_BUFFERS_PER_GATE, 100);
 
 		TaskManagerServicesConfiguration tmConfig =
-			TaskManagerServicesConfiguration.fromConfiguration(config, InetAddress.getLoopbackAddress(), true);
+			TaskManagerServicesConfiguration.fromConfiguration(config, MEM_SIZE_PARAM, InetAddress.getLoopbackAddress(), true);
 
 		assertEquals(tmConfig.getNetworkConfig().partitionRequestInitialBackoff(), 100);
 		assertEquals(tmConfig.getNetworkConfig().partitionRequestMaxBackoff(), 200);
 		assertEquals(tmConfig.getNetworkConfig().networkBuffersPerChannel(), 10);
 		assertEquals(tmConfig.getNetworkConfig().floatingNetworkBuffersPerGate(), 100);
 	}
-
-	/**
-	 * Verifies that {@link TaskManagerServicesConfiguration#hasNewNetworkBufConf(Configuration)}
-	 * returns the correct result for mixed old/new configurations.
-	 */
-	@SuppressWarnings("deprecation")
-	@Test
-	public void hasNewNetworkBufConfMixed() throws Exception {
-		Configuration config = new Configuration();
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-
-		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 1);
-		assertFalse(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-
-		// old + 1 new parameter = new:
-		Configuration config1 = config.clone();
-		config1.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
-
-		config1 = config.clone();
-		config1.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, "1024");
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
-
-		config1 = config.clone();
-		config1.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, "1024");
-		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
-	}
-
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -20,8 +20,6 @@ package org.apache.flink.streaming.runtime.io.benchmark;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
@@ -32,6 +30,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
@@ -49,6 +48,7 @@ import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfigurationBuilder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -56,7 +56,6 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 
 import static org.apache.flink.util.ExceptionUtils.suppressExceptions;
-import static org.apache.flink.util.MathUtils.checkedDownCast;
 
 /**
  * Context for network benchmarks executed by the external
@@ -192,27 +191,19 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 	private NetworkEnvironment createNettyNetworkEnvironment(
 			@SuppressWarnings("SameParameterValue") int bufferPoolSize, Configuration config) throws Exception {
 
-		int segmentSize =
-			checkedDownCast(
-				MemorySize.parse(config.getString(TaskManagerOptions.MEMORY_SEGMENT_SIZE))
-					.getBytes());
-
-		// we need this because many configs have been written with a "-1" entry
-		// similar to TaskManagerServicesConfiguration#fromConfiguration()
-		// -> please note that this directly influences the number of netty threads!
-		int slots = config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
-		if (slots == -1) {
-			slots = 1;
-		}
-
-		final NettyConfig nettyConfig = new NettyConfig(LOCAL_ADDRESS, 0, segmentSize, slots, config);
+		final NettyConfig nettyConfig = new NettyConfig(
+			LOCAL_ADDRESS,
+			0,
+			NetworkEnvironmentConfiguration.getPageSize(config),
+			// please note that the number of slots directly influences the number of netty threads!
+			ConfigurationParserUtils.getSlot(config),
+			config);
 		final NetworkEnvironmentConfiguration configuration = new NetworkEnvironmentConfigurationBuilder()
 			.setNumNetworkBuffers(bufferPoolSize)
-			.setNetworkBufferSize(segmentSize)
 			.setNettyConfig(nettyConfig)
 			.build();
 
-		return new NetworkEnvironment(configuration);
+		return new NetworkEnvironment(configuration, new TaskEventDispatcher());
 	}
 
 	protected ResultPartitionWriter createResultPartition(

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -35,7 +35,7 @@ import org.apache.flink.runtime.rest.messages.ClusterOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersInfo;
-import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.util.ExceptionUtils;
@@ -203,11 +203,9 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		// set memory constraints (otherwise this is the same test as perJobYarnCluster() above)
 		final long taskManagerMemoryMB = 1024;
 		//noinspection NumericOverflow if the calculation of the total Java memory size overflows, default configuration parameters are wrong in the first place, so we can ignore this inspection
-		final long networkBuffersMB = TaskManagerServices
-			.calculateNetworkBufferMemory(
-				(taskManagerMemoryMB -
-					ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.defaultValue()) << 20,
-				new Configuration()) >> 20;
+		final long networkBuffersMB = NetworkEnvironmentConfiguration.calculateNetworkBufferMemory(
+			(taskManagerMemoryMB - ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.defaultValue()) << 20,
+			new Configuration()) >> 20;
 		final long offHeapMemory = taskManagerMemoryMB
 			- ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.defaultValue()
 			// cutoff memory (will be added automatically)


### PR DESCRIPTION
## What is the purpose of the change

*The constructor of `NetworkEnvironment` could be refactored to only contain `NetworkEnvironmentConfiguration`, the other related components such as `TaskEventDispatcher`, `ResultPartitionManager`, `NetworkBufferPool` could be created internally.*

*We also refactor the process of generating `NetworkEnvironmentConfiguration` in `TaskManagerServiceConfiguration` to add `numNetworkBuffers` instead of previous `networkBufFraction`, `networkBufMin`, `networkBufMax`. This way seems more easy and direct to construct `NetworkBufferPool` later. `isCreditBased` field is also maintained in this component for considering the setting usage in tests.*

*Further we introduce the `NetworkEnvironmentConfigurationBuilder` for creating `NetworkEnvironmentConfiguration` easily especially for tests.*

## Brief change log

  - *Refactor the constructor of `NetworkEnvironment` to container only `NetworkEnvironmentConfiguration*
  - *Refactor the constructor of `NetworkEnvironmentConfiguration`*
  - *Introduce the NetworkEnvironmentConfigurationBuilder` for tests*

## Verifying this change

This change is already covered by existing tests, such as *NetworkEnvironmentTest* and *NetworkBufferCalculationTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)