### PR TITLE
[FLINK-12076] [table-planner-blink] Add support for generating optimized logical plan for simple group aggregate on batch

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/PlannerConfigOptions.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/PlannerConfigOptions.java
@@ -39,6 +39,16 @@ public class PlannerConfigOptions {
 							"(only count RexCall node, including leaves and interior nodes). Negative number to" +
 							" use the default threshold: double of number of nodes.");
 
+	public static final ConfigOption<String> SQL_OPTIMIZER_AGG_PHASE_ENFORCER =
+			key("sql.optimizer.agg.phase.enforcer")
+					.defaultValue("NONE")
+					.withDescription("Strategy for agg phase. Only NONE, TWO_PHASE or ONE_PHASE can be set.\n" +
+							"NONE: No special enforcer for aggregate stage. Whether to choose two stage aggregate or one" +
+							" stage aggregate depends on cost. \n" +
+							"TWO_PHASE: Enforce to use two stage aggregate which has localAggregate and globalAggregate. " +
+							"NOTE: If aggregate call does not support split into two phase, still use one stage aggregate.\n" +
+							"ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggregate.");
+
 	public static final ConfigOption<Boolean> SQL_OPTIMIZER_SHUFFLE_PARTIAL_KEY_ENABLED =
 			key("sql.optimizer.shuffle.partial-key.enabled")
 					.defaultValue(false)

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
@@ -25,10 +25,10 @@ import java.util.List;
 
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.DIVIDE;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.EQUALS;
-import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.LESS_THAN;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.GREATER_THAN;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.IF;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.IS_NULL;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.LESS_THAN;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.MINUS;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.PLUS;
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.DIVIDE;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.EQUALS;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.LESS_THAN;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.GREATER_THAN;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.IF;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.IS_NULL;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.MINUS;
@@ -77,5 +79,13 @@ public class ExpressionBuilder {
 
 	public static Expression equalTo(Expression input1, Expression input2) {
 		return call(EQUALS, input1, input2);
+	}
+
+	public static Expression lessThan(Expression input1, Expression input2) {
+		return call(LESS_THAN, input1, input2);
+	}
+
+	public static Expression greaterThan(Expression input1, Expression input2) {
+		return call(GREATER_THAN, input1, input2);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/Count1AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/Count1AggFunction.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedFieldReferenceExpression;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.InternalTypes;
+
+import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
+import static org.apache.flink.table.expressions.ExpressionBuilder.minus;
+import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
+
+/**
+ * This count1 aggregate function returns the count1 of values
+ * which go into it like [[CountAggFunction]].
+ * It differs in that null values are also counted.
+ */
+public class Count1AggFunction extends DeclarativeAggregateFunction {
+	private UnresolvedFieldReferenceExpression count1 = new UnresolvedFieldReferenceExpression("count1");
+
+	@Override
+	public int operandCount() {
+		return 1;
+	}
+
+	@Override
+	public UnresolvedFieldReferenceExpression[] aggBufferAttributes() {
+		return new UnresolvedFieldReferenceExpression[] { count1 };
+	}
+
+	@Override
+	public InternalType[] getAggBufferTypes() {
+		return new InternalType[] { InternalTypes.LONG };
+	}
+
+	@Override
+	public TypeInformation getResultType() {
+		return Types.LONG;
+	}
+
+	@Override
+	public Expression[] initialValuesExpressions() {
+		return new Expression[] {
+				/* count1 = */ literal(0L, getResultType())
+		};
+	}
+
+	@Override
+	public Expression[] accumulateExpressions() {
+		return new Expression[] {
+				/* count1 = */ plus(count1, literal(1L))
+		};
+	}
+
+	@Override
+	public Expression[] retractExpressions() {
+		return new Expression[] {
+				/* count1 = */ minus(count1, literal(1L))
+		};
+	}
+
+	@Override
+	public Expression[] mergeExpressions() {
+		return new Expression[] {
+				/* count1 = */ plus(count1, mergeOperand(count1))
+		};
+	}
+
+	@Override
+	public Expression getValueExpression() {
+		return count1;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/CountAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/CountAggFunction.java
@@ -32,7 +32,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.minus;
 import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
 
 /**
- * built-in count aggregate function
+ * built-in count aggregate function.
  */
 public class CountAggFunction extends DeclarativeAggregateFunction {
 	private UnresolvedFieldReferenceExpression count = new UnresolvedFieldReferenceExpression("count");

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/CountAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/CountAggFunction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedFieldReferenceExpression;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.InternalTypes;
+
+import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
+import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
+import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
+import static org.apache.flink.table.expressions.ExpressionBuilder.minus;
+import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
+
+/**
+ * built-in count aggregate function
+ */
+public class CountAggFunction extends DeclarativeAggregateFunction {
+	private UnresolvedFieldReferenceExpression count = new UnresolvedFieldReferenceExpression("count");
+
+	@Override
+	public int operandCount() {
+		return 1;
+	}
+
+	@Override
+	public UnresolvedFieldReferenceExpression[] aggBufferAttributes() {
+		return new UnresolvedFieldReferenceExpression[] { count };
+	}
+
+	@Override
+	public InternalType[] getAggBufferTypes() {
+		return new InternalType[] { InternalTypes.LONG };
+	}
+
+	@Override
+	public TypeInformation getResultType() {
+		return Types.LONG;
+	}
+
+	@Override
+	public Expression[] initialValuesExpressions() {
+		return new Expression[] {
+				/* count = */ literal(0L, getResultType())
+		};
+	}
+
+	@Override
+	public Expression[] accumulateExpressions() {
+		return new Expression[] {
+				/* count = */ ifThenElse(isNull(operand(0)), count, plus(count, literal(1L)))
+		};
+	}
+
+	@Override
+	public Expression[] retractExpressions() {
+		return new Expression[] {
+				/* count = */ ifThenElse(isNull(operand(0)), count, minus(count, literal(1L)))
+		};
+	}
+
+	@Override
+	public Expression[] mergeExpressions() {
+		return new Expression[] {
+				/* count = */ plus(count, mergeOperand(count))
+		};
+	}
+
+	// If all input are nulls, count will be 0 and we will get result 0.
+	@Override
+	public Expression getValueExpression() {
+		return count;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/DeclarativeAggregateFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/DeclarativeAggregateFunction.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.functions;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedFieldReferenceExpression;
+import org.apache.flink.table.type.InternalType;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Arrays;
@@ -56,6 +57,11 @@ public abstract class DeclarativeAggregateFunction extends UserDefinedFunction {
 	 * All fields of the aggregate buffer.
 	 */
 	public abstract UnresolvedFieldReferenceExpression[] aggBufferAttributes();
+
+	/**
+	 * All types of the aggregate buffer.
+	 */
+	public abstract InternalType[] getAggBufferTypes();
 
 	/**
 	 * The result type of the function.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/MaxAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/MaxAggFunction.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedFieldReferenceExpression;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.TypeConverters;
+import org.apache.flink.table.typeutils.DecimalTypeInfo;
+
+import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
+import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
+import static org.apache.flink.table.expressions.ExpressionBuilder.greaterThan;
+import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
+
+/**
+ * built-in max aggregate function.
+ */
+public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
+	private UnresolvedFieldReferenceExpression max = new UnresolvedFieldReferenceExpression("max");
+
+	@Override
+	public int operandCount() {
+		return 1;
+	}
+
+	@Override
+	public UnresolvedFieldReferenceExpression[] aggBufferAttributes() {
+		return new UnresolvedFieldReferenceExpression[] { max };
+	}
+
+	@Override
+	public InternalType[] getAggBufferTypes() {
+		return new InternalType[] { TypeConverters.createInternalTypeFromTypeInfo(getResultType()) };
+	}
+
+	@Override
+	public Expression[] initialValuesExpressions() {
+		return new Expression[] {
+				/* max = */ nullOf(getResultType())
+		};
+	}
+
+	@Override
+	public Expression[] accumulateExpressions() {
+		return new Expression[] {
+				/* max = */
+				ifThenElse(isNull(operand(0)), max,
+						ifThenElse(isNull(max), operand(0),
+								ifThenElse(greaterThan(operand(0), max), operand(0), max)))
+		};
+	}
+
+	@Override
+	public Expression[] retractExpressions() {
+		return new Expression[] {};
+	}
+
+	@Override
+	public Expression[] mergeExpressions() {
+		return new Expression[] {
+				/* max = */
+				ifThenElse(isNull(mergeOperand(max)), max,
+						ifThenElse(isNull(max), mergeOperand(max),
+								ifThenElse(greaterThan(mergeOperand(max), max), mergeOperand(max), max)))
+		};
+	}
+
+	@Override
+	public Expression getValueExpression() {
+		return max;
+	}
+
+	/**
+	 * Built-in Int Max aggregate function
+	 */
+	public static class IntMaxAggFunction extends MaxAggFunction {
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.INT;
+		}
+	}
+
+	/**
+	 * Built-in Byte Max aggregate function
+	 */
+	public static class ByteMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.BYTE;
+		}
+	}
+
+	/**
+	 * Built-in Short Max aggregate function
+	 */
+	public static class ShortMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SHORT;
+		}
+	}
+
+	/**
+	 * Built-in Long Max aggregate function
+	 */
+	public static class LongMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.LONG;
+		}
+	}
+
+	/**
+	 * Built-in Float Max aggregate function
+	 */
+	public static class FloatMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.FLOAT;
+		}
+	}
+
+	/**
+	 * Built-in Double Max aggregate function
+	 */
+	public static class DoubleMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.DOUBLE;
+		}
+	}
+
+	/**
+	 * Built-in Decimal Max aggregate function
+	 */
+	public static class DecimalMaxAggFunction extends MaxAggFunction {
+		private DecimalTypeInfo decimalType;
+
+		public DecimalMaxAggFunction(DecimalTypeInfo decimalType) {
+			this.decimalType = decimalType;
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return decimalType;
+		}
+	}
+
+	/**
+	 * Built-in Boolean Max aggregate function.
+	 */
+	public static class BooleanMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.BOOLEAN;
+		}
+	}
+
+	/**
+	 * Built-in String Max aggregate function.
+	 */
+	public static class StringMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.STRING;
+		}
+	}
+
+	/**
+	 * Built-in Date Max aggregate function.
+	 */
+	public static class DateMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_DATE;
+		}
+	}
+
+	/**
+	 * Built-in Time Max aggregate function.
+	 */
+	public static class TimeMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_TIME;
+		}
+	}
+
+	/**
+	 * Built-in Timestamp Max aggregate function.
+	 */
+	public static class TimestampMaxAggFunction extends MaxAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_TIMESTAMP;
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/MaxAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/MaxAggFunction.java
@@ -26,9 +26,9 @@ import org.apache.flink.table.type.InternalType;
 import org.apache.flink.table.type.TypeConverters;
 import org.apache.flink.table.typeutils.DecimalTypeInfo;
 
+import static org.apache.flink.table.expressions.ExpressionBuilder.greaterThan;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
-import static org.apache.flink.table.expressions.ExpressionBuilder.greaterThan;
 import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
 
 /**
@@ -90,7 +90,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Int Max aggregate function
+	 * Built-in Int Max aggregate function.
 	 */
 	public static class IntMaxAggFunction extends MaxAggFunction {
 
@@ -101,7 +101,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Byte Max aggregate function
+	 * Built-in Byte Max aggregate function.
 	 */
 	public static class ByteMaxAggFunction extends MaxAggFunction {
 		@Override
@@ -111,7 +111,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Short Max aggregate function
+	 * Built-in Short Max aggregate function.
 	 */
 	public static class ShortMaxAggFunction extends MaxAggFunction {
 		@Override
@@ -121,7 +121,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Long Max aggregate function
+	 * Built-in Long Max aggregate function.
 	 */
 	public static class LongMaxAggFunction extends MaxAggFunction {
 		@Override
@@ -131,7 +131,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Float Max aggregate function
+	 * Built-in Float Max aggregate function.
 	 */
 	public static class FloatMaxAggFunction extends MaxAggFunction {
 		@Override
@@ -141,7 +141,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Double Max aggregate function
+	 * Built-in Double Max aggregate function.
 	 */
 	public static class DoubleMaxAggFunction extends MaxAggFunction {
 		@Override
@@ -151,7 +151,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Decimal Max aggregate function
+	 * Built-in Decimal Max aggregate function.
 	 */
 	public static class DecimalMaxAggFunction extends MaxAggFunction {
 		private DecimalTypeInfo decimalType;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/MinAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/MinAggFunction.java
@@ -90,7 +90,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Int Min aggregate function
+	 * Built-in Int Min aggregate function.
 	 */
 	public static class IntMinAggFunction extends MinAggFunction {
 
@@ -101,7 +101,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Byte Min aggregate function
+	 * Built-in Byte Min aggregate function.
 	 */
 	public static class ByteMinAggFunction extends MinAggFunction {
 		@Override
@@ -111,7 +111,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Short Min aggregate function
+	 * Built-in Short Min aggregate function.
 	 */
 	public static class ShortMinAggFunction extends MinAggFunction {
 		@Override
@@ -121,7 +121,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Long Min aggregate function
+	 * Built-in Long Min aggregate function.
 	 */
 	public static class LongMinAggFunction extends MinAggFunction {
 		@Override
@@ -131,7 +131,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Float Min aggregate function
+	 * Built-in Float Min aggregate function.
 	 */
 	public static class FloatMinAggFunction extends MinAggFunction {
 		@Override
@@ -141,7 +141,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Double Min aggregate function
+	 * Built-in Double Min aggregate function.
 	 */
 	public static class DoubleMinAggFunction extends MinAggFunction {
 		@Override
@@ -151,7 +151,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Decimal Min aggregate function
+	 * Built-in Decimal Min aggregate function.
 	 */
 	public static class DecimalMinAggFunction extends MinAggFunction {
 		private DecimalTypeInfo decimalType;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/MinAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/MinAggFunction.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedFieldReferenceExpression;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.TypeConverters;
+import org.apache.flink.table.typeutils.DecimalTypeInfo;
+
+import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
+import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
+import static org.apache.flink.table.expressions.ExpressionBuilder.lessThan;
+import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
+
+/**
+ * built-in min aggregate function.
+ */
+public abstract class MinAggFunction extends DeclarativeAggregateFunction {
+	private UnresolvedFieldReferenceExpression min = new UnresolvedFieldReferenceExpression("min");
+
+	@Override
+	public int operandCount() {
+		return 1;
+	}
+
+	@Override
+	public UnresolvedFieldReferenceExpression[] aggBufferAttributes() {
+		return new UnresolvedFieldReferenceExpression[] { min };
+	}
+
+	@Override
+	public InternalType[] getAggBufferTypes() {
+		return new InternalType[] { TypeConverters.createInternalTypeFromTypeInfo(getResultType()) };
+	}
+
+	@Override
+	public Expression[] initialValuesExpressions() {
+		return new Expression[] {
+				/* min = */ nullOf(getResultType())
+		};
+	}
+
+	@Override
+	public Expression[] accumulateExpressions() {
+		return new Expression[] {
+				/* min = */
+				ifThenElse(isNull(operand(0)), min,
+						ifThenElse(isNull(min), operand(0),
+								ifThenElse(lessThan(operand(0), min), operand(0), min)))
+		};
+	}
+
+	@Override
+	public Expression[] retractExpressions() {
+		return new Expression[] {};
+	}
+
+	@Override
+	public Expression[] mergeExpressions() {
+		return new Expression[] {
+				/* min = */
+				ifThenElse(isNull(mergeOperand(min)), min,
+						ifThenElse(isNull(min), mergeOperand(min),
+								ifThenElse(lessThan(mergeOperand(min), min), mergeOperand(min), min)))
+		};
+	}
+
+	@Override
+	public Expression getValueExpression() {
+		return min;
+	}
+
+	/**
+	 * Built-in Int Min aggregate function
+	 */
+	public static class IntMinAggFunction extends MinAggFunction {
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.INT;
+		}
+	}
+
+	/**
+	 * Built-in Byte Min aggregate function
+	 */
+	public static class ByteMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.BYTE;
+		}
+	}
+
+	/**
+	 * Built-in Short Min aggregate function
+	 */
+	public static class ShortMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SHORT;
+		}
+	}
+
+	/**
+	 * Built-in Long Min aggregate function
+	 */
+	public static class LongMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.LONG;
+		}
+	}
+
+	/**
+	 * Built-in Float Min aggregate function
+	 */
+	public static class FloatMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.FLOAT;
+		}
+	}
+
+	/**
+	 * Built-in Double Min aggregate function
+	 */
+	public static class DoubleMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.DOUBLE;
+		}
+	}
+
+	/**
+	 * Built-in Decimal Min aggregate function
+	 */
+	public static class DecimalMinAggFunction extends MinAggFunction {
+		private DecimalTypeInfo decimalType;
+
+		public DecimalMinAggFunction(DecimalTypeInfo decimalType) {
+			this.decimalType = decimalType;
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return decimalType;
+		}
+	}
+
+	/**
+	 * Built-in Boolean Min aggregate function.
+	 */
+	public static class BooleanMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.BOOLEAN;
+		}
+	}
+
+	/**
+	 * Built-in String Min aggregate function.
+	 */
+	public static class StringMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.STRING;
+		}
+	}
+
+	/**
+	 * Built-in Date Min aggregate function.
+	 */
+	public static class DateMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_DATE;
+		}
+	}
+
+	/**
+	 * Built-in Time Min aggregate function.
+	 */
+	public static class TimeMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_TIME;
+		}
+	}
+
+	/**
+	 * Built-in Timestamp Min aggregate function.
+	 */
+	public static class TimestampMinAggFunction extends MinAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_TIMESTAMP;
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/Sum0AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/Sum0AggFunction.java
@@ -24,30 +24,22 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedFieldReferenceExpression;
 import org.apache.flink.table.type.DecimalType;
 import org.apache.flink.table.type.InternalType;
-import org.apache.flink.table.type.InternalTypes;
 import org.apache.flink.table.type.TypeConverters;
 import org.apache.flink.table.typeutils.DecimalTypeInfo;
 
 import java.math.BigDecimal;
 
-import static org.apache.flink.table.expressions.ExpressionBuilder.div;
-import static org.apache.flink.table.expressions.ExpressionBuilder.equalTo;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
 import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
 import static org.apache.flink.table.expressions.ExpressionBuilder.minus;
-import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
 import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
 
 /**
- * built-in avg aggregate function.
+ * built-in sum0 aggregate function.
  */
-public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
-
-	private UnresolvedFieldReferenceExpression sum = new UnresolvedFieldReferenceExpression("sum");
-	private UnresolvedFieldReferenceExpression count = new UnresolvedFieldReferenceExpression("count");
-
-	public abstract TypeInformation getSumType();
+public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
+	private UnresolvedFieldReferenceExpression sum0 = new UnresolvedFieldReferenceExpression("sum");
 
 	@Override
 	public int operandCount() {
@@ -56,121 +48,143 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 
 	@Override
 	public UnresolvedFieldReferenceExpression[] aggBufferAttributes() {
-		return new UnresolvedFieldReferenceExpression[] {
-				sum,
-				count};
+		return new UnresolvedFieldReferenceExpression[] { sum0 };
 	}
 
 	@Override
 	public InternalType[] getAggBufferTypes() {
-		return new InternalType[] {
-				TypeConverters.createInternalTypeFromTypeInfo(getSumType()),
-				InternalTypes.LONG
-		};
+		return new InternalType[] { TypeConverters.createInternalTypeFromTypeInfo(getResultType()) };
 	}
 
 	@Override
 	public Expression[] initialValuesExpressions() {
 		return new Expression[] {
-				/* sum = */ literal(0L, getSumType()),
-				/* count = */ literal(0L)};
+				/* sum0 = */ literal(0L, getResultType())
+		};
 	}
 
 	@Override
 	public Expression[] accumulateExpressions() {
 		return new Expression[] {
-				/* sum = */ ifThenElse(isNull(operand(0)), sum, plus(sum, operand(0))),
-				/* count = */ ifThenElse(isNull(operand(0)), count, plus(count, literal(1L))),
+				/* sum0 = */ ifThenElse(isNull(operand(0)), sum0, plus(sum0, operand(0)))
 		};
 	}
 
 	@Override
 	public Expression[] retractExpressions() {
 		return new Expression[] {
-				/* sum = */ ifThenElse(isNull(operand(0)), sum, minus(sum, operand(0))),
-				/* count = */ ifThenElse(isNull(operand(0)), count, minus(count, literal(1L))),
+				/* sum0 = */ ifThenElse(isNull(operand(0)), sum0, minus(sum0, operand(0)))
 		};
 	}
 
 	@Override
 	public Expression[] mergeExpressions() {
 		return new Expression[] {
-				/* sum = */ plus(sum, mergeOperand(sum)),
-				/* count = */ plus(count, mergeOperand(count))
+				/* sum0 = */ plus(sum0, mergeOperand(sum0))
 		};
 	}
 
-	/**
-	 * If all input are nulls, count will be 0 and we will get null after the division.
-	 */
 	@Override
 	public Expression getValueExpression() {
-		return ifThenElse(equalTo(count, literal(0L)), nullOf(getResultType()), div(sum, count));
+		return sum0;
 	}
 
 	/**
-	 * Built-in Int Avg aggregate function for integral arguments,
-	 * including BYTE, SHORT, INT, LONG.
-	 * The result type is DOUBLE.
+	 * Built-in Int Sum0 aggregate function
 	 */
-	public static class IntegralAvgAggFunction extends AvgAggFunction {
+	public static class IntSum0AggFunction extends Sum0AggFunction {
 
 		@Override
 		public TypeInformation getResultType() {
-			return Types.DOUBLE;
+			return Types.INT;
 		}
+	}
 
+	/**
+	 * Built-in Byte Sum0 aggregate function
+	 */
+	public static class ByteSum0AggFunction extends Sum0AggFunction {
 		@Override
-		public TypeInformation getSumType() {
+		public TypeInformation getResultType() {
+			return Types.BYTE;
+		}
+	}
+
+	/**
+	 * Built-in Short Sum0 aggregate function
+	 */
+	public static class ShortSum0AggFunction extends Sum0AggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SHORT;
+		}
+	}
+
+	/**
+	 * Built-in Long Sum0 aggregate function
+	 */
+	public static class LongSum0AggFunction extends Sum0AggFunction {
+		@Override
+		public TypeInformation getResultType() {
 			return Types.LONG;
 		}
 	}
 
 	/**
-	 * Built-in Double Avg aggregate function.
+	 * Built-in Float Sum0 aggregate function
 	 */
