### PR TITLE
[FLINK-12117][cassandra] Disable tests on Java 9

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -41,6 +41,27 @@ under the License.
 		<driver.version>3.0.0</driver.version>
 	</properties>
 
+	<profiles>
+		<profile>
+			<id>java9</id>
+			<activation>
+				<jdk>9</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<!-- cassandra does not support Java 9 -->
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -99,7 +99,6 @@ MODULES_CONNECTORS_JDK9_EXCLUSIONS="\
 !flink-filesystems/flink-s3-fs-presto,\
 !flink-formats/flink-avro,\
 !flink-connectors/flink-hbase,\
-!flink-connectors/flink-connector-cassandra,\
 !flink-connectors/flink-connector-kafka-0.9,\
 !flink-connectors/flink-connector-kafka-0.10,\
 !flink-connectors/flink-connector-kafka-0.11"


### PR DESCRIPTION
## What is the purpose of the change

Disables cassandra tests when run on Java 9 since cassandra just doesn't support it.