### PR TITLE
[FLINK-12075][yarn] Set RestOptions.BIND_PORT only to 0 if not specified

### DIFF
--- a/docs/_includes/generated/rest_configuration.html
+++ b/docs/_includes/generated/rest_configuration.html
@@ -45,7 +45,7 @@
         <tr>
             <td><h5>rest.port</h5></td>
             <td style="word-wrap: break-word;">8081</td>
-            <td>The port that the client connects to.</td>
+            <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port.</td>
         </tr>
         <tr>
             <td><h5>rest.retry.delay</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -19,8 +19,10 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /**
  * Configuration parameters for REST communication.
@@ -62,13 +64,17 @@ public class RestOptions {
 			.withDescription("The address that should be used by clients to connect to the server.");
 
 	/**
-	 * The port that the client connects to.
+	 * The port that the REST client connects to and the REST server binds to if {@link #BIND_PORT}
+	 * has not been specified.
 	 */
 	public static final ConfigOption<Integer> PORT =
 		key(REST_PORT_KEY)
 			.defaultValue(8081)
 			.withDeprecatedKeys(WebOptions.PORT.key())
-			.withDescription("The port that the client connects to.");
+			.withDescription(
+				Description.builder()
+					.text("The port that the client connects to. If %s has not been specified, then the REST server will bind to this port.", text(BIND_PORT.key()))
+					.build());
 
 	/**
 	 * The time in ms that the client waits for the leader address, e.g., Dispatcher or

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -121,17 +121,25 @@ parallelism.default: 1
 # state.backend.incremental: false
 
 #==============================================================================
-# Web Frontend
+# Rest & web frontend
 #==============================================================================
 
-# The address under which the web-based runtime monitor listens.
+# The port to which the REST client connects to. If rest.bind-port has
+# not been specified, then the server will bind to this port as well.
 #
-#web.address: 0.0.0.0
+#rest.port: 8081
 
-# The port under which the web-based runtime monitor listens.
-# A value of -1 deactivates the web server.
+# The address to which the REST client will connect to
+#
+#rest.address: 0.0.0.0
 
-rest.port: 8081
+# Port range for the REST and web server to bind to.
+#
+#rest.bind-port: 8080-8090
+
+# The address that the REST & web server binds to
+#
+#rest.bind-address: 0.0.0.0
 
 # Flag to specify whether job submission is enabled from the web-based
 # runtime monitor. Uncomment to disable.

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -98,8 +98,10 @@ public class YarnEntrypointUtils {
 			configuration.setInteger(WebOptions.PORT, 0);
 		}
 
-		// set the REST port to 0 to select it randomly
-		configuration.setString(RestOptions.BIND_PORT, "0");
+		if (!configuration.contains(RestOptions.BIND_PORT)) {
+			// set the REST port to 0 to select it randomly
+			configuration.setString(RestOptions.BIND_PORT, "0");
+		}
 
 		// if the user has set the deprecated YARN-specific config keys, we add the
 		// corresponding generic config keys instead. that way, later code needs not

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
@@ -78,7 +78,7 @@ public class YarnEntrypointUtilsTest extends TestLogger {
 
 		final Configuration configuration = loadConfiguration(workingDirectory, initialConfiguration);
 
-		// having not specified the ports should set the rest bind port to 0
+		// if the bind port is not specified it should fall back to the rest port
 		assertThat(configuration.getString(RestOptions.BIND_PORT), is(equalTo(String.valueOf(port))));
 	}
 
@@ -96,7 +96,7 @@ public class YarnEntrypointUtilsTest extends TestLogger {
 
 		final Configuration configuration = loadConfiguration(workingDirectory, initialConfiguration);
 
-		// having not specified the ports should set the rest bind port to 0
+		// bind port should have precedence over the rest port
 		assertThat(configuration.getString(RestOptions.BIND_PORT), is(equalTo(bindingPortRange)));
 	}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.clusterframework.BootstrapTools;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link YarnEntrypointUtils}.
+ */
+public class YarnEntrypointUtilsTest extends TestLogger {
+
+	private static final Logger LOG = LoggerFactory.getLogger(YarnEntrypointUtilsTest.class);
+
+	@ClassRule
+	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+	/**
+	 * Tests that the REST ports are correctly set when loading a {@link Configuration}
+	 * with unspecified REST options.
+	 */
+	@Test
+	public void testRestPortOptionsUnspecified() throws IOException {
+		final File workingDirectory = TEMPORARY_FOLDER.newFolder();
+		final Configuration initialConfiguration = new Configuration();
+
+		final Configuration configuration = loadConfiguration(workingDirectory, initialConfiguration);
+
+		// having not specified the ports should set the rest bind port to 0
+		assertThat(configuration.getString(RestOptions.BIND_PORT), is(equalTo("0")));
+	}
+
+	/**
+	 * Tests that the binding REST port is set to the REST port if set.
+	 */
+	@Test
+	public void testRestPortSpecified() throws IOException {
+		final File workingDirectory = TEMPORARY_FOLDER.newFolder();
+		final Configuration initialConfiguration = new Configuration();
+		final int port = 1337;
+		initialConfiguration.setInteger(RestOptions.PORT, port);
+
+		final Configuration configuration = loadConfiguration(workingDirectory, initialConfiguration);
+
+		// having not specified the ports should set the rest bind port to 0
+		assertThat(configuration.getString(RestOptions.BIND_PORT), is(equalTo(String.valueOf(port))));
+	}
+
+	/**
+	 * Tests that the binding REST port has precedence over the REST port if both are set.
+	 */
+	@Test
+	public void testRestPortAndBindingPortSpecified() throws IOException {
+		final File workingDirectory = TEMPORARY_FOLDER.newFolder();
+		final Configuration initialConfiguration = new Configuration();
+		final int port = 1337;
+		final String bindingPortRange = "1337-7331";
+		initialConfiguration.setInteger(RestOptions.PORT, port);
+		initialConfiguration.setString(RestOptions.BIND_PORT, bindingPortRange);
+
+		final Configuration configuration = loadConfiguration(workingDirectory, initialConfiguration);
+
+		// having not specified the ports should set the rest bind port to 0
+		assertThat(configuration.getString(RestOptions.BIND_PORT), is(equalTo(bindingPortRange)));
+	}
+
+	@Nonnull
+	private Configuration loadConfiguration(File workingDirectory, Configuration initialConfiguration) throws IOException {
+		final Map<String, String> env = new HashMap<>(4);
+		env.put(ApplicationConstants.Environment.NM_HOST.key(), "foobar");
+
+		BootstrapTools.writeConfiguration(initialConfiguration, new File(workingDirectory, "flink-conf.yaml"));
+		return YarnEntrypointUtils.loadConfiguration(workingDirectory.getAbsolutePath(), env, LOG);
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR changes the YarnEntrypointUtils#loadConfiguration so that it only
sets RestOptions.BIND_PORT to 0 if it has not been specified. This allows to
explicitly set a port range for Yarn applications which are running behind a
firewall, for example.

Moreover, this PR updates the flink-conf.yaml to contain the new rest options and comments
out the `rest.port` per default so that it will be set to `0` in the Yarn case.

## Verifying this change

* Added `YarnEntrypointUtilsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
