### PR TITLE
[FLINK-12123][tests] Upgrade Jepsen to 0.1.13

### DIFF
--- a/flink-jepsen/docker/Dockerfile-control
+++ b/flink-jepsen/docker/Dockerfile-control
@@ -16,11 +16,9 @@
 # limitations under the License.
 ################################################################################
 
-FROM debian:jessie
+FROM debian:stretch
 
-RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install -y -t jessie-backports openjdk-8-jdk && \
+RUN apt-get update && \
     apt-get install -qqy \
             less \
             libjna-java \

--- a/flink-jepsen/docker/Dockerfile-db
+++ b/flink-jepsen/docker/Dockerfile-db
@@ -16,12 +16,34 @@
 # limitations under the License.
 ################################################################################
 
-FROM debian:jessie
+FROM debian:stretch
 
-RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install -y -t jessie-backports openjdk-8-jdk && \
-    apt-get install -y apt-utils bzip2 curl faketime iproute iptables iputils-ping less libzip2 logrotate man man-db net-tools ntpdate psmisc python rsyslog runit sudo sysvinit sysvinit-core sysvinit-utils tar unzip vim wget
+RUN apt-get update && \
+    apt-get install -qqy \
+            apt-utils \
+            bzip2 \
+            curl \
+            faketime \
+            gnupg \
+            iproute \
+            iptables \
+            iputils-ping \
+            less \
+            libzip4 \
+            logrotate \
+            man \
+            man-db \
+            net-tools \
+            ntpdate \
+            openjdk-8-jdk \
+            psmisc python \
+            rsyslog \
+            runit \
+            sudo \
+            tar \
+            unzip \
+            vim \
+            wget
 
 RUN apt-get update && \
     apt-get -y install openssh-server && \

--- a/flink-jepsen/project.clj
+++ b/flink-jepsen/project.clj
@@ -22,7 +22,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"],
                  [cheshire "5.8.0"]
                  [clj-http "3.8.0"]
-                 [jepsen "0.1.11"],
+                 [jepsen "0.1.13"],
                  [jepsen.zookeeper "0.1.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [zookeeper-clj "0.9.4" :exclusions [org.slf4j/slf4j-log4j12]]]

--- a/flink-jepsen/src/jepsen/flink/flink.clj
+++ b/flink-jepsen/src/jepsen/flink/flink.clj
@@ -36,9 +36,9 @@
 (def default-flink-dist-url "https://archive.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop28-scala_2.11.tgz")
 (def hadoop-dist-url "https://archive.apache.org/dist/hadoop/common/hadoop-2.8.3/hadoop-2.8.3.tar.gz")
 (def kafka-dist-url "http://mirror.funkfreundelandshut.de/apache/kafka/2.0.1/kafka_2.11-2.0.1.tgz")
-(def deb-zookeeper-package "3.4.9-3+deb8u1")
-(def deb-mesos-package "1.5.0-2.0.2")
-(def deb-marathon-package "1.6.322")
+(def deb-zookeeper-package "3.4.9-3+deb9u1")
+(def deb-mesos-package "1.5.0-2.0.1")
+(def marathon-dist-url "https://downloads.mesosphere.io/marathon/builds/1.7.189-48bfd6000/marathon-1.7.189-48bfd6000.tgz")
 
 (def dbs
   {:flink-yarn-job           (fdb/yarn-job-db)
@@ -47,7 +47,7 @@
    :flink-mesos-session      (fdb/flink-mesos-app-master)
    :hadoop                   (hadoop/db hadoop-dist-url)
    :kafka                    (kafka/db kafka-dist-url)
-   :mesos                    (mesos/db deb-mesos-package deb-marathon-package)
+   :mesos                    (mesos/db deb-mesos-package marathon-dist-url)
    :zookeeper                (zk/db deb-zookeeper-package)})
 
 (def poll-jobs-running {:type :invoke, :f :jobs-running?, :value nil})
@@ -84,9 +84,6 @@
             :os        debian/os
             :db        (fdb/combined-db dbs)
             :nemesis   (fn/nemesis)
-            :model     (flink-checker/job-running-within-grace-period
-                         job-running-healthy-threshold
-                         job-recovery-grace-period)
             :generator (let [stop (atom nil)]
                          (->> (fg/stoppable-generator stop (client-gen))
                               (gen/nemesis
@@ -95,7 +92,8 @@
                                                    job-running-healthy-threshold
                                                    job-recovery-grace-period))))
             :client    (create-client)
-            :checker   (flink-checker/job-running-checker)})
+            :checker   (flink-checker/job-running-checker job-running-healthy-threshold
+                                                          job-recovery-grace-period)})
          (assoc opts :concurrency 1)))
 
 (defn- keys->allowed-values-help-text

--- a/flink-jepsen/src/jepsen/flink/hadoop.clj
+++ b/flink-jepsen/src/jepsen/flink/hadoop.clj
@@ -115,17 +115,36 @@
     (info "Start DataNode")
     (c/exec (str install-dir "/sbin/hadoop-daemon.sh") :--config hadoop-conf-dir :--script :hdfs :start :datanode)))
 
+(defn stop-data-node!
+  []
+  (c/exec (str install-dir "/sbin/hadoop-daemon.sh") :--config hadoop-conf-dir :--script :hdfs :stop :datanode))
+
 (defn start-resource-manager!
   [test node]
   (when (= node (resource-manager (:nodes test)))
     (info "Start ResourceManager")
     (c/exec (str install-dir "/sbin/yarn-daemon.sh") :--config hadoop-conf-dir :start :resourcemanager)))
 
