### PR TITLE
[FLINK-11309][core] Make blocking result partitions consumable 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
@@ -34,7 +34,8 @@ public interface NetworkSequenceViewReader {
 	void requestSubpartitionView(
 		ResultPartitionProvider partitionProvider,
 		ResultPartitionID resultPartitionId,
-		int subPartitionIndex) throws IOException;
+		int subPartitionIndex,
+		int attemptNumber) throws IOException;
 
 	BufferAndAvailability getNextBuffer() throws IOException, InterruptedException;
 
@@ -61,7 +62,7 @@ public interface NetworkSequenceViewReader {
 	 */
 	void setRegisteredAsAvailable(boolean isRegisteredAvailable);
 
-	void notifySubpartitionConsumed() throws IOException;
+	void notifySubpartitionConsumed(boolean finalRelease) throws IOException;
 
 	boolean isReleased();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -75,7 +75,8 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 	public void requestSubpartitionView(
 		ResultPartitionProvider partitionProvider,
 		ResultPartitionID resultPartitionId,
-		int subPartitionIndex) throws IOException {
+		int subPartitionIndex,
+		int attemptNumber) throws IOException {
 
 		synchronized (requestLock) {
 			if (subpartitionView == null) {
@@ -86,6 +87,7 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 				this.subpartitionView = partitionProvider.createSubpartitionView(
 					resultPartitionId,
 					subPartitionIndex,
+					attemptNumber,
 					this);
 			} else {
 				throw new IllegalStateException("Subpartition already requested");
@@ -173,8 +175,8 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() throws IOException {
-		subpartitionView.notifySubpartitionConsumed();
+	public void notifySubpartitionConsumed(boolean finalRelease) throws IOException {
+		subpartitionView.notifySubpartitionConsumed(finalRelease);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
@@ -59,7 +59,8 @@ class SequenceNumberingViewReader implements BufferAvailabilityListener, Network
 	public void requestSubpartitionView(
 		ResultPartitionProvider partitionProvider,
 		ResultPartitionID resultPartitionId,
-		int subPartitionIndex) throws IOException {
+		int subPartitionIndex,
+		int attemptNumber) throws IOException {
 
 		synchronized (requestLock) {
 			if (subpartitionView == null) {
@@ -70,6 +71,7 @@ class SequenceNumberingViewReader implements BufferAvailabilityListener, Network
 				this.subpartitionView = partitionProvider.createSubpartitionView(
 					resultPartitionId,
 					subPartitionIndex,
+					attemptNumber,
 					this);
 			} else {
 				throw new IllegalStateException("Subpartition already requested");
@@ -118,8 +120,8 @@ class SequenceNumberingViewReader implements BufferAvailabilityListener, Network
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() throws IOException {
-		subpartitionView.notifySubpartitionConsumed();
+	public void notifySubpartitionConsumed(boolean finalRelease) throws IOException {
+		subpartitionView.notifySubpartitionConsumed(finalRelease);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -40,7 +41,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * <p>Whenever {@link #add(BufferConsumer)} adds a finished {@link BufferConsumer} or a second
  * {@link BufferConsumer} (in which case we will assume the first one finished), we will
  * {@link PipelinedSubpartitionView#notifyDataAvailable() notify} a read view created via
- * {@link #createReadView(BufferAvailabilityListener)} of new data availability. Except by calling
+ * {@link #createReadView(int, BufferAvailabilityListener)} of new data availability. Except by calling
  * {@link #flush()} explicitly, we always only notify when the first finished buffer turns up and
  * then, the reader has to drain the buffers via {@link #pollBuffer()} until its return value shows
  * no more buffers being available. This results in a buffer queue which is either empty or has an
@@ -68,10 +69,14 @@ class PipelinedSubpartition extends ResultSubpartition {
 	/** Flag indicating whether the subpartition has been released. */
 	private volatile boolean isReleased;
 
+	/** All buffers of this subpartition. Access to the buffers is synchronized on this object. */
+	protected final ArrayDeque<BufferConsumer> buffers = new ArrayDeque<>();
+
 	// ------------------------------------------------------------------------
 
 	PipelinedSubpartition(int index, ResultPartition parent) {
 		super(index, parent);
+		baseBuffers = buffers;
 	}
 
 	@Override
@@ -83,6 +88,13 @@ class PipelinedSubpartition extends ResultSubpartition {
 	public void finish() throws IOException {
 		add(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE), true);
 		LOG.debug("{}: Finished {}.", parent.getOwningTaskName(), this);
+	}
+
+	@Override
+	protected void onConsumedSubpartition(boolean finalRelease) {
+		if (finalRelease) {
+			parent.onConsumedSubpartition(index);
+		}
 	}
 
 	private boolean add(BufferConsumer bufferConsumer, boolean finish) {
@@ -219,7 +231,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 	}
 
 	@Override
-	public PipelinedSubpartitionView createReadView(BufferAvailabilityListener availabilityListener) throws IOException {
+	public PipelinedSubpartitionView createReadView(int attemptNumber, BufferAvailabilityListener availabilityListener) throws IOException {
 		final boolean notifyDataAvailable;
 		synchronized (buffers) {
 			checkState(!isReleased);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -57,7 +57,7 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() {
+	public void notifySubpartitionConsumed(boolean finalRelease) {
 		releaseAllResources();
 	}
 
@@ -66,7 +66,7 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 		if (isReleased.compareAndSet(false, true)) {
 			// The view doesn't hold any resources and the parent cannot be restarted. Therefore,
 			// it's OK to notify about consumption as well.
-			parent.onConsumedSubpartition();
+			parent.onConsumedSubpartition(false);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -334,7 +334,7 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	/**
 	 * Returns the requested subpartition.
 	 */
-	public ResultSubpartitionView createSubpartitionView(int index, BufferAvailabilityListener availabilityListener) throws IOException {
+	public ResultSubpartitionView createSubpartitionView(int index, int attemptNumber, BufferAvailabilityListener availabilityListener) throws IOException {
 		int refCnt = pendingReferences.get();
 
 		checkState(refCnt != -1, "Partition released.");
@@ -342,7 +342,7 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 
 		checkElementIndex(index, subpartitions.length, "Subpartition not found.");
 
-		ResultSubpartitionView readView = subpartitions[index].createReadView(availabilityListener);
+		ResultSubpartitionView readView = subpartitions[index].createReadView(attemptNumber, availabilityListener);
 
 		LOG.debug("Created {}", readView);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -67,6 +67,7 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 	public ResultSubpartitionView createSubpartitionView(
 			ResultPartitionID partitionId,
 			int subpartitionIndex,
+			int attemptNumber,
 			BufferAvailabilityListener availabilityListener) throws IOException {
 
 		synchronized (registeredPartitions) {
@@ -79,7 +80,20 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 
 			LOG.debug("Requesting subpartition {} of {}.", subpartitionIndex, partition);
 
-			return partition.createSubpartitionView(subpartitionIndex, availabilityListener);
+			return partition.createSubpartitionView(subpartitionIndex, attemptNumber, availabilityListener);
+		}
+	}
+
+	public void subpartitionConsumed(ResultPartitionID partitionId, int subpartitionIndex) {
+		synchronized (registeredPartitions) {
+			final ResultPartition partition = registeredPartitions.get(partitionId.getProducerId(),
+				partitionId.getPartitionId());
+
+			if (partition == null) {
+				LOG.error("Partition {} not found.", partitionId);
+				return;
+			}
+			partition.onConsumedSubpartition(subpartitionIndex);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionProvider.java
@@ -31,6 +31,7 @@ public interface ResultPartitionProvider {
 	ResultSubpartitionView createSubpartitionView(
 			ResultPartitionID partitionId,
 			int index,
+			int attemptNumber,
 			BufferAvailabilityListener availabilityListener) throws IOException;
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -48,7 +48,7 @@ public interface ResultSubpartitionView {
 
 	void releaseAllResources() throws IOException;
 
-	void notifySubpartitionConsumed() throws IOException;
+	void notifySubpartitionConsumed(boolean finalRelease) throws IOException;
 
 	boolean isReleased();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -66,6 +66,8 @@ public abstract class InputChannel {
 
 	protected final Counter numBuffersIn;
 
+	protected int attemptNumber;
+
 	/** The current backoff (in ms). */
 	private int currentBackoff;
 
@@ -76,7 +78,8 @@ public abstract class InputChannel {
 			int initialBackoff,
 			int maxBackoff,
 			Counter numBytesIn,
-			Counter numBuffersIn) {
+			Counter numBuffersIn,
+			int attemptNumber) {
 
 		checkArgument(channelIndex >= 0);
 
@@ -95,6 +98,8 @@ public abstract class InputChannel {
 
 		this.numBytesIn = numBytesIn;
 		this.numBuffersIn = numBuffersIn;
+
+		this.attemptNumber = attemptNumber;
 	}
 
 	// ------------------------------------------------------------------------
@@ -163,12 +168,16 @@ public abstract class InputChannel {
 
 	abstract boolean isReleased();
 
-	abstract void notifySubpartitionConsumed() throws IOException;
+	abstract void notifySubpartitionConsumed(boolean finalRelease) throws IOException;
 
 	/**
 	 * Releases all resources of the channel.
 	 */
 	abstract void releaseAllResources() throws IOException;
+
+	protected void releaseRemoteClient() throws IOException {
+
+	}
 
 	// ------------------------------------------------------------------------
 	// Error notification

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -68,10 +68,11 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		ResultPartitionID partitionId,
 		ResultPartitionManager partitionManager,
 		TaskEventPublisher taskEventPublisher,
-		TaskIOMetricGroup metrics) {
+		TaskIOMetricGroup metrics,
+        int attemptNumber) {
 
 		this(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher,
-			0, 0, metrics);
+			0, 0, metrics, attemptNumber);
 	}
 
 	public LocalInputChannel(
@@ -82,9 +83,11 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		TaskEventPublisher taskEventPublisher,
 		int initialBackoff,
 		int maxBackoff,
-		TaskIOMetricGroup metrics) {
+		TaskIOMetricGroup metrics,
+		int attemptNumber) {
 
-		super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, metrics.getNumBytesInLocalCounter(), metrics.getNumBuffersInLocalCounter());
+		super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, metrics.getNumBytesInLocalCounter(),
+			metrics.getNumBuffersInLocalCounter(), attemptNumber);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventPublisher = checkNotNull(taskEventPublisher);
@@ -109,7 +112,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
 				try {
 					ResultSubpartitionView subpartitionView = partitionManager.createSubpartitionView(
-						partitionId, subpartitionIndex, this);
+						partitionId, subpartitionIndex, attemptNumber, this);
 
 					if (subpartitionView == null) {
 						throw new IOException("Error requesting subpartition.");
@@ -164,6 +167,9 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 	@Override
 	Optional<BufferAndAvailability> getNextBuffer() throws IOException, InterruptedException {
 		checkError();
+		if (isReleased) {
+			return Optional.empty();
+		}
 
 		ResultSubpartitionView subpartitionView = this.subpartitionView;
 		if (subpartitionView == null) {
@@ -238,9 +244,9 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 	}
 
 	@Override
-	void notifySubpartitionConsumed() throws IOException {
+	void notifySubpartitionConsumed(boolean finalRelease) throws IOException {
 		if (subpartitionView != null) {
-			subpartitionView.notifySubpartitionConsumed();
+			subpartitionView.notifySubpartitionConsumed(finalRelease);
 		}
 	}
 
@@ -255,7 +261,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 			ResultSubpartitionView view = subpartitionView;
 			if (view != null) {
 				view.releaseAllResources();
-				subpartitionView = null;
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -69,7 +69,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		ResultPartitionManager partitionManager,
 		TaskEventPublisher taskEventPublisher,
 		TaskIOMetricGroup metrics,
-        int attemptNumber) {
+		int attemptNumber) {
 
 		this(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher,
 			0, 0, metrics, attemptNumber);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -127,6 +127,7 @@ class UnknownInputChannel extends InputChannel {
 	}
 
 	public LocalInputChannel toLocalInputChannel() {
-		return new LocalInputChannel(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher, initialBackoff, maxBackoff, metrics, attemptNumber);
+		return new LocalInputChannel(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher,
+			initialBackoff, maxBackoff, metrics, attemptNumber);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -50,6 +50,8 @@ class UnknownInputChannel extends InputChannel {
 
 	private final TaskIOMetricGroup metrics;
 
+	private final int attemptNumber;
+
 	public UnknownInputChannel(
 			SingleInputGate gate,
 			int channelIndex,
@@ -59,9 +61,10 @@ class UnknownInputChannel extends InputChannel {
 			ConnectionManager connectionManager,
 			int initialBackoff,
 			int maxBackoff,
-			TaskIOMetricGroup metrics) {
+			TaskIOMetricGroup metrics,
+			int attemptNumber) {
 
-		super(gate, channelIndex, partitionId, initialBackoff, maxBackoff, null, null);
+		super(gate, channelIndex, partitionId, initialBackoff, maxBackoff, null, null, attemptNumber);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventPublisher = checkNotNull(taskEventPublisher);
@@ -69,6 +72,7 @@ class UnknownInputChannel extends InputChannel {
 		this.metrics = checkNotNull(metrics);
 		this.initialBackoff = initialBackoff;
 		this.maxBackoff = maxBackoff;
+		this.attemptNumber = attemptNumber;
 	}
 
 	@Override
@@ -100,7 +104,7 @@ class UnknownInputChannel extends InputChannel {
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() {
+	public void notifySubpartitionConsumed(boolean finalRelease) {
 	}
 
 	@Override
@@ -118,10 +122,11 @@ class UnknownInputChannel extends InputChannel {
 	// ------------------------------------------------------------------------
 
 	public RemoteInputChannel toRemoteInputChannel(ConnectionID producerAddress) {
-		return new RemoteInputChannel(inputGate, channelIndex, partitionId, checkNotNull(producerAddress), connectionManager, initialBackoff, maxBackoff, metrics);
+		return new RemoteInputChannel(inputGate, channelIndex, partitionId, checkNotNull(producerAddress),
+			connectionManager, initialBackoff, maxBackoff, metrics, attemptNumber);
 	}
 
 	public LocalInputChannel toLocalInputChannel() {
-		return new LocalInputChannel(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher, initialBackoff, maxBackoff, metrics);
+		return new LocalInputChannel(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher, initialBackoff, maxBackoff, metrics, attemptNumber);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -404,6 +404,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 			SingleInputGate gate = SingleInputGate.create(
 				taskNameWithSubtaskAndId,
 				jobId,
+				attemptNumber,
 				inputGateDeploymentDescriptor,
 				networkEnvironment,
 				taskEventDispatcher,
@@ -828,6 +829,10 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 				// clear the reference to the invokable. this helps guard against holding references
 				// to the invokable and its structures in cases where this Task object is still referenced
 				this.invokable = null;
+
+				for (SingleInputGate inputGate : inputGates) {
+					inputGate.finallyReleaseAllInputChannels(executionState.equals(ExecutionState.FINISHED), true);
+				}
 
 				// stop the async dispatcher.
 				// copy dispatcher reference to stack, against concurrent release

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -322,7 +322,8 @@ public class NetworkEnvironmentTest {
 			connManager,
 			0,
 			0,
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			0);
 		inputGate.setInputChannel(resultPartition.getPartitionId().getPartitionId(), channel);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -134,11 +134,11 @@ public class ClientTransportErrorHandlingTest {
 		}).when(rich[1]).onError(isA(LocalTransportException.class));
 
 		// First request is successful
-		ChannelFuture f = requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[0], 0);
+		ChannelFuture f = requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[0], 0, 0);
 		assertTrue(f.await().isSuccess());
 
 		// Second request is *not* successful
-		f = requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[1], 0);
+		f = requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[1], 0, 0);
 		assertFalse(f.await().isSuccess());
 
 		// Only the second channel should be notified about the error

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
 
 public class CreditBasedPartitionRequestClientHandlerTest {
 
-	/**
+	/**git
 	 * Tests a fix for FLINK-1627.
 	 *
 	 * <p> FLINK-1627 discovered a race condition, which could lead to an infinite loop when a
@@ -371,6 +371,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 
 			// Release the input channel
 			inputGate.close();
+			inputGate.finallyReleaseAllInputChannels(true, false);
 
 			// it should send a close request after releasing the input channel,
 			// but will not notify credits for a released input channel.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
 
 public class CreditBasedPartitionRequestClientHandlerTest {
 
-	/**git
+	/**
 	 * Tests a fix for FLINK-1627.
 	 *
 	 * <p> FLINK-1627 discovered a race condition, which could lead to an infinite loop when a

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -97,7 +97,9 @@ public class NettyMessageSerializationTest {
 		}
 
 		{
-			NettyMessage.PartitionRequest expected = new NettyMessage.PartitionRequest(new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), random.nextInt(), new InputChannelID(), random.nextInt());
+			NettyMessage.PartitionRequest expected = new NettyMessage.PartitionRequest(
+				new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), random.nextInt(),
+				new InputChannelID(), random.nextInt(), random.nextInt());
 			NettyMessage.PartitionRequest actual = encodeAndDecode(expected);
 
 			assertEquals(expected.partitionId, actual.partitionId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -252,7 +252,8 @@ public class PartitionRequestClientHandlerTest {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			0);
 
 		inputGate.setInputChannel(partitionId.getPartitionId(), inputChannel);
 		return inputChannel;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
@@ -63,11 +63,11 @@ public class ServerTransportErrorHandlingTest {
 		final ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
 
 		when(partitionManager
-			.createSubpartitionView(any(ResultPartitionID.class), anyInt(), any(BufferAvailabilityListener.class)))
+			.createSubpartitionView(any(ResultPartitionID.class), anyInt(), anyInt(), any(BufferAvailabilityListener.class)))
 			.thenAnswer(new Answer<ResultSubpartitionView>() {
 				@Override
 				public ResultSubpartitionView answer(InvocationOnMock invocationOnMock) throws Throwable {
-					BufferAvailabilityListener listener = (BufferAvailabilityListener) invocationOnMock.getArguments()[2];
+					BufferAvailabilityListener listener = (BufferAvailabilityListener) invocationOnMock.getArguments()[3];
 					listener.notifyDataAvailable();
 					return new CancelPartitionRequestTest.InfiniteSubpartitionView(outboundBuffers, sync);
 				}
@@ -100,7 +100,7 @@ public class ServerTransportErrorHandlingTest {
 			Channel ch = connect(serverAndClient);
 
 			// Write something to trigger close by server
-			ch.writeAndFlush(new NettyMessage.PartitionRequest(new ResultPartitionID(), 0, new InputChannelID(), Integer.MAX_VALUE));
+			ch.writeAndFlush(new NettyMessage.PartitionRequest(new ResultPartitionID(), 0, new InputChannelID(), Integer.MAX_VALUE, 0));
 
 			// Wait for the notification
 			if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -51,14 +51,14 @@ public class InputChannelTestUtils {
 
 			@Override
 			public ResultSubpartitionView answer(InvocationOnMock invocation) throws Throwable {
-				BufferAvailabilityListener channel = (BufferAvailabilityListener) invocation.getArguments()[2];
-				return sources[num++].createReadView(channel);
+				BufferAvailabilityListener channel = (BufferAvailabilityListener) invocation.getArguments()[3];
+				return sources[num++].createReadView(0, channel);
 			}
 		};
 
 		ResultPartitionManager manager = mock(ResultPartitionManager.class);
 		when(manager.createSubpartitionView(
-				any(ResultPartitionID.class), anyInt(), any(BufferAvailabilityListener.class)))
+				any(ResultPartitionID.class), anyInt(), anyInt(), any(BufferAvailabilityListener.class)))
 				.thenAnswer(viewCreator);
 
 		return manager;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
@@ -66,7 +66,7 @@ public class InputGateConcurrentTest {
 
 		for (int i = 0; i < numberOfChannels; i++) {
 			LocalInputChannel channel = new LocalInputChannel(gate, i, new ResultPartitionID(),
-					resultPartitionManager, mock(TaskEventDispatcher.class), UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+					resultPartitionManager, mock(TaskEventDispatcher.class), UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 			gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 
 			partitions[i] = new PipelinedSubpartition(0, resultPartition);
@@ -96,7 +96,7 @@ public class InputGateConcurrentTest {
 		for (int i = 0; i < numberOfChannels; i++) {
 			RemoteInputChannel channel = new RemoteInputChannel(
 					gate, i, new ResultPartitionID(), mock(ConnectionID.class),
-					connManager, 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+					connManager, 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 			gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 
 			sources[i] = new RemoteChannelSource(channel);
@@ -143,14 +143,15 @@ public class InputGateConcurrentTest {
 				sources[i] = new PipelinedSubpartitionSource(psp);
 
 				LocalInputChannel channel = new LocalInputChannel(gate, i, new ResultPartitionID(),
-						resultPartitionManager, mock(TaskEventDispatcher.class), UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+						resultPartitionManager, mock(TaskEventDispatcher.class),
+						UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 				gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 			}
 			else {
 				//remote channel
 				RemoteInputChannel channel = new RemoteInputChannel(
 						gate, i, new ResultPartitionID(), mock(ConnectionID.class),
-						connManager, 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+						connManager, 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 				gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 
 				sources[i] = new RemoteChannelSource(channel);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -94,7 +94,8 @@ public class InputGateFairnessTest {
 
 		for (int i = 0; i < numberOfChannels; i++) {
 			LocalInputChannel channel = new LocalInputChannel(gate, i, new ResultPartitionID(),
-					resultPartitionManager, mock(TaskEventDispatcher.class), UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+					resultPartitionManager, mock(TaskEventDispatcher.class),
+					UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 			gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 		}
 
@@ -141,7 +142,8 @@ public class InputGateFairnessTest {
 
 			for (int i = 0; i < numberOfChannels; i++) {
 				LocalInputChannel channel = new LocalInputChannel(gate, i, new ResultPartitionID(),
-					resultPartitionManager, mock(TaskEventDispatcher.class), UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+					resultPartitionManager, mock(TaskEventDispatcher.class),
+					UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 				gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 			}
 
@@ -190,7 +192,7 @@ public class InputGateFairnessTest {
 		for (int i = 0; i < numberOfChannels; i++) {
 			RemoteInputChannel channel = new RemoteInputChannel(
 					gate, i, new ResultPartitionID(), mock(ConnectionID.class),
-					connManager, 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+					connManager, 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 
 			channels[i] = channel;
 
@@ -240,7 +242,7 @@ public class InputGateFairnessTest {
 		for (int i = 0; i < numberOfChannels; i++) {
 			RemoteInputChannel channel = new RemoteInputChannel(
 					gate, i, new ResultPartitionID(), mock(ConnectionID.class),
-					connManager, 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+					connManager, 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 
 			channels[i] = channel;
 			gate.setInputChannel(new IntermediateResultPartitionID(), channel);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -83,10 +83,10 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 		final PipelinedSubpartition subpartition = createSubpartition();
 
 		// Successful request
-		assertNotNull(subpartition.createReadView(new NoOpBufferAvailablityListener()));
+		assertNotNull(subpartition.createReadView(0, new NoOpBufferAvailablityListener()));
 
 		try {
-			subpartition.createReadView(new NoOpBufferAvailablityListener());
+			subpartition.createReadView(0, new NoOpBufferAvailablityListener());
 
 			fail("Did not throw expected exception after duplicate notifyNonEmpty view request.");
 		} catch (IllegalStateException expected) {
@@ -204,7 +204,7 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 
 		TestSubpartitionProducer producer = new TestSubpartitionProducer(subpartition, isSlowProducer, producerSource);
 		TestSubpartitionConsumer consumer = new TestSubpartitionConsumer(isSlowConsumer, consumerCallback);
-		final PipelinedSubpartitionView view = subpartition.createReadView(consumer);
+		final PipelinedSubpartitionView view = subpartition.createReadView(0, consumer);
 		consumer.setSubpartitionView(view);
 
 		CompletableFuture<Boolean> producerResult = CompletableFuture.supplyAsync(
@@ -251,7 +251,7 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 			// create the read view first
 			ResultSubpartitionView view = null;
 			if (createView) {
-				view = partition.createReadView(new NoOpBufferAvailablityListener());
+				view = partition.createReadView(0, new NoOpBufferAvailablityListener());
 			}
 
 			partition.release();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -59,7 +59,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 		final ResultPartition parent = mock(ResultPartition.class);
 		subpartition = new PipelinedSubpartition(0, parent);
 		availablityListener = new AwaitableBufferAvailablityListener();
-		readView = subpartition.createReadView(availablityListener);
+		readView = subpartition.createReadView(0, availablityListener);
 	}
 
 	@After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -127,7 +127,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
 
 		// Create the view
 		BufferAvailabilityListener listener = mock(BufferAvailabilityListener.class);
-		ResultSubpartitionView view = partition.createReadView(listener);
+		ResultSubpartitionView view = partition.createReadView(0, listener);
 
 		// The added bufferConsumer and end-of-partition event
 		assertNotNull(view.getNextBuffer());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
@@ -124,7 +124,7 @@ public class InputChannelTest {
 			int initialBackoff,
 			int maxBackoff) {
 
-			super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, new SimpleCounter(), new SimpleCounter());
+			super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, new SimpleCounter(), new SimpleCounter(), 0);
 		}
 
 		@Override
@@ -146,7 +146,7 @@ public class InputChannelTest {
 		}
 
 		@Override
-		void notifySubpartitionConsumed() throws IOException {
+		void notifySubpartitionConsumed(boolean finalRelease) throws IOException {
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -210,7 +210,7 @@ public class LocalInputChannelTest {
 		LocalInputChannel ch = createLocalInputChannel(inputGate, partitionManager, backoff);
 
 		when(partitionManager
-				.createSubpartitionView(eq(ch.partitionId), eq(0), any(BufferAvailabilityListener.class)))
+				.createSubpartitionView(eq(ch.partitionId), eq(0), eq(0), any(BufferAvailabilityListener.class)))
 				.thenThrow(new PartitionNotFoundException(ch.partitionId));
 
 		Timer timer = mock(Timer.class);
@@ -226,7 +226,7 @@ public class LocalInputChannelTest {
 		// Initial request
 		ch.requestSubpartition(0);
 		verify(partitionManager)
-				.createSubpartitionView(eq(ch.partitionId), eq(0), any(BufferAvailabilityListener.class));
+				.createSubpartitionView(eq(ch.partitionId), eq(0), eq(0), any(BufferAvailabilityListener.class));
 
 		// Request subpartition and verify that the actual requests are delayed.
 		for (long expected : expectedDelays) {
@@ -253,7 +253,7 @@ public class LocalInputChannelTest {
 
 		ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
 		when(partitionManager
-				.createSubpartitionView(any(ResultPartitionID.class), anyInt(), any(BufferAvailabilityListener.class)))
+				.createSubpartitionView(any(ResultPartitionID.class), anyInt(), anyInt(), any(BufferAvailabilityListener.class)))
 				.thenReturn(view);
 
 		SingleInputGate inputGate = mock(SingleInputGate.class);
@@ -301,6 +301,7 @@ public class LocalInputChannelTest {
 			.createSubpartitionView(
 				any(ResultPartitionID.class),
 				anyInt(),
+				anyInt(),
 				any(BufferAvailabilityListener.class)))
 			.thenAnswer(new Answer<ResultSubpartitionView>() {
 				@Override
@@ -320,7 +321,8 @@ public class LocalInputChannelTest {
 			partitionManager,
 			new TaskEventDispatcher(),
 			1, 1,
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			0);
 
 		gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 
@@ -364,6 +366,7 @@ public class LocalInputChannelTest {
 		when(partitionManager.createSubpartitionView(
 			any(ResultPartitionID.class),
 			anyInt(),
+			anyInt(),
 			any(BufferAvailabilityListener.class))).thenReturn(reader);
 
 		LocalInputChannel channel = new LocalInputChannel(
@@ -372,7 +375,8 @@ public class LocalInputChannelTest {
 			new ResultPartitionID(),
 			partitionManager,
 			new TaskEventDispatcher(),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			0);
 
 		channel.requestSubpartition(0);
 
@@ -412,7 +416,8 @@ public class LocalInputChannelTest {
 				mock(TaskEventDispatcher.class),
 				initialAndMaxRequestBackoff._1(),
 				initialAndMaxRequestBackoff._2(),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				0);
 	}
 
 	/**
@@ -505,7 +510,8 @@ public class LocalInputChannelTest {
 								consumedPartitionIds[i],
 								partitionManager,
 								taskEventDispatcher,
-								UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup()));
+								UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+								0));
 			}
 
 			this.numberOfInputChannels = numberOfInputChannels;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -214,13 +214,13 @@ public class RemoteInputChannelTest {
 
 		// Initial request
 		ch.requestSubpartition(0);
-		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(0));
+		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(0), eq(0));
 
 		// Request subpartition and verify that the actual requests are delayed.
 		for (int expected : expectedDelays) {
 			ch.retriggerSubpartitionRequest(0);
 
-			verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(expected));
+			verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(expected), eq(0));
 		}
 
 		// Exception after backoff is greater than the maximum backoff.
@@ -246,11 +246,11 @@ public class RemoteInputChannelTest {
 
 		// No delay for first request
 		ch.requestSubpartition(0);
-		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(0));
+		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(0), eq(0));
 
 		// Initial delay for second request
 		ch.retriggerSubpartitionRequest(0);
-		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(backoff._1()));
+		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(backoff._1()), eq(0));
 
 		// Exception after backoff is greater than the maximum backoff.
 		try {
@@ -275,7 +275,7 @@ public class RemoteInputChannelTest {
 
 		// No delay for first request
 		ch.requestSubpartition(0);
-		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(0));
+		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(0), eq(0));
 
 		// Exception, because backoff is disabled.
 		try {
@@ -303,7 +303,8 @@ public class RemoteInputChannelTest {
 				partitionId,
 				mock(ConnectionID.class),
 				connectionManager,
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				0);
 
 		ch.onFailedPartitionRequest();
 
@@ -323,7 +324,8 @@ public class RemoteInputChannelTest {
 				new ResultPartitionID(),
 				mock(ConnectionID.class),
 				connManager,
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				0);
 
 		ch.onError(new ProducerFailedException(new RuntimeException("Expected test exception.")));
 
@@ -1055,7 +1057,8 @@ public class RemoteInputChannelTest {
 			connectionManager,
 			initialAndMaxRequestBackoff._1(),
 			initialAndMaxRequestBackoff._2(),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			0);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -169,6 +169,7 @@ public class SingleInputGateTest {
 		when(partitionManager.createSubpartitionView(
 			any(ResultPartitionID.class),
 			anyInt(),
+			anyInt(),
 			any(BufferAvailabilityListener.class))).thenReturn(iterator);
 
 		// Setup reader with one local and one unknown input channel
@@ -182,12 +183,12 @@ public class SingleInputGateTest {
 		// Local
 		ResultPartitionID localPartitionId = new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID());
 
-		InputChannel local = new LocalInputChannel(inputGate, 0, localPartitionId, partitionManager, taskEventDispatcher, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+		InputChannel local = new LocalInputChannel(inputGate, 0, localPartitionId, partitionManager, taskEventDispatcher, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 
 		// Unknown
 		ResultPartitionID unknownPartitionId = new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID());
 
-		InputChannel unknown = new UnknownInputChannel(inputGate, 1, unknownPartitionId, partitionManager, taskEventDispatcher, mock(ConnectionManager.class), 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+		InputChannel unknown = new UnknownInputChannel(inputGate, 1, unknownPartitionId, partitionManager, taskEventDispatcher, mock(ConnectionManager.class), 0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 
 		// Set channels
 		inputGate.setInputChannel(localPartitionId.getPartitionId(), local);
@@ -197,7 +198,7 @@ public class SingleInputGateTest {
 		inputGate.requestPartitions();
 
 		// Only the local channel can request
-		verify(partitionManager, times(1)).createSubpartitionView(any(ResultPartitionID.class), anyInt(), any(BufferAvailabilityListener.class));
+		verify(partitionManager, times(1)).createSubpartitionView(any(ResultPartitionID.class), anyInt(), anyInt(), any(BufferAvailabilityListener.class));
 
 		// Send event backwards and initialize unknown channel afterwards
 		final TaskEvent event = new TestTaskEvent();
@@ -209,7 +210,7 @@ public class SingleInputGateTest {
 		// After the update, the pending event should be send to local channel
 		inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(new ResultPartitionID(unknownPartitionId.getPartitionId(), unknownPartitionId.getProducerId()), ResultPartitionLocation.createLocal()));
 
-		verify(partitionManager, times(2)).createSubpartitionView(any(ResultPartitionID.class), anyInt(), any(BufferAvailabilityListener.class));
+		verify(partitionManager, times(2)).createSubpartitionView(any(ResultPartitionID.class), anyInt(), anyInt(), any(BufferAvailabilityListener.class));
 		verify(taskEventDispatcher, times(2)).publish(any(ResultPartitionID.class), any(TaskEvent.class));
 	}
 
@@ -232,7 +233,7 @@ public class SingleInputGateTest {
 			partitionManager,
 			new TaskEventDispatcher(),
 			new LocalConnectionManager(),
-			0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			0, 0, UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(), 0);
 
 		inputGate.setInputChannel(unknown.partitionId.getPartitionId(), unknown);
 
@@ -242,7 +243,7 @@ public class SingleInputGateTest {
 			ResultPartitionLocation.createLocal()));
 
 		verify(partitionManager, never()).createSubpartitionView(
-			any(ResultPartitionID.class), anyInt(), any(BufferAvailabilityListener.class));
+			any(ResultPartitionID.class), anyInt(), anyInt(), any(BufferAvailabilityListener.class));
 	}
 
 	/**
@@ -264,7 +265,8 @@ public class SingleInputGateTest {
 			new TaskEventDispatcher(),
 			new LocalConnectionManager(),
 			0, 0,
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			0);
 
 		inputGate.setInputChannel(unknown.partitionId.getPartitionId(), unknown);
 
@@ -353,6 +355,7 @@ public class SingleInputGateTest {
 		SingleInputGate gate = SingleInputGate.create(
 			"TestTask",
 			new JobID(),
+			0,
 			gateDesc,
 			netEnv,
 			new TaskEventDispatcher(),
@@ -579,7 +582,8 @@ public class SingleInputGateTest {
 			network.getConnectionManager(),
 			network.getConfiguration().partitionRequestInitialBackoff(),
 			network.getConfiguration().partitionRequestMaxBackoff(),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup()
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			0
 		);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -48,7 +48,7 @@ public class TestInputChannel extends InputChannel {
 	private boolean isReleased = false;
 
 	TestInputChannel(SingleInputGate inputGate, int channelIndex) {
-		super(inputGate, channelIndex, new ResultPartitionID(), 0, 0, new SimpleCounter(), new SimpleCounter());
+		super(inputGate, channelIndex, new ResultPartitionID(), 0, 0, new SimpleCounter(), new SimpleCounter(), 0);
 	}
 
 	public TestInputChannel read(Buffer buffer) throws IOException, InterruptedException {
@@ -148,7 +148,7 @@ public class TestInputChannel extends InputChannel {
 	}
 
 	@Override
-	void notifySubpartitionConsumed() throws IOException {
+	void notifySubpartitionConsumed(boolean finalRelease) throws IOException {
 
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionConsumer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionConsumer.java
@@ -112,7 +112,7 @@ public class TestSubpartitionConsumer implements Callable<Boolean>, BufferAvaila
 						bufferAndBacklog.buffer().recycleBuffer();
 
 						if (event.getClass() == EndOfPartitionEvent.class) {
-							subpartitionView.notifySubpartitionConsumed();
+							subpartitionView.notifySubpartitionConsumed(false);
 
 							return true;
 						}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -256,6 +256,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 			SingleInputGate gate = SingleInputGate.create(
 				"receiving task[" + channel + "]",
 				jobId,
+				0,
 				gateDescriptor,
 				environment,
 				new TaskEventDispatcher(),


### PR DESCRIPTION
multiple times to speed up batch recoveries

Change-Id: Id304257d201a9ea2c0f650c027204aabe2b2e9b9

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

make SpillableSubpartition repeatably readable to enable region failover


## Brief change log

  - BufferConsumers are hold in buffers until the corresponding ExecutionVertex terminates.
  - SpillableSubpartition is not released until the corresponding ExecutionVertex terminates.
  - SpillableSubpartition creates multi SpillableSubpartitionViews, each of which is corresponding to a Execution Attempt.
  - Accommodate relative unit tests for repeatably readable SpillableSubpartition.
  - Add new unit test testPartitionRepeatedlyReadable to verify this modification.

## Verifying this change

This change added tests and can be verified as follows:

  - Manually verified the change by running a 8 node cluser with 1 JobManagers and 8 TaskManagers, a batch WordCount example using `BATCH_FORCED` and and `region` failover-strategy, fail execution attempt of Reduce Vertex after read data. Job terminates after failover.
  - New unit test is added to verify this modification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? https://docs.google.com/document/d/1uXuJFiKODf241CKci3b0JnaF3zQ-Wt0V9wmC7kYwX-M/edit?usp=sharing
