### PR TITLE
[hotfix] load globalConfiguration from configurationDir

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -821,7 +821,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	public static void main(final String[] args) {
 		final String configurationDirectory = CliFrontend.getConfigurationDirectoryFromEnv();
 
-		final Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration();
+		final Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration(configurationDirectory);
 
 		int retCode;
 


### PR DESCRIPTION
## What is the purpose of the change
the configuration and the configDir may dismatch

## Brief change log
 load globalConfiguration from configurationDir

## Verifying this change
maked the code consistent with CliFrontend and LocalExecutor, without any test coverage

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
The S3 file system connector: (no)

## Documentation
Does this pull request introduce a new feature? (no)