### PR TITLE
[FLINK-12194][tests] Add option to disable failOnCheckpointingErrors in DataStreamAllroundTestJob

### DIFF
--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -142,6 +142,18 @@ public class DataStreamAllroundTestJobFactory {
 		.key("environment.checkpoint_interval")
 		.defaultValue(1000L);
 
+	private static final ConfigOption<Boolean> ENVIRONMENT_EXTERNALIZE_CHECKPOINT = ConfigOptions
+		.key("environment.externalize_checkpoint")
+		.defaultValue(false);
+
+	private static final ConfigOption<String> ENVIRONMENT_EXTERNALIZE_CHECKPOINT_CLEANUP = ConfigOptions
+		.key("environment.externalize_checkpoint.cleanup")
+		.defaultValue("retain");
+
+	private static final ConfigOption<Boolean> ENVIRONMENT_FAIL_ON_CHECKPOINTING_ERRORS = ConfigOptions
+		.key("environment.fail_on_checkpointing_errors")
+		.defaultValue(true);
+
 	private static final ConfigOption<Integer> ENVIRONMENT_PARALLELISM = ConfigOptions
 		.key("environment.parallelism")
 		.defaultValue(1);
@@ -161,18 +173,6 @@ public class DataStreamAllroundTestJobFactory {
 	private static final ConfigOption<Long> ENVIRONMENT_RESTART_STRATEGY_FIXED_DELAY = ConfigOptions
 		.key("environment.restart_strategy.fixed.delay")
 		.defaultValue(0L);
-
-	private static final ConfigOption<Boolean> ENVIRONMENT_EXTERNALIZE_CHECKPOINT = ConfigOptions
-		.key("environment.externalize_checkpoint")
-		.defaultValue(false);
-
-	private static final ConfigOption<String> ENVIRONMENT_EXTERNALIZE_CHECKPOINT_CLEANUP = ConfigOptions
-		.key("environment.externalize_checkpoint.cleanup")
-		.defaultValue("retain");
-
-	private static final ConfigOption<Boolean> ENVIRONMENT_FAIL_ON_CHECKPOINTING_ERRORS = ConfigOptions
-		.key("environment.fail_on_checkpointing_errors")
-		.defaultValue(true);
 
 	private static final ConfigOption<String> STATE_BACKEND = ConfigOptions
 		.key("state_backend")

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -80,6 +80,7 @@ import static org.apache.flink.streaming.tests.TestOperatorEnum.RESULT_TYPE_QUER
  *     <li>environment.checkpoint_interval (long, default - 1000): the checkpoint interval.</li>
  *     <li>environment.externalize_checkpoint (boolean, default - false): whether or not checkpoints should be externalized.</li>
  *     <li>environment.externalize_checkpoint.cleanup (String, default - 'retain'): Configures the cleanup mode for externalized checkpoints. Can be 'retain' or 'delete'.</li>
+ *     <li>environment.fail_on_checkpointing_errors (String, default - true): Sets the expected behaviour for tasks in case that they encounter an error in their checkpointing procedure.</li>
  *     <li>environment.parallelism (int, default - 1): parallelism to use for the job.</li>
  *     <li>environment.max_parallelism (int, default - 128): max parallelism to use for the job</li>
  *     <li>environment.restart_strategy (String, default - 'fixed_delay'): The failure restart strategy to use. Can be 'fixed_delay' or 'no_restart'.</li>
@@ -167,6 +168,10 @@ public class DataStreamAllroundTestJobFactory {
 	private static final ConfigOption<String> ENVIRONMENT_EXTERNALIZE_CHECKPOINT_CLEANUP = ConfigOptions
 		.key("environment.externalize_checkpoint.cleanup")
 		.defaultValue("retain");
+
+	private static final ConfigOption<Boolean> ENVIRONMENT_FAIL_ON_CHECKPOINTING_ERRORS = ConfigOptions
+		.key("environment.fail_on_checkpointing_errors")
+		.defaultValue(true);
 
 	private static final ConfigOption<String> STATE_BACKEND = ConfigOptions
 		.key("state_backend")
@@ -308,9 +313,13 @@ public class DataStreamAllroundTestJobFactory {
 				default:
 					throw new IllegalArgumentException("Unknown clean up mode for externalized checkpoints: " + cleanupModeConfig);
 			}
-
 			env.getCheckpointConfig().enableExternalizedCheckpoints(cleanupMode);
 		}
+
+		final boolean failOnCheckpointingErrors = pt.getBoolean(
+			ENVIRONMENT_FAIL_ON_CHECKPOINTING_ERRORS.key(),
+			ENVIRONMENT_FAIL_ON_CHECKPOINTING_ERRORS.defaultValue());
+		env.getCheckpointConfig().setFailOnCheckpointingErrors(failOnCheckpointingErrors);
 
 		// make parameters available in the web interface
 		env.getConfig().setGlobalJobParameters(pt);


### PR DESCRIPTION
## What is the purpose of the change

*Add option to disable `failOnCheckpointingErrors`.*


## Brief change log

  - *Add command line option to disable `failOnCheckpointingErrors`.*
  - *Refactor `DataStreamAllroundTestJobFactory`*

## Verifying this change

This change is already covered by existing tests, such as *E2E tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
