### PR TITLE
[FLINK-12079] [table-planner-blink] Add support for generating optimized logical plan for join on batch

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/PlannerConfigOptions.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/PlannerConfigOptions.java
@@ -56,5 +56,11 @@ public class PlannerConfigOptions {
 					.withDescription("When true, the optimizer will try to remove redundant sort for SortMergeJoin. " +
 							"However that will increase optimization time. Default value is false.");
 
+	public static final ConfigOption<Long> SQL_OPTIMIZER_HASH_JOIN_BROADCAST_THRESHOLD =
+			key("sql.optimizer.hash-join.broadcast.threshold")
+					.defaultValue(1024 * 1024L)
+					.withDescription("Maximum size in bytes for data that could be broadcast to each parallel " +
+							"instance that holds a partition of all data when performing a hash join. " +
+							"Broadcast will be disabled if the value is -1.");
 
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/PlannerConfigOptions.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/PlannerConfigOptions.java
@@ -38,4 +38,23 @@ public class PlannerConfigOptions {
 							" exceeds this threshold; the threshold is expressed in terms of number of nodes " +
 							"(only count RexCall node, including leaves and interior nodes). Negative number to" +
 							" use the default threshold: double of number of nodes.");
+
+	public static final ConfigOption<Boolean> SQL_OPTIMIZER_SHUFFLE_PARTIAL_KEY_ENABLED =
+			key("sql.optimizer.shuffle.partial-key.enabled")
+					.defaultValue(false)
+					.withDescription("Enables shuffle by partial partition keys. " +
+							"For example, A join with join condition: L.c1 = R.c1 and L.c2 = R.c2. " +
+							"If this flag is enabled, there are 3 shuffle strategy:\n " +
+							"1. L and R shuffle by c1 \n" +
+							"2. L and R shuffle by c2\n" +
+							"3. L and R shuffle by c1 and c2\n" +
+							"It can reduce some shuffle cost someTimes.");
+
+	public static final ConfigOption<Boolean> SQL_OPTIMIZER_SMJ_REMOVE_SORT_ENABLE =
+			key("sql.optimizer.smj.remove-sort.enable")
+					.defaultValue(false)
+					.withDescription("When true, the optimizer will try to remove redundant sort for SortMergeJoin. " +
+							"However that will increase optimization time. Default value is false.");
+
+
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
@@ -222,6 +222,10 @@ object FlinkBatchRuleSets {
     BatchExecLimitRule.INSTANCE,
     BatchExecSortLimitRule.INSTANCE,
     BatchExecRankRule.INSTANCE,
+    BatchExecHashJoinRule.INSTANCE,
+    BatchExecSortMergeJoinRule.INSTANCE,
+    BatchExecNestedLoopJoinRule.INSTANCE,
+    BatchExecSingleRowJoinRule.INSTANCE,
     BatchExecCorrelateRule.INSTANCE,
     BatchExecSinkRule.INSTANCE
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecHashJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecHashJoinRule.scala
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.JDouble
+import org.apache.flink.table.api.{OperatorType, PlannerConfigOptions, TableConfig, TableConfigOptions}
+import org.apache.flink.table.calcite.FlinkContext
+import org.apache.flink.table.plan.FlinkJoinRelType
+import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalJoin
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecHashJoin
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core.{Join, SemiJoin}
+import org.apache.calcite.util.ImmutableIntList
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecHashJoin]]
+  * if join keys are not empty and ShuffleHashJoin or BroadcastHashJoin are enabled.
+  */
+class BatchExecHashJoinRule(joinClass: Class[_ <: Join])
+  extends RelOptRule(
+    operand(joinClass,
+      operand(classOf[RelNode], any)),
+    s"BatchExecHashJoinRule_${joinClass.getSimpleName}")
+  with BatchExecJoinRuleBase {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val join: Join = call.rel(0)
+    val joinInfo = join.analyzeCondition
+    // join keys must not be empty
+    if (joinInfo.pairs().isEmpty) {
+      return false
+    }
+
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    val isShuffleHashJoinEnabled = tableConfig.isOperatorEnabled(OperatorType.ShuffleHashJoin)
+    val isBroadcastHashJoinEnabled = tableConfig.isOperatorEnabled(OperatorType.BroadcastHashJoin)
+
+    val joinType = getFlinkJoinRelType(join)
+    val leftSize = binaryRowRelNodeSize(join.getLeft)
+    val rightSize = binaryRowRelNodeSize(join.getRight)
+    val (isBroadcast, _) = canBroadcast(joinType, leftSize, rightSize, tableConfig)
+
+    // TODO use shuffle hash join if isBroadcast is true and isBroadcastHashJoinEnabled is false ?
+    if (isBroadcast) isBroadcastHashJoinEnabled else isShuffleHashJoinEnabled
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    val join: Join = call.rel(0)
+    val joinInfo = join.analyzeCondition
+    val joinType = getFlinkJoinRelType(join)
+
+    val left = join.getLeft
+    val right = join.getRight
+
+    val leftSize = binaryRowRelNodeSize(left)
+    val rightSize = binaryRowRelNodeSize(right)
+
+    val (isBroadcast, leftIsBroadcast) = canBroadcast(joinType, leftSize, rightSize, tableConfig)
+
+    val leftIsBuild = if (isBroadcast) {
+      leftIsBroadcast
+    } else if (leftSize == null || rightSize == null || leftSize == rightSize) {
+      // use left to build hash table if leftSize or rightSize is unknown or equal size.
+      // choose right to build if join is semiJoin.
+      !join.isInstanceOf[SemiJoin]
+    } else {
+      leftSize < rightSize
+    }
+
+    def transformToEquiv(leftRequiredTrait: RelTraitSet, rightRequiredTrait: RelTraitSet): Unit = {
+      val newLeft = RelOptRule.convert(left, leftRequiredTrait)
+      val newRight = RelOptRule.convert(right, rightRequiredTrait)
+      val providedTraitSet = join.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+
+      val newJoin = new BatchExecHashJoin(
+        join.getCluster,
+        providedTraitSet,
+        newLeft,
+        newRight,
+        join.getCondition,
+        join.getJoinType,
+        leftIsBuild,
+        isBroadcast)
+
+      call.transformTo(newJoin)
+    }
+
+    if (isBroadcast) {
+      val probeTrait = join.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+      val buildTrait = join.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+        .replace(FlinkRelDistribution.BROADCAST_DISTRIBUTED)
+      if (leftIsBroadcast) {
+        transformToEquiv(buildTrait, probeTrait)
+      } else {
+        transformToEquiv(probeTrait, buildTrait)
+      }
+    } else {
+      val toHashTraitByColumns = (columns: util.Collection[_ <: Number]) =>
+        join.getCluster.getPlanner.emptyTraitSet.
+          replace(FlinkConventions.BATCH_PHYSICAL).
+          replace(FlinkRelDistribution.hash(columns))
+      transformToEquiv(
+        toHashTraitByColumns(joinInfo.leftKeys),
+        toHashTraitByColumns(joinInfo.rightKeys))
+
+      // add more possibility to only shuffle by partial joinKeys, now only single one
+      val isShuffleByPartialKeyEnabled = tableConfig.getConf.getBoolean(
+        PlannerConfigOptions.SQL_OPTIMIZER_SHUFFLE_PARTIAL_KEY_ENABLED)
+      if (isShuffleByPartialKeyEnabled && joinInfo.pairs().length > 1) {
+        joinInfo.pairs().foreach { pair =>
+          transformToEquiv(
+            toHashTraitByColumns(ImmutableIntList.of(pair.source)),
+            toHashTraitByColumns(ImmutableIntList.of(pair.target)))
+        }
+      }
+    }
+
+  }
+
+  /**
+    * Decides whether the join can convert to BroadcastHashJoin.
+    *
+    * @param joinType  flink join type
+    * @param leftSize  size of join left child
+    * @param rightSize size of join right child
+    * @return an Tuple2 instance. The first element of tuple is true if join can convert to
+    *         broadcast hash join, false else. The second element of tuple is true if left side used
+    *         as broadcast side, false else.
+    */
+  private def canBroadcast(
+      joinType: FlinkJoinRelType,
+      leftSize: JDouble,
+      rightSize: JDouble,
+      tableConfig: TableConfig): (Boolean, Boolean) = {
+    // if leftSize or rightSize is unknown, cannot use broadcast
+    if (leftSize == null || rightSize == null) {
+      return (false, false)
+    }
+    val threshold = tableConfig.getConf.getLong(
+      TableConfigOptions.SQL_EXEC_HASH_JOIN_BROADCAST_THRESHOLD)
+    joinType match {
+      case FlinkJoinRelType.LEFT => (rightSize <= threshold, false)
+      case FlinkJoinRelType.RIGHT => (leftSize <= threshold, true)
+      case FlinkJoinRelType.FULL => (false, false)
+      case FlinkJoinRelType.INNER =>
+        (leftSize <= threshold || rightSize <= threshold, leftSize < rightSize)
+      // left side cannot be used as build side in SEMI/ANTI join.
+      case FlinkJoinRelType.SEMI | FlinkJoinRelType.ANTI => (rightSize <= threshold, false)
+    }
+  }
+}
+
+object BatchExecHashJoinRule {
+  val INSTANCE = new BatchExecHashJoinRule(classOf[FlinkLogicalJoin])
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecHashJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecHashJoinRule.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.plan.rules.physical.batch
 
 import org.apache.flink.table.JDouble
-import org.apache.flink.table.api.{OperatorType, PlannerConfigOptions, TableConfig, TableConfigOptions}
+import org.apache.flink.table.api.{OperatorType, PlannerConfigOptions, TableConfig}
 import org.apache.flink.table.calcite.FlinkContext
 import org.apache.flink.table.plan.FlinkJoinRelType
 import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
@@ -39,7 +39,8 @@ import scala.collection.JavaConversions._
 
 /**
   * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecHashJoin]]
-  * if join keys are not empty and ShuffleHashJoin or BroadcastHashJoin are enabled.
+  * if there exists at least one equal-join condition and
+  * ShuffleHashJoin or BroadcastHashJoin are enabled.
   */
 class BatchExecHashJoinRule(joinClass: Class[_ <: Join])
   extends RelOptRule(
@@ -163,7 +164,7 @@ class BatchExecHashJoinRule(joinClass: Class[_ <: Join])
       return (false, false)
     }
     val threshold = tableConfig.getConf.getLong(
-      TableConfigOptions.SQL_EXEC_HASH_JOIN_BROADCAST_THRESHOLD)
+      PlannerConfigOptions.SQL_OPTIMIZER_HASH_JOIN_BROADCAST_THRESHOLD)
     joinType match {
       case FlinkJoinRelType.LEFT => (rightSize <= threshold, false)
       case FlinkJoinRelType.RIGHT => (leftSize <= threshold, true)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecJoinRuleBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecJoinRuleBase.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.JDouble
+import org.apache.flink.table.plan.FlinkJoinRelType
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalJoin
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecLocalHashAggregate
+import org.apache.flink.table.plan.util.FlinkRelMdUtil
+
+import org.apache.calcite.plan.RelOptRule
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.Join
+import org.apache.calcite.tools.RelBuilder
+
+trait BatchExecJoinRuleBase {
+
+  def addLocalDistinctAgg(
+      node: RelNode,
+      distinctKeys: Seq[Int],
+      relBuilder: RelBuilder): RelNode = {
+    val localRequiredTraitSet = node.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+    val newInput = RelOptRule.convert(node, localRequiredTraitSet)
+    val providedTraitSet = localRequiredTraitSet
+
+    new BatchExecLocalHashAggregate(
+      node.getCluster,
+      relBuilder,
+      providedTraitSet,
+      newInput,
+      node.getRowType, // output row type
+      node.getRowType, // input row type
+      distinctKeys.toArray,
+      Array.empty,
+      Seq())
+  }
+
+  def getFlinkJoinRelType(join: Join): FlinkJoinRelType = join match {
+    case j: FlinkLogicalJoin =>
+      FlinkJoinRelType.toFlinkJoinRelType(j.getJoinType)
+    case _ => throw new IllegalArgumentException(s"Illegal join node: ${join.getRelTypeName}")
+  }
+
+  private[flink] def binaryRowRelNodeSize(relNode: RelNode): JDouble = {
+    val mq = relNode.getCluster.getMetadataQuery
+    val rowCount = mq.getRowCount(relNode)
+    if (rowCount == null) {
+      null
+    } else {
+      rowCount * FlinkRelMdUtil.binaryRowAverageSize(relNode)
+    }
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecNestedLoopJoinBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecNestedLoopJoinBase.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
+import org.apache.flink.table.plan.`trait`.FlinkRelDistribution.BROADCAST_DISTRIBUTED
+import org.apache.flink.table.plan.nodes.FlinkConventions.BATCH_PHYSICAL
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecNestedLoopJoin
+
+import org.apache.calcite.plan.RelOptRule
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core.{Join, JoinRelType}
+
+trait BatchExecNestedLoopJoinBase {
+
+  def createNestedLoopJoin(
+      join: Join,
+      left: RelNode,
+      right: RelNode,
+      leftIsBuild: Boolean,
+      singleRowJoin: Boolean): RelNode = {
+    var leftRequiredTrait = join.getTraitSet.replace(BATCH_PHYSICAL)
+    var rightRequiredTrait = join.getTraitSet.replace(BATCH_PHYSICAL)
+
+    if (join.getJoinType == JoinRelType.FULL) {
+      leftRequiredTrait = leftRequiredTrait.replace(FlinkRelDistribution.SINGLETON)
+      rightRequiredTrait = rightRequiredTrait.replace(FlinkRelDistribution.SINGLETON)
+    } else {
+      if (leftIsBuild) {
+        leftRequiredTrait = leftRequiredTrait.replace(BROADCAST_DISTRIBUTED)
+      } else {
+        rightRequiredTrait = rightRequiredTrait.replace(BROADCAST_DISTRIBUTED)
+      }
+    }
+
+    val newLeft = RelOptRule.convert(left, leftRequiredTrait)
+    val newRight = RelOptRule.convert(right, rightRequiredTrait)
+    val providedTraitSet = join.getTraitSet.replace(BATCH_PHYSICAL)
+
+    new BatchExecNestedLoopJoin(
+      join.getCluster,
+      providedTraitSet,
+      newLeft,
+      newRight,
+      join.getCondition,
+      join.getJoinType,
+      leftIsBuild,
+      singleRowJoin)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecNestedLoopJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecNestedLoopJoinRule.scala
@@ -37,7 +37,7 @@ class BatchExecNestedLoopJoinRule(joinClass: Class[_ <: Join])
       operand(classOf[RelNode], any)),
     s"BatchExecNestedLoopJoinRule_${joinClass.getSimpleName}")
   with BatchExecJoinRuleBase
-  with BatchExecNestedLoopJoinBase {
+  with BatchExecNestedLoopJoinRuleBase {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecNestedLoopJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecNestedLoopJoinRule.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.api.OperatorType
+import org.apache.flink.table.calcite.FlinkContext
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalJoin
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecNestedLoopJoin
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core.{Join, JoinRelType, SemiJoin}
+
+/**
+  * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecNestedLoopJoin]]
+  * if NestedLoopJoin is enabled.
+  */
+class BatchExecNestedLoopJoinRule(joinClass: Class[_ <: Join])
+  extends RelOptRule(
+    operand(joinClass,
+      operand(classOf[RelNode], any)),
+    s"BatchExecNestedLoopJoinRule_${joinClass.getSimpleName}")
+  with BatchExecJoinRuleBase
+  with BatchExecNestedLoopJoinBase {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    tableConfig.isOperatorEnabled(OperatorType.NestedLoopJoin)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val join: Join = call.rel(0)
+    val left = join.getLeft
+    val right = join.getRight
+    val leftIsBuild = isLeftBuild(join, left, right)
+    val newJoin = createNestedLoopJoin(join, left, right, leftIsBuild, singleRowJoin = false)
+    call.transformTo(newJoin)
+  }
+
+  private def isLeftBuild(join: Join, left: RelNode, right: RelNode): Boolean = {
+    if (join.isInstanceOf[SemiJoin]) {
+      return false
+    }
+    join.getJoinType match {
+      case JoinRelType.LEFT => false
+      case JoinRelType.RIGHT => true
+      case JoinRelType.INNER | JoinRelType.FULL =>
+        val leftSize = binaryRowRelNodeSize(left)
+        val rightSize = binaryRowRelNodeSize(right)
+        // use left as build size if leftSize or rightSize is unknown.
+        if (leftSize == null || rightSize == null) {
+          true
+        } else {
+          leftSize <= rightSize
+        }
+    }
+  }
+}
+
+object BatchExecNestedLoopJoinRule {
+  val INSTANCE: RelOptRule = new BatchExecNestedLoopJoinRule(classOf[FlinkLogicalJoin])
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecNestedLoopJoinRuleBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecNestedLoopJoinRuleBase.scala
@@ -26,7 +26,7 @@ import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.{Join, JoinRelType}
 
-trait BatchExecNestedLoopJoinBase {
+trait BatchExecNestedLoopJoinRuleBase {
 
   def createNestedLoopJoin(
       join: Join,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSingleRowJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSingleRowJoinRule.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.plan.FlinkJoinRelType
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalJoin
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecNestedLoopJoin
+
+import org.apache.calcite.plan.volcano.RelSubset
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.calcite.rel.core._
+
+/**
+  * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecNestedLoopJoin]]
+  * if one of join input sides returns at most a single row.
+  */
+class BatchExecSingleRowJoinRule(joinClass: Class[_ <: Join])
+  extends ConverterRule(
+    joinClass,
+    FlinkConventions.LOGICAL,
+    FlinkConventions.BATCH_PHYSICAL,
+    s"BatchExecSingleRowJoinRule_${joinClass.getSimpleName}")
+  with BatchExecJoinRuleBase
+  with BatchExecNestedLoopJoinBase {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val join: Join = call.rel(0)
+    val joinType = getFlinkJoinRelType(join)
+    joinType match {
+      case FlinkJoinRelType.INNER | FlinkJoinRelType.FULL =>
+        isSingleRow(join.getLeft) || isSingleRow(join.getRight)
+      case FlinkJoinRelType.LEFT if isSingleRow(join.getRight) => true
+      case FlinkJoinRelType.RIGHT if isSingleRow(join.getLeft) => true
+      case FlinkJoinRelType.SEMI if isSingleRow(join.getRight) => true
+      case FlinkJoinRelType.ANTI if isSingleRow(join.getRight) => true
+      case _ => false
+    }
+  }
+
+  /**
+    * Recursively checks if a [[RelNode]] returns at most a single row.
+    * Input must be a global aggregation possibly followed by projections or filters.
+    */
+  private def isSingleRow(node: RelNode): Boolean = {
+    node match {
+      case ss: RelSubset => isSingleRow(ss.getOriginal)
+      case lp: Project => isSingleRow(lp.getInput)
+      case lf: Filter => isSingleRow(lf.getInput)
+      case lc: Calc => isSingleRow(lc.getInput)
+      case la: Aggregate => la.getGroupSet.isEmpty
+      case _ => false
+    }
+  }
+
+  override def convert(rel: RelNode): RelNode = {
+    val join = rel.asInstanceOf[Join]
+    val left = join.getLeft
+    val leftIsBuild = isSingleRow(left)
+    createNestedLoopJoin(
+      join,
+      left,
+      join.getRight,
+      leftIsBuild,
+      singleRowJoin = true)
+  }
+}
+
+object BatchExecSingleRowJoinRule {
+  val INSTANCE: RelOptRule = new BatchExecSingleRowJoinRule(classOf[FlinkLogicalJoin])
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSingleRowJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSingleRowJoinRule.scala
@@ -40,7 +40,7 @@ class BatchExecSingleRowJoinRule(joinClass: Class[_ <: Join])
     FlinkConventions.BATCH_PHYSICAL,
     s"BatchExecSingleRowJoinRule_${joinClass.getSimpleName}")
   with BatchExecJoinRuleBase
-  with BatchExecNestedLoopJoinBase {
+  with BatchExecNestedLoopJoinRuleBase {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val join: Join = call.rel(0)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSortMergeJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSortMergeJoinRule.scala
@@ -36,7 +36,7 @@ import scala.collection.JavaConversions._
 
 /**
   * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecSortMergeJoin]]
-  * if join keys are not empty and SortMergeJoin is enabled.
+  * if there exists at least one equal-join condition and SortMergeJoin is enabled.
   */
 class BatchExecSortMergeJoinRule(joinClass: Class[_ <: Join])
   extends RelOptRule(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSortMergeJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecSortMergeJoinRule.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.api.{OperatorType, PlannerConfigOptions}
+import org.apache.flink.table.calcite.FlinkContext
+import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalJoin
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecSortMergeJoin
+import org.apache.flink.table.plan.util.RelFieldCollationUtil
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.calcite.rel.core.Join
+import org.apache.calcite.rel.{RelCollations, RelNode}
+import org.apache.calcite.util.ImmutableIntList
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecSortMergeJoin]]
+  * if join keys are not empty and SortMergeJoin is enabled.
+  */
+class BatchExecSortMergeJoinRule(joinClass: Class[_ <: Join])
+  extends RelOptRule(
+    operand(joinClass,
+      operand(classOf[RelNode], any)),
+    s"BatchExecSortMergeJoinRule_${joinClass.getSimpleName}")
+  with BatchExecJoinRuleBase {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val join: Join = call.rel(0)
+    val joinInfo = join.analyzeCondition
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    val isSortMergeJoinEnabled = tableConfig.isOperatorEnabled(OperatorType.SortMergeJoin)
+    !joinInfo.pairs().isEmpty && isSortMergeJoinEnabled
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val join: Join = call.rel(0)
+    val joinInfo = join.analyzeCondition
+    val left = join.getLeft
+    val right = join.getRight
+
+    def getTraitSetByShuffleKeys(
+        shuffleKeys: ImmutableIntList,
+        requireStrict: Boolean,
+        requireCollation: Boolean): RelTraitSet = {
+      var traitSet = call.getPlanner.emptyTraitSet()
+        .replace(FlinkConventions.BATCH_PHYSICAL)
+        .replace(FlinkRelDistribution.hash(shuffleKeys, requireStrict))
+      if (requireCollation) {
+        val fieldCollations = shuffleKeys.map(RelFieldCollationUtil.of(_))
+        val relCollation = RelCollations.of(fieldCollations)
+        traitSet = traitSet.replace(relCollation)
+      }
+      traitSet
+    }
+
+    def transformToEquiv(
+        leftRequiredShuffleKeys: ImmutableIntList,
+        rightRequiredShuffleKeys: ImmutableIntList,
+        requireLeftSorted: Boolean,
+        requireRightSorted: Boolean): Unit = {
+
+      val leftRequiredTrait = getTraitSetByShuffleKeys(
+        leftRequiredShuffleKeys, requireStrict = true, requireLeftSorted)
+      val rightRequiredTrait = getTraitSetByShuffleKeys(
+        rightRequiredShuffleKeys, requireStrict = true, requireRightSorted)
+
+      val newLeft = RelOptRule.convert(left, leftRequiredTrait)
+      val newRight = RelOptRule.convert(right, rightRequiredTrait)
+
+      val providedTraitSet = call.getPlanner
+        .emptyTraitSet()
+        .replace(FlinkConventions.BATCH_PHYSICAL)
+      val newJoin =  new BatchExecSortMergeJoin(
+        join.getCluster,
+        providedTraitSet,
+        newLeft,
+        newRight,
+        join.getCondition,
+        join.getJoinType,
+        requireLeftSorted,
+        requireRightSorted)
+      call.transformTo(newJoin)
+    }
+
+    val tableConfig = call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    val candidates = if (tableConfig.getConf.getBoolean(
+      PlannerConfigOptions.SQL_OPTIMIZER_SMJ_REMOVE_SORT_ENABLE)) {
+      // add more possibility to remove redundant sort, and longer optimization time
+      Array((false, false), (true, false), (false, true), (true, true))
+    } else {
+      // will not try to remove redundant sort, and shorter optimization time
+      Array((false, false))
+    }
+    candidates.foreach {
+      case (requireLeftSorted, requireRightSorted) =>
+        transformToEquiv(
+          joinInfo.leftKeys,
+          joinInfo.rightKeys,
+          requireLeftSorted,
+          requireRightSorted)
+    }
+
+    // add more possibility to only shuffle by partial joinKeys, now only single one
+    val isShuffleByPartialKeyEnabled = tableConfig.getConf.getBoolean(
+      PlannerConfigOptions.SQL_OPTIMIZER_SHUFFLE_PARTIAL_KEY_ENABLED)
+    if (isShuffleByPartialKeyEnabled && joinInfo.pairs().length > 1) {
+      joinInfo.pairs().foreach { pair =>
+        // sort require full key not partial key,
+        // so requireLeftSorted and requireRightSorted should both be false here
+        transformToEquiv(
+          ImmutableIntList.of(pair.source),
+          ImmutableIntList.of(pair.target),
+          requireLeftSorted = false,
+          requireRightSorted = false)
+      }
+    }
+  }
+}
+
+object BatchExecSortMergeJoinRule {
+  val INSTANCE: RelOptRule = new BatchExecSortMergeJoinRule(classOf[FlinkLogicalJoin])
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/BroadcastHashJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/BroadcastHashJoinTest.xml
@@ -1,0 +1,340 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testInnerJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[inner])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[d, g, a, c], isBroadcast=[true], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Calc(select=[a, c])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[left])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[d, e, f, g, h, a, b, c])
++- HashJoin(joinType=[LeftOuterJoin], where=[AND(=(a, d), $f5, <(b, h))], select=[d, e, f, g, h, $f5, a, b, c], isBroadcast=[true], build=[right])
+   :- Calc(select=[d, e, f, g, h, <(d, 2) AS $f5])
+   :  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[broadcast])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[inner])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[AND(=(a, d), <(b, h))], select=[d, e, f, g, h, a, b, c], isBroadcast=[true], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[d, e, f, g, h], where=[<(d, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2, MyTable1 WHERE a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$7], g=[$3])
++- LogicalFilter(condition=[AND(=($5, $0), <($0, 2))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+      +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[d, g, a, c], isBroadcast=[true], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Calc(select=[a, c])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithInvertedField">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE b = e AND a = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[AND(=($1, $4), =($0, $3))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[AND(=(b, e), =(a, d))], select=[a, b, c, d, e, g], isBroadcast=[true], build=[right])
+   :- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[d, e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithMultipleKeys">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$7], g=[$3])
++- LogicalJoin(condition=[AND(=($5, $0), =($6, $1))], joinType=[inner])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[AND(=(a, d), =(b, e))], select=[d, e, g, a, b, c], isBroadcast=[true], build=[right])
+   :- Calc(select=[d, e, g])
+   :  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[broadcast])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[left])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[LeftOuterJoin], where=[AND(=(a, d), $f5)], select=[d, g, $f5, a, c], isBroadcast=[true], build=[right])
+   :- Calc(select=[d, g, <(d, 2) AS $f5])
+   :  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 RIGHT OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[right])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[RightOuterJoin], where=[=(b, e)], select=[b, c, e, g], isBroadcast=[true], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Calc(select=[e, g])
+      +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE a = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[=($0, $3)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, c, d, g], isBroadcast=[true], build=[right])
+   :- Calc(select=[a, c])
+   :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[d, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 LEFT OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[left])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[LeftOuterJoin], where=[=(b, e)], select=[b, c, e, g], isBroadcast=[true], build=[right])
+   :- Calc(select=[b, c])
+   :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[right])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[RightOuterJoin], where=[AND(=(a, d), <(b, h))], select=[d, e, f, g, h, a, b, c], isBroadcast=[true], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[d, e, f, g, h], where=[<(d, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[right])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[RightOuterJoin], where=[=(a, d)], select=[d, g, a, c], isBroadcast=[true], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Calc(select=[a, c])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSelfJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM
+  (SELECT * FROM src WHERE k = 0) src1
+LEFT OUTER JOIN
+  (SELECT * from src WHERE k = 0) src2
+ON (src1.k = src2.k AND src2.k > 10)
+         ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(k=[$0], v=[$1], k0=[$2], v0=[$3])
++- LogicalJoin(condition=[AND(=($0, $2), $4)], joinType=[left])
+   :- LogicalProject(k=[$0], v=[$1])
+   :  +- LogicalFilter(condition=[=($0, 0)])
+   :     +- LogicalTableScan(table=[[src, source: [TestTableSource(k, v)]]])
+   +- LogicalProject(k=[$0], v=[$1], $f2=[>($0, 10)])
+      +- LogicalFilter(condition=[=($0, 0)])
+         +- LogicalTableScan(table=[[src, source: [TestTableSource(k, v)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[LeftOuterJoin], where=[=(k, k0)], select=[k, v, k0, v0], isBroadcast=[true], build=[right])
+:- Calc(select=[k, v], where=[=(k, 0)])
+:  +- TableSourceScan(table=[[src, source: [TestTableSource(k, v)]]], fields=[k, v])
++- Exchange(distribution=[broadcast])
+   +- Values(tuples=[[]], values=[k, v])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/NestedLoopJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/NestedLoopJoinTest.xml
@@ -1,0 +1,701 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testCrossJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 CROSS JOIN MyTable1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[true], joinType=[inner])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[d, e, f, g, h, a, b, c], build=[right])
+:- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[broadcast])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinOnFalse">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON false]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[false], joinType=[full])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[FullOuterJoin], where=[false], select=[d, e, f, g, h, a, b, c], build=[right])
+:- Exchange(distribution=[single])
+:  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinOnTrue">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON true]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[true], joinType=[full])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[FullOuterJoin], where=[true], select=[d, e, f, g, h, a, b, c], build=[right])
+:- Exchange(distribution=[single])
+:  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 FULL OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[full])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[FullOuterJoin], where=[AND(=(a, d), $f5)], select=[d, g, $f5, a, c], build=[right])
+   :- Exchange(distribution=[single])
+   :  +- Calc(select=[d, g, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[full])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[d, e, f, g, h, a, b, c])
++- NestedLoopJoin(joinType=[FullOuterJoin], where=[AND(=(a, d), $f5, <(b, h))], select=[d, e, f, g, h, $f5, a, b, c], build=[right])
+   :- Exchange(distribution=[single])
+   :  +- Calc(select=[d, e, f, g, h, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[single])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 FULL OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[full])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[FullOuterJoin], where=[=(b, e)], select=[b, c, e, g], build=[left])
+   :- Exchange(distribution=[single])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON a <> d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[<>($5, $0)], joinType=[full])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[FullOuterJoin], where=[<>(a, d)], select=[d, e, f, g, h, a, b, c], build=[right])
+:- Exchange(distribution=[single])
+:  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[inner])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[InnerJoin], where=[=(a, d)], select=[d, g, a, c], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Calc(select=[a, c])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[left])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[d, e, f, g, h, a, b, c])
++- NestedLoopJoin(joinType=[LeftOuterJoin], where=[AND(=(a, d), $f5, <(b, h))], select=[d, e, f, g, h, $f5, a, b, c], build=[right])
+   :- Calc(select=[d, e, f, g, h, <(d, 2) AS $f5])
+   :  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[broadcast])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[inner])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[AND(=(a, d), <(b, h))], select=[d, e, f, g, h, a, b, c], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[d, e, f, g, h], where=[<(d, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2, MyTable1 WHERE a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$7], g=[$3])
++- LogicalFilter(condition=[AND(=($5, $0), <($0, 2))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+      +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[InnerJoin], where=[=(a, d)], select=[d, g, a, c], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Calc(select=[a, c])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithInvertedField">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE b = e AND a = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[AND(=($1, $4), =($0, $3))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[InnerJoin], where=[AND(=(b, e), =(a, d))], select=[a, b, c, d, e, g], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Calc(select=[d, e, g])
+      +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithMultipleKeys">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$7], g=[$3])
++- LogicalJoin(condition=[AND(=($5, $0), =($6, $1))], joinType=[inner])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[InnerJoin], where=[AND(=(a, d), =(b, e))], select=[d, e, g, a, b, c], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[d, e, g])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT a, d FROM MyTable1, MyTable2 WHERE a + 1 = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], d=[$3])
++- LogicalFilter(condition=[=(+($0, 1), $3)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[=(+(a, 1), d)], select=[a, d], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[a])
+:     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- Calc(select=[d])
+   +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[SELECT a, d FROM MyTable1, MyTable2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], d=[$3])
++- LogicalJoin(condition=[true], joinType=[inner])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a, d], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[a])
+:     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- Calc(select=[d])
+   +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinNonMatchingKeyTypes">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE a = g]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[=($0, $6)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[InnerJoin], where=[=(a, g)], select=[a, c, g], build=[right])
+   :- Calc(select=[a, c])
+   :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinNoEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 LEFT OUTER JOIN MyTable1 ON a <> d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[<>($5, $0)], joinType=[left])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[<>(a, d)], select=[d, e, f, g, h, a, b, c], build=[right])
+:- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[broadcast])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinOnFalse">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 LEFT OUTER JOIN MyTable1 ON false]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[false], joinType=[left])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[d, e, f, g, h, a, b, c], build=[right])
+:- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[broadcast])
+   +- Values(tuples=[[]], values=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinOnTrue">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 LEFT OUTER JOIN MyTable1 ON true]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[true], joinType=[left])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[d, e, f, g, h, a, b, c], build=[right])
+:- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[broadcast])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[left])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[LeftOuterJoin], where=[AND(=(a, d), $f5)], select=[d, g, $f5, a, c], build=[right])
+   :- Calc(select=[d, g, <(d, 2) AS $f5])
+   :  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 RIGHT OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[right])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[RightOuterJoin], where=[=(b, e)], select=[b, c, e, g], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Calc(select=[e, g])
+      +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE a = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[=($0, $3)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, c, d, g], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[a, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Calc(select=[d, g])
+      +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinOnFalse">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 RIGHT OUTER JOIN MyTable1 ON false]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[false], joinType=[right])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[RightOuterJoin], where=[true], select=[d, e, f, g, h, a, b, c], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- Values(tuples=[[]], values=[d, e, f, g, h])
++- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 LEFT OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[left])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(b, e)], select=[b, c, e, g], build=[right])
+   :- Calc(select=[b, c])
+   :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinOnTrue">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 RIGHT OUTER JOIN MyTable1 ON true]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[true], joinType=[right])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[RightOuterJoin], where=[true], select=[d, e, f, g, h, a, b, c], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[right])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- NestedLoopJoin(joinType=[RightOuterJoin], where=[=(a, d)], select=[d, g, a, c], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Calc(select=[a, c])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 RIGHT OUTER JOIN MyTable1 ON a <> d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$5], b=[$6], c=[$7])
++- LogicalJoin(condition=[<>($5, $0)], joinType=[right])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[RightOuterJoin], where=[<>(a, d)], select=[d, e, f, g, h, a, b, c], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[right])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[RightOuterJoin], where=[AND(=(a, d), <(b, h))], select=[d, e, f, g, h, a, b, c], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[d, e, f, g, h], where=[<(d, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSelfJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM
+  (SELECT * FROM src WHERE k = 0) src1
+LEFT OUTER JOIN
+  (SELECT * from src WHERE k = 0) src2
+ON (src1.k = src2.k AND src2.k > 10)
+         ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(k=[$0], v=[$1], k0=[$2], v0=[$3])
++- LogicalJoin(condition=[AND(=($0, $2), $4)], joinType=[left])
+   :- LogicalProject(k=[$0], v=[$1])
+   :  +- LogicalFilter(condition=[=($0, 0)])
+   :     +- LogicalTableScan(table=[[src, source: [TestTableSource(k, v)]]])
+   +- LogicalProject(k=[$0], v=[$1], $f2=[>($0, 10)])
+      +- LogicalFilter(condition=[=($0, 0)])
+         +- LogicalTableScan(table=[[src, source: [TestTableSource(k, v)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(k, k0)], select=[k, v, k0, v0], build=[right])
+:- Calc(select=[k, v], where=[=(k, 0)])
+:  +- TableSourceScan(table=[[src, source: [TestTableSource(k, v)]]], fields=[k, v])
++- Exchange(distribution=[broadcast])
+   +- Values(tuples=[[]], values=[k, v])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/ShuffledHashJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/ShuffledHashJoinTest.xml
@@ -1,0 +1,429 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testFullOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 FULL OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[full])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[FullOuterJoin], where=[AND(=(a, d), $f5)], select=[d, g, $f5, a, c], build=[right])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[full])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[d, e, f, g, h, a, b, c])
++- HashJoin(joinType=[FullOuterJoin], where=[AND(=(a, d), $f5, <(b, h))], select=[d, e, f, g, h, $f5, a, b, c], build=[right])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, e, f, g, h, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 FULL OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[full])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[FullOuterJoin], where=[=(b, e)], select=[b, c, e, g], build=[left])
+   :- Exchange(distribution=[hash[b]])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[e]])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[inner])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[d, g, a, c], build=[left])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[left])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[d, e, f, g, h, a, b, c])
++- HashJoin(joinType=[LeftOuterJoin], where=[AND(=(a, d), $f5, <(b, h))], select=[d, e, f, g, h, $f5, a, b, c], build=[right])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, e, f, g, h, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[inner])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[AND(=(a, d), <(b, h))], select=[d, e, f, g, h, a, b, c], build=[left])
+:- Exchange(distribution=[hash[d]])
+:  +- Calc(select=[d, e, f, g, h], where=[<(d, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[hash[a]])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2, MyTable1 WHERE a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$7], g=[$3])
++- LogicalFilter(condition=[AND(=($5, $0), <($0, 2))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+      +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[d, g, a, c], build=[left])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithInvertedField">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE b = e AND a = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[AND(=($1, $4), =($0, $3))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[AND(=(b, e), =(a, d))], select=[a, b, c, d, e, g], build=[left])
+   :- Exchange(distribution=[hash[b, a]])
+   :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[e, d]])
+      +- Calc(select=[d, e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithMultipleKeys">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$7], g=[$3])
++- LogicalJoin(condition=[AND(=($5, $0), =($6, $1))], joinType=[inner])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[AND(=(a, d), =(b, e))], select=[d, e, g, a, b, c], build=[left])
+   :- Exchange(distribution=[hash[d, e]])
+   :  +- Calc(select=[d, e, g])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a, b]])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[left])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[LeftOuterJoin], where=[AND(=(a, d), $f5)], select=[d, g, $f5, a, c], build=[right])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 RIGHT OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[right])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[RightOuterJoin], where=[=(b, e)], select=[b, c, e, g], build=[left])
+   :- Exchange(distribution=[hash[b]])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[e]])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE a = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[=($0, $3)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, c, d, g], build=[left])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[d]])
+      +- Calc(select=[d, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 LEFT OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[left])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[LeftOuterJoin], where=[=(b, e)], select=[b, c, e, g], build=[left])
+   :- Exchange(distribution=[hash[b]])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[e]])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[right])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- HashJoin(joinType=[RightOuterJoin], where=[=(a, d)], select=[d, g, a, c], build=[left])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSelfJoinPlan">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM
+  (SELECT * FROM src WHERE k = 0) src1
+LEFT OUTER JOIN
+  (SELECT * from src WHERE k = 0) src2
+ON (src1.k = src2.k AND src2.k > 10)
+         ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(k=[$0], v=[$1], k0=[$2], v0=[$3])
++- LogicalJoin(condition=[AND(=($0, $2), $4)], joinType=[left])
+   :- LogicalProject(k=[$0], v=[$1])
+   :  +- LogicalFilter(condition=[=($0, 0)])
+   :     +- LogicalTableScan(table=[[src, source: [TestTableSource(k, v)]]])
+   +- LogicalProject(k=[$0], v=[$1], $f2=[>($0, 10)])
+      +- LogicalFilter(condition=[=($0, 0)])
+         +- LogicalTableScan(table=[[src, source: [TestTableSource(k, v)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[LeftOuterJoin], where=[=(k, k0)], select=[k, v, k0, v0], build=[right])
+:- Exchange(distribution=[hash[k]])
+:  +- Calc(select=[k, v], where=[=(k, 0)])
+:     +- TableSourceScan(table=[[src, source: [TestTableSource(k, v)]]], fields=[k, v])
++- Exchange(distribution=[hash[k]])
+   +- Values(tuples=[[]], values=[k, v])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[right])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[RightOuterJoin], where=[AND(=(a, d), <(b, h))], select=[d, e, f, g, h, a, b, c], build=[left])
+:- Exchange(distribution=[hash[d]])
+:  +- Calc(select=[d, e, f, g, h], where=[<(d, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[hash[a]])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/SortMergeJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/join/SortMergeJoinTest.xml
@@ -1,0 +1,455 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testFullOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 FULL OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[full])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[FullOuterJoin], where=[AND(=(a, d), $f5)], select=[d, g, $f5, a, c])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[full])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[d, e, f, g, h, a, b, c])
++- SortMergeJoin(joinType=[FullOuterJoin], where=[AND(=(a, d), $f5, <(b, h))], select=[d, e, f, g, h, $f5, a, b, c])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, e, f, g, h, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 FULL OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[full])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[FullOuterJoin], where=[=(b, e)], select=[b, c, e, g])
+   :- Exchange(distribution=[hash[b]])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[e]])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[inner])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[InnerJoin], where=[=(a, d)], select=[d, g, a, c])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[left])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[d, e, f, g, h, a, b, c])
++- SortMergeJoin(joinType=[LeftOuterJoin], where=[AND(=(a, d), $f5, <(b, h))], select=[d, e, f, g, h, $f5, a, b, c])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, e, f, g, h, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[inner])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortMergeJoin(joinType=[InnerJoin], where=[AND(=(a, d), <(b, h))], select=[d, e, f, g, h, a, b, c])
+:- Exchange(distribution=[hash[d]])
+:  +- Calc(select=[d, e, f, g, h], where=[<(d, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[hash[a]])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2, MyTable1 WHERE a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$7], g=[$3])
++- LogicalFilter(condition=[AND(=($5, $0), <($0, 2))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+      +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[InnerJoin], where=[=(a, d)], select=[d, g, a, c])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithInvertedField">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE b = e AND a = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[AND(=($1, $4), =($0, $3))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[InnerJoin], where=[AND(=(b, e), =(a, d))], select=[a, b, c, d, e, g])
+   :- Exchange(distribution=[hash[b, a]])
+   :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[e, d]])
+      +- Calc(select=[d, e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithMultipleKeys">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$7], g=[$3])
++- LogicalJoin(condition=[AND(=($5, $0), =($6, $1))], joinType=[inner])
+   :- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[InnerJoin], where=[AND(=(a, d), =(b, e))], select=[d, e, g, a, b, c])
+   :- Exchange(distribution=[hash[d, e]])
+   :  +- Calc(select=[d, e, g])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a, b]])
+      +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinNonMatchingKeyTypes">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE a = g]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[=($0, $6)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[InnerJoin], where=[=(a, g)], select=[a, c, g])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[g]])
+      +- Calc(select=[g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[left])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[LeftOuterJoin], where=[AND(=(a, d), $f5)], select=[d, g, $f5, a, c])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g, <(d, 2) AS $f5])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 RIGHT OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[right])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[RightOuterJoin], where=[=(b, e)], select=[b, c, e, g])
+   :- Exchange(distribution=[hash[b]])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[e]])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1, MyTable2 WHERE a = d]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalFilter(condition=[=($0, $3)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, c, d, g])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[d]])
+      +- Calc(select=[d, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable1 LEFT OUTER JOIN MyTable2 ON b = e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2], g=[$6])
++- LogicalJoin(condition=[=($1, $4)], joinType=[left])
+   :- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[LeftOuterJoin], where=[=(b, e)], select=[b, c, e, g])
+   :- Exchange(distribution=[hash[b]])
+   :  +- Calc(select=[b, c])
+   :     +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[e]])
+      +- Calc(select=[e, g])
+         +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiAndNonEquiPred">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], a=[$6], b=[$7], c=[$8])
++- LogicalJoin(condition=[AND(=($6, $0), $5, <($7, $4))], joinType=[right])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortMergeJoin(joinType=[RightOuterJoin], where=[AND(=(a, d), <(b, h))], select=[d, e, f, g, h, a, b, c])
+:- Exchange(distribution=[hash[d]])
+:  +- Calc(select=[d, e, f, g, h], where=[<(d, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
++- Exchange(distribution=[hash[a]])
+   +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithEquiAndLocalPred">
+    <Resource name="sql">
+      <![CDATA[SELECT c, g FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$8], g=[$3])
++- LogicalJoin(condition=[AND(=($6, $0), $5)], joinType=[right])
+   :- LogicalProject(d=[$0], e=[$1], f=[$2], g=[$3], h=[$4], $f5=[<($0, 2)])
+   :  +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
+   +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c, g])
++- SortMergeJoin(joinType=[RightOuterJoin], where=[=(a, d)], select=[d, g, a, c])
+   :- Exchange(distribution=[hash[d]])
+   :  +- Calc(select=[d, g], where=[<(d, 2)])
+   :     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(d, e, f, g, h)]]], fields=[d, e, f, g, h])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c])
+         +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSelfJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM
+  (SELECT * FROM src WHERE k = 0) src1
+LEFT OUTER JOIN
+  (SELECT * from src WHERE k = 0) src2
+ON (src1.k = src2.k AND src2.k > 10)
+         ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(k=[$0], v=[$1], k0=[$2], v0=[$3])
++- LogicalJoin(condition=[AND(=($0, $2), $4)], joinType=[left])
+   :- LogicalProject(k=[$0], v=[$1])
+   :  +- LogicalFilter(condition=[=($0, 0)])
+   :     +- LogicalTableScan(table=[[src, source: [TestTableSource(k, v)]]])
+   +- LogicalProject(k=[$0], v=[$1], $f2=[>($0, 10)])
+      +- LogicalFilter(condition=[=($0, 0)])
+         +- LogicalTableScan(table=[[src, source: [TestTableSource(k, v)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortMergeJoin(joinType=[LeftOuterJoin], where=[=(k, k0)], select=[k, v, k0, v0])
+:- Exchange(distribution=[hash[k]])
+:  +- Calc(select=[k, v], where=[=(k, 0)])
+:     +- TableSourceScan(table=[[src, source: [TestTableSource(k, v)]]], fields=[k, v])
++- Exchange(distribution=[hash[k]])
+   +- Values(tuples=[[]], values=[k, v])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/BroadcastHashJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/BroadcastHashJoinTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.plan.batch.sql.join
 
-import org.apache.flink.table.api.{TableConfigOptions, TableException}
+import org.apache.flink.table.api.{PlannerConfigOptions, TableConfigOptions, TableException}
 
 import org.junit.{Before, Test}
 
@@ -27,7 +27,7 @@ class BroadcastHashJoinTest extends JoinTestBase {
   @Before
   def before(): Unit = {
     util.tableEnv.getConfig.getConf.setLong(
-      TableConfigOptions.SQL_EXEC_HASH_JOIN_BROADCAST_THRESHOLD, Long.MaxValue)
+      PlannerConfigOptions.SQL_OPTIMIZER_HASH_JOIN_BROADCAST_THRESHOLD, Long.MaxValue)
     util.tableEnv.getConfig.getConf.setString(
       TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS,
       "SortMergeJoin, NestedLoopJoin, ShuffleHashJoin")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/BroadcastHashJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/BroadcastHashJoinTest.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql.join
+
+import org.apache.flink.table.api.{TableConfigOptions, TableException}
+
+import org.junit.{Before, Test}
+
+class BroadcastHashJoinTest extends JoinTestBase {
+
+  @Before
+  def before(): Unit = {
+    util.tableEnv.getConfig.getConf.setLong(
+      TableConfigOptions.SQL_EXEC_HASH_JOIN_BROADCAST_THRESHOLD, Long.MaxValue)
+    util.tableEnv.getConfig.getConf.setString(
+      TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS,
+      "SortMergeJoin, NestedLoopJoin, ShuffleHashJoin")
+  }
+
+  @Test
+  override def testJoinNonMatchingKeyTypes(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Equality join predicate on incompatible types")
+    super.testJoinNonMatchingKeyTypes()
+  }
+
+  @Test
+  override def testInnerJoinWithoutJoinPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testInnerJoinWithoutJoinPred()
+  }
+
+  @Test
+  override def testInnerJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testInnerJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testLeftOuterJoinNoEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinNoEquiPred()
+  }
+
+  @Test
+  override def testLeftOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testLeftOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testRightOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testRightOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testRightOuterJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testFullOuterJoinWithEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinWithEquiPred()
+  }
+
+  @Test
+  override def testFullOuterJoinWithEquiAndLocalPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinWithEquiAndLocalPred()
+  }
+
+  @Test
+  override def testFullOuterJoinWithEquiAndNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinWithEquiAndNonEquiPred()
+  }
+
+  @Test
+  override def testFullOuterJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testFullOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testFullOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testCrossJoin(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testCrossJoin()
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/JoinTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/JoinTestBase.scala
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.batch.sql.join
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.{TableConfigOptions, ValidationException}
+import org.apache.flink.table.util.{BatchTableTestUtil, TableTestBase}
+
+import org.junit.Test
+
+abstract class JoinTestBase extends TableTestBase {
+
+  protected val util: BatchTableTestUtil = batchTestUtil()
+  util.addTableSource[(Int, Long, String)]("MyTable1", 'a, 'b, 'c)
+  util.addTableSource[(Int, Long, Int, String, Long)]("MyTable2", 'd, 'e, 'f, 'g, 'h)
+
+  @Test(expected = classOf[ValidationException])
+  def testJoinNonExistingKey(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable1, MyTable2 WHERE foo = e")
+  }
+
+  @Test
+  def testJoinNonMatchingKeyTypes(): Unit = {
+    // TODO do implicit type coercion
+    util.verifyPlan("SELECT c, g FROM MyTable1, MyTable2 WHERE a = g")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testJoinWithAmbiguousFields(): Unit = {
+    util.addTableSource[(Int, Long, String)]("MyTable0", 'a0, 'b0, 'c)
+    util.verifyPlan("SELECT a, c FROM MyTable1, MyTable0 WHERE a = a0")
+  }
+
+  @Test
+  def testInnerJoinWithEquiPred(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable1, MyTable2 WHERE a = d")
+  }
+
+  @Test
+  def testInnerJoinWithFilter(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable2, MyTable1 WHERE a = d AND d < 2")
+  }
+
+  @Test
+  def testInnerJoinWithEquiAndLocalPred(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2")
+  }
+
+  @Test
+  def testInnerJoinWithEquiAndNonEquiPred(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 INNER JOIN MyTable1 ON a = d AND d < 2 AND b < h")
+  }
+
+  @Test
+  def testInnerJoinWithoutJoinPred(): Unit = {
+    val query = "SELECT a, d FROM MyTable1, MyTable2"
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testInnerJoinWithNonEquiPred(): Unit = {
+    val query = "SELECT a, d FROM MyTable1, MyTable2 WHERE a + 1 = d"
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testInnerJoinWithMultipleKeys(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable2 INNER JOIN MyTable1 ON a = d AND b = e")
+  }
+
+  @Test
+  def testInnerJoinWithInvertedField(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable1, MyTable2 WHERE b = e AND a = d")
+  }
+
+  @Test
+  def testLeftOuterJoinWithEquiPred(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable1 LEFT OUTER JOIN MyTable2 ON b = e")
+  }
+
+  @Test
+  def testLeftOuterJoinWithEquiAndLocalPred(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2")
+  }
+
+  @Test
+  def testLeftOuterJoinWithEquiAndNonEquiPred(): Unit = {
+    val sql = "SELECT * FROM MyTable2 LEFT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testLeftOuterJoinNoEquiPred(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 LEFT OUTER JOIN MyTable1 ON a <> d")
+  }
+
+  @Test
+  def testLeftOuterJoinOnTrue(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 LEFT OUTER JOIN MyTable1 ON true")
+  }
+
+  @Test
+  def testLeftOuterJoinOnFalse(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 LEFT OUTER JOIN MyTable1 ON false")
+  }
+
+  @Test
+  def testRightOuterJoinWithEquiPred(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable1 RIGHT OUTER JOIN MyTable2 ON b = e")
+  }
+
+  @Test
+  def testRightOuterJoinWithEquiAndLocalPred(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2")
+  }
+
+  @Test
+  def testRightOuterJoinWithEquiAndNonEquiPred(): Unit = {
+    val sql = "SELECT * FROM MyTable2 RIGHT OUTER JOIN  MyTable1 ON a = d AND d < 2 AND b < h"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testRightOuterJoinWithNonEquiPred(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 RIGHT OUTER JOIN MyTable1 ON a <> d")
+  }
+
+  @Test
+  def testRightOuterJoinOnTrue(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 RIGHT OUTER JOIN MyTable1 ON true")
+  }
+
+  @Test
+  def testRightOuterJoinOnFalse(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 RIGHT OUTER JOIN MyTable1 ON false")
+  }
+
+  @Test
+  def testFullOuterJoinWithEquiPred(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable1 FULL OUTER JOIN MyTable2 ON b = e")
+  }
+
+  @Test
+  def testFullOuterJoinWithEquiAndLocalPred(): Unit = {
+    util.verifyPlan("SELECT c, g FROM MyTable2 FULL OUTER JOIN  MyTable1 ON a = d AND d < 2")
+  }
+
+  @Test
+  def testFullOuterJoinWithEquiAndNonEquiPred(): Unit = {
+    val sql = "SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON a = d AND d < 2 AND b < h"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testFullOuterJoinWithNonEquiPred(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON a <> d")
+  }
+
+  @Test
+  def testFullOuterJoinOnTrue(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON true")
+  }
+
+  @Test
+  def testFullOuterJoinOnFalse(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 FULL OUTER JOIN MyTable1 ON false")
+  }
+
+  @Test
+  def testCrossJoin(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable2 CROSS JOIN MyTable1")
+  }
+
+  @Test
+  def testSelfJoin(): Unit = {
+    util.addTableSource[(Long, String)]("src", 'k, 'v)
+    val sql =
+      s"""SELECT * FROM
+         |  (SELECT * FROM src WHERE k = 0) src1
+         |LEFT OUTER JOIN
+         |  (SELECT * from src WHERE k = 0) src2
+         |ON (src1.k = src2.k AND src2.k > 10)
+         """.stripMargin
+    util.verifyPlan(sql)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/NestedLoopJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/NestedLoopJoinTest.scala
@@ -15,15 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink
 
-package object table {
+package org.apache.flink.table.plan.batch.sql.join
 
-  type JDouble = java.lang.Double
+import org.apache.flink.table.api.TableConfigOptions
 
-  type JList[T] = java.util.List[T]
-  type JArrayList[T] = java.util.ArrayList[T]
+import org.junit.Before
 
-  type CalcitePair[T, R] = org.apache.calcite.util.Pair[T, R]
+class NestedLoopJoinTest extends JoinTestBase {
 
+  @Before
+  def before(): Unit = {
+    util.tableEnv.getConfig.getConf.setString(
+      TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS, "SortMergeJoin, HashJoin")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/ShuffledHashJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/ShuffledHashJoinTest.scala
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql.join
+
+import org.apache.flink.table.api.{TableConfigOptions, TableException}
+
+import org.junit.{Before, Test}
+
+class ShuffledHashJoinTest extends JoinTestBase {
+
+  @Before
+  def before(): Unit = {
+    util.tableEnv.getConfig.getConf.setString(
+      TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS,
+      "SortMergeJoin, NestedLoopJoin, BroadcastHashJoin")
+  }
+
+  @Test
+  override def testJoinNonMatchingKeyTypes(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Equality join predicate on incompatible types")
+    super.testJoinNonMatchingKeyTypes()
+  }
+
+  @Test
+  override def testInnerJoinWithoutJoinPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testInnerJoinWithoutJoinPred()
+  }
+
+  @Test
+  override def testInnerJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testInnerJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testLeftOuterJoinNoEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinNoEquiPred()
+  }
+
+  @Test
+  override def testLeftOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testLeftOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testRightOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testRightOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testRightOuterJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testFullOuterJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testFullOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testFullOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testCrossJoin(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testCrossJoin()
+  }
+
+  @Test
+  override def testSelfJoin(): Unit = {
+    // TODO use shuffle hash join if isBroadcast is true and isBroadcastHashJoinEnabled is false ?
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testSelfJoin()
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/SingleRowJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/SingleRowJoinTest.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql.join
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.util.TableTestBase
+
+import org.junit.{Ignore, Test}
+
+// FIXME
+@Ignore("remove this after aggregate supports")
+class SingleRowJoinTest extends TableTestBase {
+
+  @Test
+  def testSingleRowCrossJoin(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Int)]("A", 'a1, 'a2)
+    util.verifyPlan("SELECT a1, a_sum FROM A, (SELECT SUM(a1) + SUM(a2) AS a_sum FROM A)")
+  }
+
+  @Test
+  def testSingleRowEquiJoin(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, String)]("A", 'a1, 'a2)
+    util.verifyPlan("SELECT a1, a2 FROM A, (SELECT COUNT(a1) AS cnt FROM A) WHERE a1 = cnt")
+  }
+
+  @Test
+  def testSingleRowNotEquiJoin(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, String)]("A", 'a1, 'a2)
+    util.verifyPlan("SELECT a1, a2 FROM A, (SELECT COUNT(a1) AS cnt FROM A) WHERE a1 < cnt")
+  }
+
+  @Test
+  def testSingleRowJoinWithComplexPredicate(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long)]("A", 'a1, 'a2)
+    util.addTableSource[(Int, Long)]("B", 'b1, 'b2)
+    val query =
+      """
+        |SELECT a1, a2, b1, b2 FROM A,
+        |  (SELECT min(b1) AS b1, max(b2) AS b2 FROM B)
+        |WHERE a1 < b1 AND a2 = b2
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testRightSingleLeftJoinEqualPredicate(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Long, Int)]("A", 'a1, 'a2)
+    util.addTableSource[(Int, Int)]("B", 'b1, 'b2)
+    util.verifyPlan("SELECT a2 FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) AS x  ON a1 = cnt")
+  }
+
+  @Test
+  def testRightSingleLeftJoinNotEqualPredicate(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Long, Int)]("A", 'a1, 'a2)
+    util.addTableSource[(Int, Int)]("B", 'b1, 'b2)
+    util.verifyPlan("SELECT a2 FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) AS x ON a1 > cnt")
+  }
+
+  @Test
+  def testLeftSingleRightJoinEqualPredicate(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Long, Long)]("A", 'a1, 'a2)
+    util.addTableSource[(Long, Long)]("B", 'b1, 'b2)
+    util.verifyPlan("SELECT a1 FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt = a2")
+  }
+
+  @Test
+  def testLeftSingleRightJoinNotEqualPredicate(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Long, Long)]("A", 'a1, 'a2)
+    util.addTableSource[(Long, Long)]("B", 'b1, 'b2)
+    util.verifyPlan("SELECT a1 FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt < a2")
+  }
+
+  @Test
+  def testSingleRowJoinInnerJoin(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Int)]("A", 'a1, 'a2)
+    val sql = "SELECT a2, SUM(a1) FROM A GROUP BY a2 HAVING SUM(a1) > (SELECT SUM(a1) * 0.1 FROM A)"
+    // TODO remove this after SINGLE_VALUE supported
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Unsupported Function: 'SINGLE_VALUE'")
+    util.verifyPlan(sql)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/SortMergeJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/SortMergeJoinTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql.join
+
+import org.apache.flink.table.api.{TableConfigOptions, TableException}
+
+import org.junit.{Before, Test}
+
+class SortMergeJoinTest extends JoinTestBase {
+
+  @Before
+  def before(): Unit = {
+    util.tableEnv.getConfig.getConf.setString(
+      TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS, "HashJoin, NestedLoopJoin")
+  }
+
+  @Test
+  override def testInnerJoinWithoutJoinPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testInnerJoinWithoutJoinPred()
+  }
+
+  @Test
+  override def testInnerJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testInnerJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testLeftOuterJoinNoEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinNoEquiPred()
+  }
+
+  @Test
+  override def testLeftOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testLeftOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testLeftOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testRightOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testRightOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testRightOuterJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testRightOuterJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testFullOuterJoinWithNonEquiPred(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinWithNonEquiPred()
+  }
+
+  @Test
+  override def testFullOuterJoinOnFalse(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinOnFalse()
+  }
+
+  @Test
+  override def testFullOuterJoinOnTrue(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testFullOuterJoinOnTrue()
+  }
+
+  @Test
+  override def testCrossJoin(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    super.testCrossJoin()
+  }
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
@@ -66,6 +66,17 @@ public class TableConfigOptions {
 					.withDescription("Whether to asynchronously merge sort spill files.");
 
 	// ------------------------------------------------------------------------
+	//  Join Options
+	// ------------------------------------------------------------------------
+
+	public static final ConfigOption<Long> SQL_EXEC_HASH_JOIN_BROADCAST_THRESHOLD =
+			key("sql.exec.hash-join.broadcast.threshold")
+					.defaultValue(1024 * 1024L)
+					.withDescription("Maximum size in bytes for data that could be broadcast to each parallel instance " +
+							"that holds a partition of all data when performing a hash join. " +
+							"Broadcast will be disabled if the value is -1.");
+
+	// ------------------------------------------------------------------------
 	//  Spill Options
 	// ------------------------------------------------------------------------
 
@@ -114,5 +125,18 @@ public class TableConfigOptions {
 			key("sql.exec.statebackend.onheap")
 					.defaultValue(false)
 					.withDescription("Whether the statebackend is on heap.");
+
+	// ------------------------------------------------------------------------
+	//  Other Exec Options
+	// ------------------------------------------------------------------------
+
+	public static final ConfigOption<String> SQL_EXEC_DISABLED_OPERATORS =
+			key("sql.exec.disabled-operators")
+					.defaultValue("")
+					.withDescription("Mainly for testing. A comma-separated list of name of the OperatorType, each name " +
+							"means a kind of disabled operator. Its default value is empty that means no operators are disabled. " +
+							"If the configure's value is \"NestedLoopJoin, ShuffleHashJoin\", NestedLoopJoin and ShuffleHashJoin " +
+							"are disabled. If the configure's value is \"HashJoin\", " +
+							"ShuffleHashJoin and BroadcastHashJoin are disabled.");
 
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
@@ -66,17 +66,6 @@ public class TableConfigOptions {
 					.withDescription("Whether to asynchronously merge sort spill files.");
 
 	// ------------------------------------------------------------------------
-	//  Join Options
-	// ------------------------------------------------------------------------
-
-	public static final ConfigOption<Long> SQL_EXEC_HASH_JOIN_BROADCAST_THRESHOLD =
-			key("sql.exec.hash-join.broadcast.threshold")
-					.defaultValue(1024 * 1024L)
-					.withDescription("Maximum size in bytes for data that could be broadcast to each parallel instance " +
-							"that holds a partition of all data when performing a hash join. " +
-							"Broadcast will be disabled if the value is -1.");
-
-	// ------------------------------------------------------------------------
 	//  Spill Options
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION

## What is the purpose of the change

*Add support for generating optimized logical plan for join on batch*


## Brief change log

  - *add BatchExecHashJoinRule, BatchExecNestedLoopJoinRule, BatchExecSortMergeJoinRule and BatchExecSingleRowJoinRule*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added BroadcastHashJoinTest and ShuffledHashJoinTest that validates that logical join can be converted to BatchExecHashJoin successfully*
- *Added SortMergeJoinTest that validates that logical join can be converted to BatchExecSortMergeJoin successfully*
- *Added NestedLoopJoinTest and SingleRowJoinTest that validates that logical join can be converted to BatchExecNestedLoopJoin successfully*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
