### PR TITLE
[FLINK-11915][core] Fix miscalculation of DataInputViewStream.skip

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/DataInputViewStream.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/DataInputViewStream.java
@@ -62,7 +62,7 @@ public class DataInputViewStream extends InputStream {
 
 			counter -= skippedBytes;
 		}
-		return n - counter - inputView.skipBytes((int) counter);
+		return n - counter + inputView.skipBytes((int) counter);
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/DataInputViewStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/DataInputViewStreamTest.java
@@ -36,12 +36,15 @@ public class DataInputViewStreamTest extends TestLogger {
 
 	@Test
 	public void testSkip() throws IOException {
-		try (TestDataInputView dataInputView = new TestDataInputView(new TestInputStream())) {
+		final TestInputStream inputStream = new TestInputStream();
+		try (TestDataInputView dataInputView = new TestDataInputView(inputStream)) {
 			try (DataInputViewStream dataInputViewStream = new DataInputViewStream(dataInputView)) {
 				assertEquals(1, dataInputViewStream.skip(1));
+				assertEquals(1, inputStream.skipped);
 
 				final long bigNumberToSkip = 1024L + 2L * Integer.MAX_VALUE;
 				assertEquals(bigNumberToSkip, dataInputViewStream.skip(bigNumberToSkip));
+				assertEquals(1 + bigNumberToSkip, inputStream.skipped);
 			}
 		}
 
@@ -66,6 +69,8 @@ public class DataInputViewStreamTest extends TestLogger {
 	 */
 	private static class TestInputStream extends InputStream {
 
+		long skipped = 0;
+
 		@Override
 		public int read() throws IOException {
 			return 0;
@@ -73,6 +78,7 @@ public class DataInputViewStreamTest extends TestLogger {
 
 		@Override
 		public long skip(long n) {
+			skipped += n;
 			return n;
 		}
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/DataInputViewStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/DataInputViewStreamTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test for {@link DataInputViewStream}.
+ */
+public class DataInputViewStreamTest extends TestLogger {
+
+	@Test
+	public void testSkip() throws IOException {
+		try (TestDataInputView dataInputView = new TestDataInputView(new TestInputStream())) {
+			try (DataInputViewStream dataInputViewStream = new DataInputViewStream(dataInputView)) {
+				assertEquals(1, dataInputViewStream.skip(1));
+
+				final long bigNumberToSkip = 1024L + 2L * Integer.MAX_VALUE;
+				assertEquals(bigNumberToSkip, dataInputViewStream.skip(bigNumberToSkip));
+			}
+		}
+
+	}
+
+	/**
+	 * Test implementation of {@link DataInputView}.
+	 */
+	private static class TestDataInputView extends DataInputStream implements DataInputView {
+
+		TestDataInputView(InputStream in) {
+			super(in);
+		}
+
+		@Override
+		public void skipBytesToRead(int numBytes) throws IOException {
+		}
+	}
+
+	/**
+	 * Test implementation of {@link InputStream}.
+	 */
+	private static class TestInputStream extends InputStream {
+
+		@Override
+		public int read() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public long skip(long n) {
+			return n;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

* Fix miscalculation of DataInputViewStream.skip. Currently it returns a wrong value.

## Brief change log

* Fix the wrong calculation.

## Verifying this change

This change added tests and can be verified as follows:

* Add a new unit test case for DataInputViewStream.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
