### PR TITLE
[FLINK-12197] [Formats] Avro row deser for Confluent binary format

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -40,7 +40,7 @@ under the License.
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-schema-registry-client</artifactId>
-			<version>3.3.1</version>
+			<version>5.1.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.avro</groupId>
@@ -105,6 +105,25 @@ under the License.
 									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.org.101tec</shadedPattern>
 								</relocation>
 							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Generate Test class from avro schema -->
+			<plugin>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro-maven-plugin</artifactId>
+				<version>${avro.version}</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>schema</goal>
+						</goals>
+						<configuration>
+							<testSourceDirectory>${project.basedir}/src/test/resources/avro</testSourceDirectory>
+							<testOutputDirectory>${project.basedir}/src/test/java/</testOutputDirectory>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluenceCachedSchemaCoderProvider.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluenceCachedSchemaCoderProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent;
+
+import org.apache.flink.formats.avro.SchemaCoder;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+
+/**
+ * Schema coder provider for Confluent schema registry. Cached Confluent client is used under the hood.
+ */
+public class ConfluenceCachedSchemaCoderProvider implements SchemaCoder.SchemaCoderProvider {
+
+	private static final long serialVersionUID = 4023134423033312666L;
+	private final String url;
+	private final int identityMapCapacity;
+
+	ConfluenceCachedSchemaCoderProvider(String url, int identityMapCapacity) {
+		this.url = url;
+		this.identityMapCapacity = identityMapCapacity;
+	}
+
+	@Override
+	public SchemaCoder get() {
+		return new ConfluentSchemaRegistryCoder(new CachedSchemaRegistryClient(
+			url,
+			identityMapCapacity));
+	}
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.avro.registry.confluent;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.formats.avro.AvroDeserializationSchema;
 import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
 import org.apache.flink.formats.avro.SchemaCoder;
@@ -49,7 +50,8 @@ public class ConfluentRegistryAvroDeserializationSchema<T> extends RegistryAvroD
 	 *                            {@link GenericRecord}
 	 * @param schemaCoderProvider provider for schema coder that reads writer schema from Confluent Schema Registry
 	 */
-	private ConfluentRegistryAvroDeserializationSchema(Class<T> recordClazz, @Nullable Schema reader,
+	@VisibleForTesting
+	ConfluentRegistryAvroDeserializationSchema(Class<T> recordClazz, @Nullable Schema reader,
 			SchemaCoder.SchemaCoderProvider schemaCoderProvider) {
 		super(recordClazz, reader, schemaCoderProvider);
 	}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
@@ -22,7 +22,6 @@ import org.apache.flink.formats.avro.AvroDeserializationSchema;
 import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
 import org.apache.flink.formats.avro.SchemaCoder;
 
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.specific.SpecificRecord;
@@ -81,7 +80,7 @@ public class ConfluentRegistryAvroDeserializationSchema<T> extends RegistryAvroD
 		return new ConfluentRegistryAvroDeserializationSchema<>(
 			GenericRecord.class,
 			schema,
-			new CachedSchemaCoderProvider(url, identityMapCapacity));
+			new ConfluenceCachedSchemaCoderProvider(url, identityMapCapacity));
 	}
 
 	/**
@@ -111,26 +110,7 @@ public class ConfluentRegistryAvroDeserializationSchema<T> extends RegistryAvroD
 		return new ConfluentRegistryAvroDeserializationSchema<>(
 			tClass,
 			null,
-			new CachedSchemaCoderProvider(url, identityMapCapacity)
+			new ConfluenceCachedSchemaCoderProvider(url, identityMapCapacity)
 		);
-	}
-
-	private static class CachedSchemaCoderProvider implements SchemaCoder.SchemaCoderProvider {
-
-		private static final long serialVersionUID = 4023134423033312666L;
-		private final String url;
-		private final int identityMapCapacity;
-
-		CachedSchemaCoderProvider(String url, int identityMapCapacity) {
-			this.url = url;
-			this.identityMapCapacity = identityMapCapacity;
-		}
-
-		@Override
-		public SchemaCoder get() {
-			return new ConfluentSchemaRegistryCoder(new CachedSchemaRegistryClient(
-				url,
-				identityMapCapacity));
-		}
 	}
 }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroRowDeserializationSchema.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.formats.avro.SchemaCoder;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificRecord;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Objects;
+
+import static org.apache.flink.formats.avro.utils.AvroDeserializationUtils.convertAvroRecordToRow;
+
+/**
+ * Deserialization schema that deserializes from Avro binary format to Row using {@link SchemaCoder} that uses
+ * Confluent Schema Registry.
+ */
+public class ConfluentRegistryAvroRowDeserializationSchema extends AbstractDeserializationSchema<Row> {
+	public static final int DEFAULT_IDENTITY_MAP_CAPACITY = 1000;
+
+	@VisibleForTesting
+	String schemaString;
+
+	@VisibleForTesting
+	String url;
+
+	@VisibleForTesting
+	Class<? extends SpecificRecord> recordClazz;
+
+	private int identityMapCapacity;
+
+	private transient Schema schema;
+
+	private transient RowTypeInfo typeInfo;
+
+	private transient IndexedRecord record;
+
+	private transient GenericDatumReader<IndexedRecord> datumReader;
+
+	private transient MutableByteArrayInputStream inputStream;
+
+	private transient Decoder decoder;
+
+	@VisibleForTesting
+	transient SchemaCoder schemaCoder;
+
+	@VisibleForTesting
+	ConfluentRegistryAvroRowDeserializationSchema() {}
+
+	/**
+	 * Creates {@link AbstractDeserializationSchema} that produces {@link Row}
+	 * using provided reader schema and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param schema 				schema of produced records
+	 * @param url   				url of schema registry to connect
+	 * @param identityMapCapacity	maximum number of cached schema versions (default: 1000)
+	 * @return deserialized record in form of {@link Row}
+	 */
+	public static ConfluentRegistryAvroRowDeserializationSchema forGeneric(Schema schema, String url,
+			int identityMapCapacity) {
+		return new ConfluentRegistryAvroRowDeserializationSchema(schema, url, identityMapCapacity);
+	}
+
+	/**
+	 * Creates {@link AbstractDeserializationSchema} that produces {@link Row}
+	 * using reader provided reader schema and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param schema schema of produced records
+	 * @param url    url of schema registry to connect
+	 * @return deserialized record in form of {@link Row}
+	 */
+	public static ConfluentRegistryAvroRowDeserializationSchema forGeneric(Schema schema, String url) {
+		return forGeneric(schema, url, DEFAULT_IDENTITY_MAP_CAPACITY);
+	}
+
+	/**
+	 * Creates {@link AbstractDeserializationSchema} that produces {@link Row}
+	 * using reader schema provided by {@link SpecificRecord} and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param recordClazz 			specific record class
+	 * @param url    				url of schema registry to connect
+	 * @param identityMapCapacity	maximum number of cached schema versions (default: 1000)
+	 * @return deserialized record in form of {@link Row}
+	 */
+	public static ConfluentRegistryAvroRowDeserializationSchema forSpecific(Class<? extends SpecificRecord> recordClazz,
+			String url, int identityMapCapacity) {
+		return new ConfluentRegistryAvroRowDeserializationSchema(recordClazz, url, identityMapCapacity);
+	}
+
+	/**
+	 * Creates {@link AbstractDeserializationSchema} that produces {@link Row}
+	 * using schema provided by {@link SpecificRecord} and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param recordClazz 			specific record class
+	 * @param url    				url of schema registry to connect
+	 * @return deserialized record in form of {@link Row}
+	 */
+	public static ConfluentRegistryAvroRowDeserializationSchema forSpecific(Class<? extends SpecificRecord> recordClazz,
+			String url) {
+		return forSpecific(recordClazz, url, DEFAULT_IDENTITY_MAP_CAPACITY);
+	}
+
+	protected ConfluentRegistryAvroRowDeserializationSchema(Schema schema, String url, int identityMapCapacity) {
+		this.url = url;
+		this.identityMapCapacity = identityMapCapacity;
+		this.schema = schema;
+		this.recordClazz = null;
+
+		schemaString = schema.toString();
+		typeInfo = getTypeInfo(schemaString);
+		schemaCoder = new ConfluenceCachedSchemaCoderProvider(url, identityMapCapacity).get();
+		record = new GenericData.Record(schema);
+		datumReader = new GenericDatumReader<>(schema);
+		inputStream = new MutableByteArrayInputStream();
+		decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+	}
+
+	protected ConfluentRegistryAvroRowDeserializationSchema(Class<? extends SpecificRecord> recordClazz, String url,
+			int identityMapCapacity) {
+		this.url = url;
+		this.identityMapCapacity = identityMapCapacity;
+		this.recordClazz = recordClazz;
+		this.schema = SpecificData.get().getSchema(recordClazz);
+
+		schemaString = schema.toString();
+		typeInfo = getTypeInfo(schemaString);
+		schemaCoder = new ConfluenceCachedSchemaCoderProvider(url, identityMapCapacity).get();
+		record = new GenericData.Record(schema);
+		datumReader = new GenericDatumReader<>(schema);
+		inputStream = new MutableByteArrayInputStream();
+		decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+	}
+
+	private RowTypeInfo getTypeInfo(String schemaString) {
+		TypeInformation<?> typeInfo = AvroSchemaConverter.convertToTypeInfo(schemaString);
+		Preconditions.checkArgument(typeInfo instanceof RowTypeInfo, "Row type information expected.");
+		return (RowTypeInfo) typeInfo;
+	}
+
+	@Override
+	public Row deserialize(byte[] message) throws IOException {
+		try {
+			inputStream.setBuffer(message);
+			Schema writerSchema = schemaCoder.readSchema(inputStream);
+
+			datumReader.setSchema(writerSchema);
+			datumReader.setExpected(schema);
+
+			record = datumReader.read(record, decoder);
+			return convertAvroRecordToRow(schema, typeInfo, record);
+		} catch (Exception e) {
+			throw new IOException("Failed to deserialize Avro record.", e);
+		}
+	}
+
+	@Override
+	public TypeInformation<Row> getProducedType() {
+		return typeInfo;
+	}
+
+	@VisibleForTesting
+	void writeObject(ObjectOutputStream outputStream) throws IOException {
+		outputStream.writeObject(recordClazz);
+		outputStream.writeUTF(schemaString);
+		outputStream.writeUTF(url);
+		outputStream.writeInt(identityMapCapacity);
+	}
+
+	@VisibleForTesting
+	@SuppressWarnings("unchecked")
+	void readObject(ObjectInputStream inputStream) throws ClassNotFoundException, IOException {
+		recordClazz = (Class<? extends SpecificRecord>) inputStream.readObject();
+		schemaString = inputStream.readUTF();
+		url = inputStream.readUTF();
+		identityMapCapacity = inputStream.readInt();
+
+		typeInfo = (RowTypeInfo) AvroSchemaConverter.<Row>convertToTypeInfo(schemaString);
+		schema = new Schema.Parser().parse(schemaString);
+		if (recordClazz != null) {
+			record = (SpecificRecord) SpecificData.newInstance(recordClazz, schema);
+		} else {
+			record = new GenericData.Record(schema);
+		}
+
+		datumReader = new SpecificDatumReader<>(schema);
+		this.inputStream = new MutableByteArrayInputStream();
+		decoder = DecoderFactory.get().binaryDecoder(this.inputStream, null);
+
+		schemaCoder = new ConfluenceCachedSchemaCoderProvider(url, identityMapCapacity).get();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ConfluentRegistryAvroRowDeserializationSchema that = (ConfluentRegistryAvroRowDeserializationSchema) o;
+		return Objects.equals(schemaString, that.schemaString) &&
+			Objects.equals(url, that.url) &&
+			Objects.equals(recordClazz, that.recordClazz);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(schemaString, url, recordClazz);
+	}
+}

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroRowDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroRowDeserializationSchemaTest.java
@@ -35,7 +35,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link ConfluentRegistryAvroRowDeserializationSchemaTest}.
@@ -54,7 +56,11 @@ public class ConfluentRegistryAvroRowDeserializationSchemaTest {
 		MockSchemaRegistryClient client = new MockSchemaRegistryClient();
 		int id = client.register("subj", record.getSchema());
 
-		deser.schemaCoder = new ConfluentSchemaRegistryCoder(client);
+		ConfluenceCachedSchemaCoderProvider mockSchemaCoderProvider = mock(ConfluenceCachedSchemaCoderProvider.class);
+		when(mockSchemaCoderProvider.get()).thenReturn(new ConfluentSchemaRegistryCoder(client));
+
+		deser.innerDeserializationSchema = new ConfluentRegistryAvroDeserializationSchema<>(recordClass, null,
+			mockSchemaCoderProvider);
 
 		Row actual = deser.deserialize(AvroTestUtils.serialize(testData.f1, id));
 
@@ -74,7 +80,11 @@ public class ConfluentRegistryAvroRowDeserializationSchemaTest {
 		MockSchemaRegistryClient client = new MockSchemaRegistryClient();
 		int id = client.register("subj", schema);
 
-		deser.schemaCoder = new ConfluentSchemaRegistryCoder(client);
+		ConfluenceCachedSchemaCoderProvider mockSchemaCoderProvider = mock(ConfluenceCachedSchemaCoderProvider.class);
+		when(mockSchemaCoderProvider.get()).thenReturn(new ConfluentSchemaRegistryCoder(client));
+
+		deser.innerDeserializationSchema = new ConfluentRegistryAvroDeserializationSchema<>(GenericRecord.class, schema,
+			mockSchemaCoderProvider);
 
 		Row actual = deser.deserialize(AvroTestUtils.serialize(record, id));
 
@@ -98,7 +108,6 @@ public class ConfluentRegistryAvroRowDeserializationSchemaTest {
 		ConfluentRegistryAvroRowDeserializationSchema mock = spy(ConfluentRegistryAvroRowDeserializationSchema.class);
 		mock.readObject(new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray())));
 
-		assertEquals(deser.url, mock.url);
 		assertEquals(deser.schemaString, mock.schemaString);
 		assertEquals(deser.recordClazz, mock.recordClazz);
 	}
