### PR TITLE
[hotfix][tests] Replace deprecated option key with its successor

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -503,8 +503,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-yjm", "768m",
 				// test if the cutoff is passed correctly (only useful when larger than the value
 				// of containerized.heap-cutoff-min (default: 600MB)
-				"-yD", "containerized.heap-cutoff-ratio=0.7",
-				"-yD", "yarn.tags=test-tag",
+				"-yD", ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key() + "=0.7",
+				"-yD", YarnConfigOptions.APPLICATION_TAGS.key() + "=test-tag",
 				"-ytm", "1024m",
 				"-ys", "2", // test requesting slots from YARN.
 				"-p", "2",

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -503,7 +503,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-yjm", "768m",
 				// test if the cutoff is passed correctly (only useful when larger than the value
 				// of containerized.heap-cutoff-min (default: 600MB)
-				"-yD", "yarn.heap-cutoff-ratio=0.7",
+				"-yD", "containerized.heap-cutoff-ratio=0.7",
 				"-yD", "yarn.tags=test-tag",
 				"-ytm", "1024m",
 				"-ys", "2", // test requesting slots from YARN.


### PR DESCRIPTION
## What is the purpose of the change

"yarn.heap-cutoff-ratio" is deprecated and is superseded by "containerized.heap-cutoff-ratio". Let's remove the usage of deprecated key even in tests.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol  