### PR TITLE
[FLINK-11877] Implement the runtime handling of the InputSelectable interface

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.SourceStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationHead;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationTail;
+import org.apache.flink.streaming.runtime.tasks.TwoInputSelectableStreamTask;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
 import org.apache.flink.util.OutputTag;
 
@@ -225,7 +226,10 @@ public class StreamGraph extends StreamingPlan {
 			TypeInformation<OUT> outTypeInfo,
 			String operatorName) {
 
-		addNode(vertexID, slotSharingGroup, coLocationGroup, TwoInputStreamTask.class, taskOperatorFactory, operatorName);
+		Class<? extends AbstractInvokable> vertexClass = taskOperatorFactory.isOperatorSelectiveReading() ?
+			TwoInputSelectableStreamTask.class : TwoInputStreamTask.class;
+
+		addNode(vertexID, slotSharingGroup, coLocationGroup, vertexClass, taskOperatorFactory, operatorName);
 
 		TypeSerializer<OUT> outSerializer = (outTypeInfo != null) && !(outTypeInfo instanceof MissingTypeInfo) ?
 				outTypeInfo.createSerializer(executionConfig) : null;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BoundedMultiInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BoundedMultiInput.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Interface for the multi-input operators that can process EndOfInput event.
+ */
+@PublicEvolving
+public interface BoundedMultiInput {
+
+	/**
+	 * It is notified that no more data will arrive on the input identified by the {@code inputId}.
+	 * The {@code inputId} is numbered starting from 1, and `1` indicates the first input.
+	 */
+	void endInput(int inputId) throws Exception;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BoundedOneInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BoundedOneInput.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Interface for the one-input operators that can process EndOfInput event.
+ */
+@PublicEvolving
+public interface BoundedOneInput {
+
+	/**
+	 * It is notified that no more data will arrive on the input.
+	 */
+	void endInput() throws Exception;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelectable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelectable.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Interface for stream operators that can select the input to get
+ * {@link org.apache.flink.streaming.runtime.streamrecord.StreamRecord}.
+ *
+ * <p><b>IMPORTANT:</b> This interface is a loose contract. The runtime may read multiple
+ * records continuously before calling {@code nextSelection()} again to determine whether
+ * to change the input to be read. That is, it is not guaranteed that {@code nextSelection()}
+ * will be called immediately after the operator has processed a record and the reading input
+ * will be changed according to {@link InputSelection} returned. This means that the operator
+ * may receive some data that it does not currently want to process. Therefore, if an operator
+ * needs a strict convention, it must cache the unexpected data itself and handle them correctly.
+ *
+ * <p>This interface also makes the following conventions:
+ * 1.The runtime must call {@code nextSelection()} to determine the input to read the first record.
+ * 2.When the input being read reaches the end, the runtime must call {@code nextSelection()} to
+ *   determine the next input to be read.
+ */
+@PublicEvolving
+public interface InputSelectable {
+
+	/**
+	 * Returns the next {@link InputSelection} that wants to get the record.
+	 * This method is guaranteed to not be called concurrently with other methods of the operator.
+	 */
+	InputSelection nextSelection();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+
+/**
+ * Describe the input selection that stream operators want to read records.
+ */
+@PublicEvolving
+public final class InputSelection implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The {@code InputSelection} instance which indicates to select all inputs.
+	 */
+	public static final InputSelection ALL = new InputSelection(-1, Boolean.TRUE);
+
+	/**
+	 * The {@code InputSelection} instance which indicates to select the first input.
+	 */
+	public static final InputSelection FIRST = new Builder().select(1).build();
+
+	/**
+	 * The {@code InputSelection} instance which indicates to select the second input.
+	 */
+	public static final InputSelection SECOND = new Builder().select(2).build();
+
+	private final long inputMask;
+
+	private final boolean isALLMaskOf2;
+
+	private InputSelection(long inputMask, boolean isALLMaskOf2) {
+		this.inputMask = inputMask;
+		this.isALLMaskOf2 = isALLMaskOf2;
+	}
+
+	public long getInputMask() {
+		return inputMask;
+	}
+
+	/**
+	 * Tells whether or not the input mask includes all of two inputs.
+	 *
+	 * @return {@code true} if the input mask includes all of two inputs, false otherwise.
+	 */
+	public boolean isALLMaskOf2() {
+		return isALLMaskOf2;
+	}
+
+	/**
+	 * Fairly select one of the two inputs for reading. When {@code inputMask} includes two inputs and
+	 * both inputs are available, alternately select one of them. Otherwise, select the available one
+	 * of {@code inputMask}, or return -1 to indicate no input is selected.
+	 *
+	 * <p>Note that this supports only two inputs for performance reasons.
+	 *
+	 * @param availableInputsMask The mask of all available inputs.
+	 * @param lastReadInputIndex The index of last read input.
+	 * @return the index of the input for reading or -1, and -1 indicates no input is selected (
+	 *         {@code inputMask} is empty or the inputs in {@code inputMask} are unavailable).
+	 */
+	public int fairSelectNextIndexOutOf2(int availableInputsMask, int lastReadInputIndex) {
+		int selectionMask = (int) inputMask;
+		int combineMask = availableInputsMask & selectionMask;
+
+		if (combineMask == 3) {
+			return lastReadInputIndex == 0 ? 1 : 0;
+		} else if (combineMask >= 0 && combineMask < 3) {
+			return combineMask - 1;
+		}
+
+		throw new UnsupportedOperationException("Only two inputs are supported.");
+	}
+
+	private static boolean isALLMaskOf2(long inputMask) {
+		return (3 & inputMask) == 3;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		InputSelection that = (InputSelection) o;
+		return inputMask == that.inputMask;
+	}
+
+	@Override
+	public String toString() {
+		return String.valueOf(inputMask);
+	}
+
+	/**
+	 * Utility class for creating {@link InputSelection}.
+	 */
+	public static final class Builder {
+
+		private long inputMask = 0;
+
+		/**
+		 * Selects an input identified by the given {@code inputId}.
+		 *
+		 * @param inputId
+		 *     the input id numbered starting from 1 to 64, and `1` indicates the first input.
+		 *     Specially, `-1` indicates all inputs.
+		 * @return a reference to this object.
+		 */
+		public Builder select(int inputId) {
+			if (inputId > 0 && inputId <= 64){
+				inputMask |= 1L << (inputId - 1);
+			} else if (inputId == -1L) {
+				inputMask = -1L;
+			} else {
+				throw new IllegalArgumentException("The inputId must be in the range of 1 to 64, or be -1.");
+			}
+
+			return this;
+		}
+
+		public InputSelection build() {
+			return new InputSelection(inputMask, isALLMaskOf2(inputMask));
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
@@ -88,6 +88,11 @@ public class SimpleOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
 	}
 
 	@Override
+	public boolean isOperatorSelectiveReading() {
+		return operator instanceof InputSelectable;
+	}
+
+	@Override
 	public boolean isOutputTypeConfigurable() {
 		return operator instanceof OutputTypeConfigurable;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactory.java
@@ -59,6 +59,11 @@ public interface StreamOperatorFactory<OUT> extends Serializable {
 	}
 
 	/**
+	 * Test whether the operator is selective reading one.
+	 */
+	boolean isOperatorSelectiveReading();
+
+	/**
 	 * If the stream operator need access to the output type information at {@link StreamGraph}
 	 * generation. This can be useful for cases where the output type is specified by the returns
 	 * method and, thus, after the stream operator has been created.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierDiscarder.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierDiscarder.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The BarrierDiscarder discards checkpoint barriers have been received from which input channels.
+ */
+@Internal
+public class BarrierDiscarder implements CheckpointBarrierHandler {
+
+	// ------------------------------------------------------------------------
+
+	/** The input gate, to draw the buffers and events from. */
+	private final InputGate inputGate;
+
+	/**
+	 * The number of channels. Once that many barriers have been received for a checkpoint, the
+	 * checkpoint is considered complete.
+	 */
+	private final int totalNumberOfInputChannels;
+
+
+	/** The listener to be notified on complete checkpoints. */
+	private AbstractInvokable toNotifyOnCheckpoint;
+
+	// ------------------------------------------------------------------------
+
+	public BarrierDiscarder(InputGate inputGate) {
+		this.inputGate = inputGate;
+		this.totalNumberOfInputChannels = inputGate.getNumberOfInputChannels();
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return inputGate.isAvailable();
+	}
+
+	@Override
+	public boolean isFinished() {
+		return inputGate.isFinished();
+	}
+
+	@Override
+	public Optional<BufferOrEvent> pollNext() throws Exception {
+		while (true) {
+			Optional<BufferOrEvent> next = inputGate.pollNext();
+			if (!next.isPresent()) {
+				// buffer or input exhausted
+				return next;
+			}
+
+			BufferOrEvent bufferOrEvent = next.get();
+			if (bufferOrEvent.isBuffer()) {
+				return next;
+			}
+			else if (bufferOrEvent.getEvent().getClass() != CheckpointBarrier.class &&
+				bufferOrEvent.getEvent().getClass() != CancelCheckpointMarker.class) {
+				// some other event
+				return next;
+			}
+		}
+	}
+
+	@Override
+	public void registerCheckpointEventHandler(AbstractInvokable toNotifyOnCheckpoint) {
+		if (this.toNotifyOnCheckpoint == null) {
+			this.toNotifyOnCheckpoint = toNotifyOnCheckpoint;
+		}
+		else {
+			throw new IllegalStateException("BarrierDiscarder already has a registered checkpoint notifyee");
+		}
+	}
+
+	@Override
+	public void cleanup() {
+
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return true;
+	}
+
+	@Override
+	public long getAlignmentDurationNanos() {
+		// this one does not do alignment at all
+		return 0L;
+	}
+
+	@Override
+	public int getNumberOfInputChannels() {
+		return totalNumberOfInputChannels;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -107,7 +107,7 @@ public class StreamInputProcessor<IN> {
 			inputGate,
 			taskManagerConfig,
 			taskName);
-		this.input = new StreamTaskNetworkInput(barrierHandler, inputSerializer, ioManager);
+		this.input = new StreamTaskNetworkInput(barrierHandler, inputSerializer, ioManager, 0);
 
 		this.lock = checkNotNull(lock);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskInput.java
@@ -35,4 +35,9 @@ public interface StreamTaskInput extends NullableAsyncDataInput<StreamElement>, 
 	 * it is unspecified.
 	 */
 	int getLastChannel();
+
+	/**
+	 * Returns the input index of this input.
+	 */
+	int getInputIndex();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -53,6 +53,8 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 
 	private final RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers;
 
+	private final int inputIndex;
+
 	private int lastChannel = UNSPECIFIED;
 
 	private RecordDeserializer<DeserializationDelegate<StreamElement>> currentRecordDeserializer = null;
@@ -63,7 +65,8 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 	public StreamTaskNetworkInput(
 			CheckpointBarrierHandler barrierHandler,
 			TypeSerializer<?> inputSerializer,
-			IOManager ioManager) {
+			IOManager ioManager,
+			int inputIndex) {
 		this.barrierHandler = barrierHandler;
 		this.deserializationDelegate = new NonReusingDeserializationDelegate<>(
 			new StreamElementSerializer<>(inputSerializer));
@@ -74,6 +77,8 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 			recordDeserializers[i] = new SpillingAdaptiveSpanningRecordDeserializer<>(
 				ioManager.getSpillingDirectoriesPaths());
 		}
+
+		this.inputIndex = inputIndex;
 	}
 
 	@Override
@@ -129,6 +134,11 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 	@Override
 	public int getLastChannel() {
 		return lastChannel;
+	}
+
+	@Override
+	public int getInputIndex() {
+		return inputIndex;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputSelectableProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputSelectableProcessor.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Input reader for {@link org.apache.flink.streaming.runtime.tasks.TwoInputSelectableStreamTask}
+ * in the case that the operator is InputSelectable.
+ *
+ * @param <IN1> The type of the records that arrive on the first input
+ * @param <IN2> The type of the records that arrive on the second input
+ */
+@Internal
+public class StreamTwoInputSelectableProcessor<IN1, IN2> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(StreamTwoInputSelectableProcessor.class);
+
+	private static final CompletableFuture<?> UNAVAILABLE = new CompletableFuture<>();
+
+	private final TwoInputStreamOperator<IN1, IN2, ?> streamOperator;
+	private final InputSelectable inputSelector;
+
+	private final Object lock;
+
+	private final StreamTaskInput input1;
+	private final StreamTaskInput input2;
+
+	/**
+	 * Valves that control how watermarks and stream statuses from the 2 inputs are forwarded.
+	 */
+	private final StatusWatermarkValve statusWatermarkValve1;
+	private final StatusWatermarkValve statusWatermarkValve2;
+
+	/**
+	 * Stream status for the two inputs. We need to keep track for determining when
+	 * to forward stream status changes downstream.
+	 */
+	private StreamStatus firstStatus;
+	private StreamStatus secondStatus;
+
+	private int availableInputsMask;
+
+	private int lastReadInputIndex;
+
+	private InputSelection inputSelection;
+
+	private Counter numRecordsIn;
+
+	private boolean isPrepared;
+
+	public StreamTwoInputSelectableProcessor(
+		Collection<InputGate> inputGates1,
+		Collection<InputGate> inputGates2,
+		TypeSerializer<IN1> inputSerializer1,
+		TypeSerializer<IN2> inputSerializer2,
+		Object lock,
+		IOManager ioManager,
+		StreamStatusMaintainer streamStatusMaintainer,
+		TwoInputStreamOperator<IN1, IN2, ?> streamOperator,
+		WatermarkGauge input1WatermarkGauge,
+		WatermarkGauge input2WatermarkGauge) {
+
+		checkState(streamOperator instanceof InputSelectable);
+
+		this.streamOperator = checkNotNull(streamOperator);
+		this.inputSelector = (InputSelectable) streamOperator;
+
+		this.lock = checkNotNull(lock);
+
+		InputGate unionedInputGate1 = InputGateUtil.createInputGate(inputGates1.toArray(new InputGate[0]));
+		InputGate unionedInputGate2 = InputGateUtil.createInputGate(inputGates2.toArray(new InputGate[0]));
+
+		// create a Input instance for each input
+		this.input1 = new StreamTaskNetworkInput(new BarrierDiscarder(unionedInputGate1), inputSerializer1, ioManager, 0);
+		this.input2 = new StreamTaskNetworkInput(new BarrierDiscarder(unionedInputGate2), inputSerializer2, ioManager, 1);
+
+		this.statusWatermarkValve1 = new StatusWatermarkValve(
+			unionedInputGate1.getNumberOfInputChannels(),
+			new ForwardingValveOutputHandler(streamOperator, lock, streamStatusMaintainer, input1WatermarkGauge, 0));
+		this.statusWatermarkValve2 = new StatusWatermarkValve(
+			unionedInputGate2.getNumberOfInputChannels(),
+			new ForwardingValveOutputHandler(streamOperator, lock, streamStatusMaintainer, input2WatermarkGauge, 1));
+
+		this.firstStatus = StreamStatus.ACTIVE;
+		this.secondStatus = StreamStatus.ACTIVE;
+
+		this.availableInputsMask = (int) new InputSelection.Builder().select(1).select(2).build().getInputMask();
+
+		this.lastReadInputIndex = 1; // always try to read from the first input
+
+		this.isPrepared = false;
+
+	}
+
+	public boolean processInput() throws Exception {
+		if (!isPrepared) {
+			// the preparations here are not placed in the constructor because all work in it
+			// must be executed after all operators are opened.
+			prepareForProcessing();
+		}
+
+		int readingInputIndex = selectNextReadingInputIndex();
+		if (readingInputIndex == -1) {
+			return false;
+		}
+		lastReadInputIndex = readingInputIndex;
+
+		StreamElement recordOrMark;
+		if (readingInputIndex == 0) {
+			recordOrMark = input1.pollNextNullable();
+			if (recordOrMark != null) {
+				processElement1(recordOrMark, input1.getLastChannel());
+			}
+		} else {
+			recordOrMark = input2.pollNextNullable();
+			if (recordOrMark != null) {
+				processElement2(recordOrMark, input2.getLastChannel());
+			}
+		}
+
+		if (recordOrMark == null) {
+			setUnavailableInput(readingInputIndex);
+		}
+
+		return !checkFinished();
+	}
+
+	public void cleanup() throws Exception {
+		Exception ex = null;
+		try {
+			input1.close();
+		} catch (Exception e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		try {
+			input2.close();
+		} catch (Exception e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		if (ex != null) {
+			throw ex;
+		}
+	}
+
+	private int selectNextReadingInputIndex()
+		throws InterruptedException, ExecutionException, IOException {
+
+		int readingInputIndex;
+		while ((readingInputIndex = inputSelection.fairSelectNextIndexOutOf2(availableInputsMask, lastReadInputIndex)) == -1) {
+			if (!waitForAvailableInput(inputSelection)) {
+				return -1;
+			}
+		}
+
+		// to avoid starvation, if the input selection is ALL and availableInputsMask is not ALL,
+		// always try to check and set the availability of another input
+		// TODO: because this can be a costly operation (checking volatile inside CompletableFuture`
+		//  this might be optimized to only check once per processed NetworkBuffer
+		if (availableInputsMask < 3 && inputSelection.isALLMaskOf2()) {
+			checkAndSetAvailable(1 - readingInputIndex);
+		}
+
+		return readingInputIndex;
+	}
+
+	private void processElement1(StreamElement recordOrMark, int channel) throws Exception {
+		if (recordOrMark.isRecord()) {
+			StreamRecord<IN1> record = recordOrMark.asRecord();
+			synchronized (lock) {
+				numRecordsIn.inc();
+				streamOperator.setKeyContextElement1(record);
+				streamOperator.processElement1(record);
+				inputSelection = inputSelector.nextSelection();
+			}
+		}
+		else if (recordOrMark.isWatermark()) {
+			statusWatermarkValve1.inputWatermark(recordOrMark.asWatermark(), channel);
+		} else if (recordOrMark.isStreamStatus()) {
+			statusWatermarkValve1.inputStreamStatus(recordOrMark.asStreamStatus(), channel);
+		} else if (recordOrMark.isLatencyMarker()) {
+			synchronized (lock) {
+				streamOperator.processLatencyMarker1(recordOrMark.asLatencyMarker());
+			}
+		} else {
+			throw new UnsupportedOperationException("Unknown type of StreamElement on input1");
+		}
+	}
+
+	private void processElement2(StreamElement recordOrMark, int channel) throws Exception {
+		if (recordOrMark.isRecord()) {
+			StreamRecord<IN2> record = recordOrMark.asRecord();
+			synchronized (lock) {
+				numRecordsIn.inc();
+				streamOperator.setKeyContextElement2(record);
+				streamOperator.processElement2(record);
+				inputSelection = inputSelector.nextSelection();
+			}
+		}
+		else if (recordOrMark.isWatermark()) {
+			statusWatermarkValve2.inputWatermark(recordOrMark.asWatermark(), channel);
+		} else if (recordOrMark.isStreamStatus()) {
+			statusWatermarkValve2.inputStreamStatus(recordOrMark.asStreamStatus(), channel);
+		} else if (recordOrMark.isLatencyMarker()) {
+			synchronized (lock) {
+				streamOperator.processLatencyMarker2(recordOrMark.asLatencyMarker());
+			}
+		} else {
+			throw new UnsupportedOperationException("Unknown type of StreamElement on input2");
+		}
+	}
+
+	private void prepareForProcessing() {
+		// Note: the first call to nextSelection () on the operator must be made after this operator
+		// is opened to ensure that any changes about the input selection in its open()
+		// method take effect.
+		inputSelection = inputSelector.nextSelection();
+
+		try {
+			numRecordsIn = ((OperatorMetricGroup) streamOperator
+				.getMetricGroup()).getIOMetricGroup().getNumRecordsInCounter();
+		} catch (Exception e) {
+			LOG.warn("An exception occurred during the metrics setup.", e);
+			numRecordsIn = new SimpleCounter();
+		}
+
+		isPrepared = true;
+	}
+
+	private void checkAndSetAvailable(int inputIndex) {
+		StreamTaskInput input = getInput(inputIndex);
+		if (!input.isFinished() && input.isAvailable().isDone()) {
+			setAvailableInput(inputIndex);
+		}
+	}
+
+	/**
+	 * @return false if both of the inputs are finished, true otherwise.
+	 */
+	private boolean waitForAvailableInput(InputSelection inputSelection)
+		throws ExecutionException, InterruptedException, IOException {
+
+		if (inputSelection.isALLMaskOf2()) {
+			return waitForAvailableEitherInput();
+		} else {
+			waitForOneInput(
+				(inputSelection.getInputMask() == InputSelection.FIRST.getInputMask()) ? input1 : input2);
+			return true;
+		}
+	}
+
+	private boolean waitForAvailableEitherInput()
+		throws ExecutionException, InterruptedException {
+
+		CompletableFuture<?> future1 = input1.isFinished() ? UNAVAILABLE : input1.isAvailable();
+		CompletableFuture<?> future2 = input2.isFinished() ? UNAVAILABLE : input2.isAvailable();
+
+		if (future1 == UNAVAILABLE && future2 == UNAVAILABLE) {
+			return false;
+		}
+
+		// block to wait for a available input
+		CompletableFuture.anyOf(future1, future2).get();
+
+		if (future1.isDone()) {
+			setAvailableInput(input1.getInputIndex());
+		}
+		if (future2.isDone()) {
+			setAvailableInput(input2.getInputIndex());
+		}
+
+		return true;
+	}
+
+	private void waitForOneInput(StreamTaskInput input)
+		throws IOException, ExecutionException, InterruptedException {
+
+		if (input.isFinished()) {
+			throw new IOException("Could not read the finished input: input" + (input.getInputIndex() + 1) +  ".");
+		}
+
+		input.isAvailable().get();
+		setAvailableInput(input.getInputIndex());
+	}
+
+	private boolean checkFinished() {
+		if (getInput(lastReadInputIndex).isFinished()) {
+			inputSelection = (lastReadInputIndex == 0) ? InputSelection.SECOND : InputSelection.FIRST;
+			// TODO: adds the runtime handling of the BoundedMultiInput interface;
+		}
+
+		return input1.isFinished() && input2.isFinished();
+	}
+
+	private void setAvailableInput(int inputIndex) {
+		availableInputsMask |= 1 << inputIndex;
+	}
+
+	private void setUnavailableInput(int inputIndex) {
+		availableInputsMask &= ~(1 << inputIndex);
+	}
+
+	private StreamTaskInput getInput(int inputIndex) {
+		return inputIndex == 0 ? input1 : input2;
+	}
+
+	private class ForwardingValveOutputHandler implements StatusWatermarkValve.ValveOutputHandler {
+
+		private final TwoInputStreamOperator<IN1, IN2, ?> operator;
+
+		private final Object lock;
+
+		private final StreamStatusMaintainer streamStatusMaintainer;
+
+		private final WatermarkGauge inputWatermarkGauge;
+
+		private final int inputIndex;
+
+		private ForwardingValveOutputHandler(
+			TwoInputStreamOperator<IN1, IN2, ?> operator,
+			Object lock,
+			StreamStatusMaintainer streamStatusMaintainer,
+			WatermarkGauge inputWatermarkGauge,
+			int inputIndex) {
+
+			this.operator = checkNotNull(operator);
+			this.lock = checkNotNull(lock);
+
+			this.streamStatusMaintainer = checkNotNull(streamStatusMaintainer);
+
+			this.inputWatermarkGauge = inputWatermarkGauge;
+
+			this.inputIndex = inputIndex;
+		}
+
+		@Override
+		public void handleWatermark(Watermark watermark) {
+			try {
+				synchronized (lock) {
+					inputWatermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+					if (inputIndex == 0) {
+						operator.processWatermark1(watermark);
+					} else {
+						operator.processWatermark2(watermark);
+					}
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("Exception occurred while processing valve output watermark of input"
+					+ (inputIndex + 1) + ": ", e);
+			}
+		}
+
+		@Override
+		public void handleStreamStatus(StreamStatus streamStatus) {
+			try {
+				synchronized (lock) {
+					final StreamStatus anotherStreamStatus;
+					if (inputIndex == 0) {
+						firstStatus = streamStatus;
+						anotherStreamStatus = secondStatus;
+					} else {
+						secondStatus = streamStatus;
+						anotherStreamStatus = firstStatus;
+					}
+
+					// check if we need to toggle the task's stream status
+					if (!streamStatus.equals(streamStatusMaintainer.getStreamStatus())) {
+						if (streamStatus.isActive()) {
+							// we're no longer idle if at least one input has become active
+							streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
+						} else if (anotherStreamStatus.isIdle()) {
+							// we're idle once both inputs are idle
+							streamStatusMaintainer.toggleStreamStatus(StreamStatus.IDLE);
+						}
+					}
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("Exception occurred while processing valve output stream status of input"
+					+ (inputIndex + 1) + ": ", e);
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.metrics.MinWatermarkGauge;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Abstract class for executing a {@link TwoInputStreamOperator}.
+ */
+@Internal
+public abstract class AbstractTwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputStreamOperator<IN1, IN2, OUT>> {
+
+	protected final WatermarkGauge input1WatermarkGauge;
+	protected final WatermarkGauge input2WatermarkGauge;
+	protected final MinWatermarkGauge minInputWatermarkGauge;
+
+	/**
+	 * Constructor for initialization, possibly with initial state (recovery / savepoint / etc).
+	 *
+	 * @param env The task environment for this task.
+	 */
+	public AbstractTwoInputStreamTask(Environment env) {
+		super(env);
+
+		input1WatermarkGauge = new WatermarkGauge();
+		input2WatermarkGauge = new WatermarkGauge();
+		minInputWatermarkGauge = new MinWatermarkGauge(input1WatermarkGauge, input2WatermarkGauge);
+	}
+
+	@Override
+	public void init() throws Exception {
+		StreamConfig configuration = getConfiguration();
+		ClassLoader userClassLoader = getUserCodeClassLoader();
+
+		TypeSerializer<IN1> inputDeserializer1 = configuration.getTypeSerializerIn1(userClassLoader);
+		TypeSerializer<IN2> inputDeserializer2 = configuration.getTypeSerializerIn2(userClassLoader);
+
+		int numberOfInputs = configuration.getNumberOfInputs();
+
+		ArrayList<InputGate> inputList1 = new ArrayList<InputGate>();
+		ArrayList<InputGate> inputList2 = new ArrayList<InputGate>();
+
+		List<StreamEdge> inEdges = configuration.getInPhysicalEdges(userClassLoader);
+
+		for (int i = 0; i < numberOfInputs; i++) {
+			int inputType = inEdges.get(i).getTypeNumber();
+			InputGate reader = getEnvironment().getInputGate(i);
+			switch (inputType) {
+				case 1:
+					inputList1.add(reader);
+					break;
+				case 2:
+					inputList2.add(reader);
+					break;
+				default:
+					throw new RuntimeException("Invalid input type number: " + inputType);
+			}
+		}
+
+		createInputProcessor(inputList1, inputList2, inputDeserializer1, inputDeserializer2);
+
+		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge);
+		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_1_WATERMARK, input1WatermarkGauge);
+		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_2_WATERMARK, input2WatermarkGauge);
+		// wrap watermark gauge since registered metrics must be unique
+		getEnvironment().getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge::getValue);
+	}
+
+	protected abstract void createInputProcessor(
+		Collection<InputGate> inputGates1,
+		Collection<InputGate> inputGates2,
+		TypeSerializer<IN1> inputDeserializer1,
+		TypeSerializer<IN2> inputDeserializer2) throws Exception;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputSelectableStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputSelectableStreamTask.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.io.StreamTwoInputSelectableProcessor;
+
+import java.util.Collection;
+
+/**
+ * A {@link StreamTask} for executing a {@link TwoInputStreamOperator} and supporting
+ * the {@link TwoInputStreamOperator} to select input for reading.
+ */
+@Internal
+public class TwoInputSelectableStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTask<IN1, IN2, OUT> {
+
+	private StreamTwoInputSelectableProcessor<IN1, IN2> inputProcessor;
+
+	public TwoInputSelectableStreamTask(Environment env) {
+		super(env);
+	}
+
+	@Override
+	protected void createInputProcessor(
+		Collection<InputGate> inputGates1,
+		Collection<InputGate> inputGates2,
+		TypeSerializer<IN1> inputDeserializer1,
+		TypeSerializer<IN2> inputDeserializer2) {
+
+		this.inputProcessor = new StreamTwoInputSelectableProcessor<>(
+			inputGates1, inputGates2,
+			inputDeserializer1, inputDeserializer2,
+			this,
+			getEnvironment().getIOManager(),
+			getStreamStatusMaintainer(),
+			this.headOperator,
+			input1WatermarkGauge,
+			input2WatermarkGauge);
+	}
+
+	@Override
+	protected void performDefaultAction(ActionContext context) throws Exception {
+		if (!inputProcessor.processInput()) {
+			context.allActionsCompleted();
+		}
+	}
+
+	@Override
+	protected void cleanup() throws Exception {
+		if (inputProcessor != null) {
+			inputProcessor.cleanup();
+		}
+	}
+
+	@Override
+	protected void cancelTask() {
+
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -21,91 +21,45 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
-import org.apache.flink.runtime.metrics.MetricNames;
-import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessor;
-import org.apache.flink.streaming.runtime.metrics.MinWatermarkGauge;
-import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 
 /**
- * A {@link StreamTask} for executing a {@link TwoInputStreamOperator}.
+ * A {@link StreamTask} that executes a {@link TwoInputStreamOperator} but does not support
+ * the {@link TwoInputStreamOperator} to select input for reading.
  */
 @Internal
-public class TwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputStreamOperator<IN1, IN2, OUT>> {
+public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTask<IN1, IN2, OUT> {
 
 	private StreamTwoInputProcessor<IN1, IN2> inputProcessor;
 
-	private final WatermarkGauge input1WatermarkGauge;
-	private final WatermarkGauge input2WatermarkGauge;
-	private final MinWatermarkGauge minInputWatermarkGauge;
-
-	/**
-	 * Constructor for initialization, possibly with initial state (recovery / savepoint / etc).
-	 *
-	 * @param env The task environment for this task.
-	 */
 	public TwoInputStreamTask(Environment env) {
 		super(env);
-		input1WatermarkGauge = new WatermarkGauge();
-		input2WatermarkGauge = new WatermarkGauge();
-		minInputWatermarkGauge = new MinWatermarkGauge(input1WatermarkGauge, input2WatermarkGauge);
 	}
 
 	@Override
-	public void init() throws Exception {
-		StreamConfig configuration = getConfiguration();
-		ClassLoader userClassLoader = getUserCodeClassLoader();
-
-		TypeSerializer<IN1> inputDeserializer1 = configuration.getTypeSerializerIn1(userClassLoader);
-		TypeSerializer<IN2> inputDeserializer2 = configuration.getTypeSerializerIn2(userClassLoader);
-
-		int numberOfInputs = configuration.getNumberOfInputs();
-
-		ArrayList<InputGate> inputList1 = new ArrayList<InputGate>();
-		ArrayList<InputGate> inputList2 = new ArrayList<InputGate>();
-
-		List<StreamEdge> inEdges = configuration.getInPhysicalEdges(userClassLoader);
-
-		for (int i = 0; i < numberOfInputs; i++) {
-			int inputType = inEdges.get(i).getTypeNumber();
-			InputGate reader = getEnvironment().getInputGate(i);
-			switch (inputType) {
-				case 1:
-					inputList1.add(reader);
-					break;
-				case 2:
-					inputList2.add(reader);
-					break;
-				default:
-					throw new RuntimeException("Invalid input type number: " + inputType);
-			}
-		}
+	protected void createInputProcessor(
+		Collection<InputGate> inputGates1,
+		Collection<InputGate> inputGates2,
+		TypeSerializer<IN1> inputDeserializer1,
+		TypeSerializer<IN2> inputDeserializer2) throws Exception {
 
 		this.inputProcessor = new StreamTwoInputProcessor<>(
-				inputList1, inputList2,
-				inputDeserializer1, inputDeserializer2,
-				this,
-				configuration.getCheckpointMode(),
-				getCheckpointLock(),
-				getEnvironment().getIOManager(),
-				getEnvironment().getTaskManagerInfo().getConfiguration(),
-				getStreamStatusMaintainer(),
-				this.headOperator,
-				getEnvironment().getMetricGroup().getIOMetricGroup(),
-				input1WatermarkGauge,
-				input2WatermarkGauge,
-				getTaskNameWithSubtaskAndId());
-
-		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge);
-		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_1_WATERMARK, input1WatermarkGauge);
-		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_2_WATERMARK, input2WatermarkGauge);
-		// wrap watermark gauge since registered metrics must be unique
-		getEnvironment().getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge::getValue);
+			inputGates1, inputGates2,
+			inputDeserializer1, inputDeserializer2,
+			this,
+			getConfiguration().getCheckpointMode(),
+			getCheckpointLock(),
+			getEnvironment().getIOManager(),
+			getEnvironment().getTaskManagerInfo().getConfiguration(),
+			getStreamStatusMaintainer(),
+			this.headOperator,
+			getEnvironment().getMetricGroup().getIOMetricGroup(),
+			input1WatermarkGauge,
+			input2WatermarkGauge,
+			getTaskNameWithSubtaskAndId());
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.streaming.api.operators.InputSelection.Builder;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link InputSelection}.
+ */
+public class InputSelectionTest {
+
+	@Test
+	public void testIsALLMaskOf2() {
+		assertTrue(InputSelection.ALL.isALLMaskOf2());
+		assertTrue(new Builder().select(1).select(2).build().isALLMaskOf2());
+
+		assertFalse(InputSelection.FIRST.isALLMaskOf2());
+		assertFalse(InputSelection.SECOND.isALLMaskOf2());
+		assertFalse(new Builder().select(3).build().isALLMaskOf2());
+	}
+
+	@Test
+	public void testFairSelectNextIndexOutOf2() {
+		assertEquals(1, InputSelection.ALL.fairSelectNextIndexOutOf2(3, 0));
+		assertEquals(0, new Builder().select(1).select(2).build().fairSelectNextIndexOutOf2(3, 1));
+
+		assertEquals(1, InputSelection.ALL.fairSelectNextIndexOutOf2(2, 0));
+		assertEquals(1, InputSelection.ALL.fairSelectNextIndexOutOf2(2, 1));
+		assertEquals(0, InputSelection.ALL.fairSelectNextIndexOutOf2(1, 0));
+		assertEquals(0, InputSelection.ALL.fairSelectNextIndexOutOf2(1, 1));
+		assertEquals(-1, InputSelection.ALL.fairSelectNextIndexOutOf2(0, 0));
+		assertEquals(-1, InputSelection.ALL.fairSelectNextIndexOutOf2(0, 1));
+
+		assertEquals(0, InputSelection.FIRST.fairSelectNextIndexOutOf2(1, 0));
+		assertEquals(0, InputSelection.FIRST.fairSelectNextIndexOutOf2(3, 0));
+		assertEquals(-1, InputSelection.FIRST.fairSelectNextIndexOutOf2(2, 0));
+		assertEquals(-1, InputSelection.FIRST.fairSelectNextIndexOutOf2(0, 0));
+
+		assertEquals(1, InputSelection.SECOND.fairSelectNextIndexOutOf2(2, 1));
+		assertEquals(1, InputSelection.SECOND.fairSelectNextIndexOutOf2(3, 1));
+		assertEquals(-1, InputSelection.SECOND.fairSelectNextIndexOutOf2(1, 1));
+		assertEquals(-1, InputSelection.SECOND.fairSelectNextIndexOutOf2(0, 1));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedFairSelectNextIndexOutOf2() {
+		InputSelection.ALL.fairSelectNextIndexOutOf2(7, 0);
+	}
+
+	/**
+	 * Tests for {@link Builder}.
+	 */
+	public static class BuilderTest {
+
+		@Test
+		public void testSelect() {
+			assertEquals(1L, new Builder().select(1).build().getInputMask());
+			assertEquals(7L, new Builder().select(1).select(2).select(3).build().getInputMask());
+
+			assertEquals(0x8000_0000_0000_0000L, new Builder().select(64).build().getInputMask());
+			assertEquals(0xffff_ffff_ffff_ffffL, new Builder().select(-1).build().getInputMask());
+		}
+
+		@Test(expected = IllegalArgumentException.class)
+		public void testIllegalInputId1() {
+			new Builder().select(-2);
+		}
+
+		@Test(expected = IllegalArgumentException.class)
+		public void testIllegalInputId2() {
+			new Builder().select(65);
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test selective reading.
+ */
+public class StreamTaskSelectiveReadingTest {
+
+	@Test
+	public void testAnyOrderedReading() throws Exception {
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 4"));
+
+		testBase(new AnyReadingStreamOperator("Operator0"), true, expectedOutput, true);
+	}
+
+	@Test
+	public void testAnyUnorderedReading() throws Exception {
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 4"));
+
+		testBase(new AnyReadingStreamOperator("Operator0"), false, expectedOutput, false);
+	}
+
+	@Test
+	public void testSequentialReading() throws Exception {
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 4"));
+
+		testBase(new SequentialReadingStreamOperator("Operator0"), false, expectedOutput, true);
+	}
+
+	@Test
+	public void testSpecialRuleReading() throws Exception {
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 4"));
+
+		testBase(new SpecialRuleReadingStreamOperator("Operator0", 3, 4, 2), false, expectedOutput, true);
+	}
+
+	@Test
+	public void testReadFinishedInput() {
+		try {
+			testBase(new TestReadFinishedInputStreamOperator(), false, new ConcurrentLinkedQueue<>(), true);
+			fail("should throw an IOException");
+		} catch (Throwable t) {
+			assertTrue("wrong exception, should be IOException",
+				ExceptionUtils.findThrowableWithMessage(t, "Could not read the finished input: input1").isPresent());
+		}
+	}
+
+	private void testBase(
+		TwoInputStreamOperator<String, Integer, String> streamOperator,
+		boolean prepareDataBeforeProcessing,
+		ConcurrentLinkedQueue<Object> expectedOutput,
+		boolean orderedCheck) throws Exception {
+
+		final TwoInputStreamTaskTestHarness<String, Integer, String> testHarness = new TwoInputStreamTaskTestHarness<>(
+			TestSelectiveReadingTask::new,
+			BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness.setupOutputForSingletonOperatorChain();
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setStreamOperator(streamOperator);
+		streamConfig.setOperatorID(new OperatorID());
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		boolean isProcessing = false;
+		if (!prepareDataBeforeProcessing) {
+			((TestSelectiveReadingTask) testHarness.getTask()).startProcessing();
+			isProcessing = true;
+		}
+
+		testHarness.processElement(new StreamRecord<>("Hello-1"), 0, 0);
+
+		// wait until the input is processed to test the listening and blocking logic
+		if (!prepareDataBeforeProcessing) {
+			testHarness.waitForInputProcessing();
+		}
+
+		testHarness.processElement(new StreamRecord<>("Hello-2"), 0, 0);
+		testHarness.processElement(new StreamRecord<>("Hello-3"), 0, 0);
+
+		testHarness.processElement(new StreamRecord<>(1), 1, 0);
+		testHarness.processElement(new StreamRecord<>(2), 1, 0);
+		testHarness.processElement(new StreamRecord<>(3), 1, 0);
+		testHarness.processElement(new StreamRecord<>(4), 1, 0);
+
+		testHarness.endInput();
+
+		if (!isProcessing) {
+			((TestSelectiveReadingTask) testHarness.getTask()).startProcessing();
+		}
+		testHarness.waitForTaskCompletion(10_000L);
+
+		LinkedBlockingQueue<Object> output = testHarness.getOutput();
+		if (orderedCheck) {
+			TestHarnessUtil.assertOutputEquals("Output was not correct.", expectedOutput, output);
+		} else {
+			String[] expectedResult = expectedOutput.stream()
+				.map(record -> ((StreamRecord) record).getValue().toString())
+				.toArray(String[]::new);
+			Arrays.sort(expectedResult);
+
+			String[] result = output.stream()
+				.map(record -> ((StreamRecord) record).getValue().toString())
+				.toArray(String[]::new);
+			Arrays.sort(result);
+
+			assertArrayEquals("Output was not correct.", expectedResult, result);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Utilities
+	// ------------------------------------------------------------------------
+
+	private static class TestSelectiveReadingTask<IN1, IN2, OUT> extends TwoInputSelectableStreamTask<IN1, IN2, OUT> {
+
+		private volatile boolean started;
+
+		TestSelectiveReadingTask(Environment env) {
+			super(env);
+			started = false;
+		}
+
+		@Override
+		protected void performDefaultAction(ActionContext context) throws Exception {
+			if (!started) {
+				synchronized (this) {
+					this.wait();
+				}
+			}
+
+			super.performDefaultAction(context);
+		}
+
+		public void startProcessing() {
+			started = true;
+			synchronized (this) {
+				this.notifyAll();
+			}
+		}
+	}
+
+	private static class AnyReadingStreamOperator extends AbstractStreamOperator<String>
+		implements TwoInputStreamOperator<String, Integer, String>, InputSelectable {
+
+		private final String name;
+
+		AnyReadingStreamOperator(String name) {
+			super();
+
+			this.name = name;
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return InputSelection.ALL;
+		}
+
+		@Override
+		public void processElement1(StreamRecord<String> element) {
+			output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
+		}
+
+		@Override
+		public void processElement2(StreamRecord<Integer> element) {
+			output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
+		}
+	}
+
+	/**
+	 * Test operator for sequential reading.
+	 */
+	public static class SequentialReadingStreamOperator extends AbstractStreamOperator<String>
+		implements TwoInputStreamOperator<String, Integer, String>, InputSelectable {
+
+		private final String name;
+
+		private InputSelection inputSelection;
+
+		public SequentialReadingStreamOperator(String name) {
+			super();
+
+			this.name = name;
+			this.inputSelection = InputSelection.FIRST;
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return inputSelection;
+		}
+
+		@Override
+		public void processElement1(StreamRecord<String> element) {
+			output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
+		}
+
+		@Override
+		public void processElement2(StreamRecord<Integer> element) {
+			output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
+
+			this.inputSelection = InputSelection.SECOND;
+		}
+	}
+
+	private static class SpecialRuleReadingStreamOperator extends AbstractStreamOperator<String>
+		implements TwoInputStreamOperator<String, Integer, String>, InputSelectable {
+
+		private final String name;
+
+		private final int input1Records;
+		private final int input2Records;
+
+		private final int maxContinuousReadingRecords;
+
+		private int input1ReadingRecords;
+		private int input2ReadingRecords;
+
+		private int continuousReadingRecords;
+		private InputSelection inputSelection;
+
+		SpecialRuleReadingStreamOperator(String name, int input1Records, int input2Records, int maxContinuousReadingRecords) {
+			super();
+
+			this.name = name;
+			this.input1Records = input1Records;
+			this.input2Records = input2Records;
+			this.maxContinuousReadingRecords = maxContinuousReadingRecords;
+
+			this.input1ReadingRecords = 0;
+			this.input2ReadingRecords = 0;
+			this.continuousReadingRecords = 0;
+			this.inputSelection = InputSelection.FIRST;
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return inputSelection;
+		}
+
+		@Override
+		public void processElement1(StreamRecord<String> element) {
+			output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
+
+			input1ReadingRecords++;
+			continuousReadingRecords++;
+			if (continuousReadingRecords == maxContinuousReadingRecords) {
+				continuousReadingRecords = 0;
+				if (input2ReadingRecords < input2Records) {
+					inputSelection = InputSelection.SECOND;
+					return;
+				}
+			}
+
+			inputSelection = InputSelection.FIRST;
+		}
+
+		@Override
+		public void processElement2(StreamRecord<Integer> element) {
+			output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
+
+			input2ReadingRecords++;
+			continuousReadingRecords++;
+			if (continuousReadingRecords == maxContinuousReadingRecords) {
+				continuousReadingRecords = 0;
+				if (input1ReadingRecords < input1Records) {
+					inputSelection = InputSelection.FIRST;
+					return;
+				}
+			}
+
+			inputSelection = InputSelection.SECOND;
+		}
+	}
+
+	private static class TestReadFinishedInputStreamOperator extends AbstractStreamOperator<String>
+		implements TwoInputStreamOperator<String, Integer, String>, InputSelectable {
+
+		private InputSelection inputSelection;
+
+		TestReadFinishedInputStreamOperator() {
+			super();
+
+			this.inputSelection = InputSelection.FIRST;
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return inputSelection;
+		}
+
+		@Override
+		public void processElement1(StreamRecord<String> element) {
+
+		}
+
+		@Override
+		public void processElement2(StreamRecord<Integer> element) {
+
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 
 
 /**
- * Test harness for testing a {@link TwoInputStreamTask}.
+ * Test harness for testing a {@link TwoInputStreamTask} or a {@link TwoInputSelectableStreamTask}.
  *
  * <p>This mock Invokable provides the task with a basic runtime context and allows pushing elements
  * and watermarks into the task. {@link #getOutput()} can be used to get the emitted elements
@@ -71,7 +71,7 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 	 * it should be assigned to the first (1), or second (2) input of the task.
 	 */
 	public TwoInputStreamTaskTestHarness(
-			Function<Environment, ? extends TwoInputStreamTask<IN1, IN2, OUT>> taskFactory,
+			Function<Environment, ? extends AbstractTwoInputStreamTask<IN1, IN2, OUT>> taskFactory,
 			int numInputGates,
 			int numInputChannelsPerGate,
 			int[] inputGateAssignment,
@@ -98,7 +98,7 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 	 * second task input.
 	 */
 	public TwoInputStreamTaskTestHarness(
-			Function<Environment, ? extends TwoInputStreamTask<IN1, IN2, OUT>> taskFactory,
+			Function<Environment, ? extends AbstractTwoInputStreamTask<IN1, IN2, OUT>> taskFactory,
 			TypeInformation<IN1> inputType1,
 			TypeInformation<IN2> inputType2,
 			TypeInformation<OUT> outputType) {
@@ -169,8 +169,8 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public TwoInputStreamTask<IN1, IN2, OUT> getTask() {
-		return (TwoInputStreamTask<IN1, IN2, OUT>) super.getTask();
+	public AbstractTwoInputStreamTask<IN1, IN2, OUT> getTask() {
+		return (AbstractTwoInputStreamTask<IN1, IN2, OUT>) super.getTask();
 	}
 }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/GeneratedClass.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/GeneratedClass.java
@@ -91,4 +91,8 @@ public abstract class GeneratedClass<T> implements Serializable {
 	public Object[] getReferences() {
 		return references;
 	}
+
+	public Class<?> getClass(ClassLoader classLoader) {
+		return compile(classLoader);
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/CodeGenOperatorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/CodeGenOperatorFactory.java
@@ -19,6 +19,7 @@ package org.apache.flink.table.runtime;
 
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
@@ -54,6 +55,11 @@ public class CodeGenOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
 	@Override
 	public ChainingStrategy getChainingStrategy() {
 		return strategy;
+	}
+
+	@Override
+	public boolean isOperatorSelectiveReading() {
+		return InputSelectable.class.isAssignableFrom(generatedClass.getClass(Thread.currentThread().getContextClassLoader()));
 	}
 
 	public GeneratedClass<? extends StreamOperator<OUT>> getGeneratedClass() {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StreamTaskSelectiveReadingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StreamTaskSelectiveReadingITCase.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskSelectiveReadingTest.SequentialReadingStreamOperator;
+import org.apache.flink.test.streaming.runtime.util.TestListResultSink;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for selective reading of {@code TwoInputSelectableStreamTask}.
+ */
+public class StreamTaskSelectiveReadingITCase {
+	@Test
+	public void testSequentialReading() throws Exception {
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+
+		DataStream<String> source0 = env.addSource(
+			new TestStringSource("Source0",
+				new String[] {
+					"Hello-1", "Hello-2", "Hello-3", "Hello-4", "Hello-5", "Hello-6"
+			}));
+		DataStream<Integer> source1 = env.addSource(
+			new TestIntegerSource("Source1",
+				new Integer[] {
+					1, 2, 3
+				}))
+			.setParallelism(2);
+		TestListResultSink<String> resultSink = new TestListResultSink<>();
+
+		TwoInputStreamOperator<String, Integer, String> twoInputStreamOperator = new SequentialReadingStreamOperator("Operator0");
+		twoInputStreamOperator.setChainingStrategy(ChainingStrategy.NEVER);
+
+		source0.connect(source1)
+			.transform(
+				"Custom Operator",
+				BasicTypeInfo.STRING_TYPE_INFO,
+				twoInputStreamOperator
+			)
+			.addSink(resultSink);
+
+		env.execute("Selective reading test");
+
+		List<String> result = resultSink.getResult();
+
+		List<String> expected1 = Arrays.asList(
+			"[Operator0-1]: [Source0-0]: Hello-1",
+			"[Operator0-1]: [Source0-0]: Hello-2",
+			"[Operator0-1]: [Source0-0]: Hello-3",
+			"[Operator0-1]: [Source0-0]: Hello-4",
+			"[Operator0-1]: [Source0-0]: Hello-5",
+			"[Operator0-1]: [Source0-0]: Hello-6"
+		);
+
+		List<String> expected2 = Arrays.asList(
+			"[Operator0-2]: 1",
+			"[Operator0-2]: 2",
+			"[Operator0-2]: 3",
+			"[Operator0-2]: 2",
+			"[Operator0-2]: 4",
+			"[Operator0-2]: 6"
+		);
+		Collections.sort(expected2);
+
+		assertEquals(expected1.size() + expected2.size(), result.size());
+		assertEquals(expected1, result.subList(0, expected1.size()));
+
+		List<String> result2 = result.subList(expected1.size(), expected1.size() + expected2.size());
+		Collections.sort(result2);
+		assertEquals(expected2, result2);
+	}
+
+	private abstract static class TestSource<T> extends RichParallelSourceFunction<T> {
+		private static final long serialVersionUID = 1L;
+
+		protected final String name;
+
+		private volatile boolean running = true;
+		private transient RuntimeContext context;
+
+		private final T[] elements;
+
+		public TestSource(String name, T[] elements) {
+			this.name = name;
+			this.elements = elements;
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			this.context = getRuntimeContext();
+		}
+
+		@Override
+		public void run(SourceContext<T> ctx) throws Exception {
+			int elementIndex = 0;
+			while (running) {
+				if (elementIndex < elements.length) {
+					synchronized (ctx.getCheckpointLock()) {
+						ctx.collect(outValue(elements[elementIndex], context.getIndexOfThisSubtask()));
+						elementIndex++;
+					}
+				} else {
+					break;
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+
+		protected abstract T outValue(T inValue, int subTaskIndex);
+	}
+
+	private static class TestStringSource extends TestSource<String> {
+
+		public TestStringSource(String name, String[] elements) {
+			super(name, elements);
+		}
+
+		@Override
+		protected String outValue(String inValue, int subTaskIndex) {
+			return "[" + name + "-" + subTaskIndex + "]: " + inValue;
+		}
+	}
+
+	private static class TestIntegerSource extends TestSource<Integer> {
+
+		public TestIntegerSource(String name, Integer[] elements) {
+			super(name, elements);
+		}
+
+		@Override
+		protected Integer outValue(Integer inValue, int subTaskIndex) {
+			return inValue * (subTaskIndex + 1);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

**This pull request is only about the commits starting from a certain commit [86e62bb](https://github.com/apache/flink/pull/8124/commits/86e62bb30a0bd24d903fb04d62e361cd5f11cc42),  and all commits before are from [PR#7959](https://github.com/apache/flink/pull/7959) (this pull requests depends on it).**

This pull request implements the runtime handling of the `InputSelectable` interface, and this will enable the stream operators read their input selectively. The pull does not cover to support checkpointing of selective reading, and there is no strong demand on it at this moment, so we think it can be deferred to support.


## Brief change log

  - Introduces a new interface `Input` to represent the logical input of operators.
  - Introduces a new class `NetworkInput` which implements `Input` to represent the network input. It encapsulates deserializer, network buffers, input gate, etc.
  - Introduces a new class `StreamTwoInputSelectableProcessor` to handle selective reading.
  - Introduces a new class `TwoInputSelectableStreamTask` to execute the two-input operators implementing `InputSelectable`.
  - Changes UnionInputGate to support polling the next element. 
  - Changes the `addCoOperator()` method in `StreamGraph` that set the vertex class to  `TwoInputSelectableStreamTask` when the operator is an `InputSelectable` instance.
  - Adds a new method `boolean moreAvailable()` to the `InputGate` interface for the implementation of `NetworkInput`.
  - Adds micro-benchmark code for `StreamTwoInputProcessor` and `StreamTwoInputSelectableProcessor` .


## Verifying this change

This change added tests and can be verified as follows:
  - Added test for selective reading of  the operators.
  - Added integration tests for selective reading of  the operators.
  - Extended test for the watermark and streamStatus forwarding of `StreamTwoInputSelectableProcessor`.
  - Added test for the `boolean moreAvailable()` method of  `SingleInputGate` and `UnionInputGate`. 


## Micro Benchmarks
   - Measurement: **Throughput** in the `ANY` reading mode
   - Benchmark Executor:  JMH
       * @Fork value: 3
       * Number of warmup iterations: 10
       * Number of measurement iterations: 10
       * Records per forked invocation: 100,000,000
   - Environment
       * JDK: OracleJDK 1.8.0_202
       * OS: Linux 3.10.0
       * CPU: 96 cores  Intel(R) Xeon(R) Platinum 8163 CPU @ 2.50GHz
   - Results (run three times to calculate the average)
       * **StreamTwoInputProcessor (Original) : 23681 ops/ms**
       * **StreamTwoInputProcessor (New): 23604 ops/ms**
       * **StreamTwoInputSelectableProcessor:  22849 ops/ms**
   - Summary
       * About the throughput before and after adding `volatile boolean moreDataAvailable` member into `SingleInputGate` and `UnionInputGate`,  before is 23681 ops/ms and after is 23604 ops/ms, and the difference should be considered negligible.
       * `StreamTwoInputSelectableProcessor` is about 3.5% slower than `StreamTwoInputProcessor` in throughput.

_See [the code](https://github.com/sunhaibotb/flink-benchmarks/commit/c09d6df54b9ecd2548c06f3dc835f870fad4b82e) for the benchmark executor._

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive):  **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  **no**
  - The S3 file system connector:  **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not documented**
