### PR TITLE
[FLINK-9542]ExEnv#registerCachedFile should accept Path

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -345,8 +345,8 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 			}
 
 			for (Map.Entry<String, DistributedCache.DistributedCacheEntry> artifacts : jobGraph.getUserArtifacts().entrySet()) {
-				artifactFileNames.add(new JobSubmitRequestBody.DistributedCacheFile(artifacts.getKey(), new Path(artifacts.getValue().filePath).getName()));
-				filesToUpload.add(new FileUpload(Paths.get(artifacts.getValue().filePath), RestConstants.CONTENT_TYPE_BINARY));
+				artifactFileNames.add(new JobSubmitRequestBody.DistributedCacheFile(artifacts.getKey(), new Path(artifacts.getValue().filePath.toString()).getName()));
+				filesToUpload.add(new FileUpload(Paths.get(artifacts.getValue().filePath.toString()), RestConstants.CONTENT_TYPE_BINARY));
 			}
 
 			final JobSubmitRequestBody requestBody = new JobSubmitRequestBody(

--- a/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
@@ -50,7 +50,7 @@ public class DistributedCache {
 	 */
 	public static class DistributedCacheEntry implements Serializable {
 
-		public String filePath;
+		public Path filePath;
 		public Boolean isExecutable;
 		public boolean isZipped;
 
@@ -68,7 +68,7 @@ public class DistributedCache {
 
 		/** Server-side constructor used during job-submission for zipped directories. */
 		public DistributedCacheEntry(String filePath, Boolean isExecutable, byte[] blobKey, boolean isZipped) {
-			this.filePath = filePath;
+			this.filePath = new Path(filePath);
 			this.isExecutable = isExecutable;
 			this.blobKey = blobKey;
 			this.isZipped = isZipped;
@@ -82,7 +82,7 @@ public class DistributedCache {
 		@Override
 		public String toString() {
 			return "DistributedCacheEntry{" +
-				"filePath='" + filePath + '\'' +
+				"filePath='" + filePath.toString() + '\'' +
 				", isExecutable=" + isExecutable +
 				", isZipped=" + isZipped +
 				", blobKey=" + Arrays.toString(blobKey) +
@@ -133,9 +133,9 @@ public class DistributedCache {
 		int num = conf.getInteger(CACHE_FILE_NUM, 0) + 1;
 		conf.setInteger(CACHE_FILE_NUM, num);
 		conf.setString(CACHE_FILE_NAME + num, name);
-		conf.setString(CACHE_FILE_PATH + num, e.filePath);
-		conf.setBoolean(CACHE_FILE_EXE + num, e.isExecutable || new File(e.filePath).canExecute());
-		conf.setBoolean(CACHE_FILE_DIR + num, e.isZipped || new File(e.filePath).isDirectory());
+		conf.setString(CACHE_FILE_PATH + num, e.filePath.toString());
+		conf.setBoolean(CACHE_FILE_EXE + num, e.isExecutable || new File(e.filePath.toString()).canExecute());
+		conf.setBoolean(CACHE_FILE_DIR + num, e.isZipped || new File(e.filePath.toString()).isDirectory());
 		if (e.blobKey != null) {
 			conf.setBytes(CACHE_FILE_BLOB_KEY + num, e.blobKey);
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/CollectionExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/CollectionExecutor.java
@@ -122,7 +122,7 @@ public class CollectionExecutor {
 
 	private void initCache(Set<Map.Entry<String, DistributedCache.DistributedCacheEntry>> files){
 		for(Map.Entry<String, DistributedCache.DistributedCacheEntry> file: files){
-			Future<Path> doNothing = new CompletedFuture(new Path(file.getValue().filePath));
+			Future<Path> doNothing = new CompletedFuture(file.getValue().filePath);
 			cachedFiles.put(file.getKey(), doNothing);
 		}
 	};

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -279,7 +279,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 			try {
 				java.nio.file.Path tmpDir = Files.createTempDirectory("flink-distributed-cache-" + jobGraph.getJobID());
 				for (Tuple2<String, DistributedCache.DistributedCacheEntry> originalEntry : userArtifacts) {
-					Path filePath = new Path(originalEntry.f1.filePath);
+					Path filePath = originalEntry.f1.filePath;
 					boolean isLocalDir = false;
 					try {
 						FileSystem sourceFs = filePath.getFileSystem();

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/plantranslate/JobGraphGeneratorTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/plantranslate/JobGraphGeneratorTest.java
@@ -269,7 +269,7 @@ public class JobGraphGeneratorTest {
 		assertNotNull(entry);
 		assertEquals(isExecutable, entry.isExecutable);
 		assertEquals(isZipped, entry.isZipped);
-		org.apache.flink.core.fs.Path filePath = new org.apache.flink.core.fs.Path(entry.filePath);
+		org.apache.flink.core.fs.Path filePath = entry.filePath;
 		assertTrue(filePath.getFileSystem().exists(filePath));
 		assertFalse(filePath.getFileSystem().getFileStatus(filePath).isDir());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/ClientUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/ClientUtils.java
@@ -51,7 +51,7 @@ public enum ClientUtils {
 	public static void extractAndUploadJobGraphFiles(JobGraph jobGraph, SupplierWithException<BlobClient, IOException> clientSupplier) throws FlinkException {
 		List<Path> userJars = jobGraph.getUserJars();
 		Collection<Tuple2<String, Path>> userArtifacts = jobGraph.getUserArtifacts().entrySet().stream()
-			.map(entry -> Tuple2.of(entry.getKey(), new Path(entry.getValue().filePath)))
+			.map(entry -> Tuple2.of(entry.getKey(), entry.getValue().filePath))
 			.collect(Collectors.toList());
 
 		uploadJobGraphFiles(jobGraph, userJars, userArtifacts, clientSupplier);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
@@ -288,10 +288,10 @@ public class FileCache {
 		private boolean executable;
 
 		public CopyFromDFSProcess(DistributedCacheEntry e, Path cachedPath) {
-			this.filePath = new Path(e.filePath);
+			this.filePath = e.filePath;
 			this.executable = e.isExecutable;
 
-			String sourceFile = e.filePath;
+			String sourceFile = e.filePath.toString();
 			int posOfSep = sourceFile.lastIndexOf("/");
 			if (posOfSep > 0) {
 				sourceFile = sourceFile.substring(posOfSep + 1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -575,7 +575,7 @@ public class JobGraph implements Serializable {
 		serializedBlobKey = InstantiationUtil.serializeObject(blobKey);
 
 		userArtifacts.computeIfPresent(entryName, (key, originalEntry) -> new DistributedCache.DistributedCacheEntry(
-			originalEntry.filePath,
+			originalEntry.filePath.toString(),
 			originalEntry.isExecutable,
 			serializedBlobKey,
 			originalEntry.isZipped

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/ClientUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/ClientUtilsTest.java
@@ -113,10 +113,10 @@ public class ClientUtilsTest extends TestLogger {
 		);
 
 		for (DistributedCache.DistributedCacheEntry entry : localArtifacts) {
-			jobGraph.addUserArtifact(entry.filePath, entry);
+			jobGraph.addUserArtifact(entry.filePath.toString(), entry);
 		}
 		for (DistributedCache.DistributedCacheEntry entry : distributedArtifacts) {
-			jobGraph.addUserArtifact(entry.filePath, entry);
+			jobGraph.addUserArtifact(entry.filePath.toString(), entry);
 		}
 
 		final int totalNumArtifacts = localArtifacts.size() + distributedArtifacts.size();
@@ -132,10 +132,10 @@ public class ClientUtilsTest extends TestLogger {
 		// 1 unique key for each local artifact, and null for distributed artifacts
 		assertEquals(localArtifacts.size() + 1, jobGraph.getUserArtifacts().values().stream().map(entry -> entry.blobKey).distinct().count());
 		for (DistributedCache.DistributedCacheEntry original : localArtifacts) {
-			assertState(original, jobGraph.getUserArtifacts().get(original.filePath), false, jobGraph.getJobID());
+			assertState(original, jobGraph.getUserArtifacts().get(original.filePath.toString()), false, jobGraph.getJobID());
 		}
 		for (DistributedCache.DistributedCacheEntry original : distributedArtifacts) {
-			assertState(original, jobGraph.getUserArtifacts().get(original.filePath), true, jobGraph.getJobID());
+			assertState(original, jobGraph.getUserArtifacts().get(original.filePath.toString()), true, jobGraph.getJobID());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
@@ -294,14 +294,14 @@ public class JobGraphTest extends TestLogger {
 		};
 
 		for (DistributedCache.DistributedCacheEntry entry : entries) {
-			jb.addUserArtifact(entry.filePath, entry);
+			jb.addUserArtifact(entry.filePath.toString(), entry);
 		}
 
 		for (DistributedCache.DistributedCacheEntry entry : entries) {
 			PermanentBlobKey blobKey = new PermanentBlobKey();
-			jb.setUserArtifactBlobKey(entry.filePath, blobKey);
+			jb.setUserArtifactBlobKey(entry.filePath.toString(), blobKey);
 
-			DistributedCache.DistributedCacheEntry jobGraphEntry = jb.getUserArtifacts().get(entry.filePath);
+			DistributedCache.DistributedCacheEntry jobGraphEntry = jb.getUserArtifacts().get(entry.filePath.toString());
 			assertNotNull(jobGraphEntry);
 			assertEquals(blobKey, InstantiationUtil.deserializeObject(jobGraphEntry.blobKey, ClassLoader.getSystemClassLoader(), false));
 			assertEquals(entry.isExecutable, jobGraphEntry.isExecutable);

--- a/pom.xml
+++ b/pom.xml
@@ -1783,6 +1783,7 @@ under the License.
 								<exclude>org.apache.flink.api.scala.hadoop.mapred.HadoopOutputFormat</exclude>
 								<exclude>org.apache.flink.api.scala.hadoop.mapreduce.HadoopInputFormat</exclude>
 								<exclude>org.apache.flink.api.scala.hadoop.mapreduce.HadoopOutputFormat</exclude>
+								<exclude>org.apache.flink.api.common.cache.DistributedCache</exclude>
 							</excludes>
 							<accessModifier>public</accessModifier>
 							<breakBuildOnModifications>false</breakBuildOnModifications>


### PR DESCRIPTION

## What is the purpose of the change

*related to [FLINK-9542](https://issues.apache.org/jira/browse/FLINK-9542).
 Modify the DistributedCacheEntries to contain Paths instead of Strings which could detect invalid paths earlier.
*


## Brief change log

  - *Modify the DistributedCacheEntries to contain Paths instead of Strings*


## Verifying this change

This change is already covered by existing tests, such as *(JobGraphGeneratorTest, ClientUtilsTest)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
