### PR TITLE
fix FLINK-12207 "==" bug

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDeserializationSchema.java
@@ -139,19 +139,19 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
 	// --------------------------------------------------------------------------------------------
 
 	private Object convert(JsonNode node, TypeInformation<?> info) {
-		if (info == Types.VOID || node.isNull()) {
+		if (Types.VOID.equals(info) || node.isNull()) {
 			return null;
-		} else if (info == Types.BOOLEAN) {
+		} else if (Types.BOOLEAN.equals(info)) {
 			return node.asBoolean();
-		} else if (info == Types.STRING) {
+		} else if (Types.STRING.equals(info)) {
 			return node.asText();
-		} else if (info == Types.BIG_DEC) {
+		} else if (Types.BIG_DEC.equals(info)) {
 			return node.decimalValue();
-		} else if (info == Types.BIG_INT) {
+		} else if (Types.BIG_INT.equals(info)) {
 			return node.bigIntegerValue();
-		} else if (info == Types.SQL_DATE) {
+		} else if (Types.SQL_DATE.equals(info)) {
 			return Date.valueOf(node.asText());
-		} else if (info == Types.SQL_TIME) {
+		} else if (Types.SQL_TIME.equals(info)) {
 			// according to RFC 3339 every full-time must have a timezone;
 			// until we have full timezone support, we only support UTC;
 			// users can parse their time as string as a workaround
@@ -162,7 +162,7 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
 						"Format: HH:mm:ss'Z'");
 			}
 			return Time.valueOf(time.substring(0, time.length() - 1));
-		} else if (info == Types.SQL_TIMESTAMP) {
+		} else if (Types.SQL_TIMESTAMP.equals(info)) {
 			// according to RFC 3339 every date-time must have a timezone;
 			// until we have full timezone support, we only support UTC;
 			// users can parse their time as string as a workaround

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowSerializationSchema.java
@@ -151,34 +151,34 @@ public class JsonRowSerializationSchema implements SerializationSchema<Row> {
 	}
 
 	private JsonNode convert(ContainerNode<?> container, JsonNode reuse, TypeInformation<?> info, Object object) {
-		if (info == Types.VOID || object == null) {
+		if (Types.VOID.equals(info) || object == null) {
 			return container.nullNode();
-		} else if (info == Types.BOOLEAN) {
+		} else if (Types.BOOLEAN.equals(info)) {
 			return container.booleanNode((Boolean) object);
-		} else if (info == Types.STRING) {
+		} else if (Types.STRING.equals(info)) {
 			return container.textNode((String) object);
-		} else if (info == Types.BIG_DEC) {
+		} else if (Types.BIG_DEC.equals(info)) {
 			// convert decimal if necessary
 			if (object instanceof BigDecimal) {
 				return container.numberNode((BigDecimal) object);
 			}
 			return container.numberNode(BigDecimal.valueOf(((Number) object).doubleValue()));
-		} else if (info == Types.BIG_INT) {
+		} else if (Types.BIG_INT.equals(info)) {
 			// convert integer if necessary
 			if (object instanceof BigInteger) {
 				return container.numberNode((BigInteger) object);
 			}
 			return container.numberNode(BigInteger.valueOf(((Number) object).longValue()));
-		} else if (info == Types.SQL_DATE) {
+		} else if (Types.SQL_DATE.equals(info)) {
 			return container.textNode(object.toString());
-		} else if (info == Types.SQL_TIME) {
+		} else if (Types.SQL_TIME.equals(info)) {
 			final Time time = (Time) object;
 			// strip milliseconds if possible
 			if (time.getTime() % 1000 > 0) {
 				return container.textNode(timeFormatWithMillis.format(time));
 			}
 			return container.textNode(timeFormat.format(time));
-		} else if (info == Types.SQL_TIMESTAMP) {
+		} else if (Types.SQL_TIMESTAMP.equals(info)) {
 			return container.textNode(timestampFormat.format((Timestamp) object));
 		} else if (info instanceof RowTypeInfo) {
 			if (reuse != null && reuse instanceof ObjectNode) {


### PR DESCRIPTION
When I use Json class as format instance object as fllows:

tableEnv.connect(kafka)
                .withFormat(new Json()
                        .failOnMissingField(false)
                        .deriveSchema())
                .withSchema(new Schema()
                        .field("search_time", Types.LONG())
                        .field("code", Types.INT())
                        .field("results", Types.ROW(
                                new String[]{"id", "items"},
                                new TypeInformation[]{
                                        Types.STRING(),
                                        ObjectArrayTypeInfo.getInfoFor(Row[].class,//Array.newInstance(Row.class, 10).getClass(),
                                                Types.ROW(
                                                        new String[]{"id", "name", "title", "url", "publish_time", "score"},
                                                        new TypeInformation[]{Types.STRING(),Types.STRING(),Types.STRING(),Types.STRING(),Types.LONG(),Types.FLOAT()}
                                                        ))})
                        )).inAppendMode().registerTableSource("tb_json");

I find " convert(JsonNode node, TypeInformation<?> info) “ method in JsonRowDeserializationSchema use ”==“ assert equals:
private Object convert(JsonNode node, TypeInformation<?> info) {
		if (info == Types.VOID || node.isNull()) {
			return null;
		} else if (info == Types.BOOLEAN) {
			return node.asBoolean();
		} else if (info == Types.STRING) {
			return node.asText();
		} else if (info == Types.BIG_DEC) {
			return node.decimalValue();
		} else if (info == Types.BIG_INT) {
			return node.bigIntegerValue();
		} else if (info == Types.SQL_DATE) {
			return Date.valueOf(node.asText());
		} else if (info == Types.SQL_TIME) {
			// according to RFC 3339 every full-time must have a timezone;
			// until we have full timezone support, we only support UTC;
			// users can parse their time as string as a workaround
			final String time = node.asText();
			if (time.indexOf('Z') < 0 || time.indexOf('.') >= 0) {
				throw new IllegalStateException(
					"Invalid time format. Only a time in UTC timezone without milliseconds is supported yet. " +
						"Format: HH:mm:ss'Z'");
			}
			return Time.valueOf(time.substring(0, time.length() - 1));
		} else if (info == Types.SQL_TIMESTAMP) {
			// according to RFC 3339 every date-time must have a timezone;
			// until we have full timezone support, we only support UTC;
			// users can parse their time as string as a workaround
			final String timestamp = node.asText();
			if (timestamp.indexOf('Z') < 0) {
				throw new IllegalStateException(
					"Invalid timestamp format. Only a timestamp in UTC timezone is supported yet. " +
						"Format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
			}
			return Timestamp.valueOf(timestamp.substring(0, timestamp.length() - 1).replace('T', ' '));
		} 


therefore, all if statement returns false, so i think it is a bug. 

The "convert" method in JsonRowSerializationSchema  Class has the the same problem.