### PR TITLE
[FLINK-12216][Runtime]Respect the number of bytes from input parameters in HybridMemorySegment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -333,8 +333,8 @@ public final class HybridMemorySegment extends MemorySegment {
 			target.position(targetOffset + numBytes);
 		}
 		else {
-			// neither heap buffer nor direct buffer
-			while (target.hasRemaining()) {
+			// other types of byte buffers
+			for (int i = 0; i < numBytes; i++) {
 				target.put(get(offset++));
 			}
 		}
@@ -379,8 +379,8 @@ public final class HybridMemorySegment extends MemorySegment {
 			source.position(sourceOffset + numBytes);
 		}
 		else {
-			// neither heap buffer nor direct buffer
-			while (source.hasRemaining()) {
+			// other types of byte buffers
+			for (int i = 0; i < numBytes; i++) {
 				put(offset++, source.get());
 			}
 		}

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -334,9 +334,7 @@ public final class HybridMemorySegment extends MemorySegment {
 		}
 		else {
 			// other types of byte buffers
-			for (int i = 0; i < numBytes; i++) {
-				target.put(get(offset++));
-			}
+			throw new IllegalArgumentException("The target buffer is not direct, and has no array.");
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -47,6 +48,11 @@ public class HeapMemorySegmentTest extends MemorySegmentTestBase {
 	@Override
 	MemorySegment createSegment(int size, Object owner) {
 		return new HeapMemorySegment(new byte[size], owner);
+	}
+
+	@Test(expected = ReadOnlyBufferException.class)
+	public void testHeapByteBufferGetReadOnly() {
+		testByteBufferGetReadOnly(false);
 	}
 
 	@Test

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
@@ -77,4 +77,32 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 		assertEquals(3, buf2.position());
 		assertEquals(7, buf2.limit());
 	}
+
+	@Test
+	public void testReadOnlyByteBufferPut() {
+		final byte[] buffer = new byte[100];
+		HybridMemorySegment seg = new HybridMemorySegment(buffer);
+
+		String content = "hello world";
+		ByteBuffer bb = ByteBuffer.allocate(20);
+		bb.put(content.getBytes());
+		bb.rewind();
+
+		int offset = 10;
+		int numBytes = 5;
+		seg.put(offset, bb.asReadOnlyBuffer(), numBytes);
+
+		// verify the area before the written region.
+		for (int i = 0; i < offset; i++) {
+			assertEquals(0, buffer[i]);
+		}
+
+		// verify the region that is written.
+		assertEquals("hello", new String(buffer, offset, numBytes));
+
+		// verify the area after the written region.
+		for (int i = offset + numBytes; i < buffer.length; i++) {
+			assertEquals(0, buffer[i]);
+		}
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -94,7 +95,7 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 		ByteBuffer readOnlyBuf = bb.asReadOnlyBuffer();
 		assertFalse(readOnlyBuf.isDirect());
 		assertFalse(readOnlyBuf.hasArray());
-		
+
 		seg.put(offset, readOnlyBuf, numBytes);
 
 		// verify the area before the written region.
@@ -109,5 +110,22 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 		for (int i = offset + numBytes; i < buffer.length; i++) {
 			assertEquals(0, buffer[i]);
 		}
+	}
+
+	@Test(expected = ReadOnlyBufferException.class)
+	public void testReadOnlyByteBufferGet() {
+		final byte[] buffer = new byte[100];
+		HybridMemorySegment seg = new HybridMemorySegment(buffer);
+
+		// write some data to the segment.
+		String content = "hello world";
+		seg.put(0, content.getBytes());
+
+		ByteBuffer readOnlyBuf = ByteBuffer.allocate(20).asReadOnlyBuffer();
+		assertFalse(readOnlyBuf.isDirect());
+		assertFalse(readOnlyBuf.hasArray());
+
+		// get the data to a read-only byte buffer, and expect an exception
+		seg.get(0, readOnlyBuf, content.length());
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
@@ -90,7 +90,12 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 
 		int offset = 10;
 		int numBytes = 5;
-		seg.put(offset, bb.asReadOnlyBuffer(), numBytes);
+
+		ByteBuffer readOnlyBuf = bb.asReadOnlyBuffer();
+		assertFalse(readOnlyBuf.isDirect());
+		assertFalse(readOnlyBuf.hasArray());
+		
+		seg.put(offset, readOnlyBuf, numBytes);
 
 		// verify the area before the written region.
 		for (int i = 0; i < offset; i++) {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
@@ -23,7 +23,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
-import java.nio.ReadOnlyBufferException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -82,7 +81,7 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 	@Test
 	public void testReadOnlyByteBufferPut() {
 		final byte[] buffer = new byte[100];
-		HybridMemorySegment seg = new HybridMemorySegment(buffer);
+		HybridMemorySegment seg = new HybridMemorySegment(buffer, null);
 
 		String content = "hello world";
 		ByteBuffer bb = ByteBuffer.allocate(20);
@@ -110,22 +109,5 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 		for (int i = offset + numBytes; i < buffer.length; i++) {
 			assertEquals(0, buffer[i]);
 		}
-	}
-
-	@Test(expected = ReadOnlyBufferException.class)
-	public void testReadOnlyByteBufferGet() {
-		final byte[] buffer = new byte[100];
-		HybridMemorySegment seg = new HybridMemorySegment(buffer);
-
-		// write some data to the segment.
-		String content = "hello world";
-		seg.put(0, content.getBytes());
-
-		ByteBuffer readOnlyBuf = ByteBuffer.allocate(20).asReadOnlyBuffer();
-		assertFalse(readOnlyBuf.isDirect());
-		assertFalse(readOnlyBuf.hasArray());
-
-		// get the data to a read-only byte buffer, and expect an exception
-		seg.get(0, readOnlyBuf, content.length());
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
@@ -1955,7 +1955,7 @@ public abstract class MemorySegmentTestBase {
 		assertArrayEquals(bytes, result);
 	}
 
-	@Test(expected = ReadOnlyBufferException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testHeapByteBufferGetReadOnly() {
 		testByteBufferGetReadOnly(false);
 	}
@@ -1975,7 +1975,7 @@ public abstract class MemorySegmentTestBase {
 	 * @throws ReadOnlyBufferException
 	 * 		expected exception due to writing to a read-only buffer
 	 */
-	private void testByteBufferGetReadOnly(boolean directBuffer) throws ReadOnlyBufferException {
+	protected void testByteBufferGetReadOnly(boolean directBuffer) throws ReadOnlyBufferException {
 		MemorySegment seg = createSegment(pageSize);
 
 		ByteBuffer target = (directBuffer ?


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix some bugs in class HybridMemorySegment. In particular, when reading from or writing to a ByteBuffer, the number of bytes actually read/written should be specified by the input parameter numBytes. However, the current logic reads or writes data till the ByteBuffer is exhausted.


## Brief change log

  - Fix the bug in HybridMemorySegment.java
  - Add a UT in HybridOnHeapMemorySegmentTest.
  

## Verifying this change

This change added tests and can be verified as follows:

  - Test HybridMemorySegment.testReadOnlyByteBufferPut tests the case when the ByteBuffer is neither a DirectByteBuffer, nor a HeapByteBuffer. This test will fail without this patch.
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  