### PR TITLE
[FLINK-12204][jdbc] Improve JDBCOutputFormat ClassCastException

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
@@ -198,8 +198,12 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 									// case java.sql.Types.STRUC
 							}
 						} catch (ClassCastException e) {
-							throw new RuntimeException(
-								"Field index: " + index + ", field value: " + row.getField(index) + " " + e.getMessage(), e);
+							// enrich the exception with detailed information.
+							String errorMessage = String.format(
+								"%s, field index: %s, field value: %s.", e.getMessage(), index, row.getField(index));
+							ClassCastException enrichedException = new ClassCastException(errorMessage);
+							enrichedException.setStackTrace(e.getStackTrace());
+							throw enrichedException;
 						}
 					}
 				}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
@@ -54,7 +54,7 @@ public class JDBCFullTest extends JDBCTestBase {
 	public void testEnrichedClassCastException() throws Exception {
 		exception.expect(ClassCastException.class);
 		exception.expectMessage(
-			"java.lang.String cannot be cast to java.lang.Double at index 3 of the output row.");
+			"java.lang.String cannot be cast to java.lang.Double, field index: 3, field value: 11.11.");
 
 		JDBCOutputFormat jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
 			.setDrivername(JDBCTestBase.DRIVER_CLASS)

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
@@ -50,6 +50,25 @@ public class JDBCFullTest extends JDBCTestBase {
 		runTest(true);
 	}
 
+	@Test
+	public void testEnrichedClassCastException() throws Exception {
+		exception.expect(ClassCastException.class);
+		exception.expectMessage(
+			"java.lang.String cannot be cast to java.lang.Double at index 3 of the output row.");
+
+		JDBCOutputFormat jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+			.setDrivername(JDBCTestBase.DRIVER_CLASS)
+			.setDBUrl(JDBCTestBase.DB_URL)
+			.setQuery("insert into newbooks (id, title, author, price, qty) values (?,?,?,?,?)")
+			.setSqlTypes(new int[]{Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.DOUBLE, Types.INTEGER})
+			.finish();
+
+		jdbcOutputFormat.open(1, 1);
+		Row inputRow = Row.of(1001, "Java public for dummies", "Tan Ah Teck", "11.11", 11);
+		jdbcOutputFormat.writeRecord(inputRow);
+		jdbcOutputFormat.close();
+	}
+
 	private void runTest(boolean exploitParallelism) throws Exception {
 		ExecutionEnvironment environment = ExecutionEnvironment.getExecutionEnvironment();
 		JDBCInputFormatBuilder inputBuilder = JDBCInputFormat.buildJDBCInputFormat()

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 import java.io.OutputStream;
 import java.sql.Connection;
@@ -34,6 +36,9 @@ import java.sql.Statement;
  * Base test class for JDBC Input and Output formats.
  */
 public class JDBCTestBase {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
 
 	public static final String DRIVER_CLASS = "org.apache.derby.jdbc.EmbeddedDriver";
 	public static final String DB_URL = "jdbc:derby:memory:ebookshop";


### PR DESCRIPTION

## What is the purpose of the change

This pull request enriches `ClassCastException` for `JDBCOutputFormat`. 

Note: I haven't added another wrapper for the exception. Instead, I just modify the ClassCastExceptoin’s error message and throw it. The stack would be more intuitive with less stack layer which I think is more user-friendly.

## Brief change log

  - Enriches `ClassCastException` for `JDBCOutputFormat` with the index information.
  -  Add tests to verify the enriched information.


## Verifying this change

This change added tests and can be verified as follows:

  - Added testEnrichedClassCastException to test the enriched exception.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
