### PR TITLE
[FLINK-8801][yarn/s3] Fix jars downloading issues due to inconsistent timestamp in S3 Filesystem

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -51,8 +51,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -83,8 +83,8 @@ public final class Utils {
 	/** Yarn site xml file name populated in YARN container for secure IT run. */
 	public static final String YARN_SITE_FILE_NAME = "yarn-site.xml";
 
-   /** Number of total retries to fetch the remote resources after uploaded in case of FileNotFoundException. */
-   public static final int REMOTE_RESOURCES_FETCH_NUM_RETRY = 3;
+	/** Number of total retries to fetch the remote resources after uploaded in case of FileNotFoundException. */
+	public static final int REMOTE_RESOURCES_FETCH_NUM_RETRY = 3;
 
 	/** Time to wait in milliseconds between each remote resources fetch in case of FileNotFoundException. */
 	public static final int REMOTE_RESOURCES_FETCH_WAIT_IN_MILLI = 100;
@@ -226,6 +226,7 @@ public final class Utils {
 			LOG.debug("No yarn application files directory set. Therefore, cannot clean up the data.");
 		}
 	}
+
 	/**
 	 * Creates a YARN resource for the remote object at the given location.
 	 *

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -56,7 +56,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -176,7 +175,7 @@ public final class Utils {
 
 		FileStatus[] fss = null;
 		int iter = 1;
-		while (iter <= REMOTE_RESOURCES_FETCH_NUM_RETRY) {
+		while (iter <= REMOTE_RESOURCES_FETCH_NUM_RETRY + 1) {
 			try {
 				fss = fs.listStatus(dst);
 				break;
@@ -196,7 +195,7 @@ public final class Utils {
 		if (fss != null && fss.length >  0) {
 			dstModificationTime = fss[0].getModificationTime();
 		}
-		LOG.debug("Got modification time {} from remote path {} at time {}", dstModificationTime, dst, Instant.now().toEpochMilli());
+		LOG.debug("Got modification time {} from remote path {}", dstModificationTime, dst);
 
 		// now create the resource instance
 		LocalResource resource = registerLocalResource(dst, localFile.length(), dstModificationTime > 0 ? dstModificationTime

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -236,9 +236,9 @@ public final class Utils {
 	 * @return YARN resource
 	 */
 	private static LocalResource registerLocalResource(
-		Path remoteRsrcPath,
-		long resourceSize,
-		long resourceModificationTime) {
+			Path remoteRsrcPath,
+			long resourceSize,
+			long resourceModificationTime) {
 		LocalResource localResource = Records.newRecord(LocalResource.class);
 		localResource.setResource(ConverterUtils.getYarnUrlFromURI(remoteRsrcPath.toUri()));
 		localResource.setSize(resourceSize);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -191,15 +191,18 @@ public final class Utils {
 				iter++;
 			}
 		}
-		long dstModificationTime = -1;
+
+		final long dstModificationTime;
 		if (fss != null && fss.length >  0) {
 			dstModificationTime = fss[0].getModificationTime();
+			LOG.debug("Got modification time {} from remote path {}", dstModificationTime, dst);
+		} else {
+			dstModificationTime = localFile.lastModified();
+			LOG.debug("Failed to fetch remote modification time from {}, using local timestamp {}", dst, dstModificationTime);
 		}
-		LOG.debug("Got modification time {} from remote path {}", dstModificationTime, dst);
 
 		// now create the resource instance
-		LocalResource resource = registerLocalResource(dst, localFile.length(), dstModificationTime > 0 ? dstModificationTime
-			: localFile.lastModified());
+		LocalResource resource = registerLocalResource(dst, localFile.length(), dstModificationTime);
 		return Tuple2.of(dst, resource);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This change reverts the original fix for FLINK-8801's due to its insufficient in some scenarios where S3AFilesystem does not implement `setTimes` methods.
Instead, it uses retry to wait for the remote file to be available and overwrite the local file timestamp. 

## Brief change log

  - Revert [PR 5602](https://github.com/apache/flink/pull/5602)
  - Add retry at `FileNotFoundException`

## Verifying this change

This change is already covered by existing tests, such as `YarnFileStageTestS3ITCase` for the upload path via S3.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **Yarn**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