@@ -120,7 +129,6 @@ public class ConfluentRegistryAvroRowDeserializationSchemaTest {
 		ConfluentRegistryAvroRowDeserializationSchema mock = spy(ConfluentRegistryAvroRowDeserializationSchema.class);
 		mock.readObject(new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray())));
 
-		assertEquals(deser.url, mock.url);
 		assertEquals(deser.schemaString, mock.schemaString);
 		assertEquals(deser.recordClazz, mock.recordClazz);
 	}

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroRowDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroRowDeserializationSchemaTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.formats.avro.registry.confluent.util.AvroTestUtils;
+import org.apache.flink.types.Row;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificRecord;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Unit tests for {@link ConfluentRegistryAvroRowDeserializationSchemaTest}.
+ */
+public class ConfluentRegistryAvroRowDeserializationSchemaTest {
+	@Test
+	public void testDeserializeSpecific() throws IOException, RestClientException {
+		final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData = AvroTestUtils.getSpecificTestData();
+		Class<? extends SpecificRecord> recordClass = testData.f0;
+		SpecificRecord record = testData.f1;
+		Row expected = testData.f2;
+
+		ConfluentRegistryAvroRowDeserializationSchema deser = ConfluentRegistryAvroRowDeserializationSchema
+			.forSpecific(recordClass, "localhost");
+
+		MockSchemaRegistryClient client = new MockSchemaRegistryClient();
+		int id = client.register("subj", record.getSchema());
+
+		deser.schemaCoder = new ConfluentSchemaRegistryCoder(client);
+
+		Row actual = deser.deserialize(AvroTestUtils.serialize(testData.f1, id));
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testDeserializeGeneric() throws IOException, RestClientException {
+		Tuple3<GenericRecord, Row, Schema> testData = AvroTestUtils.getGenericTestData();
+		GenericRecord record = testData.f0;
+		Row expected = testData.f1;
+		Schema schema = testData.f2;
+
+		ConfluentRegistryAvroRowDeserializationSchema deser = ConfluentRegistryAvroRowDeserializationSchema
+			.forGeneric(schema, "localhost");
+
+		MockSchemaRegistryClient client = new MockSchemaRegistryClient();
+		int id = client.register("subj", schema);
+
+		deser.schemaCoder = new ConfluentSchemaRegistryCoder(client);
+
+		Row actual = deser.deserialize(AvroTestUtils.serialize(record, id));
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testReadWriteObjectGeneric() throws IOException, ClassNotFoundException {
+		Tuple3<GenericRecord, Row, Schema> testData = AvroTestUtils.getGenericTestData();
+		Schema schema = testData.f2;
+
+		ConfluentRegistryAvroRowDeserializationSchema deser = ConfluentRegistryAvroRowDeserializationSchema
+			.forGeneric(schema, "localhost");
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		deser.writeObject(oos);
+
+		oos.flush();
+
+		ConfluentRegistryAvroRowDeserializationSchema mock = spy(ConfluentRegistryAvroRowDeserializationSchema.class);
+		mock.readObject(new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray())));
+
+		assertEquals(deser.url, mock.url);
+		assertEquals(deser.schemaString, mock.schemaString);
+		assertEquals(deser.recordClazz, mock.recordClazz);
+	}
+
+	@Test
+	public void testReadWriteObjectSpecific() throws IOException, ClassNotFoundException {
+		final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData = AvroTestUtils.getSpecificTestData();
+		Class<? extends SpecificRecord> recordClass = testData.f0;
+
+		ConfluentRegistryAvroRowDeserializationSchema deser = ConfluentRegistryAvroRowDeserializationSchema
+			.forSpecific(recordClass, "localhost");
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		deser.writeObject(oos);
+
+		oos.flush();
+
+		ConfluentRegistryAvroRowDeserializationSchema mock = spy(ConfluentRegistryAvroRowDeserializationSchema.class);
+		mock.readObject(new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray())));
+
+		assertEquals(deser.url, mock.url);
+		assertEquals(deser.schemaString, mock.schemaString);
+		assertEquals(deser.recordClazz, mock.recordClazz);
+	}
+}

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/util/AvroTestUtils.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/util/AvroTestUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent.util;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.types.Row;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificRecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Confluent compatible avro utils.
+ */
+public class AvroTestUtils {
+	public static Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> getSpecificTestData() {
+		final Address addr = Address.newBuilder()
+			.setNum(42)
+			.setStreet("Main Street 42")
+			.setCity("Test City")
+			.setState("Test State")
+			.setZip("12345")
+			.build();
+
+		final Row rowAddr = new Row(5);
+		rowAddr.setField(0, 42);
+		rowAddr.setField(1, "Main Street 42");
+		rowAddr.setField(2, "Test City");
+		rowAddr.setField(3, "Test State");
+		rowAddr.setField(4, "12345");
+
+		return new Tuple3<>(Address.class, addr, rowAddr);
+	}
+
+	public static Tuple3<GenericRecord, Row, Schema> getGenericTestData() {
+		String schemaString = "{\"type\":\"record\",\"name\":\"Address\",\"namespace\":\"org.apache.flink.formats.avro.generated\",\"fields\":" +
+			"[{\"name\":\"num\",\"type\":\"int\"},{\"name\":\"street\",\"type\":\"string\"}," +
+			"{\"name\":\"city\",\"type\":\"string\"},{\"name\":\"state\",\"type\":\"string\"}," +
+			"{\"name\":\"zip\",\"type\":\"string\"}]}";
+
+		final Schema schema = new Schema.Parser().parse(schemaString);
+
+		GenericRecord addr = new GenericData.Record(schema);
+		addr.put("num", 42);
+		addr.put("street", "Main Street 42");
+		addr.put("city", "Test City");
+		addr.put("state", "Test State");
+		addr.put("zip", "12345");
+
+		final Row rowAddr = new Row(5);
+		rowAddr.setField(0, 42);
+		rowAddr.setField(1, "Main Street 42");
+		rowAddr.setField(2, "Test City");
+		rowAddr.setField(3, "Test State");
+		rowAddr.setField(4, "12345");
+
+		return new Tuple3<>(addr, rowAddr, schema);
+	}
+
+	public static byte[] serialize(IndexedRecord record, int version) throws IOException {
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		DataOutputStream dataStream = new DataOutputStream(stream);
+		BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(dataStream, null);
+		GenericDatumWriter<Object> datumWriter = new GenericDatumWriter<>(record.getSchema());
+
+		dataStream.write(0);
+		dataStream.writeInt(version);
+		datumWriter.write(record, encoder);
+
+		encoder.flush();
+		return stream.toByteArray();
+	}
+}

