### PR TITLE
[FLINK-12140][table-planner-blink] Support e2e sort merge join operator in batch mode

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -221,16 +221,4 @@ object FlinkPlannerImpl {
     * the default field collation if not specified, Consistent with CALCITE.
     */
   val defaultCollationDirection: RelFieldCollation.Direction = RelFieldCollation.Direction.ASCENDING
-
-  /** Returns the default null direction if not specified. */
-  def getNullDefaultOrders(ascendings: Array[Boolean]): Array[Boolean] = {
-    ascendings.map { asc =>
-      FlinkPlannerImpl.defaultNullCollation.last(!asc)
-    }
-  }
-
-  /** Returns the default null direction if not specified. */
-  def getNullDefaultOrder(ascending: Boolean): Boolean = {
-    FlinkPlannerImpl.defaultNullCollation.last(!ascending)
-  }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/GenerateUtils.scala
@@ -21,12 +21,13 @@ package org.apache.flink.table.codegen
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.{AtomicType => AtomicTypeInfo}
 import org.apache.flink.table.`type`._
-import org.apache.flink.table.calcite.FlinkPlannerImpl
 import org.apache.flink.table.codegen.CodeGenUtils._
 import org.apache.flink.table.codegen.GeneratedExpression.{ALWAYS_NULL, NEVER_NULL, NO_CODE}
 import org.apache.flink.table.codegen.calls.CurrentTimePointCallGen
 import org.apache.flink.table.dataformat._
+import org.apache.flink.table.plan.util.SortUtil
 import org.apache.flink.table.typeutils.TypeCheckUtils.{isReference, isTemporal}
+
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.commons.lang3.StringEscapeUtils
 
@@ -653,7 +654,7 @@ object GenerateUtils {
       val compareFunc = newName("compareArray")
       val compareCode = generateArrayCompare(
         ctx,
-        FlinkPlannerImpl.getNullDefaultOrder(true), at, "a", "b")
+        SortUtil.getNullDefaultOrder(true), at, "a", "b")
       val funcCode: String =
         s"""
           public int $compareFunc($BINARY_ARRAY a, $BINARY_ARRAY b) {
@@ -670,7 +671,7 @@ object GenerateUtils {
         rowType.getFieldTypes.indices.toArray,
         rowType.getFieldTypes,
         orders,
-        FlinkPlannerImpl.getNullDefaultOrders(orders),
+        SortUtil.getNullDefaultOrders(orders),
         "a",
         "b")
       val compareFunc = newName("compareRow")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -22,7 +22,6 @@ import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.metrics.Gauge
 import org.apache.flink.table.`type`.{InternalType, RowType}
 import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.calcite.FlinkPlannerImpl
 import org.apache.flink.table.codegen.CodeGenUtils.{binaryRowFieldSetAccess, binaryRowSetNull}
 import org.apache.flink.table.codegen.agg.batch.AggCodeGenHelper.buildAggregateArgsMapping
 import org.apache.flink.table.codegen.{CodeGenUtils, CodeGeneratorContext, ExprCodeGenerator, GenerateUtils, GeneratedExpression, OperatorCodeGenerator, SortCodeGenerator}
@@ -31,6 +30,7 @@ import org.apache.flink.table.expressions.{CallExpression, Expression, Expressio
 import org.apache.flink.table.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.generated.{NormalizedKeyComputer, RecordComparator}
+import org.apache.flink.table.plan.util.SortUtil
 import org.apache.flink.table.runtime.aggregate.{BytesHashMap, BytesHashMapSpillMemorySegmentPool}
 import org.apache.flink.table.runtime.sort.BufferedKVExternalSorter
 import org.apache.flink.table.typeutils.BinaryRowSerializer
@@ -835,7 +835,7 @@ object HashAggCodeGenHelper {
     val keyFieldTypes = aggMapKeyType.getFieldTypes
     val keys = keyFieldTypes.indices.toArray
     val orders = keys.map((_) => true)
-    val nullsIsLast = FlinkPlannerImpl.getNullDefaultOrders(orders)
+    val nullsIsLast = SortUtil.getNullDefaultOrders(orders)
 
     val sortCodeGenerator = new SortCodeGenerator(
       ctx.tableConfig, keys, keyFieldTypes, orders, nullsIsLast)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecExchange.scala
@@ -18,10 +18,25 @@
 
 package org.apache.flink.table.plan.nodes.physical.batch
 
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.streaming.api.transformations.{PartitionTransformation, StreamTransformation}
+import org.apache.flink.streaming.runtime.partitioner.{BroadcastPartitioner, GlobalPartitioner, RebalancePartitioner}
+import org.apache.flink.table.`type`.RowType
+import org.apache.flink.table.api.BatchTableEnvironment
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.codegen.{CodeGeneratorContext, HashCodeGenerator}
+import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.plan.nodes.common.CommonPhysicalExchange
+import org.apache.flink.table.plan.nodes.exec.{BatchExecNode, ExecNode}
+import org.apache.flink.table.runtime.BinaryHashPartitioner
+import org.apache.flink.table.typeutils.BaseRowTypeInfo
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelDistribution, RelNode}
+
+import java.util
+
+import scala.collection.JavaConversions._
 
 /**
   * This RelNode represents a change of partitioning of the input elements.
@@ -77,7 +92,14 @@ class BatchExecExchange(
     inputRel: RelNode,
     relDistribution: RelDistribution)
   extends CommonPhysicalExchange(cluster, traitSet, inputRel, relDistribution)
-  with BatchPhysicalRel {
+  with BatchPhysicalRel
+  with BatchExecNode[BaseRow]{
+
+  // TODO reuse PartitionTransformation
+  // currently, an Exchange' input transformation will be reused if it is reusable,
+  // and different PartitionTransformation objects will be created which have same input.
+  // cache input transformation to reuse
+  private var reusedInput: Option[StreamTransformation[BaseRow]] = None
 
   override def copy(
       traitSet: RelTraitSet,
@@ -86,5 +108,77 @@ class BatchExecExchange(
     new BatchExecExchange(cluster, traitSet, newInput, relDistribution)
   }
 
+  override def getDamBehavior: DamBehavior = {
+    distribution.getType match {
+      case RelDistribution.Type.RANGE_DISTRIBUTED => DamBehavior.FULL_DAM
+      case _ => DamBehavior.PIPELINED
+    }
+  }
+
+  override def getInputNodes: util.List[ExecNode[BatchTableEnvironment, _]] =
+    getInputs.map(_.asInstanceOf[ExecNode[BatchTableEnvironment, _]])
+
+  override def translateToPlanInternal(
+      tableEnv: BatchTableEnvironment): StreamTransformation[BaseRow] = {
+    val input = reusedInput match {
+      case Some(transformation) => transformation
+      case None =>
+        val input = getInputNodes.get(0).translateToPlan(tableEnv)
+            .asInstanceOf[StreamTransformation[BaseRow]]
+        reusedInput = Some(input)
+        input
+    }
+
+    val inputType = input.getOutputType.asInstanceOf[BaseRowTypeInfo]
+    val outputRowType = FlinkTypeFactory.toInternalRowType(getRowType).toTypeInfo
+
+    relDistribution.getType match {
+      case RelDistribution.Type.ANY =>
+        val transformation = new PartitionTransformation(
+          input,
+          null)
+        transformation.setOutputType(outputRowType)
+        transformation
+
+      case RelDistribution.Type.SINGLETON =>
+        val transformation = new PartitionTransformation(
+          input,
+          new GlobalPartitioner[BaseRow])
+        transformation.setOutputType(outputRowType)
+        transformation
+
+      case RelDistribution.Type.RANDOM_DISTRIBUTED =>
+        val transformation = new PartitionTransformation(
+          input,
+          new RebalancePartitioner[BaseRow])
+        transformation.setOutputType(outputRowType)
+        transformation
+
+      case RelDistribution.Type.BROADCAST_DISTRIBUTED =>
+        val transformation = new PartitionTransformation(
+          input,
+          new BroadcastPartitioner[BaseRow])
+        transformation.setOutputType(outputRowType)
+        transformation
+
+      case RelDistribution.Type.HASH_DISTRIBUTED =>
+        // TODO Eliminate duplicate keys
+        val keys = relDistribution.getKeys
+        val partitioner = new BinaryHashPartitioner(
+          HashCodeGenerator.generateRowHash(
+            CodeGeneratorContext(tableEnv.config),
+            new RowType(inputType.getInternalTypes: _*),
+            "HashPartitioner",
+            keys.map(_.intValue()).toArray))
+        val transformation = new PartitionTransformation(
+          input,
+          partitioner)
+        transformation.setOutputType(outputRowType)
+        transformation
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"not support RelDistribution: ${relDistribution.getType} now!")
+    }
+  }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/SortUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/SortUtil.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.api.common.operators.Order
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.calcite.FlinkPlannerImpl
+
+import org.apache.calcite.rel.RelFieldCollation.Direction
+import org.apache.calcite.rel.`type`._
+import org.apache.calcite.rel.{RelCollation, RelFieldCollation}
+
+import scala.collection.mutable
+
+/**
+  * Common methods for Flink sort operators.
+  */
+object SortUtil {
+
+  /**
+    * Returns the direction of the first sort field.
+    *
+    * @param collationSort The list of sort collations.
+    * @return The direction of the first sort field.
+    */
+  def getFirstSortDirection(collationSort: RelCollation): Direction = {
+    collationSort.getFieldCollations.get(0).direction
+  }
+
+  /**
+    * Returns the first sort field.
+    *
+    * @param collationSort The list of sort collations.
+    * @param rowType       The row type of the input.
+    * @return The first sort field.
+    */
+  def getFirstSortField(collationSort: RelCollation, rowType: RelDataType): RelDataTypeField = {
+    val idx = collationSort.getFieldCollations.get(0).getFieldIndex
+    rowType.getFieldList.get(idx)
+  }
+
+  /** Returns the default null direction if not specified. */
+  def getNullDefaultOrders(ascendings: Array[Boolean]): Array[Boolean] = {
+    ascendings.map { asc =>
+      FlinkPlannerImpl.defaultNullCollation.last(!asc)
+    }
+  }
+
+  /** Returns the default null direction if not specified. */
+  def getNullDefaultOrder(ascending: Boolean): Boolean = {
+    FlinkPlannerImpl.defaultNullCollation.last(!ascending)
+  }
+
+  def getKeysAndOrders(
+      fieldCollations: Seq[RelFieldCollation]): (Array[Int], Array[Boolean], Array[Boolean]) = {
+    val fieldMappingDirections = fieldCollations.map(c =>
+      (c.getFieldIndex, directionToOrder(c.getDirection)))
+    val keys = fieldMappingDirections.map(_._1)
+    val orders = fieldMappingDirections.map(_._2 == Order.ASCENDING)
+    val nullsIsLast = fieldCollations.map(_.nullDirection).map {
+      case RelFieldCollation.NullDirection.LAST => true
+      case RelFieldCollation.NullDirection.FIRST => false
+      case RelFieldCollation.NullDirection.UNSPECIFIED =>
+        throw new TableException(s"Do not support UNSPECIFIED for null order.")
+    }.toArray
+
+    deduplicateSortKeys(keys.toArray, orders.toArray, nullsIsLast)
+  }
+
+  def deduplicateSortKeys(
+      keys: Array[Int],
+      orders: Array[Boolean],
+      nullsIsLast: Array[Boolean]): (Array[Int], Array[Boolean], Array[Boolean]) = {
+    val keySet = new mutable.HashSet[Int]
+    val keyBuffer = new mutable.ArrayBuffer[Int]
+    val orderBuffer = new mutable.ArrayBuffer[Boolean]
+    val nullsIsLastBuffer = new mutable.ArrayBuffer[Boolean]
+    for (i <- keys.indices) {
+      if (keySet.add(keys(i))) {
+        keyBuffer += keys(i)
+        orderBuffer += orders(i)
+        nullsIsLastBuffer += nullsIsLast(i)
+      }
+    }
+    (keyBuffer.toArray, orderBuffer.toArray, nullsIsLastBuffer.toArray)
+  }
+
+  def directionToOrder(direction: Direction): Order = {
+    direction match {
+      case Direction.ASCENDING | Direction.STRICTLY_ASCENDING => Order.ASCENDING
+      case Direction.DESCENDING | Direction.STRICTLY_DESCENDING => Order.DESCENDING
+      case _ => throw new IllegalArgumentException("Unsupported direction.")
+    }
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/codegen/SortCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/codegen/SortCodeGeneratorTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.operators.sort.QuickSort;
 import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.dataformat.BinaryArray;
 import org.apache.flink.table.dataformat.BinaryGeneric;
 import org.apache.flink.table.dataformat.BinaryRow;
@@ -43,6 +42,7 @@ import org.apache.flink.table.generated.GeneratedNormalizedKeyComputer;
 import org.apache.flink.table.generated.GeneratedRecordComparator;
 import org.apache.flink.table.generated.NormalizedKeyComputer;
 import org.apache.flink.table.generated.RecordComparator;
+import org.apache.flink.table.plan.util.SortUtil;
 import org.apache.flink.table.runtime.sort.BinaryInMemorySortBuffer;
 import org.apache.flink.table.type.ArrayType;
 import org.apache.flink.table.type.DecimalType;
@@ -126,7 +126,7 @@ public class SortCodeGeneratorTest {
 
 			keys = new int[] {0};
 			orders = new boolean[] {rnd.nextBoolean()};
-			nullsIsLast = FlinkPlannerImpl.getNullDefaultOrders(orders);
+			nullsIsLast = SortUtil.getNullDefaultOrders(orders);
 			testInner();
 		}
 	}
@@ -149,7 +149,7 @@ public class SortCodeGeneratorTest {
 			keys[i] = indexQueue.poll();
 			orders[i] = rnd.nextBoolean();
 		}
-		nullsIsLast = FlinkPlannerImpl.getNullDefaultOrders(orders);
+		nullsIsLast = SortUtil.getNullDefaultOrders(orders);
 	}
 
 	private Object[] shuffle(Object[] objects) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/InnerJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/InnerJoinITCase.scala
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.sql.join
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.TableConfigOptions
+import org.apache.flink.table.runtime.batch.sql.join.JoinType.{JoinType, NestedLoopJoin, SortMergeJoin}
+import org.apache.flink.table.runtime.utils.BatchTestBase
+import org.apache.flink.table.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.runtime.utils.TestData._
+import org.apache.flink.table.typeutils.BigDecimalTypeInfo
+
+import org.junit.{Before, Test}
+
+import java.math.{BigDecimal => JBigDecimal}
+
+import scala.collection.Seq
+import scala.util.Random
+
+// @RunWith(classOf[Parameterized]) TODO
+class InnerJoinITCase extends BatchTestBase with JoinITCaseBase {
+
+  val expectedJoinType: JoinType = JoinType.SortMergeJoin
+
+  private lazy val myUpperCaseData = Seq(
+    row(1, "A"),
+    row(2, "B"),
+    row(3, "C"),
+    row(4, "D"),
+    row(5, "E"),
+    row(6, "F"),
+    row(null, "G"))
+
+  private lazy val myLowerCaseData = Seq(
+    row(1, "a"),
+    row(2, "b"),
+    row(3, "c"),
+    row(4, "d"),
+    row(null, "e")
+  )
+
+  private lazy val myTestData1 = Seq(
+    row(1, 1),
+    row(1, 2),
+    row(2, 1),
+    row(2, 2),
+    row(3, 1),
+    row(3, 2)
+  )
+
+  private lazy val myTestData2 = Seq(
+    row(1, 1),
+    row(1, 2),
+    row(2, 1),
+    row(2, 2),
+    row(3, 1),
+    row(3, 2)
+  )
+
+  @Before
+  def before(): Unit = {
+    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 3)
+    registerCollection("myUpperCaseData", myUpperCaseData, INT_STRING, Array(true, false), "N, L")
+    registerCollection("myLowerCaseData", myLowerCaseData, INT_STRING, Array(true, false), "n, l")
+    registerCollection("myTestData1", myTestData1, INT_INT, Array(false, false), "a, b")
+    registerCollection("myTestData2", myTestData2, INT_INT, Array(false, false), "a, b")
+    disableOtherJoinOpForJoin(tEnv, expectedJoinType)
+  }
+
+  @Test
+  def testOneMatchPerRow(): Unit = {
+    checkResult(
+      "SELECT * FROM myUpperCaseData u, myLowerCaseData l WHERE u.N = l.n",
+      Seq(
+        row(1, "A", 1, "a"),
+        row(2, "B", 2, "b"),
+        row(3, "C", 3, "c"),
+        row(4, "D", 4, "d")
+      ))
+  }
+
+  @Test
+  def testMultipleMatches(): Unit = {
+    expectedJoinType match {
+      case NestedLoopJoin =>
+        checkResult(
+          "SELECT * FROM myTestData1 A, myTestData2 B WHERE A.a = B.a and A.a = 1",
+          Seq(
+            row(1, 1, 1, 1),
+            row(1, 1, 1, 2),
+            row(1, 2, 1, 1),
+            row(1, 2, 1, 2)
+          ))
+      case _ =>
+      // A.a = B.a and A.a = 1 => A.a = 1 and B.a = 1, so after ftd and join condition simplified,
+      // join condition is TRUE. Only NestedLoopJoin can handle join without any equi-condition.
+    }
+  }
+
+  @Test
+  def testNoMatches(): Unit = {
+    checkResult(
+      "SELECT * FROM myTestData1 A, myTestData2 B WHERE A.a = B.a and A.a = 1 and B.a = 2",
+      Seq())
+  }
+
+  @Test
+  def testDecimalAsKey(): Unit = {
+    val DEC_INT = new RowTypeInfo(BigDecimalTypeInfo.of(9, 0), INT_TYPE_INFO)
+    registerCollection(
+      "leftTable",
+      Seq(
+        row(new JBigDecimal(0), 0),
+        row(new JBigDecimal(1), 1),
+        row(new JBigDecimal(2), 2)
+      ),
+      DEC_INT,
+      "a, b")
+    registerCollection(
+      "rightTable",
+      Seq(
+        row(new JBigDecimal(0), 0),
+        row(new JBigDecimal(1), 1)
+      ),
+      DEC_INT,
+      "c, d")
+    checkResult(
+      "SELECT * FROM leftTable, rightTable WHERE a = c",
+      Seq(
+        row(0, 0, 0, 0),
+        row(1, 1, 1, 1)
+      ))
+  }
+
+  @Test
+  def testBigForSpill(): Unit = {
+
+    conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_SORT_BUFFER_MEM, 1)
+    //TODO ensure hash join spilled
+//    conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_HASH_JOIN_TABLE_MEM, 2)
+    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 1)
+
+    val bigData = Random.shuffle(
+      bigIntStringData.union(bigIntStringData).union(bigIntStringData).union(bigIntStringData))
+    registerCollection("bigData1", bigData, INT_STRING, "a, b")
+    registerCollection("bigData2", bigData, INT_STRING, "c, d")
+
+    checkResult(
+      "SELECT a, b FROM bigData1, bigData2 WHERE a = c",
+      bigIntStringData.flatMap(row => Seq.fill(16)(row)))
+  }
+
+  @Test
+  def testSortMergeJoinOutputOrder(): Unit = {
+    if (expectedJoinType == SortMergeJoin) {
+      tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 1)
+      env.getConfig.setParallelism(1)
+
+      conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_SORT_BUFFER_MEM, 1)
+
+      val bigData = Random.shuffle(
+        bigIntStringData.union(bigIntStringData).union(bigIntStringData).union(bigIntStringData))
+      registerCollection("bigData1", bigData, INT_STRING, "a, b")
+      registerCollection("bigData2", bigData, INT_STRING, "c, d")
+
+      checkResult(
+        "SELECT a, b FROM bigData1, bigData2 WHERE a = c",
+        bigIntStringData.flatMap(row => Seq.fill(16)(row)),
+        isSorted = true)
+    }
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/JoinConditionTypeCoerceRuleITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/JoinConditionTypeCoerceRuleITCase.scala
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.sql.join
+
+import org.apache.flink.table.api.TableConfigOptions
+import org.apache.flink.table.runtime.utils.BatchTestBase
+import org.apache.flink.table.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.runtime.utils.TestData._
+
+import org.junit.{Before, Ignore, Test}
+
+// @RunWith(classOf[Parameterized]) TODO
+@Ignore // TODO support JoinConditionTypeCoerce
+class JoinConditionTypeCoerceRuleITCase extends BatchTestBase with JoinITCaseBase {
+  @Before
+  def before(): Unit = {
+    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 3)
+    registerCollection(
+      "t1",
+      numericData,
+      numericType,
+      nullablesOfNumericData,
+      "a, b, c, d, e")
+    registerCollection(
+      "t2",
+      numericData,
+      numericType,
+      nullablesOfNumericData,
+      "a, b, c, d, e")
+    // Disable NestedLoopJoin.
+    disableOtherJoinOpForJoin(tEnv, JoinType.SortMergeJoin)
+  }
+
+  @Test
+  def testInnerJoinIntEqualsLong(): Unit = {
+    val sqlQuery = "select t1.* from t1, t2 where t1.a = t2.b"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInnerJoinIntEqualsFloat(): Unit = {
+    val sqlQuery = "select t1.* from t1, t2 where t1.a = t2.c"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInnerJoinIntEqualsDouble(): Unit = {
+    val sqlQuery = "select t1.* from t1, t2 where t1.a = t2.d"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInnerJoinIntEqualsDecimal(): Unit = {
+    val sqlQuery = "select t1.* from t1, t2 where t1.a = t2.e"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInnerJoinFloatEqualsDouble(): Unit = {
+    val sqlQuery = "select t1.* from t1, t2 where t1.c = t2.d"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInnerJoinFloatEqualsDecimal(): Unit = {
+    val sqlQuery = "select t1.* from t1, t2 where t1.c = t2.e"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInnerJoinDoubleEqualsDecimal(): Unit = {
+    val sqlQuery = "select t1.* from t1, t2 where t1.d = t2.e"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInToSemiJoinIntEqualsLong(): Unit = {
+    val sqlQuery = "select * from t1 where t1.a in (select b from t2)"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInToSemiJoinIntEqualsFloat(): Unit = {
+    val sqlQuery = "select * from t1 where t1.a in (select c from t2)"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInToSemiJoinIntEqualsDouble(): Unit = {
+    val sqlQuery = "select * from t1 where t1.a in (select d from t2)"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInToSemiJoinIntEqualsDecimal(): Unit = {
+    val sqlQuery = "select * from t1 where t1.a in (select e from t2)"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInToSemiJoinFloatEqualsDouble(): Unit = {
+    val sqlQuery = "select * from t1 where t1.c in (select d from t2)"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInToSemiJoinFloatEqualsDecimal(): Unit = {
+    val sqlQuery = "select * from t1 where t1.c in (select e from t2)"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+
+  @Test
+  def testInToSemiJoinDoubleEqualsDecimal(): Unit = {
+    val sqlQuery = "select * from t1 where t1.d in (select e from t2)"
+    checkResult(sqlQuery, Seq(
+      row(1, 1, 1.0, 1.0, "1.000000000000000000"),
+      row(2, 2, 2.0, 2.0, "2.000000000000000000"),
+      row(3, 3, 3.0, 3.0, "3.000000000000000000")))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/JoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/JoinITCase.scala
@@ -1,0 +1,838 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.sql.join
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO}
+import org.apache.flink.api.common.typeutils.TypeComparator
+import org.apache.flink.api.java.typeutils.{GenericTypeInfo, ObjectArrayTypeInfo, RowTypeInfo}
+import org.apache.flink.table.api.{TableConfigOptions, Types}
+import org.apache.flink.table.runtime.TwoInputOperatorWrapper
+import org.apache.flink.table.runtime.batch.sql.join.JoinType.{BroadcastHashJoin, HashJoin, JoinType, NestedLoopJoin, SortMergeJoin}
+import org.apache.flink.table.runtime.utils.BatchTestBase
+import org.apache.flink.table.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.runtime.utils.TestData._
+import org.apache.flink.table.sinks.CollectRowTableSink
+import org.apache.flink.types.Row
+
+import org.junit.{Assert, Before, Ignore, Test}
+
+import scala.collection.JavaConversions._
+import scala.collection.Seq
+
+// @RunWith(classOf[Parameterized]) TODO
+class JoinITCase() extends BatchTestBase with JoinITCaseBase {
+
+  val expectedJoinType: JoinType = SortMergeJoin
+
+  @Before
+  def before(): Unit = {
+    registerCollection("SmallTable3", smallData3, type3, nullablesOfSmallData3, "a, b, c")
+    registerCollection("Table3", data3, type3, nullablesOfData3, "a, b, c")
+    registerCollection("Table5", data5, type5, nullablesOfData5, "d, e, f, g, h")
+    registerCollection("NullTable3", nullData3, type3, nullablesOfNullData3, "a, b, c")
+    registerCollection("NullTable5", nullData5, type5, nullablesOfNullData5, "d, e, f, g, h")
+    registerCollection("l", data2_1, INT_DOUBLE, "a, b")
+    registerCollection("r", data2_2, INT_DOUBLE, "c, d")
+    registerCollection("t", data2_3, INT_DOUBLE, nullablesOfData2_3, "c, d")
+    disableOtherJoinOpForJoin(tEnv, expectedJoinType)
+  }
+
+  @Test
+  def testJoin(): Unit = {
+    checkResult(
+      "SELECT c, g FROM SmallTable3, Table5 WHERE b = e",
+      Seq(
+        row("Hi", "Hallo"),
+        row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt")
+      ))
+  }
+
+  @Test
+  def testLongHashJoinGenerator(): Unit = {
+    if (expectedJoinType == HashJoin) {
+      val sink = (new CollectRowTableSink).configure(Array("c"), Array(Types.STRING))
+      tEnv.writeToSink(
+        tEnv.sqlQuery("SELECT c FROM SmallTable3, Table5 WHERE b = e"),
+        sink,
+        "collect")
+
+      var haveTwoOp = false
+      env.getStreamGraph.getOperators.foreach(o =>
+        o.f1 match {
+          case two: TwoInputOperatorWrapper[_, _, _] =>
+            Assert.assertTrue(two.getGeneratedClass.getCode.contains("LongHashJoinOperator"))
+            haveTwoOp = true
+          case _ =>
+        }
+      )
+      Assert.assertTrue(haveTwoOp)
+    }
+  }
+
+  @Ignore
+  @Test
+  def testOneSideSmjFieldError(): Unit = {
+    if (expectedJoinType == SortMergeJoin) {
+      registerCollection("PojoSmallTable3", smallData3,
+        new RowTypeInfo(INT_TYPE_INFO, LONG_TYPE_INFO,
+          new GenericTypeInfoWithoutComparator[String](classOf[String])),
+        nullablesOfSmallData3, "a, b, c")
+      registerCollection("PojoTable5", data5,
+        new RowTypeInfo(INT_TYPE_INFO, LONG_TYPE_INFO, INT_TYPE_INFO,
+          new GenericTypeInfoWithoutComparator[String](classOf[String]), LONG_TYPE_INFO),
+        nullablesOfData5, "d, e, f, g, h")
+
+      checkResult(
+        "SELECT c, g FROM (SELECT h, g, f, e, d FROM PojoSmallTable3, PojoTable5 WHERE b = e)," +
+          " PojoSmallTable3 WHERE b = e",
+        Seq(
+          row("Hi", "Hallo"),
+          row("Hello", "Hallo Welt"),
+          row("Hello", "Hallo Welt"),
+          row("Hello world", "Hallo Welt"),
+          row("Hello world", "Hallo Welt")
+        ))
+    }
+  }
+
+  @Test
+  def testJoinSameFieldEqual(): Unit = {
+    checkResult(
+      "SELECT c, g FROM SmallTable3, Table5 WHERE b = e and b = h",
+      Seq(
+        row("Hi", "Hallo"),
+        row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt")
+      ))
+  }
+
+  @Test
+  def testJoinOn(): Unit = {
+    checkResult(
+      "SELECT c, g FROM SmallTable3 JOIN Table5 ON b = e",
+      Seq(
+        row("Hi", "Hallo"),
+        row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt")
+      ))
+  }
+
+  @Test
+  def testJoinNoMatches(): Unit = {
+    checkResult(
+      "SELECT c, g FROM SmallTable3, Table5 where c = g",
+      Seq())
+  }
+
+  @Test
+  def testJoinNoMatchesWithSubquery(): Unit = {
+    checkResult(
+      "SELECT c, g FROM " +
+        "(SELECT * FROM SmallTable3 WHERE b>2), (SELECT * FROM Table5 WHERE e>2) WHERE b = e",
+      Seq())
+  }
+
+  @Test
+  def testJoinWithFilter(): Unit = {
+    checkResult(
+      "SELECT c, g FROM SmallTable3, Table5 WHERE b = e AND b < 2",
+      Seq(
+        row("Hi", "Hallo")
+      ))
+  }
+
+  @Test
+  def testJoinWithJoinFilter(): Unit = {
+    checkResult(
+      "SELECT c, g FROM Table3, Table5 WHERE b = e AND a < 6",
+      Seq(
+        row("Hi", "Hallo"),
+        row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt"),
+        row("Hello world, how are you?", "Hallo Welt wie"),
+        row("I am fine.", "Hallo Welt wie")
+      ))
+  }
+
+  @Test
+  def testInnerJoinWithNonEquiJoinPredicate(): Unit = {
+    checkResult(
+      "SELECT c, g FROM Table3, Table5 WHERE b = e AND a < 6 AND h < b",
+      Seq(
+        row("Hello world, how are you?", "Hallo Welt wie"),
+        row("I am fine.", "Hallo Welt wie")
+      ))
+  }
+
+  @Test
+  def testJoinWithMultipleKeys(): Unit = {
+    checkResult(
+      "SELECT c, g FROM NullTable3, NullTable5 WHERE a = d AND b = h",
+      Seq(
+        row("Hi", "Hallo"),
+        row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt wie gehts?"),
+        row("Hello world", "ABC"),
+        row("I am fine.", "HIJ"),
+        row("I am fine.", "IJK")
+      ))
+  }
+
+  @Test
+  def testJoinWithAlias(): Unit = {
+    registerCollection("AliasTable5", data5, type5, "d, e, f, g, c")
+    checkResult(
+      "SELECT AliasTable5.c, T.`1-_./Ü` FROM " +
+        "(SELECT a, b, c AS `1-_./Ü` FROM Table3) AS T, AliasTable5 WHERE a = d AND a < 4",
+      Seq(
+        row("1", "Hi"),
+        row("2", "Hello"),
+        row("1", "Hello"),
+        row("2", "Hello world"),
+        row("2", "Hello world"),
+        row("3", "Hello world")
+      ))
+  }
+
+  @Test
+  def testLeftJoinWithMultipleKeys(): Unit = {
+    checkResult(
+      "SELECT c, g FROM NullTable3 LEFT JOIN NullTable5 ON a = d and b = h",
+      Seq(
+        row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt wie gehts?"), row("Hello world", "ABC"),
+        row("I am fine.", "HIJ"), row("I am fine.", "IJK"),
+        row("Hello world, how are you?", null), row("Luke Skywalker", null),
+        row("Comment#1", null), row("Comment#2", null), row("Comment#3", null),
+        row("Comment#4", null), row("Comment#5", null), row("Comment#6", null),
+        row("Comment#7", null), row("Comment#8", null), row("Comment#9", null),
+        row("Comment#10", null), row("Comment#11", null), row("Comment#12", null),
+        row("Comment#13", null), row("Comment#14", null), row("Comment#15", null),
+        row("NullTuple", null), row("NullTuple", null)
+      ))
+  }
+
+  @Test
+  def testLeftJoinWithNonEquiJoinPred(): Unit = {
+    checkResult(
+      "SELECT c, g FROM NullTable3 LEFT JOIN NullTable5 ON a = d and b <= h",
+      Seq(
+        row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt wie gehts?"), row("Hello world", "ABC"),
+        row("Hello world", "BCD"), row("I am fine.", "HIJ"), row("I am fine.", "IJK"),
+        row("Hello world, how are you?", null), row("Luke Skywalker", null),
+        row("Comment#1", null), row("Comment#2", null), row("Comment#3", null),
+        row("Comment#4", null), row("Comment#5", null), row("Comment#6", null),
+        row("Comment#7", null), row("Comment#8", null), row("Comment#9", null),
+        row("Comment#10", null), row("Comment#11", null), row("Comment#12", null),
+        row("Comment#13", null), row("Comment#14", null), row("Comment#15", null),
+        row("NullTuple", null), row("NullTuple", null)
+      ))
+  }
+
+  @Test
+  def testLeftJoinWithLeftLocalPred(): Unit = {
+    checkResult(
+      "SELECT c, g FROM NullTable3 LEFT JOIN NullTable5 ON a = d and b = 2",
+      Seq(
+        row("Hi", null), row("Hello", "Hallo Welt"), row("Hello", "Hallo Welt wie"),
+        row("Hello world", "Hallo Welt wie gehts?"), row("Hello world", "ABC"),
+        row("Hello world", "BCD"), row("I am fine.", null),
+        row("Hello world, how are you?", null), row("Luke Skywalker", null),
+        row("Comment#1", null), row("Comment#2", null), row("Comment#3", null),
+        row("Comment#4", null), row("Comment#5", null), row("Comment#6", null),
+        row("Comment#7", null), row("Comment#8", null), row("Comment#9", null),
+        row("Comment#10", null), row("Comment#11", null), row("Comment#12", null),
+        row("Comment#13", null), row("Comment#14", null), row("Comment#15", null),
+        row("NullTuple", null), row("NullTuple", null)
+      ))
+  }
+
+  @Test
+  def testRightJoinWithMultipleKeys(): Unit = {
+    checkResult(
+      "SELECT c, g FROM NullTable3 RIGHT JOIN NullTable5 ON a = d and b = h",
+      Seq(
+        row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt wie gehts?"), row("Hello world", "ABC"),
+        row("I am fine.", "HIJ"), row("I am fine.", "IJK"),
+        row(null, "Hallo Welt wie"), row(null, "BCD"), row(null, "CDE"),
+        row(null, "DEF"), row(null, "EFG"), row(null, "FGH"),
+        row(null, "GHI"), row(null, "JKL"), row(null, "KLM"),
+        row(null, "NullTuple"), row(null, "NullTuple")
+      ))
+  }
+
+  @Test
+  def testRightJoinWithNonEquiJoinPred(): Unit = {
+    checkResult(
+      "SELECT c, g FROM NullTable5 RIGHT JOIN NullTable3 ON a = d and b <= h",
+      Seq(
+        row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt wie gehts?"), row("Hello world", "ABC"),
+        row("Hello world", "BCD"), row("I am fine.", "HIJ"), row("I am fine.", "IJK"),
+        row("Hello world, how are you?", null), row("Luke Skywalker", null),
+        row("Comment#1", null), row("Comment#2", null), row("Comment#3", null),
+        row("Comment#4", null), row("Comment#5", null), row("Comment#6", null),
+        row("Comment#7", null), row("Comment#8", null), row("Comment#9", null),
+        row("Comment#10", null), row("Comment#11", null), row("Comment#12", null),
+        row("Comment#13", null), row("Comment#14", null), row("Comment#15", null),
+        row("NullTuple", null), row("NullTuple", null)
+      ))
+  }
+
+  @Test
+  def testRightJoinWithLeftLocalPred(): Unit = {
+    checkResult(
+      "SELECT c, g FROM NullTable5 RIGHT JOIN NullTable3 ON a = d and b = 2",
+      Seq(
+        row("Hi", null), row("Hello", "Hallo Welt"), row("Hello", "Hallo Welt wie"),
+        row("Hello world", "Hallo Welt wie gehts?"), row("Hello world", "ABC"),
+        row("Hello world", "BCD"), row("I am fine.", null),
+        row("Hello world, how are you?", null), row("Luke Skywalker", null),
+        row("Comment#1", null), row("Comment#2", null), row("Comment#3", null),
+        row("Comment#4", null), row("Comment#5", null), row("Comment#6", null),
+        row("Comment#7", null), row("Comment#8", null), row("Comment#9", null),
+        row("Comment#10", null), row("Comment#11", null), row("Comment#12", null),
+        row("Comment#13", null), row("Comment#14", null), row("Comment#15", null),
+        row("NullTuple", null), row("NullTuple", null)
+      ))
+  }
+
+  @Test
+  def testFullOuterJoinWithMultipleKeys(): Unit = {
+    if (expectedJoinType != BroadcastHashJoin && expectedJoinType != NestedLoopJoin) {
+      checkResult(
+        "SELECT c, g FROM NullTable3 FULL JOIN NullTable5 ON a = d and b = h",
+        Seq(
+          row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+          row("Hello world", "Hallo Welt wie gehts?"), row("Hello world", "ABC"),
+          row("I am fine.", "HIJ"), row("I am fine.", "IJK"),
+          row(null, "Hallo Welt wie"), row(null, "BCD"), row(null, "CDE"),
+          row(null, "DEF"), row(null, "EFG"), row(null, "FGH"),
+          row(null, "GHI"), row(null, "JKL"), row(null, "KLM"),
+          row("Hello world, how are you?", null), row("Luke Skywalker", null),
+          row("Comment#1", null), row("Comment#2", null), row("Comment#3", null),
+          row("Comment#4", null), row("Comment#5", null), row("Comment#6", null),
+          row("Comment#7", null), row("Comment#8", null), row("Comment#9", null),
+          row("Comment#10", null), row("Comment#11", null), row("Comment#12", null),
+          row("Comment#13", null), row("Comment#14", null), row("Comment#15", null),
+          row("NullTuple", null), row("NullTuple", null),
+          row(null, "NullTuple"), row(null, "NullTuple")
+        ))
+    }
+  }
+
+  @Test
+  def testFullJoinWithNonEquiJoinPred(): Unit = {
+    if (expectedJoinType != BroadcastHashJoin && expectedJoinType != NestedLoopJoin) {
+      checkResult(
+        "SELECT c, g FROM NullTable3 FULL JOIN NullTable5 ON a = d and b <= h",
+        Seq(
+          // join matcher
+          row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+          row("Hello world", "Hallo Welt wie gehts?"), row("Hello world", "ABC"),
+          row("Hello world", "BCD"), row("I am fine.", "HIJ"), row("I am fine.", "IJK"),
+
+          // preserved left
+          row("Hello world, how are you?", null), row("Luke Skywalker", null),
+          row("Comment#1", null), row("Comment#2", null), row("Comment#3", null),
+          row("Comment#4", null), row("Comment#5", null), row("Comment#6", null),
+          row("Comment#7", null), row("Comment#8", null), row("Comment#9", null),
+          row("Comment#10", null), row("Comment#11", null), row("Comment#12", null),
+          row("Comment#13", null), row("Comment#14", null), row("Comment#15", null),
+          row("NullTuple", null), row("NullTuple", null),
+
+          // preserved right
+          row(null, "Hallo Welt wie"), row(null, "CDE"),
+          row(null, "DEF"), row(null, "EFG"), row(null, "FGH"),
+          row(null, "GHI"), row(null, "JKL"), row(null, "KLM"),
+          row(null, "NullTuple"), row(null, "NullTuple")
+        ))
+    }
+  }
+
+  @Test
+  def testFullJoinWithLeftLocalPred(): Unit = {
+    if (expectedJoinType != BroadcastHashJoin && expectedJoinType != NestedLoopJoin) {
+      checkResult(
+        "SELECT c, g FROM NullTable3 FULL JOIN NullTable5 ON a = d and b >= 2 and h = 1",
+        Seq(
+          // join matcher
+          row("Hello", "Hallo Welt wie"),
+          row("Hello world, how are you?", "DEF"),
+          row("Hello world, how are you?", "EFG"),
+          row("I am fine.", "GHI"),
+
+          // preserved left
+          row("Hi", null), row("Hello world", null), row("Luke Skywalker", null),
+          row("Comment#1", null), row("Comment#2", null), row("Comment#3", null),
+          row("Comment#4", null), row("Comment#5", null), row("Comment#6", null),
+          row("Comment#7", null), row("Comment#8", null), row("Comment#9", null),
+          row("Comment#10", null), row("Comment#11", null), row("Comment#12", null),
+          row("Comment#13", null), row("Comment#14", null), row("Comment#15", null),
+          row("NullTuple", null), row("NullTuple", null),
+
+          // preserved right
+          row(null, "Hallo"), row(null, "Hallo Welt"), row(null, "Hallo Welt wie gehts?"),
+          row(null, "ABC"), row(null, "BCD"), row(null, "CDE"), row(null, "FGH"),
+          row(null, "HIJ"), row(null, "IJK"), row(null, "JKL"), row(null, "KLM"),
+          row(null, "NullTuple"), row(null, "NullTuple")
+        ))
+    }
+  }
+
+  @Test
+  def testFullOuterJoin(): Unit = {
+    if (expectedJoinType != BroadcastHashJoin && expectedJoinType != NestedLoopJoin) {
+      checkResult(
+        "SELECT c, g FROM SmallTable3 FULL OUTER JOIN Table5 ON b = e",
+        Seq(
+          row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+          row("Hello world", "Hallo Welt"),
+          row(null, "Hallo Welt wie gehts?"), row(null, "Hallo Welt wie"),
+          row(null, "ABC"), row(null, "BCD"), row(null, "CDE"),
+          row(null, "DEF"), row(null, "EFG"), row(null, "FGH"),
+          row(null, "GHI"), row(null, "HIJ"), row(null, "IJK"),
+          row(null, "JKL"), row(null, "KLM")
+        ))
+    }
+  }
+
+  @Test
+  def testFullOuterJoinWithoutEqualCond(): Unit = {
+    if (expectedJoinType == NestedLoopJoin) {
+      checkResult(
+        "SELECT t1.c, t2.c FROM SmallTable3 t1 FULL OUTER JOIN SmallTable3 t2 ON t1.b > t2.b",
+        Seq(
+          row("Hello world", "Hi"), row("Hello", "Hi"), row("Hi", null),
+          row(null, "Hello"), row(null, "Hello world")
+        ))
+    }
+  }
+
+  @Test
+  def testSingleRowFullOuterJoinWithoutEqualCond(): Unit = {
+    if (expectedJoinType == NestedLoopJoin) {
+      checkResult(
+        "SELECT c, mc FROM SmallTable3 t1 FULL OUTER JOIN " +
+          "(SELECT min(b) AS mb, max(c) AS mc FROM SmallTable3) t2 ON b > mb",
+        Seq(
+          row("Hello world", "Hi"), row("Hello", "Hi"), row("Hi", null)
+        ))
+    }
+  }
+
+  @Test
+  def testSingleRowFullOuterJoinWithoutEqualCondNoMatch(): Unit = {
+    if (expectedJoinType == NestedLoopJoin) {
+      checkResult(
+        "SELECT c, mc FROM SmallTable3 t1 FULL OUTER JOIN " +
+          "(SELECT max(b) AS mb, max(c) AS mc FROM SmallTable3) t2 ON b > mb",
+        Seq(
+          row("Hello world", null), row("Hello", null), row("Hi", null), row(null, "Hi")
+        ))
+    }
+  }
+
+  @Test
+  def testLeftOuterJoin(): Unit = {
+    checkResult(
+      "SELECT c, g FROM Table5 LEFT OUTER JOIN SmallTable3 ON b = e",
+      Seq(
+        row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt"),
+        row(null, "Hallo Welt wie gehts?"), row(null, "Hallo Welt wie"),
+        row(null, "ABC"), row(null, "BCD"), row(null, "CDE"),
+        row(null, "DEF"), row(null, "EFG"), row(null, "FGH"),
+        row(null, "GHI"), row(null, "HIJ"), row(null, "IJK"),
+        row(null, "JKL"), row(null, "KLM")
+      ))
+  }
+
+  @Test
+  def testRightOuterJoin(): Unit = {
+    checkResult(
+      "SELECT c, g FROM SmallTable3 RIGHT OUTER JOIN Table5 ON b = e",
+      Seq(
+        row("Hi", "Hallo"), row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt"),
+        row(null, "Hallo Welt wie gehts?"), row(null, "Hallo Welt wie"),
+        row(null, "ABC"), row(null, "BCD"), row(null, "CDE"),
+        row(null, "DEF"), row(null, "EFG"), row(null, "FGH"),
+        row(null, "GHI"), row(null, "HIJ"), row(null, "IJK"),
+        row(null, "JKL"), row(null, "KLM")
+      ))
+  }
+
+  // join with agg
+  @Ignore
+  @Test
+  def testJoinWithAggregation(): Unit = {
+    checkResult(
+      "SELECT COUNT(g), COUNT(b) FROM SmallTable3, Table5 WHERE a = d",
+      Seq(row(6L, 6L)))
+  }
+
+  @Ignore
+  @Test
+  def testCrossWithUnnest(): Unit = {
+    val data = List(
+      row(1, 1L, Array("Hi", "w")),
+      row(2, 2L, Array("Hello", "k")),
+      row(3, 2L, Array("Hello world", "x"))
+    )
+    registerCollection("T", data,
+      new RowTypeInfo(INT_TYPE_INFO, LONG_TYPE_INFO, STRING_ARRAY_TYPE_INFO),
+      "a, b, c")
+
+    checkResult(
+      "SELECT a, s FROM T, UNNEST(T.c) as A (s)",
+      Seq())
+  }
+
+  @Ignore
+  @Test
+  def testJoinWithUnnestOfTuple(): Unit = {
+    val data = List(
+      row(1, Array(row(12, "45.6"), row(2, "45.612"))),
+      row(2, Array(row(13, "41.6"), row(1, "45.2136"))),
+      row(3, Array(row(18, "42.6"))))
+    registerCollection("T", data,
+      new RowTypeInfo(INT_TYPE_INFO,
+        ObjectArrayTypeInfo.getInfoFor(classOf[Array[Row]],
+          new RowTypeInfo(INT_TYPE_INFO, STRING_TYPE_INFO))),
+      "a, b")
+
+    checkResult(
+      "SELECT a, b, x, y " +
+        "FROM " +
+        "  (SELECT a, b FROM T WHERE a < 3) as tf, " +
+        "  UNNEST(tf.b) as A (x, y) " +
+        "WHERE x > a",
+      Seq())
+  }
+
+  @Ignore
+  @Test
+  def testJoinConditionNeedSimplify(): Unit = {
+    checkResult(
+      "SELECT A.d FROM Table5 A JOIN SmallTable3 B ON (A.d=B.a and B.a>2) or (A.d=B.a and B.b=1)",
+      Seq(row(1), row(3), row(3), row(3)))
+  }
+
+  @Ignore
+  @Test
+  def testJoinConditionDerivedFromCorrelatedSubQueryNeedSimplify(): Unit = {
+    checkResult(
+      "SELECT B.a FROM SmallTable3 B WHERE b = (" +
+        "select count(*) from Table5 A where (A.d=B.a and A.d<3) or (A.d=B.a and B.b=5))",
+      Seq(row(1), row(2)))
+  }
+
+  @Ignore
+  @Test
+  def testSimple(): Unit = {
+    checkResult(
+      "select a, b from l where a in (select c from r where c > 2)",
+      Seq(row(3, 3.0), row(6, null)))
+  }
+
+  @Test
+  def testSelect(): Unit = {
+    checkResult(
+      "select t.a from (select 1 as a)t",
+      Seq(row(1)))
+  }
+
+  @Test
+  def testCorrelated(): Unit = {
+    expectedJoinType match {
+      case NestedLoopJoin =>
+        checkResult(
+          "select t.a from (select l.a from l, r where l.a = r.c and l.a = 6)t",
+          Seq(row(6)))
+      case _ =>
+      // l.a=r.c and l.a = 6 => l.a=6 and r.c=6, so after ftd and join condition simplified, join
+      // condition is TRUE. Only NestedLoopJoin can handle join without any equi-condition.
+    }
+  }
+
+  @Ignore
+  @Test
+  def testCorrelatedExist(): Unit = {
+    checkResult(
+      "select * from l where exists (select * from r where l.a = r.c)",
+      Seq(row(2, 1.0), row(2, 1.0), row(3, 3.0), row(6, null)))
+
+    checkResult(
+      "select * from l where exists (select * from r where l.a = r.c) and l.a <= 2",
+      Seq(row(2, 1.0), row(2, 1.0)))
+  }
+
+  @Ignore
+  @Test
+  def testCorrelatedNotExist(): Unit = {
+    checkResult(
+      "select * from l where not exists (select * from r where l.a = r.c and l.b <> r.d)",
+      Seq(row(1, 2.0), row(1, 2.0), row(6, null), row(null, 5.0), row(null, null)))
+  }
+
+  @Ignore
+  @Test
+  def testUncorrelatedScalar(): Unit = {
+    checkResult(
+      "select (select 1) as b",
+      Seq(row(1)))
+
+    checkResult(
+      "select (select 1 as b)",
+      Seq(row(1)))
+
+    checkResult(
+      "select (select 1 as a) as b",
+      Seq(row(1)))
+  }
+
+  @Ignore
+  @Test
+  def testEqualWithAggScalar(): Unit = {
+    checkResult(
+      "select a, b from l where a = (select distinct (c) from r where c = 2)",
+      Seq(row(2, 1.0), row(2, 1.0)))
+  }
+
+  @Ignore
+  @Test
+  def testComparisonsScalar(): Unit = {
+    if (expectedJoinType == NestedLoopJoin) {
+      checkEmptyResult(
+        "select a, b from l where a = (select c from r where 1 = 2)")
+
+      checkResult(
+        "select a, b from l where a >= 1.0 * (select avg(d) from r where c > 2)",
+        row(2, 1.0) :: row(2, 1.0) :: row(3, 3.0) :: row(6, null) :: Nil)
+    }
+
+    checkResult(
+      "select a, b from l where a * b < 2.0 * (select avg(d) from r where l.a = r.c and c < 6 )",
+      row(2, 1.0) :: row(2, 1.0) :: Nil)
+  }
+
+  @Test
+  def testJoinWithNull(): Unit = {
+    checkResult(
+      "SELECT c, g FROM NullTable3, NullTable5 " +
+        "WHERE (a = d OR (a IS NULL AND d IS NULL)) AND b = h",
+      Seq(
+        row("Hi", "Hallo"),
+        row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt wie gehts?"),
+        row("Hello world", "ABC"),
+        row("I am fine.", "HIJ"),
+        row("I am fine.", "IJK"),
+        row("NullTuple", "NullTuple"),
+        row("NullTuple", "NullTuple"),
+        row("NullTuple", "NullTuple"),
+        row("NullTuple", "NullTuple")
+      ))
+
+    checkResult(
+      "SELECT c, g FROM NullTable3, NullTable5 " +
+        "WHERE (a = d OR (a IS NULL AND d IS NULL)) and c = 'NullTuple'",
+      Seq(
+        row("NullTuple", "NullTuple"),
+        row("NullTuple", "NullTuple"),
+        row("NullTuple", "NullTuple"),
+        row("NullTuple", "NullTuple")
+      ))
+
+    registerCollection(
+      "NullT", Seq(row(null, null, "c")), type3, allNullablesOfNullData3, "a, b, c")
+    checkResult(
+      "SELECT T1.a, T1.b, T1.c FROM NullT T1, NullT T2 WHERE " +
+        "(T1.a = T2.a OR (T1.a IS NULL AND T2.a IS NULL)) " +
+        "AND (T1.b = T2.b OR (T1.b IS NULL AND T2.b IS NULL)) AND T1.c = T2.c",
+      Seq(row("null", "null", "c")))
+  }
+
+  @Test
+  def testSingleRowJoin(): Unit = {
+    if (expectedJoinType == NestedLoopJoin) {
+      checkResult(
+        "SELECT s, a, b, c FROM SmallTable3 JOIN (SELECT SUM(b) AS s FROM SmallTable3) ON true",
+        Seq(
+          row(5L, 1, 1L, "Hi"),
+          row(5L, 2, 2L, "Hello"),
+          row(5L, 3, 2L, "Hello world")
+        )
+      )
+
+      checkResult(
+        "SELECT s, a, b, c FROM (SELECT SUM(b) AS s FROM SmallTable3) JOIN SmallTable3 ON true",
+        Seq(
+          row(5L, 1, 1L, "Hi"),
+          row(5L, 2, 2L, "Hello"),
+          row(5L, 3, 2L, "Hello world")
+        )
+      )
+
+      checkResult(
+        "SELECT s, a, b, c FROM SmallTable3 JOIN (SELECT SUM(b) AS s FROM SmallTable3) ON s <> b",
+        Seq(
+          row(5L, 1, 1L, "Hi"),
+          row(5L, 2, 2L, "Hello"),
+          row(5L, 3, 2L, "Hello world")
+        )
+      )
+
+      checkResult(
+        "SELECT s, a, b, c FROM (SELECT SUM(b) AS s FROM SmallTable3) JOIN SmallTable3 ON s <> b",
+        Seq(
+          row(5L, 1, 1L, "Hi"),
+          row(5L, 2, 2L, "Hello"),
+          row(5L, 3, 2L, "Hello world")
+        )
+      )
+    }
+  }
+
+  @Test
+  def testNonEmptyTableJoinEmptyTable(): Unit = {
+    if (expectedJoinType == NestedLoopJoin) {
+      checkResult(
+        "SELECT s, a, b, c FROM " +
+          "SmallTable3 JOIN (SELECT SUM(b) AS s FROM SmallTable3 HAVING COUNT(*) < 0) ON true",
+        Seq()
+      )
+
+      checkResult(
+        "SELECT s, a, b, c FROM " +
+          "(SELECT SUM(b) AS s FROM SmallTable3 HAVING COUNT(*) < 0) JOIN SmallTable3 ON true",
+        Seq()
+      )
+
+      checkResult(
+        "SELECT s, a, b, c FROM SmallTable3 FULL JOIN " +
+          "(SELECT SUM(b) AS s FROM SmallTable3 HAVING COUNT(*) < 0) ON true",
+        Seq(row(null, 1, 1, "Hi"), row(null, 2, 2, "Hello"), row(null, 3, 2, "Hello world"))
+      )
+
+      checkResult(
+        "SELECT s, a, b, c FROM (SELECT SUM(b) AS s FROM SmallTable3 HAVING COUNT(*) < 0) " +
+          "FULL JOIN SmallTable3 ON true",
+        Seq(row(null, 1, 1, "Hi"), row(null, 2, 2, "Hello"), row(null, 3, 2, "Hello world"))
+      )
+    }
+  }
+
+  @Test
+  def testEmptyTableJoinEmptyTable(): Unit = {
+    if (expectedJoinType == NestedLoopJoin) {
+      checkResult(
+        "SELECT sa, sb FROM " +
+          "(SELECT SUM(a) AS sa FROM SmallTable3 HAVING COUNT(*) < 0) JOIN " +
+          "(SELECT SUM(b) AS sb FROM SmallTable3 HAVING COUNT(*) < 0) ON true",
+        Seq()
+      )
+
+      checkResult(
+        "SELECT sa, sb FROM " +
+          "(SELECT SUM(b) AS sb FROM SmallTable3 HAVING COUNT(*) < 0) JOIN " +
+          "(SELECT SUM(a) AS sa FROM SmallTable3 HAVING COUNT(*) < 0) ON true",
+        Seq()
+      )
+
+      checkResult(
+        "SELECT sa, sb FROM " +
+          "(SELECT SUM(a) AS sa FROM SmallTable3 HAVING COUNT(*) < 0) FULL JOIN " +
+          "(SELECT SUM(b) AS sb FROM SmallTable3 HAVING COUNT(*) < 0) ON true",
+        Seq()
+      )
+
+      checkResult(
+        "SELECT sa, sb FROM " +
+          "(SELECT SUM(b) AS sb FROM SmallTable3 HAVING COUNT(*) < 0) FULL JOIN " +
+          "(SELECT SUM(a) AS sa FROM SmallTable3 HAVING COUNT(*) < 0) ON true",
+        Seq()
+      )
+    }
+  }
+
+  @Ignore
+  @Test
+  def testJoinCollation(): Unit = {
+    conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_SORT_BUFFER_MEM, 1)
+    checkResult(
+      """
+        |WITH v1 AS (
+        |  SELECT t1.a AS a, (t1.b + t2.b) AS b
+        |    FROM SmallTable3 AS t1, SmallTable3 AS t2 WHERE t1.a = t2.a
+        |),
+        |
+        |v2 AS (
+        |  SELECT t1.a AS a, (t1.b * t2.b) AS b
+        |    FROM SmallTable3 AS t1, SmallTable3 AS t2 WHERE t1.a = t2.a
+        |)
+        |
+        |SELECT v1.a, v2.a, v1.b, v2.b FROM v1, v2 WHERE v1.a = v2.a
+      """.stripMargin,
+      Seq(
+        row(1, 1, 2L, 1L),
+        row(2, 2, 4L, 4L),
+        row(3, 3, 4L, 4L)
+      )
+    )
+
+    checkResult(
+      """
+        |WITH v1 AS (
+        |  SELECT t1.a AS a, (t1.b + t2.b) AS b
+        |    FROM SmallTable3 AS t1, SmallTable3 AS t2 WHERE t1.a = t2.a
+        |),
+        |
+        |v2 AS (
+        |  SELECT t1.b AS a, (t1.b * t2.b) AS b
+        |    FROM SmallTable3 AS t1, SmallTable3 AS t2 WHERE t1.b = t2.b
+        |)
+        |
+        |SELECT v1.a, v2.a, v1.b, v2.b FROM v1, v2 WHERE v1.a = v2.a
+      """.stripMargin,
+      Seq(
+        row(1, 1L, 2L, 1L),
+        row(2, 2L, 4L, 4L),
+        row(2, 2L, 4L, 4L),
+        row(2, 2L, 4L, 4L),
+        row(2, 2L, 4L, 4L)
+      )
+    )
+  }
+}
+
+class GenericTypeInfoWithoutComparator[T](clazz: Class[T]) extends GenericTypeInfo[T](clazz) {
+
+  override def createComparator(
+      sortOrderAscending: Boolean,
+      executionConfig: ExecutionConfig): TypeComparator[T] = {
+    throw new RuntimeException("Not expected!")
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/JoinITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/JoinITCaseBase.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.sql.join
+
+import org.apache.flink.table.api.{PlannerConfigOptions, TableConfigOptions, TableEnvironment}
+import org.apache.flink.table.runtime.batch.sql.join.JoinType.{BroadcastHashJoin, HashJoin, JoinType, NestedLoopJoin, SortMergeJoin}
+
+/**
+  * providing join it case utility functions.
+  */
+trait JoinITCaseBase {
+
+  def disableBroadcastHashJoin(tEnv: TableEnvironment): Unit = {
+    tEnv.getConfig.getConf.setLong(
+      PlannerConfigOptions.SQL_OPTIMIZER_HASH_JOIN_BROADCAST_THRESHOLD, -1)
+  }
+
+  def disableOtherJoinOpForJoin(tEnv: TableEnvironment, expected: JoinType): Unit = {
+    val disabledOperators = expected match {
+      case BroadcastHashJoin => "NestedLoopJoin, SortMergeJoin"
+      case HashJoin =>
+        disableBroadcastHashJoin(tEnv)
+        "NestedLoopJoin, SortMergeJoin"
+      case SortMergeJoin => "HashJoin, NestedLoopJoin"
+      case NestedLoopJoin => "HashJoin, SortMergeJoin"
+    }
+    tEnv.getConfig.getConf.setString(
+      TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS, disabledOperators)
+  }
+}
+
+object JoinType extends Enumeration {
+  type JoinType = Value
+  val BroadcastHashJoin, HashJoin, SortMergeJoin, NestedLoopJoin = Value
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/OuterJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/OuterJoinITCase.scala
@@ -1,0 +1,388 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.sql.join
+
+import org.apache.flink.table.api.TableConfigOptions
+import org.apache.flink.table.runtime.batch.sql.join.JoinType.{BroadcastHashJoin, JoinType, NestedLoopJoin}
+import org.apache.flink.table.runtime.utils.BatchTestBase
+import org.apache.flink.table.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.runtime.utils.TestData._
+
+import org.junit.{Before, Ignore, Test}
+
+import scala.collection.Seq
+
+//@RunWith(classOf[Parameterized]) TODO
+class OuterJoinITCase extends BatchTestBase with JoinITCaseBase {
+
+  val expectedJoinType: JoinType = JoinType.SortMergeJoin
+
+  private lazy val leftT = Seq(
+    row(1, 2.0),
+    row(2, 100.0),
+    row(2, 1.0), // This row is duplicated to ensure that we will have multiple buffered matches
+    row(2, 1.0),
+    row(3, 3.0),
+    row(5, 1.0),
+    row(6, 6.0),
+    row(null, null)
+  )
+
+  private lazy val rightT = Seq(
+    row(0, 0.0),
+    row(2, 3.0), // This row is duplicated to ensure that we will have multiple buffered matches
+    row(2, -1.0),
+    row(2, -1.0),
+    row(2, 3.0),
+    row(3, 2.0),
+    row(4, 1.0),
+    row(5, 3.0),
+    row(7, 7.0),
+    row(null, null)
+  )
+
+  @Before
+  def before(): Unit = {
+    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 3)
+    registerCollection("uppercasedata", upperCaseData, INT_STRING, nullablesOfUpperCaseData, "N, L")
+    registerCollection("lowercasedata", lowerCaseData, INT_STRING, nullablesOfLowerCaseData, "n, l")
+    registerCollection("allnulls", allNulls, INT_ONLY, nullablesOfAllNulls, "a")
+    registerCollection("leftT", leftT, INT_DOUBLE, "a, b")
+    registerCollection("rightT", rightT, INT_DOUBLE, "c, d")
+    disableOtherJoinOpForJoin(tEnv, expectedJoinType)
+  }
+
+  @Test
+  def testLeftOuter(): Unit = {
+    checkResult(
+      "SELECT * FROM leftT LEFT JOIN rightT ON a = c and b < d",
+      Seq(
+        row(null, null, null, null),
+        row(1, 2.0, null, null),
+        row(2, 100.0, null, null),
+        row(2, 1.0, 2, 3.0),
+        row(2, 1.0, 2, 3.0),
+        row(2, 1.0, 2, 3.0),
+        row(2, 1.0, 2, 3.0),
+        row(3, 3.0, null, null),
+        row(5, 1.0, 5, 3.0),
+        row(6, 6.0, null, null)
+      ))
+  }
+
+  @Test
+  def testRightOuter(): Unit = {
+    checkResult(
+      "SELECT * FROM leftT RIGHT JOIN rightT ON a = c and b < d",
+      Seq(
+        row(null, null, null, null),
+        row(null, null, 0, 0.0),
+        row(2, 1.0, 2, 3.0),
+        row(2, 1.0, 2, 3.0),
+        row(null, null, 2, -1.0),
+        row(null, null, 2, -1.0),
+        row(2, 1.0, 2, 3.0),
+        row(2, 1.0, 2, 3.0),
+        row(null, null, 3, 2.0),
+        row(null, null, 4, 1.0),
+        row(5, 1.0, 5, 3.0),
+        row(null, null, 7, 7.0)
+      ))
+  }
+
+  @Test
+  def testFullOuter(): Unit = {
+    if (expectedJoinType != NestedLoopJoin && expectedJoinType != BroadcastHashJoin) {
+      checkResult(
+        "SELECT * FROM leftT FULL JOIN rightT ON a = c and b < d",
+        Seq(
+          row(1, 2.0, null, null),
+          row(null, null, 2, -1.0),
+          row(null, null, 2, -1.0),
+          row(2, 100.0, null, null),
+          row(2, 1.0, 2, 3.0),
+          row(2, 1.0, 2, 3.0),
+          row(2, 1.0, 2, 3.0),
+          row(2, 1.0, 2, 3.0),
+          row(3, 3.0, null, null),
+          row(5, 1.0, 5, 3.0),
+          row(6, 6.0, null, null),
+          row(null, null, 0, 0.0),
+          row(null, null, 3, 2.0),
+          row(null, null, 4, 1.0),
+          row(null, null, 7, 7.0),
+          row(null, null, null, null),
+          row(null, null, null, null)
+        ))
+    }
+  }
+
+  @Test
+  def testLeftEmptyOuter(): Unit = {
+    checkResult(
+      "SELECT * FROM (SELECT * FROM leftT WHERE FALSE) " +
+          "LEFT JOIN (SELECT * FROM rightT WHERE FALSE) ON a = c and b < d",
+      Seq())
+  }
+
+  @Test
+  def testRightEmptyOuter(): Unit = {
+    checkResult(
+      "SELECT * FROM (SELECT * FROM leftT WHERE FALSE) " +
+          "RIGHT JOIN (SELECT * FROM rightT WHERE FALSE) ON a = c and b < d",
+      Seq())
+  }
+
+  @Test
+  def testFullEmptyOuter(): Unit = {
+    if (expectedJoinType != NestedLoopJoin && expectedJoinType != BroadcastHashJoin) {
+      checkResult(
+        "SELECT * FROM (SELECT * FROM leftT WHERE FALSE) " +
+            "FULL JOIN (SELECT * FROM rightT WHERE FALSE) ON a = c and b < d",
+        Seq())
+    }
+  }
+
+  @Test
+  def testLeftUpperAndLower(): Unit = {
+    checkResult(
+      "SELECT * FROM uppercasedata u LEFT JOIN lowercasedata l ON l.n = u.N",
+      row(1, "A", 1, "a") ::
+          row(2, "B", 2, "b") ::
+          row(3, "C", 3, "c") ::
+          row(4, "D", 4, "d") ::
+          row(5, "E", null, null) ::
+          row(6, "F", null, null) :: Nil)
+
+    checkResult(
+      "SELECT * FROM uppercasedata u LEFT JOIN lowercasedata l ON l.n = u.N AND l.n > 1",
+      row(1, "A", null, null) ::
+          row(2, "B", 2, "b") ::
+          row(3, "C", 3, "c") ::
+          row(4, "D", 4, "d") ::
+          row(5, "E", null, null) ::
+          row(6, "F", null, null) :: Nil)
+
+    checkResult(
+      "SELECT * FROM uppercasedata u LEFT JOIN lowercasedata l ON l.n = u.N AND u.N > 1",
+      row(1, "A", null, null) ::
+          row(2, "B", 2, "b") ::
+          row(3, "C", 3, "c") ::
+          row(4, "D", 4, "d") ::
+          row(5, "E", null, null) ::
+          row(6, "F", null, null) :: Nil)
+
+    checkResult(
+      "SELECT * FROM uppercasedata u LEFT JOIN lowercasedata l ON l.n = u.N AND l.l > u.L",
+      row(1, "A", 1, "a") ::
+          row(2, "B", 2, "b") ::
+          row(3, "C", 3, "c") ::
+          row(4, "D", 4, "d") ::
+          row(5, "E", null, null) ::
+          row(6, "F", null, null) :: Nil)
+  }
+
+  @Ignore
+  @Test
+  def testLeftUpperAndLowerWithAgg(): Unit = {
+    checkResult(
+      """
+        |SELECT l.N, count(*)
+        |FROM uppercasedata l LEFT JOIN allnulls r ON (l.N = r.a)
+        |GROUP BY l.N
+      """.stripMargin,
+      row(
+        1, 1) ::
+          row(2, 1) ::
+          row(3, 1) ::
+          row(4, 1) ::
+          row(5, 1) ::
+          row(6, 1) :: Nil)
+
+    checkResult(
+      """
+        |SELECT r.a, count(*)
+        |FROM uppercasedata l LEFT OUTER JOIN allnulls r ON (l.N = r.a)
+        |GROUP BY r.a
+      """.stripMargin,
+      row(null, 6) :: Nil)
+  }
+
+  @Test
+  def testRightUpperAndLower(): Unit = {
+    checkResult(
+      "SELECT * FROM lowercasedata l RIGHT JOIN uppercasedata u ON l.n = u.N",
+      row(1, "a", 1, "A") ::
+          row(2, "b", 2, "B") ::
+          row(3, "c", 3, "C") ::
+          row(4, "d", 4, "D") ::
+          row(null, null, 5, "E") ::
+          row(null, null, 6, "F") :: Nil)
+    checkResult(
+      "SELECT * FROM lowercasedata l RIGHT JOIN uppercasedata u ON l.n = u.N AND l.n > 1",
+      row(null, null, 1, "A") ::
+          row(2, "b", 2, "B") ::
+          row(3, "c", 3, "C") ::
+          row(4, "d", 4, "D") ::
+          row(null, null, 5, "E") ::
+          row(null, null, 6, "F") :: Nil)
+    checkResult(
+      "SELECT * FROM lowercasedata l RIGHT JOIN uppercasedata u ON l.n = u.N AND u.N > 1",
+      row(null, null, 1, "A") ::
+          row(2, "b", 2, "B") ::
+          row(3, "c", 3, "C") ::
+          row(4, "d", 4, "D") ::
+          row(null, null, 5, "E") ::
+          row(null, null, 6, "F") :: Nil)
+    checkResult(
+      "SELECT * FROM lowercasedata l RIGHT JOIN uppercasedata u ON l.n = u.N AND l.l > u.L",
+      row(1, "a", 1, "A") ::
+          row(2, "b", 2, "B") ::
+          row(3, "c", 3, "C") ::
+          row(4, "d", 4, "D") ::
+          row(null, null, 5, "E") ::
+          row(null, null, 6, "F") :: Nil)
+
+
+  }
+
+  @Ignore
+  @Test
+  def testRightUpperAndLowerWithAgg(): Unit = {
+    checkResult(
+      """
+        |SELECT l.a, count(*)
+        |FROM allnulls l RIGHT OUTER JOIN uppercasedata r ON (l.a = r.N)
+        |GROUP BY l.a
+      """.stripMargin,
+      row(null, 6) :: Nil)
+
+    checkResult(
+      """
+        |SELECT r.N, count(*)
+        |FROM allnulls l RIGHT OUTER JOIN uppercasedata r ON (l.a = r.N)
+        |GROUP BY r.N
+      """.stripMargin,
+      row(1
+        , 1) ::
+          row(2, 1) ::
+          row(3, 1) ::
+          row(4, 1) ::
+          row(5, 1) ::
+          row(6, 1) :: Nil)
+  }
+
+  @Test
+  def testFullUpperAndLower(): Unit = {
+    if (expectedJoinType != NestedLoopJoin && expectedJoinType != BroadcastHashJoin) {
+      val leftData = upperCaseData.filter(_.getField(0).asInstanceOf[Int] <= 4)
+      val rightData = upperCaseData.filter(_.getField(0).asInstanceOf[Int] >= 3)
+
+      registerCollection("leftUpper", leftData, INT_STRING, "N, L")
+      registerCollection("rightUpper", rightData, INT_STRING, "N, L")
+
+      checkResult(
+        "SELECT * FROM leftUpper FULL JOIN rightUpper ON leftUpper.N = rightUpper.N",
+        row(1, "A", null, null) ::
+            row(2, "B", null, null) ::
+            row(3, "C", 3, "C") ::
+            row(4, "D", 4, "D") ::
+            row(null, null, 5, "E") ::
+            row(null, null, 6, "F") :: Nil)
+
+      checkResult(
+        "SELECT * FROM leftUpper FULL JOIN rightUpper ON " +
+            "leftUpper.N = rightUpper.N AND leftUpper.N <> 3",
+        row(1, "A", null, null) ::
+            row(2, "B", null, null) ::
+            row(3, "C", null, null) ::
+            row(null, null, 3, "C") ::
+            row(4, "D", 4, "D") ::
+            row(null, null, 5, "E") ::
+            row(null, null, 6, "F") :: Nil)
+
+      checkResult(
+        "SELECT * FROM leftUpper FULL JOIN rightUpper ON " +
+            "leftUpper.N = rightUpper.N AND rightUpper.N <> 3",
+        row(1, "A", null, null) ::
+            row(2, "B", null, null) ::
+            row(3, "C", null, null) ::
+            row(null, null, 3, "C") ::
+            row(4, "D", 4, "D") ::
+            row(null, null, 5, "E") ::
+            row(null, null, 6, "F") :: Nil)
+    }
+  }
+
+  @Ignore
+  @Test
+  def testFullUpperAndLowerWithAgg(): Unit = {
+    if (expectedJoinType != NestedLoopJoin && expectedJoinType != BroadcastHashJoin) {
+      checkResult(
+        """
+        |SELECT l.a, count(*)
+        |FROM allnulls l FULL OUTER JOIN uppercasedata r ON (l.a = r.N)
+        |GROUP BY l.a
+      """.
+            stripMargin,
+      row(null, 10) :: Nil)
+
+      checkResult(
+        """
+          |SELECT r.N, count(*)
+          |FROM allnulls l FULL OUTER JOIN uppercasedata r ON (l.a = r.N)
+          |GROUP BY r.N
+        """.stripMargin,
+        row
+        (1, 1) ::
+            row(2, 1) ::
+            row(3, 1) ::
+            row(4, 1) ::
+            row(5, 1) ::
+            row(6, 1) ::
+            row(null, 4) :: Nil)
+
+      checkResult(
+        """
+          |SELECT l.N, count(*)
+          |FROM uppercasedata l FULL OUTER JOIN allnulls r ON (l.N = r.a)
+          |GROUP BY l.N
+        """.stripMargin,
+        row(1
+          ,
+          1) ::
+            row(2, 1) ::
+            row(3, 1) ::
+            row(4, 1) ::
+            row(5, 1) ::
+            row(6, 1) ::
+            row(null, 4) :: Nil)
+
+        checkResult(
+          """
+          |SELECT r.a, count(*)
+          |FROM uppercasedata l FULL OUTER JOIN allnulls r ON (l.N = r.a)
+          |GROUP BY r.a
+        """.
+              stripMargin,
+        row(
+          null, 10) :: Nil)
+    }
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/BatchTestBase.scala
@@ -408,6 +408,8 @@ object BatchTestBase {
   def initConfigForTest(conf: TableConfig): TableConfig = {
     // TODO prepare for some resource config
     conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, PARALLELISM)
+    conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_SORT_BUFFER_MEM, 2)
+    conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_EXTERNAL_BUFFER_MEM, 1)
     conf
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/TestData.scala
@@ -61,16 +61,16 @@ object TestData {
     row(null, null, null)
   )
 
-  val allNullablesOfNullData3 = Seq(true, true, true)
+  val allNullablesOfNullData3 = Array(true, true, true)
 
-  val nullablesOfNullData3 = Seq(true, false, false)
+  val nullablesOfNullData3 = Array(true, false, false)
 
   lazy val nullData5: Seq[Row] = data5 ++ Seq(
     row(null, 999L, 999, "NullTuple", 999L),
     row(null, 999L, 999, "NullTuple", 999L)
   )
 
-  val nullablesOfNullData5 = Seq(true, false, false, false, false)
+  val nullablesOfNullData5 = Array(true, false, false, false, false)
 
   lazy val smallData3 = Seq(
     row(1, 1L, "Hi"),
@@ -78,7 +78,7 @@ object TestData {
     row(3, 2L, "Hello world")
   )
 
-  val nullablesOfSmallData3 = Seq(false, false, false)
+  val nullablesOfSmallData3 = Array(false, false, false)
 
   lazy val smallData5 = Seq(
     row(1, 1L, 0, "Hallo", 1L),

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
@@ -91,11 +91,26 @@ public class TableConfigOptions {
 	//  Resource Options
 	// ------------------------------------------------------------------------
 
+	/**
+	 * How many Bytes per MB.
+	 */
+	public static final long SIZE_IN_MB =  1024L * 1024;
+
 	public static final ConfigOption<Integer> SQL_RESOURCE_DEFAULT_PARALLELISM =
 			key("sql.resource.default.parallelism")
 					.defaultValue(-1)
 					.withDescription("Default parallelism of the job. If any node do not have special parallelism, use it." +
 							"Its default value is the num of cpu cores in the client host.");
+
+	public static final ConfigOption<Integer> SQL_RESOURCE_EXTERNAL_BUFFER_MEM =
+			key("sql.resource.external-buffer.memory.mb")
+					.defaultValue(10)
+					.withDescription("Sets the externalBuffer memory size that is used in sortMergeJoin and overWindow.");
+
+	public static final ConfigOption<Integer> SQL_RESOURCE_SORT_BUFFER_MEM =
+			key("sql.resource.sort.buffer.memory.mb")
+					.defaultValue(32)
+					.withDescription("Sets the buffer reserved memory size for sort. It defines the lower limit for the sort.");
 
 	// ------------------------------------------------------------------------
 	//  MiniBatch Options

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/BinaryHashPartitioner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/BinaryHashPartitioner.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime;
+
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.generated.GeneratedHashFunction;
+import org.apache.flink.table.generated.HashFunction;
+import org.apache.flink.util.MathUtils;
+
+/**
+ * Hash partitioner for {@link BinaryRow}.
+ */
+public class BinaryHashPartitioner extends StreamPartitioner<BaseRow> {
+
+	private GeneratedHashFunction genHashFunc;
+
+	private transient HashFunction hashFunc;
+
+	public BinaryHashPartitioner(GeneratedHashFunction genHashFunc) {
+		this.genHashFunc = genHashFunc;
+	}
+
+	@Override
+	public StreamPartitioner<BaseRow> copy() {
+		return this;
+	}
+
+	@Override
+	public int selectChannel(SerializationDelegate<StreamRecord<BaseRow>> record) {
+		return MathUtils.murmurHash(
+				getHashFunc().hashCode(record.getInstance().getValue())) % numberOfChannels;
+	}
+
+	private HashFunction getHashFunc() {
+		if (hashFunc == null) {
+			try {
+				hashFunc = genHashFunc.newInstance(Thread.currentThread().getContextClassLoader());
+				genHashFunc = null;
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return hashFunc;
+	}
+
+	@Override
+	public String toString() {
+		return "HASH(" + genHashFunc.getClassName() + ")";
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/TwoInputOperatorWrapper.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/TwoInputOperatorWrapper.java
@@ -60,6 +60,11 @@ public class TwoInputOperatorWrapper<IN1, IN2, OUT>
 		return operator;
 	}
 
+	@VisibleForTesting
+	public GeneratedClass<TwoInputStreamOperator<IN1, IN2, OUT>> getGeneratedClass() {
+		return generatedClass;
+	}
+
 	@Override
 	public void open() throws Exception {
 		operator.open();

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/SortMergeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/SortMergeJoinOperator.java
@@ -447,6 +447,8 @@ public class SortMergeJoinOperator extends TableStreamOperator<BaseRow>
 
 	@Override
 	public void close() throws Exception {
+		endInput1(); // TODO remove it
+		endInput2(); // TODO remove it
 		super.close();
 		if (this.sorter1 != null) {
 			this.sorter1.close();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/Int2HashJoinOperatorTest.java
@@ -248,6 +248,18 @@ public class Int2HashJoinOperatorTest implements Serializable {
 			int expectOutKeySize,
 			int expectOutVal,
 			boolean semiJoin) throws Exception {
+		joinAndAssert(operator, input1, input2, expectOutSize, expectOutKeySize, expectOutVal, semiJoin, true);
+	}
+
+	static void joinAndAssert(
+			StreamOperator operator,
+			MutableObjectIterator<BinaryRow> input1,
+			MutableObjectIterator<BinaryRow> input2,
+			int expectOutSize,
+			int expectOutKeySize,
+			int expectOutVal,
+			boolean semiJoin,
+			boolean invokeEndInput) throws Exception {
 		BaseRowTypeInfo typeInfo = new BaseRowTypeInfo(InternalTypes.INT, InternalTypes.INT);
 		BaseRowTypeInfo baseRowType = new BaseRowTypeInfo(
 				InternalTypes.INT, InternalTypes.INT, InternalTypes.INT, InternalTypes.INT);
@@ -268,14 +280,18 @@ public class Int2HashJoinOperatorTest implements Serializable {
 			testHarness.processElement(new StreamRecord<>(row1), 0, 0);
 		}
 		testHarness.waitForInputProcessing();
-		endInput1(testHarness);
+		if (invokeEndInput) {
+			endInput1(testHarness);
+		}
 
 		BinaryRow row2;
 		while ((row2 = input2.next()) != null) {
 			testHarness.processElement(new StreamRecord<>(row2), 1, 0);
 		}
 		testHarness.waitForInputProcessing();
-		endInput2(testHarness);
+		if (invokeEndInput) {
+			endInput2(testHarness);
+		}
 
 		testHarness.endInput();
 		testHarness.waitForInputProcessing();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/Int2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/Int2SortMergeJoinOperatorTest.java
@@ -153,7 +153,7 @@ public class Int2SortMergeJoinOperatorTest {
 		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys2, probeValsPerKey, true);
 
 		StreamOperator operator = newOperator(SortMergeJoinType.SEMI, false);
-		joinAndAssert(operator, buildInput, probeInput, 90, 9, 45, true);
+		joinAndAssert(operator, buildInput, probeInput, 90, 9, 45, true, false);
 	}
 
 	@Test
@@ -167,7 +167,7 @@ public class Int2SortMergeJoinOperatorTest {
 		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys2, probeValsPerKey, true);
 
 		StreamOperator operator = newOperator(SortMergeJoinType.ANTI, false);
-		joinAndAssert(operator, buildInput, probeInput, 10, 1, 45, true);
+		joinAndAssert(operator, buildInput, probeInput, 10, 1, 45, true, false);
 	}
 
 	private void buildJoin(
@@ -178,7 +178,7 @@ public class Int2SortMergeJoinOperatorTest {
 
 		joinAndAssert(
 				getOperator(type),
-				input1, input2, expertOutSize, expertOutKeySize, expertOutVal, false);
+				input1, input2, expertOutSize, expertOutKeySize, expertOutVal, false, false);
 	}
 
 	private StreamOperator getOperator(SortMergeJoinType type) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/RandomSortMergeInnerJoinTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/RandomSortMergeInnerJoinTest.java
@@ -60,9 +60,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.apache.flink.table.runtime.join.Int2HashJoinOperatorTest.endInput1;
-import static org.apache.flink.table.runtime.join.Int2HashJoinOperatorTest.endInput2;
-
 /**
  * Test for sort merge inner join.
  */
@@ -269,28 +266,24 @@ public class RandomSortMergeInnerJoinTest {
 				testHarness.processElement(new StreamRecord<>(newRow(tuple2.f0, tuple2.f1), initialTime), 0, 0);
 			}
 			testHarness.waitForInputProcessing();
-			endInput1(testHarness);
 
 			tuple2 = new Tuple2<>();
 			while ((tuple2 = input2.next(tuple2)) != null) {
 				testHarness.processElement(new StreamRecord<>(newRow(tuple2.f0, tuple2.f1), initialTime), 1, 0);
 			}
 			testHarness.waitForInputProcessing();
-			endInput2(testHarness);
 		} else {
 			Tuple2<Integer, String> tuple2 = new Tuple2<>();
 			while ((tuple2 = input2.next(tuple2)) != null) {
 				testHarness.processElement(new StreamRecord<>(newRow(tuple2.f0, tuple2.f1), initialTime), 1, 0);
 			}
 			testHarness.waitForInputProcessing();
-			endInput2(testHarness);
 
 			tuple2 = new Tuple2<>();
 			while ((tuple2 = input1.next(tuple2)) != null) {
 				testHarness.processElement(new StreamRecord<>(newRow(tuple2.f0, tuple2.f1), initialTime), 0, 0);
 			}
 			testHarness.waitForInputProcessing();
-			endInput1(testHarness);
 		}
 
 		testHarness.endInput();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/String2SortMergeJoinOperatorTest.java
@@ -49,8 +49,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.apache.flink.table.runtime.join.Int2HashJoinOperatorTest.endInput1;
-import static org.apache.flink.table.runtime.join.Int2HashJoinOperatorTest.endInput2;
 import static org.apache.flink.table.runtime.join.String2HashJoinOperatorTest.newRow;
 import static org.apache.flink.table.runtime.join.String2HashJoinOperatorTest.transformToBinary;
 
@@ -163,8 +161,6 @@ public class String2SortMergeJoinOperatorTest {
 		testHarness.processElement(new StreamRecord<>(newRow("b", "4"), initialTime), 1, 0);
 		testHarness.waitForInputProcessing();
 
-		endInput1(testHarness);
-		endInput2(testHarness);
 		testHarness.endInput();
 		return testHarness;
 	}


### PR DESCRIPTION
## What is the purpose of the change

Complete BatchExecSortMergeJoin and support join it cases.
Support queries like "select a, b, c, e from T1, T2 where T1.a = T2.d" run in batch mode

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
