### PR TITLE
[FLINK-12183 ] Get a valid start index when archive execution graph 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
@@ -82,4 +82,11 @@ public interface AccessExecutionVertex {
 	 * @return execution for the given attempt number
 	 */
 	AccessExecution getPriorExecutionAttempt(int attemptNumber);
+
+	/**
+	 * Returns the valid attempt start index for the given execution.
+	 *
+	 * @return valid attempt start index for the given execution.
+	 */
+	int getValidAttemptStartIndex();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
@@ -101,4 +101,13 @@ public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializa
 			throw new IllegalArgumentException("attempt does not exist");
 		}
 	}
+
+	@Override
+	public int getValidAttemptStartIndex() {
+		if (priorExecutions.size() <= priorExecutions.getSizeLimit()) {
+			return 0;
+		} else {
+			return priorExecutions.size() - priorExecutions.getSizeLimit();
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -316,6 +316,11 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		}
 	}
 
+	@Override
+	public int getValidAttemptStartIndex() {
+		throw new UnsupportedOperationException("ExecutionVertex doesn't need to implement this method.");
+	}
+
 	public ArchivedExecution getLatestPriorExecution() {
 		synchronized (priorExecutions) {
 			final int size = priorExecutions.size();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandler.java
@@ -98,7 +98,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandler
 
 				archive.add(new ArchivedJson(curAttemptPath, curAttemptJson));
 
-				for (int x = 0; x < subtask.getCurrentExecutionAttempt().getAttemptNumber(); x++) {
+				for (int x = subtask.getValidAttemptStartIndex(); x < subtask.getCurrentExecutionAttempt().getAttemptNumber(); x++) {
 					AccessExecution attempt = subtask.getPriorExecutionAttempt(x);
 					ResponseBody json = createAccumulatorInfo(attempt);
 					String path = getMessageHeaders().getTargetRestEndpointURL()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandler.java
@@ -112,7 +112,7 @@ public class SubtaskExecutionAttemptDetailsHandler
 
 				archive.add(new ArchivedJson(curAttemptPath, curAttemptJson));
 
-				for (int x = 0; x < subtask.getCurrentExecutionAttempt().getAttemptNumber(); x++) {
+				for (int x = subtask.getValidAttemptStartIndex(); x < subtask.getCurrentExecutionAttempt().getAttemptNumber(); x++) {
 					AccessExecution attempt = subtask.getPriorExecutionAttempt(x);
 					ResponseBody json = createDetailsInfo(attempt, graph.getJobID(), task.getJobVertexId(), null);
 					String path = getMessageHeaders().getTargetRestEndpointURL()


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR fixes FLINK-12183. The problem was that the per-job Yarn cluster doesn't stop after cancel a running job if the job restarted many times, like 1000 times, in a short time.

The bug is in archiveExecutionGraph() phase before executing removeJobAndRegisterTerminationFuture(). The CompletableFuture thread will exit unexpectedly with NullPointerException in archiveExecutionGraph() phase. It's hard to find that because here it only catches IOException. In SubtaskExecutionAttemptDetailsHandler and  SubtaskExecutionAttemptAccumulatorsHandler, when calling archiveJsonWithPath() method, it will construct some json information about prior execution attempts but the index is from 0 which might be dropped index for the for loop.  In default, it will return null when trying to get the prior execution attempt (AccessExecution attempt = subtask.getPriorExecutionAttempt(x)).

## Brief change log

  - *Get a valid start Index when getting the prior execution attempt*
 
## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
