### PR TITLE
[FLINK-12082] Bump up the jython-standalone version

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -5776,7 +5776,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Python Software Foundation License. (https://opensource.org/licenses/PythonSoftFoundation.php)
 See bundled license files for details.
 
-- org.python:jython-standalone:2.7.1
+- org.python:jython-standalone:2.7.1b3
 
 flink-metrics-graphite
 Copyright 2014-2019 The Apache Software Foundation

--- a/flink-libraries/flink-streaming-python/pom.xml
+++ b/flink-libraries/flink-streaming-python/pom.xml
@@ -61,7 +61,7 @@ under the License.
 		<dependency>
 			<groupId>org.python</groupId>
 			<artifactId>jython-standalone</artifactId>
-			<version>2.7.1</version>
+			<version>2.7.1b3</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-libraries/flink-streaming-python/src/main/resources/META-INF/NOTICE
+++ b/flink-libraries/flink-streaming-python/src/main/resources/META-INF/NOTICE
@@ -7,4 +7,4 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Python Software Foundation License. (https://opensource.org/licenses/PythonSoftFoundation.php)
 See bundled license files for details.
 
-- org.python:jython-standalone:2.7.1
+- org.python:jython-standalone:2.7.1b3


### PR DESCRIPTION
## What is the purpose of the change
This PR's  purpose  is  bump up the jython-standalone version

## Brief change log
- upgrade jython-standalone from 2.7.1 to 2.7.1b3 according to CVE-2016-4000


## Verifying this change


This change is already covered by existing tests in flink-streaming-python.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes /**no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes /**no** / don't know)
  - The S3 file system connector: (yes /**no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
