### PR TITLE
[BP-1.7][FLINK-12075][yarn] Set RestOptions.BIND_PORT only to 0 if not specified

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -121,17 +121,20 @@ parallelism.default: 1
 # state.backend.incremental: false
 
 #==============================================================================
-# Web Frontend
+# Rest & web frontend
 #==============================================================================
 
-# The address under which the web-based runtime monitor listens.
+# The port to which the REST client connects to and the server binds to.
 #
-#web.address: 0.0.0.0
+#rest.port: 8081
 
-# The port under which the web-based runtime monitor listens.
-# A value of -1 deactivates the web server.
+# The address to which the REST client will connect to
+#
+#rest.address: 0.0.0.0
 
-rest.port: 8081
+# The address that the REST & web server binds to
+#
+#rest.bind-address: 0.0.0.0
 
 # Flag to specify whether job submission is enabled from the web-based
 # runtime monitor. Uncomment to disable.

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -98,7 +98,7 @@ public class YarnEntrypointUtils {
 			configuration.setInteger(WebOptions.PORT, 0);
 		}
 
-		if (configuration.getInteger(RestOptions.PORT) >= 0) {
+		if (!configuration.contains(RestOptions.PORT)) {
 			// set the REST port to 0 to select it randomly
 			configuration.setInteger(RestOptions.PORT, 0);
 		}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
@@ -78,7 +78,7 @@ public class YarnEntrypointUtilsTest extends TestLogger {
 
 		final Configuration configuration = loadConfiguration(workingDirectory, initialConfiguration);
 
-		// having not specified the ports should set the rest bind port to 0
+		// if the bind port is not specified it should fall back to the rest port
 		assertThat(configuration.getInteger(RestOptions.PORT), is(equalTo(port)));
 	}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.clusterframework.BootstrapTools;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link YarnEntrypointUtils}.
+ */
+public class YarnEntrypointUtilsTest extends TestLogger {
+
+	private static final Logger LOG = LoggerFactory.getLogger(YarnEntrypointUtilsTest.class);
+
+	@ClassRule
+	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+	/**
+	 * Tests that the REST ports are correctly set when loading a {@link Configuration}
+	 * with unspecified REST options.
+	 */
+	@Test
+	public void testRestPortOptionsUnspecified() throws IOException {
+		final File workingDirectory = TEMPORARY_FOLDER.newFolder();
+		final Configuration initialConfiguration = new Configuration();
+
+		final Configuration configuration = loadConfiguration(workingDirectory, initialConfiguration);
+
+		// having not specified the ports should set the rest bind port to 0
+		assertThat(configuration.getInteger(RestOptions.PORT), is(equalTo(0)));
+	}
+
+	/**
+	 * Tests that the REST port option is respected if it has been specified.
+	 */
+	@Test
+	public void testRestPortSpecified() throws IOException {
+		final File workingDirectory = TEMPORARY_FOLDER.newFolder();
+		final Configuration initialConfiguration = new Configuration();
+		final int port = 1337;
+		initialConfiguration.setInteger(RestOptions.PORT, port);
+
+		final Configuration configuration = loadConfiguration(workingDirectory, initialConfiguration);
+
+		// having not specified the ports should set the rest bind port to 0
+		assertThat(configuration.getInteger(RestOptions.PORT), is(equalTo(port)));
+	}
+
+	@Nonnull
+	private Configuration loadConfiguration(File workingDirectory, Configuration initialConfiguration) throws IOException {
+		final Map<String, String> env = new HashMap<>(4);
+		env.put(ApplicationConstants.Environment.NM_HOST.key(), "foobar");
+
+		BootstrapTools.writeConfiguration(initialConfiguration, new File(workingDirectory, "flink-conf.yaml"));
+		return YarnEntrypointUtils.loadConfiguration(workingDirectory.getAbsolutePath(), env, LOG);
+	}
+
+}


### PR DESCRIPTION
Backport of #8096 for `release-1.7`.