### PR TITLE
[FLINK-12102][tests] Fix FlinkILoopTest on Java 9

### DIFF
--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -35,6 +35,7 @@ import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -52,6 +53,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(PlanExecutor.class)
+@PowerMockIgnore("javax.tools.*")
 public class FlinkILoopTest extends TestLogger {
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes an issue in the FlinkILoopTest where the test failed on Java 9.

From my understanding, powermock loads classes in a separate classloader during mocking. However powermock does not account for Java 9 modules (see https://github.com/powermock/powermock/issues/864), due to which the loading will fail if the class is not available by default on java 9, as is the case for `javax` classes.

Apparently the `PowerMockIgnore` annotation stops powermock from separately loading the class, and thus the test can pass.


## Verifying this change

I ran the test successfully on java 9 on a dev branch: https://travis-ci.org/zentol/flink/jobs/518712231
