### PR TITLE
[FLINK-11920][scala] Reuse java classpath

### DIFF
--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
@@ -192,16 +192,8 @@ object EnumValueSerializerUpgradeTest {
 
     val settings = new GenericRunnerSettings(out.println _)
 
-    val classLoader = Thread.currentThread().getContextClassLoader
-
-    val urls = classLoader match {
-      case urlClassLoader: URLClassLoader =>
-        urlClassLoader.getURLs
-      case x => throw new IllegalStateException(s"Not possible to extract URLs " +
-        s"from class loader $x.")
-    }
-
-    settings.classpath.value = urls.map(_.toString).mkString(java.io.File.pathSeparator)
+    // use the java classpath so that scala libraries are available to the compiler
+    settings.usejavacp.value = true
     settings.outdir.value = file.getParent
 
     val reporter = new ConsoleReporter(settings)

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -42,7 +42,6 @@ MODULES_CORE_JDK9_EXCLUSIONS="\
 !flink-state-backends/flink-statebackend-rocksdb,\
 !flink-clients,\
 !flink-runtime,\
-!flink-scala,\
 !flink-scala-shell"
 
 MODULES_LIBRARIES="\


### PR DESCRIPTION
Simplifies the `EnumValueSerializerUpgradeTest` by setting `usejavacp` instead of manually re-creating the classpath.

With this the test passes on Java 9. Replacing the URLClassLoader with `ClassLoaderUtils#getClassPathURLs` was not sufficient.