### PR TITLE
[FLINK-12146][network] Remove unregister task from NetworkEnvironment to simplify the interface of ShuffleService

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -36,6 +36,8 @@ import org.apache.flink.runtime.taskmanager.TaskActions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -329,6 +331,10 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 		if (bufferPool != null) {
 			bufferPool.lazyDestroy();
 		}
+	}
+
+	public void fail(@Nullable Throwable throwable) {
+		partitionManager.releasePartitionsProducedBy(partitionId.getProducerId(), throwable);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -836,12 +836,8 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 					dispatcher.shutdownNow();
 				}
 
-				for (ResultPartition partition : producedPartitions) {
-					taskEventDispatcher.unregisterPartition(partition.getPartitionId());
-				}
-
 				// free the network resources
-				network.unregisterTask(this);
+				releaseNetworkResources();
 
 				// free memory resources
 				if (invokable != null) {
@@ -874,6 +870,47 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 			}
 			catch (Throwable t) {
 				LOG.error("Error during metrics de-registration of task {} ({}).", taskNameWithSubtask, executionId, t);
+			}
+		}
+	}
+
+	/**
+	 * Releases network resources before task exits. We should also fail the partition to release if the task
+	 * has failed, is canceled, or is being canceled at the moment.
+	 */
+	private void releaseNetworkResources() {
+		LOG.debug("Release task {} network resources (state: {}).", taskNameWithSubtask, getExecutionState());
+
+		for (ResultPartition partition : producedPartitions) {
+			taskEventDispatcher.unregisterPartition(partition.getPartitionId());
+			if (isCanceledOrFailed()) {
+				partition.fail(getFailureCause());
+			}
+		}
+
+		closeNetworkResources();
+	}
+
+	/**
+	 * There are two scenarios to close the network resources. One is from {@link TaskCanceler} to early
+	 * release partitions and gates. Another is from task thread during task exiting.
+	 */
+	private void closeNetworkResources() {
+		for (ResultPartition partition : producedPartitions) {
+			try {
+				partition.close();
+			} catch (Throwable t) {
+				ExceptionUtils.rethrowIfFatalError(t);
+				LOG.error("Failed to release result partition for task {}.", taskNameWithSubtask, t);
+			}
+		}
+
+		for (InputGate inputGate : inputGates) {
+			try {
+				inputGate.close();
+			} catch (Throwable t) {
+				ExceptionUtils.rethrowIfFatalError(t);
+				LOG.error("Failed to release input gate for task {}.", taskNameWithSubtask, t);
 			}
 		}
 	}
@@ -1044,13 +1081,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 						// case the canceling could not continue
 
 						// The canceller calls cancel and interrupts the executing thread once
-						Runnable canceler = new TaskCanceler(
-								LOG,
-								invokable,
-								executingThread,
-								taskNameWithSubtask,
-								producedPartitions,
-								inputGates);
+						Runnable canceler = new TaskCanceler(LOG, this :: closeNetworkResources, invokable, executingThread, taskNameWithSubtask);
 
 						Thread cancelThread = new Thread(
 								executingThread.getThreadGroup(),
@@ -1458,26 +1489,17 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 	private static class TaskCanceler implements Runnable {
 
 		private final Logger logger;
+		private final Runnable networkResourcesCloser;
 		private final AbstractInvokable invokable;
 		private final Thread executer;
 		private final String taskName;
-		private final ResultPartition[] producedPartitions;
-		private final InputGate[] inputGates;
 
-		public TaskCanceler(
-				Logger logger,
-				AbstractInvokable invokable,
-				Thread executer,
-				String taskName,
-				ResultPartition[] producedPartitions,
-				InputGate[] inputGates) {
-
+		TaskCanceler(Logger logger, Runnable networkResourcesCloser, AbstractInvokable invokable, Thread executer, String taskName) {
 			this.logger = logger;
+			this.networkResourcesCloser = networkResourcesCloser;
 			this.invokable = invokable;
 			this.executer = executer;
 			this.taskName = taskName;
-			this.producedPartitions = producedPartitions;
-			this.inputGates = inputGates;
 		}
 
 		@Override
@@ -1499,23 +1521,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 				//
 				// Don't do this before cancelling the invokable. Otherwise we
 				// will get misleading errors in the logs.
-				for (ResultPartition partition : producedPartitions) {
-					try {
-						partition.close();
-					} catch (Throwable t) {
-						ExceptionUtils.rethrowIfFatalError(t);
-						LOG.error("Failed to release result partition buffer pool for task {}.", taskName, t);
-					}
-				}
-
-				for (InputGate inputGate : inputGates) {
-					try {
-						inputGate.close();
-					} catch (Throwable t) {
-						ExceptionUtils.rethrowIfFatalError(t);
-						LOG.error("Failed to release input gate for task {}.", taskName, t);
-					}
-				}
+				networkResourcesCloser.run();
 
 				// send the initial interruption signal, if requested
 				if (invokable.shouldInterruptOnCancel()) {


### PR DESCRIPTION
## What is the purpose of the change

*`NetworkEnvironment#unregisterTask` is used for closing partition/gate and releasing partition from `ResultPartitionManager`. partition/gate close could be done in task which already maintains the arrays of them. Further we could release partition from `ResultPartitionManager` inside `ResultPartition` via introducing `ResultPartition#fail(Throwable)`. To do so, the `NetworkEnvironment#unregisterTask` could be totally replaced to remove. The benefit is simplifying the method of `NetworkEnvironment` which would be regarded as default `ShuffleService` implementation.*

## Brief change log

  - *Remove `unregisterTask` from `NetworkEnvironment`*
  - *Introduce `close(Throwable)` in `ResultPartition` for releasing*
  - *Fix the related logic in task class*

## Verifying this change

*This change is already covered by existing tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)