### PR TITLE
[FLINK-12217][table] OperationTreeBuilder.map() should perform ExpressionResolver.resolve()

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
@@ -348,12 +348,15 @@ class OperationTreeBuilder(private val tableEnv: TableEnvironment) {
 
   def map(mapFunction: Expression, child: TableOperation): TableOperation = {
 
-    if (!isScalarFunction(mapFunction)) {
+    val resolver = resolverFor(tableCatalog, functionCatalog, child).build()
+    val resolvedMapFunction = resolveSingleExpression(mapFunction, resolver)
+
+    if (!isScalarFunction(resolvedMapFunction)) {
       throw new ValidationException("Only ScalarFunction can be used in the map operator.")
     }
 
     val expandedFields = new CallExpression(BuiltInFunctionDefinitions.FLATTEN,
-      List(mapFunction).asJava)
+      List(resolvedMapFunction).asJava)
     project(Collections.singletonList(expandedFields), child)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CalcStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CalcStringExpressionTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.api.stream.table.stringexpr
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.Literal
+import org.apache.flink.table.expressions.utils.Func23
 import org.apache.flink.table.utils.TableTestBase
 import org.junit.Test
 
@@ -164,6 +165,18 @@ class CalcStringExpressionTest extends TableTestBase {
 
     val t1 = t.dropColumns('a, 'c)
     val t2 = t.dropColumns("a,c")
+
+    verifyTableEquals(t1, t2)
+  }
+
+  @Test
+  def testMap(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    util.tableEnv.registerFunction("func", Func23)
+
+    val t1 = t.map("func(a, b, c)")
+    val t2 = t.map(Func23('a, 'b, 'c))
 
     verifyTableEquals(t1, t2)
   }


### PR DESCRIPTION

## What is the purpose of the change

This pull request fixes the problem for OperationTreeBuilder.map(). In OperationTreeBuilder.map(), we should resolve all LookupCallExpression for the case of java, otherwise, exceptions will be thrown.

## Brief change log

  - Add resolver logic for OperationTreeBuilder.map().
  - Add test.


## Verifying this change

This change added tests and can be verified as follows:

  - Added tests to cover the case of java in CalcStringExpressionTest.testMap().
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
