### PR TITLE
[FLINK-10195] [RabbitMQ] - RabbitMQ Source With Checkpointing Doesn't Backpressure Correctly

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-connector-rabbitmq/pom.xml
@@ -37,7 +37,7 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<rabbitmq.version>4.2.0</rabbitmq.version>
+		<rabbitmq.version>5.6.0</rabbitmq.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfig.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfig.java
@@ -76,6 +76,7 @@ public class RMQConnectionConfig implements Serializable {
 	 * @param requestedChannelMax requested maximum channel number
 	 * @param requestedFrameMax requested maximum frame size
 	 * @param requestedHeartbeat requested heartbeat interval
+	 * @param clientBufferCapacity the number of records that can sit in memory at once
 	 * @throws NullPointerException if host or virtual host or username or password is null
 	 */
 	private RMQConnectionConfig(String host, Integer port, String virtualHost, String username, String password,
@@ -87,6 +88,7 @@ public class RMQConnectionConfig implements Serializable {
 		Preconditions.checkNotNull(virtualHost, "virtualHost can not be null");
 		Preconditions.checkNotNull(username, "username can not be null");
 		Preconditions.checkNotNull(password, "password can not be null");
+		Preconditions.checkArgument(clientBufferCapacity>0, "Buffer capacity must be greater than 0");
 		this.host = host;
 		this.port = port;
 		this.virtualHost = virtualHost;
@@ -452,6 +454,11 @@ public class RMQConnectionConfig implements Serializable {
 			return this;
 		}
 
+		/**
+		 * Sets the number of records that can sit in memory unacked at once
+		 * @param clientBufferCapacity the number of records
+		 * @return the Builder
+		 */
 		public Builder setClientBufferCapacity(int clientBufferCapacity) {
 			this.clientBufferCapacity = clientBufferCapacity;
 			return this;

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfig.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfig.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.rabbitmq.common;
 
+import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
 import org.apache.flink.util.Preconditions;
 
 import com.rabbitmq.client.ConnectionFactory;
@@ -31,10 +33,10 @@ import java.security.NoSuchAlgorithmException;
 /**
  * Connection Configuration for RMQ.
  * If {@link Builder#setUri(String)} has been set then {@link RMQConnectionConfig#RMQConnectionConfig(String, Integer,
- * Boolean, Boolean, Integer, Integer, Integer, Integer)}
+ * Boolean, Boolean, Integer, Integer, Integer, Integer, Integer)}
  * will be used for initialize the RMQ connection or
  * {@link RMQConnectionConfig#RMQConnectionConfig(String, Integer, String, String, String, Integer, Boolean,
- * Boolean, Integer, Integer, Integer, Integer)}
+ * Boolean, Integer, Integer, Integer, Integer, Integer)}
  * will be used for initialize the RMQ connection
  */
 public class RMQConnectionConfig implements Serializable {
@@ -58,27 +60,28 @@ public class RMQConnectionConfig implements Serializable {
 	private Integer requestedChannelMax;
 	private Integer requestedFrameMax;
 	private Integer requestedHeartbeat;
+	private Integer clientBufferCapacity;
 
 	/**
-	*
-	* @param host host name
-	* @param port port
-	* @param virtualHost virtual host
-	* @param username username
-	* @param password password
-	* @param networkRecoveryInterval connection recovery interval in milliseconds
-	* @param automaticRecovery if automatic connection recovery
-	* @param topologyRecovery if topology recovery
-	* @param connectionTimeout connection timeout
-	* @param requestedChannelMax requested maximum channel number
-	* @param requestedFrameMax requested maximum frame size
-	* @param requestedHeartbeat requested heartbeat interval
-	* @throws NullPointerException if host or virtual host or username or password is null
-	*/
+	 *
+	 * @param host host name
+	 * @param port port
+	 * @param virtualHost virtual host
+	 * @param username username
+	 * @param password password
+	 * @param networkRecoveryInterval connection recovery interval in milliseconds
+	 * @param automaticRecovery if automatic connection recovery
+	 * @param topologyRecovery if topology recovery
+	 * @param connectionTimeout connection timeout
+	 * @param requestedChannelMax requested maximum channel number
+	 * @param requestedFrameMax requested maximum frame size
+	 * @param requestedHeartbeat requested heartbeat interval
+	 * @throws NullPointerException if host or virtual host or username or password is null
+	 */
 	private RMQConnectionConfig(String host, Integer port, String virtualHost, String username, String password,
-								Integer networkRecoveryInterval, Boolean automaticRecovery,
-								Boolean topologyRecovery, Integer connectionTimeout, Integer requestedChannelMax,
-								Integer requestedFrameMax, Integer requestedHeartbeat){
+									  Integer networkRecoveryInterval, Boolean automaticRecovery,
+									  Boolean topologyRecovery, Integer connectionTimeout, Integer requestedChannelMax,
+									  Integer requestedFrameMax, Integer requestedHeartbeat, Integer clientBufferCapacity){
 		Preconditions.checkNotNull(host, "host can not be null");
 		Preconditions.checkNotNull(port, "port can not be null");
 		Preconditions.checkNotNull(virtualHost, "virtualHost can not be null");
@@ -97,23 +100,24 @@ public class RMQConnectionConfig implements Serializable {
 		this.requestedChannelMax = requestedChannelMax;
 		this.requestedFrameMax = requestedFrameMax;
 		this.requestedHeartbeat = requestedHeartbeat;
+		this.clientBufferCapacity = clientBufferCapacity;
 	}
 
 	/**
-	*
-	* @param uri the connection URI
-	* @param networkRecoveryInterval connection recovery interval in milliseconds
-	* @param automaticRecovery if automatic connection recovery
-	* @param topologyRecovery if topology recovery
-	* @param connectionTimeout connection timeout
-	* @param requestedChannelMax requested maximum channel number
-	* @param requestedFrameMax requested maximum frame size
-	* @param requestedHeartbeat requested heartbeat interval
-	* @throws NullPointerException if URI is null
-	*/
+	 *
+	 * @param uri the connection URI
+	 * @param networkRecoveryInterval connection recovery interval in milliseconds
+	 * @param automaticRecovery if automatic connection recovery
+	 * @param topologyRecovery if topology recovery
+	 * @param connectionTimeout connection timeout
+	 * @param requestedChannelMax requested maximum channel number
+	 * @param requestedFrameMax requested maximum frame size
+	 * @param requestedHeartbeat requested heartbeat interval
+	 * @throws NullPointerException if URI is null
+	 */
 	private RMQConnectionConfig(String uri, Integer networkRecoveryInterval, Boolean automaticRecovery,
-								Boolean topologyRecovery, Integer connectionTimeout, Integer requestedChannelMax,
-								Integer requestedFrameMax, Integer requestedHeartbeat){
+									  Boolean topologyRecovery, Integer connectionTimeout, Integer requestedChannelMax,
+									  Integer requestedFrameMax, Integer requestedHeartbeat, Integer clientBufferCapacity){
 		Preconditions.checkNotNull(uri, "Uri can not be null");
 		this.uri = uri;
 
@@ -124,6 +128,7 @@ public class RMQConnectionConfig implements Serializable {
 		this.requestedChannelMax = requestedChannelMax;
 		this.requestedFrameMax = requestedFrameMax;
 		this.requestedHeartbeat = requestedHeartbeat;
+		this.clientBufferCapacity = clientBufferCapacity;
 	}
 
 	/** @return the host to use for connections */
@@ -225,6 +230,17 @@ public class RMQConnectionConfig implements Serializable {
 	}
 
 	/**
+	 * Retrieve the buffer capacity of the rabbitMQ client.
+	 * @return The capacity of the internal buffer, defaults to {@link Integer#MAX_VALUE} if not set
+	 */
+	public Integer getClientBufferCapacity() {
+		if (clientBufferCapacity == null) {
+			return Integer.MAX_VALUE;
+		}
+		return clientBufferCapacity;
+	}
+
+	/**
 	 *
 	 * @return Connection Factory for RMQ
 	 * @throws URISyntaxException if Malformed URI has been passed
@@ -301,6 +317,8 @@ public class RMQConnectionConfig implements Serializable {
 		private Integer requestedChannelMax;
 		private Integer requestedFrameMax;
 		private Integer requestedHeartbeat;
+
+		private Integer clientBufferCapacity;
 
 		private String uri;
 
@@ -434,27 +452,33 @@ public class RMQConnectionConfig implements Serializable {
 			return this;
 		}
 
+		public Builder setClientBufferCapacity(int clientBufferCapacity) {
+			this.clientBufferCapacity = clientBufferCapacity;
+			return this;
+		}
+
 		/**
 		 * The Builder method.
 		 *
 		 * <p>If URI is NULL we use host, port, vHost, username, password combination
 		 * to initialize connection. using  {@link RMQConnectionConfig#RMQConnectionConfig(String, Integer, String, String, String,
-		 * Integer, Boolean, Boolean, Integer, Integer, Integer, Integer)}.
+		 * Integer, Boolean, Boolean, Integer, Integer, Integer, Integer, Integer)}.
 		 *
 		 * <p>Otherwise the URI will be used to initialize the client connection
-		 * {@link RMQConnectionConfig#RMQConnectionConfig(String, Integer, Boolean, Boolean, Integer, Integer, Integer, Integer)}
+		 * {@link RMQConnectionConfig#RMQConnectionConfig(String, Integer, Boolean, Boolean, Integer, Integer, Integer, Integer, Integer)}
 		 * @return RMQConnectionConfig
 		 */
 		public RMQConnectionConfig build(){
 			if (this.uri != null) {
 				return new RMQConnectionConfig(this.uri, this.networkRecoveryInterval,
 					this.automaticRecovery, this.topologyRecovery, this.connectionTimeout, this.requestedChannelMax,
-					this.requestedFrameMax, this.requestedHeartbeat);
+					this.requestedFrameMax, this.requestedHeartbeat, this.clientBufferCapacity);
 			} else {
 				return new RMQConnectionConfig(this.host, this.port, this.virtualHost, this.username, this.password,
 					this.networkRecoveryInterval, this.automaticRecovery, this.topologyRecovery,
-					this.connectionTimeout, this.requestedChannelMax, this.requestedFrameMax, this.requestedHeartbeat);
+					this.connectionTimeout, this.requestedChannelMax, this.requestedFrameMax, this.requestedHeartbeat, this.clientBufferCapacity);
 			}
 		}
 	}
 }
+

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfig.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfig.java
@@ -1,4 +1,3 @@
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,7 +17,6 @@
 
 package org.apache.flink.streaming.connectors.rabbitmq.common;
 
-import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
 import org.apache.flink.util.Preconditions;
 
 import com.rabbitmq.client.ConnectionFactory;
@@ -80,15 +78,15 @@ public class RMQConnectionConfig implements Serializable {
 	 * @throws NullPointerException if host or virtual host or username or password is null
 	 */
 	private RMQConnectionConfig(String host, Integer port, String virtualHost, String username, String password,
-									  Integer networkRecoveryInterval, Boolean automaticRecovery,
-									  Boolean topologyRecovery, Integer connectionTimeout, Integer requestedChannelMax,
-									  Integer requestedFrameMax, Integer requestedHeartbeat, Integer clientBufferCapacity){
+									Integer networkRecoveryInterval, Boolean automaticRecovery,
+									Boolean topologyRecovery, Integer connectionTimeout, Integer requestedChannelMax,
+									Integer requestedFrameMax, Integer requestedHeartbeat, Integer clientBufferCapacity){
 		Preconditions.checkNotNull(host, "host can not be null");
 		Preconditions.checkNotNull(port, "port can not be null");
 		Preconditions.checkNotNull(virtualHost, "virtualHost can not be null");
 		Preconditions.checkNotNull(username, "username can not be null");
 		Preconditions.checkNotNull(password, "password can not be null");
-		Preconditions.checkArgument(clientBufferCapacity>0, "Buffer capacity must be greater than 0");
+		Preconditions.checkArgument(clientBufferCapacity > 0, "Buffer capacity must be greater than 0");
 		this.host = host;
 		this.port = port;
 		this.virtualHost = virtualHost;
@@ -118,8 +116,8 @@ public class RMQConnectionConfig implements Serializable {
 	 * @throws NullPointerException if URI is null
 	 */
 	private RMQConnectionConfig(String uri, Integer networkRecoveryInterval, Boolean automaticRecovery,
-									  Boolean topologyRecovery, Integer connectionTimeout, Integer requestedChannelMax,
-									  Integer requestedFrameMax, Integer requestedHeartbeat, Integer clientBufferCapacity){
+									Boolean topologyRecovery, Integer connectionTimeout, Integer requestedChannelMax,
+									Integer requestedFrameMax, Integer requestedHeartbeat, Integer clientBufferCapacity){
 		Preconditions.checkNotNull(uri, "Uri can not be null");
 		this.uri = uri;
 
@@ -320,7 +318,7 @@ public class RMQConnectionConfig implements Serializable {
 		private Integer requestedFrameMax;
 		private Integer requestedHeartbeat;
 
-		private Integer clientBufferCapacity;
+		private Integer clientBufferCapacity = Integer.MAX_VALUE;
 
 		private String uri;
 
@@ -455,7 +453,7 @@ public class RMQConnectionConfig implements Serializable {
 		}
 
 		/**
-		 * Sets the number of records that can sit in memory unacked at once
+		 * Sets the number of records that can sit in memory unacked at once.
 		 * @param clientBufferCapacity the number of records
 		 * @return the Builder
 		 */

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RabbitMQConsumer.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RabbitMQConsumer.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.streaming.connectors.rabbitmq.common;
 
 import com.rabbitmq.client.AMQP.BasicProperties;

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RabbitMQConsumer.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RabbitMQConsumer.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.rabbitmq.common;
+
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.AlreadyClosedException;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ConsumerCancelledException;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Delivery;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.ShutdownSignalException;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Blocking Rabbit MQ Consumer.
+ * Automatically writes data to an internal buffer.
+ * If RabbitMQ fills the buffer the connection is killed until the buffer is emptied
+ */
+public class RabbitMQConsumer extends DefaultConsumer {
+
+	private final BlockingQueue<Delivery> buffer;
+
+	private final String queue;
+	private final boolean autoAck;
+	private volatile AtomicBoolean cancelled = new AtomicBoolean(false);
+	private volatile AtomicBoolean shutdown = new AtomicBoolean(false);
+
+	public RabbitMQConsumer(String queue, boolean autoAck, Channel ch) {
+		this(queue, autoAck, ch, new LinkedBlockingQueue<>(Integer.MAX_VALUE));
+	}
+
+	public RabbitMQConsumer(String queue, int capacity, boolean autoAck, Channel ch) {
+		this(queue, autoAck, ch, new LinkedBlockingQueue<>(capacity));
+	}
+
+	public RabbitMQConsumer(String queue, boolean autoAck, Channel ch, BlockingQueue<Delivery> buffer) {
+		super(ch);
+		this.queue = queue;
+		this.buffer = buffer;
+		this.autoAck = autoAck;
+	}
+
+	@Override
+	public void handleDelivery(String consumerTag, Envelope envelope, BasicProperties properties, byte[] body) {
+		try {
+			boolean hasBeenAdded = buffer.offer(new Delivery(envelope, properties, body), 1, TimeUnit.SECONDS);
+			while (!hasBeenAdded || shutdown.get()) {
+				hasBeenAdded = buffer.offer(new Delivery(envelope, properties, body), 1, TimeUnit.SECONDS);
+			}
+		} catch (InterruptedException e) {
+			handleDelivery(consumerTag, envelope, properties, body);
+		}
+	}
+
+	@Override
+	public void handleCancel(String consumerTag) throws IOException {
+		super.handleCancel(consumerTag);
+		cancelled.set(true);
+	}
+
+	@Override
+	public void handleCancelOk(String consumerTag) {
+		super.handleCancelOk(consumerTag);
+		cancelled.set(true);
+	}
+
+	@Override
+	public void handleShutdownSignal(String consumerTag, ShutdownSignalException sig) {
+		super.handleShutdownSignal(consumerTag, sig);
+		shutdown.set(true);
+		cancelled.set(true);
+	}
+
+	@Override
+	public void handleConsumeOk(String consumerTag) {
+		super.handleConsumeOk(consumerTag);
+		cancelled.set(false);
+	}
+
+	@Override
+	public void handleRecoverOk(String consumerTag) {
+		super.handleRecoverOk(consumerTag);
+		cancelled.set(false);
+	}
+
+	public Delivery nextDelivery(long timeout, TimeUnit unit)
+		throws InterruptedException, ShutdownSignalException, ConsumerCancelledException, IOException {
+		if (cancelled.get() && !shutdown.get() && buffer.remainingCapacity() > buffer.size() / 2) {
+			try {
+				getChannel().basicConsume(queue, autoAck, this.getConsumerTag(), this);
+			} catch (AlreadyClosedException ignored) {
+					/*Auto-recovery mechanisms can cause errors
+					because there is no concurrency handling around channel actions */
+				nextDelivery(timeout, unit);
+			} catch (IOException e) {
+				if (!(e.getCause() instanceof ShutdownSignalException)) {
+					throw e;
+				}
+			}
+			cancelled.set(false);
+		} else if (buffer.remainingCapacity() == 0 && !cancelled.get()) {
+			try {
+				getChannel().basicCancel(this.getConsumerTag());
+			} catch (IOException e) {
+				if (!(e.getCause() instanceof ShutdownSignalException)) {
+					throw e;
+				}
+			} catch (AlreadyClosedException ignored) {
+				/* Auto-recovery mechanisms can cause errors
+					because there is no concurrency handling around channel actions */
+				nextDelivery(timeout, unit);
+			}
+			cancelled.set(true);
+		}
+		return buffer.poll(timeout, unit);
+	}
+}
+

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.connectors.rabbitmq;
 
-import com.rabbitmq.client.*;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.state.OperatorStateStore;
@@ -36,6 +35,12 @@ import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig
 import org.apache.flink.streaming.connectors.rabbitmq.common.RabbitMQConsumer;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Delivery;
+import com.rabbitmq.client.Envelope;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.rabbitmq;
 
+import com.rabbitmq.client.*;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.state.OperatorStateStore;
@@ -32,14 +33,9 @@ import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
+import org.apache.flink.streaming.connectors.rabbitmq.common.RabbitMQConsumer;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.QueueingConsumer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +49,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
@@ -362,14 +359,14 @@ public class RMQSourceTest {
 		public void open(Configuration config) throws Exception {
 			super.open(config);
 
-			consumer = Mockito.mock(QueueingConsumer.class);
+			consumer = Mockito.mock(RabbitMQConsumer.class);
 
 			// Mock for delivery
-			final QueueingConsumer.Delivery deliveryMock = Mockito.mock(QueueingConsumer.Delivery.class);
+			final Delivery deliveryMock = Mockito.mock(Delivery.class);
 			Mockito.when(deliveryMock.getBody()).thenReturn("test".getBytes(ConfigConstants.DEFAULT_CHARSET));
 
 			try {
-				Mockito.when(consumer.nextDelivery()).thenReturn(deliveryMock);
+				Mockito.when(consumer.nextDelivery(1, TimeUnit.SECONDS)).thenReturn(deliveryMock);
 			} catch (InterruptedException e) {
 				fail("Couldn't setup up deliveryMock");
 			}


### PR DESCRIPTION
## What Does This Change 
Currently RabbitMQ Connection doesn't backpressure when setting no limit to unacked messages.  Data is stored in an in memory buffer until the heap pops. This resolves this issue by allowing the user to specify a buffer size, limiting the number of data points stored in memory. by default the behavior will be the same.

## Brief change log
  - Added optional configuration parameter for specifying buffer size
  - Created mechanism for turning on and off the connection as the buffer gets too full or empty


## Verifying this change

  - Manually verified the change by running a RabbitMQ instance with 18 million records (~37 GB) of data and and a task manager with a couple of GB or RAM writing slowly to a Sink

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes) - Updated RabbitMQ to use latest
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
