### PR TITLE
[hotfix][DataStream] Remove deprecated config `flushAlways` in StreamConfig

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -202,10 +202,6 @@ public class StreamConfig implements Serializable {
 		return config.getLong(BUFFER_TIMEOUT, DEFAULT_TIMEOUT);
 	}
 
-	public boolean isFlushAlwaysEnabled() {
-		return getBufferTimeout() == 0;
-	}
-
 	public void setStreamOperator(StreamOperator<?> operator) {
 		if (operator != null) {
 			config.setClass(USER_FUNCTION, operator.getClass());


### PR DESCRIPTION
## What is the purpose of the change

The `flushAlways` config in RecordWriter has been removed, and now setting batch timeout to 0 doesn't mean flushing each record anymore. We should remove this config from StreamConfig.

## Brief change log

Remove `isFlushAlwaysEnabled` from StreamConfig.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
