### PR TITLE
[FLINK-12259][flink-clients]Improve debuggability of method invocatio…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -104,8 +104,8 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 			System.setErr(originalErr);
 
 			try {
-				combinedStdOut.close();
-				combinedStdErr.close();
+				baos.close();
+				baes.close();
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.client.program;
 
-import org.apache.commons.io.output.TeeOutputStream;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.plan.FlinkPlan;
+
+import org.apache.commons.io.output.TeeOutputStream;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -28,6 +28,7 @@ import org.apache.flink.optimizer.plan.FlinkPlan;
 import org.apache.commons.io.output.TeeOutputStream;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 
 /**
@@ -101,6 +102,13 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 			unsetAsContext();
 			System.setOut(originalOut);
 			System.setErr(originalErr);
+
+			try {
+				combinedStdOut.close();
+				combinedStdErr.close();
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
 		}
 
 		String stdout = baos.toString();

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.commons.io.output.TeeOutputStream;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -74,9 +75,11 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 		PrintStream originalOut = System.out;
 		PrintStream originalErr = System.err;
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		System.setOut(new PrintStream(baos));
+		TeeOutputStream combinedStdOut = new TeeOutputStream(originalOut, baos);
+		System.setOut(new PrintStream(combinedStdOut));
 		ByteArrayOutputStream baes = new ByteArrayOutputStream();
-		System.setErr(new PrintStream(baes));
+		TeeOutputStream combinedStdErr = new TeeOutputStream(originalErr, baes);
+		System.setErr(new PrintStream(combinedStdErr));
 
 		setAsContext();
 		try {

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.client.program;
 
-import org.apache.commons.io.output.TeeOutputStream;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobSubmissionResult;
@@ -54,7 +53,10 @@ import java.io.PrintStream;
 import java.net.URL;
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -49,6 +49,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URL;
 import java.util.Collections;
@@ -228,7 +229,7 @@ public class ClientTest extends TestLogger {
 	}
 
 	@Test
-	public void testGetExecutionPlanDebugOutput() throws ProgramInvocationException {
+	public void testGetExecutionPlanDebugOutput() throws ProgramInvocationException, IOException {
 		PackagedProgram prg = new PackagedProgram(TestOptimizerPlan.class, "/tmp");
 		Optimizer optimizer = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), config);
 
@@ -259,6 +260,9 @@ public class ClientTest extends TestLogger {
 			// restore stdout/stderr
 			System.setOut(originalOut);
 			System.setErr(originalErr);
+
+			baos.close();
+			baes.close();
 		}
 	}
 


### PR DESCRIPTION
…n failures in OptimizerPlanEnvironment

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix JIRA 12259: Improve debuggability of method invocation failures in OptimizerPlanEnvironment 


## Brief change log

  - Fix the problem in OptimizerPlanEnvironment by printing debugging info in the console, as well as encoding debugging info in the exception.
  - Add a test case to verify debugging info is sent to both channels: ClientTest#testGetExecutionPlanDebugOutput.


## Verifying this change

This change added tests and can be verified as follows:

  - Debugging info is sent to both channels
  - Debugging info in both channels are identical
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  
