### PR TITLE
[hotfix][utils] Remove overwork LeaderRetrievalUtils.getRecoverMode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
-import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
@@ -52,7 +51,7 @@ public class HighAvailabilityServicesUtils {
 	public static HighAvailabilityServices createAvailableOrEmbeddedServices(
 		Configuration config,
 		Executor executor) throws Exception {
-		HighAvailabilityMode highAvailabilityMode = LeaderRetrievalUtils.getRecoveryMode(config);
+		HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(config);
 
 		switch (highAvailabilityMode) {
 			case NONE:
@@ -80,7 +79,7 @@ public class HighAvailabilityServicesUtils {
 		Executor executor,
 		AddressResolution addressResolution) throws Exception {
 
-		HighAvailabilityMode highAvailabilityMode = LeaderRetrievalUtils.getRecoveryMode(configuration);
+		HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(configuration);
 
 		switch (highAvailabilityMode) {
 			case NONE:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -19,11 +19,7 @@
 package org.apache.flink.runtime.util;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -163,19 +159,6 @@ public class LeaderRetrievalUtils {
 				connectionInfo.failure(exception);
 			}
 		}
-	}
-
-	/**
-	 * Gets the recovery mode as configured, based on {@link HighAvailabilityOptions#HA_MODE}.
-	 * 
-	 * @param config The configuration to read the recovery mode from.
-	 * @return The recovery mode.
-	 * 
-	 * @throws IllegalConfigurationException Thrown, if the recovery mode does not correspond
-	 *                                       to a known value.
-	 */
-	public static HighAvailabilityMode getRecoveryMode(Configuration config) {
-		return HighAvailabilityMode.fromConfig(config);
 	}
 	
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

`LeaderRetrievalUtils.getRecoverMode` is an alias of `HighAvailabilityMode.fromConfig`. However, it provides no extra readability or functionality, but why it belongs to `LeaderRetrievalUtils` is unclear. I'd like to remove `LeaderRetrievalUtils.getRecoverMode` and simply replace with `HighAvailabilityMode.fromConfig`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol @pnowojski 