### PR TITLE
[FLINK-11757] Add the version number of Flink 1.8 to MigrationVersion

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/migration/MigrationVersion.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/migration/MigrationVersion.java
@@ -31,7 +31,8 @@ public enum MigrationVersion {
 	v1_4("1.4"),
 	v1_5("1.5"),
 	v1_6("1.6"),
-	v1_7("1.7");
+	v1_7("1.7"),
+	v1_8("1.8");
 
 	private String versionStr;
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds the version number of Flink 1.8 to MigrationVersion*


## Brief change log

  - *Add the version number of Flink 1.8 to MigrationVersion*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