--- a/flink-formats/flink-avro-confluent-registry/src/test/resources/avro/address.avsc
+++ b/flink-formats/flink-avro-confluent-registry/src/test/resources/avro/address.avsc
@@ -1,0 +1,27 @@
+{
+  "type": "record",
+  "name": "Address",
+  "namespace": "org.apache.flink.formats.avro.generated",
+  "fields": [
+    {
+      "name": "num",
+      "type": "int"
+    },
+    {
+      "name": "street",
+      "type": "string"
+    },
+    {
+      "name": "city",
+      "type": "string"
+    },
+    {
+      "name": "state",
+      "type": "string"
+    },
+    {
+      "name": "zip",
+      "type": "string"
+    }
+  ]
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -19,22 +19,16 @@ package org.apache.flink.formats.avro;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
-import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.MapTypeInfo;
-import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
@@ -42,26 +36,14 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeFieldType;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.lang.reflect.Array;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
+
+import static org.apache.flink.formats.avro.utils.AvroDeserializationUtils.convertAvroRecordToRow;
 
 /**
  * Deserialization schema from Avro bytes to {@link Row}.
@@ -192,157 +174,6 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
 	@Override
 	public int hashCode() {
 		return Objects.hash(recordClazz, schemaString);
-	}
-
-	// --------------------------------------------------------------------------------------------
-
-	private Row convertAvroRecordToRow(Schema schema, RowTypeInfo typeInfo, IndexedRecord record) {
-		final List<Schema.Field> fields = schema.getFields();
-		final TypeInformation<?>[] fieldInfo = typeInfo.getFieldTypes();
-		final int length = fields.size();
-		final Row row = new Row(length);
-		for (int i = 0; i < length; i++) {
-			final Schema.Field field = fields.get(i);
-			row.setField(i, convertAvroType(field.schema(), fieldInfo[i], record.get(i)));
-		}
-		return row;
-	}
-
-	private Object convertAvroType(Schema schema, TypeInformation<?> info, Object object) {
-		// we perform the conversion based on schema information but enriched with pre-computed
-		// type information where useful (i.e., for arrays)
-
-		if (object == null) {
-			return null;
-		}
-		switch (schema.getType()) {
-			case RECORD:
-				if (object instanceof IndexedRecord) {
-					return convertAvroRecordToRow(schema, (RowTypeInfo) info, (IndexedRecord) object);
-				}
-				throw new IllegalStateException("IndexedRecord expected but was: " + object.getClass());
-			case ENUM:
-			case STRING:
-				return object.toString();
-			case ARRAY:
-				if (info instanceof BasicArrayTypeInfo) {
-					final TypeInformation<?> elementInfo = ((BasicArrayTypeInfo<?, ?>) info).getComponentInfo();
-					return convertToObjectArray(schema.getElementType(), elementInfo, object);
-				} else {
-					final TypeInformation<?> elementInfo = ((ObjectArrayTypeInfo<?, ?>) info).getComponentInfo();
-					return convertToObjectArray(schema.getElementType(), elementInfo, object);
-				}
-			case MAP:
-				final MapTypeInfo<?, ?> mapTypeInfo = (MapTypeInfo<?, ?>) info;
-				final Map<String, Object> convertedMap = new HashMap<>();
-				final Map<?, ?> map = (Map<?, ?>) object;
-				for (Map.Entry<?, ?> entry : map.entrySet()) {
-					convertedMap.put(
-						entry.getKey().toString(),
-						convertAvroType(schema.getValueType(), mapTypeInfo.getValueTypeInfo(), entry.getValue()));
-				}
-				return convertedMap;
-			case UNION:
-				final List<Schema> types = schema.getTypes();
-				final int size = types.size();
-				final Schema actualSchema;
-				if (size == 2 && types.get(0).getType() == Schema.Type.NULL) {
-					return convertAvroType(types.get(1), info, object);
-				} else if (size == 2 && types.get(1).getType() == Schema.Type.NULL) {
-					return convertAvroType(types.get(0), info, object);
-				} else if (size == 1) {
-					return convertAvroType(types.get(0), info, object);
-				} else {
-					// generic type
-					return object;
-				}
-			case FIXED:
-				final byte[] fixedBytes = ((GenericFixed) object).bytes();
-				if (info == Types.BIG_DEC) {
-					return convertToDecimal(schema, fixedBytes);
-				}
-				return fixedBytes;
-			case BYTES:
-				final ByteBuffer byteBuffer = (ByteBuffer) object;
-				final byte[] bytes = new byte[byteBuffer.remaining()];
-				byteBuffer.get(bytes);
-				if (info == Types.BIG_DEC) {
-					return convertToDecimal(schema, bytes);
-				}
-				return bytes;
-			case INT:
-				if (info == Types.SQL_DATE) {
-					return convertToDate(object);
-				} else if (info == Types.SQL_TIME) {
-					return convertToTime(object);
-				}
-				return object;
-			case LONG:
-				if (info == Types.SQL_TIMESTAMP) {
-					return convertToTimestamp(object);
-				}
-				return object;
-			case FLOAT:
-			case DOUBLE:
-			case BOOLEAN:
-				return object;
-		}
-		throw new RuntimeException("Unsupported Avro type:" + schema);
-	}
-
-	private BigDecimal convertToDecimal(Schema schema, byte[] bytes) {
-		final LogicalTypes.Decimal decimalType = (LogicalTypes.Decimal) schema.getLogicalType();
-		return new BigDecimal(new BigInteger(bytes), decimalType.getScale());
-	}
-
-	private Date convertToDate(Object object) {
-		final long millis;
-		if (object instanceof Integer) {
-			final Integer value = (Integer) object;
-			// adopted from Apache Calcite
-			final long t = (long) value * 86400000L;
-			millis = t - (long) LOCAL_TZ.getOffset(t);
-		} else {
-			// use 'provided' Joda time
-			final LocalDate value = (LocalDate) object;
-			millis = value.toDate().getTime();
-		}
-		return new Date(millis);
-	}
-
-	private Time convertToTime(Object object) {
-		final long millis;
-		if (object instanceof Integer) {
-			millis = (Integer) object;
-		} else {
-			// use 'provided' Joda time
-			final LocalTime value = (LocalTime) object;
-			millis = (long) value.get(DateTimeFieldType.millisOfDay());
-		}
-		return new Time(millis - LOCAL_TZ.getOffset(millis));
-	}
-
-	private Timestamp convertToTimestamp(Object object) {
-		final long millis;
-		if (object instanceof Long) {
-			millis = (Long) object;
-		} else {
-			// use 'provided' Joda time
-			final DateTime value = (DateTime) object;
-			millis = value.toDate().getTime();
-		}
-		return new Timestamp(millis - LOCAL_TZ.getOffset(millis));
-	}
-
-	private Object[] convertToObjectArray(Schema elementSchema, TypeInformation<?> elementInfo, Object object) {
-		final List<?> list = (List<?>) object;
-		final Object[] convertedArray = (Object[]) Array.newInstance(
-			elementInfo.getTypeClass(),
-			list.size());
-		for (int i = 0; i < list.size(); i++) {
-			convertedArray[i] = convertAvroType(elementSchema, elementInfo, list.get(i));
-		}
-		return convertedArray;
 	}
 
 	private void writeObject(ObjectOutputStream outputStream) throws IOException {

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/AvroDeserializationUtils.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/AvroDeserializationUtils.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.utils;
+
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.MapTypeInfo;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.types.Row;
+
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * Avro deserialization utilities.
+ */
+public class AvroDeserializationUtils {
+	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
+	public static Row convertAvroRecordToRow(Schema schema, RowTypeInfo typeInfo, IndexedRecord record) {
+		final List<Schema.Field> fields = schema.getFields();
+		final TypeInformation<?>[] fieldInfo = typeInfo.getFieldTypes();
+		final int length = fields.size();
+		final Row row = new Row(length);
+		for (int i = 0; i < length; i++) {
+			final Schema.Field field = fields.get(i);
+			row.setField(i, convertAvroType(field.schema(), fieldInfo[i], record.get(i)));
+		}
+		return row;
+	}
+
+	public static Object convertAvroType(Schema schema, TypeInformation<?> info, Object object) {
+		// we perform the conversion based on schema information but enriched with pre-computed
+		// type information where useful (i.e., for arrays)
+
+		if (object == null) {
+			return null;
+		}
+		switch (schema.getType()) {
+			case RECORD:
+				if (object instanceof IndexedRecord) {
+					return convertAvroRecordToRow(schema, (RowTypeInfo) info, (IndexedRecord) object);
+				}
+				throw new IllegalStateException("IndexedRecord expected but was: " + object.getClass());
+			case ENUM:
+			case STRING:
+				return object.toString();
+			case ARRAY:
+				if (info instanceof BasicArrayTypeInfo) {
+					final TypeInformation<?> elementInfo = ((BasicArrayTypeInfo<?, ?>) info).getComponentInfo();
+					return convertToObjectArray(schema.getElementType(), elementInfo, object);
+				} else {
+					final TypeInformation<?> elementInfo = ((ObjectArrayTypeInfo<?, ?>) info).getComponentInfo();
+					return convertToObjectArray(schema.getElementType(), elementInfo, object);
+				}
+			case MAP:
+				final MapTypeInfo<?, ?> mapTypeInfo = (MapTypeInfo<?, ?>) info;
+				final Map<String, Object> convertedMap = new HashMap<>();
+				final Map<?, ?> map = (Map<?, ?>) object;
+				for (Map.Entry<?, ?> entry : map.entrySet()) {
+					convertedMap.put(
+						entry.getKey().toString(),
+						convertAvroType(schema.getValueType(), mapTypeInfo.getValueTypeInfo(), entry.getValue()));
+				}
+				return convertedMap;
+			case UNION:
+				final List<Schema> types = schema.getTypes();
+				final int size = types.size();
+				final Schema actualSchema;
+				if (size == 2 && types.get(0).getType() == Schema.Type.NULL) {
+					return convertAvroType(types.get(1), info, object);
+				} else if (size == 2 && types.get(1).getType() == Schema.Type.NULL) {
+					return convertAvroType(types.get(0), info, object);
+				} else if (size == 1) {
+					return convertAvroType(types.get(0), info, object);
+				} else {
+					// generic type
+					return object;
+				}
+			case FIXED:
+				final byte[] fixedBytes = ((GenericFixed) object).bytes();
+				if (info.equals(Types.BIG_DEC)) {
+					return convertToDecimal(schema, fixedBytes);
+				}
+				return fixedBytes;
+			case BYTES:
+				final ByteBuffer byteBuffer = (ByteBuffer) object;
+				final byte[] bytes = new byte[byteBuffer.remaining()];
+				byteBuffer.get(bytes);
+				if (info.equals(Types.BIG_DEC)) {
+					return convertToDecimal(schema, bytes);
+				}
+				return bytes;
+			case INT:
+				if (info.equals(Types.SQL_DATE)) {
+					return convertToDate(object);
+				} else if (info.equals(Types.SQL_TIME)) {
+					return convertToTime(object);
+				}
+				return object;
+			case LONG:
+				if (info.equals(Types.SQL_TIMESTAMP)) {
+					return convertToTimestamp(object);
+				}
+				return object;
+			case FLOAT:
+			case DOUBLE:
+			case BOOLEAN:
+				return object;
+		}
+		throw new RuntimeException("Unsupported Avro type:" + schema);
+	}
+
+	private static BigDecimal convertToDecimal(Schema schema, byte[] bytes) {
+		final LogicalTypes.Decimal decimalType = (LogicalTypes.Decimal) schema.getLogicalType();
+		return new BigDecimal(new BigInteger(bytes), decimalType.getScale());
+	}
+
+	private static Date convertToDate(Object object) {
+		final long millis;
+		if (object instanceof Integer) {
+			final Integer value = (Integer) object;
+			// adopted from Apache Calcite
+			final long t = (long) value * 86400000L;
+			millis = t - (long) LOCAL_TZ.getOffset(t);
+		} else {
+			// use 'provided' Joda time
+			final LocalDate value = (LocalDate) object;
+			millis = value.toDate().getTime();
+		}
+		return new Date(millis);
+	}
+
+	private static Time convertToTime(Object object) {
+		final long millis;
+		if (object instanceof Integer) {
+			millis = (Integer) object;
+		} else {
+			// use 'provided' Joda time
+			final LocalTime value = (LocalTime) object;
+			millis = (long) value.get(DateTimeFieldType.millisOfDay());
+		}
+		return new Time(millis - LOCAL_TZ.getOffset(millis));
+	}
+
+	private static Timestamp convertToTimestamp(Object object) {
+		final long millis;
+		if (object instanceof Long) {
+			millis = (Long) object;
+		} else {
+			// use 'provided' Joda time
+			final DateTime value = (DateTime) object;
+			millis = value.toDate().getTime();
+		}
+		return new Timestamp(millis - LOCAL_TZ.getOffset(millis));
+	}
+
+	private static Object[] convertToObjectArray(Schema elementSchema, TypeInformation<?> elementInfo, Object object) {
+		final List<?> list = (List<?>) object;
+		final Object[] convertedArray = (Object[]) Array.newInstance(
+			elementInfo.getTypeClass(),
+			list.size());
+		for (int i = 0; i < list.size(); i++) {
+			convertedArray[i] = convertAvroType(elementSchema, elementInfo, list.get(i));
+		}
+		return convertedArray;
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroDeserializationUtilsTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroDeserializationUtilsTest.java
@@ -1,0 +1,33 @@
+package org.apache.flink.formats.avro.utils;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.types.Row;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificRecord;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for AvroDeserializationUtils.
+ */
+public class AvroDeserializationUtilsTest {
+
+	@Test
+	public void testConvertAvroRecordToRow() {
+		final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData = AvroTestUtils.getSpecificTestData();
+		Class<? extends SpecificRecord> recordClass = testData.f0;
+		SpecificRecord record = testData.f1;
+		Row recordRow = testData.f2;
+		Schema schema = testData.f1.getSchema();
+
+		TypeInformation<Row> rowTypeInfo = AvroSchemaConverter.convertToTypeInfo(recordClass);
+		Row actual = AvroDeserializationUtils.convertAvroRecordToRow(schema, (RowTypeInfo) rowTypeInfo, record);
+
+		assertEquals(recordRow, actual);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, the following avro deserializators are available:

- Core avro binary layout for both Specific/Generic and Row
- Confluent Specific/Generic record layout

The intention of this task is to fill the gap and provide Confluent avro deser for Row type.
This will allow to harness Table API to pipelines that work with avro and Confluent schema registry.

## Brief change log

  - Add ConfluentRegistryAvroRowDeserializationSchema
  - Extract utilities from AvroRowDeserializationSchema
  - Use the same approach as for AvroRowDeserializationSchema, extending AbstractDeserializationSchema instead of AvroDeserializationSchema cause' the latter works with Generic/SpecificRecord abstractions from avro libs 


## Verifying this change

This change added tests and can be verified running JUnit tests for `flink-avro` and `flink-avro-confluent-registry` modules.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes (deserializers, if this matters)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
