### PR TITLE
[FLINK-12223][Runtime]HeapMemorySegment.getArray should return null a…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
@@ -95,7 +95,7 @@ public final class HeapMemorySegment extends MemorySegment {
 	 * @return The byte array that backs this memory segment, or null, if the segment has been freed.
 	 */
 	public byte[] getArray() {
-		return this.heapMemory;
+		return this.memory;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -271,7 +271,7 @@ public abstract class MemorySegment {
 
 	/**
 	 * Wraps the chunk of the underlying memory located between <tt>offset</tt> and
-	 * <tt>length</tt> in a NIO ByteBuffer.
+	 * <tt>offset + length</tt> in a NIO ByteBuffer.
 	 *
 	 * @param offset The offset in the memory segment.
 	 * @param length The number of bytes to be wrapped as a buffer.
@@ -1272,7 +1272,7 @@ public abstract class MemorySegment {
 
 	/**
 	 * Bulk copy method. Copies {@code numBytes} bytes to target unsafe object and pointer.
-	 * NOTE: This is a unsafe method, no check here, please be carefully.
+	 * NOTE: This is a unsafe method, no check here, please be careful.
 	 *
 	 * @param offset The position where the bytes are started to be read from in this memory segment.
 	 * @param target The unsafe memory to copy the bytes to.
@@ -1294,7 +1294,7 @@ public abstract class MemorySegment {
 
 	/**
 	 * Bulk copy method. Copies {@code numBytes} bytes from source unsafe object and pointer.
-	 * NOTE: This is a unsafe method, no check here, please be carefully.
+	 * NOTE: This is a unsafe method, no check here, please be careful.
 	 *
 	 * @param offset The position where the bytes are started to be write in this memory segment.
 	 * @param source The unsafe memory to copy the bytes from.

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
@@ -24,7 +24,10 @@ import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link HeapMemorySegment} in off-heap mode.

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
@@ -24,9 +24,7 @@ import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Tests for the {@link HeapMemorySegment} in off-heap mode.
@@ -66,5 +64,14 @@ public class HeapMemorySegmentTest extends MemorySegmentTestBase {
 		assertEquals(3, buf1.limit());
 		assertEquals(3, buf2.position());
 		assertEquals(7, buf2.limit());
+	}
+
+	@Test
+	public void testGetArrayAfterFree() {
+		final byte[] buffer = new byte[100];
+		HeapMemorySegment seg = new HeapMemorySegment(buffer);
+
+		seg.free();
+		assertNull(seg.getArray());
 	}
 }


### PR DESCRIPTION
…rs in HybridMemorySegment

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix a bug in class HeapMemorySegment. The getArray method should return null after the segment is freed. But it does not.


## Brief change log

  - Fix the bug in class HeapMemorySegment
  - Add a UT in HeapMemorySegmentTest.
  

## Verifying this change

This change added tests and can be verified as follows:

  - Test HeapMemorySegmentTest.testGetArrayAfterFree will fail without this fix, and it runs successfully with this patch.
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  