### PR TITLE
FLINK-12119 [build-system] add owasp-dependency-check plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1813,6 +1813,23 @@ under the License.
 					</executions>
 				</plugin>
 
+				<plugin>
+					<!-- run via "mvn org.owasp:dependency-check-maven:aggregate" -->
+					<groupId>org.owasp</groupId>
+					<artifactId>dependency-check-maven</artifactId>
+					<version>5.0.0-M2</version>
+					<configuration>
+						<format>ALL</format>
+						<skipSystemScope>true</skipSystemScope>
+						<skipProvidedScope>true</skipProvidedScope>
+						<excludes>
+							<exclude>*flink-docs</exclude>
+							<exclude>*flink-end-to-end-tests</exclude>
+							<exclude>*flink-fs-tests*</exclude>
+							<exclude>*flink-yarn-tests*</exclude>
+						</excludes>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
## What is the purpose of the change

* Add OWASP dependency check to Flink build to keep track of known security vulnerabilities in Flink's dependencies

## Brief change log

* Added maven-dependency-check plugin check to parent pom
* Skipping dependency-check for docs, contrib, yarn-tests & fs-tests


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

Run {{mvn clean org.owasp:dependency-check-maven:5.0.0-M2:aggregate}} and check depdency-report in target directory

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes, to the build-system
  - If yes, how is the feature documented? not sure, where to document it
