### PR TITLE
[FLINK-12065][e2e] Ignore reflection access warnings

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -352,7 +352,16 @@ function check_logs_for_exceptions {
 
 function check_logs_for_non_empty_out_files {
   echo "Checking for non-empty .out files..."
-  if grep -ri "." $FLINK_DIR/log/*.out > /dev/null; then
+  # exclude reflective access warnings as these are expected (and currently unavoidable) on Java 9
+  if grep -ri -v \
+    -e "WARNING: An illegal reflective access" \
+    -e "WARNING: Illegal reflective access"\
+    -e "WARNING: Please consider reporting"\
+    -e "WARNING: Use --illegal-access"\
+    -e "WARNING: All illegal access"\
+    $FLINK_DIR/log/*.out\
+   | grep "." \
+   > /dev/null; then
     echo "Found non-empty .out files:"
     cat $FLINK_DIR/log/*.out
     EXIT_CODE=1


### PR DESCRIPTION
## What is the purpose of the change

For several of our end-to-end tests we verify that the .out files are empty at the end of the test. When running them on Java 9 however they will print a warning about illegal reflective accesses. For the time being we cannot remove these accesses (this would require migrating from Unsafe), nor can we hide these warnings.

Thus we have to ignore these warnings when running the e2e tests, which this PR implements.

## Verifying this change

In this [build](https://travis-ci.org/zentol/flink/jobs/519154949) we can see that the e2e tests do not fail due to warnings. To ensure that we still fail due to other output one can take a distribution, write something into the .out files, and create a script that only calls the .out check function.
