### PR TITLE
[FLINK-12198] Flink JDBC Connector: Update existing JDBCInputFormat t…

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormat.java
@@ -116,6 +116,7 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 	private transient PreparedStatement statement;
 	private transient ResultSet resultSet;
 	private int fetchSize;
+	private Boolean autoCommit;
 
 	private boolean hasNext;
 	private Object[][] parameterValues;
@@ -143,6 +144,11 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 			} else {
 				dbConn = DriverManager.getConnection(dbURL, username, password);
 			}
+
+			if (autoCommit != null) {
+				dbConn.setAutoCommit(autoCommit);
+			}
+
 			statement = dbConn.prepareStatement(queryTemplate, resultSetType, resultSetConcurrency);
 			if (fetchSize == Integer.MIN_VALUE || fetchSize > 0) {
 				statement.setFetchSize(fetchSize);
@@ -323,6 +329,11 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 		return statement;
 	}
 
+	@VisibleForTesting
+	Connection getDbConn() {
+		return dbConn;
+	}
+
 	/**
 	 * A builder used to set parameters to the output format's configuration in a fluent way.
 	 * @return builder
@@ -393,6 +404,11 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 			Preconditions.checkArgument(fetchSize == Integer.MIN_VALUE || fetchSize > 0,
 				"Illegal value %s for fetchSize, has to be positive or Integer.MIN_VALUE.", fetchSize);
 			format.fetchSize = fetchSize;
+			return this;
+		}
+
+		public JDBCInputFormatBuilder setAutoCommit(Boolean autoCommit) {
+			format.autoCommit = autoCommit;
 			return this;
 		}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
@@ -155,28 +155,6 @@ public class JDBCInputFormatTest extends JDBCTestBase {
 	}
 
 	@Test
-	public void testAutoCommitFalse() {
-		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-			.setDrivername(DRIVER_CLASS)
-			.setDBUrl(DB_URL)
-			.setQuery(SELECT_ALL_BOOKS)
-			.setRowTypeInfo(ROW_TYPE_INFO)
-			.setAutoCommit(false)
-			.finish();
-	}
-
-	@Test
-	public void testAutoCommitTrue() {
-		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-			.setDrivername(DRIVER_CLASS)
-			.setDBUrl(DB_URL)
-			.setQuery(SELECT_ALL_BOOKS)
-			.setRowTypeInfo(ROW_TYPE_INFO)
-			.setAutoCommit(true)
-			.finish();
-	}
-
-	@Test
 	public void testDefaultAutoCommitIsUsedIfNotConfiguredOtherwise() throws SQLException, ClassNotFoundException {
 
 		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
@@ -155,6 +155,63 @@ public class JDBCInputFormatTest extends JDBCTestBase {
 	}
 
 	@Test
+	public void testAutoCommitFalse() {
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+			.setDrivername(DRIVER_CLASS)
+			.setDBUrl(DB_URL)
+			.setQuery(SELECT_ALL_BOOKS)
+			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setAutoCommit(false)
+			.finish();
+	}
+
+	@Test
+	public void testAutoCommitTrue() {
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+			.setDrivername(DRIVER_CLASS)
+			.setDBUrl(DB_URL)
+			.setQuery(SELECT_ALL_BOOKS)
+			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setAutoCommit(true)
+			.finish();
+	}
+
+	@Test
+	public void testDefaultAutoCommitIsUsedIfNotConfiguredOtherwise() throws SQLException, ClassNotFoundException {
+
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+			.setDrivername(DRIVER_CLASS)
+			.setDBUrl(DB_URL)
+			.setQuery(SELECT_ALL_BOOKS)
+			.setRowTypeInfo(ROW_TYPE_INFO)
+			.finish();
+		jdbcInputFormat.openInputFormat();
+
+		Class.forName(DRIVER_CLASS);
+		final boolean defaultAutoCommit = DriverManager.getConnection(DB_URL).getAutoCommit();
+
+		Assert.assertEquals(defaultAutoCommit, jdbcInputFormat.getDbConn().getAutoCommit());
+
+	}
+
+	@Test
+	public void testAutoCommitCanBeConfigured() throws SQLException {
+
+		final boolean desiredAutoCommit = false;
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+			.setDrivername(DRIVER_CLASS)
+			.setDBUrl(DB_URL)
+			.setQuery(SELECT_ALL_BOOKS)
+			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setAutoCommit(desiredAutoCommit)
+			.finish();
+
+		jdbcInputFormat.openInputFormat();
+		Assert.assertEquals(desiredAutoCommit, jdbcInputFormat.getDbConn().getAutoCommit());
+
+	}
+
+	@Test
 	public void testJDBCInputFormatWithoutParallelism() throws IOException {
 		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
 				.setDrivername(DRIVER_CLASS)


### PR DESCRIPTION
…o support setting auto-commit mode of DB connection.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request makes Flink JDBC to support setting auto-commit mode on the respective DB connection.*


## Brief change log

*The required modifications was performed in JDBCInputFormat.class (i.e., org.apache.flink.api.java.io.jdbc package) as follows:*
  - *A new Boolean field was added to enable/disable auto-commit mode.*
  - *The 'openInputFormat' function was updated to set auto-commit mode if the aforementioned field has no null value.*
  - *JDBCInputFormatBuilder static class was modified adding a new function to set auto-commit mode.*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit tests: testAutoCommitFalse, testAutoCommitTrue, testDefaultAutoCommitIsUsedIfNotConfiguredOtherwise & testAutoCommitCanBeConfigured*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
