### PR TITLE
[hotfix] Fix typo in YarnConfigurationITCase

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -181,7 +181,7 @@ public class YarnConfigurationITCase extends YarnTestBase {
 				final long expectedHeadSize = containeredTaskManagerParameters.taskManagerHeapSizeMB() << 20L;
 
 				// We compare here physical memory assigned to a container with the heap memory that we should pass to
-				// jvm as Xmx parameter. Those value might differ significantly due to sytem page size or jvm
+				// jvm as Xmx parameter. Those value might differ significantly due to system page size or jvm
 				// implementation therefore we use 15% threshold here.
 				assertThat(
 					(double) taskManagerInfo.getHardwareDescription().getSizeOfJvmHeap() / (double) expectedHeadSize,


### PR DESCRIPTION
Fix a typo in YarnConfigurationITCase.