-	public static class DoubleAvgAggFunction extends AvgAggFunction {
-
+	public static class FloatSum0AggFunction extends Sum0AggFunction {
 		@Override
 		public TypeInformation getResultType() {
-			return Types.DOUBLE;
-		}
-
-		@Override
-		public TypeInformation getSumType() {
-			return Types.DOUBLE;
+			return Types.FLOAT;
 		}
 
 		@Override
 		public Expression[] initialValuesExpressions() {
-			return new Expression[] {literal(0D), literal(0L)};
+			return new Expression[] {
+					/* sum0 = */ literal(0.0f, getResultType())
+			};
 		}
 	}
 
 	/**
-	 * Built-in Decimal Avg aggregate function.
+	 * Built-in Double Sum0 aggregate function
 	 */
-	public static class DecimalAvgAggFunction extends AvgAggFunction {
-
-		private final DecimalTypeInfo type;
-
-		public DecimalAvgAggFunction(DecimalTypeInfo type) {
-			this.type = type;
-		}
-
+	public static class DoubleSum0AggFunction extends Sum0AggFunction {
 		@Override
 		public TypeInformation getResultType() {
-			return DecimalType.inferAggAvgType(type.scale()).toTypeInfo();
-		}
-
-		@Override
-		public TypeInformation getSumType() {
-			return DecimalType.inferAggSumType(type.scale()).toTypeInfo();
+			return Types.DOUBLE;
 		}
 
 		@Override
 		public Expression[] initialValuesExpressions() {
-			return new Expression[] {literal(new BigDecimal(0)), literal(0L)};
+			return new Expression[] {
+					/* sum0 = */ literal(0.0d, getResultType())
+			};
+		}
+	}
+
+	/**
+	 * Built-in Decimal Sum0 aggregate function
+	 */
+	public static class DecimalSum0AggFunction extends Sum0AggFunction {
+		private DecimalTypeInfo decimalType;
+
+		public DecimalSum0AggFunction(DecimalTypeInfo decimalType) {
+			this.decimalType = decimalType;
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			DecimalType sumType = DecimalType.inferAggSumType(decimalType.scale());
+			return new DecimalTypeInfo(sumType.precision(), sumType.scale());
+		}
+
+		@Override
+		public Expression[] initialValuesExpressions() {
+			return new Expression[] {
+					/* sum0 = */ literal(new BigDecimal(0), getResultType())
+			};
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/Sum0AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/Sum0AggFunction.java
@@ -90,7 +90,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Int Sum0 aggregate function
+	 * Built-in Int Sum0 aggregate function.
 	 */
 	public static class IntSum0AggFunction extends Sum0AggFunction {
 
@@ -101,7 +101,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Byte Sum0 aggregate function
+	 * Built-in Byte Sum0 aggregate function.
 	 */
 	public static class ByteSum0AggFunction extends Sum0AggFunction {
 		@Override
@@ -111,7 +111,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Short Sum0 aggregate function
+	 * Built-in Short Sum0 aggregate function.
 	 */
 	public static class ShortSum0AggFunction extends Sum0AggFunction {
 		@Override
@@ -121,7 +121,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Long Sum0 aggregate function
+	 * Built-in Long Sum0 aggregate function.
 	 */
 	public static class LongSum0AggFunction extends Sum0AggFunction {
 		@Override
@@ -131,7 +131,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Float Sum0 aggregate function
+	 * Built-in Float Sum0 aggregate function.
 	 */
 	public static class FloatSum0AggFunction extends Sum0AggFunction {
 		@Override
@@ -148,7 +148,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Double Sum0 aggregate function
+	 * Built-in Double Sum0 aggregate function.
 	 */
 	public static class DoubleSum0AggFunction extends Sum0AggFunction {
 		@Override
@@ -165,7 +165,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Decimal Sum0 aggregate function
+	 * Built-in Decimal Sum0 aggregate function.
 	 */
 	public static class DecimalSum0AggFunction extends Sum0AggFunction {
 		private DecimalTypeInfo decimalType;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/SumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/SumAggFunction.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedFieldReferenceExpression;
 import org.apache.flink.table.type.DecimalType;
 import org.apache.flink.table.type.InternalType;
-import org.apache.flink.table.type.InternalTypes;
 import org.apache.flink.table.type.TypeConverters;
 import org.apache.flink.table.typeutils.DecimalTypeInfo;
 
@@ -95,7 +94,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Int Sum aggregate function
+	 * Built-in Int Sum aggregate function.
 	 */
 	public static class IntSumAggFunction extends SumAggFunction {
 
@@ -106,7 +105,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Byte Sum aggregate function
+	 * Built-in Byte Sum aggregate function.
 	 */
 	public static class ByteSumAggFunction extends SumAggFunction {
 		@Override
@@ -116,7 +115,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Short Sum aggregate function
+	 * Built-in Short Sum aggregate function.
 	 */
 	public static class ShortSumAggFunction extends SumAggFunction {
 		@Override
@@ -126,7 +125,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Long Sum aggregate function
+	 * Built-in Long Sum aggregate function.
 	 */
 	public static class LongSumAggFunction extends SumAggFunction {
 		@Override
@@ -136,7 +135,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Float Sum aggregate function
+	 * Built-in Float Sum aggregate function.
 	 */
 	public static class FloatSumAggFunction extends SumAggFunction {
 		@Override
@@ -146,7 +145,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Double Sum aggregate function
+	 * Built-in Double Sum aggregate function.
 	 */
 	public static class DoubleSumAggFunction extends SumAggFunction {
 		@Override
@@ -156,7 +155,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	}
 
 	/**
-	 * Built-in Decimal Sum aggregate function
+	 * Built-in Decimal Sum aggregate function.
 	 */
 	public static class DecimalSumAggFunction extends SumAggFunction {
 		private DecimalTypeInfo decimalType;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/SumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/SumAggFunction.java
@@ -28,26 +28,17 @@ import org.apache.flink.table.type.InternalTypes;
 import org.apache.flink.table.type.TypeConverters;
 import org.apache.flink.table.typeutils.DecimalTypeInfo;
 
-import java.math.BigDecimal;
-
-import static org.apache.flink.table.expressions.ExpressionBuilder.div;
-import static org.apache.flink.table.expressions.ExpressionBuilder.equalTo;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
-import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
 import static org.apache.flink.table.expressions.ExpressionBuilder.minus;
 import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
 import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
 
 /**
- * built-in avg aggregate function.
+ * built-in sum aggregate function.
  */
-public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
-
+public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	private UnresolvedFieldReferenceExpression sum = new UnresolvedFieldReferenceExpression("sum");
-	private UnresolvedFieldReferenceExpression count = new UnresolvedFieldReferenceExpression("count");
-
-	public abstract TypeInformation getSumType();
 
 	@Override
 	public int operandCount() {
@@ -56,121 +47,128 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 
 	@Override
 	public UnresolvedFieldReferenceExpression[] aggBufferAttributes() {
-		return new UnresolvedFieldReferenceExpression[] {
-				sum,
-				count};
+		return new UnresolvedFieldReferenceExpression[] { sum };
 	}
 
 	@Override
 	public InternalType[] getAggBufferTypes() {
-		return new InternalType[] {
-				TypeConverters.createInternalTypeFromTypeInfo(getSumType()),
-				InternalTypes.LONG
-		};
+		return new InternalType[] { TypeConverters.createInternalTypeFromTypeInfo(getResultType()) };
 	}
 
 	@Override
 	public Expression[] initialValuesExpressions() {
 		return new Expression[] {
-				/* sum = */ literal(0L, getSumType()),
-				/* count = */ literal(0L)};
+				/* sum = */ nullOf(getResultType())
+		};
 	}
 
 	@Override
 	public Expression[] accumulateExpressions() {
 		return new Expression[] {
-				/* sum = */ ifThenElse(isNull(operand(0)), sum, plus(sum, operand(0))),
-				/* count = */ ifThenElse(isNull(operand(0)), count, plus(count, literal(1L))),
+				/* sum = */
+				ifThenElse(isNull(operand(0)), sum,
+						ifThenElse(isNull(sum), operand(0), plus(sum, operand(0))))
 		};
 	}
 
 	@Override
 	public Expression[] retractExpressions() {
 		return new Expression[] {
-				/* sum = */ ifThenElse(isNull(operand(0)), sum, minus(sum, operand(0))),
-				/* count = */ ifThenElse(isNull(operand(0)), count, minus(count, literal(1L))),
+				/* sum = */
+				ifThenElse(isNull(operand(0)), sum,
+						ifThenElse(isNull(sum), operand(0), minus(sum, operand(0))))
 		};
 	}
 
 	@Override
 	public Expression[] mergeExpressions() {
 		return new Expression[] {
-				/* sum = */ plus(sum, mergeOperand(sum)),
-				/* count = */ plus(count, mergeOperand(count))
+				/* sum = */
+				ifThenElse(isNull(mergeOperand(sum)), sum,
+						ifThenElse(isNull(sum), mergeOperand(sum), plus(sum, mergeOperand(sum))))
 		};
 	}
 
-	/**
-	 * If all input are nulls, count will be 0 and we will get null after the division.
-	 */
 	@Override
 	public Expression getValueExpression() {
-		return ifThenElse(equalTo(count, literal(0L)), nullOf(getResultType()), div(sum, count));
+		return sum;
 	}
 
 	/**
-	 * Built-in Int Avg aggregate function for integral arguments,
-	 * including BYTE, SHORT, INT, LONG.
-	 * The result type is DOUBLE.
+	 * Built-in Int Sum aggregate function
 	 */
-	public static class IntegralAvgAggFunction extends AvgAggFunction {
+	public static class IntSumAggFunction extends SumAggFunction {
 
 		@Override
 		public TypeInformation getResultType() {
-			return Types.DOUBLE;
+			return Types.INT;
 		}
+	}
 
+	/**
+	 * Built-in Byte Sum aggregate function
+	 */
+	public static class ByteSumAggFunction extends SumAggFunction {
 		@Override
-		public TypeInformation getSumType() {
+		public TypeInformation getResultType() {
+			return Types.BYTE;
+		}
+	}
+
+	/**
+	 * Built-in Short Sum aggregate function
+	 */
+	public static class ShortSumAggFunction extends SumAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SHORT;
+		}
+	}
+
+	/**
+	 * Built-in Long Sum aggregate function
+	 */
+	public static class LongSumAggFunction extends SumAggFunction {
+		@Override
+		public TypeInformation getResultType() {
 			return Types.LONG;
 		}
 	}
 
 	/**
-	 * Built-in Double Avg aggregate function.
+	 * Built-in Float Sum aggregate function
 	 */
-	public static class DoubleAvgAggFunction extends AvgAggFunction {
-
+	public static class FloatSumAggFunction extends SumAggFunction {
 		@Override
 		public TypeInformation getResultType() {
-			return Types.DOUBLE;
-		}
-
-		@Override
-		public TypeInformation getSumType() {
-			return Types.DOUBLE;
-		}
-
-		@Override
-		public Expression[] initialValuesExpressions() {
-			return new Expression[] {literal(0D), literal(0L)};
+			return Types.FLOAT;
 		}
 	}
 
 	/**
-	 * Built-in Decimal Avg aggregate function.
+	 * Built-in Double Sum aggregate function
 	 */
-	public static class DecimalAvgAggFunction extends AvgAggFunction {
+	public static class DoubleSumAggFunction extends SumAggFunction {
+		@Override
+		public TypeInformation getResultType() {
+			return Types.DOUBLE;
+		}
+	}
 
-		private final DecimalTypeInfo type;
+	/**
+	 * Built-in Decimal Sum aggregate function
+	 */
+	public static class DecimalSumAggFunction extends SumAggFunction {
+		private DecimalTypeInfo decimalType;
 
-		public DecimalAvgAggFunction(DecimalTypeInfo type) {
-			this.type = type;
+		public DecimalSumAggFunction(DecimalTypeInfo decimalType) {
+			this.decimalType = decimalType;
 		}
 
 		@Override
 		public TypeInformation getResultType() {
-			return DecimalType.inferAggAvgType(type.scale()).toTypeInfo();
-		}
-
-		@Override
-		public TypeInformation getSumType() {
-			return DecimalType.inferAggSumType(type.scale()).toTypeInfo();
-		}
-
-		@Override
-		public Expression[] initialValuesExpressions() {
-			return new Expression[] {literal(new BigDecimal(0)), literal(0L)};
+			DecimalType sumType = DecimalType.inferAggSumType(decimalType.scale());
+			return new DecimalTypeInfo(sumType.precision(), sumType.scale());
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/AggSqlFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/AggSqlFunctions.java
@@ -15,12 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.table.functions.sql;
 
 import org.apache.flink.table.functions.sql.internal.SqlAuxiliaryGroupAggFunction;
 
 import org.apache.calcite.sql.SqlAggFunction;
 
+/**
+ * aggregate functions.
+ */
 public class AggSqlFunctions {
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/AggSqlFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/AggSqlFunctions.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.functions.sql;
+
+import org.apache.flink.table.functions.sql.internal.SqlAuxiliaryGroupAggFunction;
+
+import org.apache.calcite.sql.SqlAggFunction;
+
+public class AggSqlFunctions {
+
+	/**
+	 * <code>AUXILIARY_GROUP</code> aggregate function.
+	 * Only be used in internally.
+	 */
+	public static final SqlAggFunction AUXILIARY_GROUP = new SqlAuxiliaryGroupAggFunction();
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/internal/SqlAuxiliaryGroupAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/internal/SqlAuxiliaryGroupAggFunction.java
@@ -15,25 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.functions.sql.internal
 
-import org.apache.flink.annotation.Internal
+package org.apache.flink.table.functions.sql.internal;
 
-import org.apache.calcite.sql.`type`.{OperandTypes, ReturnTypes, SqlOperandTypeInference}
-import org.apache.calcite.sql.{SqlAggFunction, SqlFunctionCategory, SqlIdentifier, SqlKind}
+import org.apache.flink.annotation.Internal;
+
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
 
 /**
-  * An internal [[SqlAggFunction]] to represents auxiliary group keys
-  * which will not be computed as key and does not also affect the correctness of the final result.
-  */
+ * An internal [[SqlAggFunction]] to represents auxiliary group keys
+ * which will not be computed as key and does not also affect the correctness of the final result.
+ */
 @Internal
-object SqlAuxiliaryGroupAggFunction extends SqlAggFunction(
-  "AUXILIARY_GROUP",
-  null.asInstanceOf[SqlIdentifier],
-  SqlKind.OTHER_FUNCTION,
-  ReturnTypes.ARG0,
-  null.asInstanceOf[SqlOperandTypeInference],
-  OperandTypes.ANY,
-  SqlFunctionCategory.SYSTEM,
-  false,
-  false)
+public class SqlAuxiliaryGroupAggFunction extends SqlAggFunction {
+
+	public SqlAuxiliaryGroupAggFunction() {
+		super("AUXILIARY_GROUP",
+				null,
+				SqlKind.OTHER_FUNCTION,
+				ReturnTypes.ARG0,
+				null,
+				OperandTypes.ANY,
+				SqlFunctionCategory.SYSTEM,
+				false,
+				false);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableConfig.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableConfig.scala
@@ -145,6 +145,7 @@ class TableConfig {
   def setCalciteConfig(calciteConfig: CalciteConfig): Unit = {
     this.calciteConfig = Preconditions.checkNotNull(calciteConfig)
   }
+
   /**
     * Returns true if given [[OperatorType]] is enabled, else false.
     */
@@ -175,4 +176,3 @@ object AggPhaseEnforcer extends Enumeration {
   type AggPhaseEnforcer = Value
   val NONE, ONE_PHASE, TWO_PHASE = Value
 }
-

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/dataview/DataViewUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/dataview/DataViewUtils.scala
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.dataview
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.java.typeutils.{PojoField, PojoTypeInfo, RowTypeInfo}
+import org.apache.flink.table.`type`.{RowType, TypeConverters}
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.dataview._
+import org.apache.flink.table.dataformat.GenericRow
+import org.apache.flink.table.functions.AggregateFunction
+import org.apache.flink.table.typeutils._
+
+import java.util
+
+import scala.collection.mutable
+
+object DataViewUtils {
+
+  /**
+    * Use NullSerializer for StateView fields from accumulator type information.
+    *
+    * @param index index of aggregate function
+    * @param aggFun aggregate function
+    * @param externalAccType accumulator type information, only support pojo type
+    * @param isStateBackedDataViews is data views use state backend
+    * @return mapping of accumulator type information and data view config which contains id,
+    *         field name and state descriptor
+    */
+  def useNullSerializerForStateViewFieldsFromAccType(
+      index: Int,
+      aggFun: AggregateFunction[_, _],
+      externalAccType: TypeInformation[_],
+      isStateBackedDataViews: Boolean): (TypeInformation[_], Array[DataViewSpec]) = {
+
+    val acc = aggFun.createAccumulator()
+    val accumulatorSpecs = new mutable.ArrayBuffer[DataViewSpec]
+
+    externalAccType match {
+      case pojoType: PojoTypeInfo[_] if pojoType.getArity > 0 =>
+        val arity = pojoType.getArity
+        val newPojoFields = new util.ArrayList[PojoField]()
+
+        for (i <- 0 until arity) {
+          val pojoField = pojoType.getPojoFieldAt(i)
+          val field = pojoField.getField
+          val fieldName = field.getName
+          field.setAccessible(true)
+          val instance = field.get(acc)
+          val (newTypeInfo: TypeInformation[_], spec: Option[DataViewSpec]) =
+            decorateDataViewTypeInfo(
+              pojoField.getTypeInformation,
+              instance,
+              isStateBackedDataViews,
+              index,
+              i,
+              fieldName)
+
+          newPojoFields.add(new PojoField(field, newTypeInfo))
+          if (spec.isDefined) {
+            accumulatorSpecs += spec.get
+          }
+        }
+        val pojoTypeInfo = new PojoTypeInfo(externalAccType.getTypeClass, newPojoFields)
+        (pojoTypeInfo, accumulatorSpecs.toArray)
+
+      // RowType's ExternalTypeInfo is RowTypeInfo
+      // so we add another check => acc.isInstanceOf[GenericRow]
+      case r: RowTypeInfo if acc.isInstanceOf[GenericRow] =>
+        val accInstance = acc.asInstanceOf[GenericRow]
+        val (arity, fieldNames, fieldTypes) = (r.getArity, r.getFieldNames, r.getFieldTypes)
+        val newFieldTypes = for (i <- 0 until arity) yield {
+          val fieldName = fieldNames(i)
+          val fieldInstance = accInstance.getField(i)
+          val (newTypeInfo: TypeInformation[_], spec: Option[DataViewSpec]) =
+            decorateDataViewTypeInfo(
+              fieldTypes(i),
+              fieldInstance,
+              isStateBackedDataViews,
+              index,
+              i,
+              fieldName)
+          if (spec.isDefined) {
+            accumulatorSpecs += spec.get
+          }
+          TypeConverters.createInternalTypeFromTypeInfo(newTypeInfo)
+        }
+
+        val newType = new RowType(newFieldTypes.toArray, fieldNames)
+        (TypeConverters.createExternalTypeInfoFromInternalType(newType), accumulatorSpecs.toArray)
+      case ct: CompositeType[_] if includesDataView(ct) =>
+        throw new TableException(
+          "MapView, SortedMapView and ListView only supported in accumulators of POJO type.")
+      case _ => (externalAccType, Array.empty)
+    }
+  }
+
+  /** Recursively checks if composite type includes a data view type. */
+  def includesDataView(ct: CompositeType[_]): Boolean = {
+    (0 until ct.getArity).exists(i =>
+      ct.getTypeAt(i) match {
+        case nestedCT: CompositeType[_] => includesDataView(nestedCT)
+        case t: TypeInformation[_] if t.getTypeClass == classOf[ListView[_]] => true
+        case t: TypeInformation[_] if t.getTypeClass == classOf[MapView[_, _]] => true
+        // TODO supports SortedMapView
+        // case t: TypeInformation[_] if t.getTypeClass == classOf[SortedMapView[_, _]] => true
+        case _ => false
+      }
+    )
+  }
+
+  /** Analyse dataview element types and decorate the dataview typeinfos */
+  def decorateDataViewTypeInfo(
+      info: TypeInformation[_],
+      instance: AnyRef,
+      isStateBackedDataViews: Boolean,
+      aggIndex: Int,
+      fieldIndex: Int,
+      fieldName: String): (TypeInformation[_], Option[DataViewSpec]) = {
+    var spec: Option[DataViewSpec] = None
+    val resultTypeInfo: TypeInformation[_] = info match {
+      case ct: CompositeType[_] if includesDataView(ct) =>
+        throw new TableException(
+          "MapView, SortedMapView and ListView only supported at first level of " +
+            "accumulators of Pojo type.")
+      // TODO supports MapViewTypeInfo, SortedMapViewTypeInfo, ListViewTypeInfo
+
+      case t: TypeInformation[_] => t
+    }
+
+    (resultTypeInfo, spec)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/functions/sql/internal/SqlAuxiliaryGroupAggFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/functions/sql/internal/SqlAuxiliaryGroupAggFunction.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.functions.sql.internal
+
+import org.apache.flink.annotation.Internal
+
+import org.apache.calcite.sql.`type`.{OperandTypes, ReturnTypes, SqlOperandTypeInference}
+import org.apache.calcite.sql.{SqlAggFunction, SqlFunctionCategory, SqlIdentifier, SqlKind}
+
+/**
+  * An internal [[SqlAggFunction]] to represents auxiliary group keys
+  * which will not be computed as key and does not also affect the correctness of the final result.
+  */
+@Internal
+object SqlAuxiliaryGroupAggFunction extends SqlAggFunction(
+  "AUXILIARY_GROUP",
+  null.asInstanceOf[SqlIdentifier],
+  SqlKind.OTHER_FUNCTION,
+  ReturnTypes.ARG0,
+  null.asInstanceOf[SqlOperandTypeInference],
+  OperandTypes.ANY,
+  SqlFunctionCategory.SYSTEM,
+  false,
+  false)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
@@ -222,6 +222,8 @@ object FlinkBatchRuleSets {
     BatchExecLimitRule.INSTANCE,
     BatchExecSortLimitRule.INSTANCE,
     BatchExecRankRule.INSTANCE,
+    BatchExecHashAggRule.INSTANCE,
+    BatchExecSortAggRule.INSTANCE,
     BatchExecHashJoinRule.INSTANCE,
     BatchExecSortMergeJoinRule.INSTANCE,
     BatchExecNestedLoopJoinRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecAggRuleBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecAggRuleBase.scala
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.JArrayList
+import org.apache.flink.table.`type`.{InternalType, TypeConverters}
+import org.apache.flink.table.api.{AggPhaseEnforcer, PlannerConfigOptions, TableConfig, TableException}
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.dataformat.BinaryRow
+import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
+import org.apache.flink.table.functions.{AggregateFunction, DeclarativeAggregateFunction, UserDefinedFunction}
+import org.apache.flink.table.plan.util.{AggregateUtil, FlinkRelOptUtil, RelFieldCollationUtil}
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.Aggregate
+import org.apache.calcite.rel.{RelCollation, RelCollations, RelFieldCollation}
+import org.apache.calcite.util.Util
+
+import scala.collection.JavaConversions._
+
+trait BatchExecAggRuleBase {
+
+  protected def inferLocalAggType(
+      inputRowType: RelDataType,
+      agg: Aggregate,
+      groupSet: Array[Int],
+      auxGroupSet: Array[Int],
+      aggFunctions: Array[UserDefinedFunction],
+      aggBufferTypes: Array[Array[InternalType]]): RelDataType = {
+
+    val typeFactory = agg.getCluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    val aggCallNames = Util.skip(
+      agg.getRowType.getFieldNames, groupSet.length + auxGroupSet.length).toList.toArray[String]
+    inferLocalAggType(
+      inputRowType, typeFactory, aggCallNames, groupSet, auxGroupSet, aggFunctions, aggBufferTypes)
+  }
+
+  protected def inferLocalAggType(
+      inputRowType: RelDataType,
+      typeFactory: FlinkTypeFactory,
+      aggCallNames: Array[String],
+      groupSet: Array[Int],
+      auxGroupSet: Array[Int],
+      aggFunctions: Array[UserDefinedFunction],
+      aggBufferTypes: Array[Array[InternalType]]): RelDataType = {
+
+    val aggBufferFieldNames = new Array[Array[String]](aggFunctions.length)
+    var index = -1
+    aggFunctions.zipWithIndex.foreach {
+      case (udf, aggIndex) =>
+        aggBufferFieldNames(aggIndex) = udf match {
+          case _: AggregateFunction[_, _] =>
+            Array(aggCallNames(aggIndex))
+          case agf: DeclarativeAggregateFunction =>
+            agf.aggBufferAttributes.map { attr =>
+              index += 1
+              s"${attr.getName}$$$index"
+            }
+          case _: UserDefinedFunction =>
+            throw new TableException(s"Don't get localAgg merge name")
+        }
+    }
+
+    // local agg output order: groupSet + auxGroupSet + aggCalls
+    val aggBufferSqlTypes = aggBufferTypes.flatten.map { t =>
+      val nullable = !FlinkTypeFactory.isTimeIndicatorType(t)
+      typeFactory.createTypeFromInternalType(t, nullable)
+    }
+
+    val localAggFieldTypes = (
+      groupSet.map(inputRowType.getFieldList.get(_).getType) ++ // groupSet
+        auxGroupSet.map(inputRowType.getFieldList.get(_).getType) ++ // auxGroupSet
+        aggBufferSqlTypes // aggCalls
+      ).toList
+
+    val localAggFieldNames = (
+      groupSet.map(inputRowType.getFieldList.get(_).getName) ++ // groupSet
+        auxGroupSet.map(inputRowType.getFieldList.get(_).getName) ++ // auxGroupSet
+        aggBufferFieldNames.flatten.toArray[String] // aggCalls
+      ).toList
+
+    typeFactory.createStructType(localAggFieldTypes, localAggFieldNames)
+  }
+
+  protected def isTwoPhaseAggWorkable(
+      aggFunctions: Array[UserDefinedFunction],
+      tableConfig: TableConfig): Boolean = {
+    getAggEnforceStrategy(tableConfig) match {
+      case AggPhaseEnforcer.ONE_PHASE => false
+      case _ => doAllSupportMerge(aggFunctions)
+    }
+  }
+
+  protected def isOnePhaseAggWorkable(
+      agg: Aggregate,
+      aggFunctions: Array[UserDefinedFunction],
+      tableConfig: TableConfig): Boolean = {
+    getAggEnforceStrategy(tableConfig) match {
+      case AggPhaseEnforcer.ONE_PHASE => true
+      case AggPhaseEnforcer.TWO_PHASE => !doAllSupportMerge(aggFunctions)
+      case AggPhaseEnforcer.NONE =>
+        if (!doAllSupportMerge(aggFunctions)) {
+          true
+        } else {
+          // if ndv of group key in aggregate is Unknown and all aggFunctions are splittable,
+          // use two-phase agg.
+          // else whether choose one-phase agg or two-phase agg depends on CBO.
+          val mq = agg.getCluster.getMetadataQuery
+          mq.getDistinctRowCount(agg.getInput, agg.getGroupSet, null) != null
+        }
+    }
+  }
+
+  protected def doAllSupportMerge(aggFunctions: Array[UserDefinedFunction]): Boolean = {
+    val supportLocalAgg = aggFunctions.forall {
+      case _: DeclarativeAggregateFunction => true
+      case a => ifMethodExistInFunction("merge", a)
+    }
+    //it means grouping without aggregate functions
+    aggFunctions.isEmpty || supportLocalAgg
+  }
+
+  protected def isEnforceOnePhaseAgg(tableConfig: TableConfig): Boolean = {
+    getAggEnforceStrategy(tableConfig) == AggPhaseEnforcer.ONE_PHASE
+  }
+
+  protected def isEnforceTwoPhaseAgg(tableConfig: TableConfig): Boolean = {
+    getAggEnforceStrategy(tableConfig) == AggPhaseEnforcer.TWO_PHASE
+  }
+
+  protected def getAggEnforceStrategy(tableConfig: TableConfig): AggPhaseEnforcer.Value = {
+    val aggPrefConfig = tableConfig.getConf.getString(
+      PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER)
+    AggPhaseEnforcer.values.find(_.toString.equalsIgnoreCase(aggPrefConfig))
+      .getOrElse(throw new IllegalArgumentException(
+        "Agg phase enforcer can only set to be: NONE, ONE_PHASE, TWO_PHASE!"))
+  }
+
+  protected def isAggBufferFixedLength(agg: Aggregate): Boolean = {
+    val (_, aggCallsWithoutAuxGroupCalls) = FlinkRelOptUtil.checkAndSplitAggCalls(agg)
+    val (_, aggBufferTypes, _) = AggregateUtil.transformToBatchAggregateFunctions(
+      aggCallsWithoutAuxGroupCalls, agg.getInput.getRowType)
+
+    isAggBufferFixedLength(aggBufferTypes.map(_.map(TypeConverters.createInternalTypeFromTypeInfo)))
+  }
+
+  protected def isAggBufferFixedLength(aggBufferTypes: Array[Array[InternalType]]): Boolean = {
+    val aggBuffAttributesTypes = aggBufferTypes.flatten
+    val isAggBufferFixedLength = aggBuffAttributesTypes.forall(BinaryRow.isMutable)
+    // it means grouping without aggregate functions
+    aggBuffAttributesTypes.isEmpty || isAggBufferFixedLength
+  }
+
+  protected def createRelCollation(groupSet: Array[Int]): RelCollation = {
+    val fields = new JArrayList[RelFieldCollation]()
+    for (field <- groupSet) {
+      fields.add(RelFieldCollationUtil.of(field))
+    }
+    RelCollations.of(fields)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecAggRuleBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecAggRuleBase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.dataformat.BinaryRow
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.functions.{AggregateFunction, DeclarativeAggregateFunction, UserDefinedFunction}
-import org.apache.flink.table.plan.util.{AggregateUtil, FlinkRelOptUtil, RelFieldCollationUtil}
+import org.apache.flink.table.plan.util.{AggregateUtil, RelFieldCollationUtil}
 
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Aggregate
@@ -152,7 +152,7 @@ trait BatchExecAggRuleBase {
   }
 
   protected def isAggBufferFixedLength(agg: Aggregate): Boolean = {
-    val (_, aggCallsWithoutAuxGroupCalls) = FlinkRelOptUtil.checkAndSplitAggCalls(agg)
+    val (_, aggCallsWithoutAuxGroupCalls) = AggregateUtil.checkAndSplitAggCalls(agg)
     val (_, aggBufferTypes, _) = AggregateUtil.transformToBatchAggregateFunctions(
       aggCallsWithoutAuxGroupCalls, agg.getInput.getRowType)
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecHashAggRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecHashAggRule.scala
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.`type`.TypeConverters
+import org.apache.flink.table.api.OperatorType
+import org.apache.flink.table.calcite.FlinkContext
+import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalAggregate
+import org.apache.flink.table.plan.nodes.physical.batch.{BatchExecHashAggregate,
+  BatchExecLocalHashAggregate}
+import org.apache.flink.table.plan.util.{AggregateUtil, FlinkRelOptUtil}
+import org.apache.flink.table.api.PlannerConfigOptions
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.RelNode
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule that matches [[FlinkLogicalAggregate]] which all aggregate function buffer are fix length,
+  * and converts it to
+  * {{{
+  *   BatchExecHashAggregate (global)
+  *   +- BatchExecExchange (hash by group keys if group keys is not empty, else singleton)
+  *      +- BatchExecLocalHashAggregate (local)
+  *         +- input of agg
+  * }}}
+  * when all aggregate functions are mergeable
+  * and [[PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER]] is TWO_PHASE, or
+  * {{{
+  *   BatchExecHashAggregate
+  *   +- BatchExecExchange (hash by group keys if group keys is not empty, else singleton)
+  *      +- input of agg
+  * }}}
+  * when some aggregate functions are not mergeable
+  * or [[PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER]] is ONE_PHASE.
+  *
+  * Notes: if [[PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER]] is NONE,
+  * this rule will try to create two possibilities above, and chooses the best one based on cost.
+  */
+class BatchExecHashAggRule
+  extends RelOptRule(
+    operand(classOf[FlinkLogicalAggregate],
+      operand(classOf[RelNode], any)),
+    "BatchExecHashAggRule")
+  with BatchExecAggRuleBase {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    if (!tableConfig.isOperatorEnabled(OperatorType.HashAgg)) {
+      return false
+    }
+    val agg: FlinkLogicalAggregate = call.rel(0)
+    // HashAgg cannot process aggregate whose agg buffer is not fix length
+    isAggBufferFixedLength(agg)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    val agg: FlinkLogicalAggregate = call.rel(0)
+    val input: RelNode = call.rels(1)
+    val inputRowType = input.getRowType
+
+    if (agg.indicator) {
+      throw new UnsupportedOperationException("Not support group sets aggregate now.")
+    }
+
+    val groupSet = agg.getGroupSet.toArray
+    val (auxGroupSet, aggCallsWithoutAuxGroupCalls) = FlinkRelOptUtil.checkAndSplitAggCalls(agg)
+
+    val (_, aggBufferTypes, aggFunctions) = AggregateUtil.transformToBatchAggregateFunctions(
+      aggCallsWithoutAuxGroupCalls, inputRowType)
+
+    val aggCallToAggFunction = aggCallsWithoutAuxGroupCalls.zip(aggFunctions)
+    val aggProvidedTraitSet = agg.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+
+    // create two-phase agg if possible
+    if (isTwoPhaseAggWorkable(aggFunctions, tableConfig)) {
+      // create BatchExecLocalHashAggregate
+      val localAggRowType = inferLocalAggType(
+        inputRowType,
+        agg,
+        groupSet,
+        auxGroupSet,
+        aggFunctions,
+        aggBufferTypes.map(_.map(TypeConverters.createInternalTypeFromTypeInfo)))
+      val localRequiredTraitSet = input.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+      val newInput = RelOptRule.convert(input, localRequiredTraitSet)
+      val providedTraitSet = localRequiredTraitSet
+      val localHashAgg = new BatchExecLocalHashAggregate(
+        agg.getCluster,
+        call.builder(),
+        providedTraitSet,
+        newInput,
+        localAggRowType,
+        inputRowType,
+        groupSet,
+        auxGroupSet,
+        aggCallToAggFunction)
+
+      // create global BatchExecHashAggregate
+      val globalGroupSet = groupSet.indices.toArray
+      val globalAuxGroupSet = (groupSet.length until groupSet.length + auxGroupSet.length).toArray
+      val globalDistributions = if (agg.getGroupCount != 0) {
+        val distributionFields = globalGroupSet.map(Integer.valueOf).toList
+        Seq(
+          FlinkRelDistribution.hash(distributionFields),
+          FlinkRelDistribution.hash(distributionFields, requireStrict = false))
+      } else {
+        Seq(FlinkRelDistribution.SINGLETON)
+      }
+      globalDistributions.foreach { globalDistribution =>
+        val requiredTraitSet = localHashAgg.getTraitSet.replace(globalDistribution)
+        val newLocalHashAgg = RelOptRule.convert(localHashAgg, requiredTraitSet)
+        val globalHashAgg = new BatchExecHashAggregate(
+          agg.getCluster,
+          call.builder(),
+          aggProvidedTraitSet,
+          newLocalHashAgg,
+          agg.getRowType,
+          newLocalHashAgg.getRowType,
+          globalGroupSet,
+          globalAuxGroupSet,
+          aggCallToAggFunction,
+          true)
+        call.transformTo(globalHashAgg)
+      }
+    }
+
+    // create one-phase agg if possible
+    if (isOnePhaseAggWorkable(agg, aggFunctions, tableConfig)) {
+      val requiredDistributions = if (agg.getGroupCount != 0) {
+        val distributionFields = groupSet.map(Integer.valueOf).toList
+        Seq(
+          FlinkRelDistribution.hash(distributionFields, requireStrict = false),
+          FlinkRelDistribution.hash(distributionFields))
+      } else {
+        Seq(FlinkRelDistribution.SINGLETON)
+      }
+      requiredDistributions.foreach { requiredDistribution =>
+        val requiredTraitSet = input.getTraitSet
+          .replace(FlinkConventions.BATCH_PHYSICAL)
+          .replace(requiredDistribution)
+        val newInput = RelOptRule.convert(input, requiredTraitSet)
+        val hashAgg = new BatchExecHashAggregate(
+          agg.getCluster,
+          call.builder(),
+          aggProvidedTraitSet,
+          newInput,
+          agg.getRowType,
+          input.getRowType,
+          groupSet,
+          auxGroupSet,
+          aggCallToAggFunction,
+          false)
+        call.transformTo(hashAgg)
+      }
+    }
+  }
+}
+
+object BatchExecHashAggRule {
+  val INSTANCE = new BatchExecHashAggRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecHashAggRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecHashAggRule.scala
@@ -18,15 +18,13 @@
 package org.apache.flink.table.plan.rules.physical.batch
 
 import org.apache.flink.table.`type`.TypeConverters
-import org.apache.flink.table.api.OperatorType
+import org.apache.flink.table.api.{OperatorType, PlannerConfigOptions}
 import org.apache.flink.table.calcite.FlinkContext
 import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalAggregate
-import org.apache.flink.table.plan.nodes.physical.batch.{BatchExecHashAggregate,
-  BatchExecLocalHashAggregate}
-import org.apache.flink.table.plan.util.{AggregateUtil, FlinkRelOptUtil}
-import org.apache.flink.table.api.PlannerConfigOptions
+import org.apache.flink.table.plan.nodes.physical.batch.{BatchExecHashAggregate, BatchExecLocalHashAggregate}
+import org.apache.flink.table.plan.util.AggregateUtil
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -84,7 +82,7 @@ class BatchExecHashAggRule
     }
 
     val groupSet = agg.getGroupSet.toArray
-    val (auxGroupSet, aggCallsWithoutAuxGroupCalls) = FlinkRelOptUtil.checkAndSplitAggCalls(agg)
+    val (auxGroupSet, aggCallsWithoutAuxGroupCalls) = AggregateUtil.checkAndSplitAggCalls(agg)
 
     val (_, aggBufferTypes, aggFunctions) = AggregateUtil.transformToBatchAggregateFunctions(
       aggCallsWithoutAuxGroupCalls, inputRowType)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSortAggRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSortAggRule.scala
@@ -78,7 +78,7 @@ class BatchExecSortAggRule
       throw new UnsupportedOperationException("Not support group sets aggregate now.")
     }
 
-    val (auxGroupSet, aggCallsWithoutAuxGroupCalls) = FlinkRelOptUtil.checkAndSplitAggCalls(agg)
+    val (auxGroupSet, aggCallsWithoutAuxGroupCalls) = AggregateUtil.checkAndSplitAggCalls(agg)
 
     val (_, aggBufferTypes, aggFunctions) = AggregateUtil.transformToBatchAggregateFunctions(
       aggCallsWithoutAuxGroupCalls, inputRowType)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSortAggRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSortAggRule.scala
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.`type`.TypeConverters
+import org.apache.flink.table.api.{OperatorType, PlannerConfigOptions}
+import org.apache.flink.table.calcite.FlinkContext
+import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalAggregate
+import org.apache.flink.table.plan.nodes.physical.batch.{BatchExecLocalSortAggregate, BatchExecSortAggregate}
+import org.apache.flink.table.plan.util.{AggregateUtil, FlinkRelOptUtil}
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel._
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule that converts [[FlinkLogicalAggregate]] to
+  * {{{
+  *   BatchExecSortAggregate (global)
+  *   +- Sort (exists if group keys are not empty)
+  *      +- BatchExecExchange (hash by group keys if group keys is not empty, else singleton)
+  *         +- BatchExecLocalSortAggregate (local)
+  *           +- Sort (exists if group keys are not empty)
+  *              +- input of agg
+  * }}}
+  * when all aggregate functions are mergeable
+  * and [[PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER]] is TWO_PHASE, or
+  * {{{
+  *   BatchExecSortAggregate
+  *   +- Sort (exists if group keys are not empty)
+  *      +- BatchExecExchange (hash by group keys if group keys is not empty, else singleton)
+  *         +- input of agg
+  * }}}
+  * when some aggregate functions are not mergeable
+  * or [[PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER]] is ONE_PHASE.
+  *
+  * Notes: if [[PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER]] is NONE,
+  * this rule will try to create two possibilities above, and chooses the best one based on cost.
+  */
+class BatchExecSortAggRule
+  extends RelOptRule(
+    operand(classOf[FlinkLogicalAggregate],
+      operand(classOf[RelNode], any)),
+    "BatchExecSortAggRule")
+  with BatchExecAggRuleBase {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    tableConfig.isOperatorEnabled(OperatorType.SortAgg)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    val agg: FlinkLogicalAggregate = call.rel(0)
+    val input: RelNode = call.rel(1)
+    val inputRowType = input.getRowType
+
+    if (agg.indicator) {
+      throw new UnsupportedOperationException("Not support group sets aggregate now.")
+    }
+
+    val (auxGroupSet, aggCallsWithoutAuxGroupCalls) = FlinkRelOptUtil.checkAndSplitAggCalls(agg)
+
+    val (_, aggBufferTypes, aggFunctions) = AggregateUtil.transformToBatchAggregateFunctions(
+      aggCallsWithoutAuxGroupCalls, inputRowType)
+    val groupSet = agg.getGroupSet.toArray
+    val aggCallToAggFunction = aggCallsWithoutAuxGroupCalls.zip(aggFunctions)
+    // TODO aggregate include projection now, so do not provide new trait will be safe
+    val aggProvidedTraitSet = agg.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+
+    // create two-phase agg if possible
+    if (isTwoPhaseAggWorkable(aggFunctions, tableConfig)) {
+      val localAggRelType = inferLocalAggType(
+        inputRowType,
+        agg,
+        groupSet,
+        auxGroupSet,
+        aggFunctions,
+        aggBufferTypes.map(_.map(TypeConverters.createInternalTypeFromTypeInfo)))
+      // create BatchExecLocalSortAggregate
+      var localRequiredTraitSet = input.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+      if (agg.getGroupCount != 0) {
+        val sortCollation = createRelCollation(groupSet)
+        localRequiredTraitSet = localRequiredTraitSet.replace(sortCollation)
+      }
+      val newLocalInput = RelOptRule.convert(input, localRequiredTraitSet)
+      val providedLocalTraitSet = localRequiredTraitSet
+      val localSortAgg = new BatchExecLocalSortAggregate(
+        agg.getCluster,
+        call.builder(),
+        providedLocalTraitSet,
+        newLocalInput,
+        localAggRelType,
+        newLocalInput.getRowType,
+        groupSet,
+        auxGroupSet,
+        aggCallToAggFunction)
+
+      // create global BatchExecSortAggregate
+      val globalGroupSet = groupSet.indices.toArray
+      val globalAuxGroupSet = (groupSet.length until groupSet.length + auxGroupSet.length).toArray
+      val (globalDistributions, globalCollation) = if (agg.getGroupCount != 0) {
+        // global agg should use groupSet's indices as distribution fields
+        val distributionFields = globalGroupSet.map(Integer.valueOf).toList
+        (
+          Seq(
+            FlinkRelDistribution.hash(distributionFields),
+            FlinkRelDistribution.hash(distributionFields, requireStrict = false)),
+          createRelCollation(globalGroupSet)
+        )
+      } else {
+        (Seq(FlinkRelDistribution.SINGLETON), RelCollations.EMPTY)
+      }
+      globalDistributions.foreach { globalDistribution =>
+        val requiredTraitSet = localSortAgg.getTraitSet
+          .replace(globalDistribution)
+          .replace(globalCollation)
+
+        val newInputForFinalAgg = RelOptRule.convert(localSortAgg, requiredTraitSet)
+        val globalSortAgg = new BatchExecSortAggregate(
+          agg.getCluster,
+          call.builder(),
+          aggProvidedTraitSet,
+          newInputForFinalAgg,
+          agg.getRowType,
+          newInputForFinalAgg.getRowType,
+          globalGroupSet,
+          globalAuxGroupSet,
+          aggCallToAggFunction,
+          isMerge = true)
+        call.transformTo(globalSortAgg)
+      }
+    }
+
+    // create one-phase agg if possible
+    if (isOnePhaseAggWorkable(agg, aggFunctions, tableConfig)) {
+      val requiredDistributions = if (agg.getGroupCount != 0) {
+        val distributionFields = groupSet.map(Integer.valueOf).toList
+        Seq(
+          FlinkRelDistribution.hash(distributionFields),
+          FlinkRelDistribution.hash(distributionFields, requireStrict = false))
+      } else {
+        Seq(FlinkRelDistribution.SINGLETON)
+      }
+      requiredDistributions.foreach { requiredDistribution =>
+        var requiredTraitSet = input.getTraitSet
+          .replace(FlinkConventions.BATCH_PHYSICAL)
+          .replace(requiredDistribution)
+        if (agg.getGroupCount != 0) {
+          val sortCollation = createRelCollation(groupSet)
+          requiredTraitSet = requiredTraitSet.replace(sortCollation)
+        }
+        val newInput = RelOptRule.convert(input, requiredTraitSet)
+        val sortAgg = new BatchExecSortAggregate(
+          agg.getCluster,
+          call.builder(),
+          aggProvidedTraitSet,
+          newInput,
+          agg.getRowType,
+          newInput.getRowType,
+          groupSet,
+          auxGroupSet,
+          aggCallToAggFunction,
+          isMerge = false
+        )
+        call.transformTo(sortAgg)
+      }
+    }
+  }
+}
+
+object BatchExecSortAggRule {
+  val INSTANCE = new BatchExecSortAggRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/AggFunctionFactory.scala
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.table.`type`.InternalTypes._
+import org.apache.flink.table.`type`.{DecimalType, InternalType}
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.functions.utils.AggSqlFunction
+import org.apache.flink.table.typeutils.DecimalTypeInfo
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.sql.fun._
+import org.apache.calcite.sql.{SqlAggFunction, SqlKind}
+
+import scala.collection.JavaConversions._
+
+/**
+  * The class of agg function factory which is used to create AggregateFunction or
+  * DeclarativeAggregateFunction from Calcite AggregateCall
+  *
+  * @param inputType the input rel data type
+  * @param orderKeyIdx the indexes of order key (null when is not over agg)
+  * @param needRetraction true if need retraction
+  */
+class AggFunctionFactory(
+    inputType: RelDataType,
+    orderKeyIdx: Array[Int],
+    needRetraction: Array[Boolean]) {
+
+  /**
+    * The entry point to create an aggregate function from the given AggregateCall
+    */
+  def createAggFunction(call: AggregateCall, index: Int): UserDefinedFunction = {
+
+    val argTypes: Array[InternalType] = call.getArgList
+      .map(inputType.getFieldList.get(_).getType) // RelDataType
+      .map(FlinkTypeFactory.toInternalType) // InternalType
+      .toArray
+
+    call.getAggregation match {
+      case a: SqlAvgAggFunction if a.kind == SqlKind.AVG => createAvgAggFunction(argTypes)
+
+      case _: SqlSumAggFunction => createSumAggFunction(argTypes, index)
+
+      case _: SqlSumEmptyIsZeroAggFunction => createSum0AggFunction(argTypes)
+
+      // TODO supports SqlIncrSumAggFunction
+
+      case a: SqlMinMaxAggFunction if a.getKind == SqlKind.MIN =>
+        createMinAggFunction(argTypes, index)
+
+      case a: SqlMinMaxAggFunction if a.getKind == SqlKind.MAX =>
+        createMaxAggFunction(argTypes, index)
+
+      case _: SqlCountAggFunction if call.getArgList.size() > 1 =>
+        throw new TableException("We now only support the count of one field.")
+
+      // TODO supports ApproximateCountDistinctAggFunction and CountDistinctAggFunction
+
+      case _: SqlCountAggFunction if call.getArgList.isEmpty => createCount1AggFunction(argTypes)
+
+      case _: SqlCountAggFunction => createCountAggFunction(argTypes)
+
+      // TODO supports SqlRankFunction (ROW_NUMBER, RANK and DENSE_RANK)
+      // TODO supports SqlLeadLagAggFunction
+      // TODO supports SqlMax2ndAggFunction
+      // TODO supports SqlSingleValueAggFunction
+      // TODO supports SqlFirstLastValueAggFunction (FIRST_VALUE and LAST_VALUE)
+      // TODO supports SqlConcatAggFunction
+      // TODO supports SqlCardinalityCountAggFunction
+      // TODO supports COLLECT SqlAggFunction
+
+      case udagg: AggSqlFunction => udagg.getFunction
+
+      case unSupported: SqlAggFunction =>
+        throw new TableException(s"Unsupported Function: '${unSupported.getName}'")
+    }
+  }
+
+  private def createAvgAggFunction(argTypes: Array[InternalType]): UserDefinedFunction = {
+    argTypes(0) match {
+      case BYTE | SHORT | INT | LONG =>
+        new org.apache.flink.table.functions.AvgAggFunction.IntegralAvgAggFunction
+      case FLOAT | DOUBLE =>
+        new org.apache.flink.table.functions.AvgAggFunction.DoubleAvgAggFunction
+      case d: DecimalType =>
+        val decimalTypeInfo = DecimalTypeInfo.of(d.precision(), d.scale())
+        new org.apache.flink.table.functions.AvgAggFunction.DecimalAvgAggFunction(decimalTypeInfo)
+      case t: InternalType =>
+        throw new TableException(s"Avg aggregate function does not support type: ''$t''.\n" +
+          s"Please re-check the data type.")
+    }
+  }
+
+  private def createSumAggFunction(argTypes: Array[InternalType], index: Int)
+  : UserDefinedFunction = {
+    if (needRetraction(index)) {
+      // TODO implements this
+      throw new TableException("Unsupported now")
+    } else {
+      argTypes(0) match {
+        case BYTE =>
+          new org.apache.flink.table.functions.SumAggFunction.ByteSumAggFunction
+        case SHORT =>
+          new org.apache.flink.table.functions.SumAggFunction.ShortSumAggFunction
+        case INT =>
+          new org.apache.flink.table.functions.SumAggFunction.IntSumAggFunction
+        case LONG =>
+          new org.apache.flink.table.functions.SumAggFunction.LongSumAggFunction
+        case FLOAT =>
+          new org.apache.flink.table.functions.SumAggFunction.FloatSumAggFunction
+        case DOUBLE =>
+          new org.apache.flink.table.functions.SumAggFunction.DoubleSumAggFunction
+        case d: DecimalType =>
+          val decimalTypeInfo = DecimalTypeInfo.of(d.precision(), d.scale())
+          new org.apache.flink.table.functions.SumAggFunction.DecimalSumAggFunction(decimalTypeInfo)
+        case t: InternalType =>
+          throw new TableException(s"Sum aggregate function does not support type: ''$t''.\n" +
+            s"Please re-check the data type.")
+      }
+    }
+  }
+
+  private def createSum0AggFunction(argTypes: Array[InternalType]): UserDefinedFunction = {
+    argTypes(0) match {
+      case BYTE =>
+        new org.apache.flink.table.functions.Sum0AggFunction.ByteSum0AggFunction
+      case SHORT =>
+        new org.apache.flink.table.functions.Sum0AggFunction.ShortSum0AggFunction
+      case INT =>
+        new org.apache.flink.table.functions.Sum0AggFunction.IntSum0AggFunction
+      case LONG =>
+        new org.apache.flink.table.functions.Sum0AggFunction.LongSum0AggFunction
+      case FLOAT =>
+        new org.apache.flink.table.functions.Sum0AggFunction.FloatSum0AggFunction
+      case DOUBLE =>
+        new org.apache.flink.table.functions.Sum0AggFunction.DoubleSum0AggFunction
+      case d: DecimalType =>
+        val decimalTypeInfo = DecimalTypeInfo.of(d.precision(), d.scale())
+        new org.apache.flink.table.functions.Sum0AggFunction.DecimalSum0AggFunction(decimalTypeInfo)
+      case t: InternalType =>
+        throw new TableException(s"Sum0 aggregate function does not support type: ''$t''.\n" +
+          s"Please re-check the data type.")
+    }
+  }
+
+  private def createMinAggFunction(
+      argTypes: Array[InternalType], index: Int): UserDefinedFunction = {
+    if (needRetraction(index)) {
+      // TODO implements this
+      throw new TableException("Unsupported now")
+    } else {
+      argTypes(0) match {
+        case BYTE =>
+          new org.apache.flink.table.functions.MinAggFunction.ByteMinAggFunction
+        case SHORT =>
+          new org.apache.flink.table.functions.MinAggFunction.ShortMinAggFunction
+        case INT =>
+          new org.apache.flink.table.functions.MinAggFunction.IntMinAggFunction
+        case LONG =>
+          new org.apache.flink.table.functions.MinAggFunction.LongMinAggFunction
+        case FLOAT =>
+          new org.apache.flink.table.functions.MinAggFunction.FloatMinAggFunction
+        case DOUBLE =>
+          new org.apache.flink.table.functions.MinAggFunction.DoubleMinAggFunction
+        case BOOLEAN =>
+          new org.apache.flink.table.functions.MinAggFunction.BooleanMinAggFunction
+        case STRING =>
+          new org.apache.flink.table.functions.MinAggFunction.StringMinAggFunction
+        case DATE =>
+          new org.apache.flink.table.functions.MinAggFunction.DateMinAggFunction
+        case TIME =>
+          new org.apache.flink.table.functions.MinAggFunction.TimeMinAggFunction
+        case TIMESTAMP |  PROCTIME_INDICATOR | ROWTIME_INDICATOR =>
+          new org.apache.flink.table.functions.MinAggFunction.TimestampMinAggFunction
+        case d: DecimalType =>
+          val decimalTypeInfo = DecimalTypeInfo.of(d.precision(), d.scale())
+          new org.apache.flink.table.functions.MinAggFunction.DecimalMinAggFunction(decimalTypeInfo)
+        case t: InternalType =>
+          throw new TableException(s"Min aggregate function does not support type: ''$t''.\n" +
+            s"Please re-check the data type.")
+      }
+    }
+  }
+
+  private def createMaxAggFunction(
+      argTypes: Array[InternalType], index: Int): UserDefinedFunction = {
+    if (needRetraction(index)) {
+      // TODO implements this
+      throw new TableException("Unsupported now")
+    } else {
+      argTypes(0) match {
+        case BYTE =>
+          new org.apache.flink.table.functions.MaxAggFunction.ByteMaxAggFunction
+        case SHORT =>
+          new org.apache.flink.table.functions.MaxAggFunction.ShortMaxAggFunction
+        case INT =>
+          new org.apache.flink.table.functions.MaxAggFunction.IntMaxAggFunction
+        case LONG =>
+          new org.apache.flink.table.functions.MaxAggFunction.LongMaxAggFunction
+        case FLOAT =>
+          new org.apache.flink.table.functions.MaxAggFunction.FloatMaxAggFunction
+        case DOUBLE =>
+          new org.apache.flink.table.functions.MaxAggFunction.DoubleMaxAggFunction
+        case BOOLEAN =>
+          new org.apache.flink.table.functions.MaxAggFunction.BooleanMaxAggFunction
+        case STRING =>
+          new org.apache.flink.table.functions.MaxAggFunction.StringMaxAggFunction
+        case DATE =>
+          new org.apache.flink.table.functions.MaxAggFunction.DateMaxAggFunction
+        case TIME =>
+          new org.apache.flink.table.functions.MaxAggFunction.TimeMaxAggFunction
+        case TIMESTAMP | PROCTIME_INDICATOR | ROWTIME_INDICATOR =>
+          new org.apache.flink.table.functions.MaxAggFunction.TimestampMaxAggFunction
+        case d: DecimalType =>
+          val decimalTypeInfo = DecimalTypeInfo.of(d.precision(), d.scale())
+          new org.apache.flink.table.functions.MaxAggFunction.DecimalMaxAggFunction(decimalTypeInfo)
+        case t: InternalType =>
+          throw new TableException(s"Max aggregate function does not support type: ''$t''.\n" +
+            s"Please re-check the data type.")
+      }
+    }
+  }
+
+  private def createCount1AggFunction(argTypes: Array[InternalType]): UserDefinedFunction = {
+    new org.apache.flink.table.functions.Count1AggFunction
+  }
+
+  private def createCountAggFunction(argTypes: Array[InternalType]): UserDefinedFunction = {
+    new org.apache.flink.table.functions.CountAggFunction
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/AggregateUtil.scala
@@ -1,0 +1,444 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
+import org.apache.flink.table.`type`.InternalTypes._
+import org.apache.flink.table.`type`.{DecimalType, InternalType, InternalTypes, RowType, TypeConverters}
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.calcite.{FlinkTypeFactory, FlinkTypeSystem}
+import org.apache.flink.table.dataview.DataViewSpec
+import org.apache.flink.table.dataview.DataViewUtils.useNullSerializerForStateViewFieldsFromAccType
+import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
+import org.apache.flink.table.functions.{AggregateFunction, DeclarativeAggregateFunction, UserDefinedFunction}
+import org.apache.flink.table.typeutils.{BinaryStringTypeInfo, DecimalTypeInfo, MapViewTypeInfo}
+
+import org.apache.calcite.rel.`type`._
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.sql.SqlRankFunction
+import org.apache.calcite.sql.fun._
+
+import java.util
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+object AggregateUtil extends Enumeration {
+
+  def transformToBatchAggregateFunctions(
+      aggregateCalls: Seq[AggregateCall],
+      inputRowType: RelDataType,
+      orderKeyIdx: Array[Int] = null)
+  : (Array[Array[Int]], Array[Array[TypeInformation[_]]], Array[UserDefinedFunction]) = {
+
+    val aggInfos = transformToAggregateInfoList(
+      aggregateCalls,
+      inputRowType,
+      orderKeyIdx,
+      Array.fill(aggregateCalls.size)(false),
+      needInputCount = false,
+      isStateBackedDataViews = false,
+      needDistinctInfo = false).aggInfos
+
+    val aggFields = aggInfos.map(_.argIndexes)
+    val bufferTypes = aggInfos.map(_.externalAccTypes)
+    val functions = aggInfos.map(_.function)
+
+    (aggFields, bufferTypes, functions)
+  }
+
+  def transformToBatchAggregateInfoList(
+      aggregateCalls: Seq[AggregateCall],
+      inputRowType: RelDataType,
+      orderKeyIdx: Array[Int] = null,
+      needRetractions: Array[Boolean] = null): AggregateInfoList = {
+
+    val needRetractionArray = if (needRetractions == null) {
+      Array.fill(aggregateCalls.size)(false)
+    } else {
+      needRetractions
+    }
+
+    transformToAggregateInfoList(
+      aggregateCalls,
+      inputRowType,
+      orderKeyIdx,
+      needRetractionArray,
+      needInputCount = false,
+      isStateBackedDataViews = false,
+      needDistinctInfo = false)
+  }
+
+  def transformToStreamAggregateInfoList(
+      aggregateCalls: Seq[AggregateCall],
+      inputRowType: RelDataType,
+      needRetraction: Array[Boolean],
+      needInputCount: Boolean,
+      isStateBackendDataViews: Boolean,
+      needDistinctInfo: Boolean = true): AggregateInfoList = {
+    transformToAggregateInfoList(
+      aggregateCalls,
+      inputRowType,
+      orderKeyIdx = null,
+      needRetraction ++ Array(needInputCount), // for additional count1
+      needInputCount,
+      isStateBackendDataViews,
+      needDistinctInfo)
+  }
+
+  /**
+    * Transforms calcite aggregate calls to AggregateInfos.
+    *
+    * @param aggregateCalls   the calcite aggregate calls
+    * @param inputRowType     the input rel data type
+    * @param orderKeyIdx      the index of order by field in the input, null if not over agg
+    * @param needRetraction   whether the aggregate function need retract method
+    * @param needInputCount   whether need to calculate the input counts, which is used in
+    *                         aggregation with retraction input.If needed,
+    *                         insert a count(1) aggregate into the agg list.
+    * @param isStateBackedDataViews   whether the dataview in accumulator use state or heap
+    * @param needDistinctInfo  whether need to extract distinct information
+    */
+  private def transformToAggregateInfoList(
+      aggregateCalls: Seq[AggregateCall],
+      inputRowType: RelDataType,
+      orderKeyIdx: Array[Int],
+      needRetraction: Array[Boolean],
+      needInputCount: Boolean,
+      isStateBackedDataViews: Boolean,
+      needDistinctInfo: Boolean): AggregateInfoList = {
+
+    // Step-1:
+    // if need inputCount, find count1 in the existed aggregate calls first,
+    // if not exist, insert a new count1 and remember the index
+    val (count1AggIndex, count1AggInserted, aggCalls) = insertInputCountAggregate(
+      needInputCount,
+      aggregateCalls)
+
+    // Step-2:
+    // extract distinct information from aggregate calls
+    val (distinctInfos, newAggCalls) = extractDistinctInformation(
+      needDistinctInfo,
+      aggCalls,
+      inputRowType,
+      isStateBackedDataViews,
+      needInputCount) // needInputCount means whether the aggregate consume retractions
+
+    // Step-3:
+    // create aggregate information
+    val factory = new AggFunctionFactory(inputRowType, orderKeyIdx, needRetraction)
+    val aggInfos = newAggCalls.zipWithIndex.map { case (call, index) =>
+      val argIndexes = call.getAggregation match {
+        case _: SqlRankFunction => orderKeyIdx
+        case _ => call.getArgList.map(_.intValue()).toArray
+      }
+
+      val function = factory.createAggFunction(call, index)
+      val (externalAccTypes, viewSpecs, externalResultType) = function match {
+        case a: DeclarativeAggregateFunction =>
+          val bufferTypes: Array[InternalType] = a.getAggBufferTypes
+          val bufferTypeInfos = bufferTypes.map(
+            TypeConverters.createInternalTypeInfoFromInternalType)
+          (bufferTypeInfos, Array.empty[DataViewSpec], a.getResultType)
+        case a: AggregateFunction[_, _] =>
+          val externalAccType = getAccumulatorTypeOfAggregateFunction(a)
+          val (newExternalAccType, specs) = useNullSerializerForStateViewFieldsFromAccType(
+            index,
+            a,
+            externalAccType,
+            isStateBackedDataViews)
+          (Array(newExternalAccType), specs, getResultTypeOfAggregateFunction(a))
+        case _ => throw new TableException(s"Unsupported function: $function")
+      }
+
+      AggregateInfo(
+        call,
+        function,
+        index,
+        argIndexes,
+        externalAccTypes.asInstanceOf[Array[TypeInformation[_]]],
+        viewSpecs,
+        externalResultType,
+        needRetraction(index))
+
+    }.toArray
+
+    AggregateInfoList(aggInfos, count1AggIndex, count1AggInserted, distinctInfos)
+  }
+
+
+  /**
+    * Inserts an InputCount aggregate which is count1 actually if needed.
+    * @param needInputCount whether to insert an InputCount aggregate
+    * @param aggregateCalls original aggregate calls
+    * @return (count1AggIndex, count1AggInserted, newaggCalls)
+    */
+  private def insertInputCountAggregate(
+      needInputCount: Boolean,
+      aggregateCalls: Seq[AggregateCall]): (Option[Int], Boolean, Seq[AggregateCall]) = {
+
+    var count1AggIndex: Option[Int] = None
+    var count1AggInserted: Boolean = false
+    if (!needInputCount) {
+      return (count1AggIndex, count1AggInserted, aggregateCalls)
+    }
+
+    // if need inputCount, find count1 in the existed aggregate calls first,
+    // if not exist, insert a new count1 and remember the index
+    var newAggCalls = aggregateCalls
+    aggregateCalls.zipWithIndex.foreach { case (call, index) =>
+      if (call.getAggregation.isInstanceOf[SqlCountAggFunction] &&
+        call.filterArg < 0 &&
+        call.getArgList.isEmpty &&
+        !call.isApproximate &&
+        !call.isDistinct) {
+        count1AggIndex = Some(index)
+      }
+    }
+
+    // count1 not exist in aggregateCalls, insert a count1 in it.
+    val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem)
+    if (count1AggIndex.isEmpty) {
+
+      val count1 = AggregateCall.create(
+        SqlStdOperatorTable.COUNT,
+        false,
+        false,
+        new util.ArrayList[Integer](),
+        -1,
+        typeFactory.createTypeFromInternalType(InternalTypes.LONG, isNullable = false),
+        "_$count1$_")
+
+      count1AggIndex = Some(aggregateCalls.length)
+      count1AggInserted = true
+      newAggCalls = aggregateCalls ++ Seq(count1)
+    }
+
+    (count1AggIndex, count1AggInserted, newAggCalls)
+  }
+
+  /**
+    * Extracts DistinctInfo array from the aggregate calls,
+    * and change the distinct aggregate to non-distinct aggregate.
+    *
+    * @param needDistinctInfo whether to extract distinct information
+    * @param aggCalls   the original aggregate calls
+    * @param inputType  the input rel data type
+    * @param isStateBackedDataViews whether the dataview in accumulator use state or heap
+    * @param consumeRetraction  whether the distinct aggregate consumes retraction messages
+    * @return (distinctInfoArray, newAggCalls)
+    */
+  private def extractDistinctInformation(
+      needDistinctInfo: Boolean,
+      aggCalls: Seq[AggregateCall],
+      inputType: RelDataType,
+      isStateBackedDataViews: Boolean,
+      consumeRetraction: Boolean)
+  : (Array[DistinctInfo], Seq[AggregateCall]) = {
+
+    if (!needDistinctInfo) {
+      return (Array(), aggCalls)
+    }
+
+    val distinctMap = mutable.LinkedHashMap.empty[String, DistinctInfo]
+    val newAggCalls = aggCalls.zipWithIndex.map { case (call, index) =>
+      val argIndexes = call.getArgList.map(_.intValue()).toArray
+
+      // extract distinct information and replace a new call
+      if (call.isDistinct && !call.isApproximate && argIndexes.length > 0) {
+        val argTypes: Array[InternalType] = call
+          .getArgList
+          .map(inputType.getFieldList.get(_).getType) // RelDataType
+          .map(FlinkTypeFactory.toInternalType) // InternalType
+          .toArray
+
+        val keyType = createDistinctKeyType(argTypes)
+        val distinctInfo = distinctMap.getOrElseUpdate(
+          argIndexes.mkString(","),
+          DistinctInfo(
+            argIndexes,
+            keyType,
+            null, // later fill in
+            excludeAcc = false,
+            null, // later fill in
+            consumeRetraction,
+            ArrayBuffer.empty[Int],
+            ArrayBuffer.empty[Int]))
+        // add current agg to the distinct agg list
+        distinctInfo.filterArgs += call.filterArg
+        distinctInfo.aggIndexes += index
+
+        AggregateCall.create(
+          call.getAggregation,
+          false,
+          false,
+          call.getArgList,
+          -1, // remove filterArg
+          call.getType,
+          call.getName)
+      } else {
+        call
+      }
+    }
+
+    // fill in the acc type and dataview spec
+    val distinctInfos = distinctMap.values.zipWithIndex.map { case (d, index) =>
+      val valueType = if (consumeRetraction) {
+        if (d.filterArgs.length <= 1) {
+          Types.LONG
+        } else {
+          Types.PRIMITIVE_ARRAY(Types.LONG)
+        }
+      } else {
+        if (d.filterArgs.length <= 64) {
+          Types.LONG
+        } else {
+          Types.PRIMITIVE_ARRAY(Types.LONG)
+        }
+      }
+
+      val accTypeInfo = new MapViewTypeInfo(
+        // distinct is internal code gen, use internal type serializer.
+        d.keyType,
+        valueType,
+        isStateBackedDataViews,
+        // the mapview serializer should handle null keys
+        nullAware = true)
+
+      val distinctMapViewSpec = if (isStateBackedDataViews) {
+        // TODO supports MapViewSpec
+        throw new TableException("MapViewSpec is not supported now")
+      } else {
+        None
+      }
+
+      DistinctInfo(
+        d.argIndexes,
+        d.keyType,
+        accTypeInfo,
+        excludeAcc = false,
+        distinctMapViewSpec,
+        consumeRetraction,
+        d.filterArgs,
+        d.aggIndexes)
+    }
+
+    (distinctInfos.toArray, newAggCalls)
+  }
+
+  def createDistinctKeyType(argTypes: Array[InternalType]): TypeInformation[_] = {
+    if (argTypes.length == 1) {
+      argTypes(0) match {
+        case BYTE => Types.BYTE
+        case SHORT => Types.SHORT
+        case INT => Types.INT
+        case LONG => Types.LONG
+        case FLOAT => Types.FLOAT
+        case DOUBLE => Types.DOUBLE
+        case BOOLEAN => Types.BOOLEAN
+        case DATE | TIME => Types.INT
+        case TIMESTAMP => Types.LONG
+        case STRING => BinaryStringTypeInfo.INSTANCE
+        case d: DecimalType => DecimalTypeInfo.of(d.precision(), d.scale())
+        case t =>
+          throw new TableException(s"Distinct aggregate function does not support type: $t.\n" +
+            s"Please re-check the data type.")
+      }
+    } else {
+      TypeConverters.createExternalTypeInfoFromInternalType(new RowType(argTypes: _*))
+    }
+  }
+
+  /**
+    * Return true if all aggregates can be partially merged. False otherwise.
+    */
+  def doAllSupportPartialMerge(aggInfos: Array[AggregateInfo]): Boolean = {
+    val supportMerge = aggInfos.map(_.function).forall {
+      case _: DeclarativeAggregateFunction => true
+      case a => ifMethodExistInFunction("merge", a)
+    }
+
+    //it means grouping without aggregate functions
+    aggInfos.isEmpty || supportMerge
+  }
+
+  /**
+    * Return true if all aggregates can be split. False otherwise.
+    */
+  def doAllAggSupportSplit(aggCalls: util.List[AggregateCall]): Boolean = {
+    // TODO supports SqlConcatAggFunction
+    aggCalls.forall { aggCall =>
+      aggCall.getAggregation match {
+        case _: SqlCountAggFunction |
+             _: SqlAvgAggFunction |
+             _: SqlMinMaxAggFunction |
+             _: SqlSumAggFunction |
+             _: SqlSumEmptyIsZeroAggFunction |
+             _: SqlSingleValueAggFunction => true
+        case _: SqlFirstLastValueAggFunction => aggCall.getArgList.size() == 1
+        case _ => false
+      }
+    }
+  }
+
+  /**
+    * Derives output row type from stream local aggregate
+    */
+  def inferStreamLocalAggRowType(
+      aggInfoList: AggregateInfoList,
+      inputType: RelDataType,
+      groupSet: Array[Int],
+      typeFactory: FlinkTypeFactory): RelDataType = {
+
+    val accTypes = aggInfoList.getAccTypes
+    val groupingTypes = groupSet
+      .map(inputType.getFieldList.get(_).getType)
+      .map(FlinkTypeFactory.toInternalType)
+    val groupingNames = groupSet.map(inputType.getFieldNames.get(_))
+    val accFieldNames = inferStreamAggAccumulatorNames(aggInfoList)
+
+    typeFactory.buildRelDataType(
+      groupingNames ++ accFieldNames,
+      groupingTypes ++ accTypes.map(TypeConverters.createInternalTypeFromTypeInfo))
+  }
+
+  /**
+    * Derives accumulators names from stream aggregate
+    */
+  def inferStreamAggAccumulatorNames(aggInfoList: AggregateInfoList): Array[String] = {
+    var index = -1
+    val aggBufferNames = aggInfoList.aggInfos.indices.flatMap { i =>
+      aggInfoList.aggInfos(i).function match {
+        case _: AggregateFunction[_, _] =>
+          val name = aggInfoList.aggInfos(i).agg.getAggregation.getName.toLowerCase
+          index += 1
+          Array(s"$name$$$index")
+        case daf: DeclarativeAggregateFunction =>
+          daf.aggBufferAttributes.map { a =>
+            index += 1
+            s"${a.getName}$$$index"
+          }
+      }
+    }
+    val distinctBufferNames = aggInfoList.distinctInfos.indices.map { i =>
+      s"distinct$$$i"
+    }
+    (aggBufferNames ++ distinctBufferNames).toArray
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/FlinkRelOptUtil.scala
@@ -19,11 +19,10 @@ package org.apache.flink.table.plan.util
 
 import org.apache.flink.api.common.operators.Order
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.functions.sql.internal.SqlAuxiliaryGroupAggFunction
 
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rel.RelFieldCollation.Direction
-import org.apache.calcite.rel.core.{Aggregate, AggregateCall, JoinInfo}
+import org.apache.calcite.rel.core.{AggregateCall, JoinInfo}
 import org.apache.calcite.rel.{RelFieldCollation, RelNode}
 import org.apache.calcite.rex.{RexLiteral, RexNode}
 import org.apache.calcite.sql.{SqlExplainLevel, SqlKind}
@@ -33,7 +32,6 @@ import org.apache.calcite.util.mapping.IntPair
 import java.io.{PrintWriter, StringWriter}
 import java.util
 
-import scala.collection.JavaConversions._
 import scala.collection.mutable
 
 object FlinkRelOptUtil {
@@ -110,59 +108,6 @@ object FlinkRelOptUtil {
     */
   def containsAccurateDistinctCall(aggCalls: Seq[AggregateCall]): Boolean = {
     aggCalls.exists(call => call.isDistinct && !call.isApproximate)
-  }
-
-  /**
-    * Check whether AUXILIARY_GROUP aggCalls is in the front of the given agg's aggCallList,
-    * and whether aggCallList contain AUXILIARY_GROUP when the given agg's groupSet is empty
-    * or the indicator is true.
-    * Returns AUXILIARY_GROUP aggCalls' args and other aggCalls.
-    *
-    * @param agg aggregate
-    * @return returns AUXILIARY_GROUP aggCalls' args and other aggCalls
-    */
-  def checkAndSplitAggCalls(agg: Aggregate): (Array[Int], Seq[AggregateCall]) = {
-    var nonAuxGroupCallsStartIdx = -1
-
-    val aggCalls = agg.getAggCallList
-    aggCalls.zipWithIndex.foreach {
-      case (call, idx) =>
-        if (call.getAggregation == SqlAuxiliaryGroupAggFunction) {
-          require(call.getArgList.size == 1)
-        }
-        if (nonAuxGroupCallsStartIdx >= 0) {
-          // the left aggCalls should not be AUXILIARY_GROUP
-          require(call.getAggregation != SqlAuxiliaryGroupAggFunction,
-            "AUXILIARY_GROUP should be in the front of aggCall list")
-        }
-        if (nonAuxGroupCallsStartIdx < 0 &&
-          call.getAggregation != SqlAuxiliaryGroupAggFunction) {
-          nonAuxGroupCallsStartIdx = idx
-        }
-    }
-
-    if (nonAuxGroupCallsStartIdx < 0) {
-      nonAuxGroupCallsStartIdx = aggCalls.length
-    }
-
-    val (auxGroupCalls, otherAggCalls) = aggCalls.splitAt(nonAuxGroupCallsStartIdx)
-    if (agg.getGroupCount == 0) {
-      require(auxGroupCalls.isEmpty,
-        "AUXILIARY_GROUP aggCalls should be empty when groupSet is empty")
-    }
-    if (agg.indicator) {
-      require(auxGroupCalls.isEmpty,
-        "AUXILIARY_GROUP aggCalls should be empty when indicator is true")
-    }
-
-    val auxGrouping = auxGroupCalls.map(_.getArgList.head.toInt).toArray
-    require(auxGrouping.length + otherAggCalls.length == aggCalls.length)
-    (auxGrouping, otherAggCalls)
-  }
-
-  def checkAndGetFullGroupSet(agg: Aggregate): Array[Int] = {
-    val (auxGroupSet, _) = checkAndSplitAggCalls(agg)
-    agg.getGroupSet.toArray ++ auxGroupSet
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/plan/util/JavaUserDefinedAggFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/plan/util/JavaUserDefinedAggFunctions.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.functions.AggregateFunction;
+
+/**
+ * Test aggregator functions.
+ */
+public class JavaUserDefinedAggFunctions {
+
+	/**
+	 * Accumulator of VarSumAggFunction.
+	 */
+	public static class VarSumAcc {
+		public long sum;
+	}
+
+	/**
+	 * Only used for test.
+	 */
+	public static class VarSumAggFunction extends AggregateFunction<Long, VarSumAcc> {
+
+		@Override
+		public VarSumAcc createAccumulator() {
+			return new VarSumAcc();
+		}
+
+		public void accumulate(VarSumAcc acc, Integer ...args) {
+			for (Integer x : args) {
+				if (x != null) {
+					acc.sum += x.longValue();
+				}
+			}
+		}
+
+		@Override
+		public Long getValue(VarSumAcc accumulator) {
+			return accumulator.sum;
+		}
+	}
+
+	/**
+	 * Only used for test.
+	 * The difference between the class and VarSumAggFunction is accumulator type.
+	 */
+	public static class VarSum1AggFunction extends AggregateFunction<Long, VarSumAcc> {
+
+		@Override
+		public VarSumAcc createAccumulator() {
+			return new VarSumAcc();
+		}
+
+		public void accumulate(VarSumAcc acc, Integer... args) {
+			for (Integer x : args) {
+				if (x != null) {
+					acc.sum += x.longValue();
+				}
+			}
+		}
+
+		@Override
+		public Long getValue(VarSumAcc accumulator) {
+			return accumulator.sum;
+		}
+
+		@Override
+		public TypeInformation<Long> getResultType() {
+			return Types.LONG;
+		}
+	}
+
+	/**
+	 * Only used for test.
+	 * The difference between the class and VarSumAggFunction is accumulator type.
+	 */
+	public static class VarSum2AggFunction extends AggregateFunction<Long, Long> {
+
+		@Override
+		public Long createAccumulator() {
+			return 0L;
+		}
+
+		public void accumulate(Long acc, Integer... args) {
+			for (Integer x : args) {
+				if (x != null) {
+					acc += x.longValue();
+				}
+			}
+		}
+
+		@Override
+		public Long getValue(Long accumulator) {
+			return accumulator;
+		}
+
+		@Override
+		public TypeInformation<Long> getResultType() {
+			return Types.LONG;
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/HashAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/HashAggregateTest.xml
@@ -1,0 +1,1000 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testAggNotSupportMerge[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Exchange(distribution=[hash[b]])
+   +- Calc(select=[b, a])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggNotSupportMerge[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Exchange(distribution=[hash[b]])
+   +- Calc(select=[b, a])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggNotSupportMerge[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Exchange(distribution=[hash[b]])
+   +- Calc(select=[b, a])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilter[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- LocalHashAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3])
+      +- Calc(select=[a, b, c], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilter[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[AVG(a) AS EXPR$0, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- Calc(select=[a, b, c], where=[=(a, 1)])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilter[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- LocalHashAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3])
+      +- Calc(select=[a, b, c], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilterOnNestedFields[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c), SUM(c._1) FROM MyTable2 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)], EXPR$3=[SUM($3)])
++- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$2._1])
+   +- LogicalFilter(condition=[=($0, 1)])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2, Final_SUM(sum$4) AS EXPR$3])
++- Exchange(distribution=[single])
+   +- LocalHashAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3, Partial_SUM($f3) AS sum$4])
+      +- Calc(select=[a, b, c, c._1 AS $f3], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilterOnNestedFields[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c), SUM(c._1) FROM MyTable2 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)], EXPR$3=[SUM($3)])
++- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$2._1])
+   +- LogicalFilter(condition=[=($0, 1)])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[AVG(a) AS EXPR$0, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2, SUM($f3) AS EXPR$3])
++- Exchange(distribution=[single])
+   +- Calc(select=[a, b, c, c._1 AS $f3], where=[=(a, 1)])
+      +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilterOnNestedFields[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c), SUM(c._1) FROM MyTable2 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)], EXPR$3=[SUM($3)])
++- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$2._1])
+   +- LogicalFilter(condition=[=($0, 1)])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2, Final_SUM(sum$4) AS EXPR$3])
++- Exchange(distribution=[single])
+   +- LocalHashAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3, Partial_SUM($f3) AS sum$4])
+      +- Calc(select=[a, b, c, c._1 AS $f3], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutFunction[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b FROM MyTable1 GROUP BY a, b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
++- Exchange(distribution=[hash[a, b]])
+   +- LocalHashAggregate(groupBy=[a, b], select=[a, b])
+      +- Calc(select=[a, b])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutFunction[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b FROM MyTable1 GROUP BY a, b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[a, b], select=[a, b])
++- Exchange(distribution=[hash[a, b]])
+   +- Calc(select=[a, b])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutFunction[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b FROM MyTable1 GROUP BY a, b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
++- Exchange(distribution=[hash[a, b]])
+   +- LocalHashAggregate(groupBy=[a, b], select=[a, b])
+      +- Calc(select=[a, b])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutGroupBy[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- LocalHashAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutGroupBy[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[AVG(a) AS EXPR$0, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutGroupBy[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- LocalHashAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvg[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT AVG(`byte`),
+       AVG(`short`),
+       AVG(`int`),
+       AVG(`long`),
+       AVG(`float`),
+       AVG(`double`),
+       AVG(`decimal3020`),
+       AVG(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($1)], EXPR$2=[AVG($2)], EXPR$3=[AVG($3)], EXPR$4=[AVG($4)], EXPR$5=[AVG($5)], EXPR$6=[AVG($6)], EXPR$7=[AVG($7)]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_AVG(sum$2, count$3) AS EXPR$1, Final_AVG(sum$4, count$5) AS EXPR$2, Final_AVG(sum$6, count$7) AS EXPR$3, Final_AVG(sum$8, count$9) AS EXPR$4, Final_AVG(sum$10, count$11) AS EXPR$5, Final_AVG(sum$12, count$13) AS EXPR$6, Final_AVG(sum$14, count$15) AS EXPR$7]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT sum$0, BIGINT count$1, BIGINT sum$2, BIGINT count$3, BIGINT sum$4, BIGINT count$5, BIGINT sum$6, BIGINT count$7, DOUBLE sum$8, BIGINT count$9, DOUBLE sum$10, BIGINT count$11, DECIMAL(38, 20) sum$12, BIGINT count$13, DECIMAL(38, 5) sum$14, BIGINT count$15)]
+   +- LocalHashAggregate(select=[Partial_AVG(byte) AS (sum$0, count$1), Partial_AVG(short) AS (sum$2, count$3), Partial_AVG(int) AS (sum$4, count$5), Partial_AVG(long) AS (sum$6, count$7), Partial_AVG(float) AS (sum$8, count$9), Partial_AVG(double) AS (sum$10, count$11), Partial_AVG(decimal3020) AS (sum$12, count$13), Partial_AVG(decimal105) AS (sum$14, count$15)]), rowType=[RecordType(BIGINT sum$0, BIGINT count$1, BIGINT sum$2, BIGINT count$3, BIGINT sum$4, BIGINT count$5, BIGINT sum$6, BIGINT count$7, DOUBLE sum$8, BIGINT count$9, DOUBLE sum$10, BIGINT count$11, DECIMAL(38, 20) sum$12, BIGINT count$13, DECIMAL(38, 5) sum$14, BIGINT count$15)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvg[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT AVG(`byte`),
+       AVG(`short`),
+       AVG(`int`),
+       AVG(`long`),
+       AVG(`float`),
+       AVG(`double`),
+       AVG(`decimal3020`),
+       AVG(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($1)], EXPR$2=[AVG($2)], EXPR$3=[AVG($3)], EXPR$4=[AVG($4)], EXPR$5=[AVG($5)], EXPR$6=[AVG($6)], EXPR$7=[AVG($7)]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[AVG(byte) AS EXPR$0, AVG(short) AS EXPR$1, AVG(int) AS EXPR$2, AVG(long) AS EXPR$3, AVG(float) AS EXPR$4, AVG(double) AS EXPR$5, AVG(decimal3020) AS EXPR$6, AVG(decimal105) AS EXPR$7]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvg[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT AVG(`byte`),
+       AVG(`short`),
+       AVG(`int`),
+       AVG(`long`),
+       AVG(`float`),
+       AVG(`double`),
+       AVG(`decimal3020`),
+       AVG(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($1)], EXPR$2=[AVG($2)], EXPR$3=[AVG($3)], EXPR$4=[AVG($4)], EXPR$5=[AVG($5)], EXPR$6=[AVG($6)], EXPR$7=[AVG($7)]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_AVG(sum$2, count$3) AS EXPR$1, Final_AVG(sum$4, count$5) AS EXPR$2, Final_AVG(sum$6, count$7) AS EXPR$3, Final_AVG(sum$8, count$9) AS EXPR$4, Final_AVG(sum$10, count$11) AS EXPR$5, Final_AVG(sum$12, count$13) AS EXPR$6, Final_AVG(sum$14, count$15) AS EXPR$7]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT sum$0, BIGINT count$1, BIGINT sum$2, BIGINT count$3, BIGINT sum$4, BIGINT count$5, BIGINT sum$6, BIGINT count$7, DOUBLE sum$8, BIGINT count$9, DOUBLE sum$10, BIGINT count$11, DECIMAL(38, 20) sum$12, BIGINT count$13, DECIMAL(38, 5) sum$14, BIGINT count$15)]
+   +- LocalHashAggregate(select=[Partial_AVG(byte) AS (sum$0, count$1), Partial_AVG(short) AS (sum$2, count$3), Partial_AVG(int) AS (sum$4, count$5), Partial_AVG(long) AS (sum$6, count$7), Partial_AVG(float) AS (sum$8, count$9), Partial_AVG(double) AS (sum$10, count$11), Partial_AVG(decimal3020) AS (sum$12, count$13), Partial_AVG(decimal105) AS (sum$14, count$15)]), rowType=[RecordType(BIGINT sum$0, BIGINT count$1, BIGINT sum$2, BIGINT count$3, BIGINT sum$4, BIGINT count$5, BIGINT sum$6, BIGINT count$7, DOUBLE sum$8, BIGINT count$9, DOUBLE sum$10, BIGINT count$11, DECIMAL(38, 20) sum$12, BIGINT count$13, DECIMAL(38, 5) sum$14, BIGINT count$15)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCount[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT COUNT(`byte`),
+       COUNT(`short`),
+       COUNT(`int`),
+       COUNT(`long`),
+       COUNT(`float`),
+       COUNT(`double`),
+       COUNT(`decimal3020`),
+       COUNT(`decimal105`),
+       COUNT(`boolean`),
+       COUNT(`date`),
+       COUNT(`time`),
+       COUNT(`timestamp`),
+       COUNT(`string`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)], EXPR$1=[COUNT($1)], EXPR$2=[COUNT($2)], EXPR$3=[COUNT($3)], EXPR$4=[COUNT($4)], EXPR$5=[COUNT($5)], EXPR$6=[COUNT($6)], EXPR$7=[COUNT($7)], EXPR$8=[COUNT($8)], EXPR$9=[COUNT($9)], EXPR$10=[COUNT($10)], EXPR$11=[COUNT($11)], EXPR$12=[COUNT($12)]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10], string=[$7]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_COUNT(count$0) AS EXPR$0, Final_COUNT(count$1) AS EXPR$1, Final_COUNT(count$2) AS EXPR$2, Final_COUNT(count$3) AS EXPR$3, Final_COUNT(count$4) AS EXPR$4, Final_COUNT(count$5) AS EXPR$5, Final_COUNT(count$6) AS EXPR$6, Final_COUNT(count$7) AS EXPR$7, Final_COUNT(count$8) AS EXPR$8, Final_COUNT(count$9) AS EXPR$9, Final_COUNT(count$10) AS EXPR$10, Final_COUNT(count$11) AS EXPR$11, Final_COUNT(count$12) AS EXPR$12]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count$0, BIGINT count$1, BIGINT count$2, BIGINT count$3, BIGINT count$4, BIGINT count$5, BIGINT count$6, BIGINT count$7, BIGINT count$8, BIGINT count$9, BIGINT count$10, BIGINT count$11, BIGINT count$12)]
+   +- LocalHashAggregate(select=[Partial_COUNT(byte) AS count$0, Partial_COUNT(short) AS count$1, Partial_COUNT(int) AS count$2, Partial_COUNT(long) AS count$3, Partial_COUNT(float) AS count$4, Partial_COUNT(double) AS count$5, Partial_COUNT(decimal3020) AS count$6, Partial_COUNT(decimal105) AS count$7, Partial_COUNT(boolean) AS count$8, Partial_COUNT(date) AS count$9, Partial_COUNT(time) AS count$10, Partial_COUNT(timestamp) AS count$11, Partial_COUNT(string) AS count$12]), rowType=[RecordType(BIGINT count$0, BIGINT count$1, BIGINT count$2, BIGINT count$3, BIGINT count$4, BIGINT count$5, BIGINT count$6, BIGINT count$7, BIGINT count$8, BIGINT count$9, BIGINT count$10, BIGINT count$11, BIGINT count$12)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCount[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT COUNT(`byte`),
+       COUNT(`short`),
+       COUNT(`int`),
+       COUNT(`long`),
+       COUNT(`float`),
+       COUNT(`double`),
+       COUNT(`decimal3020`),
+       COUNT(`decimal105`),
+       COUNT(`boolean`),
+       COUNT(`date`),
+       COUNT(`time`),
+       COUNT(`timestamp`),
+       COUNT(`string`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)], EXPR$1=[COUNT($1)], EXPR$2=[COUNT($2)], EXPR$3=[COUNT($3)], EXPR$4=[COUNT($4)], EXPR$5=[COUNT($5)], EXPR$6=[COUNT($6)], EXPR$7=[COUNT($7)], EXPR$8=[COUNT($8)], EXPR$9=[COUNT($9)], EXPR$10=[COUNT($10)], EXPR$11=[COUNT($11)], EXPR$12=[COUNT($12)]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10], string=[$7]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[COUNT(byte) AS EXPR$0, COUNT(short) AS EXPR$1, COUNT(int) AS EXPR$2, COUNT(long) AS EXPR$3, COUNT(float) AS EXPR$4, COUNT(double) AS EXPR$5, COUNT(decimal3020) AS EXPR$6, COUNT(decimal105) AS EXPR$7, COUNT(boolean) AS EXPR$8, COUNT(date) AS EXPR$9, COUNT(time) AS EXPR$10, COUNT(timestamp) AS EXPR$11, COUNT(string) AS EXPR$12]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCount[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT COUNT(`byte`),
+       COUNT(`short`),
+       COUNT(`int`),
+       COUNT(`long`),
+       COUNT(`float`),
+       COUNT(`double`),
+       COUNT(`decimal3020`),
+       COUNT(`decimal105`),
+       COUNT(`boolean`),
+       COUNT(`date`),
+       COUNT(`time`),
+       COUNT(`timestamp`),
+       COUNT(`string`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)], EXPR$1=[COUNT($1)], EXPR$2=[COUNT($2)], EXPR$3=[COUNT($3)], EXPR$4=[COUNT($4)], EXPR$5=[COUNT($5)], EXPR$6=[COUNT($6)], EXPR$7=[COUNT($7)], EXPR$8=[COUNT($8)], EXPR$9=[COUNT($9)], EXPR$10=[COUNT($10)], EXPR$11=[COUNT($11)], EXPR$12=[COUNT($12)]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10], string=[$7]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_COUNT(count$0) AS EXPR$0, Final_COUNT(count$1) AS EXPR$1, Final_COUNT(count$2) AS EXPR$2, Final_COUNT(count$3) AS EXPR$3, Final_COUNT(count$4) AS EXPR$4, Final_COUNT(count$5) AS EXPR$5, Final_COUNT(count$6) AS EXPR$6, Final_COUNT(count$7) AS EXPR$7, Final_COUNT(count$8) AS EXPR$8, Final_COUNT(count$9) AS EXPR$9, Final_COUNT(count$10) AS EXPR$10, Final_COUNT(count$11) AS EXPR$11, Final_COUNT(count$12) AS EXPR$12]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count$0, BIGINT count$1, BIGINT count$2, BIGINT count$3, BIGINT count$4, BIGINT count$5, BIGINT count$6, BIGINT count$7, BIGINT count$8, BIGINT count$9, BIGINT count$10, BIGINT count$11, BIGINT count$12)]
+   +- LocalHashAggregate(select=[Partial_COUNT(byte) AS count$0, Partial_COUNT(short) AS count$1, Partial_COUNT(int) AS count$2, Partial_COUNT(long) AS count$3, Partial_COUNT(float) AS count$4, Partial_COUNT(double) AS count$5, Partial_COUNT(decimal3020) AS count$6, Partial_COUNT(decimal105) AS count$7, Partial_COUNT(boolean) AS count$8, Partial_COUNT(date) AS count$9, Partial_COUNT(time) AS count$10, Partial_COUNT(timestamp) AS count$11, Partial_COUNT(string) AS count$12]), rowType=[RecordType(BIGINT count$0, BIGINT count$1, BIGINT count$2, BIGINT count$3, BIGINT count$4, BIGINT count$5, BIGINT count$6, BIGINT count$7, BIGINT count$8, BIGINT count$9, BIGINT count$10, BIGINT count$11, BIGINT count$12)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregate[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1, Final_COUNT(count$1) AS EXPR$2])
++- Exchange(distribution=[hash[a]])
+   +- LocalHashAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0, Partial_COUNT(c) AS count$1])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStart[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count1$0)]
+   +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0]), rowType=[RecordType(BIGINT count1$0)]
+      +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStart[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[COUNT(*) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(INTEGER $f0)]
+   +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStart[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count1$0)]
+   +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0]), rowType=[RecordType(BIGINT count1$0)]
+      +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregate[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[a], select=[a, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2])
++- Exchange(distribution=[hash[a]])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregate[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1, Final_COUNT(count$1) AS EXPR$2])
++- Exchange(distribution=[hash[a]])
+   +- LocalHashAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0, Partial_COUNT(c) AS count$1])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregateWithFilter[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), count(c) FROM MyTable1 WHERE a = 1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1, Final_COUNT(count$1) AS EXPR$2])
++- Exchange(distribution=[hash[a]])
+   +- LocalHashAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0, Partial_COUNT(c) AS count$1])
+      +- Calc(select=[a, b, c], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregateWithFilter[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), count(c) FROM MyTable1 WHERE a = 1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[a], select=[a, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2])
++- Exchange(distribution=[hash[a]])
+   +- Calc(select=[a, b, c], where=[=(a, 1)])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregateWithFilter[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), count(c) FROM MyTable1 WHERE a = 1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1, Final_COUNT(count$1) AS EXPR$2])
++- Exchange(distribution=[hash[a]])
+   +- LocalHashAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0, Partial_COUNT(c) AS count$1])
+      +- Calc(select=[a, b, c], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithFixLengthType[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MAX(`byte`),
+       MAX(`short`),
+       MAX(`int`),
+       MAX(`long`),
+       MAX(`float`),
+       MAX(`double`),
+       MAX(`decimal3020`),
+       MAX(`decimal105`),
+       MAX(`boolean`),
+       MAX(`date`),
+       MAX(`time`),
+       MAX(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], EXPR$1=[MAX($1)], EXPR$2=[MAX($2)], EXPR$3=[MAX($3)], EXPR$4=[MAX($4)], EXPR$5=[MAX($5)], EXPR$6=[MAX($6)], EXPR$7=[MAX($7)], EXPR$8=[MAX($8)], EXPR$9=[MAX($9)], EXPR$10=[MAX($10)], EXPR$11=[MAX($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_MAX(max$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1, Final_MAX(max$2) AS EXPR$2, Final_MAX(max$3) AS EXPR$3, Final_MAX(max$4) AS EXPR$4, Final_MAX(max$5) AS EXPR$5, Final_MAX(max$6) AS EXPR$6, Final_MAX(max$7) AS EXPR$7, Final_MAX(max$8) AS EXPR$8, Final_MAX(max$9) AS EXPR$9, Final_MAX(max$10) AS EXPR$10, Final_MAX(max$11) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT max$0, SMALLINT max$1, INTEGER max$2, BIGINT max$3, FLOAT max$4, DOUBLE max$5, DECIMAL(30, 20) max$6, DECIMAL(10, 5) max$7, BOOLEAN max$8, INTEGER max$9, INTEGER max$10, BIGINT max$11)]
+   +- LocalHashAggregate(select=[Partial_MAX(byte) AS max$0, Partial_MAX(short) AS max$1, Partial_MAX(int) AS max$2, Partial_MAX(long) AS max$3, Partial_MAX(float) AS max$4, Partial_MAX(double) AS max$5, Partial_MAX(decimal3020) AS max$6, Partial_MAX(decimal105) AS max$7, Partial_MAX(boolean) AS max$8, Partial_MAX(date) AS max$9, Partial_MAX(time) AS max$10, Partial_MAX(timestamp) AS max$11]), rowType=[RecordType(TINYINT max$0, SMALLINT max$1, INTEGER max$2, BIGINT max$3, FLOAT max$4, DOUBLE max$5, DECIMAL(30, 20) max$6, DECIMAL(10, 5) max$7, BOOLEAN max$8, INTEGER max$9, INTEGER max$10, BIGINT max$11)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithFixLengthType[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MAX(`byte`),
+       MAX(`short`),
+       MAX(`int`),
+       MAX(`long`),
+       MAX(`float`),
+       MAX(`double`),
+       MAX(`decimal3020`),
+       MAX(`decimal105`),
+       MAX(`boolean`),
+       MAX(`date`),
+       MAX(`time`),
+       MAX(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], EXPR$1=[MAX($1)], EXPR$2=[MAX($2)], EXPR$3=[MAX($3)], EXPR$4=[MAX($4)], EXPR$5=[MAX($5)], EXPR$6=[MAX($6)], EXPR$7=[MAX($7)], EXPR$8=[MAX($8)], EXPR$9=[MAX($9)], EXPR$10=[MAX($10)], EXPR$11=[MAX($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[MAX(byte) AS EXPR$0, MAX(short) AS EXPR$1, MAX(int) AS EXPR$2, MAX(long) AS EXPR$3, MAX(float) AS EXPR$4, MAX(double) AS EXPR$5, MAX(decimal3020) AS EXPR$6, MAX(decimal105) AS EXPR$7, MAX(boolean) AS EXPR$8, MAX(date) AS EXPR$9, MAX(time) AS EXPR$10, MAX(timestamp) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithFixLengthType[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MAX(`byte`),
+       MAX(`short`),
+       MAX(`int`),
+       MAX(`long`),
+       MAX(`float`),
+       MAX(`double`),
+       MAX(`decimal3020`),
+       MAX(`decimal105`),
+       MAX(`boolean`),
+       MAX(`date`),
+       MAX(`time`),
+       MAX(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], EXPR$1=[MAX($1)], EXPR$2=[MAX($2)], EXPR$3=[MAX($3)], EXPR$4=[MAX($4)], EXPR$5=[MAX($5)], EXPR$6=[MAX($6)], EXPR$7=[MAX($7)], EXPR$8=[MAX($8)], EXPR$9=[MAX($9)], EXPR$10=[MAX($10)], EXPR$11=[MAX($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_MAX(max$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1, Final_MAX(max$2) AS EXPR$2, Final_MAX(max$3) AS EXPR$3, Final_MAX(max$4) AS EXPR$4, Final_MAX(max$5) AS EXPR$5, Final_MAX(max$6) AS EXPR$6, Final_MAX(max$7) AS EXPR$7, Final_MAX(max$8) AS EXPR$8, Final_MAX(max$9) AS EXPR$9, Final_MAX(max$10) AS EXPR$10, Final_MAX(max$11) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT max$0, SMALLINT max$1, INTEGER max$2, BIGINT max$3, FLOAT max$4, DOUBLE max$5, DECIMAL(30, 20) max$6, DECIMAL(10, 5) max$7, BOOLEAN max$8, INTEGER max$9, INTEGER max$10, BIGINT max$11)]
+   +- LocalHashAggregate(select=[Partial_MAX(byte) AS max$0, Partial_MAX(short) AS max$1, Partial_MAX(int) AS max$2, Partial_MAX(long) AS max$3, Partial_MAX(float) AS max$4, Partial_MAX(double) AS max$5, Partial_MAX(decimal3020) AS max$6, Partial_MAX(decimal105) AS max$7, Partial_MAX(boolean) AS max$8, Partial_MAX(date) AS max$9, Partial_MAX(time) AS max$10, Partial_MAX(timestamp) AS max$11]), rowType=[RecordType(TINYINT max$0, SMALLINT max$1, INTEGER max$2, BIGINT max$3, FLOAT max$4, DOUBLE max$5, DECIMAL(30, 20) max$6, DECIMAL(10, 5) max$7, BOOLEAN max$8, INTEGER max$9, INTEGER max$10, BIGINT max$11)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSum[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT SUM(`byte`),
+       SUM(`short`),
+       SUM(`int`),
+       SUM(`long`),
+       SUM(`float`),
+       SUM(`double`),
+       SUM(`decimal3020`),
+       SUM(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[SUM($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)], EXPR$4=[SUM($4)], EXPR$5=[SUM($5)], EXPR$6=[SUM($6)], EXPR$7=[SUM($7)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS EXPR$0, Final_SUM(sum$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2, Final_SUM(sum$3) AS EXPR$3, Final_SUM(sum$4) AS EXPR$4, Final_SUM(sum$5) AS EXPR$5, Final_SUM(sum$6) AS EXPR$6, Final_SUM(sum$7) AS EXPR$7]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT sum$0, SMALLINT sum$1, INTEGER sum$2, BIGINT sum$3, FLOAT sum$4, DOUBLE sum$5, DECIMAL(38, 20) sum$6, DECIMAL(38, 5) sum$7)]
+   +- LocalHashAggregate(select=[Partial_SUM(byte) AS sum$0, Partial_SUM(short) AS sum$1, Partial_SUM(int) AS sum$2, Partial_SUM(long) AS sum$3, Partial_SUM(float) AS sum$4, Partial_SUM(double) AS sum$5, Partial_SUM(decimal3020) AS sum$6, Partial_SUM(decimal105) AS sum$7]), rowType=[RecordType(TINYINT sum$0, SMALLINT sum$1, INTEGER sum$2, BIGINT sum$3, FLOAT sum$4, DOUBLE sum$5, DECIMAL(38, 20) sum$6, DECIMAL(38, 5) sum$7)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithFixLengthType[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MIN(`byte`),
+       MIN(`short`),
+       MIN(`int`),
+       MIN(`long`),
+       MIN(`float`),
+       MIN(`double`),
+       MIN(`decimal3020`),
+       MIN(`decimal105`),
+       MIN(`boolean`),
+       MIN(`date`),
+       MIN(`time`),
+       MIN(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)], EXPR$1=[MIN($1)], EXPR$2=[MIN($2)], EXPR$3=[MIN($3)], EXPR$4=[MIN($4)], EXPR$5=[MIN($5)], EXPR$6=[MIN($6)], EXPR$7=[MIN($7)], EXPR$8=[MIN($8)], EXPR$9=[MIN($9)], EXPR$10=[MIN($10)], EXPR$11=[MIN($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_MIN(min$0) AS EXPR$0, Final_MIN(min$1) AS EXPR$1, Final_MIN(min$2) AS EXPR$2, Final_MIN(min$3) AS EXPR$3, Final_MIN(min$4) AS EXPR$4, Final_MIN(min$5) AS EXPR$5, Final_MIN(min$6) AS EXPR$6, Final_MIN(min$7) AS EXPR$7, Final_MIN(min$8) AS EXPR$8, Final_MIN(min$9) AS EXPR$9, Final_MIN(min$10) AS EXPR$10, Final_MIN(min$11) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT min$0, SMALLINT min$1, INTEGER min$2, BIGINT min$3, FLOAT min$4, DOUBLE min$5, DECIMAL(30, 20) min$6, DECIMAL(10, 5) min$7, BOOLEAN min$8, INTEGER min$9, INTEGER min$10, BIGINT min$11)]
+   +- LocalHashAggregate(select=[Partial_MIN(byte) AS min$0, Partial_MIN(short) AS min$1, Partial_MIN(int) AS min$2, Partial_MIN(long) AS min$3, Partial_MIN(float) AS min$4, Partial_MIN(double) AS min$5, Partial_MIN(decimal3020) AS min$6, Partial_MIN(decimal105) AS min$7, Partial_MIN(boolean) AS min$8, Partial_MIN(date) AS min$9, Partial_MIN(time) AS min$10, Partial_MIN(timestamp) AS min$11]), rowType=[RecordType(TINYINT min$0, SMALLINT min$1, INTEGER min$2, BIGINT min$3, FLOAT min$4, DOUBLE min$5, DECIMAL(30, 20) min$6, DECIMAL(10, 5) min$7, BOOLEAN min$8, INTEGER min$9, INTEGER min$10, BIGINT min$11)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithFixLengthType[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MIN(`byte`),
+       MIN(`short`),
+       MIN(`int`),
+       MIN(`long`),
+       MIN(`float`),
+       MIN(`double`),
+       MIN(`decimal3020`),
+       MIN(`decimal105`),
+       MIN(`boolean`),
+       MIN(`date`),
+       MIN(`time`),
+       MIN(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)], EXPR$1=[MIN($1)], EXPR$2=[MIN($2)], EXPR$3=[MIN($3)], EXPR$4=[MIN($4)], EXPR$5=[MIN($5)], EXPR$6=[MIN($6)], EXPR$7=[MIN($7)], EXPR$8=[MIN($8)], EXPR$9=[MIN($9)], EXPR$10=[MIN($10)], EXPR$11=[MIN($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_MIN(min$0) AS EXPR$0, Final_MIN(min$1) AS EXPR$1, Final_MIN(min$2) AS EXPR$2, Final_MIN(min$3) AS EXPR$3, Final_MIN(min$4) AS EXPR$4, Final_MIN(min$5) AS EXPR$5, Final_MIN(min$6) AS EXPR$6, Final_MIN(min$7) AS EXPR$7, Final_MIN(min$8) AS EXPR$8, Final_MIN(min$9) AS EXPR$9, Final_MIN(min$10) AS EXPR$10, Final_MIN(min$11) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT min$0, SMALLINT min$1, INTEGER min$2, BIGINT min$3, FLOAT min$4, DOUBLE min$5, DECIMAL(30, 20) min$6, DECIMAL(10, 5) min$7, BOOLEAN min$8, INTEGER min$9, INTEGER min$10, BIGINT min$11)]
+   +- LocalHashAggregate(select=[Partial_MIN(byte) AS min$0, Partial_MIN(short) AS min$1, Partial_MIN(int) AS min$2, Partial_MIN(long) AS min$3, Partial_MIN(float) AS min$4, Partial_MIN(double) AS min$5, Partial_MIN(decimal3020) AS min$6, Partial_MIN(decimal105) AS min$7, Partial_MIN(boolean) AS min$8, Partial_MIN(date) AS min$9, Partial_MIN(time) AS min$10, Partial_MIN(timestamp) AS min$11]), rowType=[RecordType(TINYINT min$0, SMALLINT min$1, INTEGER min$2, BIGINT min$3, FLOAT min$4, DOUBLE min$5, DECIMAL(30, 20) min$6, DECIMAL(10, 5) min$7, BOOLEAN min$8, INTEGER min$9, INTEGER min$10, BIGINT min$11)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSum[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT SUM(`byte`),
+       SUM(`short`),
+       SUM(`int`),
+       SUM(`long`),
+       SUM(`float`),
+       SUM(`double`),
+       SUM(`decimal3020`),
+       SUM(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[SUM($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)], EXPR$4=[SUM($4)], EXPR$5=[SUM($5)], EXPR$6=[SUM($6)], EXPR$7=[SUM($7)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[SUM(byte) AS EXPR$0, SUM(short) AS EXPR$1, SUM(int) AS EXPR$2, SUM(long) AS EXPR$3, SUM(float) AS EXPR$4, SUM(double) AS EXPR$5, SUM(decimal3020) AS EXPR$6, SUM(decimal105) AS EXPR$7]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithFixLengthType[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MIN(`byte`),
+       MIN(`short`),
+       MIN(`int`),
+       MIN(`long`),
+       MIN(`float`),
+       MIN(`double`),
+       MIN(`decimal3020`),
+       MIN(`decimal105`),
+       MIN(`boolean`),
+       MIN(`date`),
+       MIN(`time`),
+       MIN(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)], EXPR$1=[MIN($1)], EXPR$2=[MIN($2)], EXPR$3=[MIN($3)], EXPR$4=[MIN($4)], EXPR$5=[MIN($5)], EXPR$6=[MIN($6)], EXPR$7=[MIN($7)], EXPR$8=[MIN($8)], EXPR$9=[MIN($9)], EXPR$10=[MIN($10)], EXPR$11=[MIN($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[MIN(byte) AS EXPR$0, MIN(short) AS EXPR$1, MIN(int) AS EXPR$2, MIN(long) AS EXPR$3, MIN(float) AS EXPR$4, MIN(double) AS EXPR$5, MIN(decimal3020) AS EXPR$6, MIN(decimal105) AS EXPR$7, MIN(boolean) AS EXPR$8, MIN(date) AS EXPR$9, MIN(time) AS EXPR$10, MIN(timestamp) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSum[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT SUM(`byte`),
+       SUM(`short`),
+       SUM(`int`),
+       SUM(`long`),
+       SUM(`float`),
+       SUM(`double`),
+       SUM(`decimal3020`),
+       SUM(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[SUM($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)], EXPR$4=[SUM($4)], EXPR$5=[SUM($5)], EXPR$6=[SUM($6)], EXPR$7=[SUM($7)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS EXPR$0, Final_SUM(sum$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2, Final_SUM(sum$3) AS EXPR$3, Final_SUM(sum$4) AS EXPR$4, Final_SUM(sum$5) AS EXPR$5, Final_SUM(sum$6) AS EXPR$6, Final_SUM(sum$7) AS EXPR$7]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT sum$0, SMALLINT sum$1, INTEGER sum$2, BIGINT sum$3, FLOAT sum$4, DOUBLE sum$5, DECIMAL(38, 20) sum$6, DECIMAL(38, 5) sum$7)]
+   +- LocalHashAggregate(select=[Partial_SUM(byte) AS sum$0, Partial_SUM(short) AS sum$1, Partial_SUM(int) AS sum$2, Partial_SUM(long) AS sum$3, Partial_SUM(float) AS sum$4, Partial_SUM(double) AS sum$5, Partial_SUM(decimal3020) AS sum$6, Partial_SUM(decimal105) AS sum$7]), rowType=[RecordType(TINYINT sum$0, SMALLINT sum$1, INTEGER sum$2, BIGINT sum$3, FLOAT sum$4, DOUBLE sum$5, DECIMAL(38, 20) sum$6, DECIMAL(38, 5) sum$7)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/SortAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/SortAggregateTest.xml
@@ -1,0 +1,1205 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testAggNotSupportMerge[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Sort(orderBy=[b ASC])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[b, a])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggNotSupportMerge[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Sort(orderBy=[b ASC])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[b, a])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggNotSupportMerge[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Sort(orderBy=[b ASC])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[b, a])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilter[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- LocalSortAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3])
+      +- Calc(select=[a, b, c], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilter[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[AVG(a) AS EXPR$0, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- Calc(select=[a, b, c], where=[=(a, 1)])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilter[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- LocalSortAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3])
+      +- Calc(select=[a, b, c], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilterOnNestedFields[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c), SUM(c._1) FROM MyTable2 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)], EXPR$3=[SUM($3)])
++- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$2._1])
+   +- LogicalFilter(condition=[=($0, 1)])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2, Final_SUM(sum$4) AS EXPR$3])
++- Exchange(distribution=[single])
+   +- LocalSortAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3, Partial_SUM($f3) AS sum$4])
+      +- Calc(select=[a, b, c, c._1 AS $f3], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilterOnNestedFields[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c), SUM(c._1) FROM MyTable2 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)], EXPR$3=[SUM($3)])
++- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$2._1])
+   +- LogicalFilter(condition=[=($0, 1)])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[AVG(a) AS EXPR$0, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2, SUM($f3) AS EXPR$3])
++- Exchange(distribution=[single])
+   +- Calc(select=[a, b, c, c._1 AS $f3], where=[=(a, 1)])
+      +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithFilterOnNestedFields[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c), SUM(c._1) FROM MyTable2 WHERE a = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)], EXPR$3=[SUM($3)])
++- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$2._1])
+   +- LogicalFilter(condition=[=($0, 1)])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2, Final_SUM(sum$4) AS EXPR$3])
++- Exchange(distribution=[single])
+   +- LocalSortAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3, Partial_SUM($f3) AS sum$4])
+      +- Calc(select=[a, b, c, c._1 AS $f3], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutFunction[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b FROM MyTable1 GROUP BY a, b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
++- Sort(orderBy=[a ASC, b ASC])
+   +- Exchange(distribution=[hash[a, b]])
+      +- LocalSortAggregate(groupBy=[a, b], select=[a, b])
+         +- Sort(orderBy=[a ASC, b ASC])
+            +- Calc(select=[a, b])
+               +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutFunction[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b FROM MyTable1 GROUP BY a, b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[a, b], select=[a, b])
++- Sort(orderBy=[a ASC, b ASC])
+   +- Exchange(distribution=[hash[a, b]])
+      +- Calc(select=[a, b])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutFunction[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b FROM MyTable1 GROUP BY a, b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
++- Sort(orderBy=[a ASC, b ASC])
+   +- Exchange(distribution=[hash[a, b]])
+      +- LocalSortAggregate(groupBy=[a, b], select=[a, b])
+         +- Sort(orderBy=[a ASC, b ASC])
+            +- Calc(select=[a, b])
+               +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutGroupBy[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- LocalSortAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutGroupBy[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[AVG(a) AS EXPR$0, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithoutGroupBy[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_SUM(sum$2) AS EXPR$1, Final_COUNT(count$3) AS EXPR$2])
++- Exchange(distribution=[single])
+   +- LocalSortAggregate(select=[Partial_AVG(a) AS (sum$0, count$1), Partial_SUM(b) AS sum$2, Partial_COUNT(c) AS count$3])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvg[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT AVG(`byte`),
+       AVG(`short`),
+       AVG(`int`),
+       AVG(`long`),
+       AVG(`float`),
+       AVG(`double`),
+       AVG(`decimal3020`),
+       AVG(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($1)], EXPR$2=[AVG($2)], EXPR$3=[AVG($3)], EXPR$4=[AVG($4)], EXPR$5=[AVG($5)], EXPR$6=[AVG($6)], EXPR$7=[AVG($7)]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_AVG(sum$2, count$3) AS EXPR$1, Final_AVG(sum$4, count$5) AS EXPR$2, Final_AVG(sum$6, count$7) AS EXPR$3, Final_AVG(sum$8, count$9) AS EXPR$4, Final_AVG(sum$10, count$11) AS EXPR$5, Final_AVG(sum$12, count$13) AS EXPR$6, Final_AVG(sum$14, count$15) AS EXPR$7]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT sum$0, BIGINT count$1, BIGINT sum$2, BIGINT count$3, BIGINT sum$4, BIGINT count$5, BIGINT sum$6, BIGINT count$7, DOUBLE sum$8, BIGINT count$9, DOUBLE sum$10, BIGINT count$11, DECIMAL(38, 20) sum$12, BIGINT count$13, DECIMAL(38, 5) sum$14, BIGINT count$15)]
+   +- LocalSortAggregate(select=[Partial_AVG(byte) AS (sum$0, count$1), Partial_AVG(short) AS (sum$2, count$3), Partial_AVG(int) AS (sum$4, count$5), Partial_AVG(long) AS (sum$6, count$7), Partial_AVG(float) AS (sum$8, count$9), Partial_AVG(double) AS (sum$10, count$11), Partial_AVG(decimal3020) AS (sum$12, count$13), Partial_AVG(decimal105) AS (sum$14, count$15)]), rowType=[RecordType(BIGINT sum$0, BIGINT count$1, BIGINT sum$2, BIGINT count$3, BIGINT sum$4, BIGINT count$5, BIGINT sum$6, BIGINT count$7, DOUBLE sum$8, BIGINT count$9, DOUBLE sum$10, BIGINT count$11, DECIMAL(38, 20) sum$12, BIGINT count$13, DECIMAL(38, 5) sum$14, BIGINT count$15)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvg[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT AVG(`byte`),
+       AVG(`short`),
+       AVG(`int`),
+       AVG(`long`),
+       AVG(`float`),
+       AVG(`double`),
+       AVG(`decimal3020`),
+       AVG(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($1)], EXPR$2=[AVG($2)], EXPR$3=[AVG($3)], EXPR$4=[AVG($4)], EXPR$5=[AVG($5)], EXPR$6=[AVG($6)], EXPR$7=[AVG($7)]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[AVG(byte) AS EXPR$0, AVG(short) AS EXPR$1, AVG(int) AS EXPR$2, AVG(long) AS EXPR$3, AVG(float) AS EXPR$4, AVG(double) AS EXPR$5, AVG(decimal3020) AS EXPR$6, AVG(decimal105) AS EXPR$7]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvg[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT AVG(`byte`),
+       AVG(`short`),
+       AVG(`int`),
+       AVG(`long`),
+       AVG(`float`),
+       AVG(`double`),
+       AVG(`decimal3020`),
+       AVG(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($1)], EXPR$2=[AVG($2)], EXPR$3=[AVG($3)], EXPR$4=[AVG($4)], EXPR$5=[AVG($5)], EXPR$6=[AVG($6)], EXPR$7=[AVG($7)]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final_AVG(sum$2, count$3) AS EXPR$1, Final_AVG(sum$4, count$5) AS EXPR$2, Final_AVG(sum$6, count$7) AS EXPR$3, Final_AVG(sum$8, count$9) AS EXPR$4, Final_AVG(sum$10, count$11) AS EXPR$5, Final_AVG(sum$12, count$13) AS EXPR$6, Final_AVG(sum$14, count$15) AS EXPR$7]), rowType=[RecordType(DOUBLE EXPR$0, DOUBLE EXPR$1, DOUBLE EXPR$2, DOUBLE EXPR$3, DOUBLE EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 6) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT sum$0, BIGINT count$1, BIGINT sum$2, BIGINT count$3, BIGINT sum$4, BIGINT count$5, BIGINT sum$6, BIGINT count$7, DOUBLE sum$8, BIGINT count$9, DOUBLE sum$10, BIGINT count$11, DECIMAL(38, 20) sum$12, BIGINT count$13, DECIMAL(38, 5) sum$14, BIGINT count$15)]
+   +- LocalSortAggregate(select=[Partial_AVG(byte) AS (sum$0, count$1), Partial_AVG(short) AS (sum$2, count$3), Partial_AVG(int) AS (sum$4, count$5), Partial_AVG(long) AS (sum$6, count$7), Partial_AVG(float) AS (sum$8, count$9), Partial_AVG(double) AS (sum$10, count$11), Partial_AVG(decimal3020) AS (sum$12, count$13), Partial_AVG(decimal105) AS (sum$14, count$15)]), rowType=[RecordType(BIGINT sum$0, BIGINT count$1, BIGINT sum$2, BIGINT count$3, BIGINT sum$4, BIGINT count$5, BIGINT sum$6, BIGINT count$7, DOUBLE sum$8, BIGINT count$9, DOUBLE sum$10, BIGINT count$11, DECIMAL(38, 20) sum$12, BIGINT count$13, DECIMAL(38, 5) sum$14, BIGINT count$15)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCount[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT COUNT(`byte`),
+       COUNT(`short`),
+       COUNT(`int`),
+       COUNT(`long`),
+       COUNT(`float`),
+       COUNT(`double`),
+       COUNT(`decimal3020`),
+       COUNT(`decimal105`),
+       COUNT(`boolean`),
+       COUNT(`date`),
+       COUNT(`time`),
+       COUNT(`timestamp`),
+       COUNT(`string`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)], EXPR$1=[COUNT($1)], EXPR$2=[COUNT($2)], EXPR$3=[COUNT($3)], EXPR$4=[COUNT($4)], EXPR$5=[COUNT($5)], EXPR$6=[COUNT($6)], EXPR$7=[COUNT($7)], EXPR$8=[COUNT($8)], EXPR$9=[COUNT($9)], EXPR$10=[COUNT($10)], EXPR$11=[COUNT($11)], EXPR$12=[COUNT($12)]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10], string=[$7]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_COUNT(count$0) AS EXPR$0, Final_COUNT(count$1) AS EXPR$1, Final_COUNT(count$2) AS EXPR$2, Final_COUNT(count$3) AS EXPR$3, Final_COUNT(count$4) AS EXPR$4, Final_COUNT(count$5) AS EXPR$5, Final_COUNT(count$6) AS EXPR$6, Final_COUNT(count$7) AS EXPR$7, Final_COUNT(count$8) AS EXPR$8, Final_COUNT(count$9) AS EXPR$9, Final_COUNT(count$10) AS EXPR$10, Final_COUNT(count$11) AS EXPR$11, Final_COUNT(count$12) AS EXPR$12]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count$0, BIGINT count$1, BIGINT count$2, BIGINT count$3, BIGINT count$4, BIGINT count$5, BIGINT count$6, BIGINT count$7, BIGINT count$8, BIGINT count$9, BIGINT count$10, BIGINT count$11, BIGINT count$12)]
+   +- LocalSortAggregate(select=[Partial_COUNT(byte) AS count$0, Partial_COUNT(short) AS count$1, Partial_COUNT(int) AS count$2, Partial_COUNT(long) AS count$3, Partial_COUNT(float) AS count$4, Partial_COUNT(double) AS count$5, Partial_COUNT(decimal3020) AS count$6, Partial_COUNT(decimal105) AS count$7, Partial_COUNT(boolean) AS count$8, Partial_COUNT(date) AS count$9, Partial_COUNT(time) AS count$10, Partial_COUNT(timestamp) AS count$11, Partial_COUNT(string) AS count$12]), rowType=[RecordType(BIGINT count$0, BIGINT count$1, BIGINT count$2, BIGINT count$3, BIGINT count$4, BIGINT count$5, BIGINT count$6, BIGINT count$7, BIGINT count$8, BIGINT count$9, BIGINT count$10, BIGINT count$11, BIGINT count$12)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCount[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT COUNT(`byte`),
+       COUNT(`short`),
+       COUNT(`int`),
+       COUNT(`long`),
+       COUNT(`float`),
+       COUNT(`double`),
+       COUNT(`decimal3020`),
+       COUNT(`decimal105`),
+       COUNT(`boolean`),
+       COUNT(`date`),
+       COUNT(`time`),
+       COUNT(`timestamp`),
+       COUNT(`string`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)], EXPR$1=[COUNT($1)], EXPR$2=[COUNT($2)], EXPR$3=[COUNT($3)], EXPR$4=[COUNT($4)], EXPR$5=[COUNT($5)], EXPR$6=[COUNT($6)], EXPR$7=[COUNT($7)], EXPR$8=[COUNT($8)], EXPR$9=[COUNT($9)], EXPR$10=[COUNT($10)], EXPR$11=[COUNT($11)], EXPR$12=[COUNT($12)]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10], string=[$7]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[COUNT(byte) AS EXPR$0, COUNT(short) AS EXPR$1, COUNT(int) AS EXPR$2, COUNT(long) AS EXPR$3, COUNT(float) AS EXPR$4, COUNT(double) AS EXPR$5, COUNT(decimal3020) AS EXPR$6, COUNT(decimal105) AS EXPR$7, COUNT(boolean) AS EXPR$8, COUNT(date) AS EXPR$9, COUNT(time) AS EXPR$10, COUNT(timestamp) AS EXPR$11, COUNT(string) AS EXPR$12]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCount[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT COUNT(`byte`),
+       COUNT(`short`),
+       COUNT(`int`),
+       COUNT(`long`),
+       COUNT(`float`),
+       COUNT(`double`),
+       COUNT(`decimal3020`),
+       COUNT(`decimal105`),
+       COUNT(`boolean`),
+       COUNT(`date`),
+       COUNT(`time`),
+       COUNT(`timestamp`),
+       COUNT(`string`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)], EXPR$1=[COUNT($1)], EXPR$2=[COUNT($2)], EXPR$3=[COUNT($3)], EXPR$4=[COUNT($4)], EXPR$5=[COUNT($5)], EXPR$6=[COUNT($6)], EXPR$7=[COUNT($7)], EXPR$8=[COUNT($8)], EXPR$9=[COUNT($9)], EXPR$10=[COUNT($10)], EXPR$11=[COUNT($11)], EXPR$12=[COUNT($12)]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10], string=[$7]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_COUNT(count$0) AS EXPR$0, Final_COUNT(count$1) AS EXPR$1, Final_COUNT(count$2) AS EXPR$2, Final_COUNT(count$3) AS EXPR$3, Final_COUNT(count$4) AS EXPR$4, Final_COUNT(count$5) AS EXPR$5, Final_COUNT(count$6) AS EXPR$6, Final_COUNT(count$7) AS EXPR$7, Final_COUNT(count$8) AS EXPR$8, Final_COUNT(count$9) AS EXPR$9, Final_COUNT(count$10) AS EXPR$10, Final_COUNT(count$11) AS EXPR$11, Final_COUNT(count$12) AS EXPR$12]), rowType=[RecordType(BIGINT EXPR$0, BIGINT EXPR$1, BIGINT EXPR$2, BIGINT EXPR$3, BIGINT EXPR$4, BIGINT EXPR$5, BIGINT EXPR$6, BIGINT EXPR$7, BIGINT EXPR$8, BIGINT EXPR$9, BIGINT EXPR$10, BIGINT EXPR$11, BIGINT EXPR$12)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count$0, BIGINT count$1, BIGINT count$2, BIGINT count$3, BIGINT count$4, BIGINT count$5, BIGINT count$6, BIGINT count$7, BIGINT count$8, BIGINT count$9, BIGINT count$10, BIGINT count$11, BIGINT count$12)]
+   +- LocalSortAggregate(select=[Partial_COUNT(byte) AS count$0, Partial_COUNT(short) AS count$1, Partial_COUNT(int) AS count$2, Partial_COUNT(long) AS count$3, Partial_COUNT(float) AS count$4, Partial_COUNT(double) AS count$5, Partial_COUNT(decimal3020) AS count$6, Partial_COUNT(decimal105) AS count$7, Partial_COUNT(boolean) AS count$8, Partial_COUNT(date) AS count$9, Partial_COUNT(time) AS count$10, Partial_COUNT(timestamp) AS count$11, Partial_COUNT(string) AS count$12]), rowType=[RecordType(BIGINT count$0, BIGINT count$1, BIGINT count$2, BIGINT count$3, BIGINT count$4, BIGINT count$5, BIGINT count$6, BIGINT count$7, BIGINT count$8, BIGINT count$9, BIGINT count$10, BIGINT count$11, BIGINT count$12)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregate[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1, Final_COUNT(count$1) AS EXPR$2])
++- Sort(orderBy=[a ASC])
+   +- Exchange(distribution=[hash[a]])
+      +- LocalSortAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0, Partial_COUNT(c) AS count$1])
+         +- Sort(orderBy=[a ASC])
+            +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStart[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count1$0)]
+   +- LocalSortAggregate(select=[Partial_COUNT(*) AS count1$0]), rowType=[RecordType(BIGINT count1$0)]
+      +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStart[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[COUNT(*) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(INTEGER $f0)]
+   +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStart[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count1$0)]
+   +- LocalSortAggregate(select=[Partial_COUNT(*) AS count1$0]), rowType=[RecordType(BIGINT count1$0)]
+      +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregate[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[a], select=[a, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2])
++- Sort(orderBy=[a ASC])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregate[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1, Final_COUNT(count$1) AS EXPR$2])
++- Sort(orderBy=[a ASC])
+   +- Exchange(distribution=[hash[a]])
+      +- LocalSortAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0, Partial_COUNT(c) AS count$1])
+         +- Sort(orderBy=[a ASC])
+            +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregateWithFilter[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), count(c) FROM MyTable1 WHERE a = 1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1, Final_COUNT(count$1) AS EXPR$2])
++- Sort(orderBy=[a ASC])
+   +- Exchange(distribution=[hash[a]])
+      +- LocalSortAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0, Partial_COUNT(c) AS count$1])
+         +- Sort(orderBy=[a ASC])
+            +- Calc(select=[a, b, c], where=[=(a, 1)])
+               +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregateWithFilter[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), count(c) FROM MyTable1 WHERE a = 1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[a], select=[a, SUM(b) AS EXPR$1, COUNT(c) AS EXPR$2])
++- Sort(orderBy=[a ASC])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c], where=[=(a, 1)])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggregateWithFilter[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, SUM(b), count(c) FROM MyTable1 WHERE a = 1 GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT($2)])
++- LogicalFilter(condition=[=($0, 1)])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1, Final_COUNT(count$1) AS EXPR$2])
++- Sort(orderBy=[a ASC])
+   +- Exchange(distribution=[hash[a]])
+      +- LocalSortAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0, Partial_COUNT(c) AS count$1])
+         +- Sort(orderBy=[a ASC])
+            +- Calc(select=[a, b, c], where=[=(a, 1)])
+               +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithFixLengthType[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MAX(`byte`),
+       MAX(`short`),
+       MAX(`int`),
+       MAX(`long`),
+       MAX(`float`),
+       MAX(`double`),
+       MAX(`decimal3020`),
+       MAX(`decimal105`),
+       MAX(`boolean`),
+       MAX(`date`),
+       MAX(`time`),
+       MAX(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], EXPR$1=[MAX($1)], EXPR$2=[MAX($2)], EXPR$3=[MAX($3)], EXPR$4=[MAX($4)], EXPR$5=[MAX($5)], EXPR$6=[MAX($6)], EXPR$7=[MAX($7)], EXPR$8=[MAX($8)], EXPR$9=[MAX($9)], EXPR$10=[MAX($10)], EXPR$11=[MAX($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MAX(max$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1, Final_MAX(max$2) AS EXPR$2, Final_MAX(max$3) AS EXPR$3, Final_MAX(max$4) AS EXPR$4, Final_MAX(max$5) AS EXPR$5, Final_MAX(max$6) AS EXPR$6, Final_MAX(max$7) AS EXPR$7, Final_MAX(max$8) AS EXPR$8, Final_MAX(max$9) AS EXPR$9, Final_MAX(max$10) AS EXPR$10, Final_MAX(max$11) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT max$0, SMALLINT max$1, INTEGER max$2, BIGINT max$3, FLOAT max$4, DOUBLE max$5, DECIMAL(30, 20) max$6, DECIMAL(10, 5) max$7, BOOLEAN max$8, INTEGER max$9, INTEGER max$10, BIGINT max$11)]
+   +- LocalSortAggregate(select=[Partial_MAX(byte) AS max$0, Partial_MAX(short) AS max$1, Partial_MAX(int) AS max$2, Partial_MAX(long) AS max$3, Partial_MAX(float) AS max$4, Partial_MAX(double) AS max$5, Partial_MAX(decimal3020) AS max$6, Partial_MAX(decimal105) AS max$7, Partial_MAX(boolean) AS max$8, Partial_MAX(date) AS max$9, Partial_MAX(time) AS max$10, Partial_MAX(timestamp) AS max$11]), rowType=[RecordType(TINYINT max$0, SMALLINT max$1, INTEGER max$2, BIGINT max$3, FLOAT max$4, DOUBLE max$5, DECIMAL(30, 20) max$6, DECIMAL(10, 5) max$7, BOOLEAN max$8, INTEGER max$9, INTEGER max$10, BIGINT max$11)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithFixLengthType[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MAX(`byte`),
+       MAX(`short`),
+       MAX(`int`),
+       MAX(`long`),
+       MAX(`float`),
+       MAX(`double`),
+       MAX(`decimal3020`),
+       MAX(`decimal105`),
+       MAX(`boolean`),
+       MAX(`date`),
+       MAX(`time`),
+       MAX(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], EXPR$1=[MAX($1)], EXPR$2=[MAX($2)], EXPR$3=[MAX($3)], EXPR$4=[MAX($4)], EXPR$5=[MAX($5)], EXPR$6=[MAX($6)], EXPR$7=[MAX($7)], EXPR$8=[MAX($8)], EXPR$9=[MAX($9)], EXPR$10=[MAX($10)], EXPR$11=[MAX($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[MAX(byte) AS EXPR$0, MAX(short) AS EXPR$1, MAX(int) AS EXPR$2, MAX(long) AS EXPR$3, MAX(float) AS EXPR$4, MAX(double) AS EXPR$5, MAX(decimal3020) AS EXPR$6, MAX(decimal105) AS EXPR$7, MAX(boolean) AS EXPR$8, MAX(date) AS EXPR$9, MAX(time) AS EXPR$10, MAX(timestamp) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithFixLengthType[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MAX(`byte`),
+       MAX(`short`),
+       MAX(`int`),
+       MAX(`long`),
+       MAX(`float`),
+       MAX(`double`),
+       MAX(`decimal3020`),
+       MAX(`decimal105`),
+       MAX(`boolean`),
+       MAX(`date`),
+       MAX(`time`),
+       MAX(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], EXPR$1=[MAX($1)], EXPR$2=[MAX($2)], EXPR$3=[MAX($3)], EXPR$4=[MAX($4)], EXPR$5=[MAX($5)], EXPR$6=[MAX($6)], EXPR$7=[MAX($7)], EXPR$8=[MAX($8)], EXPR$9=[MAX($9)], EXPR$10=[MAX($10)], EXPR$11=[MAX($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MAX(max$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1, Final_MAX(max$2) AS EXPR$2, Final_MAX(max$3) AS EXPR$3, Final_MAX(max$4) AS EXPR$4, Final_MAX(max$5) AS EXPR$5, Final_MAX(max$6) AS EXPR$6, Final_MAX(max$7) AS EXPR$7, Final_MAX(max$8) AS EXPR$8, Final_MAX(max$9) AS EXPR$9, Final_MAX(max$10) AS EXPR$10, Final_MAX(max$11) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT max$0, SMALLINT max$1, INTEGER max$2, BIGINT max$3, FLOAT max$4, DOUBLE max$5, DECIMAL(30, 20) max$6, DECIMAL(10, 5) max$7, BOOLEAN max$8, INTEGER max$9, INTEGER max$10, BIGINT max$11)]
+   +- LocalSortAggregate(select=[Partial_MAX(byte) AS max$0, Partial_MAX(short) AS max$1, Partial_MAX(int) AS max$2, Partial_MAX(long) AS max$3, Partial_MAX(float) AS max$4, Partial_MAX(double) AS max$5, Partial_MAX(decimal3020) AS max$6, Partial_MAX(decimal105) AS max$7, Partial_MAX(boolean) AS max$8, Partial_MAX(date) AS max$9, Partial_MAX(time) AS max$10, Partial_MAX(timestamp) AS max$11]), rowType=[RecordType(TINYINT max$0, SMALLINT max$1, INTEGER max$2, BIGINT max$3, FLOAT max$4, DOUBLE max$5, DECIMAL(30, 20) max$6, DECIMAL(10, 5) max$7, BOOLEAN max$8, INTEGER max$9, INTEGER max$10, BIGINT max$11)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithVariableLengthType[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT MAX(`string`) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- LogicalProject(string=[$7]), rowType=[RecordType(VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MAX(max$0) AS EXPR$0]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(VARCHAR(65536) max$0)]
+   +- LocalSortAggregate(select=[Partial_MAX(string) AS max$0]), rowType=[RecordType(VARCHAR(65536) max$0)]
+      +- Calc(select=[string]), rowType=[RecordType(VARCHAR(65536) string)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithVariableLengthType[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT MAX(`string`) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- LogicalProject(string=[$7]), rowType=[RecordType(VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[MAX(string) AS EXPR$0]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(VARCHAR(65536) string)]
+   +- Calc(select=[string]), rowType=[RecordType(VARCHAR(65536) string)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMaxWithVariableLengthType[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT MAX(`string`) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- LogicalProject(string=[$7]), rowType=[RecordType(VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MAX(max$0) AS EXPR$0]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(VARCHAR(65536) max$0)]
+   +- LocalSortAggregate(select=[Partial_MAX(string) AS max$0]), rowType=[RecordType(VARCHAR(65536) max$0)]
+      +- Calc(select=[string]), rowType=[RecordType(VARCHAR(65536) string)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithFixLengthType[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MIN(`byte`),
+       MIN(`short`),
+       MIN(`int`),
+       MIN(`long`),
+       MIN(`float`),
+       MIN(`double`),
+       MIN(`decimal3020`),
+       MIN(`decimal105`),
+       MIN(`boolean`),
+       MIN(`date`),
+       MIN(`time`),
+       MIN(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)], EXPR$1=[MIN($1)], EXPR$2=[MIN($2)], EXPR$3=[MIN($3)], EXPR$4=[MIN($4)], EXPR$5=[MIN($5)], EXPR$6=[MIN($6)], EXPR$7=[MIN($7)], EXPR$8=[MIN($8)], EXPR$9=[MIN($9)], EXPR$10=[MIN($10)], EXPR$11=[MIN($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MIN(min$0) AS EXPR$0, Final_MIN(min$1) AS EXPR$1, Final_MIN(min$2) AS EXPR$2, Final_MIN(min$3) AS EXPR$3, Final_MIN(min$4) AS EXPR$4, Final_MIN(min$5) AS EXPR$5, Final_MIN(min$6) AS EXPR$6, Final_MIN(min$7) AS EXPR$7, Final_MIN(min$8) AS EXPR$8, Final_MIN(min$9) AS EXPR$9, Final_MIN(min$10) AS EXPR$10, Final_MIN(min$11) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT min$0, SMALLINT min$1, INTEGER min$2, BIGINT min$3, FLOAT min$4, DOUBLE min$5, DECIMAL(30, 20) min$6, DECIMAL(10, 5) min$7, BOOLEAN min$8, INTEGER min$9, INTEGER min$10, BIGINT min$11)]
+   +- LocalSortAggregate(select=[Partial_MIN(byte) AS min$0, Partial_MIN(short) AS min$1, Partial_MIN(int) AS min$2, Partial_MIN(long) AS min$3, Partial_MIN(float) AS min$4, Partial_MIN(double) AS min$5, Partial_MIN(decimal3020) AS min$6, Partial_MIN(decimal105) AS min$7, Partial_MIN(boolean) AS min$8, Partial_MIN(date) AS min$9, Partial_MIN(time) AS min$10, Partial_MIN(timestamp) AS min$11]), rowType=[RecordType(TINYINT min$0, SMALLINT min$1, INTEGER min$2, BIGINT min$3, FLOAT min$4, DOUBLE min$5, DECIMAL(30, 20) min$6, DECIMAL(10, 5) min$7, BOOLEAN min$8, INTEGER min$9, INTEGER min$10, BIGINT min$11)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithFixLengthType[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MIN(`byte`),
+       MIN(`short`),
+       MIN(`int`),
+       MIN(`long`),
+       MIN(`float`),
+       MIN(`double`),
+       MIN(`decimal3020`),
+       MIN(`decimal105`),
+       MIN(`boolean`),
+       MIN(`date`),
+       MIN(`time`),
+       MIN(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)], EXPR$1=[MIN($1)], EXPR$2=[MIN($2)], EXPR$3=[MIN($3)], EXPR$4=[MIN($4)], EXPR$5=[MIN($5)], EXPR$6=[MIN($6)], EXPR$7=[MIN($7)], EXPR$8=[MIN($8)], EXPR$9=[MIN($9)], EXPR$10=[MIN($10)], EXPR$11=[MIN($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[MIN(byte) AS EXPR$0, MIN(short) AS EXPR$1, MIN(int) AS EXPR$2, MIN(long) AS EXPR$3, MIN(float) AS EXPR$4, MIN(double) AS EXPR$5, MIN(decimal3020) AS EXPR$6, MIN(decimal105) AS EXPR$7, MIN(boolean) AS EXPR$8, MIN(date) AS EXPR$9, MIN(time) AS EXPR$10, MIN(timestamp) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithFixLengthType[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MIN(`byte`),
+       MIN(`short`),
+       MIN(`int`),
+       MIN(`long`),
+       MIN(`float`),
+       MIN(`double`),
+       MIN(`decimal3020`),
+       MIN(`decimal105`),
+       MIN(`boolean`),
+       MIN(`date`),
+       MIN(`time`),
+       MIN(`timestamp`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)], EXPR$1=[MIN($1)], EXPR$2=[MIN($2)], EXPR$3=[MIN($3)], EXPR$4=[MIN($4)], EXPR$5=[MIN($5)], EXPR$6=[MIN($6)], EXPR$7=[MIN($7)], EXPR$8=[MIN($8)], EXPR$9=[MIN($9)], EXPR$10=[MIN($10)], EXPR$11=[MIN($11)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12], boolean=[$6], date=[$8], time=[$9], timestamp=[$10]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MIN(min$0) AS EXPR$0, Final_MIN(min$1) AS EXPR$1, Final_MIN(min$2) AS EXPR$2, Final_MIN(min$3) AS EXPR$3, Final_MIN(min$4) AS EXPR$4, Final_MIN(min$5) AS EXPR$5, Final_MIN(min$6) AS EXPR$6, Final_MIN(min$7) AS EXPR$7, Final_MIN(min$8) AS EXPR$8, Final_MIN(min$9) AS EXPR$9, Final_MIN(min$10) AS EXPR$10, Final_MIN(min$11) AS EXPR$11]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(30, 20) EXPR$6, DECIMAL(10, 5) EXPR$7, BOOLEAN EXPR$8, DATE EXPR$9, TIME(0) EXPR$10, TIMESTAMP(3) EXPR$11)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT min$0, SMALLINT min$1, INTEGER min$2, BIGINT min$3, FLOAT min$4, DOUBLE min$5, DECIMAL(30, 20) min$6, DECIMAL(10, 5) min$7, BOOLEAN min$8, INTEGER min$9, INTEGER min$10, BIGINT min$11)]
+   +- LocalSortAggregate(select=[Partial_MIN(byte) AS min$0, Partial_MIN(short) AS min$1, Partial_MIN(int) AS min$2, Partial_MIN(long) AS min$3, Partial_MIN(float) AS min$4, Partial_MIN(double) AS min$5, Partial_MIN(decimal3020) AS min$6, Partial_MIN(decimal105) AS min$7, Partial_MIN(boolean) AS min$8, Partial_MIN(date) AS min$9, Partial_MIN(time) AS min$10, Partial_MIN(timestamp) AS min$11]), rowType=[RecordType(TINYINT min$0, SMALLINT min$1, INTEGER min$2, BIGINT min$3, FLOAT min$4, DOUBLE min$5, DECIMAL(30, 20) min$6, DECIMAL(10, 5) min$7, BOOLEAN min$8, INTEGER min$9, INTEGER min$10, BIGINT min$11)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105, boolean, date, time, timestamp]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105, BOOLEAN boolean, DATE date, TIME(0) time, TIMESTAMP(3) timestamp)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithVariableLengthType[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT MIN(`string`) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- LogicalProject(string=[$7]), rowType=[RecordType(VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MIN(min$0) AS EXPR$0]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(VARCHAR(65536) min$0)]
+   +- LocalSortAggregate(select=[Partial_MIN(string) AS min$0]), rowType=[RecordType(VARCHAR(65536) min$0)]
+      +- Calc(select=[string]), rowType=[RecordType(VARCHAR(65536) string)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithVariableLengthType[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT MIN(`string`) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- LogicalProject(string=[$7]), rowType=[RecordType(VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[MIN(string) AS EXPR$0]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(VARCHAR(65536) string)]
+   +- Calc(select=[string]), rowType=[RecordType(VARCHAR(65536) string)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinWithVariableLengthType[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT MIN(`string`) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- LogicalProject(string=[$7]), rowType=[RecordType(VARCHAR(65536) string)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MIN(min$0) AS EXPR$0]), rowType=[RecordType(VARCHAR(65536) EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(VARCHAR(65536) min$0)]
+   +- LocalSortAggregate(select=[Partial_MIN(string) AS min$0]), rowType=[RecordType(VARCHAR(65536) min$0)]
+      +- Calc(select=[string]), rowType=[RecordType(VARCHAR(65536) string)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSum[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT SUM(`byte`),
+       SUM(`short`),
+       SUM(`int`),
+       SUM(`long`),
+       SUM(`float`),
+       SUM(`double`),
+       SUM(`decimal3020`),
+       SUM(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[SUM($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)], EXPR$4=[SUM($4)], EXPR$5=[SUM($5)], EXPR$6=[SUM($6)], EXPR$7=[SUM($7)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS EXPR$0, Final_SUM(sum$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2, Final_SUM(sum$3) AS EXPR$3, Final_SUM(sum$4) AS EXPR$4, Final_SUM(sum$5) AS EXPR$5, Final_SUM(sum$6) AS EXPR$6, Final_SUM(sum$7) AS EXPR$7]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT sum$0, SMALLINT sum$1, INTEGER sum$2, BIGINT sum$3, FLOAT sum$4, DOUBLE sum$5, DECIMAL(38, 20) sum$6, DECIMAL(38, 5) sum$7)]
+   +- LocalSortAggregate(select=[Partial_SUM(byte) AS sum$0, Partial_SUM(short) AS sum$1, Partial_SUM(int) AS sum$2, Partial_SUM(long) AS sum$3, Partial_SUM(float) AS sum$4, Partial_SUM(double) AS sum$5, Partial_SUM(decimal3020) AS sum$6, Partial_SUM(decimal105) AS sum$7]), rowType=[RecordType(TINYINT sum$0, SMALLINT sum$1, INTEGER sum$2, BIGINT sum$3, FLOAT sum$4, DOUBLE sum$5, DECIMAL(38, 20) sum$6, DECIMAL(38, 5) sum$7)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPojoAccumulator[aggStrategy=NONE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Sort(orderBy=[b ASC])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[b, a])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPojoAccumulator[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Sort(orderBy=[b ASC])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[b, a])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSum[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT SUM(`byte`),
+       SUM(`short`),
+       SUM(`int`),
+       SUM(`long`),
+       SUM(`float`),
+       SUM(`double`),
+       SUM(`decimal3020`),
+       SUM(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[SUM($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)], EXPR$4=[SUM($4)], EXPR$5=[SUM($5)], EXPR$6=[SUM($6)], EXPR$7=[SUM($7)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[SUM(byte) AS EXPR$0, SUM(short) AS EXPR$1, SUM(int) AS EXPR$2, SUM(long) AS EXPR$3, SUM(float) AS EXPR$4, SUM(double) AS EXPR$5, SUM(decimal3020) AS EXPR$6, SUM(decimal105) AS EXPR$7]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+      +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPojoAccumulator[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT b, var_sum(a) FROM MyTable1 GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[var_sum($1)])
++- LogicalProject(b=[$1], a=[$0])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[b], select=[b, var_sum(a) AS EXPR$1])
++- Sort(orderBy=[b ASC])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[b, a])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSum[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT SUM(`byte`),
+       SUM(`short`),
+       SUM(`int`),
+       SUM(`long`),
+       SUM(`float`),
+       SUM(`double`),
+       SUM(`decimal3020`),
+       SUM(`decimal105`)
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[SUM($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)], EXPR$4=[SUM($4)], EXPR$5=[SUM($5)], EXPR$6=[SUM($6)], EXPR$7=[SUM($7)]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- LogicalProject(byte=[$0], short=[$1], int=[$2], long=[$3], float=[$4], double=[$5], decimal3020=[$11], decimal105=[$12]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS EXPR$0, Final_SUM(sum$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2, Final_SUM(sum$3) AS EXPR$3, Final_SUM(sum$4) AS EXPR$4, Final_SUM(sum$5) AS EXPR$5, Final_SUM(sum$6) AS EXPR$6, Final_SUM(sum$7) AS EXPR$7]), rowType=[RecordType(TINYINT EXPR$0, SMALLINT EXPR$1, INTEGER EXPR$2, BIGINT EXPR$3, FLOAT EXPR$4, DOUBLE EXPR$5, DECIMAL(38, 20) EXPR$6, DECIMAL(38, 5) EXPR$7)]
++- Exchange(distribution=[single]), rowType=[RecordType(TINYINT sum$0, SMALLINT sum$1, INTEGER sum$2, BIGINT sum$3, FLOAT sum$4, DOUBLE sum$5, DECIMAL(38, 20) sum$6, DECIMAL(38, 5) sum$7)]
+   +- LocalSortAggregate(select=[Partial_SUM(byte) AS sum$0, Partial_SUM(short) AS sum$1, Partial_SUM(int) AS sum$2, Partial_SUM(long) AS sum$3, Partial_SUM(float) AS sum$4, Partial_SUM(double) AS sum$5, Partial_SUM(decimal3020) AS sum$6, Partial_SUM(decimal105) AS sum$7]), rowType=[RecordType(TINYINT sum$0, SMALLINT sum$1, INTEGER sum$2, BIGINT sum$3, FLOAT sum$4, DOUBLE sum$5, DECIMAL(38, 20) sum$6, DECIMAL(38, 5) sum$7)]
+      +- Calc(select=[byte, short, int, long, float, double, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+         +- TableSourceScan(table=[[MyTable, source: [TestTableSource(byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105)]]], fields=[byte, short, int, long, float, double, boolean, string, date, time, timestamp, decimal3020, decimal105]), rowType=[RecordType(TINYINT byte, SMALLINT short, INTEGER int, BIGINT long, FLOAT float, DOUBLE double, BOOLEAN boolean, VARCHAR(65536) string, DATE date, TIME(0) time, TIMESTAMP(3) timestamp, DECIMAL(30, 20) decimal3020, DECIMAL(10, 5) decimal105)]
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/SingleRowJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/SingleRowJoinTest.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testSingleRowNotEquiJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT a1, a2 FROM A, (SELECT COUNT(a1) AS cnt FROM A) WHERE a1 < cnt]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], a2=[$1])
++- LogicalFilter(condition=[<($0, $2)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+      +- LogicalAggregate(group=[{}], cnt=[COUNT($0)])
+         +- LogicalProject(a1=[$0])
+            +- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a1, a2])
++- NestedLoopJoin(joinType=[InnerJoin], where=[<(a1, cnt)], select=[a1, a2, cnt], build=[right], singleRowJoin=[true])
+   :- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+   +- Exchange(distribution=[broadcast])
+      +- HashAggregate(isMerge=[true], select=[Final_COUNT(count$0) AS cnt])
+         +- Exchange(distribution=[single])
+            +- LocalHashAggregate(select=[Partial_COUNT(a1) AS count$0])
+               +- Calc(select=[a1])
+                  +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftSingleRightJoinEqualPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT a1 FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt = a2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$1])
++- LogicalJoin(condition=[=($0, $2)], joinType=[right])
+   :- LogicalAggregate(group=[{}], cnt=[COUNT()])
+   :  +- LogicalProject($f0=[0])
+   :     +- LogicalTableScan(table=[[B, source: [TestTableSource(b1, b2)]]])
+   +- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a1])
++- HashJoin(joinType=[RightOuterJoin], where=[=(cnt, a2)], select=[cnt, a1, a2], build=[left])
+   :- Exchange(distribution=[hash[cnt]])
+   :  +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS cnt])
+   :     +- Exchange(distribution=[single])
+   :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+   :           +- Calc(select=[0 AS $f0])
+   :              +- TableSourceScan(table=[[B, source: [TestTableSource(b1, b2)]]], fields=[b1, b2])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftSingleRightJoinNotEqualPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT a1 FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt < a2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$1])
++- LogicalJoin(condition=[<($0, $2)], joinType=[right])
+   :- LogicalAggregate(group=[{}], cnt=[COUNT()])
+   :  +- LogicalProject($f0=[0])
+   :     +- LogicalTableScan(table=[[B, source: [TestTableSource(b1, b2)]]])
+   +- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a1])
++- NestedLoopJoin(joinType=[RightOuterJoin], where=[<(cnt, a2)], select=[cnt, a1, a2], build=[left], singleRowJoin=[true])
+   :- Exchange(distribution=[broadcast])
+   :  +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS cnt])
+   :     +- Exchange(distribution=[single])
+   :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+   :           +- Calc(select=[0 AS $f0])
+   :              +- TableSourceScan(table=[[B, source: [TestTableSource(b1, b2)]]], fields=[b1, b2])
+   +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightSingleLeftJoinNotEqualPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT a2 FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) AS x ON a1 > cnt]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a2=[$1])
++- LogicalJoin(condition=[>($0, $2)], joinType=[left])
+   :- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+   +- LogicalAggregate(group=[{}], cnt=[COUNT()])
+      +- LogicalProject($f0=[0])
+         +- LogicalTableScan(table=[[B, source: [TestTableSource(b1, b2)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a2])
++- NestedLoopJoin(joinType=[LeftOuterJoin], where=[>(a1, cnt)], select=[a1, a2, cnt], build=[right], singleRowJoin=[true])
+   :- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+   +- Exchange(distribution=[broadcast])
+      +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS cnt])
+         +- Exchange(distribution=[single])
+            +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+               +- Calc(select=[0 AS $f0])
+                  +- TableSourceScan(table=[[B, source: [TestTableSource(b1, b2)]]], fields=[b1, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSingleRowCrossJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT a1, a_sum FROM A, (SELECT SUM(a1) + SUM(a2) AS a_sum FROM A)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], a_sum=[$2])
++- LogicalJoin(condition=[true], joinType=[inner])
+   :- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+   +- LogicalProject(a_sum=[+($0, $1)])
+      +- LogicalAggregate(group=[{}], agg#0=[SUM($0)], agg#1=[SUM($1)])
+         +- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, a_sum], build=[right], singleRowJoin=[true])
+:- Calc(select=[a1])
+:  +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
++- Exchange(distribution=[broadcast])
+   +- Calc(select=[+($f0, $f1) AS a_sum])
+      +- HashAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS $f0, Final_SUM(sum$1) AS $f1])
+         +- Exchange(distribution=[single])
+            +- LocalHashAggregate(select=[Partial_SUM(a1) AS sum$0, Partial_SUM(a2) AS sum$1])
+               +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightSingleLeftJoinEqualPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT a2 FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) AS x  ON a1 = cnt]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a2=[$1])
++- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+   :- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+   +- LogicalAggregate(group=[{}], cnt=[COUNT()])
+      +- LogicalProject($f0=[0])
+         +- LogicalTableScan(table=[[B, source: [TestTableSource(b1, b2)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a2])
++- HashJoin(joinType=[LeftOuterJoin], where=[=(a1, cnt)], select=[a1, a2, cnt], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+   +- Exchange(distribution=[hash[cnt]])
+      +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS cnt])
+         +- Exchange(distribution=[single])
+            +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+               +- Calc(select=[0 AS $f0])
+                  +- TableSourceScan(table=[[B, source: [TestTableSource(b1, b2)]]], fields=[b1, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSingleRowEquiJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT a1, a2 FROM A, (SELECT COUNT(a1) AS cnt FROM A) WHERE a1 = cnt]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], a2=[$1])
++- LogicalFilter(condition=[=(CAST($0):BIGINT, $2)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+      +- LogicalAggregate(group=[{}], cnt=[COUNT($0)])
+         +- LogicalProject(a1=[$0])
+            +- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a1, a2])
++- NestedLoopJoin(joinType=[InnerJoin], where=[=(CAST(a1), cnt)], select=[a1, a2, cnt], build=[right], singleRowJoin=[true])
+   :- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+   +- Exchange(distribution=[broadcast])
+      +- HashAggregate(isMerge=[true], select=[Final_COUNT(count$0) AS cnt])
+         +- Exchange(distribution=[single])
+            +- LocalHashAggregate(select=[Partial_COUNT(a1) AS count$0])
+               +- Calc(select=[a1])
+                  +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSingleRowJoinWithComplexPredicate">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a1, a2, b1, b2 FROM A,
+  (SELECT min(b1) AS b1, max(b2) AS b2 FROM B)
+WHERE a1 < b1 AND a2 = b2
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], a2=[$1], b1=[$2], b2=[$3])
++- LogicalFilter(condition=[AND(<($0, $2), =($1, $3))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2)]]])
+      +- LogicalAggregate(group=[{}], b1=[MIN($0)], b2=[MAX($1)])
+         +- LogicalTableScan(table=[[B, source: [TestTableSource(b1, b2)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[AND(<(a1, b1), =(a2, b2))], select=[a1, a2, b1, b2], build=[right])
+:- Exchange(distribution=[hash[a2]])
+:  +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2)]]], fields=[a1, a2])
++- Exchange(distribution=[hash[b2]])
+   +- HashAggregate(isMerge=[true], select=[Final_MIN(min$0) AS b1, Final_MAX(max$1) AS b2])
+      +- Exchange(distribution=[single])
+         +- LocalHashAggregate(select=[Partial_MIN(b1) AS min$0, Partial_MAX(b2) AS max$1])
+            +- TableSourceScan(table=[[B, source: [TestTableSource(b1, b2)]]], fields=[b1, b2])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/AggregateTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/AggregateTestBase.scala
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.batch.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.Types
+import org.apache.flink.table.plan.util.JavaUserDefinedAggFunctions.{VarSum1AggFunction, VarSum2AggFunction}
+import org.apache.flink.table.typeutils.DecimalTypeInfo
+import org.apache.flink.table.util.{BatchTableTestUtil, TableTestBase}
+
+import org.apache.calcite.sql.SqlExplainLevel
+import org.junit.Test
+
+abstract class AggregateTestBase extends TableTestBase {
+
+  protected val util: BatchTableTestUtil = batchTestUtil()
+  util.addTableSource("MyTable",
+    Array[TypeInformation[_]](
+      Types.BYTE, Types.SHORT, Types.INT, Types.LONG, Types.FLOAT, Types.DOUBLE, Types.BOOLEAN,
+      Types.STRING, Types.SQL_DATE, Types.SQL_TIME, Types.SQL_TIMESTAMP,
+      DecimalTypeInfo.of(30, 20), DecimalTypeInfo.of(10, 5)),
+    Array("byte", "short", "int", "long", "float", "double", "boolean",
+      "string", "date", "time", "timestamp", "decimal3020", "decimal105"))
+  util.addTableSource[(Int, Long, String)]("MyTable1", 'a, 'b, 'c)
+
+  def verifyPlanWithType(sql: String): Unit = {
+    util.doVerifyPlan(sql, explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
+      withRowType = true,
+      printPlanBefore = true)
+  }
+
+  @Test
+  def testAvg(): Unit = {
+    verifyPlanWithType(
+      """
+        |SELECT AVG(`byte`),
+        |       AVG(`short`),
+        |       AVG(`int`),
+        |       AVG(`long`),
+        |       AVG(`float`),
+        |       AVG(`double`),
+        |       AVG(`decimal3020`),
+        |       AVG(`decimal105`)
+        |FROM MyTable
+      """.stripMargin)
+  }
+
+  @Test
+  def testSum(): Unit = {
+    verifyPlanWithType(
+      """
+        |SELECT SUM(`byte`),
+        |       SUM(`short`),
+        |       SUM(`int`),
+        |       SUM(`long`),
+        |       SUM(`float`),
+        |       SUM(`double`),
+        |       SUM(`decimal3020`),
+        |       SUM(`decimal105`)
+        |FROM MyTable
+      """.stripMargin)
+  }
+
+  @Test
+  def testCount(): Unit = {
+    verifyPlanWithType(
+      """
+        |SELECT COUNT(`byte`),
+        |       COUNT(`short`),
+        |       COUNT(`int`),
+        |       COUNT(`long`),
+        |       COUNT(`float`),
+        |       COUNT(`double`),
+        |       COUNT(`decimal3020`),
+        |       COUNT(`decimal105`),
+        |       COUNT(`boolean`),
+        |       COUNT(`date`),
+        |       COUNT(`time`),
+        |       COUNT(`timestamp`),
+        |       COUNT(`string`)
+        |FROM MyTable
+      """.stripMargin)
+  }
+
+  @Test
+  def testCountStart(): Unit = {
+    verifyPlanWithType("SELECT COUNT(*) FROM MyTable")
+  }
+
+  @Test
+  def testMinWithFixLengthType(): Unit = {
+    verifyPlanWithType(
+      """
+        |SELECT MIN(`byte`),
+        |       MIN(`short`),
+        |       MIN(`int`),
+        |       MIN(`long`),
+        |       MIN(`float`),
+        |       MIN(`double`),
+        |       MIN(`decimal3020`),
+        |       MIN(`decimal105`),
+        |       MIN(`boolean`),
+        |       MIN(`date`),
+        |       MIN(`time`),
+        |       MIN(`timestamp`)
+        |FROM MyTable
+      """.stripMargin)
+  }
+
+  @Test
+  def testMinWithVariableLengthType(): Unit = {
+    verifyPlanWithType("SELECT MIN(`string`) FROM MyTable")
+  }
+
+  @Test
+  def testMaxWithFixLengthType(): Unit = {
+    verifyPlanWithType(
+      """
+        |SELECT MAX(`byte`),
+        |       MAX(`short`),
+        |       MAX(`int`),
+        |       MAX(`long`),
+        |       MAX(`float`),
+        |       MAX(`double`),
+        |       MAX(`decimal3020`),
+        |       MAX(`decimal105`),
+        |       MAX(`boolean`),
+        |       MAX(`date`),
+        |       MAX(`time`),
+        |       MAX(`timestamp`)
+        |FROM MyTable
+      """.stripMargin)
+  }
+
+  @Test
+  def testMaxWithVariableLengthType(): Unit = {
+    verifyPlanWithType("SELECT MAX(`string`) FROM MyTable")
+  }
+
+  @Test
+  def testAggregateWithoutFunction(): Unit = {
+    util.verifyPlan("SELECT a, b FROM MyTable1 GROUP BY a, b")
+  }
+
+  @Test
+  def testAggregateWithoutGroupBy(): Unit = {
+    util.verifyPlan("SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1")
+  }
+
+  @Test
+  def testAggregateWithFilter(): Unit = {
+    util.verifyPlan("SELECT AVG(a), SUM(b), COUNT(c) FROM MyTable1 WHERE a = 1")
+  }
+
+  @Test
+  def testAggregateWithFilterOnNestedFields(): Unit = {
+    util.addTableSource[(Int, Long, (Int, Long))]("MyTable2", 'a, 'b, 'c)
+    util.verifyPlan("SELECT AVG(a), SUM(b), COUNT(c), SUM(c._1) FROM MyTable2 WHERE a = 1")
+  }
+
+  @Test
+  def testGroupAggregate(): Unit = {
+    util.verifyPlan("SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a")
+  }
+
+  @Test
+  def testGroupAggregateWithFilter(): Unit = {
+    util.verifyPlan("SELECT a, SUM(b), count(c) FROM MyTable1 WHERE a = 1 GROUP BY a")
+  }
+
+  @Test
+  def testAggNotSupportMerge(): Unit = {
+    util.tableEnv.registerFunction("var_sum", new VarSum2AggFunction)
+    util.verifyPlan("SELECT b, var_sum(a) FROM MyTable1 GROUP BY b")
+  }
+
+  @Test
+  def testPojoAccumulator(): Unit = {
+    util.tableEnv.registerFunction("var_sum", new VarSum1AggFunction)
+    util.verifyPlan("SELECT b, var_sum(a) FROM MyTable1 GROUP BY b")
+  }
+
+  // TODO supports group sets
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/HashAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/HashAggregateTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.batch.sql
+
+import org.apache.flink.table.api.AggPhaseEnforcer.AggPhaseEnforcer
+import org.apache.flink.table.api.{AggPhaseEnforcer, OperatorType, PlannerConfigOptions, TableConfigOptions, TableException, ValidationException}
+
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[Parameterized])
+class HashAggregateTest(aggStrategy: AggPhaseEnforcer) extends AggregateTestBase {
+
+  @Before
+  def before(): Unit = {
+    // disable sort agg
+    util.tableEnv.getConfig.getConf.setString(
+      TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS, OperatorType.SortAgg.toString)
+    util.tableEnv.getConfig.getConf.setString(
+      PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER, aggStrategy.toString)
+  }
+
+  override def testMinWithVariableLengthType(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testMinWithVariableLengthType()
+  }
+
+  override def testMaxWithVariableLengthType(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testMaxWithVariableLengthType()
+  }
+
+  override def testPojoAccumulator(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testPojoAccumulator()
+  }
+}
+
+object HashAggregateTest {
+
+  @Parameterized.Parameters(name = "aggStrategy={0}")
+  def parameters(): util.Collection[AggPhaseEnforcer] = {
+    Seq[AggPhaseEnforcer](
+      AggPhaseEnforcer.NONE,
+      AggPhaseEnforcer.ONE_PHASE,
+      AggPhaseEnforcer.TWO_PHASE
+    )
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/SortAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/SortAggregateTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.batch.sql
+
+import org.apache.flink.table.api.AggPhaseEnforcer.AggPhaseEnforcer
+import org.apache.flink.table.api.{AggPhaseEnforcer, OperatorType, PlannerConfigOptions, TableConfigOptions}
+
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[Parameterized])
+class SortAggregateTest(aggStrategy: AggPhaseEnforcer) extends AggregateTestBase {
+
+  @Before
+  def before(): Unit = {
+    // disable hash agg
+    util.tableEnv.getConfig.getConf.setString(
+      TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS, OperatorType.HashAgg.toString)
+    util.tableEnv.getConfig.getConf.setString(
+      PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER, aggStrategy.toString)
+  }
+}
+
+object SortAggregateTest {
+
+  @Parameterized.Parameters(name = "aggStrategy={0}")
+  def parameters(): util.Collection[AggPhaseEnforcer] = {
+    Seq[AggPhaseEnforcer](
+      AggPhaseEnforcer.NONE,
+      AggPhaseEnforcer.ONE_PHASE,
+      AggPhaseEnforcer.TWO_PHASE
+    )
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/UnionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/UnionTest.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.plan.batch.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.table.util.TableTestBase
 
-import org.apache.calcite.sql.SqlExplainLevel
 import org.junit.{Before, Test}
 
 // TODO add more union case after aggregation and join supported
@@ -60,10 +59,7 @@ class UnionTest extends TableTestBase {
         | UNION ALL
         | SELECT a, CAST(0 aS DECIMAL(2, 1)) FROM MyTable2)
       """.stripMargin
-    util.doVerifyPlan(sqlQuery,
-      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
-      withRowType = true,
-      printPlanBefore = true)
+    util.verifyPlanWithType(sqlQuery)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/ValuesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/ValuesTest.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.plan.batch.sql
 
 import org.apache.flink.table.util.TableTestBase
 
-import org.apache.calcite.sql.SqlExplainLevel
 import org.junit.Test
 
 class ValuesTest extends TableTestBase {
@@ -44,12 +43,7 @@ class ValuesTest extends TableTestBase {
 
   @Test
   def testDiffTypes(): Unit = {
-    val sql = "SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)"
-    util.doVerifyPlan(
-      sql,
-      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
-      withRowType = true,
-      printPlanBefore = true)
+    util.verifyPlanWithType("SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)")
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/SingleRowJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/SingleRowJoinTest.scala
@@ -22,10 +22,8 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.util.TableTestBase
 
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
-// FIXME
-@Ignore("remove this after aggregate supports")
 class SingleRowJoinTest extends TableTestBase {
 
   @Test
@@ -60,6 +58,8 @@ class SingleRowJoinTest extends TableTestBase {
         |  (SELECT min(b1) AS b1, max(b2) AS b2 FROM B)
         |WHERE a1 < b1 AND a2 = b2
       """.stripMargin
+    // TODO NestedLoopJoin is more efficient than HashJoin for this query,
+    //  check this plan after metadata handler introduced
     util.verifyPlan(query)
   }
 
@@ -68,6 +68,8 @@ class SingleRowJoinTest extends TableTestBase {
     val util = batchTestUtil()
     util.addTableSource[(Long, Int)]("A", 'a1, 'a2)
     util.addTableSource[(Int, Int)]("B", 'b1, 'b2)
+    // TODO NestedLoopJoin is more efficient than HashJoin for this query,
+    //  check this plan after metadata handler introduced
     util.verifyPlan("SELECT a2 FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) AS x  ON a1 = cnt")
   }
 
@@ -84,6 +86,8 @@ class SingleRowJoinTest extends TableTestBase {
     val util = batchTestUtil()
     util.addTableSource[(Long, Long)]("A", 'a1, 'a2)
     util.addTableSource[(Long, Long)]("B", 'b1, 'b2)
+    // TODO NestedLoopJoin is more efficient than HashJoin for this query,
+    //  check this plan after metadata handler introduced
     util.verifyPlan("SELECT a1 FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt = a2")
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/UnionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/UnionTest.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.plan.stream.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.table.util.TableTestBase
 
-import org.apache.calcite.sql.SqlExplainLevel
 import org.junit.{Before, Test}
 
 // TODO add more union case after aggregation and join supported
@@ -60,10 +59,7 @@ class UnionTest extends TableTestBase {
         | UNION ALL
         | SELECT a, CAST(0 aS DECIMAL(2, 1)) FROM MyTable2)
       """.stripMargin
-    util.doVerifyPlan(sqlQuery,
-      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
-      withRowType = true,
-      printPlanBefore = true)
+    util.verifyPlanWithType(sqlQuery)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/ValuesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/ValuesTest.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.plan.stream.sql
 
 import org.apache.flink.table.util.TableTestBase
 
-import org.apache.calcite.sql.SqlExplainLevel
 import org.junit.Test
 
 class ValuesTest extends TableTestBase {
@@ -44,12 +43,7 @@ class ValuesTest extends TableTestBase {
 
   @Test
   def testDiffTypes(): Unit = {
-    val sql = "SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)"
-    util.doVerifyPlan(
-      sql,
-      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
-      withRowType = true,
-      printPlanBefore = true)
+    util.verifyPlanWithType("SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)")
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/util/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/util/TableTestBase.scala
@@ -202,6 +202,14 @@ abstract class TableTestUtil(test: TableTestBase) {
       printPlanBefore = true)
   }
 
+  def verifyPlanWithType(sql: String): Unit = {
+    doVerifyPlan(
+      sql,
+      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
+      withRowType = true,
+      printPlanBefore = true)
+  }
+
   def verifyExplain(): Unit = doVerifyExplain()
 
   def verifyExplain(sql: String): Unit = {


### PR DESCRIPTION
## What is the purpose of the change

*Add support for generating optimized logical plan for simple group aggregate on batch*


## Brief change log

  - *add BatchExecHashAggRule to convert logical aggregate to BatchExecHashAggregate*
  - *add BatchExecSortAggRule to convert logical aggregate to BatchExecSortAggregate*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added HashAggregateTest for BatchExecHashAggregate*
  - *Added SortAggregateTest for BatchExecSortAggregate*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
