### PR TITLE
[FLINK-9787]Change ExecutionConfig#getGlobalJobParameters to return a…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -162,7 +162,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	// ------------------------------- User code values --------------------------------------------
 
-	private GlobalJobParameters globalJobParameters;
+	private GlobalJobParameters globalJobParameters = new GlobalJobParameters();
 
 	// Serializers and types registered with Kryo and the PojoSerializer
 	// we store them in linked maps/sets to ensure they are registered in order in all kryo instances.
@@ -761,6 +761,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 * @param globalJobParameters Custom user configuration object
 	 */
 	public void setGlobalJobParameters(GlobalJobParameters globalJobParameters) {
+		Preconditions.checkNotNull(globalJobParameters, "globalJobParameters shouldn't be null");
 		this.globalJobParameters = globalJobParameters;
 	}
 
@@ -1064,6 +1065,15 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 		 */
 		public Map<String, String> toMap() {
 			return Collections.emptyMap();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == null || this.getClass() != obj.getClass()) {
+				return false;
+			}
+
+			return true;
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
@@ -152,4 +152,11 @@ public class ExecutionConfigTest extends TestLogger {
 		assertEquals(objectReuseEnabled, copy1.isObjectReuseEnabled());
 		assertEquals(parallelism, copy1.getParallelism());
 	}
+
+	@Test
+	public void testGlobalParametersNotNull() {
+		final ExecutionConfig config = new ExecutionConfig();
+
+		assertNotNull(config.getGlobalJobParameters());
+	}
 }


### PR DESCRIPTION

## What is the purpose of the change

*related to [FLINK-9787](https://issues.apache.org/jira/browse/FLINK-9787). Change ExecutionConfig#getGlobalJobParameters to return an instance of GlobalJobParameters instead of null if no custom globalJobParameters are set yet*


## Brief change log

  - *change ExecutionConfig#getGlobalJobParameters and add test*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added ExecutionConfigTest#testGlobalParameters *


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
