### PR TITLE
[FLINK-12230][runtime] Remove method JobMaster#getExecutionGraph()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1742,9 +1742,4 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	RestartStrategy getRestartStrategy() {
 		return restartStrategy;
 	}
-
-	@VisibleForTesting
-	ExecutionGraph getExecutionGraph() {
-		return executionGraph;
-	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*Remove method `JobMaster#getExecutionGraph()`. This is needed because the `JobMaster` will not have access to the `ExecutionGraph` in future*


## Brief change log

  - *Remove method `JobMaster#getExecutionGraph()`*

## Verifying this change

This change is already covered by existing tests, such as *JobMasterTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
