### PR TITLE
[FLINK-12165][table-planner] Added resolution rule that checks all unresolved expressions are resolved

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/ExpressionResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/ExpressionResolver.java
@@ -82,7 +82,8 @@ public class ExpressionResolver {
 			ResolverRules.OVER_WINDOWS,
 			ResolverRules.FIELD_RESOLVE,
 			ResolverRules.FLATTEN_CALL,
-			ResolverRules.RESOLVE_CALL_BY_ARGUMENTS);
+			ResolverRules.RESOLVE_CALL_BY_ARGUMENTS,
+			ResolverRules.VERIFY_NO_MORE_UNRESOLVED_EXPRESSIONS);
 	}
 
 	private final PlannerExpressionConverter bridgeConverter = PlannerExpressionConverter.INSTANCE();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ResolverRules.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ResolverRules.java
@@ -57,6 +57,12 @@ public final class ResolverRules {
 	 */
 	public static final ResolverRule FLATTEN_STAR_REFERENCE = new StarReferenceFlatteningRule();
 
+	/**
+	 * Checks that the output of {@link org.apache.flink.table.expressions.ExpressionResolver} has no more unresolved
+	 * expressions. See {@link VerifyNoUnresolvedExpressionsRule} for details.
+	 */
+	public static final ResolverRule VERIFY_NO_MORE_UNRESOLVED_EXPRESSIONS = new VerifyNoUnresolvedExpressionsRule();
+
 	private ResolverRules() {
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRule.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions.rules;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.ApiExpressionDefaultVisitor;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.LookupCallExpression;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
+
+import java.util.List;
+
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.FLATTEN;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.OVER;
+
+/**
+ * Verifies that there is no more unresolved expressions. Checks for expression like:
+ * <ul>
+ *     <li>{@link UnresolvedReferenceExpression}</li>
+ *     <li>{@link LookupCallExpression}</li>
+ *     <li>{@link org.apache.flink.table.expressions.BuiltInFunctionDefinitions#OVER} that still contains
+ *     just alias to corresponding window</li>
+ *     <li>{@link org.apache.flink.table.expressions.BuiltInFunctionDefinitions#FLATTEN}</li>
+ * </ul>
+ */
+@Internal
+final class VerifyNoUnresolvedExpressionsRule implements ResolverRule {
+
+	private static final NoUnresolvedCallsChecker checker = new NoUnresolvedCallsChecker();
+
+	@Override
+	public List<Expression> apply(List<Expression> expression, ResolutionContext context) {
+		expression.forEach(expr -> expr.accept(checker));
+		return expression;
+	}
+
+	private static class NoUnresolvedCallsChecker extends ApiExpressionDefaultVisitor<Void> {
+
+		@Override
+		public Void visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference) {
+			throw getException("reference", unresolvedReference);
+		}
+
+		@Override
+		public Void visitLookupCall(LookupCallExpression lookupCall) {
+			throw getException("lookup call", lookupCall);
+		}
+
+		@Override
+		public Void visitCall(CallExpression call) {
+			if (call.getFunctionDefinition() == OVER && call.getChildren().size() <= 2) {
+				throw getException("OVER call", call);
+			} else if (call.getFunctionDefinition() == FLATTEN) {
+				throw getException("FLATTEN call", call);
+			}
+			call.getChildren().forEach(expr -> expr.accept(this));
+
+			return null;
+		}
+
+		private TableException getException(String expressionType, Expression call) {
+			return new TableException(String.format(
+				"Unexpected unresolved %s: %s. All expressions should be resolved by now",
+				expressionType, call));
+		}
+
+		@Override
+		protected Void defaultMethod(Expression expression) {
+			return null;
+		}
+	}
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRuleTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions.rules;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
+import org.apache.flink.table.expressions.rules.ResolverRule.ResolutionContext;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.lookupCall;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.AS;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.COUNT;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.FLATTEN;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.OVER;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link VerifyNoUnresolvedExpressionsRule}.
+ */
+public class VerifyNoUnresolvedExpressionsRuleTest {
+
+	private static final ResolverRule resolverRule = ResolverRules.VERIFY_NO_MORE_UNRESOLVED_EXPRESSIONS;
+
+	private static final ResolutionContext resolutionContext = mock(ResolutionContext.class);
+
+	@Test(expected = TableException.class)
+	public void testUnresolvedReferenceIsCatched() {
+		List<Expression> expressions = asList(
+			unresolvedRef("field"),
+			new FieldReferenceExpression("resolvedField", Types.INT, 0, 0));
+		resolverRule.apply(expressions, resolutionContext);
+	}
+
+	@Test(expected = TableException.class)
+	public void testNestedUnresolvedReferenceIsCatched() {
+		List<Expression> expressions = asList(
+			call(AS, unresolvedRef("field"), valueLiteral("fieldAlias")),
+			new FieldReferenceExpression("resolvedField", Types.INT, 0, 0));
+		resolverRule.apply(expressions, resolutionContext);
+	}
+
+	@Test(expected = TableException.class)
+	public void testFlattenCallIsCatched() {
+		List<Expression> expressions = singletonList(
+			call(FLATTEN, new FieldReferenceExpression("resolvedField", Types.INT, 0, 0))
+		);
+		resolverRule.apply(expressions, resolutionContext);
+	}
+
+	@Test(expected = TableException.class)
+	public void testUnresolvedOverWindowIsCatched() {
+		List<Expression> expressions = singletonList(
+			call(OVER,
+				call(COUNT, new FieldReferenceExpression("resolvedField", Types.INT, 0, 0)),
+				new UnresolvedReferenceExpression("w")
+			)
+		);
+		resolverRule.apply(expressions, resolutionContext);
+	}
+
+	@Test(expected = TableException.class)
+	public void testLookupCallIsCatched() {
+		List<Expression> expressions = singletonList(
+			lookupCall("unresolvedCall", new FieldReferenceExpression("resolvedField", Types.INT, 0, 0))
+		);
+		resolverRule.apply(expressions, resolutionContext);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Adds a rule to `ExpressionResolver` that makes sure all expressions coming out of it are resolved.

## Brief change log

- Added `VerifyNoUnresolvedExpressionsRule`
- Enabled this rule in `ExpressionResolver`


## Verifying this change

- Added tests in `VerifyNoUnresolvedExpressionsRuleTest` for negative cases
- For positive cases (when all expressions are resolved) all current tests should pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
