### PR TITLE
[FLINK-11534] [container] Allow ExecutionMode configuration

### DIFF
--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
@@ -92,8 +93,7 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 		}
 
 		Configuration configuration = loadConfiguration(clusterConfiguration);
-
-		configuration.setString(ClusterEntrypoint.EXECUTION_MODE, ExecutionMode.DETACHED.toString());
+		setDefaultExecutionModeIfNotConfigured(configuration);
 
 		StandaloneJobClusterEntryPoint entrypoint = new StandaloneJobClusterEntryPoint(
 			configuration,
@@ -103,5 +103,17 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 			clusterConfiguration.getJobClassName());
 
 		ClusterEntrypoint.runClusterEntrypoint(entrypoint);
+	}
+
+	@VisibleForTesting
+	static void setDefaultExecutionModeIfNotConfigured(Configuration configuration) {
+		if (isNoExecutionModeConfigured(configuration)) {
+			// In contrast to other places, the default for standalone job clusters is ExecutionMode.DETACHED
+			configuration.setString(ClusterEntrypoint.EXECUTION_MODE, ExecutionMode.DETACHED.toString());
+		}
+	}
+
+	private static boolean isNoExecutionModeConfigured(Configuration configuration) {
+		return configuration.getString(ClusterEntrypoint.EXECUTION_MODE, null) == null;
 	}
 }

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPointTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPointTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypoint.ExecutionMode;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for the {@link StandaloneJobClusterEntryPoint}.
+ */
+public class StandaloneJobClusterEntryPointTest extends TestLogger {
+
+	/**
+	 * Tests that the default {@link ExecutionMode} is {@link ExecutionMode#DETACHED}.
+	 */
+	@Test
+	public void testDefaultExecutionModeIsDetached() {
+		Configuration configuration = new Configuration();
+
+		StandaloneJobClusterEntryPoint.setDefaultExecutionModeIfNotConfigured(configuration);
+
+		assertThat(getExecutionMode(configuration), equalTo(ExecutionMode.DETACHED));
+	}
+
+	/**
+	 * Tests that {@link ExecutionMode} is not overwritten if provided.
+	 */
+	@Test
+	public void testDontOverwriteExecutionMode() {
+		Configuration configuration = new Configuration();
+		setExecutionMode(configuration, ExecutionMode.NORMAL);
+
+		StandaloneJobClusterEntryPoint.setDefaultExecutionModeIfNotConfigured(configuration);
+
+		// Don't overwrite provided configuration
+		assertThat(getExecutionMode(configuration), equalTo(ExecutionMode.NORMAL));
+	}
+
+	private static void setExecutionMode(Configuration configuration, ExecutionMode executionMode) {
+		configuration.setString(ClusterEntrypoint.EXECUTION_MODE, executionMode.toString());
+	}
+
+	private static ExecutionMode getExecutionMode(Configuration configuration) {
+		return ExecutionMode.valueOf(configuration.getString(ClusterEntrypoint.EXECUTION_MODE));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

* Allow users to configure `ExecutionMode` when running `StandaloneJobClusterEntryPoint` (before this change, we always set it to `ExecutionMode#DETACHED`)
* Users can use option to configure `ExecutionMode#NORMAL` which keeps the Dispatcher alive until the final execution result is fetched

## Brief change log

* Check whether the configuration includes an entry for ExecutionMode before setting the default `ExecutionMode#DETACHED`

## Verifying this change

* Adds a test for the static helper
* Tested this end to end and verified that the process only exists after I fetch the final execution result

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
