### PR TITLE
[FLINK-12087][table-runtime-blink] Introduce over window operators to blink batch

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.CAST;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.DIVIDE;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.EQUALS;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.GREATER_THAN;
@@ -87,5 +88,13 @@ public class ExpressionBuilder {
 
 	public static Expression greaterThan(Expression input1, Expression input2) {
 		return call(GREATER_THAN, input1, input2);
+	}
+
+	public static Expression cast(Expression input1, Expression input2) {
+		return call(CAST, input1, input2);
+	}
+
+	public static TypeLiteralExpression typeLiteral(TypeInformation<?> type) {
+		return new TypeLiteralExpression(type);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/LeadLagAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/LeadLagAggFunction.java
@@ -23,8 +23,10 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.runtime.over.frame.OffsetOverFrame;
+import org.apache.flink.table.type.DecimalType;
 import org.apache.flink.table.type.InternalType;
 import org.apache.flink.table.type.TypeConverters;
+import org.apache.flink.table.typeutils.BigDecimalTypeInfo;
 
 import static org.apache.flink.table.expressions.ExpressionBuilder.cast;
 import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
@@ -116,7 +118,175 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 
 		@Override
 		public TypeInformation getResultType() {
+			return Types.INT;
+		}
+	}
+
+	/**
+	 * ByteLeadLagAggFunction.
+	 */
+	public static class ByteLeadLagAggFunction extends LeadLagAggFunction {
+
+		public ByteLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.BYTE;
+		}
+	}
+
+	/**
+	 * ShortLeadLagAggFunction.
+	 */
+	public static class ShortLeadLagAggFunction extends LeadLagAggFunction {
+
+		public ShortLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SHORT;
+		}
+	}
+
+	/**
+	 * LongLeadLagAggFunction.
+	 */
+	public static class LongLeadLagAggFunction extends LeadLagAggFunction {
+
+		public LongLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.LONG;
+		}
+	}
+
+	/**
+	 * FloatLeadLagAggFunction.
+	 */
+	public static class FloatLeadLagAggFunction extends LeadLagAggFunction {
+
+		public FloatLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.FLOAT;
+		}
+	}
+
+	/**
+	 * DoubleLeadLagAggFunction.
+	 */
+	public static class DoubleLeadLagAggFunction extends LeadLagAggFunction {
+
+		public DoubleLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
 			return Types.DOUBLE;
+		}
+	}
+
+	/**
+	 * BooleanLeadLagAggFunction.
+	 */
+	public static class BooleanLeadLagAggFunction extends LeadLagAggFunction {
+
+		public BooleanLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.BOOLEAN;
+		}
+	}
+
+	/**
+	 * DecimalLeadLagAggFunction.
+	 */
+	public static class DecimalLeadLagAggFunction extends LeadLagAggFunction {
+
+		private final DecimalType decimalType;
+
+		public DecimalLeadLagAggFunction(int operandCount, DecimalType decimalType) {
+			super(operandCount);
+			this.decimalType = decimalType;
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return BigDecimalTypeInfo.of(decimalType.precision(), decimalType.scale());
+		}
+	}
+
+	/**
+	 * StringLeadLagAggFunction.
+	 */
+	public static class StringLeadLagAggFunction extends LeadLagAggFunction {
+
+		public StringLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.STRING;
+		}
+	}
+
+	/**
+	 * DateLeadLagAggFunction.
+	 */
+	public static class DateLeadLagAggFunction extends LeadLagAggFunction {
+
+		public DateLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_DATE;
+		}
+	}
+
+	/**
+	 * TimeLeadLagAggFunction.
+	 */
+	public static class TimeLeadLagAggFunction extends LeadLagAggFunction {
+
+		public TimeLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_TIME;
+		}
+	}
+
+	/**
+	 * TimestampLeadLagAggFunction.
+	 */
+	public static class TimestampLeadLagAggFunction extends LeadLagAggFunction {
+
+		public TimestampLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.SQL_TIMESTAMP;
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/LeadLagAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/LeadLagAggFunction.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
+import org.apache.flink.table.runtime.over.frame.OffsetOverFrame;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.TypeConverters;
+
+import static org.apache.flink.table.expressions.ExpressionBuilder.cast;
+import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
+import static org.apache.flink.table.expressions.ExpressionBuilder.typeLiteral;
+
+/**
+ * LEAD and LAG aggregate functions return the value of given expression evaluated at given offset.
+ * The functions only are used by over window.
+ *
+ * <p>LAG(input, offset, default) - Returns the value of `input` at the `offset`th row
+ * before the current row in the window. The default value of `offset` is 1 and the default
+ * value of `default` is null. If the value of `input` at the `offset`th row is null,
+ * null is returned. If there is no such offset row (e.g., when the offset is 1, the first
+ * row of the window does not have any previous row), `default` is returned.
+ *
+ * <p>LEAD(input, offset, default) - Returns the value of `input` at the `offset`th row
+ * after the current row in the window. The default value of `offset` is 1 and the default
+ * value of `default` is null. If the value of `input` at the `offset`th row is null,
+ * null is returned. If there is no such an offset row (e.g., when the offset is 1, the last
+ * row of the window does not have any subsequent row), `default` is returned.
+ *
+ * <p>These two aggregate functions are special, and only are used by over window. So here the
+ * concrete implementation is closely related to {@link OffsetOverFrame}.
+ */
+public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
+
+	private int operandCount;
+
+	//If the length of function's args is 3, then the function has the default value.
+	private boolean existDefaultValue;
+
+	private UnresolvedReferenceExpression value = new UnresolvedReferenceExpression("leadlag");
+
+	public LeadLagAggFunction(int operandCount) {
+		this.operandCount = operandCount;
+		existDefaultValue = operandCount == 3;
+	}
+
+	@Override
+	public int operandCount() {
+		return operandCount;
+	}
+
+	@Override
+	public UnresolvedReferenceExpression[] aggBufferAttributes() {
+		return new UnresolvedReferenceExpression[] {value};
+	}
+
+	@Override
+	public InternalType[] getAggBufferTypes() {
+		return new InternalType[] {TypeConverters.createInternalTypeFromTypeInfo(getResultType())};
+	}
+
+	@Override
+	public Expression[] initialValuesExpressions() {
+		return new Expression[] {literal(null, getResultType())};
+	}
+
+	@Override
+	public Expression[] accumulateExpressions() {
+		return new Expression[] {operand(0)};
+	}
+
+	// TODO hack, use the current input reset the buffer value.
+	@Override
+	public Expression[] retractExpressions() {
+		return new Expression[] {existDefaultValue ? cast(operand(2),
+				typeLiteral(getResultType())) : literal(null, getResultType())};
+	}
+
+	@Override
+	public Expression[] mergeExpressions() {
+		return new Expression[0];
+	}
+
+	@Override
+	public Expression getValueExpression() {
+		return value;
+	}
+
+	/**
+	 * IntLeadLagAggFunction.
+	 */
+	public static class IntLeadLagAggFunction extends LeadLagAggFunction {
+
+		public IntLeadLagAggFunction(int operandCount) {
+			super(operandCount);
+		}
+
+		@Override
+		public TypeInformation getResultType() {
+			return Types.DOUBLE;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/GeneratedAggsHandleFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/GeneratedAggsHandleFunction.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.generated;
 /**
  * Describes a generated {@link AggsHandleFunction}.
  */
-public final class GeneratedAggsHandleFunction extends GeneratedClass<AggsHandleFunction> {
+public class GeneratedAggsHandleFunction extends GeneratedClass<AggsHandleFunction> {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/BufferDataOverWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/BufferDataOverWindowOperator.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over;
+
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.JoinedRow;
+import org.apache.flink.table.generated.GeneratedRecordComparator;
+import org.apache.flink.table.generated.RecordComparator;
+import org.apache.flink.table.runtime.TableStreamOperator;
+import org.apache.flink.table.runtime.context.ExecutionContextImpl;
+import org.apache.flink.table.runtime.over.frame.OverWindowFrame;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+import org.apache.flink.table.runtime.util.StreamRecordCollector;
+import org.apache.flink.table.typeutils.AbstractRowSerializer;
+
+/**
+ * the operator for OVER window need cache data by ResettableExternalBuffer for {@link OverWindowFrame}.
+ */
+public class BufferDataOverWindowOperator extends TableStreamOperator<BaseRow>
+		implements OneInputStreamOperator<BaseRow, BaseRow> {
+
+	private final int memorySize;
+	private final OverWindowFrame[] overWindowFrames;
+	private GeneratedRecordComparator genComparator;
+	private final boolean isRowAllInFixedPart;
+
+	private RecordComparator partitionComparator;
+	private BaseRow lastInput;
+	private JoinedRow[] joinedRows;
+	private StreamRecordCollector<BaseRow> collector;
+	private AbstractRowSerializer<BaseRow> serializer;
+	private ResettableExternalBuffer currentData;
+
+	/**
+	 * @param memorySize           the memory is assigned to a resettable external buffer.
+	 * @param overWindowFrames     the window frames belong to this operator.
+	 * @param genComparator       the generated sort which is used for generating the comparator among
+	 */
+	public BufferDataOverWindowOperator(
+			int memorySize,
+			OverWindowFrame[] overWindowFrames,
+			GeneratedRecordComparator genComparator,
+			boolean isRowAllInFixedPart) {
+		this.memorySize = memorySize;
+		this.overWindowFrames = overWindowFrames;
+		this.genComparator = genComparator;
+		this.isRowAllInFixedPart = isRowAllInFixedPart;
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		ClassLoader cl = getUserCodeClassloader();
+		serializer = (AbstractRowSerializer) getOperatorConfig().getTypeSerializerIn1(cl);
+		partitionComparator = genComparator.newInstance(cl);
+		genComparator = null;
+
+		MemoryManager memManager = getContainingTask().getEnvironment().getMemoryManager();
+		this.currentData = new ResettableExternalBuffer(
+				getContainingTask().getEnvironment().getMemoryManager(),
+				getContainingTask().getEnvironment().getIOManager(),
+				memManager.allocatePages(this, memorySize / memManager.getPageSize()),
+				serializer, isRowAllInFixedPart);
+
+		collector = new StreamRecordCollector<>(output);
+		joinedRows = new JoinedRow[overWindowFrames.length];
+		for (int i = 0; i < overWindowFrames.length; i++) {
+			overWindowFrames[i].open(new ExecutionContextImpl(this, getRuntimeContext()));
+			joinedRows[i] = new JoinedRow();
+		}
+	}
+
+	@Override
+	public void processElement(StreamRecord<BaseRow> element) throws Exception {
+		BaseRow input = element.getValue();
+		if (lastInput != null && partitionComparator.compare(lastInput, input) != 0) {
+			processCurrentData();
+		}
+		lastInput = serializer.copy(input);
+		currentData.add(lastInput);
+	}
+
+	public void endInput() throws Exception {
+		if (currentData.size() > 0) {
+			processCurrentData();
+		}
+	}
+
+	private void processCurrentData() throws Exception {
+		currentData.complete();
+		for (OverWindowFrame frame : overWindowFrames) {
+			frame.prepare(currentData);
+		}
+		int rowIndex = 0;
+		ResettableExternalBuffer.BufferIterator bufferIterator = currentData.newIterator();
+		while (bufferIterator.advanceNext()) {
+			BinaryRow currentRow = bufferIterator.getRow();
+			BaseRow output = currentRow;
+			// TODO Reform AggsHandleFunction.getValue instead of use JoinedRow. Multilayer JoinedRow is slow.
+			for (int i = 0; i < overWindowFrames.length; i++) {
+				OverWindowFrame frame = overWindowFrames[i];
+				BaseRow value = frame.process(rowIndex, currentRow);
+				output = joinedRows[i].replace(output, value);
+			}
+			collector.collect(output);
+			rowIndex += 1;
+		}
+		bufferIterator.close();
+		currentData.reset();
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		this.currentData.close();
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/NonBufferOverWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/NonBufferOverWindowOperator.java
@@ -36,7 +36,9 @@ import org.apache.flink.table.typeutils.AbstractRowSerializer;
  * Then this operator can calculate the accumulator by the current row.
  *
  * <p>Some over windows do not need to buffer data, such as {@code rows between unbounded preceding and 0},
- * rank, etc. We introduce NonBufferOverWindowOperator to reduce the overhead of data copy in buffer.
+ * rank, etc. We introduce {@link NonBufferOverWindowOperator} to reduce the overhead of data copy in buffer.
+ *
+ * <p>NOTE: Use {@link NonBufferOverWindowOperator} only when all frames do not need buffer data.
  */
 public class NonBufferOverWindowOperator extends TableStreamOperator<BaseRow>
 		implements OneInputStreamOperator<BaseRow, BaseRow> {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/NonBufferOverWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/NonBufferOverWindowOperator.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over;
+
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.JoinedRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedRecordComparator;
+import org.apache.flink.table.generated.RecordComparator;
+import org.apache.flink.table.runtime.TableStreamOperator;
+import org.apache.flink.table.runtime.context.ExecutionContextImpl;
+import org.apache.flink.table.runtime.util.StreamRecordCollector;
+import org.apache.flink.table.typeutils.AbstractRowSerializer;
+
+/**
+ * The operator for OVER window don't need cache data.
+ * Then this operator can calculate the accumulator by the current row.
+ *
+ * <p>Some over windows do not need to buffer data, such as {@code rows between unbounded preceding and 0},
+ * rank, etc. We introduce NonBufferOverWindowOperator to reduce the overhead of data copy in buffer.
+ */
+public class NonBufferOverWindowOperator extends TableStreamOperator<BaseRow>
+		implements OneInputStreamOperator<BaseRow, BaseRow> {
+
+	private GeneratedAggsHandleFunction[] aggsHandlers;
+	private GeneratedRecordComparator genComparator;
+	private final boolean[] resetAccumulators;
+
+	private RecordComparator partitionComparator;
+	private BaseRow lastInput;
+	private AggsHandleFunction[] processors;
+	private JoinedRow[] joinedRows;
+	private StreamRecordCollector<BaseRow> collector;
+	private AbstractRowSerializer<BaseRow> serializer;
+
+	public NonBufferOverWindowOperator(
+			GeneratedAggsHandleFunction[] aggsHandlers,
+			GeneratedRecordComparator genComparator,
+			boolean[] resetAccumulators) {
+		this.aggsHandlers = aggsHandlers;
+		this.genComparator = genComparator;
+		this.resetAccumulators = resetAccumulators;
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		ClassLoader cl = getUserCodeClassloader();
+		serializer = (AbstractRowSerializer) getOperatorConfig().getTypeSerializerIn1(cl);
+		partitionComparator = genComparator.newInstance(cl);
+		genComparator = null;
+
+		collector = new StreamRecordCollector<>(output);
+		processors = new AggsHandleFunction[aggsHandlers.length];
+		joinedRows = new JoinedRow[aggsHandlers.length];
+		for (int i = 0; i < aggsHandlers.length; i++) {
+			AggsHandleFunction func = aggsHandlers[i].newInstance(cl);
+			func.open(new ExecutionContextImpl(this, getRuntimeContext()));
+			processors[i] = func;
+			joinedRows[i] = new JoinedRow();
+		}
+		aggsHandlers = null;
+	}
+
+	@Override
+	public void processElement(StreamRecord<BaseRow> element) throws Exception {
+		BaseRow input = element.getValue();
+		boolean changePartition = lastInput == null || partitionComparator.compare(lastInput, input) != 0;
+
+		//calculate the ACC
+		BaseRow output = input;
+		for (int i = 0; i < processors.length; i++) {
+			AggsHandleFunction processor = processors[i];
+
+			if (changePartition || resetAccumulators[i]) {
+				processor.setAccumulators(processor.createAccumulators());
+			}
+
+			// TODO Reform AggsHandleFunction.getValue instead of use JoinedRow. Multilayer JoinedRow is slow.
+			processor.accumulate(input);
+			BaseRow value = processor.getValue();
+			output = joinedRows[i].replace(output, value);
+		}
+		collector.collect(output);
+
+		if (changePartition) {
+			lastInput = serializer.copy(input);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/InsensitiveOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/InsensitiveOverFrame.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+
+/**
+ * The insensitive window frame calculates the statements which shouldn't care the window frame,
+ * for example RANK/DENSE_RANK/PERCENT_RANK/CUME_DIST/ROW_NUMBER.
+ */
+public class InsensitiveOverFrame implements OverWindowFrame {
+
+	private GeneratedAggsHandleFunction aggsHandleFunction;
+	private AggsHandleFunction processor;
+
+	public InsensitiveOverFrame(
+			GeneratedAggsHandleFunction aggsHandleFunction) {
+		this.aggsHandleFunction = aggsHandleFunction;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		processor = aggsHandleFunction.newInstance(ctx.getRuntimeContext().getUserCodeClassLoader());
+		processor.open(ctx);
+
+		this.aggsHandleFunction = null;
+	}
+
+	@Override
+	public void prepare(ResettableExternalBuffer rows) throws Exception {
+		//reset the accumulator value
+		processor.setAccumulators(processor.createAccumulators());
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		processor.accumulate(current);
+		return processor.getValue();
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/OffsetOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/OffsetOverFrame.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+
+import java.util.function.Function;
+
+/**
+ * The offset window frame calculates frames containing LEAD/LAG statements.
+ *
+ * <p>See {@code LeadLagAggFunction}.
+ */
+public class OffsetOverFrame implements OverWindowFrame {
+
+	private GeneratedAggsHandleFunction aggsHandleFunction;
+	private final long offset;
+	private final Function<BaseRow, Long> calcOffsetFunc;
+
+	private AggsHandleFunction processor;
+
+	//inputIterator and inputIndex are need when calcOffsetFunc is null.
+	private ResettableExternalBuffer.BufferIterator inputIterator;
+	private long inputIndex = 0L;
+
+	//externalBuffer is need when calcOffsetFunc is not null.
+	private ResettableExternalBuffer externalBuffer;
+
+	private long currentBufferLength = 0L;
+
+	/**
+	 * @param aggsHandleFunction the aggregate function
+	 * @param offset it means the offset within a partition if calcOffsetFunc is null.
+	 * @param calcOffsetFunc calculate the real offset when the function is not null.
+	 */
+	public OffsetOverFrame(
+			GeneratedAggsHandleFunction aggsHandleFunction,
+			long offset,
+			Function<BaseRow, Long> calcOffsetFunc) {
+		this.aggsHandleFunction = aggsHandleFunction;
+		this.offset = offset;
+		this.calcOffsetFunc = calcOffsetFunc;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		processor = aggsHandleFunction.newInstance(ctx.getRuntimeContext().getUserCodeClassLoader());
+		processor.open(ctx);
+
+		this.aggsHandleFunction = null;
+	}
+
+	@Override
+	public void prepare(ResettableExternalBuffer rows) throws Exception {
+		//reset the accumulator value
+		processor.setAccumulators(processor.createAccumulators());
+		currentBufferLength = rows.size();
+		inputIndex = offset;
+		if (calcOffsetFunc == null) {
+			if (inputIterator != null) {
+				inputIterator.close();
+			}
+			if (offset >= 0) {
+				inputIterator = rows.newIterator((int) offset);
+			} else {
+				inputIterator = rows.newIterator();
+			}
+		} else {
+			externalBuffer = rows;
+		}
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		if (calcOffsetFunc != null) {
+			//poor performance here
+			long realIndex = calcOffsetFunc.apply(current) + index;
+			if (realIndex >= 0 && realIndex < currentBufferLength) {
+				ResettableExternalBuffer.BufferIterator tempIterator = externalBuffer.newIterator((int) realIndex);
+				processor.accumulate(OverWindowFrame.getNextOrNull(tempIterator));
+				tempIterator.close();
+			} else {
+				// reset the default based current row
+				// NOTE: Special methods customized for LeadLagAggFunction.
+				// TODO refactor it.
+				processor.retract(current);
+			}
+		} else {
+			if (inputIndex >= 0 && inputIndex < currentBufferLength) {
+				processor.accumulate(OverWindowFrame.getNextOrNull(inputIterator));
+			} else {
+				//reset the default based current row
+				processor.retract(current);
+			}
+			inputIndex += 1;
+		}
+		return processor.getValue();
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/OverWindowFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/OverWindowFrame.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+
+import java.io.Serializable;
+
+/**
+ * A window frame calculates the results for those records belong to a window frame. Before use a frame
+ * must be prepared by passing it all the records in the current partition. A frame is a subset of the
+ * current partition and the frame clause specifies how to define the subset. Frames are determined with
+ * respect to the current row, which enables a frame to move within a partition depending on the location
+ * of the current row within its partition. More information:
+ * https://docs.oracle.com/cd/E17952_01/mysql-8.0-en/window-functions-frames.html
+ *
+ * <p>E.g.:
+ * SELECT d, e, f,
+ *  sum(e) over (partition by d order by e rows between 5 PRECEDING and 2 FOLLOWING),              -- frame 1
+ *  count(*) over (partition by d order by e desc rows between 6 PRECEDING and 2 FOLLOWING),       -- frame 2
+ *  max(f) over (partition by d order by e rows between UNBOUNDED PRECEDING and CURRENT ROW),      -- frame 3
+ *  min(h) over (partition by d order by e desc rows between CURRENT ROW and UNBOUNDED FOLLOWING), -- frame 4
+ *  h FROM Table5
+ * The above sql has 4 frames.
+ *
+ * <p>Over AGG means that every Row has a corresponding output.
+ * OverWindowFrame is called by:
+ * 1.Get all data and invoke {@link #prepare(ResettableExternalBuffer)} for partition
+ * 2.Then each Row is traversed one by one to invoke {@link #process(int, BaseRow)} to get the calculation
+ * results of the currentRow.
+ */
+public interface OverWindowFrame extends Serializable {
+
+	/**
+	 * Open to init with {@link ExecutionContext}.
+	 */
+	void open(ExecutionContext ctx) throws Exception;
+
+	/**
+	 * Prepare for next partition.
+	 */
+	void prepare(ResettableExternalBuffer rows) throws Exception;
+
+	/**
+	 * return the ACC of the window frame.
+	 */
+	BaseRow process(int index, BaseRow current) throws Exception;
+
+	/**
+	 * Get next row from iterator. Return null if iterator has no next.
+	 * TODO Maybe copy is repeated.
+	 */
+	static BinaryRow getNextOrNull(ResettableExternalBuffer.BufferIterator iterator) {
+		return iterator.advanceNext() ? iterator.getRow().copy() : null;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RangeSlidingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RangeSlidingOverFrame.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedRecordComparator;
+import org.apache.flink.table.generated.RecordComparator;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.type.RowType;
+
+/**
+ * The range sliding window frame calculates frames with the following SQL form:
+ * ... RANGE BETWEEN [window frame preceding] AND [window frame following]
+ * [window frame preceding] ::= [unsigned_value_specification] PRECEDING | CURRENT ROW
+ * [window frame following] ::= [unsigned_value_specification] FOLLOWING | CURRENT ROW
+ *
+ * <p>e.g.: ... RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING.
+ */
+public class RangeSlidingOverFrame extends SlidingOverFrame {
+
+	private GeneratedRecordComparator lboundComparator;
+	private GeneratedRecordComparator rboundComparator;
+
+	private RecordComparator lbound;
+	private RecordComparator rbound;
+
+	/**
+	 * @param lboundComparator comparator used to identify the lower bound of an output row.
+	 * @param rboundComparator comparator used to identify the upper bound of an output row.
+	 */
+	public RangeSlidingOverFrame(
+			RowType inputType,
+			RowType valueType,
+			GeneratedAggsHandleFunction aggsHandleFunction,
+			GeneratedRecordComparator lboundComparator,
+			GeneratedRecordComparator rboundComparator) {
+		super(inputType, valueType, aggsHandleFunction);
+		this.lboundComparator = lboundComparator;
+		this.rboundComparator = rboundComparator;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		super.open(ctx);
+		ClassLoader cl = ctx.getRuntimeContext().getUserCodeClassLoader();
+		lbound = lboundComparator.newInstance(cl);
+		rbound = rboundComparator.newInstance(cl);
+
+		this.lboundComparator = null;
+		this.rboundComparator = null;
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		boolean bufferUpdated = index == 0;
+
+		// Drop all rows from the buffer for which the input row value is smaller than
+		// the output row lower bound.
+		while (!buffer.isEmpty() && lbound.compare(buffer.peek(), current) < 0) {
+			buffer.remove();
+			bufferUpdated = true;
+		}
+
+		// Add all rows to the buffer for which the input row value is equal to or less than
+		// the output row upper bound.
+		while (nextRow != null && rbound.compare(nextRow, current) <= 0) {
+			if (lbound.compare(nextRow, current) >= 0) {
+				buffer.add(inputSer.copy(nextRow));
+				bufferUpdated = true;
+			}
+			nextRow = OverWindowFrame.getNextOrNull(inputIterator);
+		}
+
+		return accumulateBuffer(bufferUpdated);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RangeUnboundedFollowingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RangeUnboundedFollowingOverFrame.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedRecordComparator;
+import org.apache.flink.table.generated.RecordComparator;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+import org.apache.flink.table.type.RowType;
+
+/**
+ * The range unboundedFollowing window frame calculates frames with the following SQL form:
+ * ... RANGE BETWEEN [window frame preceding] AND UNBOUNDED FOLLOWING
+ * [window frame preceding] ::= [unsigned_value_specification] PRECEDING | CURRENT ROW
+ *
+ * <p>e.g.: ... RANGE BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING.
+ */
+public class RangeUnboundedFollowingOverFrame extends UnboundedFollowingOverFrame {
+
+	private GeneratedRecordComparator boundComparator;
+	private RecordComparator lbound;
+
+	public RangeUnboundedFollowingOverFrame(
+			RowType valueType,
+			GeneratedAggsHandleFunction aggsHandleFunction,
+			GeneratedRecordComparator boundComparator) {
+		super(valueType, aggsHandleFunction);
+		this.boundComparator = boundComparator;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		super.open(ctx);
+		lbound = boundComparator.newInstance(ctx.getRuntimeContext().getUserCodeClassLoader());
+		this.boundComparator = null;
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		boolean bufferUpdated = index == 0;
+
+		// Ignore all the rows from the buffer for which the input row value is smaller than
+		// the output row lower bound.
+		ResettableExternalBuffer.BufferIterator iterator = input.newIterator(inputIndex);
+
+		BinaryRow nextRow = OverWindowFrame.getNextOrNull(iterator);
+		while (nextRow != null && lbound.compare(nextRow, current) < 0) {
+			inputIndex += 1;
+			bufferUpdated = true;
+			nextRow = OverWindowFrame.getNextOrNull(iterator);
+		}
+
+		return accumulateIterator(bufferUpdated, nextRow, iterator);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RangeUnboundedPrecedingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RangeUnboundedPrecedingOverFrame.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedRecordComparator;
+import org.apache.flink.table.generated.RecordComparator;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+
+/**
+ * The range UnboundPreceding window frame calculates frames with the following SQL form:
+ * ... RANGE BETWEEN UNBOUNDED PRECEDING AND [window frame following]
+ * [window frame following] ::= [unsigned_value_specification] FOLLOWING | CURRENT ROW
+ *
+ * <p>e.g.: ... RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING.
+ */
+public class RangeUnboundedPrecedingOverFrame extends UnboundedPrecedingOverFrame {
+
+	private GeneratedRecordComparator boundComparator;
+	private RecordComparator rbound;
+
+	public RangeUnboundedPrecedingOverFrame(
+			GeneratedAggsHandleFunction aggsHandleFunction,
+			GeneratedRecordComparator boundComparator) {
+		super(aggsHandleFunction);
+		this.boundComparator = boundComparator;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		super.open(ctx);
+		rbound = boundComparator.newInstance(ctx.getRuntimeContext().getUserCodeClassLoader());
+		this.boundComparator = null;
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		boolean bufferUpdated = index == 0;
+
+		// Add all rows to the aggregates for which the input row value is equal to or less than
+		// the output row upper bound.
+		while (nextRow != null && rbound.compare(nextRow, current) <= 0) {
+			processor.accumulate(nextRow);
+			nextRow = OverWindowFrame.getNextOrNull(inputIterator);
+			bufferUpdated = true;
+		}
+		if (bufferUpdated) {
+			accValue = processor.getValue();
+		}
+		return accValue;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RowSlidingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RowSlidingOverFrame.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+import org.apache.flink.table.type.RowType;
+
+/**
+ * The row sliding window frame calculates frames with the following SQL form:
+ * ... ROW BETWEEN [window frame preceding] AND [window frame following]
+ * [window frame preceding] ::= [unsigned_value_specification] PRECEDING | CURRENT ROW
+ * [window frame following] ::= [unsigned_value_specification] FOLLOWING | CURRENT ROW
+ *
+ * <p>e.g.: ... ROW BETWEEN 1 PRECEDING AND 1 FOLLOWING.
+ */
+public class RowSlidingOverFrame extends SlidingOverFrame {
+
+	private final int leftBound;
+	private final int rightBound;
+
+	/**
+	 * Index of the right bound input row.
+	 */
+	private int inputRightIndex = 0;
+
+	/**
+	 * Index of the left bound input row.
+	 */
+	private int inputLeftIndex = 0;
+
+	public RowSlidingOverFrame(
+			RowType inputType,
+			RowType valueType,
+			GeneratedAggsHandleFunction aggsHandleFunction,
+			int leftBound,
+			int rightBound) {
+		super(inputType, valueType, aggsHandleFunction);
+		this.leftBound = leftBound;
+		this.rightBound = rightBound;
+	}
+
+	@Override
+	public void prepare(ResettableExternalBuffer rows) throws Exception {
+		super.prepare(rows);
+		inputRightIndex = 0;
+		inputLeftIndex = 0;
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		boolean bufferUpdated = index == 0;
+
+		// Drop all rows from the buffer util left bound.
+		while (!buffer.isEmpty() && inputLeftIndex < index - leftBound) {
+			buffer.remove();
+			inputLeftIndex += 1;
+			bufferUpdated = true;
+		}
+
+		// Add all rows to the buffer util right bound.
+		while (nextRow != null && inputRightIndex <= index + rightBound) {
+			if (inputLeftIndex < index - leftBound) {
+				inputLeftIndex += 1;
+			} else {
+				buffer.add(inputSer.copy(nextRow));
+				bufferUpdated = true;
+			}
+			nextRow = OverWindowFrame.getNextOrNull(inputIterator);
+			inputRightIndex += 1;
+		}
+
+		return accumulateBuffer(bufferUpdated);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RowUnboundedFollowingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RowUnboundedFollowingOverFrame.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+import org.apache.flink.table.type.RowType;
+
+/**
+ * The row unboundedFollowing window frame calculates frames with the following SQL form:
+ * ... ROW BETWEEN [window frame preceding] AND UNBOUNDED FOLLOWING
+ * [window frame preceding] ::= [unsigned_value_specification] PRECEDING | CURRENT ROW
+ *
+ * <p>e.g.: ... ROW BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING.
+ */
+public class RowUnboundedFollowingOverFrame extends UnboundedFollowingOverFrame {
+
+	private int leftBound;
+
+	public RowUnboundedFollowingOverFrame(
+			RowType valueType,
+			GeneratedAggsHandleFunction aggsHandleFunction,
+			int leftBound) {
+		super(valueType, aggsHandleFunction);
+		this.leftBound = leftBound;
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		boolean bufferUpdated = index == 0;
+
+		// Ignore all the rows from the buffer util left bound.
+		ResettableExternalBuffer.BufferIterator iterator = input.newIterator(inputIndex);
+
+		BinaryRow nextRow = OverWindowFrame.getNextOrNull(iterator);
+		while (nextRow != null && inputIndex < index - leftBound) {
+			inputIndex += 1;
+			bufferUpdated = true;
+			nextRow = OverWindowFrame.getNextOrNull(iterator);
+		}
+
+		return accumulateIterator(bufferUpdated, nextRow, iterator);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RowUnboundedPrecedingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/RowUnboundedPrecedingOverFrame.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+
+/**
+ * The row UnboundPreceding window frame calculates frames with the following SQL form:
+ * ... ROW BETWEEN UNBOUNDED PRECEDING AND [window frame following]
+ * [window frame following] ::= [unsigned_value_specification] FOLLOWING | CURRENT ROW
+ *
+ * <p>e.g.: ... ROW BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING.
+ */
+public class RowUnboundedPrecedingOverFrame extends UnboundedPrecedingOverFrame {
+
+	private int rightBound;
+
+	/**
+	 * Index of the right bound input row.
+	 */
+	private int inputRightIndex = 0;
+
+	public RowUnboundedPrecedingOverFrame(
+			GeneratedAggsHandleFunction aggsHandleFunction, int rightBound) {
+		super(aggsHandleFunction);
+		this.rightBound = rightBound;
+	}
+
+	@Override
+	public void prepare(ResettableExternalBuffer rows) throws Exception {
+		super.prepare(rows);
+		inputRightIndex = 0;
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		boolean bufferUpdated = index == 0;
+
+		// Add all rows to the aggregates util right bound.
+		while (nextRow != null && inputRightIndex <= index + rightBound) {
+			processor.accumulate(nextRow);
+			nextRow = OverWindowFrame.getNextOrNull(inputIterator);
+			inputRightIndex += 1;
+			bufferUpdated = true;
+		}
+		if (bufferUpdated) {
+			accValue = processor.getValue();
+		}
+		return accValue;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/SlidingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/SlidingOverFrame.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+import org.apache.flink.table.type.RowType;
+import org.apache.flink.table.typeutils.BaseRowSerializer;
+
+import java.util.ArrayDeque;
+
+/**
+ * The sliding window frame.
+ * See {@link RowSlidingOverFrame} and {@link RangeSlidingOverFrame}.
+ */
+public abstract class SlidingOverFrame implements OverWindowFrame {
+
+	private final RowType inputType;
+	private final RowType valueType;
+	private GeneratedAggsHandleFunction aggsHandleFunction;
+
+	private transient AggsHandleFunction processor;
+	transient BaseRowSerializer inputSer;
+	private transient BaseRowSerializer valueSer;
+
+	transient ResettableExternalBuffer.BufferIterator inputIterator;
+
+	/** The next row from `input`. */
+	transient BinaryRow nextRow;
+
+	/** The rows within current sliding window. */
+	transient ArrayDeque<BaseRow> buffer;
+
+	private transient BaseRow accValue;
+
+	public SlidingOverFrame(
+			RowType inputType,
+			RowType valueType,
+			GeneratedAggsHandleFunction aggsHandleFunction) {
+		this.inputType = inputType;
+		this.valueType = valueType;
+		this.aggsHandleFunction = aggsHandleFunction;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		ExecutionConfig conf = ctx.getRuntimeContext().getExecutionConfig();
+		this.inputSer = new BaseRowSerializer(conf, inputType.getFieldTypes());
+		this.valueSer = new BaseRowSerializer(conf, valueType.getFieldTypes());
+
+		ClassLoader cl = ctx.getRuntimeContext().getUserCodeClassLoader();
+		processor = aggsHandleFunction.newInstance(cl);
+		processor.open(ctx);
+		buffer = new ArrayDeque<>();
+		this.aggsHandleFunction = null;
+	}
+
+	@Override
+	public void prepare(ResettableExternalBuffer rows) throws Exception {
+		if (inputIterator != null) {
+			inputIterator.close();
+		}
+		inputIterator = rows.newIterator();
+		nextRow = OverWindowFrame.getNextOrNull(inputIterator);
+		buffer.clear();
+		//cleanup the retired accumulators value
+		processor.setAccumulators(processor.createAccumulators());
+	}
+
+	BaseRow accumulateBuffer(boolean bufferUpdated) throws Exception {
+		// Only recalculate and update when the buffer changes.
+		if (bufferUpdated) {
+			//cleanup the retired accumulators value
+			processor.setAccumulators(processor.createAccumulators());
+			for (BaseRow row : buffer) {
+				processor.accumulate(row);
+			}
+			accValue = valueSer.copy(processor.getValue());
+		}
+		return accValue;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/UnboundedFollowingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/UnboundedFollowingOverFrame.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+import org.apache.flink.table.type.RowType;
+import org.apache.flink.table.typeutils.BaseRowSerializer;
+
+/**
+ * The UnboundedFollowing window frame.
+ * See {@link RowUnboundedFollowingOverFrame} and {@link RangeUnboundedFollowingOverFrame}.
+ */
+public abstract class UnboundedFollowingOverFrame implements OverWindowFrame {
+
+	private GeneratedAggsHandleFunction aggsHandleFunction;
+	private final RowType valueType;
+
+	private AggsHandleFunction processor;
+	private BaseRow accValue;
+
+	/** Rows of the partition currently being processed. */
+	ResettableExternalBuffer input;
+
+	private BaseRowSerializer valueSer;
+
+	/**
+	 * Index of the first input row with a value equal to or greater than the lower bound of the
+	 * current output row.
+	 */
+	int inputIndex = 0;
+
+	public UnboundedFollowingOverFrame(
+			RowType valueType,
+			GeneratedAggsHandleFunction aggsHandleFunction) {
+		this.valueType = valueType;
+		this.aggsHandleFunction = aggsHandleFunction;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		ClassLoader cl = ctx.getRuntimeContext().getUserCodeClassLoader();
+		processor = aggsHandleFunction.newInstance(cl);
+		processor.open(ctx);
+
+		this.aggsHandleFunction = null;
+		this.valueSer = new BaseRowSerializer(ctx.getRuntimeContext().getExecutionConfig(), valueType.getFieldTypes());
+	}
+
+	@Override
+	public void prepare(ResettableExternalBuffer rows) throws Exception {
+		input = rows;
+		//cleanup the retired accumulators value
+		processor.setAccumulators(processor.createAccumulators());
+		inputIndex = 0;
+	}
+
+	BaseRow accumulateIterator(
+			boolean bufferUpdated,
+			BinaryRow firstRow,
+			ResettableExternalBuffer.BufferIterator iterator) throws Exception {
+		// Only recalculate and update when the buffer changes.
+		if (bufferUpdated) {
+			//cleanup the retired accumulators value
+			processor.setAccumulators(processor.createAccumulators());
+
+			if (firstRow != null) {
+				processor.accumulate(firstRow);
+			}
+			while (iterator.advanceNext()) {
+				processor.accumulate(iterator.getRow());
+			}
+			accValue = valueSer.copy(processor.getValue());
+		}
+		iterator.close();
+		return accValue;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/UnboundedOverWindowFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/UnboundedOverWindowFrame.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+import org.apache.flink.table.type.RowType;
+import org.apache.flink.table.typeutils.BaseRowSerializer;
+
+/**
+ * The unbounded window frame calculates frames with the following SQL forms:
+ * ... (No Frame Definition)
+ * ... BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+ */
+public class UnboundedOverWindowFrame implements OverWindowFrame {
+
+	private GeneratedAggsHandleFunction aggsHandleFunction;
+	private final RowType valueType;
+
+	private AggsHandleFunction processor;
+	private BaseRow accValue;
+
+	private BaseRowSerializer valueSer;
+
+	public UnboundedOverWindowFrame(
+			GeneratedAggsHandleFunction aggsHandleFunction,
+			RowType valueType) {
+		this.aggsHandleFunction = aggsHandleFunction;
+		this.valueType = valueType;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		ClassLoader cl = ctx.getRuntimeContext().getUserCodeClassLoader();
+		processor = aggsHandleFunction.newInstance(cl);
+		processor.open(ctx);
+		this.aggsHandleFunction = null;
+		this.valueSer = new BaseRowSerializer(ctx.getRuntimeContext().getExecutionConfig(), valueType.getFieldTypes());
+	}
+
+	@Override
+	public void prepare(ResettableExternalBuffer rows) throws Exception {
+		//cleanup the retired accumulators value
+		processor.setAccumulators(processor.createAccumulators());
+		ResettableExternalBuffer.BufferIterator iterator = rows.newIterator();
+		while (iterator.advanceNext()) {
+			processor.accumulate(iterator.getRow());
+		}
+		accValue = valueSer.copy(processor.getValue());
+		iterator.close();
+	}
+
+	@Override
+	public BaseRow process(int index, BaseRow current) throws Exception {
+		return accValue;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/UnboundedPrecedingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/frame/UnboundedPrecedingOverFrame.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over.frame;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+
+/**
+ * The UnboundedPreceding window frame.
+ * See {@link RowUnboundedPrecedingOverFrame} and {@link RangeUnboundedPrecedingOverFrame}.
+ */
+public abstract class UnboundedPrecedingOverFrame implements OverWindowFrame {
+
+	private GeneratedAggsHandleFunction aggsHandleFunction;
+
+	AggsHandleFunction processor;
+	BaseRow accValue;
+
+	/**
+	 * An iterator over the input.
+	 */
+	ResettableExternalBuffer.BufferIterator inputIterator;
+
+	/** The next row from `input`. */
+	BinaryRow nextRow;
+
+	public UnboundedPrecedingOverFrame(GeneratedAggsHandleFunction aggsHandleFunction) {
+		this.aggsHandleFunction = aggsHandleFunction;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+		ClassLoader cl = ctx.getRuntimeContext().getUserCodeClassLoader();
+		processor = aggsHandleFunction.newInstance(cl);
+		processor.open(ctx);
+		this.aggsHandleFunction = null;
+	}
+
+	@Override
+	public void prepare(ResettableExternalBuffer rows) throws Exception {
+		if (inputIterator != null) {
+			inputIterator.close();
+		}
+		inputIterator = rows.newIterator();
+		if (inputIterator.advanceNext()) {
+			nextRow = inputIterator.getRow().copy();
+		}
+		//reset the accumulators value
+		processor.setAccumulators(processor.createAccumulators());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/over/BufferDataOverWindowOperatorTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over;
+
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.generated.GeneratedRecordComparator;
+import org.apache.flink.table.generated.RecordComparator;
+import org.apache.flink.table.runtime.over.frame.InsensitiveOverFrame;
+import org.apache.flink.table.runtime.over.frame.OffsetOverFrame;
+import org.apache.flink.table.runtime.over.frame.OverWindowFrame;
+import org.apache.flink.table.runtime.over.frame.RangeSlidingOverFrame;
+import org.apache.flink.table.runtime.over.frame.RangeUnboundedFollowingOverFrame;
+import org.apache.flink.table.runtime.over.frame.RangeUnboundedPrecedingOverFrame;
+import org.apache.flink.table.runtime.over.frame.RowSlidingOverFrame;
+import org.apache.flink.table.runtime.over.frame.RowUnboundedFollowingOverFrame;
+import org.apache.flink.table.runtime.over.frame.RowUnboundedPrecedingOverFrame;
+import org.apache.flink.table.runtime.over.frame.UnboundedOverWindowFrame;
+import org.apache.flink.table.type.InternalTypes;
+import org.apache.flink.table.type.RowType;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.apache.flink.table.runtime.over.NonBufferOverWindowOperatorTest.comparator;
+import static org.apache.flink.table.runtime.over.NonBufferOverWindowOperatorTest.function;
+import static org.apache.flink.table.runtime.over.NonBufferOverWindowOperatorTest.inputSer;
+import static org.apache.flink.table.runtime.over.NonBufferOverWindowOperatorTest.inputType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link BufferDataOverWindowOperator}.
+ */
+public class BufferDataOverWindowOperatorTest {
+
+	private static final int MEMORY_SIZE = 50 * 1024 * 32;
+	private RowType valueType = new RowType(InternalTypes.LONG);
+
+	private List<GenericRow> collect;
+	private MemoryManager memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+	private IOManager ioManager;
+	private BufferDataOverWindowOperator operator;
+	private GeneratedRecordComparator boundComparator = new GeneratedRecordComparator("", "", new Object[0]) {
+		@Override
+		public RecordComparator newInstance(ClassLoader classLoader) {
+			return (RecordComparator) (o1, o2) -> (int) (o1.getLong(1) - o2.getLong(1));
+		}
+	};
+
+	@Before
+	public void before() throws Exception {
+		ioManager = new IOManagerAsync();
+		collect = new ArrayList<>();
+	}
+
+	@Test
+	public void testOffsetWindowFrame() throws Exception {
+		test(new OverWindowFrame[] {
+				new OffsetOverFrame(function, 2, null),
+						new OffsetOverFrame(function, 1, r -> (long) r.getInt(0))},
+				new GenericRow[] {
+				GenericRow.of(0, 1L, 4L, 1L, 1L),
+				GenericRow.of(0, 1L, 1L, 2L, 2L),
+				GenericRow.of(0, 1L, 1L, 1L, 3L),
+				GenericRow.of(0, 1L, 1L, 0L, 4L),
+				GenericRow.of(1, 5L, 2L, -5L, -5L),
+				GenericRow.of(2, 5L, 4L, 6L, 6L),
+				GenericRow.of(2, 6L, 2L, 12L, 12L),
+				GenericRow.of(2, 6L, 2L, 6L, 6L),
+				GenericRow.of(2, 6L, 2L, 0L, 0L)
+		});
+	}
+
+	@Test
+	public void testInsensitiveAndUnbounded() throws Exception {
+		test(new OverWindowFrame[] {
+						new InsensitiveOverFrame(function),
+						new UnboundedOverWindowFrame(function, new RowType(InternalTypes.LONG))},
+				new GenericRow[] {
+						GenericRow.of(0, 1L, 4L, 1L, 4L),
+						GenericRow.of(0, 1L, 1L, 2L, 4L),
+						GenericRow.of(0, 1L, 1L, 3L, 4L),
+						GenericRow.of(0, 1L, 1L, 4L, 4L),
+						GenericRow.of(1, 5L, 2L, 5L, 5L),
+						GenericRow.of(2, 5L, 4L, 5L, 23L),
+						GenericRow.of(2, 6L, 2L, 11L, 23L),
+						GenericRow.of(2, 6L, 2L, 17L, 23L),
+						GenericRow.of(2, 6L, 2L, 23L, 23L)
+				});
+	}
+
+	@Test
+	public void testPreceding() throws Exception {
+		test(new OverWindowFrame[] {
+						new RowUnboundedPrecedingOverFrame(function, 1),
+						new RangeUnboundedPrecedingOverFrame(function, boundComparator)},
+				new GenericRow[] {
+						GenericRow.of(0, 1L, 4L, 2L, 4L),
+						GenericRow.of(0, 1L, 1L, 3L, 4L),
+						GenericRow.of(0, 1L, 1L, 4L, 4L),
+						GenericRow.of(0, 1L, 1L, 4L, 4L),
+						GenericRow.of(1, 5L, 2L, 5L, 5L),
+						GenericRow.of(2, 5L, 4L, 11L, 5L),
+						GenericRow.of(2, 6L, 2L, 17L, 23L),
+						GenericRow.of(2, 6L, 2L, 23L, 23L),
+						GenericRow.of(2, 6L, 2L, 23L, 23L)
+				});
+	}
+
+	@Test
+	public void testFollowing() throws Exception {
+		test(new OverWindowFrame[] {
+						new RowUnboundedFollowingOverFrame(valueType, function, 1),
+						new RangeUnboundedFollowingOverFrame(valueType, function, boundComparator)},
+				new GenericRow[] {
+						GenericRow.of(0, 1L, 4L, 4L, 4L),
+						GenericRow.of(0, 1L, 1L, 4L, 4L),
+						GenericRow.of(0, 1L, 1L, 3L, 4L),
+						GenericRow.of(0, 1L, 1L, 2L, 4L),
+						GenericRow.of(1, 5L, 2L, 5L, 5L),
+						GenericRow.of(2, 5L, 4L, 23L, 23L),
+						GenericRow.of(2, 6L, 2L, 23L, 18L),
+						GenericRow.of(2, 6L, 2L, 18L, 18L),
+						GenericRow.of(2, 6L, 2L, 12L, 18L)
+				});
+	}
+
+	@Test
+	public void testSliding() throws Exception {
+		test(new OverWindowFrame[] {
+						new RowSlidingOverFrame(inputType, valueType, function, 1, 1),
+						new RangeSlidingOverFrame(inputType, valueType, function, boundComparator, boundComparator)},
+				new GenericRow[] {
+						GenericRow.of(0, 1L, 4L, 2L, 4L),
+						GenericRow.of(0, 1L, 1L, 3L, 4L),
+						GenericRow.of(0, 1L, 1L, 3L, 4L),
+						GenericRow.of(0, 1L, 1L, 2L, 4L),
+						GenericRow.of(1, 5L, 2L, 5L, 5L),
+						GenericRow.of(2, 5L, 4L, 11L, 5L),
+						GenericRow.of(2, 6L, 2L, 17L, 18L),
+						GenericRow.of(2, 6L, 2L, 18L, 18L),
+						GenericRow.of(2, 6L, 2L, 12L, 18L)
+				});
+	}
+
+	private void test(OverWindowFrame[] frames, GenericRow[] expect) throws Exception {
+		operator = new BufferDataOverWindowOperator(MEMORY_SIZE, frames, comparator, true) {
+			{
+				output = new NonBufferOverWindowOperatorTest.ConsumerOutput(new Consumer<BaseRow>() {
+					@Override
+					public void accept(BaseRow r) {
+						collect.add(GenericRow.of(r.getInt(0), r.getLong(1),
+								r.getLong(2), r.getLong(3), r.getLong(4)));
+					}
+				});
+			}
+
+			@Override
+			public ClassLoader getUserCodeClassloader() {
+				return Thread.currentThread().getContextClassLoader();
+			}
+
+			@Override
+			public StreamConfig getOperatorConfig() {
+				StreamConfig conf = mock(StreamConfig.class);
+				when(conf.<BaseRow>getTypeSerializerIn1(getUserCodeClassloader()))
+						.thenReturn(inputSer);
+				return conf;
+			}
+
+			@Override
+			public StreamTask<?, ?> getContainingTask() {
+				StreamTask task = mock(StreamTask.class);
+				Environment env = mock(Environment.class);
+				when(task.getEnvironment()).thenReturn(env);
+				when(env.getMemoryManager()).thenReturn(memoryManager);
+				when(env.getIOManager()).thenReturn(ioManager);
+				return task;
+			}
+
+			@Override
+			public StreamingRuntimeContext getRuntimeContext() {
+				return mock(StreamingRuntimeContext.class);
+			}
+		};
+		operator.open();
+		addRow(0, 1L, 4L); /* 1 **/
+		addRow(0, 1L, 1L); /* 2 **/
+		addRow(0, 1L, 1L); /* 3 **/
+		addRow(0, 1L, 1L); /* 4 **/
+		addRow(1, 5L, 2L); /* 5 **/
+		addRow(2, 5L, 4L); /* 6 **/
+		addRow(2, 6L, 2L); /* 7 **/
+		addRow(2, 6L, 2L); /* 8 **/
+		addRow(2, 6L, 2L); /* 9 **/
+		operator.endInput();
+		GenericRow[] outputs = this.collect.toArray(new GenericRow[0]);
+		Assert.assertArrayEquals(expect, outputs);
+		operator.close();
+	}
+
+	private void addRow(Object... fields) throws Exception {
+		operator.processElement(new StreamRecord<>(GenericRow.of(fields)));
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/over/NonBufferOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/over/NonBufferOverWindowOperatorTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.generated.GeneratedRecordComparator;
+import org.apache.flink.table.generated.RecordComparator;
+import org.apache.flink.table.runtime.sort.IntRecordComparator;
+import org.apache.flink.table.type.InternalTypes;
+import org.apache.flink.table.type.RowType;
+import org.apache.flink.table.typeutils.BaseRowSerializer;
+import org.apache.flink.util.OutputTag;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link NonBufferOverWindowOperator}.
+ */
+public class NonBufferOverWindowOperatorTest {
+
+	static GeneratedAggsHandleFunction function =
+			new GeneratedAggsHandleFunction("Function1", "", new Object[0]) {
+		@Override
+		public AggsHandleFunction newInstance(ClassLoader classLoader) {
+			return new SumAggsHandleFunction(1);
+		}
+	};
+	static GeneratedRecordComparator comparator = new GeneratedRecordComparator("Comparator", "", new Object[0]) {
+		@Override
+		public RecordComparator newInstance(ClassLoader classLoader) {
+			return new IntRecordComparator();
+		}
+	};
+	static RowType inputType = new RowType(InternalTypes.INT, InternalTypes.LONG, InternalTypes.LONG);
+	static BaseRowSerializer inputSer = new BaseRowSerializer(
+			new ExecutionConfig(),
+			inputType.getFieldTypes());
+
+	private static GeneratedAggsHandleFunction[] functions;
+
+	static {
+		GeneratedAggsHandleFunction function2 = new GeneratedAggsHandleFunction("Function2", "", new Object[0]) {
+			@Override
+			public AggsHandleFunction newInstance(ClassLoader classLoader) {
+				return new SumAggsHandleFunction(2);
+			}
+		};
+		functions = new GeneratedAggsHandleFunction[] {function, function2};
+	}
+
+	private NonBufferOverWindowOperator operator;
+	private List<GenericRow> collect;
+
+	@Before
+	public void before() throws Exception {
+		collect = new ArrayList<>();
+	}
+
+	@Test
+	public void testNormal() throws Exception {
+		test(new boolean[] {false, false}, new GenericRow[] {
+				GenericRow.of(0, 1L, 4L, 1L, 4L),
+				GenericRow.of(0, 1L, 1L, 2L, 5L),
+				GenericRow.of(1, 5L, 2L, 5L, 2L),
+				GenericRow.of(2, 5L, 4L, 5L, 4L),
+				GenericRow.of(2, 6L, 2L, 11L, 6L)
+		});
+	}
+
+	@Test
+	public void testResetAccumulators() throws Exception {
+		test(new boolean[] {true, false}, new GenericRow[] {
+				GenericRow.of(0, 1L, 4L, 1L, 4L),
+				GenericRow.of(0, 1L, 1L, 1L, 5L),
+				GenericRow.of(1, 5L, 2L, 5L, 2L),
+				GenericRow.of(2, 5L, 4L, 5L, 4L),
+				GenericRow.of(2, 6L, 2L, 6L, 6L)
+		});
+	}
+
+	private void test(boolean[] resetAccumulators, GenericRow[] expect) throws Exception {
+		operator = new NonBufferOverWindowOperator(functions, comparator, resetAccumulators) {
+			{
+				output = new ConsumerOutput(new Consumer<BaseRow>() {
+					@Override
+					public void accept(BaseRow r) {
+						collect.add(GenericRow.of(r.getInt(0), r.getLong(1),
+								r.getLong(2), r.getLong(3), r.getLong(4)));
+					}
+				});
+			}
+
+			@Override
+			public ClassLoader getUserCodeClassloader() {
+				return Thread.currentThread().getContextClassLoader();
+			}
+
+			@Override
+			public StreamConfig getOperatorConfig() {
+				StreamConfig conf = mock(StreamConfig.class);
+				when(conf.<BaseRow>getTypeSerializerIn1(getUserCodeClassloader()))
+						.thenReturn(inputSer);
+				return conf;
+			}
+
+			@Override
+			public StreamingRuntimeContext getRuntimeContext() {
+				return mock(StreamingRuntimeContext.class);
+			}
+		};
+		operator.open();
+		addRow(0, 1L, 4L);
+		addRow(0, 1L, 1L);
+		addRow(1, 5L, 2L);
+		addRow(2, 5L, 4L);
+		addRow(2, 6L, 2L);
+		GenericRow[] outputs = this.collect.toArray(new GenericRow[0]);
+		Assert.assertArrayEquals(expect, outputs);
+	}
+
+	private void addRow(Object... fields) throws Exception {
+		operator.processElement(new StreamRecord<>(GenericRow.of(fields)));
+	}
+
+	/**
+	 * Output of Consumer.
+	 */
+	static class ConsumerOutput implements Output<StreamRecord<BaseRow>> {
+
+		private final Consumer<BaseRow> consumer;
+
+		public ConsumerOutput(Consumer<BaseRow> consumer) {
+			this.consumer = consumer;
+		}
+
+		@Override
+		public void emitWatermark(Watermark mark) {
+			throw new RuntimeException();
+		}
+
+		@Override
+		public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+			throw new RuntimeException();
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) {
+			throw new RuntimeException();
+		}
+
+		@Override
+		public void collect(StreamRecord<BaseRow> record) {
+			consumer.accept(record.getValue());
+		}
+
+		@Override
+		public void close() {}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/over/SumAggsHandleFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/over/SumAggsHandleFunction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.over;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.generated.AggsHandleFunction;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+
+/**
+ * Test {@link AggsHandleFunction}.
+ */
+public class SumAggsHandleFunction implements AggsHandleFunction {
+
+	private final int inputIndex;
+	private long sum;
+
+	public SumAggsHandleFunction(int inputIndex) {
+		this.inputIndex = inputIndex;
+	}
+
+	@Override
+	public void open(ExecutionContext ctx) throws Exception {
+	}
+
+	@Override
+	public void accumulate(BaseRow input) throws Exception {
+		sum += input.getLong(inputIndex);
+	}
+
+	@Override
+	public void retract(BaseRow input) throws Exception {
+		sum -= input.getLong(inputIndex);
+	}
+
+	@Override
+	public void merge(BaseRow accumulator) throws Exception {
+		sum += accumulator.getLong(0);
+	}
+
+	@Override
+	public void setAccumulators(BaseRow accumulator) throws Exception {
+		sum = accumulator.getLong(0);
+	}
+
+	@Override
+	public void resetAccumulators() throws Exception {
+		sum  = 0L;
+	}
+
+	@Override
+	public BaseRow getAccumulators() throws Exception {
+		return GenericRow.of(sum);
+	}
+
+	@Override
+	public BaseRow createAccumulators() throws Exception {
+		return GenericRow.of(0L);
+	}
+
+	@Override
+	public BaseRow getValue() throws Exception {
+		return getAccumulators();
+	}
+
+	@Override
+	public void cleanup() throws Exception {
+	}
+
+	@Override
+	public void close() throws Exception {
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce NonBufferOverWindowOperator: Some over windows do not need to buffer data, such as rank, rows between unbounded preceding and 0, etc. We introduce NonBufferOverWindowOperator to reduce the overhead of data copy in buffer.

Introduce BufferDataOverWindowOperator and OverWindowFrame: 1. Minimize duplicate computation in various OverWindowFrame implementations. 2. An OverWindowOperator can compute multiple window frames.

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
