### PR TITLE
[hotfix][table]Improve column operations doc in tableAPI.

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -186,61 +186,8 @@ Table result = orders.select("a, c as d");
 {% highlight java %}
 Table result = orders.select("*");
 {% endhighlight %}
-      </td>
-    </tr>
-  <tr>
-          <td>
-            <strong>AddColumns</strong><br>
-            <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
-          </td>
-          <td>
-          <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
-{% highlight java %}
-Table orders = tableEnv.scan("Orders");
-Table result = orders.addColumns("concat(c, 'sunny')");
-{% endhighlight %}
 </td>
         </tr>
-        
- <tr>
-     <td>
-                    <strong>AddOrReplaceColumns</strong><br>
-                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
-                  </td>
-                  <td>
-                  <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
-{% highlight java %}
-Table orders = tableEnv.scan("Orders");
-Table result = orders.addOrReplaceColumns("concat(c, 'sunny') as desc");
-{% endhighlight %}
-                  </td>
-                </tr>
-         <tr>
-                  <td>
-                    <strong>DropColumns</strong><br>
-                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
-                  </td>
-                  <td>
-                  <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
-{% highlight java %}
-Table orders = tableEnv.scan("Orders");
-Table result = orders.dropColumns("b, c");
-{% endhighlight %}
-                  </td>
-                </tr>
-         <tr>
-                  <td>
-                    <strong>RenameColumns</strong><br>
-                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
-                  </td>
-                  <td>
-                  <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
-{% highlight java %}
-Table orders = tableEnv.scan("Orders");
-Table result = orders.renameColumns("b as b2, c as c2");
-{% endhighlight %}
-                  </td>
-                </tr>
     <tr>
       <td>
         <strong>As</strong><br>
@@ -317,6 +264,123 @@ val result = orders.select('*)
 {% endhighlight %}
       </td>
     </tr>
+    <tr>
+      <td>
+        <strong>As</strong><br>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+      </td>
+      <td>
+        <p>Renames fields.</p>
+{% highlight scala %}
+val orders: Table = tableEnv.scan("Orders").as('x, 'y, 'z, 't)
+{% endhighlight %}
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        <strong>Where / Filter</strong><br>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+      </td>
+      <td>
+        <p>Similar to a SQL WHERE clause. Filters out rows that do not pass the filter predicate.</p>
+{% highlight scala %}
+val orders: Table = tableEnv.scan("Orders")
+val result = orders.filter('a % 2 === 0)
+{% endhighlight %}
+or
+{% highlight scala %}
+val orders: Table = tableEnv.scan("Orders")
+val result = orders.where('b === "red")
+{% endhighlight %}
+      </td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</div>
+
+{% top %}
+
+### Column Operations
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Operators</th>
+      <th class="text-center">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+          <td>
+            <strong>AddColumns</strong><br>
+            <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+          </td>
+          <td>
+          <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
+{% highlight java %}
+Table orders = tableEnv.scan("Orders");
+Table result = orders.addColumns("concat(c, 'sunny')");
+{% endhighlight %}
+</td>
+        </tr>
+        
+ <tr>
+     <td>
+                    <strong>AddOrReplaceColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                  <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
+{% highlight java %}
+Table orders = tableEnv.scan("Orders");
+Table result = orders.addOrReplaceColumns("concat(c, 'sunny') as desc");
+{% endhighlight %}
+                  </td>
+                </tr>
+         <tr>
+                  <td>
+                    <strong>DropColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                  <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
+{% highlight java %}
+Table orders = tableEnv.scan("Orders");
+Table result = orders.dropColumns("b, c");
+{% endhighlight %}
+                  </td>
+                </tr>
+         <tr>
+                  <td>
+                    <strong>RenameColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                  <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
+{% highlight java %}
+Table orders = tableEnv.scan("Orders");
+Table result = orders.renameColumns("b as b2, c as c2");
+{% endhighlight %}
+                  </td>
+                </tr>
+  </tbody>
+</table>
+
+</div>
+<div data-lang="scala" markdown="1">
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Operators</th>
+      <th class="text-center">Description</th>
+    </tr>
+  </thead>
+  <tbody>
      <tr>
           <td>
             <strong>AddColumns</strong><br>
@@ -369,37 +433,6 @@ val result = orders.renameColumns('b as 'b2, 'c as 'c2)
 {% endhighlight %}
                   </td>
                 </tr>                
-    <tr>
-      <td>
-        <strong>As</strong><br>
-        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
-      </td>
-      <td>
-        <p>Renames fields.</p>
-{% highlight scala %}
-val orders: Table = tableEnv.scan("Orders").as('x, 'y, 'z, 't)
-{% endhighlight %}
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <strong>Where / Filter</strong><br>
-        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
-      </td>
-      <td>
-        <p>Similar to a SQL WHERE clause. Filters out rows that do not pass the filter predicate.</p>
-{% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
-val result = orders.filter('a % 2 === 0)
-{% endhighlight %}
-or
-{% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
-val result = orders.where('b === "red")
-{% endhighlight %}
-      </td>
-    </tr>
   </tbody>
 </table>
 </div>


### PR DESCRIPTION
## What is the purpose of the change

Move the document of AddColumns/AddOrReplaceColumns/DropColumns/RenameColumns to a separate menu, similar to Set Operations.


## Brief change log
  - Move the document of AddColumns/AddOrReplaceColumns/DropColumns/RenameColumns to a separate menu

## Verifying this change
This change is only a document improvement.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
