### PR TITLE
[FLINK-12112][tests] Properly print process output

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -194,16 +194,16 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 		}
 		catch (Exception e) {
 			e.printStackTrace();
-			printProcessLog("TaskManager 1", taskManagerProcess1.getOutput().toString());
-			printProcessLog("TaskManager 2", taskManagerProcess1.getOutput().toString());
-			printProcessLog("TaskManager 3", taskManagerProcess1.getOutput().toString());
+			printProcessLog("TaskManager 1", taskManagerProcess1);
+			printProcessLog("TaskManager 2", taskManagerProcess2);
+			printProcessLog("TaskManager 3", taskManagerProcess3);
 			fail(e.getMessage());
 		}
 		catch (Error e) {
 			e.printStackTrace();
-			printProcessLog("TaskManager 1", taskManagerProcess1.getOutput().toString());
-			printProcessLog("TaskManager 2", taskManagerProcess1.getOutput().toString());
-			printProcessLog("TaskManager 3", taskManagerProcess1.getOutput().toString());
+			printProcessLog("TaskManager 1", taskManagerProcess1);
+			printProcessLog("TaskManager 2", taskManagerProcess2);
+			printProcessLog("TaskManager 3", taskManagerProcess3);
 			throw e;
 		}
 		finally {
@@ -230,7 +230,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 
 		if (!process.getProcess().waitFor(30, TimeUnit.SECONDS)) {
 			log.error("{} did not shutdown in time.", processName);
-			printProcessLog(processName, process.getOutput().toString());
+			printProcessLog(processName, process);
 			process.getProcess().destroyForcibly();
 		}
 	}
@@ -245,18 +245,20 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 	 */
 	public abstract void testTaskManagerFailure(Configuration configuration, File coordinateDir) throws Exception;
 
-	protected static void printProcessLog(String processName, String log) {
-		if (log == null || log.length() == 0) {
-			return;
+	protected static void printProcessLog(String processName, TestProcess process) {
+		if (process == null) {
+			System.out.println("-----------------------------------------");
+			System.out.println(" PROCESS " + processName + " WAS NOT STARTED.");
+			System.out.println("-----------------------------------------");
+		} else {
+			System.out.println("-----------------------------------------");
+			System.out.println(" BEGIN SPAWNED PROCESS LOG FOR " + processName);
+			System.out.println("-----------------------------------------");
+			System.out.println(process.getOutput().toString());
+			System.out.println("-----------------------------------------");
+			System.out.println("		END SPAWNED PROCESS LOG");
+			System.out.println("-----------------------------------------");
 		}
-
-		System.out.println("-----------------------------------------");
-		System.out.println(" BEGIN SPAWNED PROCESS LOG FOR " + processName);
-		System.out.println("-----------------------------------------");
-		System.out.println(log);
-		System.out.println("-----------------------------------------");
-		System.out.println("		END SPAWNED PROCESS LOG");
-		System.out.println("-----------------------------------------");
 	}
 
 	protected static void touchFile(File file) throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

Fixes an issue in the `AbstractTaskManagerProcessFailureRecoveryTest` where the test, during the process output dumping,
a) prints the logs of the first TM 3 times
b) is very prone to NullPointerExceptions.

