### PR TITLE
[FLINK-12130][clients] Apply command line options to configuration before installing security modules

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -69,13 +69,8 @@ public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<
 		baseOptions.addOption(zookeeperNamespaceOption);
 	}
 
-	/**
-	 * Override configuration settings by specified command line options.
-	 *
-	 * @param commandLine containing the overriding values
-	 * @return Effective configuration with the overridden configuration settings
-	 */
-	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
+	@Override
+	public Configuration applyCommandLineOptionsToConfiguration(Configuration configuration, CommandLine commandLine) throws FlinkException {
 		final Configuration resultingConfiguration = new Configuration(configuration);
 
 		if (commandLine.hasOption(addressOption.getOpt())) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -75,7 +75,7 @@ public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<
 	 * @param commandLine containing the overriding values
 	 * @return Effective configuration with the overridden configuration settings
 	 */
-	protected Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
+	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		final Configuration resultingConfiguration = new Configuration(configuration);
 
 		if (commandLine.hasOption(addressOption.getOpt())) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -1113,8 +1113,15 @@ public class CliFrontend {
 			final CliFrontend cli = new CliFrontend(
 				configuration,
 				customCommandLines);
+			// apply command options to configuration.
+			Configuration effectiveConfiguration = cli.configuration;
+			final CommandLine commandLine = CliFrontendParser.parse(cli.customCommandLineOptions, args, false);
+			final CustomCommandLine<?> customCommandLine = cli.getActiveCustomCommandLine(commandLine);
+			if (customCommandLine instanceof AbstractCustomCommandLine) {
+				effectiveConfiguration = ((AbstractCustomCommandLine) customCommandLine).applyCommandLineOptionsToConfiguration(commandLine);
+			}
 
-			SecurityUtils.install(new SecurityConfiguration(cli.configuration));
+			SecurityUtils.install(new SecurityConfiguration(effectiveConfiguration));
 			int retCode = SecurityUtils.getInstalledContext()
 					.runSecured(() -> cli.parseParameters(args));
 			System.exit(retCode);

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -1114,12 +1114,9 @@ public class CliFrontend {
 				configuration,
 				customCommandLines);
 			// apply command options to configuration.
-			Configuration effectiveConfiguration = cli.configuration;
 			final CommandLine commandLine = CliFrontendParser.parse(cli.customCommandLineOptions, args, false);
 			final CustomCommandLine<?> customCommandLine = cli.getActiveCustomCommandLine(commandLine);
-			if (customCommandLine instanceof AbstractCustomCommandLine) {
-				effectiveConfiguration = ((AbstractCustomCommandLine) customCommandLine).applyCommandLineOptionsToConfiguration(commandLine);
-			}
+			final Configuration effectiveConfiguration = customCommandLine.applyCommandLineOptionsToConfiguration(cli.configuration, commandLine);
 
 			SecurityUtils.install(new SecurityConfiguration(effectiveConfiguration));
 			int retCode = SecurityUtils.getInstalledContext()

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -1115,12 +1115,14 @@ public class CliFrontend {
 				configuration,
 				customCommandLines);
 
-			Tuple2<CommandLine, FunctionWithException<CommandLine, Integer, Exception>> commandLineAction = cli.parseParameters(args);
+			final Tuple2<CommandLine, FunctionWithException<CommandLine, Integer, Exception>> commandLineAction = cli.parseParameters(args);
 
 			// apply command options to configuration.
-			final CustomCommandLine<?> customCommandLine = cli.getActiveCustomCommandLine(commandLineAction.f0);
-			final Configuration effectiveConfiguration =
-				commandLineAction.f0 == null ? cli.configuration : customCommandLine.applyCommandLineOptionsToConfiguration(cli.configuration, commandLineAction.f0);
+			Configuration effectiveConfiguration = cli.configuration;
+			if (commandLineAction.f0 != null) {
+				final CustomCommandLine<?> customCommandLine = cli.getActiveCustomCommandLine(commandLineAction.f0);
+				effectiveConfiguration = customCommandLine.applyCommandLineOptionsToConfiguration(cli.configuration, commandLineAction.f0);
+			}
 
 			SecurityUtils.install(new SecurityConfiguration(effectiveConfiguration));
 			int retCode = SecurityUtils.getInstalledContext().runSecured(() -> {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.cli;
 
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
@@ -90,6 +91,15 @@ public interface CustomCommandLine<T> {
 	 * @throws FlinkException if the ClusterSpecification could not be created
 	 */
 	ClusterSpecification getClusterSpecification(CommandLine commandLine) throws FlinkException;
+
+	/**
+	 * Override configuration settings by specified command line options.
+	 *
+	 * @param configuration containing the current values
+	 * @param commandLine containing the overriding values
+	 * @return Effective configuration with the overridden configuration settings
+	 */
+	Configuration applyCommandLineOptionsToConfiguration(Configuration configuration, CommandLine commandLine) throws FlinkException;
 
 	default CommandLine parseCommandLineOptions(String[] args, boolean stopAtNonOptions) throws CliArgsException {
 		final Options options = new Options();

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -57,7 +57,7 @@ public class DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterId> {
 	@Override
 	public StandaloneClusterDescriptor createClusterDescriptor(
 			CommandLine commandLine) throws FlinkException {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(configuration, commandLine);
 
 		return new StandaloneClusterDescriptor(effectiveConfiguration);
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -56,33 +56,33 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		// test cancel properly
 		JobID jid = new JobID();
 
-		String[] parameters = { jid.toString() };
+		String[] parameters = {"cancel", jid.toString() };
 		final ClusterClient<String> clusterClient = createClusterClient();
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 
-		testFrontend.cancel(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 
 		Mockito.verify(clusterClient, times(1)).cancel(any(JobID.class));
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testMissingJobId() throws Exception {
-		String[] parameters = {};
+		String[] parameters = {"cancel"};
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.cancel(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
-		String[] parameters = {"-v", "-l"};
+		String[] parameters = {"cancel", "-v", "-l"};
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.cancel(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	/**
@@ -94,10 +94,10 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 			// Cancel with savepoint (no target directory)
 			JobID jid = new JobID();
 
-			String[] parameters = { "-s", jid.toString() };
+			String[] parameters = {"cancel", "-s", jid.toString() };
 			final ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-			testFrontend.cancel(parameters);
+			parseParametersAndRun(testFrontend, parameters);
 
 			Mockito.verify(clusterClient, times(1))
 				.cancelWithSavepoint(any(JobID.class), isNull(String.class));
@@ -107,10 +107,10 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 			// Cancel with savepoint (with target directory)
 			JobID jid = new JobID();
 
-			String[] parameters = { "-s", "targetDirectory", jid.toString() };
+			String[] parameters = {"cancel", "-s", "targetDirectory", jid.toString() };
 			final ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-			testFrontend.cancel(parameters);
+			parseParametersAndRun(testFrontend, parameters);
 
 			Mockito.verify(clusterClient, times(1))
 				.cancelWithSavepoint(any(JobID.class), notNull(String.class));
@@ -120,23 +120,23 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 	@Test(expected = CliArgsException.class)
 	public void testCancelWithSavepointWithoutJobId() throws Exception {
 		// Cancel with savepoint (with target directory), but no job ID
-		String[] parameters = { "-s", "targetDirectory" };
+		String[] parameters = {"cancel", "-s", "targetDirectory" };
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.cancel(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testCancelWithSavepointWithoutParameters() throws Exception {
 		// Cancel with savepoint (no target directory) and no job ID
-		String[] parameters = { "-s" };
+		String[] parameters = {"cancel", "-s" };
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.cancel(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	private static ClusterClient<String> createClusterClient() throws Exception {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
@@ -40,22 +40,22 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 
 	@Test(expected = CliArgsException.class)
 	public void testMissingOption() throws Exception {
-		String[] parameters = {};
+		String[] parameters = {"cancel"};
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.cancel(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
-		String[] parameters = {"-v", "-l"};
+		String[] parameters = {"cancel", "-v", "-l"};
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.cancel(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test
@@ -63,12 +63,12 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 		replaceStdOut();
 		try {
 
-			String[] parameters = new String[]{CliFrontendTestUtils.getTestJarPath(), "-f", "true"};
+			String[] parameters = new String[]{"info", CliFrontendTestUtils.getTestJarPath(), "-f", "true"};
 			Configuration configuration = getConfiguration();
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
 				Collections.singletonList(getCli(configuration)));
-			testFrontend.info(parameters);
+			parseParametersAndRun(testFrontend, parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\": \"1\""));
 		}
 		finally {
@@ -80,12 +80,12 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 	public void testShowExecutionPlanWithParallelism() {
 		replaceStdOut();
 		try {
-			String[] parameters = {"-p", "17", CliFrontendTestUtils.getTestJarPath()};
+			String[] parameters = {"info", "-p", "17", CliFrontendTestUtils.getTestJarPath()};
 			Configuration configuration = getConfiguration();
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
 				Collections.singletonList(getCli(configuration)));
-			testFrontend.info(parameters);
+			parseParametersAndRun(testFrontend, parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\": \"17\""));
 		}
 		catch (Exception e) {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -90,22 +90,22 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
-		String[] parameters = {"-v", "-k"};
+		String[] parameters = {"list", "-v", "-k"};
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.list(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test
 	public void testList() throws Exception {
 		// test list properly
 		{
-			String[] parameters = {"-r", "-s", "-a"};
+			String[] parameters = {"list", "-r", "-s", "-a"};
 			ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-			testFrontend.list(parameters);
+			parseParametersAndRun(testFrontend, parameters);
 			Mockito.verify(clusterClient, times(1))
 				.listJobs();
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendModifyTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendModifyTest.java
@@ -108,7 +108,11 @@ public class CliFrontendModifyTest extends CliFrontendTestBase {
 		final TestingClusterClient clusterClient = new TestingClusterClient(rescaleJobFuture, getConfiguration());
 		final MockedCliFrontend cliFrontend = new MockedCliFrontend(clusterClient);
 
-		cliFrontend.modify(args);
+		String[] parameters = new String[args.length + 1];
+		parameters[0] = "modify";
+		System.arraycopy(args, 0, parameters, 1, args.length);
+
+		parseParametersAndRun(cliFrontend, parameters);
 
 		assertThat(rescaleJobFuture.isDone(), Matchers.is(true));
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
-import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -52,7 +51,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the RUN command with {@link PackagedProgram PackagedPrograms}.
  */
-public class CliFrontendPackageProgramTest extends TestLogger {
+public class CliFrontendPackageProgramTest extends CliFrontendTestBase {
 
 	private CliFrontend frontend;
 
@@ -167,7 +166,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 	@Test(expected = CliArgsException.class)
 	public void testNoJarNoArgumentsAtAll() throws Exception {
-		frontend.run(new String[0]);
+		parseParametersAndRun(frontend, new String[]{"run"});
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -112,34 +112,34 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		// test unrecognized option
-		String[] parameters = {"-v", "-l", "-a", "some", "program", "arguments"};
+		String[] parameters = {"run", "-v", "-l", "-a", "some", "program", "arguments"};
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.run(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testInvalidParallelismOption() throws Exception {
 		// test configure parallelism with non integer value
-		String[] parameters = {"-v", "-p", "text",  getTestJarPath()};
+		String[] parameters = {"run", "-v", "-p", "text",  getTestJarPath()};
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.run(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testParallelismWithOverflow() throws Exception {
 		// test configure parallelism with overflow integer value
-		String[] parameters = {"-v", "-p", "475871387138",  getTestJarPath()};
+		String[] parameters = {"run", "-v", "-p", "475871387138",  getTestJarPath()};
 		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.run(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -153,7 +153,11 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		RunTestingCliFrontend testFrontend =
 			new RunTestingCliFrontend(cli, expectedParallelism, logging,
 				isDetached);
-		testFrontend.run(parameters); // verifies the expected values (see below)
+
+		String[] args = new String[parameters.length + 1];
+		args[0] = "run";
+		System.arraycopy(parameters, 0, args, 1, parameters.length);
+		parseParametersAndRun(testFrontend, args); // verifies the expected values (see below)
 	}
 
 	private static final class RunTestingCliFrontend extends CliFrontend {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -85,8 +85,8 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 		try {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
-			String[] parameters = { jobId.toString() };
-			frontend.savepoint(parameters);
+			String[] parameters = {"savepoint", jobId.toString() };
+			parseParametersAndRun(frontend, parameters);
 
 			verify(clusterClient, times(1))
 				.triggerSavepoint(eq(jobId), isNull(String.class));
@@ -113,10 +113,10 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 		try {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
-			String[] parameters = { jobId.toString() };
+			String[] parameters = {"savepoint", jobId.toString() };
 
 			try {
-				frontend.savepoint(parameters);
+				parseParametersAndRun(frontend, parameters);
 
 				fail("Savepoint should have failed.");
 			} catch (FlinkException e) {
@@ -136,9 +136,9 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 		try {
 			CliFrontend frontend = new MockedCliFrontend(new RestClusterClient<>(getConfiguration(), StandaloneClusterId.getInstance()));
 
-			String[] parameters = { "invalid job id" };
+			String[] parameters = {"savepoint", "invalid job id" };
 			try {
-				frontend.savepoint(parameters);
+				parseParametersAndRun(frontend, parameters);
 				fail("Should have failed.");
 			} catch (CliArgsException e) {
 				assertThat(e.getMessage(), Matchers.containsString("Cannot parse JobID"));
@@ -166,8 +166,8 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 		try {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
-			String[] parameters = { jobId.toString(), savepointDirectory };
-			frontend.savepoint(parameters);
+			String[] parameters = {"savepoint", jobId.toString(), savepointDirectory };
+			parseParametersAndRun(frontend, parameters);
 
 			verify(clusterClient, times(1))
 				.triggerSavepoint(eq(jobId), eq(savepointDirectory));
@@ -198,8 +198,8 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 
 			CliFrontend frontend = new MockedCliFrontend(clusterClient);
 
-			String[] parameters = { "-d", savepointPath };
-			frontend.savepoint(parameters);
+			String[] parameters = {"savepoint", "-d", savepointPath };
+			parseParametersAndRun(frontend, parameters);
 
 			String outMsg = buffer.toString();
 			assertTrue(outMsg.contains(savepointPath));
@@ -235,9 +235,9 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			out.close();
 
 			final String disposePath = "any-path";
-			String[] parameters = { "-d", disposePath, "-j", f.getAbsolutePath() };
+			String[] parameters = {"savepoint", "-d", disposePath, "-j", f.getAbsolutePath() };
 
-			frontend.savepoint(parameters);
+			parseParametersAndRun(frontend, parameters);
 
 			final String actualSavepointPath = disposeSavepointFuture.get();
 
@@ -261,10 +261,10 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 		try {
 			CliFrontend frontend = new MockedCliFrontend(clusterClient);
 
-			String[] parameters = { "-d", savepointPath };
+			String[] parameters = {"savepoint", "-d", savepointPath };
 
 			try {
-				frontend.savepoint(parameters);
+				parseParametersAndRun(frontend, parameters);
 
 				fail("Savepoint should have failed.");
 			} catch (Exception e) {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
@@ -62,11 +62,11 @@ public class CliFrontendStopTest extends CliFrontendTestBase {
 		JobID jid = new JobID();
 		String jidString = jid.toString();
 
-		String[] parameters = { jidString };
+		String[] parameters = {"stop", jidString };
 		final ClusterClient<String> clusterClient = createClusterClient(null);
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 
-		testFrontend.stop(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 
 		Mockito.verify(clusterClient, times(1)).stop(any(JobID.class));
 	}
@@ -74,23 +74,23 @@ public class CliFrontendStopTest extends CliFrontendTestBase {
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		// test unrecognized option
-		String[] parameters = { "-v", "-l" };
+		String[] parameters = {"stop", "-v", "-l" };
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.stop(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testMissingJobId() throws Exception {
 		// test missing job id
-		String[] parameters = {};
+		String[] parameters = {"stop"};
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
-		testFrontend.stop(parameters);
+		parseParametersAndRun(testFrontend, parameters);
 	}
 
 	@Test
@@ -98,14 +98,14 @@ public class CliFrontendStopTest extends CliFrontendTestBase {
 		// test unknown job Id
 		JobID jid = new JobID();
 
-		String[] parameters = { jid.toString() };
+		String[] parameters = {"stop", jid.toString() };
 		String expectedMessage = "Test exception";
 		FlinkException testException = new FlinkException(expectedMessage);
 		final ClusterClient<String> clusterClient = createClusterClient(testException);
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 
 		try {
-			testFrontend.stop(parameters);
+			parseParametersAndRun(testFrontend, parameters);
 			fail("Should have failed.");
 		} catch (FlinkException e) {
 			assertTrue(ExceptionUtils.findThrowableWithMessage(e, expectedMessage).isPresent());

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.client.cli;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.apache.commons.cli.CommandLine;
 
 /**
  * Base test class for {@link CliFrontend} tests.
@@ -35,5 +39,10 @@ public abstract class CliFrontendTestBase extends TestLogger {
 
 	static AbstractCustomCommandLine<?> getCli(Configuration configuration) {
 		return new DefaultCLI(configuration);
+	}
+
+	static int parseParametersAndRun(CliFrontend cliFrontend, String[] args) throws Exception {
+		Tuple2<CommandLine, FunctionWithException<CommandLine, Integer, Exception>> commandLineAction = cliFrontend.parseParameters(args);
+		return commandLineAction.f1.apply(commandLineAction.f0);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
@@ -22,6 +22,8 @@ import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
@@ -73,5 +75,10 @@ public class DummyCustomCommandLine<T> implements CustomCommandLine {
 	@Override
 	public ClusterSpecification getClusterSpecification(CommandLine commandLine) {
 		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
+	}
+
+	@Override
+	public Configuration applyCommandLineOptionsToConfiguration(Configuration configuration, CommandLine commandLine) throws FlinkException {
+		return configuration;
 	}
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -26,8 +27,10 @@ import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 
+import org.apache.commons.cli.CommandLine;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -833,14 +836,16 @@ public abstract class YarnTestBase extends TestLogger {
 							"",
 							"",
 							true);
-						returnValue = yCli.run(args);
+						final CommandLine commandLine = yCli.parseCommandLineOptions(args, true);
+						returnValue = yCli.run(commandLine);
 						break;
 					case CLI_FRONTEND:
 						try {
 							CliFrontend cli = new CliFrontend(
 								configuration,
 								CliFrontend.loadCustomCommandLines(configuration, configurationDirectory));
-							returnValue = cli.parseParameters(args);
+							Tuple2<CommandLine, FunctionWithException<CommandLine, Integer, Exception>> commandLineAction = cli.parseParameters(args);
+							returnValue = commandLineAction.f1.apply(commandLineAction.f0);
 						} catch (Exception e) {
 							throw new RuntimeException("Failed to execute the following args with CliFrontend: "
 								+ Arrays.toString(args), e);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -448,7 +448,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 	@Override
 	public AbstractYarnClusterDescriptor createClusterDescriptor(CommandLine commandLine) throws FlinkException {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(configuration, commandLine);
 
 		return createDescriptor(
 			effectiveConfiguration,
@@ -471,13 +471,13 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 	@Override
 	public ClusterSpecification getClusterSpecification(CommandLine commandLine) throws FlinkException {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(configuration, commandLine);
 
 		return createClusterSpecification(effectiveConfiguration, commandLine);
 	}
 
 	@Override
-	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
+	public Configuration applyCommandLineOptionsToConfiguration(Configuration configuration, CommandLine commandLine) throws FlinkException {
 		// we ignore the addressOption because it can only contain "yarn-cluster"
 		final Configuration effectiveConfiguration = new Configuration(configuration);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -477,7 +477,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	}
 
 	@Override
-	protected Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
+	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		// we ignore the addressOption because it can only contain "yarn-cluster"
 		final Configuration effectiveConfiguration = new Configuration(configuration);
 
@@ -517,6 +517,16 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 		if (commandLine.hasOption(slots.getOpt())) {
 			effectiveConfiguration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, Integer.parseInt(commandLine.getOptionValue(slots.getOpt())));
+		}
+
+		if (commandLine.hasOption(dynamicproperties.getOpt())) {
+			final Properties properties = commandLine.getOptionProperties(dynamicproperties.getOpt());
+			properties.stringPropertyNames().forEach((String key) -> {
+				String value = properties.getProperty(key);
+				if (value != null) {
+					effectiveConfiguration.setString(key, value);
+				}
+			});
 		}
 
 		if (isYarnPropertiesFileMode(commandLine)) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -586,12 +586,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		return effectiveConfiguration;
 	}
 
-	public int run(String[] args) throws CliArgsException, FlinkException {
-		//
-		//	Command Line Options
-		//
-		final CommandLine cmd = parseCommandLineOptions(args, true);
-
+	public int run(CommandLine cmd) throws FlinkException {
 		if (cmd.hasOption(help.getOpt())) {
 			printUsage();
 			return 0;
@@ -842,9 +837,15 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 				"",
 				""); // no prefix for the YARN session
 
-			SecurityUtils.install(new SecurityConfiguration(flinkConfiguration));
+			//
+			//	Command Line Options
+			//
+			final CommandLine commandLine = cli.parseCommandLineOptions(args, true);
+			Configuration effectiveConfiguraion = cli.applyCommandLineOptionsToConfiguration(flinkConfiguration, commandLine);
 
-			retCode = SecurityUtils.getInstalledContext().runSecured(() -> cli.run(args));
+			SecurityUtils.install(new SecurityConfiguration(effectiveConfiguraion));
+
+			retCode = SecurityUtils.getInstalledContext().runSecured(() -> cli.run(commandLine));
 		} catch (CliArgsException e) {
 			retCode = handleCliArgsException(e);
 		} catch (Throwable t) {


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes dynamic properties in command line taking effect before installing security modules, so the users can configure Kerberos credentials through command line, like this:

`flink run -m yarn-cluster -yD security.kerberos.login.keytab=/path/to/keytab -yD security.kerberos.login.principal=xxx /path/to/my.jar`

## Brief change log

  - *Make applyCommandLineOptionsToConfiguration(CommandLine commandLine) a method of interface CustomCommandLine and change it to applyCommandLineOptionsToConfiguration(Configuration configuration, CommandLine commandLine), as suggested by* @aljoscha 
  - *Make org.apache.flink.client.cli.CliFrontend#parseParameters return parsed CommandLine*
  - *Apply command line options to configuration before installing security modules*


## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.client.cli.CliFrontendRunTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes, it affects deployment**)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
