### PR TITLE
[FLINK-10441]Don't log warning when creating upload directory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
@@ -104,7 +104,7 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
 						currentHttpRequest = ReferenceCountUtil.retain(httpRequest);
 
 						// make sure that we still have a upload dir in case that it got deleted in the meanwhile
-						RestServerEndpoint.createUploadDir(uploadDir, LOG);
+						RestServerEndpoint.createUploadDir(uploadDir, LOG, false);
 
 						currentUploadDir = Files.createDirectory(uploadDir.resolve(UUID.randomUUID().toString()));
 					} else {
@@ -116,7 +116,7 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
 			} else if (msg instanceof HttpContent && currentHttpPostRequestDecoder != null) {
 				LOG.trace("Received http content.");
 				// make sure that we still have a upload dir in case that it got deleted in the meanwhile
-				RestServerEndpoint.createUploadDir(uploadDir, LOG);
+				RestServerEndpoint.createUploadDir(uploadDir, LOG, false);
 
 				final HttpContent httpContent = (HttpContent) msg;
 				currentHttpPostRequestDecoder.offer(httpContent);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -107,7 +107,7 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 		this.sslHandlerFactory = configuration.getSslHandlerFactory();
 
 		this.uploadDir = configuration.getUploadDir();
-		createUploadDir(uploadDir, log);
+		createUploadDir(uploadDir, log, true);
 
 		this.maxContentLength = configuration.getMaxContentLength();
 		this.responseHeaders = configuration.getResponseHeaders();
@@ -446,12 +446,20 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 
 	/**
 	 * Creates the upload dir if needed.
+	 * @param uploadDir directory to check
+	 * @param log logger used for logging output
+	 * @param initial indicates whether is initial startup
+	 * @throws IOException
 	 */
 	@VisibleForTesting
-	static void createUploadDir(final Path uploadDir, final Logger log) throws IOException {
+	static void createUploadDir(final Path uploadDir, final Logger log, boolean initial) throws IOException {
 		if (!Files.exists(uploadDir)) {
-			log.info("Upload directory {} does not exist, or has been deleted externally. " +
-				"Previously uploaded files are no longer available.", uploadDir);
+			if (initial) {
+				log.info("Upload directory {} does not exist. " + uploadDir);
+			} else {
+				log.warn("Upload directory {} has been deleted externally. " +
+					"Previously uploaded files are no longer available.", uploadDir);
+			}
 			checkAndCreateUploadDir(uploadDir, log);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -450,7 +450,7 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 	@VisibleForTesting
 	static void createUploadDir(final Path uploadDir, final Logger log) throws IOException {
 		if (!Files.exists(uploadDir)) {
-			log.warn("Upload directory {} does not exist, or has been deleted externally. " +
+			log.info("Upload directory {} does not exist, or has been deleted externally. " +
 				"Previously uploaded files are no longer available.", uploadDir);
 			checkAndCreateUploadDir(uploadDir, log);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -446,15 +446,11 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 
 	/**
 	 * Creates the upload dir if needed.
-	 * @param uploadDir directory to check
-	 * @param log logger used for logging output
-	 * @param initial indicates whether is initial startup
-	 * @throws IOException
 	 */
 	@VisibleForTesting
-	static void createUploadDir(final Path uploadDir, final Logger log, boolean initial) throws IOException {
+	static void createUploadDir(final Path uploadDir, final Logger log, final boolean initialCreation) throws IOException {
 		if (!Files.exists(uploadDir)) {
-			if (initial) {
+			if (initialCreation) {
 				log.info("Upload directory {} does not exist. " + uploadDir);
 			} else {
 				log.warn("Upload directory {} has been deleted externally. " +

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
@@ -80,7 +80,7 @@ public class RestServerEndpointTest extends TestLogger {
 		final File file = temporaryFolder.newFolder();
 		final Path testUploadDir = file.toPath().resolve("testUploadDir");
 		assertFalse(Files.exists(testUploadDir));
-		RestServerEndpoint.createUploadDir(testUploadDir, NOPLogger.NOP_LOGGER);
+		RestServerEndpoint.createUploadDir(testUploadDir, NOPLogger.NOP_LOGGER, true);
 		assertTrue(Files.exists(testUploadDir));
 	}
 
@@ -92,7 +92,7 @@ public class RestServerEndpointTest extends TestLogger {
 		final Path testUploadDir = file.toPath().resolve("testUploadDir");
 		assertFalse(Files.exists(testUploadDir));
 		try {
-			RestServerEndpoint.createUploadDir(testUploadDir, NOPLogger.NOP_LOGGER);
+			RestServerEndpoint.createUploadDir(testUploadDir, NOPLogger.NOP_LOGGER, true);
 			fail("Expected exception not thrown.");
 		} catch (IOException e) {
 		}


### PR DESCRIPTION

## What is the purpose of the change

*This PR is related to [FLINK-10441](https://issues.apache.org/jira/browse/FLINK-10441). RestServerEndpoint.createUploadDir(Path, Logger) logs a warning if the upload directory does not exist, it's better to log the creation of the web directory on INFO instead of the warning.*


## Brief change log

  - *log the creation of the web directory on INFO instead of the warning*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