+(defn stop-resource-manager!
+  []
+  (c/exec (str install-dir "/sbin/yarn-daemon.sh") :--config hadoop-conf-dir :stop :resourcemanager))
+
 (defn start-node-manager!
   [test node]
   (when (some #{node} (data-nodes (:nodes test)))
     (info "Start NodeManager")
     (c/exec (str install-dir "/sbin/yarn-daemon.sh") :--config hadoop-conf-dir :start :nodemanager)))
+
+(defn stop-node-manager!
+  []
+  (c/exec (str install-dir "/sbin/yarn-daemon.sh") :--config hadoop-conf-dir :stop :nodemanager))
+
+(defn stop-all!
+  []
+  (stop-name-node!)
+  (stop-data-node!)
+  (stop-resource-manager!)
+  (stop-node-manager!))
 
 (defn db
   [url]
@@ -143,7 +162,7 @@
     (teardown! [_ _ _]
       (info "Teardown Hadoop")
       (c/su
-        (cu/grepkill! "hadoop")
+        (stop-all!)
         (c/exec :rm :-rf install-dir)))
 
     db/LogFiles

--- a/flink-jepsen/src/jepsen/flink/utils.clj
+++ b/flink-jepsen/src/jepsen/flink/utils.clj
@@ -71,12 +71,14 @@
 
 ;;; runit process supervisor (http://smarden.org/runit/)
 
-(def runit-version "2.1.2-3")
+(def runit-version "2.1.2-9.2")
+(def runit-systemd-version "2.1.2-9.2")
 
 (defn- install-process-supervisor!
   "Installs the process supervisor."
   []
-  (debian/install {:runit runit-version}))
+  (debian/install {:runit         runit-version
+                   :runit-systemd runit-systemd-version}))
 
 (defn create-supervised-service!
   "Registers a service with the process supervisor and starts it."
@@ -91,6 +93,7 @@
                                                "exec 2>&1"
                                                (str "exec " cmd)]) :> run-script)
       (c/exec :chmod :+x run-script)
+      (c/exec :mkdir :-p "/etc/service")
       (c/exec :ln :-sfT service-dir (str "/etc/service/" service-name)))))
 
 (defn stop-supervised-service!
@@ -108,4 +111,4 @@
     ;; HACK:
     ;; Remove all symlinks in /etc/service except sshd.
     ;; This is only relevant when tests are run in Docker because there sshd is started using runit.
-    (meh (c/exec :find (c/lit (str "/etc/service -maxdepth 1 -type l ! -name 'sshd' -delete"))))))
+    (meh (c/exec :find (c/lit (str "/etc/service -mindepth 1 -maxdepth 1 -type l -not -name 'sshd' -delete"))))))

--- a/flink-jepsen/test/jepsen/flink/checker_test.clj
+++ b/flink-jepsen/test/jepsen/flink/checker_test.clj
@@ -30,11 +30,10 @@
     (is (= [false true false] (all-jobs-running?-history history)))))
 
 (deftest job-running-checker-test
-  (let [checker (job-running-checker)
+  (let [checker (job-running-checker 3 60 10)
         test {}
-        model (job-running-within-grace-period 3 60 10)
         opts {}
-        check (fn [history] (checker/check checker test model history opts))
+        check (fn [history] (checker/check checker test history opts))
         job-running-value {"3886d6b547969c3f15c53896bb496b8f" true}
         job-not-running-value {"3886d6b547969c3f15c53896bb496b8f" false}]
     (testing "Model should be inconsistent if job is not running after grace period."

--- a/flink-jepsen/test/jepsen/flink/generator_test.clj
+++ b/flink-jepsen/test/jepsen/flink/generator_test.clj
@@ -14,19 +14,19 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(ns jepsen.flink.nemesis-test
+(ns jepsen.flink.generator-test
   (:require [clojure.test :refer :all])
-  (:require [jepsen.flink.nemesis :refer :all]))
+  (:require [jepsen.flink.generator :refer :all]))
 
 (deftest inc-by-factor-test
   (testing "Should not increase if factor is 1."
-    (is (= 10 (@#'jepsen.flink.nemesis/inc-by-factor 10 1))))
+    (is (= 10 (@#'jepsen.flink.generator/inc-by-factor 10 1))))
 
   (testing "Should increase by factor."
-    (is (= 15 (@#'jepsen.flink.nemesis/inc-by-factor 10 1.5))))
+    (is (= 15 (@#'jepsen.flink.generator/inc-by-factor 10 1.5))))
 
   (testing "Should round down."
-    (is (= 15 (@#'jepsen.flink.nemesis/inc-by-factor 10 1.52))))
+    (is (= 15 (@#'jepsen.flink.generator/inc-by-factor 10 1.52))))
 
   (testing "Should throw if factor < 1."
-    (is (thrown? AssertionError (@#'jepsen.flink.nemesis/inc-by-factor 1 0)))))
+    (is (thrown? AssertionError (@#'jepsen.flink.generator/inc-by-factor 1 0)))))


### PR DESCRIPTION
## What is the purpose of the change

*Upgrade Jepsen dependency to get support for Debian Stretch (Jessie has reached EOL).*


## Brief change log

  - *See commits*

## Verifying this change

This change is already covered by existing tests, such as *the change is a test*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
