### PR TITLE
[FLINK-12214]. Add JobListener to capture job submission process

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -116,6 +116,9 @@ public class LocalExecutor extends PlanExecutor {
 
 				// start it up
 				jobExecutorService = createJobExecutorService(jobExecutorServiceConfiguration);
+				if (jobExecutorService instanceof MiniCluster) {
+					((MiniCluster) jobExecutorService).setJobListeners(this.jobListeners);
+				}
 			} else {
 				throw new IllegalStateException("The local executor was already started.");
 			}

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -150,6 +150,7 @@ public class RemoteExecutor extends PlanExecutor {
 			if (client == null) {
 				client = new RestClusterClient<>(clientConfiguration, "RemoteExecutor");
 				client.setPrintStatusDuringExecution(isPrintingStatusDuringExecution());
+				client.setJobListeners(this.jobListeners);
 			}
 			else {
 				throw new IllegalStateException("The remote executor was already started.");

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobListener;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.configuration.Configuration;
@@ -99,6 +100,8 @@ public abstract class ClusterClient<T> {
 	/** Switch for blocking/detached job submission of the client. */
 	private boolean detachedJobSubmission = false;
 
+	protected List<JobListener> jobListeners;
+
 	// ------------------------------------------------------------------------
 	//                            Construction
 	// ------------------------------------------------------------------------
@@ -171,6 +174,10 @@ public abstract class ClusterClient<T> {
 	 */
 	public void setPrintStatusDuringExecution(boolean print) {
 		this.printStatusDuringExecution = print;
+	}
+
+	public void setJobListeners(List<JobListener> jobListeners) {
+		this.jobListeners = jobListeners;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/JobListener.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobListener.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common;
+
+/**
+ * Hooks for job submission and execution which is invoked in client side.
+ */
+public interface JobListener {
+
+	/**
+	 * Inovoked when job is submitted to cluster successfully.
+	 *
+	 * @param jobId
+	 */
+	void onJobSubmitted(JobID jobId);
+
+	/**
+	 * Invoked when job is completed.
+	 *
+	 * @param jobResult
+	 */
+	void onJobExecuted(JobExecutionResult jobResult);
+
+	/**
+	 * Invoked when job is canceled.
+	 *
+	 * @param jobId
+	 * @param savepointPath
+	 */
+	void onJobCanceled(JobID jobId, String savepointPath);
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -51,6 +51,12 @@ public abstract class PlanExecutor {
 	/** If true, all execution progress updates are not only logged, but also printed to System.out */
 	private boolean printUpdatesToSysout = true;
 
+	protected List<JobListener> jobListeners;
+
+	public void setJobListeners(List<JobListener> jobListeners) {
+		this.jobListeners = jobListeners;
+	}
+
 	/**
 	 * Sets whether the executor should print progress results to "standard out" ({@link System#out}).
 	 * All progress messages are logged using the configured logging framework independent of the value

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobListener;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.io.FileInputFormat;
@@ -128,6 +129,8 @@ public abstract class ExecutionEnvironment {
 	/** Flag to indicate whether sinks have been cleared in previous executions. */
 	private boolean wasExecuted = false;
 
+	private List<JobListener> jobListeners = new ArrayList<>();
+
 	/**
 	 * Creates a new Execution Environment.
 	 */
@@ -146,6 +149,14 @@ public abstract class ExecutionEnvironment {
 	 */
 	public ExecutionConfig getConfig() {
 		return config;
+	}
+
+	public void addJobListener(JobListener jobListener) {
+		this.jobListeners.add(jobListener);
+	}
+
+	public List<JobListener> getJobListeners() {
+		return this.jobListeners;
 	}
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -121,6 +121,7 @@ public class LocalEnvironment extends ExecutionEnvironment {
 
 		// create a new local executor
 		executor = PlanExecutor.createLocalExecutor(configuration);
+		executor.setJobListeners(this.getJobListeners());
 		executor.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());
 
 		// if we have a session, start the mini cluster eagerly to have it available across sessions

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -209,6 +209,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 			executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration,
 				jarFiles, globalClasspaths);
 			executor.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());
+			executor.setJobListeners(this.getJobListeners());
 		}
 
 		// if we are using sessions, we keep the executor running

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
@@ -77,6 +77,7 @@ public class ScalaShellRemoteEnvironment extends RemoteEnvironment {
 		);
 
 		executor.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());
+		executor.setJobListeners(getJobListeners());
 
 		return executor;
 	}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -18,12 +18,12 @@
 package org.apache.flink.api.scala
 
 import com.esotericsoftware.kryo.Serializer
-import org.apache.flink.annotation.{PublicEvolving, Public}
+import org.apache.flink.annotation.{Public, PublicEvolving}
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult, JobID}
+import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult, JobID, JobListener}
 import org.apache.flink.api.java.io._
 import org.apache.flink.api.java.operators.DataSource
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -86,6 +86,12 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * value can be overridden by individual operations using [[DataSet.setParallelism]]
    */
   def getParallelism = javaEnv.getParallelism
+
+  def getJobListeners : java.util.List[JobListener] = javaEnv.getJobListeners
+
+  def addJobListener(jobListener: JobListener) ={
+    javaEnv.addJobListener(jobListener)
+  }
 
   /**
     * Sets the restart strategy configuration. The configuration specifies which restart strategy

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -115,7 +115,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 		}
 
 		MiniCluster miniCluster = new MiniCluster(cfg);
-
+		miniCluster.setJobListeners(jobListeners);
 		try {
 			miniCluster.start();
 			configuration.setInteger(RestOptions.PORT, miniCluster.getRestAddress().get().getPort());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobListener;
 import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.StoppableFunction;
@@ -144,6 +145,7 @@ public abstract class StreamExecutionEnvironment {
 
 	protected final List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile = new ArrayList<>();
 
+	protected List<JobListener> jobListeners = new ArrayList<>();
 
 	// --------------------------------------------------------------------------------------------
 	// Constructor and Properties
@@ -162,6 +164,15 @@ public abstract class StreamExecutionEnvironment {
 	public List<Tuple2<String, DistributedCache.DistributedCacheEntry>> getCachedFiles() {
 		return cacheFile;
 	}
+
+	public void addJobListener(JobListener jobListener) {
+		this.jobListeners.add(jobListener);
+	}
+
+	public List<JobListener> getJobListeners() {
+		return this.jobListeners;
+	}
+
 
 	/**
 	 * Sets the parallelism for operations executed through this environment.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.scala
 
 import com.esotericsoftware.kryo.Serializer
 import org.apache.flink.annotation.{Internal, Public, PublicEvolving}
+import org.apache.flink.api.common.JobListener
 import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -55,6 +56,12 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     * Gets cache files.
     */
   def getCachedFiles = javaEnv.getCachedFiles
+
+  def getJobListeners: java.util.List[JobListener] = javaEnv.getJobListeners
+
+  def addJobListener(jobListener: JobListener) = {
+    javaEnv.addJobListener(jobListener)
+  }
 
   /**
    * Sets the parallelism for operations executed through this environment.


### PR DESCRIPTION
## What is the purpose of the change

This PR is to add JobListener to capture job submission process, so that third party libraries can add hooks in the process of job submission.

## Brief change log
I add api in `ExecutionEnviroment`/`StreamExecutionEnviroment` to allow user add customized JobListener, and these JobListeners will be passed to `ClusterClient` which do the actual job execution. 

## Verifying this change

Unit test is added. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, JobListener is PublicEvolving api )
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
