### PR TITLE
[FLINK-12099] Disable elasticsearch 1 tests on java 9

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch/pom.xml
@@ -84,6 +84,27 @@ under the License.
 
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>java9</id>
+			<activation>
+				<jdk>9</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<!-- ES 1 does not support Java 9 -->
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -102,7 +102,6 @@ MODULES_CONNECTORS_JDK9_EXCLUSIONS="\
 !flink-formats/flink-avro,\
 !flink-connectors/flink-hbase,\
 !flink-connectors/flink-connector-cassandra,\
-!flink-connectors/flink-connector-elasticsearch,\
 !flink-connectors/flink-connector-kafka-0.9,\
 !flink-connectors/flink-connector-kafka-0.10,\
 !flink-connectors/flink-connector-kafka-0.11"


### PR DESCRIPTION
ES1 simply doesn't support Java 9 so the tests are disabled in that case.