### PR TITLE
[FLINK-12261][table-planner-blink] Support e2e group window in blink batch

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/BuiltInFunctionDefinitions.java
@@ -330,6 +330,8 @@ public final class BuiltInFunctionDefinitions {
 		new FunctionDefinition("in", SCALAR_FUNCTION);
 	public static final FunctionDefinition CAST =
 		new FunctionDefinition("cast", SCALAR_FUNCTION);
+	public static final FunctionDefinition REINTERPRET_CAST =
+			new FunctionDefinition("reinterpretCast", SCALAR_FUNCTION);
 	public static final FunctionDefinition AS =
 		new FunctionDefinition("as", OTHER_FUNCTION);
 	public static final FunctionDefinition STREAM_RECORD_TIMESTAMP =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql2rel/AuxiliaryConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql2rel/AuxiliaryConverter.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql2rel;
+
+/*
+ * THIS FILE HAS BEEN COPIED FROM THE APACHE CALCITE PROJECT UNTIL CALCITE-1761 IS FIXED.
+ */
+
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+/** Converts an expression for a group window function (e.g. TUMBLE)
+ * into an expression for an auxiliary group function (e.g. TUMBLE_START).
+ *
+ * @see SqlStdOperatorTable#TUMBLE
+ */
+public interface AuxiliaryConverter {
+	/** Converts an expression.
+	 *
+	 * @param rexBuilder Rex  builder
+	 * @param groupCall Call to the group function, e.g. "TUMBLE($2, 36000)"
+	 * @param e Expression holding result of the group function, e.g. "$0"
+	 *
+	 * @return Expression for auxiliary function, e.g. "$0 + 36000" converts
+	 * the result of TUMBLE to the result of TUMBLE_END
+	 */
+	RexNode convert(RexBuilder rexBuilder, RexNode groupCall, RexNode e);
+
+	/** Simple implementation of {@link AuxiliaryConverter}. */
+	class Impl implements AuxiliaryConverter {
+		private final SqlFunction f;
+
+		public Impl(SqlFunction f) {
+			this.f = f;
+		}
+
+		public RexNode convert(RexBuilder rexBuilder, RexNode groupCall,
+			RexNode e) {
+			return rexBuilder.makeCall(this.f, e);
+			// FLINK QUICK FIX
+			// we do not use this logic right now
+//      switch (f.getKind()) {
+//      case TUMBLE_START:
+//      case HOP_START:
+//      case SESSION_START:
+//      case SESSION_END: // TODO: ?
+//        return e;
+//      case TUMBLE_END:
+//        return rexBuilder.makeCall(
+//            SqlStdOperatorTable.PLUS, e,
+//            ((RexCall) groupCall).operands.get(1));
+//      case HOP_END:
+//        return rexBuilder.makeCall(
+//            SqlStdOperatorTable.PLUS, e,
+//            ((RexCall) groupCall).operands.get(2));
+//      default:
+//        throw new AssertionError("unknown: " + f);
+//      }
+		}
+	}
+}
+
+// End AuxiliaryConverter.java

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql2rel/AuxiliaryConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql2rel/AuxiliaryConverter.java
@@ -17,7 +17,8 @@
 package org.apache.calcite.sql2rel;
 
 /*
- * THIS FILE HAS BEEN COPIED FROM THE APACHE CALCITE PROJECT UNTIL CALCITE-1761 IS FIXED.
+ * THIS FILE HAS BEEN COPIED FROM THE APACHE CALCITE PROJECT.
+ * We need support extended TUMBLE_ROWTIME and so on in FlinkSqlOperatorTable.
  */
 
 import org.apache.calcite.rex.RexBuilder;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
@@ -34,9 +34,12 @@ import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.IF;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.IS_NULL;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.LESS_THAN;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.MINUS;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.MOD;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.NOT;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.OR;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.PLUS;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.REINTERPRET_CAST;
+import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.TIMES;
 import static org.apache.flink.table.expressions.InternalFunctionDefinitions.THROW_EXCEPTION;
 
 /**
@@ -80,7 +83,8 @@ public class ExpressionBuilder {
 		return call(IS_NULL, input);
 	}
 
-	public static Expression ifThenElse(Expression condition, Expression ifTrue, Expression ifFalse) {
+	public static Expression ifThenElse(Expression condition, Expression ifTrue,
+			Expression ifFalse) {
 		return call(IF, condition, ifTrue, ifFalse);
 	}
 
@@ -96,6 +100,14 @@ public class ExpressionBuilder {
 		return call(DIVIDE, input1, input2);
 	}
 
+	public static Expression times(Expression input1, Expression input2) {
+		return call(TIMES, input1, input2);
+	}
+
+	public static Expression mod(Expression input1, Expression input2) {
+		return call(MOD, input1, input2);
+	}
+
 	public static Expression equalTo(Expression input1, Expression input2) {
 		return call(EQUALS, input1, input2);
 	}
@@ -108,8 +120,13 @@ public class ExpressionBuilder {
 		return call(GREATER_THAN, input1, input2);
 	}
 
-	public static Expression cast(Expression input1, Expression input2) {
-		return call(CAST, input1, input2);
+	public static Expression cast(Expression child, Expression type) {
+		return call(CAST, child, type);
+	}
+
+	public static Expression reinterpretCast(Expression child, Expression type,
+			boolean checkOverflow) {
+		return call(REINTERPRET_CAST, child, type, literal(checkOverflow));
 	}
 
 	public static TypeLiteralExpression typeLiteral(TypeInformation<?> type) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/RexNodeConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/RexNodeConverter.java
@@ -91,6 +91,16 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 							createInternalTypeFromTypeInfo(type.getType()),
 							child.getType().isNullable()),
 					child);
+		} else if (call.getFunctionDefinition().equals(BuiltInFunctionDefinitions.REINTERPRET_CAST)) {
+			RexNode child = call.getChildren().get(0).accept(this);
+			TypeLiteralExpression type = (TypeLiteralExpression) call.getChildren().get(1);
+			RexNode checkOverflow = call.getChildren().get(2).accept(this);
+			return relBuilder.getRexBuilder().makeReinterpretCast(
+					typeFactory.createTypeFromInternalType(
+							createInternalTypeFromTypeInfo(type.getType()),
+							child.getType().isNullable()),
+					child,
+					checkOverflow);
 		}
 
 		List<RexNode> child = convertCallChildren(call);
@@ -143,6 +153,10 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 			return relBuilder.call(FlinkSqlOperatorTable.AND, child);
 		} else if (BuiltInFunctionDefinitions.NOT.equals(def)) {
 			return relBuilder.call(FlinkSqlOperatorTable.NOT, child);
+		} else if (BuiltInFunctionDefinitions.TIMES.equals(def)) {
+			return relBuilder.call(FlinkSqlOperatorTable.MULTIPLY, child);
+		} else if (BuiltInFunctionDefinitions.MOD.equals(def)) {
+			return relBuilder.call(FlinkSqlOperatorTable.MOD, child);
 		} else {
 			throw new UnsupportedOperationException(def.getName());
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/FlinkSqlOperatorTable.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlGroupedWindowFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
@@ -39,6 +40,9 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.apache.flink.table.calcite.type.FlinkReturnTypes.ARG0_VARCHAR_FORCE_NULLABLE;
 import static org.apache.flink.table.calcite.type.FlinkReturnTypes.FLINK_DIV_NULLABLE;
@@ -892,7 +896,58 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	// Window SQL functions
 	// -----------------------------------------------------------------------------
 
-	// TODO: add window functions here
+	/**
+	 * We need custom group auxiliary functions in order to support nested windows.
+	 */
+	public static final SqlGroupedWindowFunction TUMBLE = new SqlGroupedWindowFunction(
+			SqlKind.TUMBLE, null,
+			OperandTypes.or(OperandTypes.DATETIME_INTERVAL, OperandTypes.DATETIME_INTERVAL_TIME)) {
+		@Override
+		public List<SqlGroupedWindowFunction> getAuxiliaryFunctions() {
+			return Arrays.asList(TUMBLE_START, TUMBLE_END, TUMBLE_ROWTIME, TUMBLE_PROCTIME);
+		}
+	};
+
+	public static final SqlGroupedWindowFunction TUMBLE_START = TUMBLE.auxiliary(SqlKind.TUMBLE_START);
+	public static final SqlGroupedWindowFunction TUMBLE_END = TUMBLE.auxiliary(SqlKind.TUMBLE_END);
+	public static final SqlGroupedWindowFunction TUMBLE_ROWTIME =
+			TUMBLE.auxiliary("TUMBLE_ROWTIME", SqlKind.OTHER_FUNCTION);
+	public static final SqlGroupedWindowFunction TUMBLE_PROCTIME =
+			TUMBLE.auxiliary("TUMBLE_PROCTIME", SqlKind.OTHER_FUNCTION);
+
+	public static final SqlGroupedWindowFunction HOP = new SqlGroupedWindowFunction(
+			SqlKind.HOP,
+			null,
+			OperandTypes.or(
+			OperandTypes.DATETIME_INTERVAL_INTERVAL,
+			OperandTypes.DATETIME_INTERVAL_INTERVAL_TIME)) {
+		@Override
+		public List<SqlGroupedWindowFunction> getAuxiliaryFunctions() {
+			return Arrays.asList(HOP_START, HOP_END, HOP_ROWTIME, HOP_PROCTIME);
+		}
+	};
+
+	public static final SqlGroupedWindowFunction HOP_START = HOP.auxiliary(SqlKind.HOP_START);
+	public static final SqlGroupedWindowFunction HOP_END = HOP.auxiliary(SqlKind.HOP_END);
+	public static final SqlGroupedWindowFunction HOP_ROWTIME = HOP.auxiliary("HOP_ROWTIME", SqlKind.OTHER_FUNCTION);
+	public static final SqlGroupedWindowFunction HOP_PROCTIME = HOP.auxiliary("HOP_PROCTIME", SqlKind.OTHER_FUNCTION);
+
+	public static final SqlGroupedWindowFunction SESSION = new SqlGroupedWindowFunction(
+			SqlKind.SESSION,
+			null,
+			OperandTypes.or(OperandTypes.DATETIME_INTERVAL, OperandTypes.DATETIME_INTERVAL_TIME)) {
+		@Override
+		public List<SqlGroupedWindowFunction> getAuxiliaryFunctions() {
+			return Arrays.asList(SESSION_START, SESSION_END, SESSION_ROWTIME, SESSION_PROCTIME);
+		}
+	};
+
+	public static final SqlGroupedWindowFunction SESSION_START = SESSION.auxiliary(SqlKind.SESSION_START);
+	public static final SqlGroupedWindowFunction SESSION_END = SESSION.auxiliary(SqlKind.SESSION_END);
+	public static final SqlGroupedWindowFunction SESSION_ROWTIME =
+			SESSION.auxiliary("SESSION_ROWTIME", SqlKind.OTHER_FUNCTION);
+	public static final SqlGroupedWindowFunction SESSION_PROCTIME =
+			SESSION.auxiliary("SESSION_PROCTIME", SqlKind.OTHER_FUNCTION);
 
 	// -----------------------------------------------------------------------------
 	// operators extend from Calcite

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/CodeGeneratorContext.scala
@@ -601,7 +601,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
       functionContextClass: Class[_ <: FunctionContext] = classOf[FunctionContext],
       contextTerm: String = null): String = {
     val classQualifier = function.getClass.getCanonicalName
-    val fieldTerm = s"function_${function.functionIdentifier}"
+    val fieldTerm = CodeGenUtils.udfFieldName(function)
 
     addReusableObjectInternal(function, fieldTerm, classQualifier)
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/AggsHandlerCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/AggsHandlerCodeGenerator.scala
@@ -644,13 +644,13 @@ class AggsHandlerCodeGenerator(
           // return a Timestamp(Internal is long)
           GeneratedExpression(
             s"$NAMESPACE_TERM.getEnd()", "false", "", w.resultType)
-//        case r: RowtimeAttribute =>
-//          // return a rowtime, use long as internal type
-//          GeneratedExpression(
-//            s"$NAMESPACE_TERM.getEnd() - 1", "false", "", r.resultType.toInternalType)
-//        case p: ProctimeAttribute =>
-//          // ignore this property, it will be null at the position later
-//          GeneratedExpression("-1L", "true", "", p.resultType.toInternalType)
+        case r: RowtimeAttribute =>
+          // return a rowtime, use long as internal type
+          GeneratedExpression(
+            s"$NAMESPACE_TERM.getEnd() - 1", "false", "", r.resultType)
+        case p: ProctimeAttribute =>
+          // ignore this property, it will be null at the position later
+          GeneratedExpression("-1L", "true", "", p.resultType)
       }
       valueExprs = valueExprs ++ windowExprs
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.util.SingleElementIterator
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.table.`type`.TypeConverters.{createInternalTypeFromTypeInfo, createInternalTypeInfoFromInternalType}
 import org.apache.flink.table.`type`.{ArrayType, InternalType, MapType, RowType, StringType}
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.codegen.CodeGenUtils.{boxedTypeTermForExternalType, genToExternal, genToInternal, newName, primitiveTypeTermForType}
 import org.apache.flink.table.codegen.OperatorCodeGenerator.STREAM_RECORD
 import org.apache.flink.table.codegen.{CodeGenUtils, CodeGeneratorContext, ExprCodeGenerator, GenerateUtils, GeneratedExpression, OperatorCodeGenerator}
@@ -126,7 +125,6 @@ object AggCodeGenHelper {
       isMerge: Boolean,
       isFinal: Boolean,
       ctx: CodeGeneratorContext,
-      config: TableConfig,
       builder: RelBuilder,
       grouping: Array[Int],
       auxGrouping: Array[Int],
@@ -148,7 +146,6 @@ object AggCodeGenHelper {
     val aggBufferExprs = genFlatAggBufferExprs(
       isMerge,
       ctx,
-      config,
       builder,
       auxGrouping,
       aggregates,
@@ -158,7 +155,6 @@ object AggCodeGenHelper {
 
     val initAggBufferCode = genInitFlatAggregateBuffer(
       ctx,
-      config,
       builder,
       inputType,
       inputTerm,
@@ -172,7 +168,6 @@ object AggCodeGenHelper {
     val doAggregateCode = genAggregateByFlatAggregateBuffer(
       isMerge,
       ctx,
-      config,
       builder,
       inputType,
       inputTerm,
@@ -189,7 +184,6 @@ object AggCodeGenHelper {
       isMerge,
       isFinal,
       ctx,
-      config,
       builder,
       grouping,
       auxGrouping,
@@ -319,7 +313,6 @@ object AggCodeGenHelper {
   private[flink] def genFlatAggBufferExprs(
       isMerge: Boolean,
       ctx: CodeGeneratorContext,
-      config: TableConfig,
       builder: RelBuilder,
       auxGrouping: Array[Int],
       aggregates: Seq[UserDefinedFunction],
@@ -352,7 +345,6 @@ object AggCodeGenHelper {
     */
   private[flink] def genInitFlatAggregateBuffer(
       ctx: CodeGeneratorContext,
-      config: TableConfig,
       builder: RelBuilder,
       inputType: RowType,
       inputTerm: String,
@@ -423,7 +415,6 @@ object AggCodeGenHelper {
   private[flink] def genAggregateByFlatAggregateBuffer(
       isMerge: Boolean,
       ctx: CodeGeneratorContext,
-      config: TableConfig,
       builder: RelBuilder,
       inputType: RowType,
       inputTerm: String,
@@ -438,7 +429,6 @@ object AggCodeGenHelper {
     if (isMerge) {
       genMergeFlatAggregateBuffer(
         ctx,
-        config,
         builder,
         inputTerm,
         inputType,
@@ -452,7 +442,6 @@ object AggCodeGenHelper {
     } else {
       genAccumulateFlatAggregateBuffer(
         ctx,
-        config,
         builder,
         inputTerm,
         inputType,
@@ -470,7 +459,6 @@ object AggCodeGenHelper {
       isMerge: Boolean,
       isFinal: Boolean,
       ctx: CodeGeneratorContext,
-      config: TableConfig,
       builder: RelBuilder,
       grouping: Array[Int],
       auxGrouping: Array[Int],
@@ -488,7 +476,6 @@ object AggCodeGenHelper {
       val getValueExprs = genGetValueFromFlatAggregateBuffer(
         isMerge,
         ctx,
-        config,
         builder,
         auxGrouping,
         aggregates,
@@ -514,7 +501,6 @@ object AggCodeGenHelper {
   private[flink] def genGetValueFromFlatAggregateBuffer(
       isMerge: Boolean,
       ctx: CodeGeneratorContext,
-      config: TableConfig,
       builder: RelBuilder,
       auxGrouping: Array[Int],
       aggregates: Seq[UserDefinedFunction],
@@ -562,7 +548,6 @@ object AggCodeGenHelper {
     */
   private[flink] def genMergeFlatAggregateBuffer(
       ctx: CodeGeneratorContext,
-      config: TableConfig,
       builder: RelBuilder,
       inputTerm: String,
       inputType: RowType,
@@ -622,7 +607,6 @@ object AggCodeGenHelper {
     */
   private[flink] def genAccumulateFlatAggregateBuffer(
       ctx: CodeGeneratorContext,
-      config: TableConfig,
       builder: RelBuilder,
       inputTerm: String,
       inputType: RowType,
@@ -714,8 +698,7 @@ object AggCodeGenHelper {
       operatorBaseClass: String,
       processCode: String,
       endInputCode: String,
-      inputType: RowType,
-      config: TableConfig): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
+      inputType: RowType): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
     ctx.addReusableMember("private boolean hasInput = false;")
     ctx.addReusableMember(s"$STREAM_RECORD element = new $STREAM_RECORD((Object)null);")
     OperatorCodeGenerator.generateOneInputStreamOperator(
@@ -724,7 +707,7 @@ object AggCodeGenHelper {
       processCode,
       endInputCode,
       inputType,
-      config,
+      ctx.tableConfig,
       lazyInputUnboxingCode = true)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggWithoutKeysCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggWithoutKeysCodeGenerator.scala
@@ -52,7 +52,6 @@ object AggWithoutKeysCodeGenerator {
     val aggBufferTypes = AggCodeGenHelper.getAggBufferTypes(inputType, Array(), aggregates)
     val aggArgs = aggInfoList.aggInfos.map(_.argIndexes)
 
-    val config = ctx.tableConfig
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
 
     // register udagg
@@ -63,7 +62,6 @@ object AggWithoutKeysCodeGenerator {
       isMerge,
       isFinal,
       ctx,
-      config,
       builder,
       Array(),
       Array(),
@@ -115,7 +113,6 @@ object AggWithoutKeysCodeGenerator {
       classOf[TableStreamOperator[BaseRow]].getCanonicalName,
       processCode,
       endInputCode,
-      inputType,
-      config)
+      inputType)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashWindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashWindowCodeGenerator.scala
@@ -1,0 +1,737 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codegen.agg.batch
+
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.api.java.typeutils.ListTypeInfo
+import org.apache.flink.runtime.operators.sort.QuickSort
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.table.`type`.TypeConverters.createInternalTypeFromTypeInfo
+import org.apache.flink.table.`type`.{InternalType, RowType}
+import org.apache.flink.table.api.window.TimeWindow
+import org.apache.flink.table.api.{TableConfig, Types}
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.codegen.CodeGenUtils.{BINARY_ROW, newName}
+import org.apache.flink.table.codegen.OperatorCodeGenerator.generateCollect
+import org.apache.flink.table.codegen.agg.batch.AggCodeGenHelper.genGroupKeyChangedCheckCode
+import org.apache.flink.table.codegen.agg.batch.HashAggCodeGenHelper.{genHashAggOutputExpr, genRetryAppendToMap, prepareHashAggKVTypes, prepareHashAggMap}
+import org.apache.flink.table.codegen.{CodeGenUtils, CodeGeneratorContext, ExprCodeGenerator, GenerateUtils, GeneratedExpression, ProjectionCodeGenerator}
+import org.apache.flink.table.dataformat.{BaseRow, BinaryRow}
+import org.apache.flink.table.generated.GeneratedOperator
+import org.apache.flink.table.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
+import org.apache.flink.table.plan.util.AggregateInfoList
+import org.apache.flink.table.runtime.TableStreamOperator
+import org.apache.flink.table.runtime.aggregate.{BytesHashMap, BytesHashMapSpillMemorySegmentPool}
+import org.apache.flink.table.runtime.sort.BinaryKVInMemorySortBuffer
+import org.apache.flink.table.typeutils.BinaryRowSerializer
+import org.apache.flink.util.MutableObjectIterator
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.tools.RelBuilder
+import org.apache.commons.math3.util.ArithmeticUtils
+
+/**
+  * Tumbling window: like [[HashAggCodeGenerator]].
+  *
+  * Sliding window:
+  * 1.enableAssignPane + 2 phase:
+  * -- assign pane + hash agg
+  *     -- distribute by (key)
+  *       -- global hash agg(key + pane)
+  *         -- sort by (key + pane)
+  *           -- assign window + sort agg
+  * 2.disableAssignPane + 1 phase:
+  * -- distribute by (key)
+  *   -- assign window + hash agg[(key + window) -> agg buffer].
+  */
+class HashWindowCodeGenerator(
+    ctx: CodeGeneratorContext,
+    relBuilder: RelBuilder,
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    aggInfoList: AggregateInfoList,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = true,
+    isMerge: Boolean,
+    isFinal: Boolean)
+  extends WindowCodeGenerator(
+    relBuilder,
+    window,
+    inputTimeFieldIndex,
+    inputTimeIsDate,
+    namedProperties,
+    aggInfoList,
+    inputRowType,
+    grouping,
+    auxGrouping,
+    enableAssignPane,
+    isMerge,
+    isFinal) {
+
+  private lazy val aggBufferRowType = new RowType(aggBufferTypes.flatten, aggBufferNames.flatten)
+
+  private lazy val aggMapKeyRowType = new RowType(
+    groupKeyRowType.getFieldTypes :+ timestampInternalType,
+    groupKeyRowType.getFieldNames :+ "assignedTs")
+
+  private val config = ctx.tableConfig
+
+  def gen(
+      inputType: RowType,
+      outputType: RowType,
+      buffLimitSize: Int,
+      reservedAggMapMemory: Long,
+      maxManagedMemory: Long,
+      windowStart: Long,
+      windowSize: Long,
+      slideSize: Long): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
+    val className = if (isFinal) "HashWinAgg" else "LocalHashWinAgg"
+    val suffix = if (grouping.isEmpty) "WithoutKeys" else "WithKeys"
+
+    val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
+    // add logger
+    val logTerm = CodeGenUtils.newName("LOG")
+    ctx.addReusableLogger(logTerm, className)
+
+    // gen code to do aggregate using aggregate map
+    val aggMapKey = newName("aggMapKey")
+    val aggMapKeyWriter = newName("aggMapKeyWriter")
+    val (processElementPerWindow, outputResultFromMap) = genHashWindowAggCodes(config,
+      reservedAggMapMemory, maxManagedMemory, buffLimitSize, windowSize,
+      slideSize, inputTerm, inputType,
+      outputType, aggMapKey, logTerm)
+
+    val (processCode, outputWhenEndInputCode) = if (isFinal && isMerge) {
+      // prepare for aggregate map key's projection
+      val projAggMapKeyCode = ProjectionCodeGenerator.generateProjectionExpression(ctx,
+        inputType,
+        aggMapKeyRowType,
+        grouping :+ grouping.length,
+        inputTerm = inputTerm,
+        outRecordTerm = aggMapKey,
+        outRecordWriterTerm = aggMapKeyWriter).code
+
+      val processCode =
+        s"""
+           |if (!$inputTerm.isNullAt($inputTimeFieldIndex)) {
+           |  hasInput = true;
+           |  // input field access for group key projection, window/pane assign
+           |  // and aggregate map update
+           |  ${ctx.reuseInputUnboxingCode(inputTerm)}
+           |  // build aggregate map key
+           |  $projAggMapKeyCode
+           |  // look up aggregate map and aggregate
+           |  $processElementPerWindow
+           |}
+       """.stripMargin
+
+      (processCode, outputResultFromMap)
+    } else {
+      // gen code to assign windows/pane to current input
+      val assignTimestampExprs = genTimestampAssignExprs(
+        enableAssignPane, config, windowStart, windowSize, slideSize, window, inputTerm, inputType)
+
+      val processCode =
+        if (!isSlidingWindowWithOverlapping(enableAssignPane, window, slideSize, windowSize)) {
+          // Each input will be assigned with only one window, in the cases of
+          // Tumbling window, Sliding window with slideSize >= windowSize or with pane optimization.
+          assert(assignTimestampExprs.size == 1)
+          val assignTimestampExpr = assignTimestampExprs.head
+
+          // prepare for aggregate map key's projection
+          val accessAssignedTimestampExpr = GeneratedExpression(
+            assignTimestampExpr.resultTerm, "false", "", timestampInternalType)
+          val prepareInitAggMapKeyExpr = prepareAggMapKeyExpr(inputTerm, inputType,
+            Some(accessAssignedTimestampExpr), aggMapKeyRowType, aggMapKey, aggMapKeyWriter)
+          val processAggregate =
+            s"""
+               |  // build aggregate map key
+               |  ${prepareInitAggMapKeyExpr.code}
+               |  // aggregate by each input with assigned timestamp
+               |  $processElementPerWindow
+           """.stripMargin
+
+          // gen code to filter invalid windows in the case of jumping window
+          val processEachInput = if (isJumpingWindow(slideSize, windowSize)) {
+            val checkValidWindow = s"${getInputTimeValue(inputTerm, inputTimeFieldIndex)} < " +
+                s"${assignTimestampExpr.resultTerm} + ${windowSize}L"
+            s"""
+               |if ($checkValidWindow) {
+               |  // build aggregate map key
+               |  ${prepareInitAggMapKeyExpr.code}
+               |  // aggregate by each input with assigned timestamp
+               |  $processAggregate
+               |}
+           """.stripMargin
+          } else {
+            processAggregate
+          }
+          s"""
+             |if (!$inputTerm.isNullAt($inputTimeFieldIndex)) {
+             |  hasInput = true;
+             |  // input field access for group key projection, window/pane assign
+             |   // and aggregate map update
+             |  ${ctx.reuseInputUnboxingCode(inputTerm)}
+             |  // assign timestamp(window or pane)
+             |  ${assignTimestampExpr.code}
+             |  // process each input
+             |  $processEachInput
+             |}""".stripMargin
+        } else {
+          // Otherwise, each input will be assigned with overlapping windows.
+          assert(assignTimestampExprs.size > 1)
+          val assignedWindows = newName("assignedWindows")
+          ctx.addReusableMember(
+            s"transient java.util.List<java.lang.Long> $assignedWindows" +
+                s" = new java.util.ArrayList<java.lang.Long>();")
+          val prepareCodes = for (expr <- assignTimestampExprs) yield {
+            s"""
+               |${expr.code}
+               |$assignedWindows.add(${expr.resultTerm});
+               """.stripMargin
+          }
+          val code =
+            s"""
+               |$assignedWindows.clear();
+               |${prepareCodes.mkString("\n").trim}
+               """.stripMargin
+          val assignTimestampExpr =
+            new GeneratedExpression(assignedWindows, "false", code,
+              createInternalTypeFromTypeInfo(new ListTypeInfo(Types.LONG)))
+
+          // gen code to filter invalid overlapping windows
+          val assignedTimestamp = newName("assignedTimestamp")
+          val timestampTerm = s"${getInputTimeValue(inputTerm, inputTimeFieldIndex)}"
+          val checkValidWindow = s"$timestampTerm >= $assignedTimestamp " +
+              s" && $timestampTerm < $assignedTimestamp + ${windowSize}L"
+
+          // prepare for aggregate map key's projection
+          val prepareInitAggMapKeyExpr = prepareAggMapKeyExpr(
+            inputTerm, inputType, None, aggMapKeyRowType, aggMapKey, aggMapKeyWriter)
+          val realAssignedValue = if (inputTimeIsDate) {
+            convertToIntValue(s"$assignedTimestamp")
+          } else {
+            assignedTimestamp
+          }
+          val updateAssignedTsCode = s"$aggMapKey.set$timestampInternalTypeName(${
+            grouping.length
+          }, $realAssignedValue);"
+
+          s"""
+             |if (!$inputTerm.isNullAt($inputTimeFieldIndex)) {
+             |  hasInput = true;
+             |  // input field access for group key projection, window/pane assign
+             |  // and aggregate map update
+             |  ${ctx.reuseInputUnboxingCode(inputTerm)}
+             |  // assign windows/pane
+             |  ${assignTimestampExpr.code}
+             |  // build aggregate map key
+             |  ${prepareInitAggMapKeyExpr.code}
+             |  // we assigned all the possible overlapping windows in this case,
+             |  // so need filtering the invalid window here
+             |  for (Long $assignedTimestamp : ${assignTimestampExpr.resultTerm}) {
+             |    if ($checkValidWindow) {
+             |     // update input's assigned timestamp
+             |     $updateAssignedTsCode
+             |     $processElementPerWindow
+             |    } else {
+             |     break;
+             |    }
+             |  }
+             |}
+       """.stripMargin
+        }
+      (processCode, outputResultFromMap)
+    }
+
+    val baseClass = classOf[TableStreamOperator[_]].getName
+    val endInputCode = if (isFinal) {
+      s"""
+         |$outputWhenEndInputCode
+         """.stripMargin
+    } else {
+      outputWhenEndInputCode
+    }
+    AggCodeGenHelper.generateOperator(
+      ctx, className + suffix, baseClass, processCode, endInputCode, inputType, config)
+  }
+
+  private def genTimestampAssignExprs(
+      assignPane: Boolean,
+      config: TableConfig,
+      windowStart: Long,
+      windowSize: Long,
+      slideSize: Long,
+      window: LogicalWindow,
+      inputTerm: String,
+      inputType: RowType): Seq[GeneratedExpression] = {
+    window match {
+      case SlidingGroupWindow(_, timeField, _, _) =>
+        if (assignPane) {
+          val paneSize = ArithmeticUtils.gcd(windowSize, slideSize)
+          Seq(genAlignedWindowStartExpr(
+            ctx, config, inputTerm, inputType, timeField, windowStart, paneSize))
+        } else if (slideSize >= windowSize) {
+          Seq(genAlignedWindowStartExpr(
+            ctx, config, inputTerm, inputType, timeField, windowStart, slideSize))
+        } else {
+          val maxNumOverlapping = math.ceil(windowSize * 1.0 / slideSize).toInt
+          val exprs = for (index <- 0 until maxNumOverlapping) yield {
+            genAlignedWindowStartExpr(
+              ctx, config, inputTerm, inputType, timeField, windowStart, slideSize, index)
+          }
+          exprs
+        }
+      case TumblingGroupWindow(_, timeField, _) =>
+        Seq(genAlignedWindowStartExpr(
+          ctx, config, inputTerm, inputType, timeField, windowStart, windowSize))
+      case _ =>
+        throw new RuntimeException(s"Bug. Assign pane for $window is not supported.")
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  private def prepareAggMapKeyExpr(
+      inputTerm: String,
+      inputType: InternalType,
+      assignedTimestampExpr: Option[GeneratedExpression],
+      currentKeyType: RowType,
+      currentKeyTerm: String,
+      currentKeyWriterTerm: String): GeneratedExpression = {
+    val codeGen = new ExprCodeGenerator(ctx, false)
+        .bindInput(inputType, inputTerm = inputTerm)
+    val expr = if (assignedTimestampExpr.isDefined) {
+      val assignedLongTimestamp = assignedTimestampExpr.get
+      if (inputTimeIsDate) {
+        val dateTerm = ctx.addReusableLocalVariable("int", "dateTerm")
+        val convertDateCode =
+          s"""
+             |  ${assignedLongTimestamp.code}
+             |  $dateTerm = ${convertToIntValue(assignedLongTimestamp.resultTerm)};
+           """.stripMargin
+        GeneratedExpression(
+          dateTerm,
+          assignedLongTimestamp.nullTerm,
+          convertDateCode,
+          timestampInternalType)
+      } else {
+        assignedLongTimestamp
+      }
+    } else {
+      val value = if (inputTimeIsDate) "-1" else "-1L"
+      GeneratedExpression(value, "false", "", timestampInternalType)
+    }
+    // There will be only assigned timestamp field when no grouping window aggregate case.
+    codeGen.generateResultExpression(
+      grouping.map(
+        idx => GenerateUtils.generateFieldAccess(ctx, inputType, inputTerm, idx)) :+ expr,
+      currentKeyType.asInstanceOf[RowType],
+      classOf[BinaryRow],
+      outRow = currentKeyTerm,
+      outRowWriter = Some(currentKeyWriterTerm))
+  }
+
+  private def genGroupWindowHashAggCodes(
+      config: TableConfig,
+      isMerge: Boolean,
+      isFinal: Boolean,
+      windowSize: Long,
+      slideSize: Long,
+      aggMapKeyTypesTerm: String,
+      aggBufferTypesTerm: String,
+      bufferLimitSize: Int,
+      aggregateMapTerm: String,
+      inputTerm: String,
+      inputType: RowType,
+      outputType: RowType,
+      currentAggBufferTerm: String): (GeneratedExpression, GeneratedExpression, String) = {
+    // build mapping for DeclarativeAggregationFunction binding references
+    val offset = if (isMerge) grouping.length + 1 else grouping.length
+    val argsMapping = AggCodeGenHelper.buildAggregateArgsMapping(
+      isMerge, offset, inputType,  auxGrouping, aggArgs, aggBufferTypes)
+    val aggBuffMapping = HashAggCodeGenHelper.buildAggregateAggBuffMapping(aggBufferTypes)
+    // gen code to create empty agg buffer
+    val initedAggBuffer = HashAggCodeGenHelper.genReusableEmptyAggBuffer(
+      ctx, config, builder, inputTerm, inputType, auxGrouping, aggregates, aggBufferRowType)
+    if (auxGrouping.isEmpty) {
+      // init aggBuffer in open function when there is no auxGrouping
+      ctx.addReusableOpenStatement(initedAggBuffer.code)
+    }
+    // gen code to update agg buffer from the aggregate map
+    val doAggregateExpr = HashAggCodeGenHelper.genAggregate(isMerge, ctx, config, builder,
+      inputType, inputTerm, auxGrouping, aggregates, aggCallToAggFunction,
+      argsMapping, aggBuffMapping, currentAggBufferTerm, aggBufferRowType)
+
+    // gen code to set hash agg result
+    val aggOutputCode = if (isFinal && enableAssignPane) {
+      // gen output by sort and merge pre accumulate results
+      genOutputByMerging(config,
+        windowSize, slideSize, bufferLimitSize,
+        outputType, aggregateMapTerm, argsMapping, aggBuffMapping,
+        aggMapKeyTypesTerm, aggBufferTypesTerm, aggMapKeyRowType, aggBufferRowType)
+    } else {
+      genOutputDirectly(config, windowSize, inputTerm, inputType, outputType,
+        aggregateMapTerm, argsMapping, aggBuffMapping)
+    }
+
+    (initedAggBuffer, doAggregateExpr, aggOutputCode)
+  }
+
+  private def genOutputByMerging(
+      config: TableConfig,
+      windowSize: Long,
+      slideSize: Long,
+      bufferLimitSize: Int,
+      outputType: RowType,
+      aggregateMapTerm: String,
+      argsMapping: Array[Array[(Int, InternalType)]],
+      aggBuffMapping: Array[Array[(Int, InternalType)]],
+      aggKeyTypeTerm: String,
+      aggBufferTypeTerm: String,
+      aggMapKeyType: RowType,
+      aggBufferType: RowType): String = {
+    val keyComputerTerm = CodeGenUtils.newName("keyComputer")
+    val recordComparatorTerm = CodeGenUtils.newName("recordComparator")
+    val prepareSorterCode = HashAggCodeGenHelper.genKVSorterPrepareCode(
+      ctx, keyComputerTerm, recordComparatorTerm, aggMapKeyType)
+
+    val memPoolTypeTerm = classOf[BytesHashMapSpillMemorySegmentPool].getName
+    val binaryRowSerializerTypeTerm = classOf[BinaryRowSerializer].getName
+
+    val sorterBufferType = classOf[BinaryKVInMemorySortBuffer].getName
+    val sorterBufferTerm = newName("buffer")
+
+    val createSorterBufferCode =
+      s"""
+         |   $prepareSorterCode
+         |   $sorterBufferType $sorterBufferTerm = $sorterBufferType.createBuffer(
+         |      $keyComputerTerm,
+         |      new $binaryRowSerializerTypeTerm($aggKeyTypeTerm.length),
+         |      new $binaryRowSerializerTypeTerm($aggBufferTypeTerm.length),
+         |      $recordComparatorTerm,
+         |      $aggregateMapTerm.getRecordAreaMemorySegments(),
+         |      $aggregateMapTerm.getNumElements(),
+         |      new $memPoolTypeTerm($aggregateMapTerm.getBucketAreaMemorySegments())
+         |   );
+       """.stripMargin
+
+    val reuseAggMapKeyTerm = newName("reusedKey")
+    val reuseAggBufferTerm = newName("reusedValue")
+    val reuseKVTerm = newName("reusedKV")
+    val binaryRow = classOf[BinaryRow].getName
+    val kvType = classOf[JTuple2[_,_]].getName
+    ctx.addReusableMember(
+      s"transient $binaryRow $reuseAggMapKeyTerm = new $binaryRow(${aggMapKeyType.getArity});")
+    ctx.addReusableMember(
+      s"transient $binaryRow $reuseAggBufferTerm = new $binaryRow(${aggBufferType.getArity});")
+    ctx.addReusableMember(
+      s"transient $kvType<$binaryRow, $binaryRow> $reuseKVTerm = " +
+          s"new  $kvType<$binaryRow, $binaryRow>($reuseAggMapKeyTerm, $reuseAggBufferTerm);"
+    )
+
+    // ---------------------------------------------------------------------------------------------
+    // gen code to create a buffer to group all the elements having the same grouping key
+    val windowElementType = getWindowsGroupingElementInfo()
+    // project into aggregate map key and value into prepared window element
+    val bufferWindowElementTerm = newName("prepareWinElement")
+    val bufferWindowElementWriterTerm = newName("prepareWinElementWriter")
+    val exprCodegen = new ExprCodeGenerator(ctx, false)
+    // TODO refine this. Is it possible to reuse grouping key projection?
+    val accessKeyExprs = for (idx <- 0 until aggMapKeyType.getArity - 1) yield
+      GenerateUtils.generateFieldAccess(
+        ctx, aggMapKeyType, reuseAggMapKeyTerm, idx)
+    val accessTimestampExpr = GenerateUtils.generateFieldAccess(
+      ctx, aggMapKeyType,
+      reuseAggMapKeyTerm, aggMapKeyType.getArity - 1)
+    val accessValExprs = for (idx <- 0 until aggBufferType.getArity) yield
+      GenerateUtils.generateFieldAccess(
+        ctx, aggBufferType, reuseAggBufferTerm, idx)
+    val accessExprs = (accessKeyExprs :+ GeneratedExpression(
+      accessTimestampExpr.resultTerm,
+      "false",
+      accessTimestampExpr.code,
+      timestampInternalType)) ++ accessValExprs
+    val buildWindowsGroupingElementExpr = exprCodegen.generateResultExpression(
+      accessExprs,
+      windowElementType,
+      classOf[BinaryRow],
+      outRow = bufferWindowElementTerm,
+      outRowWriter = Some(bufferWindowElementWriterTerm))
+
+    // ---------------------------------------------------------------------------------------------
+    // gen code to apply aggregate functions to grouping window elements
+    val timeWindowType = classOf[TimeWindow].getName
+    val currentWindow = newName("currentWindow")
+    ctx.addReusableMember(s"transient $timeWindowType $currentWindow = null;")
+
+    // gen code to assign window and aggregate
+    val windowsGrouping = CodeGenUtils.newName("windowsGrouping")
+    val (processCode, endCode) = if (grouping.isEmpty) {
+      val (triggerWindowAgg, endWindowAgg) = genWindowAggCodes(
+        enablePreAcc = true, ctx, config, windowSize, slideSize, windowsGrouping, bufferLimitSize,
+        windowElementType, inputTimeFieldIndex, currentWindow, None, outputType)
+      val process =
+        s"""
+           |// prepare windows grouping input
+           |${buildWindowsGroupingElementExpr.code}
+           |$windowsGrouping
+           |  .addInputToBuffer(($BINARY_ROW)${buildWindowsGroupingElementExpr.resultTerm});
+           |$triggerWindowAgg
+         """.stripMargin
+      (process, endWindowAgg)
+    } else {
+      // project grouping keys from aggregate map's key
+      val groupKeyTerm = newName("groupKey")
+      val groupKeyWriterTerm = newName("groupKeyWriter")
+      val projGroupingKeyCode = ProjectionCodeGenerator.generateProjectionExpression(ctx,
+        aggMapKeyType,
+        groupKeyRowType,
+        grouping.indices.toArray,
+        inputTerm = reuseAggMapKeyTerm,
+        outRecordTerm = groupKeyTerm,
+        outRecordWriterTerm = groupKeyWriterTerm).code
+
+
+      ("GroupingKeyFromAggMapKey", ctx,
+        groupKeyRowType, grouping.indices.toArray,
+        aggMapKeyType, reuseAggMapKeyTerm, groupKeyTerm, groupKeyWriterTerm)
+
+      // gen code to check group key changed
+      val lastKeyTerm = newName("lastKey")
+      ctx.addReusableMember(s"transient $BINARY_ROW $lastKeyTerm = null;")
+      val keyNotEqualsCode = genGroupKeyChangedCheckCode(groupKeyTerm, lastKeyTerm)
+
+      val (triggerWindowAgg, endWindowAgg) = genWindowAggCodes(
+        enablePreAcc = true, ctx, config, windowSize, slideSize, windowsGrouping, bufferLimitSize,
+        windowElementType, inputTimeFieldIndex, currentWindow, Some(lastKeyTerm), outputType)
+
+      val process =
+        s"""
+           |// project agg grouping key
+           |$projGroupingKeyCode
+           |// prepare windows grouping input
+           |${buildWindowsGroupingElementExpr.code}
+           |if ($lastKeyTerm == null) {
+           |  $lastKeyTerm = $groupKeyTerm.copy();
+           |} else if ($keyNotEqualsCode) {
+           |  $endWindowAgg
+           |  $lastKeyTerm = $groupKeyTerm.copy();
+           |}
+           |$windowsGrouping
+           |  .addInputToBuffer(($BINARY_ROW)${buildWindowsGroupingElementExpr.resultTerm});
+           |$triggerWindowAgg
+         """.stripMargin
+      val end =
+        s"""
+           | $endWindowAgg
+           | $lastKeyTerm = null;
+       """.stripMargin
+      (process, end)
+    }
+
+    val sortType = classOf[QuickSort].getName
+    val bufferIteratorType = classOf[MutableObjectIterator[_]].getName
+    s"""
+       | if (hasInput) {
+       |  // sort by grouping keys and assigned timestamp
+       |  $createSorterBufferCode
+       |  new $sortType().sort($sorterBufferTerm);
+       |  // merge and get result
+       |  $bufferIteratorType<$kvType<$binaryRow, $binaryRow>> iterator =
+       |    $sorterBufferTerm.getIterator();
+       |  while (iterator.next($reuseKVTerm) != null) {
+       |      // reusable input fields access
+       |      ${ctx.reuseInputUnboxingCode(bufferWindowElementTerm)}
+       |      $processCode
+       |   }
+       |  $endCode
+       | }
+       """.stripMargin
+  }
+
+  private def genOutputDirectly(
+      config: TableConfig,
+      windowSize: Long,
+      inputTerm: String,
+      inputType: RowType,
+      outputType: RowType,
+      aggregateMapTerm: String,
+      argsMapping: Array[Array[(Int, InternalType)]],
+      aggBuffMapping: Array[Array[(Int, InternalType)]]): String = {
+    val outputTerm = "hashAggOutput"
+    ctx.addReusableOutputRecord(outputType, getOutputRowClass, outputTerm)
+    val (reuseAggMapEntryTerm, reuseAggMapKeyTerm, reuseAggBufferTerm) =
+      HashAggCodeGenHelper.prepareTermForAggMapIteration(
+        ctx, outputTerm, outputType, aggMapKeyRowType, aggBufferRowType, getOutputRowClass)
+
+    val windowAggOutputExpr = if (isFinal) {
+      // project group key if exists
+      val (groupKey, projGroupKeyCode) = if (!grouping.isEmpty) {
+        val groupKey = newName("groupKey")
+        val keyProjectionCode = ProjectionCodeGenerator.generateProjectionExpression(
+          ctx, aggMapKeyRowType, groupKeyRowType, grouping.indices.toArray,
+          inputTerm = reuseAggMapKeyTerm,
+          outRecordTerm = groupKey,
+          outRecordWriterTerm = newName("groupKeyWriter")).code
+        (Some(groupKey), keyProjectionCode)
+      } else {
+        (None, "")
+      }
+
+      // gen agg result
+      val resultExpr = genHashAggOutputExpr(
+        isMerge, isFinal, ctx, config, builder, auxGrouping, aggregates,
+        argsMapping, aggBuffMapping, outputTerm, outputType, inputTerm, inputType, groupKey,
+        reuseAggBufferTerm, aggBufferRowType)
+
+      // update current window
+      val timeWindowType = classOf[TimeWindow].getName
+      val currentWindow = newName("currentWindow")
+      ctx.addReusableMember(s"transient $timeWindowType $currentWindow = null;")
+      val assignedTsIndex = grouping.length
+      val currentWindowCode =
+        s"""
+           |$currentWindow = $timeWindowType.of(
+           |${convertToLongValue(s"$reuseAggMapKeyTerm.get$timestampInternalTypeName" +
+            s"($assignedTsIndex)")},
+           |${convertToLongValue(s"$reuseAggMapKeyTerm.get$timestampInternalTypeName" +
+            s"($assignedTsIndex)")}
+           | + ${windowSize}L);
+        """.stripMargin
+
+      val winResExpr =
+        genWindowAggOutputWithWindowPorps(ctx, outputType, currentWindow, resultExpr)
+
+      val output =
+        s"""
+           |// update current window
+           |$currentWindowCode
+           |// project current group keys if exist
+           |$projGroupKeyCode
+           |// build agg output
+           |${winResExpr.code}
+         """.stripMargin
+      new GeneratedExpression(
+        winResExpr.resultTerm, "false", output, outputType)
+    } else {
+      genHashAggOutputExpr(isMerge, isFinal, ctx, config, builder, auxGrouping,
+        aggregates, argsMapping, aggBuffMapping, outputTerm, outputType, inputTerm, inputType,
+        Some(reuseAggMapKeyTerm), reuseAggBufferTerm, aggBufferRowType)
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // gen code to iterating the aggregate map and output to downstream
+    val mapEntryTypeTerm = classOf[BytesHashMap.Entry].getCanonicalName
+    s"""
+       |org.apache.flink.util.MutableObjectIterator<$mapEntryTypeTerm> iterator =
+       |  $aggregateMapTerm.getEntryIterator();
+       |while (iterator.next($reuseAggMapEntryTerm) != null) {
+       |   ${ctx.reuseInputUnboxingCode(reuseAggBufferTerm)}
+       |   ${windowAggOutputExpr.code}
+       |   ${generateCollect(windowAggOutputExpr.resultTerm)}
+       |}
+       """.stripMargin
+  }
+
+  private def genHashWindowAggCodes(
+      config: TableConfig,
+      reservedAggMapMemory: Long,
+      maxManagedMemory: Long,
+      buffLimitSize: Int,
+      windowSize: Long,
+      slideSize: Long,
+      inputTerm: String,
+      inputType: RowType,
+      outputType: RowType,
+      aggMapKey: String,
+      logTerm: String): (String, String) = {
+    // prepare aggregate map
+    val aggMapKeyTypesTerm = CodeGenUtils.newName("aggMapKeyTypes")
+    val aggBufferTypesTerm = CodeGenUtils.newName("aggBufferTypes")
+    prepareHashAggKVTypes(
+      ctx, aggMapKeyTypesTerm, aggBufferTypesTerm, aggMapKeyRowType, aggBufferRowType)
+    val aggregateMapTerm = CodeGenUtils.newName("aggregateMap")
+    prepareHashAggMap(
+      ctx, config, reservedAggMapMemory, maxManagedMemory
+      , aggMapKeyTypesTerm, aggBufferTypesTerm, aggregateMapTerm)
+
+    // gen code to do aggregate by window using aggregate map
+    val currentAggBufferTerm =
+      ctx.addReusableLocalVariable(classOf[BinaryRow].getName, "currentAggBuffer")
+    val (initedAggBufferExpr, doAggregateExpr, outputResultFromMap) = genGroupWindowHashAggCodes(
+      config, isMerge, isFinal, windowSize, slideSize, aggMapKeyTypesTerm, aggBufferTypesTerm,
+      buffLimitSize, aggregateMapTerm, inputTerm, inputType, outputType, currentAggBufferTerm)
+
+    // -------------------------------------------------------------------------------------------
+    val lazyInitAggBufferCode = if (auxGrouping.nonEmpty) {
+      s"""
+         |// lazy init agg buffer (with auxGrouping)
+         |${initedAggBufferExpr.code}
+       """.stripMargin
+    } else {
+      ""
+    }
+
+    val lookupInfo =
+      ctx.addReusableLocalVariable(classOf[BytesHashMap.LookupInfo].getCanonicalName, "lookupInfo")
+    val dealWithAggHashMapOOM = if (isFinal) {
+      s"""throw new java.io.IOException("Hash window aggregate map OOM.");"""
+    } else {
+      val retryAppend = genRetryAppendToMap(
+        aggregateMapTerm, aggMapKey, initedAggBufferExpr, lookupInfo, currentAggBufferTerm)
+      val logMapOutput = CodeGenUtils.genLogInfo(
+        logTerm, s"BytesHashMap out of memory with {} entries, output directly.",
+        s"$aggregateMapTerm.getNumElements()")
+      s"""
+         |$logMapOutput
+         | // hash map out of memory, output directly
+         |$outputResultFromMap
+         | // retry append
+         |$retryAppend
+          """.stripMargin
+    }
+
+    val process =
+      s"""
+         |// look up output buffer using current key (grouping keys ..., assigned timestamp)
+         |$lookupInfo = $aggregateMapTerm.lookup($aggMapKey);
+         |$currentAggBufferTerm = $lookupInfo.getValue();
+         |if (!$lookupInfo.isFound()) {
+         |  $lazyInitAggBufferCode
+         |  // append empty agg buffer into aggregate map for current group key
+         |  try {
+         |    $currentAggBufferTerm =
+         |      $aggregateMapTerm.append($lookupInfo, ${initedAggBufferExpr.resultTerm});
+         |  } catch (java.io.EOFException exp) {
+         |    $dealWithAggHashMapOOM
+         |  }
+         |}
+         |// aggregate buffer fields access
+         |${ctx.reuseInputUnboxingCode(currentAggBufferTerm)}
+         |// do aggregate and update agg buffer
+         |${doAggregateExpr.code}
+       """.stripMargin.trim
+
+    (process, outputResultFromMap)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/SortAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/SortAggCodeGenerator.scala
@@ -46,7 +46,6 @@ object SortAggCodeGenerator {
       auxGrouping: Array[Int],
       isMerge: Boolean,
       isFinal: Boolean): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
-    val config = ctx.tableConfig
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
 
     val aggCallToAggFunction = aggInfoList.aggInfos.map(info => (info.agg, info.function))
@@ -81,7 +80,6 @@ object SortAggCodeGenerator {
       isMerge,
       isFinal,
       ctx,
-      config,
       builder,
       grouping,
       auxGrouping,
@@ -146,7 +144,6 @@ object SortAggCodeGenerator {
       classOf[TableStreamOperator[BaseRow]].getCanonicalName,
       processCode,
       endInputCode,
-      inputType,
-      config)
+      inputType)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/SortWindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/SortWindowCodeGenerator.scala
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codegen.agg.batch
+
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.table.`type`.RowType
+import org.apache.flink.table.api.window.TimeWindow
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.codegen.CodeGenUtils.BINARY_ROW
+import org.apache.flink.table.codegen.agg.batch.AggCodeGenHelper.genGroupKeyChangedCheckCode
+import org.apache.flink.table.codegen.{CodeGenUtils, CodeGeneratorContext, ProjectionCodeGenerator}
+import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.functions.AggregateFunction
+import org.apache.flink.table.generated.GeneratedOperator
+import org.apache.flink.table.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
+import org.apache.flink.table.plan.util.AggregateInfoList
+import org.apache.flink.table.runtime.TableStreamOperator
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.tools.RelBuilder
+
+/**
+  * Tumbling window: like [[SortAggCodeGenerator]].
+  *
+  * Sliding window:
+  * 1.enableAssignPane + 1 phase:
+  * -- distribute by (key)
+  *   -- sort by (key + ts)
+  *     -- assign pane + sort agg + assign window + sort agg
+  * 2.enableAssignPane + 2 phase:
+  * -- sort by (key + ts)
+  *   -- assign pane + sort agg 
+  *     -- distribute by (key)
+  *       -- sort by (key + pane)
+  *         -- assign window + sort agg
+  * 3.disableAssignPane + 1 phase:
+  * -- distribute by (key)
+  *   -- sort by (key +ts)
+  *     -- assign window + sort agg.
+  */
+class SortWindowCodeGenerator(
+    ctx: CodeGeneratorContext,
+    relBuilder: RelBuilder,
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    aggInfoList: AggregateInfoList,
+    inputRowType: RelDataType,
+    inputType: RowType,
+    outputType: RowType,
+    buffLimitSize: Int,
+    windowStart: Long,
+    windowSize: Long,
+    slideSize: Long,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = true,
+    isMerge: Boolean,
+    isFinal: Boolean)
+  extends WindowCodeGenerator(
+    relBuilder,
+    window,
+    inputTimeFieldIndex,
+    inputTimeIsDate,
+    namedProperties,
+    aggInfoList,
+    inputRowType,
+    grouping,
+    auxGrouping,
+    enableAssignPane,
+    isMerge,
+    isFinal) {
+
+  def genWithoutKeys(): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
+    val config = ctx.tableConfig
+
+    val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
+
+    aggCallToAggFunction
+        .map(_._2).filter(a => a.isInstanceOf[AggregateFunction[_, _]])
+        .map(a => ctx.addReusableFunction(a))
+
+    val timeWindowType = classOf[TimeWindow].getName
+    val currentWindow = CodeGenUtils.newName("currentWindow")
+    ctx.addReusableMember(s"transient $timeWindowType $currentWindow = null;")
+
+    val windowsGrouping = CodeGenUtils.newName("windowsGrouping")
+    val enablePreAcc = choosePreAcc || isMerge
+    val windowElementType = getWindowsGroupingElementInfo(enablePreAcc)
+
+    val (triggerWindowAgg, endWindowAgg) = genWindowAggCodes(
+      enablePreAcc, ctx, config, windowSize, slideSize, windowsGrouping, buffLimitSize,
+      windowElementType, inputTimeFieldIndex, currentWindow, None, outputType)
+
+    val (processInput, endProcessInput) =
+      if (enablePreAcc) {
+        genPreAccumulate(ctx, config, windowStart, slideSize, windowSize, inputTerm,
+          inputType, outputType, windowsGrouping, windowElementType, None, triggerWindowAgg,
+          endWindowAgg)
+      } else {
+        (s"""
+            |hasInput = true;
+            |$windowsGrouping.addInputToBuffer(($BINARY_ROW)$inputTerm);
+            |$triggerWindowAgg
+         """.stripMargin, endWindowAgg)
+      }
+
+    val processCode =
+      s"""
+         |if (!$inputTerm.isNullAt($inputTimeFieldIndex)) {
+         |  $processInput
+         |}
+         |""".stripMargin
+
+    val endInputCode =
+      s"""
+         |if (hasInput) {
+         |  $endProcessInput
+         |}""".stripMargin
+
+    val className = if (isFinal) "SortWinAggWithoutKeys" else "LocalSortWinAggWithoutKeys"
+    val baseClass = classOf[TableStreamOperator[_]].getName
+    AggCodeGenHelper.generateOperator(
+      ctx, className, baseClass, processCode, endInputCode, inputType, config)
+  }
+
+  def genWithKeys(): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
+    val config = ctx.tableConfig
+    aggCallToAggFunction
+        .map(_._2).filter(a => a.isInstanceOf[AggregateFunction[_, _]])
+        .map(a => ctx.addReusableFunction(a))
+
+    val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
+
+    val currentKey = CodeGenUtils.newName("currentKey")
+    val currentKeyWriter = CodeGenUtils.newName("currentKeyWriter")
+    val lastKey = CodeGenUtils.newName("lastKey")
+    ctx.addReusableMember(s"transient $BINARY_ROW $lastKey = null;")
+
+    val keyProjectionCode = ProjectionCodeGenerator.generateProjectionExpression(
+      ctx,
+      inputType,
+      groupKeyRowType,
+      grouping,
+      inputTerm = inputTerm,
+      outRecordTerm = currentKey,
+      outRecordWriterTerm = currentKeyWriter).code
+
+    val keyNotEqualsCode = genGroupKeyChangedCheckCode(currentKey, lastKey)
+
+    // gen code to merge pre-accumulated results
+    val timeWindowType = classOf[TimeWindow].getName
+    val currentWindow = CodeGenUtils.newName("currentWindow")
+    ctx.addReusableMember(s"transient $timeWindowType $currentWindow = null;")
+
+    val windowsGrouping = CodeGenUtils.newName("windowsGrouping")
+    val enablePreAcc = choosePreAcc || isMerge
+    val windowElementType = getWindowsGroupingElementInfo(enablePreAcc)
+
+    val (triggerWindowAgg, endWindowAgg) = genWindowAggCodes(
+      enablePreAcc, ctx, config, windowSize, slideSize, windowsGrouping, buffLimitSize,
+      windowElementType, inputTimeFieldIndex, currentWindow, Some(lastKey), outputType)
+
+    val (processCurrentKeyInput, endProcessCurrentKeyInput) =
+      if (enablePreAcc) {
+        genPreAccumulate(ctx, config, windowStart, slideSize, windowSize, inputTerm,
+          inputType, outputType, windowsGrouping, windowElementType, Some(lastKey),
+          triggerWindowAgg, endWindowAgg)
+      } else {
+        (s"""
+            |hasInput = true;
+            |$windowsGrouping.addInputToBuffer(($BINARY_ROW)$inputTerm);
+            |$triggerWindowAgg
+         """.stripMargin, endWindowAgg)
+      }
+
+    val processCode =
+      s"""
+         |if (!$inputTerm.isNullAt($inputTimeFieldIndex)) {
+         |  // reusable input fields access
+         |  ${ctx.reuseInputUnboxingCode(inputTerm)}
+         |  // project key from input
+         |  $keyProjectionCode
+         |  // find next group and aggregate
+         |  if ($lastKey == null) {
+         |   $lastKey = $currentKey.copy();
+         |  } else if ($keyNotEqualsCode) {
+         |    $endProcessCurrentKeyInput
+         |    $lastKey = $currentKey.copy();
+         |  }
+         |  // assign each input with an aligned window start timestamp
+         |  // and do accumulate if possible
+         |  // buffer it into current group buffer
+         |  // and do aggregation for all trigger windows if exits
+         |  $processCurrentKeyInput
+         |}
+         |""".stripMargin.trim
+
+    val endInputCode =
+      s"""
+         |if (hasInput) {
+         |  $endProcessCurrentKeyInput
+         |}
+         """.stripMargin
+
+    val className = if (isFinal) "SortWinAggWithKeys" else "LocalSortWinAggWithKeys"
+    val baseClass = classOf[TableStreamOperator[_]].getName
+    AggCodeGenHelper.generateOperator(
+      ctx, className, baseClass, processCode, endInputCode, inputType, config)
+  }
+
+  private def choosePreAcc: Boolean = {
+    // pre accumulate by pane
+    enableAssignPane ||
+        // pre accumulate by window
+        window.isInstanceOf[TumblingGroupWindow] ||
+        (window.isInstanceOf[SlidingGroupWindow] && slideSize == windowSize)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/SortWindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/SortWindowCodeGenerator.scala
@@ -89,8 +89,6 @@ class SortWindowCodeGenerator(
     isFinal) {
 
   def genWithoutKeys(): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
-    val config = ctx.tableConfig
-
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
 
     aggCallToAggFunction
@@ -106,13 +104,31 @@ class SortWindowCodeGenerator(
     val windowElementType = getWindowsGroupingElementInfo(enablePreAcc)
 
     val (triggerWindowAgg, endWindowAgg) = genWindowAggCodes(
-      enablePreAcc, ctx, config, windowSize, slideSize, windowsGrouping, buffLimitSize,
-      windowElementType, inputTimeFieldIndex, currentWindow, None, outputType)
+      enablePreAcc,
+      ctx,
+      windowSize,
+      slideSize,
+      windowsGrouping,
+      buffLimitSize,
+      windowElementType,
+      inputTimeFieldIndex,
+      currentWindow,
+      None,
+      outputType)
 
     val (processInput, endProcessInput) =
       if (enablePreAcc) {
-        genPreAccumulate(ctx, config, windowStart, slideSize, windowSize, inputTerm,
-          inputType, outputType, windowsGrouping, windowElementType, None, triggerWindowAgg,
+        genPreAccumulate(ctx,
+          windowStart,
+          slideSize,
+          windowSize,
+          inputTerm,
+          inputType,
+          outputType,
+          windowsGrouping,
+          windowElementType,
+          None,
+          triggerWindowAgg,
           endWindowAgg)
       } else {
         (s"""
@@ -138,11 +154,10 @@ class SortWindowCodeGenerator(
     val className = if (isFinal) "SortWinAggWithoutKeys" else "LocalSortWinAggWithoutKeys"
     val baseClass = classOf[TableStreamOperator[_]].getName
     AggCodeGenHelper.generateOperator(
-      ctx, className, baseClass, processCode, endInputCode, inputType, config)
+      ctx, className, baseClass, processCode, endInputCode, inputType)
   }
 
   def genWithKeys(): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
-    val config = ctx.tableConfig
     aggCallToAggFunction
         .map(_._2).filter(a => a.isInstanceOf[AggregateFunction[_, _]])
         .map(a => ctx.addReusableFunction(a))
@@ -175,14 +190,32 @@ class SortWindowCodeGenerator(
     val windowElementType = getWindowsGroupingElementInfo(enablePreAcc)
 
     val (triggerWindowAgg, endWindowAgg) = genWindowAggCodes(
-      enablePreAcc, ctx, config, windowSize, slideSize, windowsGrouping, buffLimitSize,
-      windowElementType, inputTimeFieldIndex, currentWindow, Some(lastKey), outputType)
+      enablePreAcc,
+      ctx,
+      windowSize,
+      slideSize,
+      windowsGrouping,
+      buffLimitSize,
+      windowElementType,
+      inputTimeFieldIndex,
+      currentWindow,
+      Some(lastKey),
+      outputType)
 
     val (processCurrentKeyInput, endProcessCurrentKeyInput) =
       if (enablePreAcc) {
-        genPreAccumulate(ctx, config, windowStart, slideSize, windowSize, inputTerm,
-          inputType, outputType, windowsGrouping, windowElementType, Some(lastKey),
-          triggerWindowAgg, endWindowAgg)
+        genPreAccumulate(ctx,
+          windowStart,
+          slideSize,
+          windowSize,
+          inputTerm,
+          inputType,
+          outputType,
+          windowsGrouping,
+          windowElementType,
+          Some(lastKey),
+          triggerWindowAgg,
+          endWindowAgg)
       } else {
         (s"""
             |hasInput = true;
@@ -223,7 +256,7 @@ class SortWindowCodeGenerator(
     val className = if (isFinal) "SortWinAggWithKeys" else "LocalSortWinAggWithKeys"
     val baseClass = classOf[TableStreamOperator[_]].getName
     AggCodeGenHelper.generateOperator(
-      ctx, className, baseClass, processCode, endInputCode, inputType, config)
+      ctx, className, baseClass, processCode, endInputCode, inputType)
   }
 
   private def choosePreAcc: Boolean = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/WindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/WindowCodeGenerator.scala
@@ -1,0 +1,689 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codegen.agg.batch
+
+import org.apache.flink.table.`type`.TypeConverters.createInternalTypeFromTypeInfo
+import org.apache.flink.table.`type`.{InternalType, InternalTypes, RowType}
+import org.apache.flink.table.api.window.TimeWindow
+import org.apache.flink.table.api.{TableConfig, Types}
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.codegen.CodeGenUtils.{BINARY_ROW, boxedTypeTermForType, newName}
+import org.apache.flink.table.codegen.GenerateUtils.generateFieldAccess
+import org.apache.flink.table.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
+import org.apache.flink.table.codegen.OperatorCodeGenerator.generateCollect
+import org.apache.flink.table.codegen.agg.batch.AggCodeGenHelper.{buildAggregateArgsMapping, genAggregateByFlatAggregateBuffer, genFlatAggBufferExprs, genInitFlatAggregateBuffer}
+import org.apache.flink.table.codegen.agg.batch.WindowCodeGenerator.{asLong, isTimeIntervalLiteral}
+import org.apache.flink.table.codegen.{CodeGenUtils, CodeGeneratorContext, ExprCodeGenerator, GenerateUtils, GeneratedExpression}
+import org.apache.flink.table.dataformat.{BaseRow, BinaryRow, GenericRow, JoinedRow}
+import org.apache.flink.table.expressions.ExpressionBuilder.{ifThenElse, lessThan, literal, minus, mod, plus, reinterpretCast, times, typeLiteral}
+import org.apache.flink.table.expressions.{Expression, RexNodeConverter, ValueLiteralExpression}
+import org.apache.flink.table.functions.aggfunctions.DeclarativeAggregateFunction
+import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils.getAccumulatorTypeOfAggregateFunction
+import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
+import org.apache.flink.table.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
+import org.apache.flink.table.plan.util.{AggregateInfoList, AggregateUtil}
+import org.apache.flink.table.runtime.util.RowIterator
+import org.apache.flink.table.runtime.window.grouping.{WindowsGrouping, HeapWindowsGrouping}
+import org.apache.flink.table.typeutils.{RowIntervalTypeInfo, TimeIntervalTypeInfo}
+
+import org.apache.calcite.avatica.util.DateTimeUtils
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.tools.RelBuilder
+import org.apache.commons.math3.util.ArithmeticUtils
+
+abstract class WindowCodeGenerator(
+    relBuilder: RelBuilder,
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    aggInfoList: AggregateInfoList,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = true,
+    val isMerge: Boolean,
+    val isFinal: Boolean) {
+
+  lazy val builder: RelBuilder = relBuilder.values(inputRowType)
+  lazy val timestampInternalType: InternalType =
+    if (inputTimeIsDate) InternalTypes.INT else InternalTypes.LONG
+  lazy val timestampInternalTypeName: String = if (inputTimeIsDate) "Int" else "Long"
+  lazy val aggCallToAggFunction: Array[(AggregateCall, UserDefinedFunction)] =
+    aggInfoList.aggInfos.map(info => (info.agg, info.function))
+  lazy val aggregateCalls: Seq[AggregateCall] = aggCallToAggFunction.map(_._1)
+  lazy val aggregates: Seq[UserDefinedFunction] = aggCallToAggFunction.map(_._2)
+
+  lazy val aggArgs: Array[Array[Int]] = aggInfoList.aggInfos.map(_.argIndexes)
+
+  // currently put auxGrouping to aggBuffer in code-gen
+  lazy val aggBufferNames: Array[Array[String]] = auxGrouping.zipWithIndex.map {
+    case (_, index) => Array(s"aux_group$index")
+  } ++ aggregates.zipWithIndex.toArray.map {
+    case (a: DeclarativeAggregateFunction, index) =>
+      val idx = auxGrouping.length + index
+      a.aggBufferAttributes.map(attr => s"agg${idx}_${attr.getName}")
+    case (_: AggregateFunction[_, _], index) =>
+      val idx = auxGrouping.length + index
+      Array(s"agg$idx")
+  }
+
+  lazy val aggBufferTypes: Array[Array[InternalType]] = auxGrouping.map { index =>
+    Array(FlinkTypeFactory.toInternalType(inputRowType.getFieldList.get(index).getType))
+  } ++ aggregates.map {
+    case a: DeclarativeAggregateFunction => a.getAggBufferTypes
+    case a: AggregateFunction[_, _] =>
+      Array(getAccumulatorTypeOfAggregateFunction(a)).map(createInternalTypeFromTypeInfo)
+  }.toArray[Array[InternalType]]
+
+  lazy val groupKeyRowType = new RowType(
+    grouping.map { index =>
+      FlinkTypeFactory.toInternalType(inputRowType.getFieldList.get(index).getType)
+    }, grouping.map(inputRowType.getFieldNames.get(_)))
+
+  // get udagg instance names
+  lazy val udaggs: Map[AggregateFunction[_, _], String] = aggregates
+      .filter(a => a.isInstanceOf[AggregateFunction[_, _]])
+      .map(a => a -> CodeGenUtils.udfFieldName(a)).toMap
+      .asInstanceOf[Map[AggregateFunction[_, _], String]]
+
+  lazy val windowedGroupKeyType: RowType = new RowType(
+    groupKeyRowType.getFieldTypes :+ timestampInternalType,
+    groupKeyRowType.getFieldNames :+ "assignedTs$")
+
+  def getOutputRowClass: Class[_ <: BaseRow] =
+    if (namedProperties.isEmpty && grouping.isEmpty) classOf[GenericRow] else classOf[JoinedRow]
+
+  private[flink] def getWindowsGroupingElementInfo(
+      enablePreAccumulate: Boolean = true): RowType = {
+    if (enablePreAccumulate) {
+      val (groupKeyNames, groupKeyTypes) =
+        (groupKeyRowType.getFieldNames, groupKeyRowType.getFieldTypes)
+      val (aggBuffNames, aggBuffTypes) =
+        (aggBufferNames.flatten, aggBufferTypes.flatten)
+      new RowType(
+        (groupKeyTypes :+ timestampInternalType) ++ aggBuffTypes,
+        (groupKeyNames :+ "assignedTs$") ++ aggBuffNames)
+    } else {
+      FlinkTypeFactory.toInternalRowType(inputRowType)
+    }
+  }
+
+  private[flink] def genCreateWindowsGroupingCode(
+      ctx: CodeGeneratorContext,
+      inputTimeFieldIndex: Int,
+      windowSize: Long,
+      slideSize: Long,
+      groupingTerm: String,
+      bufferLimitSize: Int): Unit = {
+    val windowsGrouping = classOf[HeapWindowsGrouping].getName
+    ctx.addReusableMember(
+      s"transient $windowsGrouping $groupingTerm " +
+          s"= new $windowsGrouping(" +
+          s"$bufferLimitSize, ${windowSize}L, ${slideSize}L," +
+          s" $inputTimeFieldIndex, $inputTimeIsDate);")
+    ctx.addReusableCloseStatement(s"$groupingTerm.close();")
+  }
+
+  /**
+    * Using [[WindowsGrouping#buildTriggerWindowElementsIterator]]
+    * to iterate the windows assigned with the current keyed or all grouped input.
+    * Apply aggregate functions within the each window scope in turns.
+    */
+  private[flink] def genTriggerWindowAggByWindowsGroupingCode(
+      ctx: CodeGeneratorContext,
+      groupingTerm: String,
+      currentWindow: String,
+      currentWindowElement: String,
+      initAggBufferCode: String,
+      doAggregateCode: String,
+      outputWinAggResExpr: GeneratedExpression): String = {
+    val rowIter = classOf[RowIterator[BinaryRow]].getName
+    val statements =
+      s"""
+         |while ($groupingTerm.hasTriggerWindow()) {
+         |  $rowIter elementIterator = $groupingTerm.buildTriggerWindowElementsIterator();
+         |  $currentWindow = $groupingTerm.getTriggerWindow();
+         |  // init agg buffer
+         |  $initAggBufferCode
+         |  // do aggregate
+         |  boolean hasElement = false;
+         |  while(elementIterator.advanceNext()) {
+         |    hasElement = true;
+         |    $BINARY_ROW $currentWindowElement = ($BINARY_ROW) elementIterator.getRow();
+         |    ${ctx.reuseInputUnboxingCode(currentWindowElement)}
+         |    $doAggregateCode
+         |  }
+         |  if (hasElement) {
+         |    // write output
+         |    ${outputWinAggResExpr.code}
+         |    ${generateCollect(outputWinAggResExpr.resultTerm)}
+         |  }
+         |}""".stripMargin
+    val functionName = CodeGenUtils.newName("triggerWindowProcess")
+    val functionCode =
+      s"""
+         |private void $functionName() {
+         |  ${ctx.reuseLocalVariableCode()}
+         |  $statements
+         |}
+       """.stripMargin
+    ctx.addReusableMember(functionCode)
+    s"$functionName();"
+  }
+
+  private[flink] def genTriggerLeftoverWindowAggCode(
+      groupingTerm: String, triggerProcessCode: String): String = {
+    s"""
+       | $groupingTerm.advanceWatermarkToTriggerAllWindows();
+       | $triggerProcessCode
+       | $groupingTerm.reset();
+       """.stripMargin
+  }
+
+  private[flink] def genSortWindowAggCodes(
+      enablePreAcc: Boolean,
+      ctx: CodeGeneratorContext,
+      config: TableConfig,
+      inputTerm: String,
+      inputType: RowType,
+      outputType: RowType,
+      currentKey: Option[String],
+      currentWindow: String): (String, String, GeneratedExpression) = {
+    // gen code to apply aggregate functions to grouping window elements
+    val offset = if (enablePreAcc) grouping.length + 1 else grouping.length
+    val argsMapping = buildAggregateArgsMapping(
+      enablePreAcc, offset, inputType, auxGrouping, aggArgs, aggBufferTypes)
+    val aggBufferExprs = genFlatAggBufferExprs(enablePreAcc, ctx, config, builder, auxGrouping,
+      aggregates, argsMapping, aggBufferNames, aggBufferTypes)
+    val initAggBufferCode = genInitFlatAggregateBuffer(
+      ctx, config, builder, inputType, inputTerm,
+      grouping, auxGrouping, aggregates, udaggs, aggBufferExprs)
+    val doAggregateCode = genAggregateByFlatAggregateBuffer(
+      enablePreAcc, ctx, config, builder, inputType, inputTerm, auxGrouping, aggCallToAggFunction,
+      aggregates, udaggs, argsMapping, aggBufferNames, aggBufferTypes, aggBufferExprs)
+
+    // --------------------------------------------------------------------------------------------
+    // gen code to set group window aggregate output
+    val valueRow = CodeGenUtils.newName("valueRow")
+    val resultCodegen = new ExprCodeGenerator(ctx, false)
+    val setValueResult = if (isFinal) {
+      AggCodeGenHelper.genSortAggOutputExpr(
+        enablePreAcc, isFinal = true, ctx, config, builder, grouping, auxGrouping, aggregates,
+        aggInfoList.aggInfos.map(_.externalResultType), udaggs,
+        argsMapping, aggBufferNames, aggBufferTypes, aggBufferExprs, outputType)
+    } else {
+      // output assigned window and agg buffer
+      val valueRowType = new RowType(
+        timestampInternalType +: aggBufferExprs.map(_.resultType): _*)
+      val wStartCode = if (inputTimeIsDate) {
+        convertToIntValue(s"$currentWindow.getStart()")
+      } else {
+        s"$currentWindow.getStart()"
+      }
+      resultCodegen.generateResultExpression(GeneratedExpression(
+        s"$wStartCode", NEVER_NULL, NO_CODE, timestampInternalType) +:
+          aggBufferExprs,
+        valueRowType,
+        classOf[GenericRow],
+        outRow = valueRow)
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // add grouping keys if exists
+    val resultExpr = currentKey match {
+      case Some(key) =>
+        // generate agg result
+        val windowAggResultTerm = CodeGenUtils.newName("windowAggResult")
+        ctx.addReusableOutputRecord(outputType, classOf[JoinedRow], windowAggResultTerm)
+        val output =
+          s"""
+             |${setValueResult.code}
+             |$windowAggResultTerm.replace($key, ${setValueResult.resultTerm});
+         """.stripMargin
+        new GeneratedExpression(windowAggResultTerm, NEVER_NULL, output, outputType)
+      // all group agg output
+      case _ => setValueResult
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // add window props if needed
+    val outputExpr = if (isFinal) {
+      genWindowAggOutputWithWindowPorps(ctx, outputType, currentWindow, resultExpr)
+    } else {
+      resultExpr
+    }
+    (initAggBufferCode, doAggregateCode, outputExpr)
+  }
+
+  private[flink] def genWindowAggCodes(
+      enablePreAcc: Boolean,
+      ctx: CodeGeneratorContext,
+      config: TableConfig,
+      windowSize: Long,
+      slideSize: Long,
+      windowsGrouping: String,
+      bufferLimitSize: Int,
+      windowElementType: RowType,
+      inputTimeFieldIndex: Int,
+      currentWindow: String,
+      groupKey: Option[String],
+      outputType: RowType): (String, String) = {
+    // gen code to do aggregate by window or pane
+    val windowElemTerm = CodeGenUtils.newName("winElement")
+    val (initAggBuffCode, doAggCode, outputWinAggResExpr) = genSortWindowAggCodes(
+      enablePreAcc = enablePreAcc, ctx, config,
+      windowElemTerm, windowElementType, outputType, groupKey, currentWindow)
+
+    // gen code to create windows grouping buffer
+    genCreateWindowsGroupingCode(
+      ctx, inputTimeFieldIndex, windowSize, slideSize, windowsGrouping, bufferLimitSize)
+
+    // merge pre-accumulate result and output
+    val processCode = genTriggerWindowAggByWindowsGroupingCode(
+      ctx, windowsGrouping, currentWindow, windowElemTerm,
+      initAggBuffCode, doAggCode, outputWinAggResExpr)
+    val endCode = genTriggerLeftoverWindowAggCode(windowsGrouping, processCode)
+
+    (processCode, endCode)
+  }
+
+  private[flink] def genPreAccumulate(
+      ctx: CodeGeneratorContext,
+      config: TableConfig,
+      windowStart: Long,
+      slideSize: Long,
+      windowSize: Long,
+      inputTerm: String,
+      inputType: RowType,
+      outputType: RowType,
+      windowsTerm: String,
+      windowElementType: RowType,
+      lastKey: Option[String],
+      triggerWindowAggCode: String,
+      endWindowAggCode: String): (String, String) = {
+    // gen code to assign timestamp
+    def genAssignTimestampExpr(
+        ctx: CodeGeneratorContext,
+        config: TableConfig,
+        inputTerm: String,
+        inputType: RowType): GeneratedExpression = {
+      if (isFinal && isMerge) {
+        // get assigned timestamp by local window agg
+        val ret = GenerateUtils.generateFieldAccess(
+          ctx,
+          windowedGroupKeyType,
+          inputTerm,
+          windowedGroupKeyType.getArity - 1)
+        if (inputTimeIsDate) {
+          val timestamp = ctx.addReusableLocalVariable("long", "timestamp")
+          val convertToLongCode =
+            s"""
+               |  ${ret.code}
+               |  $timestamp = ${convertToLongValue(ret.resultTerm)};
+           """.stripMargin
+          GeneratedExpression(timestamp, ret.nullTerm, convertToLongCode, InternalTypes.LONG)
+        } else {
+          ret
+        }
+      } else {
+        // assign timestamp with each input
+        window match {
+          case SlidingGroupWindow(_, timeField, size, slide) if isTimeIntervalLiteral(size) =>
+            val (slideSize, windowSize) = (asLong(slide), asLong(size))
+            if (enableAssignPane) {
+              val paneSize = ArithmeticUtils.gcd(windowSize, slideSize)
+              genAlignedWindowStartExpr(
+                ctx, config, inputTerm, inputType, timeField, windowStart, paneSize)
+            } else {
+              assert(slideSize >= windowSize)
+              genAlignedWindowStartExpr(
+                ctx, config, inputTerm, inputType, timeField, windowStart, slideSize)
+            }
+          case TumblingGroupWindow(_, timeField, size) =>
+            genAlignedWindowStartExpr(
+              ctx, config, inputTerm, inputType, timeField, windowStart, asLong(size))
+          case _ =>
+            throw new RuntimeException(s"Bug. Assign pane for $window is not supported.")
+        }
+      }
+    }
+    val assignedTsExpr = genAssignTimestampExpr(ctx, config, inputTerm, inputType)
+
+    // gen code to do aggregate by assigned ts
+    val lastTimestampTerm = CodeGenUtils.newName("lastTimestamp")
+    ctx.addReusableMember(s"transient long $lastTimestampTerm = -1;")
+    val preAccResult = CodeGenUtils.newName("prepareWinElement")
+    val preAccResultWriter = CodeGenUtils.newName("prepareWinElementWriter")
+    ctx.addReusableOutputRecord(
+      windowElementType, classOf[BinaryRow], preAccResult, Some(preAccResultWriter))
+
+    val timeWindowType = classOf[TimeWindow].getName
+    val currentWindow = newName("currentWindow")
+    ctx.addReusableMember(s"transient $timeWindowType $currentWindow = null;")
+
+    // output or merge pre accumulate results by window
+    val (initAggBufferCode, doAggregateCode, mergeOrOutput, mergeOrOutputLastPane) =
+      if (isFinal && enableAssignPane) {
+        // case: global/complete window agg: Sliding window with with pane optimization
+        val offset = if (isMerge) grouping.length + 1 else grouping.length
+        val argsMapping = buildAggregateArgsMapping(isMerge, offset, inputType, auxGrouping,
+          aggArgs, aggBufferTypes)
+        val aggBufferExprs = genFlatAggBufferExprs(isMerge, ctx, config, builder, auxGrouping,
+          aggregates, argsMapping, aggBufferNames, aggBufferTypes)
+        val initAggBufferCode = genInitFlatAggregateBuffer(ctx, config, builder, inputType,
+          inputTerm, grouping, auxGrouping, aggregates, udaggs, aggBufferExprs)
+        val doAggregateCode = genAggregateByFlatAggregateBuffer(
+          isMerge, ctx, config, builder, inputType, inputTerm, auxGrouping, aggCallToAggFunction,
+          aggregates, udaggs, argsMapping, aggBufferNames, aggBufferTypes, aggBufferExprs)
+
+        // project pre accumulated results into a binary row to fit to WindowsGrouping
+        val exprCodegen = new ExprCodeGenerator(ctx, false)
+        val setResultExprs = grouping.indices.map(
+          generateFieldAccess(
+            ctx, groupKeyRowType, lastKey.get, _, config.getNullCheck)) ++
+            (GeneratedExpression(lastTimestampTerm, NEVER_NULL, NO_CODE, InternalTypes.LONG)
+                +: aggBufferExprs)
+        val setPanedAggResultExpr = exprCodegen.generateResultExpression(
+          setResultExprs, windowElementType, classOf[BinaryRow],
+          preAccResult, Some(preAccResultWriter))
+
+        // using windows grouping buffer to merge paned agg results
+        val merge =
+          s"""
+             |${setPanedAggResultExpr.code}
+             |// buffer into current group buffer
+             |$windowsTerm.addInputToBuffer(($BINARY_ROW)${setPanedAggResultExpr.resultTerm});
+             |// trigger window aggregate
+             |$triggerWindowAggCode
+       """.stripMargin
+        val mergeLast =
+          s"""
+             |${setPanedAggResultExpr.code}
+             |// buffer into current group buffer
+             |$windowsTerm.addInputToBuffer(($BINARY_ROW)${setPanedAggResultExpr.resultTerm});
+             |// last pane triggered windows will be triggered again when grouping keys changed
+             |$endWindowAggCode
+         """.stripMargin
+
+        (initAggBufferCode, doAggregateCode, merge, mergeLast)
+      } else {
+        // case1: local window agg
+        // case2: global window agg: Tumbling window, Sliding window with windowSize == slideSize
+        // or without pane optimization
+        // case3: complete window agg: Tumbling window, Sliding window with windowSize == slideSize
+        val (initAggBuffCode, doAggCode, outputWinAggResExpr) = genSortWindowAggCodes(
+          isMerge, ctx, config,
+          inputTerm, inputType, outputType, lastKey, currentWindow)
+
+        val output =
+          s"""
+             |// update current window
+             |$currentWindow =
+             |  $timeWindowType.of($lastTimestampTerm, $lastTimestampTerm + ${windowSize}L);
+             |// build window agg output
+             |${outputWinAggResExpr.code}
+             |// output result
+             |${generateCollect(outputWinAggResExpr.resultTerm)}
+           """.stripMargin
+
+        (initAggBuffCode, doAggCode, output, output)
+      }
+
+    val preAccCode =
+      s"""
+         | hasInput = true;
+         | // aggregate in sort agg way
+         | if ($lastTimestampTerm == -1) {
+         |    $initAggBufferCode
+         |    $lastTimestampTerm = ${assignedTsExpr.resultTerm};
+         | } else if ($lastTimestampTerm != ${assignedTsExpr.resultTerm}) {
+         |    $mergeOrOutput
+         |    // update active timestamp
+         |    $lastTimestampTerm = ${assignedTsExpr.resultTerm};
+         |    // init agg buffer
+         |    $initAggBufferCode
+         | }
+         | // accumulate
+         | $doAggregateCode
+         """.stripMargin
+
+    // gen code to filter invalid windows in the case of jumping window
+    val processEachInput = if (!isMerge && isJumpingWindow(slideSize, windowSize)) {
+      s"""
+         |if (${getInputTimeValue(inputTerm, inputTimeFieldIndex)}) <
+         |      ${assignedTsExpr.resultTerm} + ${windowSize}L) {
+         |  $preAccCode
+         |}
+           """.stripMargin
+    } else {
+      preAccCode
+    }
+
+    val processFuncName = CodeGenUtils.newName("preAccumulate")
+    val inputTypeTerm = boxedTypeTermForType(inputType)
+    ctx.addReusableMember(
+      s"""
+         |private void $processFuncName($inputTypeTerm $inputTerm) throws java.io.IOException {
+         |  ${ctx.reuseLocalVariableCode()}
+         |  // assign timestamp (pane/window)
+         |  ${ctx.reuseInputUnboxingCode(inputTerm)}
+         |  ${assignedTsExpr.code}
+         |  $processEachInput
+         |}
+         """.stripMargin)
+
+    val endProcessFuncName = CodeGenUtils.newName("endPreAccumulate")
+    val setLastPaneAggResultCode =
+      s"""
+         | // merge paned agg results or output directly
+         | $mergeOrOutputLastPane
+         | $lastTimestampTerm = -1;
+       """.stripMargin
+    ctx.addReusableMember(
+      s"""
+         |private void $endProcessFuncName() throws java.io.IOException {
+         |  ${ctx.reuseLocalVariableCode()}
+         |  $setLastPaneAggResultCode
+         |}
+         """.stripMargin)
+    (s"$processFuncName($inputTerm);", s"$endProcessFuncName();")
+  }
+
+  /**
+    * Generate code to set the group window aggregate result.
+    * If the group window aggregate has window auxiliary functions' projection with it,
+    * two Timestamp typed fields will be added at the last of the output row indicating
+    * the window's start and end timestamp property, to which the windowed aggregate result belongs.
+    */
+  private[flink] def genWindowAggOutputWithWindowPorps(
+      ctx: CodeGeneratorContext,
+      outputType: RowType,
+      currentWindowTerm: String,
+      aggResultExpr: GeneratedExpression): GeneratedExpression = {
+    // output window property if necessary
+    val propSize = namedProperties.size
+    if (namedProperties.isEmpty || !isFinal) {
+      // group window aggregate without window auxiliary function projection
+      // or local window aggregate
+      aggResultExpr
+    } else {
+      // window property fields always added at last when building the LogicalWindowAggregate
+      val propOutputType = {
+        val outputFields = outputType.getFieldTypes
+        val lastFieldPos = outputFields.size - 1
+        val propFields =
+          for (offset <- lastFieldPos - propSize + 1 to lastFieldPos) yield outputFields(offset)
+        new RowType(propFields: _*)
+      }
+
+      // reusable row to set window property fields
+      val propTerm = CodeGenUtils.newName("windowProp")
+      ctx.addReusableOutputRecord(propOutputType, classOf[GenericRow], propTerm)
+      val windowAggResultWithPropTerm = CodeGenUtils.newName("windowAggResultWithProperty")
+      ctx.addReusableOutputRecord(outputType, classOf[JoinedRow], windowAggResultWithPropTerm)
+
+      // set window start, end property according to window type
+      val (startPos, endPos, rowTimePos) = AggregateUtil.computeWindowPropertyPos(namedProperties)
+      val lastPos = propSize - 1
+
+      // get assigned window start timestamp
+      def windowProps(size: Expression) = {
+        val (startWValue, endWValue, rowTimeValue) = (
+            s"$currentWindowTerm.getStart()",
+            s"$currentWindowTerm.getEnd()",
+            s"$currentWindowTerm.maxTimestamp()")
+        val start = if (startPos.isDefined) {
+          s"$propTerm.setLong($lastPos + ${startPos.get}, $startWValue);"
+        } else ""
+        val end = if (endPos.isDefined) {
+          s"$propTerm.setLong($lastPos + ${endPos.get}, $endWValue);"
+        } else ""
+        val rowTime = if (rowTimePos.isDefined) {
+          s"$propTerm.setLong($lastPos + ${rowTimePos.get}, $rowTimeValue);"
+        } else ""
+        (start, end, rowTime)
+      }
+
+      // compute window start, window end, window rowTime
+      val (setWindowStart, setWindowEnd, setWindowRowTime) = window match {
+        case TumblingGroupWindow(_, _, size) if isTimeIntervalLiteral(size) =>
+          windowProps(size)
+        case SlidingGroupWindow(_, _, size, _) if isTimeIntervalLiteral(size) =>
+          windowProps(size)
+        case _ =>
+          throw new UnsupportedOperationException(
+            s"Window $window is not supported in a batch environment.")
+      }
+      val output =
+        s"""
+           |${aggResultExpr.code}
+           |$setWindowStart
+           |$setWindowEnd
+           |$setWindowRowTime
+           |$windowAggResultWithPropTerm.replace(${aggResultExpr.resultTerm}, $propTerm);
+         """.stripMargin
+      new GeneratedExpression(
+        windowAggResultWithPropTerm, NEVER_NULL, output, outputType)
+    }
+  }
+
+  private[flink] def isJumpingWindow(slideSize: Long, windowSize: Long) : Boolean = {
+    window.isInstanceOf[SlidingGroupWindow] && slideSize > windowSize
+  }
+
+  private[flink] def genAlignedWindowStartExpr(
+      ctx: CodeGeneratorContext,
+      config: TableConfig,
+      inputTerm: String,
+      inputType: RowType,
+      timeField: Expression,
+      windowStart: Long,
+      slideSize: Long,
+      index: Int = 0): GeneratedExpression = {
+    val exprCodegen = new ExprCodeGenerator(ctx, nullableInput = false)
+        .bindInput(inputType, inputTerm = inputTerm)
+    val timeStampInLong = reinterpretCast(timeField, typeLiteral(Types.LONG), false)
+    val millValue: Long = if (inputTimeIsDate) DateTimeUtils.MILLIS_PER_DAY else 1L
+    val timeStampValue = times(timeStampInLong, literal(millValue))
+    val remainder = mod(minus(timeStampValue, literal(windowStart)), literal(slideSize))
+    // handle both positive and negative cases
+    val expr = minus(minus(
+      timeStampValue,
+      ifThenElse(
+        lessThan(remainder, literal(0)),
+        plus(remainder, literal(slideSize)),
+        remainder)),
+      literal(index * slideSize))
+    exprCodegen.generateExpression(expr.accept(
+      new RexNodeConverter(relBuilder.values(inputRowType))))
+  }
+
+  def getGrouping: Array[Int] = grouping
+
+  def getAuxGrouping: Array[Int] = auxGrouping
+
+  def getAggCallList: Seq[AggregateCall] = aggCallToAggFunction.map(_._1)
+
+  def getInputTimeValue(inputTerm: String, index: Int): String = {
+    if(inputTimeIsDate) {
+      s"""
+         |$inputTerm.getInt($index) * ${DateTimeUtils.MILLIS_PER_DAY}L
+       """.stripMargin
+    } else {
+      s"$inputTerm.getLong($index)"
+    }
+  }
+
+  def convertToIntValue(inputTerm: String): String = {
+    if (inputTimeIsDate) {
+      s"(int)($inputTerm/${DateTimeUtils.MILLIS_PER_DAY})"
+    } else {
+      inputTerm
+    }
+  }
+
+  def convertToLongValue(inputTerm: String): String = {
+    if (inputTimeIsDate) {
+      s"(long)($inputTerm * ${DateTimeUtils.MILLIS_PER_DAY}L)"
+    } else {
+      inputTerm
+    }
+  }
+
+  def isSlidingWindowWithOverlapping(
+      enableAssignPane: Boolean,
+      window: LogicalWindow,
+      slideSize: Long,
+      windowSize: Long): Boolean = {
+    window.isInstanceOf[SlidingGroupWindow] && slideSize < windowSize && !enableAssignPane
+  }
+}
+
+object WindowCodeGenerator {
+
+  def getWindowDef(window: LogicalWindow): (Long, Long) = {
+    val (windowSize, slideSize): (Long, Long) = window match {
+      case TumblingGroupWindow(_, _, size) if isTimeIntervalLiteral(size) =>
+        (asLong(size), asLong(size))
+      case SlidingGroupWindow(_, _, size, slide) if isTimeIntervalLiteral(size) =>
+        (asLong(size), asLong(slide))
+      case _ =>
+        // count tumbling/sliding window and session window not supported now
+        throw new UnsupportedOperationException(s"Window $window is not supported right now.")
+    }
+    (windowSize, slideSize)
+  }
+
+  def asLong(expr: Expression): Long = expr match {
+    case literal: ValueLiteralExpression
+      if literal.getType == TimeIntervalTypeInfo.INTERVAL_MILLIS ||
+          literal.getType == RowIntervalTypeInfo.INTERVAL_ROWS =>
+      literal.getValue.asInstanceOf[java.lang.Long]
+    case _ => throw new IllegalArgumentException()
+  }
+
+  def isTimeIntervalLiteral(expr: Expression): Boolean = expr match {
+    case literal: ValueLiteralExpression
+      if literal.getType == TimeIntervalTypeInfo.INTERVAL_MILLIS => true
+    case _ => false
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/expressions/windowProperties.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/expressions/windowProperties.scala
@@ -19,43 +19,61 @@
 package org.apache.flink.table.expressions
 
 import org.apache.flink.table.`type`.{InternalType, InternalTypes, TimestampType}
-import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
-
-import java.util
-import java.util.Collections
+import org.apache.flink.table.api.TableException
 
 trait WindowProperty {
-
-  def toNamedWindowProperty(name: String): NamedWindowProperty
-
   def resultType: InternalType
-
 }
 
-abstract class AbstractWindowProperty(child: Expression)
-  extends Expression
-  with WindowProperty {
-
-  override def toString = s"WindowProperty($child)"
-
-  override def accept[T](exprVisitor: ExpressionVisitor[T]): T =
-    exprVisitor.visit(this)
-
-  override def getChildren: util.List[Expression] = Collections.emptyList()
-
-  def toNamedWindowProperty(name: String): NamedWindowProperty = NamedWindowProperty(name, this)
+abstract class AbstractWindowProperty(reference: WindowReference) extends WindowProperty {
+  override def toString = s"WindowProperty($reference)"
 }
 
-case class WindowStart(child: Expression) extends AbstractWindowProperty(child) {
+/**
+  * Indicate timeField type.
+  */
+case class WindowReference(name: String, tpe: Option[InternalType] = None) {
+  override def toString: String = s"'$name"
+}
+
+case class WindowStart(reference: WindowReference) extends AbstractWindowProperty(reference) {
 
   override def resultType: TimestampType = InternalTypes.TIMESTAMP
 
-  override def toString: String = s"start($child)"
+  override def toString: String = s"start($reference)"
 }
 
-case class WindowEnd(child: Expression) extends AbstractWindowProperty(child) {
+case class WindowEnd(reference: WindowReference) extends AbstractWindowProperty(reference) {
 
   override def resultType: TimestampType = InternalTypes.TIMESTAMP
 
-  override def toString: String = s"end($child)"
+  override def toString: String = s"end($reference)"
+}
+
+case class RowtimeAttribute(reference: WindowReference) extends AbstractWindowProperty(reference) {
+
+  override def resultType: InternalType = {
+    reference match {
+      case WindowReference(_, Some(tpe)) if tpe == InternalTypes.ROWTIME_INDICATOR =>
+        // rowtime window
+        InternalTypes.ROWTIME_INDICATOR
+      case WindowReference(_, Some(tpe))
+        if tpe == InternalTypes.LONG || tpe == InternalTypes.TIMESTAMP =>
+        // batch time window
+        InternalTypes.TIMESTAMP
+      case _ =>
+        throw new TableException("WindowReference of RowtimeAttribute has invalid type. " +
+            "Please report this bug.")
+    }
+  }
+
+  override def toString: String = s"rowtime($reference)"
+}
+
+case class ProctimeAttribute(reference: WindowReference)
+  extends AbstractWindowProperty(reference) {
+
+  override def resultType: InternalType = InternalTypes.PROCTIME_INDICATOR
+
+  override def toString: String = s"proctime($reference)"
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/logical/groupWindows.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/logical/groupWindows.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.logical
+
+import org.apache.flink.table.expressions._
+
+/**
+  * Logical super class for group windows.
+  *
+  * @param aliasAttribute window alias
+  * @param timeAttribute time field indicating event-time or processing-time
+  */
+abstract class LogicalWindow(
+    val aliasAttribute: WindowReference,
+    val timeAttribute: FieldReferenceExpression) {
+
+  override def toString: String = getClass.getSimpleName
+}
+
+// ------------------------------------------------------------------------------------------------
+// Tumbling group windows
+// ------------------------------------------------------------------------------------------------
+
+case class TumblingGroupWindow(
+    alias: WindowReference,
+    timeField: FieldReferenceExpression,
+    size: ValueLiteralExpression)
+  extends LogicalWindow(
+    alias,
+    timeField) {
+}
+
+// ------------------------------------------------------------------------------------------------
+// Sliding group windows
+// ------------------------------------------------------------------------------------------------
+
+case class SlidingGroupWindow(
+    alias: WindowReference,
+    timeField: FieldReferenceExpression,
+    size: ValueLiteralExpression,
+    slide: ValueLiteralExpression)
+  extends LogicalWindow(
+    alias,
+    timeField) {
+
+  override def toString: String = s"SlidingGroupWindow($alias, $timeField, $size, $slide)"
+}
+
+// ------------------------------------------------------------------------------------------------
+// Session group windows
+// ------------------------------------------------------------------------------------------------
+
+case class SessionGroupWindow(
+    alias: WindowReference,
+    timeField: FieldReferenceExpression,
+    gap: ValueLiteralExpression)
+  extends LogicalWindow(
+    alias,
+    timeField) {
+
+  override def toString: String = s"SessionGroupWindow($alias, $timeField, $gap)"
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/LogicalWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/LogicalWindowAggregate.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.calcite
+
+import java.util
+
+import org.apache.calcite.plan.{Convention, RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
+import org.apache.calcite.rel.{RelNode, RelShuttle, RelWriter}
+import org.apache.calcite.util.ImmutableBitSet
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.logical.LogicalWindow
+
+final class LogicalWindowAggregate(
+    window: LogicalWindow,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    child: RelNode,
+    indicatorFlag: Boolean,
+    groupSet: ImmutableBitSet,
+    groupSets: util.List[ImmutableBitSet],
+    aggCalls: util.List[AggregateCall])
+    extends Aggregate(cluster, traitSet, child, indicatorFlag, groupSet, groupSets, aggCalls) {
+
+  def getWindow: LogicalWindow = window
+
+  def getNamedProperties: Seq[NamedWindowProperty] = namedProperties
+
+  override def copy(
+      traitSet: RelTraitSet,
+      input: RelNode,
+      indicator: Boolean,
+      groupSet: ImmutableBitSet,
+      groupSets: util.List[ImmutableBitSet],
+      aggCalls: util.List[AggregateCall]): Aggregate = {
+    new LogicalWindowAggregate(
+      window,
+      namedProperties,
+      cluster,
+      traitSet,
+      input,
+      indicator,
+      groupSet,
+      groupSets,
+      aggCalls)
+  }
+
+  def copy(namedProperties: Seq[NamedWindowProperty]): LogicalWindowAggregate = {
+    new LogicalWindowAggregate(
+      window,
+      namedProperties,
+      cluster,
+      traitSet,
+      input,
+      indicator,
+      getGroupSet,
+      getGroupSets,
+      aggCalls)
+  }
+
+  override def accept(shuttle: RelShuttle): RelNode = shuttle.visit(this)
+
+  override def deriveRowType(): RelDataType = {
+    val aggregateRowType = super.deriveRowType()
+    val typeFactory = getCluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    val builder = typeFactory.builder
+    builder.addAll(aggregateRowType.getFieldList)
+    namedProperties.foreach { namedProp =>
+      builder.add(
+        namedProp.name,
+        typeFactory.createTypeFromInternalType(namedProp.property.resultType, isNullable = true)
+      )
+    }
+    builder.build()
+  }
+
+  /**
+    * The [[getDigest]] should be uniquely identifies the node; another node
+    * is equivalent if and only if it has the same value. The [[getDigest]] is
+    * computed by [[explainTerms(pw)]], so it should contains window information
+    * to identify different WindowAggregate nodes, otherwise WindowAggregate node
+    * can be replaced by any other WindowAggregate node.
+    */
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+        .item("window", window)
+        .item("properties", namedProperties.map(_.name).mkString(", "))
+  }
+}
+
+object LogicalWindowAggregate {
+
+  def create(
+      window: LogicalWindow,
+      namedProperties: Seq[NamedWindowProperty],
+      aggregate: Aggregate): LogicalWindowAggregate = {
+    val cluster: RelOptCluster = aggregate.getCluster
+    val traitSet: RelTraitSet = cluster.traitSetOf(Convention.NONE)
+    new LogicalWindowAggregate(
+      window,
+      namedProperties,
+      cluster,
+      traitSet,
+      aggregate.getInput,
+      aggregate.indicator,
+      aggregate.getGroupSet,
+      aggregate.getGroupSets,
+      aggregate.getAggCallList)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalWindowAggregate.scala
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.logical
+
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.logical.LogicalWindow
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.calcite.LogicalWindowAggregate
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.calcite.rel.{RelNode, RelShuttle, RelWriter}
+import org.apache.calcite.sql.SqlKind
+import org.apache.calcite.util.ImmutableBitSet
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+class FlinkLogicalWindowAggregate(
+    window: LogicalWindow,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    child: RelNode,
+    indicator: Boolean,
+    groupSet: ImmutableBitSet,
+    groupSets: util.List[ImmutableBitSet],
+    aggCalls: util.List[AggregateCall])
+  extends Aggregate(cluster, traitSet, child, indicator, groupSet, groupSets, aggCalls)
+  with FlinkLogicalRel {
+
+  def getWindow: LogicalWindow = window
+
+  def getNamedProperties: Seq[NamedWindowProperty] = namedProperties
+
+  override def copy(
+      traitSet: RelTraitSet,
+      input: RelNode,
+      indicator: Boolean,
+      groupSet: ImmutableBitSet,
+      groupSets: util.List[ImmutableBitSet],
+      aggCalls: util.List[AggregateCall])
+    : Aggregate = {
+    new FlinkLogicalWindowAggregate(
+      window,
+      namedProperties,
+      cluster,
+      traitSet,
+      input,
+      indicator,
+      groupSet,
+      groupSets,
+      aggCalls)
+  }
+
+  override def accept(shuttle: RelShuttle): RelNode = shuttle.visit(this)
+
+  override def deriveRowType(): RelDataType = {
+    val aggregateRowType = super.deriveRowType()
+    val typeFactory = getCluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    val builder = typeFactory.builder
+    builder.addAll(aggregateRowType.getFieldList)
+    namedProperties.foreach { namedProp =>
+      builder.add(
+        namedProp.name,
+        typeFactory.createTypeFromInternalType(namedProp.property.resultType, isNullable = true)
+      )
+    }
+    builder.build()
+  }
+
+  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
+    val child = this.getInput
+    val rowCnt = mq.getRowCount(child)
+    val rowSize = mq.getAverageRowSize(child)
+    val aggCnt = this.getAggCallList.size
+    // group by CPU cost(multiple by 1.1 to encourage less group keys) + agg call CPU cost
+    val cpuCost: Double = rowCnt * getGroupCount * 1.1 + rowCnt * aggCnt
+    planner.getCostFactory.makeCost(rowCnt, cpuCost, rowCnt * rowSize)
+  }
+
+  /**
+    * The [[getDigest]] should be uniquely identifies the node; another node
+    * is equivalent if and only if it has the same value. The [[getDigest]] is
+    * computed by [[explainTerms(pw)]], so it should contains window information
+    * to identify different WindowAggregate nodes, otherwise WindowAggregate node
+    * can be replaced by any other WindowAggregate node.
+    */
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+      .item("window", window)
+      .item("properties", namedProperties.map(_.name).mkString(", "))
+  }
+}
+
+class FlinkLogicalWindowAggregateConverter
+  extends ConverterRule(
+    classOf[LogicalWindowAggregate],
+    Convention.NONE,
+    FlinkConventions.LOGICAL,
+    "FlinkLogicalWindowAggregateConverter") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val agg = call.rel(0).asInstanceOf[LogicalWindowAggregate]
+
+    // we do not support these functions natively
+    // they have to be converted using the WindowAggregateReduceFunctionsRule
+    agg.getAggCallList.asScala.map(_.getAggregation.getKind).forall {
+      // we support AVG
+      case SqlKind.AVG => true
+      // but none of the other AVG agg functions
+      case k if SqlKind.AVG_AGG_FUNCTIONS.contains(k) => false
+      case _ => true
+    }
+  }
+
+  override def convert(rel: RelNode): RelNode = {
+    val agg = rel.asInstanceOf[LogicalWindowAggregate]
+    val newInput = RelOptRule.convert(agg.getInput, FlinkConventions.LOGICAL)
+    val traitSet = newInput.getCluster.traitSet().replace(FlinkConventions.LOGICAL).simplify()
+
+    new FlinkLogicalWindowAggregate(
+      agg.getWindow,
+      agg.getNamedProperties,
+      rel.getCluster,
+      traitSet,
+      newInput,
+      agg.indicator,
+      agg.getGroupSet,
+      agg.getGroupSets,
+      agg.getAggCallList)
+  }
+
+}
+
+object FlinkLogicalWindowAggregate {
+  val CONVERTER = new FlinkLogicalWindowAggregateConverter
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecHashWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecHashWindowAggregate.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.batch
+
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.plan.logical.LogicalWindow
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.tools.RelBuilder
+
+import java.util
+
+class BatchExecHashWindowAggregate(
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    relBuilder: RelBuilder,
+    traitSet: RelTraitSet,
+    inputNode: RelNode,
+    aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    aggInputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = false,
+    isMerge: Boolean)
+  extends BatchExecHashWindowAggregateBase(
+    window,
+    inputTimeFieldIndex,
+    inputTimeIsDate,
+    namedProperties,
+    cluster,
+    relBuilder,
+    traitSet,
+    inputNode,
+    aggCallToAggFunction,
+    outputRowType,
+    inputRowType,
+    aggInputRowType,
+    grouping,
+    auxGrouping,
+    enableAssignPane,
+    isMerge,
+    isFinal = true) {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new BatchExecHashWindowAggregate(
+      window,
+      inputTimeFieldIndex,
+      inputTimeIsDate,
+      namedProperties,
+      cluster,
+      relBuilder,
+      traitSet,
+      inputs.get(0),
+      aggCallToAggFunction,
+      getRowType,
+      inputRowType,
+      aggInputRowType,
+      grouping,
+      auxGrouping,
+      enableAssignPane,
+      isMerge)
+  }
+
+  override def getDamBehavior: DamBehavior = DamBehavior.FULL_DAM
+
+  override def getOperatorName: String = {
+    val aggregateNamePrefix = if (isMerge) "Global" else "Complete"
+    aggregateNamePrefix + "WindowHashAggregateBatchExec"
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecHashWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecHashWindowAggregateBase.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.batch
+
+import org.apache.flink.streaming.api.transformations.{OneInputTransformation, StreamTransformation}
+import org.apache.flink.table.api.{BatchTableEnvironment, TableConfigOptions}
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.codegen.CodeGeneratorContext
+import org.apache.flink.table.codegen.agg.batch.{HashWindowCodeGenerator, WindowCodeGenerator}
+import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.plan.cost.{FlinkCost, FlinkCostFactory}
+import org.apache.flink.table.plan.logical.LogicalWindow
+import org.apache.flink.table.plan.nodes.exec.{BatchExecNode, ExecNode}
+import org.apache.flink.table.plan.util.AggregateUtil.transformToBatchAggregateInfoList
+import org.apache.flink.table.plan.util.FlinkRelMdUtil
+import org.apache.flink.table.runtime.OneInputOperatorWrapper
+import org.apache.flink.table.runtime.aggregate.BytesHashMap
+
+import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.calcite.tools.RelBuilder
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+abstract class BatchExecHashWindowAggregateBase(
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    relBuilder: RelBuilder,
+    traitSet: RelTraitSet,
+    inputNode: RelNode,
+    aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    aggInputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = false,
+    isMerge: Boolean,
+    isFinal: Boolean)
+  extends BatchExecWindowAggregateBase(
+    window,
+    namedProperties,
+    cluster,
+    traitSet,
+    inputNode,
+    aggCallToAggFunction,
+    outputRowType,
+    inputRowType,
+    grouping,
+    auxGrouping,
+    enableAssignPane,
+    isMerge,
+    isFinal)
+  with BatchExecNode[BaseRow] {
+
+  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
+    val numOfGroupKey = grouping.length
+    val inputRowCnt = mq.getRowCount(getInput())
+    if (inputRowCnt == null) {
+      return null
+    }
+    // does not take pane optimization into consideration here
+    // calculate hash code of groupKeys + timestamp
+    val hashCpuCost = FlinkCost.HASH_CPU_COST * inputRowCnt * (numOfGroupKey + 1)
+    val aggFunctionCpuCost = FlinkCost.FUNC_CPU_COST * inputRowCnt * aggCallToAggFunction.size
+    val rowCnt = mq.getRowCount(this)
+    // assume memory is enough to hold hashTable to simplify the estimation because spill will not
+    // happen under the assumption
+    //  We aim for a 200% utilization of the bucket table.
+    val bucketSize = rowCnt * BytesHashMap.BUCKET_SIZE / FlinkCost.HASH_COLLISION_WEIGHT
+    val recordSize = rowCnt * (FlinkRelMdUtil.binaryRowAverageSize(this) + BytesHashMap
+        .RECORD_EXTRA_LENGTH)
+    val memCost = bucketSize + recordSize
+    val costFactory = planner.getCostFactory.asInstanceOf[FlinkCostFactory]
+    costFactory.makeCost(rowCnt, hashCpuCost + aggFunctionCpuCost, 0, 0, memCost)
+  }
+
+  override def getInputNodes: util.List[ExecNode[BatchTableEnvironment, _]] =
+    List(getInput.asInstanceOf[ExecNode[BatchTableEnvironment, _]])
+
+  def getOperatorName: String
+
+  override def translateToPlanInternal(
+      tableEnv: BatchTableEnvironment): StreamTransformation[BaseRow] = {
+    val input = getInputNodes.get(0).translateToPlan(tableEnv)
+        .asInstanceOf[StreamTransformation[BaseRow]]
+    val ctx = CodeGeneratorContext(tableEnv.getConfig)
+    val outputType = FlinkTypeFactory.toInternalRowType(getRowType)
+    val inputType = FlinkTypeFactory.toInternalRowType(inputRowType)
+
+    val aggInfos = transformToBatchAggregateInfoList(
+      aggCallToAggFunction.map(_._1), aggInputRowType)
+
+    val groupBufferLimitSize = tableEnv.getConfig.getConf.getInteger(
+      TableConfigOptions.SQL_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT)
+
+    val (windowSize: Long, slideSize: Long) = WindowCodeGenerator.getWindowDef(window)
+
+    val reservedManagedMem = tableEnv.config.getConf.getInteger(
+      TableConfigOptions.SQL_RESOURCE_HASH_AGG_TABLE_MEM) * TableConfigOptions.SIZE_IN_MB
+    val maxManagedMem = tableEnv.config.getConf.getInteger(
+      TableConfigOptions.SQL_RESOURCE_HASH_AGG_TABLE_MAX_MEM) * TableConfigOptions.SIZE_IN_MB
+
+    val generatedOperator = new HashWindowCodeGenerator(
+      ctx, relBuilder, window, inputTimeFieldIndex,
+      inputTimeIsDate, namedProperties,
+      aggInfos, inputRowType, grouping, auxGrouping, enableAssignPane, isMerge, isFinal).gen(
+      inputType, outputType, groupBufferLimitSize, reservedManagedMem, maxManagedMem, 0,
+      windowSize, slideSize)
+    val operator = new OneInputOperatorWrapper[BaseRow, BaseRow](generatedOperator)
+    new OneInputTransformation(
+      input,
+      getOperatorName,
+      operator,
+      outputType.toTypeInfo,
+      input.getParallelism)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecLocalHashWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecLocalHashWindowAggregate.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.batch
+
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.plan.logical.LogicalWindow
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.tools.RelBuilder
+
+import java.util
+
+class BatchExecLocalHashWindowAggregate(
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    relBuilder: RelBuilder,
+    traitSet: RelTraitSet,
+    inputNode: RelNode,
+    aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = false)
+  extends BatchExecHashWindowAggregateBase(
+    window,
+    inputTimeFieldIndex,
+    inputTimeIsDate,
+    namedProperties,
+    cluster,
+    relBuilder,
+    traitSet,
+    inputNode,
+    aggCallToAggFunction,
+    outputRowType,
+    inputRowType,
+    inputRowType,
+    grouping,
+    auxGrouping,
+    enableAssignPane,
+    isMerge = false,
+    isFinal = false) {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new BatchExecLocalHashWindowAggregate(
+      window,
+      inputTimeFieldIndex,
+      inputTimeIsDate,
+      namedProperties,
+      cluster,
+      relBuilder,
+      traitSet,
+      inputs.get(0),
+      aggCallToAggFunction,
+      getRowType,
+      inputRowType,
+      grouping,
+      auxGrouping,
+      enableAssignPane)
+  }
+
+  override def getDamBehavior: DamBehavior = DamBehavior.MATERIALIZING
+
+  override def getOperatorName: String = {
+    "LocalWindowHashAggregateBatchExec"
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecLocalSortWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecLocalSortWindowAggregate.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.batch
+
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.streaming.api.transformations.StreamTransformation
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.plan.logical.LogicalWindow
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.tools.RelBuilder
+
+import java.util
+
+class BatchExecLocalSortWindowAggregate(
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    relBuilder: RelBuilder,
+    traitSet: RelTraitSet,
+    inputNode: RelNode,
+    aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = false)
+  extends BatchExecSortWindowAggregateBase(
+    window,
+    inputTimeFieldIndex,
+    inputTimeIsDate,
+    namedProperties,
+    cluster,
+    relBuilder,
+    traitSet,
+    inputNode,
+    aggCallToAggFunction,
+    outputRowType,
+    inputRowType,
+    inputRowType,
+    grouping,
+    auxGrouping,
+    enableAssignPane,
+    isMerge = false,
+    isFinal = false) {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new BatchExecLocalSortWindowAggregate(
+      window,
+      inputTimeFieldIndex,
+      inputTimeIsDate,
+      namedProperties,
+      cluster,
+      relBuilder,
+      traitSet,
+      inputs.get(0),
+      aggCallToAggFunction,
+      outputRowType,
+      inputRowType,
+      grouping,
+      auxGrouping,
+      enableAssignPane)
+  }
+
+  override def getDamBehavior: DamBehavior = DamBehavior.MATERIALIZING
+
+  override def getOperatorName: String = "LocalSortWindowAggregateBatchExec"
+
+  override def getParallelism(input: StreamTransformation[BaseRow], conf: TableConfig): Int =
+    input.getParallelism
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecSortWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecSortWindowAggregate.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.batch
+
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.streaming.api.transformations.StreamTransformation
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.plan.logical.LogicalWindow
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.tools.RelBuilder
+
+class BatchExecSortWindowAggregate(
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    relBuilder: RelBuilder,
+    traitSet: RelTraitSet,
+    inputNode: RelNode,
+    aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    aggInputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = false,
+    isMerge: Boolean)
+  extends BatchExecSortWindowAggregateBase(
+    window,
+    inputTimeFieldIndex,
+    inputTimeIsDate,
+    namedProperties,
+    cluster,
+    relBuilder,
+    traitSet,
+    inputNode,
+    aggCallToAggFunction,
+    outputRowType,
+    inputRowType,
+    aggInputRowType,
+    grouping,
+    auxGrouping,
+    enableAssignPane,
+    isMerge,
+    isFinal = true) {
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new BatchExecSortWindowAggregate(
+      window,
+      inputTimeFieldIndex,
+      inputTimeIsDate,
+      namedProperties,
+      cluster,
+      relBuilder,
+      traitSet,
+      inputs.get(0),
+      aggCallToAggFunction,
+      getRowType,
+      inputRowType,
+      aggInputRowType,
+      grouping,
+      auxGrouping,
+      enableAssignPane,
+      isMerge)
+  }
+
+  override def getDamBehavior: DamBehavior = DamBehavior.PIPELINED
+
+  override def getOperatorName: String = {
+    val aggregateNamePrefix = if (isMerge) "Global" else "Complete"
+    aggregateNamePrefix + "WindowSortAggregateBatchExec"
+  }
+
+  override def getParallelism(input: StreamTransformation[BaseRow], conf: TableConfig): Int = {
+    if (isFinal && grouping.length == 0) 1 else input.getParallelism
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecSortWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecSortWindowAggregateBase.scala
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.batch
+
+import org.apache.flink.streaming.api.transformations.{OneInputTransformation, StreamTransformation}
+import org.apache.flink.table.api.{BatchTableEnvironment, TableConfig, TableConfigOptions}
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.codegen.CodeGeneratorContext
+import org.apache.flink.table.codegen.agg.batch.{SortWindowCodeGenerator, WindowCodeGenerator}
+import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.plan.cost.{FlinkCost, FlinkCostFactory}
+import org.apache.flink.table.plan.logical.LogicalWindow
+import org.apache.flink.table.plan.nodes.exec.{BatchExecNode, ExecNode}
+import org.apache.flink.table.plan.util.AggregateUtil.transformToBatchAggregateInfoList
+import org.apache.flink.table.runtime.OneInputOperatorWrapper
+
+import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.calcite.tools.RelBuilder
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+abstract class BatchExecSortWindowAggregateBase(
+    window: LogicalWindow,
+    inputTimeFieldIndex: Int,
+    inputTimeIsDate: Boolean,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    relBuilder: RelBuilder,
+    traitSet: RelTraitSet,
+    inputNode: RelNode,
+    aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    aggInputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = false,
+    isMerge: Boolean,
+    isFinal: Boolean)
+  extends BatchExecWindowAggregateBase(
+    window,
+    namedProperties,
+    cluster,
+    traitSet,
+    inputNode,
+    aggCallToAggFunction,
+    outputRowType,
+    inputRowType,
+    grouping,
+    auxGrouping,
+    enableAssignPane,
+    isMerge,
+    isFinal)
+  with BatchExecNode[BaseRow] {
+
+  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
+    val inputRowCnt = mq.getRowCount(getInput)
+    if (inputRowCnt == null) {
+      return null
+    }
+    // does not take pane optimization into consideration here
+    // sort is not done here
+    val cpu = FlinkCost.FUNC_CPU_COST * inputRowCnt * aggCallToAggFunction.size
+    val averageRowSize: Double = mq.getAverageRowSize(this)
+    val memCost = averageRowSize
+    val costFactory = planner.getCostFactory.asInstanceOf[FlinkCostFactory]
+    costFactory.makeCost(mq.getRowCount(this), cpu, 0, 0, memCost)
+  }
+
+  override def getInputNodes: util.List[ExecNode[BatchTableEnvironment, _]] =
+    List(getInput.asInstanceOf[ExecNode[BatchTableEnvironment, _]])
+
+  def getOperatorName: String
+
+  def getParallelism(input: StreamTransformation[BaseRow], conf: TableConfig): Int
+
+  override def translateToPlanInternal(
+      tableEnv: BatchTableEnvironment): StreamTransformation[BaseRow] = {
+    val input = getInputNodes.get(0).translateToPlan(tableEnv)
+        .asInstanceOf[StreamTransformation[BaseRow]]
+    val ctx = CodeGeneratorContext(tableEnv.getConfig)
+    val outputType = FlinkTypeFactory.toInternalRowType(getRowType)
+    val inputType = FlinkTypeFactory.toInternalRowType(inputRowType)
+
+    val aggInfos = transformToBatchAggregateInfoList(
+      aggCallToAggFunction.map(_._1), aggInputRowType)
+
+    val groupBufferLimitSize = tableEnv.getConfig.getConf.getInteger(
+      TableConfigOptions.SQL_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT)
+
+    val (windowSize: Long, slideSize: Long) = WindowCodeGenerator.getWindowDef(window)
+
+    val generator = new SortWindowCodeGenerator(
+      ctx, relBuilder, window, inputTimeFieldIndex,
+      inputTimeIsDate, namedProperties,
+      aggInfos, inputRowType, inputType, outputType,
+      groupBufferLimitSize, 0L, windowSize, slideSize,
+      grouping, auxGrouping, enableAssignPane, isMerge, isFinal)
+    val generatedOperator = if (grouping.isEmpty) {
+      generator.genWithoutKeys()
+    } else {
+      generator.genWithKeys()
+    }
+    val operator = new OneInputOperatorWrapper[BaseRow, BaseRow](generatedOperator)
+    new OneInputTransformation(
+      input,
+      getOperatorName,
+      operator,
+      outputType.toTypeInfo,
+      getParallelism(input, tableEnv.config))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecWindowAggregateBase.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.batch
+
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.plan.logical.LogicalWindow
+import org.apache.flink.table.plan.util.RelExplainUtil
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+
+abstract class BatchExecWindowAggregateBase(
+    window: LogicalWindow,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputNode: RelNode,
+    aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    enableAssignPane: Boolean = true,
+    val isMerge: Boolean,
+    val isFinal: Boolean)
+  extends SingleRel(cluster, traitSet, inputNode)
+  with BatchPhysicalRel {
+
+  if (grouping.isEmpty && auxGrouping.nonEmpty) {
+    throw new TableException("auxGrouping should be empty if grouping is emtpy.")
+  }
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+      .itemIf("groupBy",
+        RelExplainUtil.fieldToString(grouping, inputRowType), grouping.nonEmpty)
+      .itemIf("auxGrouping",
+        RelExplainUtil.fieldToString(auxGrouping, inputRowType), auxGrouping.nonEmpty)
+      .item("window", window)
+      .itemIf("properties", namedProperties.map(_.name).mkString(", "), namedProperties.nonEmpty)
+      .item("select",
+        RelExplainUtil.windowAggregationToString(
+          inputRowType,
+          grouping,
+          auxGrouping,
+          outputRowType,
+          aggCallToAggFunction,
+          enableAssignPane,
+          isMerge = isMerge,
+          isGlobal = isFinal))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.plan.rules
 
 import org.apache.flink.table.plan.nodes.logical._
+import org.apache.flink.table.plan.rules.common.WindowPropertiesRules
 import org.apache.flink.table.plan.rules.logical._
 import org.apache.flink.table.plan.rules.physical.FlinkExpandConversionRule
 import org.apache.flink.table.plan.rules.physical.batch._
@@ -65,6 +66,11 @@ object FlinkBatchRuleSets {
   val DEFAULT_REWRITE_RULES: RuleSet = RuleSets.ofList((
     REDUCE_EXPRESSION_RULES.asScala ++
       List(
+        // Transform window to LogicalWindowAggregate
+        BatchExecLogicalWindowAggregateRule.INSTANCE,
+        WindowPropertiesRules.WINDOW_PROPERTIES_RULE,
+        WindowPropertiesRules.WINDOW_PROPERTIES_HAVING_RULE,
+
         // slices a project into sections which contain window agg functions
         // and sections which do not.
         ProjectToWindowRule.PROJECT,
@@ -199,6 +205,7 @@ object FlinkBatchRuleSets {
     FlinkLogicalDataStreamTableScan.CONVERTER,
     FlinkLogicalExpand.CONVERTER,
     FlinkLogicalRank.CONVERTER,
+    FlinkLogicalWindowAggregate.CONVERTER,
     FlinkLogicalSink.CONVERTER
   )
 
@@ -236,6 +243,7 @@ object FlinkBatchRuleSets {
     BatchExecSingleRowJoinRule.INSTANCE,
     BatchExecCorrelateRule.INSTANCE,
     BatchExecOverWindowAggRule.INSTANCE,
+    BatchExecWindowAggregateRule.INSTANCE,
     BatchExecSinkRule.INSTANCE
   )
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
@@ -197,6 +197,7 @@ object FlinkStreamRuleSets {
     FlinkLogicalDataStreamTableScan.CONVERTER,
     FlinkLogicalExpand.CONVERTER,
     FlinkLogicalWatermarkAssigner.CONVERTER,
+    FlinkLogicalWindowAggregate.CONVERTER,
     FlinkLogicalSink.CONVERTER
   )
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/common/LogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/common/LogicalWindowAggregateRule.scala
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.common
+
+import com.google.common.collect.ImmutableList
+import org.apache.calcite.plan._
+import org.apache.calcite.plan.hep.HepRelVertex
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
+import org.apache.calcite.rex._
+import org.apache.calcite.util.ImmutableBitSet
+import org.apache.flink.table.api._
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.functions.sql.FlinkSqlOperatorTable
+import org.apache.flink.table.plan.logical.LogicalWindow
+import org.apache.flink.table.plan.nodes.calcite.LogicalWindowAggregate
+
+import _root_.scala.collection.JavaConversions._
+
+abstract class LogicalWindowAggregateRule(ruleName: String)
+  extends RelOptRule(
+    RelOptRule.operand(classOf[LogicalAggregate],
+      RelOptRule.operand(classOf[LogicalProject], RelOptRule.none())),
+    ruleName) {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val agg = call.rel(0).asInstanceOf[LogicalAggregate]
+
+    val groupSets = agg.getGroupSets.size() != 1 || agg.getGroupSets.get(0) != agg.getGroupSet
+
+    val windowExpressions = getWindowExpressions(agg)
+    if (windowExpressions.length > 1) {
+      throw new TableException("Only a single window group function may be used in GROUP BY")
+    }
+
+    !groupSets && !agg.indicator && windowExpressions.nonEmpty
+  }
+
+  /**
+    * Transform LogicalAggregate with windowing expression to LogicalProject
+    * + LogicalWindowAggregate + LogicalProject.
+    *
+    * The transformation adds an additional LogicalProject at the top to ensure
+    * that the types are equivalent.
+    */
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val agg = call.rel[LogicalAggregate](0)
+    val project = agg.getInput.asInstanceOf[HepRelVertex].getCurrentRel.asInstanceOf[LogicalProject]
+
+    val (windowExpr, windowExprIdx) = getWindowExpressions(agg).head
+    val window = translateWindow(windowExpr, project.getInput.getRowType)
+
+    val rexBuilder = call.builder().getRexBuilder
+
+    val inAggGroupExpression = getInAggregateGroupExpression(rexBuilder, windowExpr)
+
+    val newGroupSet = agg.getGroupSet.except(ImmutableBitSet.of(windowExprIdx))
+
+    val builder = call.builder()
+
+    val newProject = builder
+      .push(project.getInput)
+      .project(project.getChildExps.updated(windowExprIdx, inAggGroupExpression))
+      .build()
+
+    // we don't use the builder here because it uses RelMetadataQuery which affects the plan
+    val newAgg = LogicalAggregate.create(
+      newProject,
+      agg.indicator,
+      newGroupSet,
+      ImmutableList.of(newGroupSet),
+      agg.getAggCallList)
+
+    // create an additional project to conform with types
+    val outAggGroupExpression0 = getOutAggregateGroupExpression(rexBuilder, windowExpr)
+    // fix up the nullability if it is changed.
+    val outAggGroupExpression = if (windowExpr.getType.isNullable !=
+      outAggGroupExpression0.getType.isNullable) {
+      builder.getRexBuilder.makeAbstractCast(
+        builder.getRexBuilder.matchNullability(outAggGroupExpression0.getType, windowExpr),
+        outAggGroupExpression0)
+    } else {
+      outAggGroupExpression0
+    }
+    val transformed = call.builder()
+    transformed.push(LogicalWindowAggregate.create(
+      window,
+      Seq[NamedWindowProperty](),
+      newAgg))
+      .project(transformed.fields().patch(windowExprIdx, Seq(outAggGroupExpression), 0))
+
+    call.transformTo(transformed.build())
+  }
+
+  private[table] def getWindowExpressions(agg: LogicalAggregate): Seq[(RexCall, Int)] = {
+    val project = agg.getInput.asInstanceOf[HepRelVertex].getCurrentRel.asInstanceOf[LogicalProject]
+    val groupKeys = agg.getGroupSet
+
+    // get grouping expressions
+    val groupExpr = project.getProjects.zipWithIndex.filter(p => groupKeys.get(p._2))
+
+    // filter grouping expressions for window expressions
+    groupExpr.filter { g =>
+      g._1 match {
+        case call: RexCall =>
+          call.getOperator match {
+            case FlinkSqlOperatorTable.TUMBLE =>
+              if (call.getOperands.size() == 2) {
+                true
+              } else {
+                throw new TableException("TUMBLE window with alignment is not supported yet.")
+              }
+            case FlinkSqlOperatorTable.HOP =>
+              if (call.getOperands.size() == 3) {
+                true
+              } else {
+                throw new TableException("HOP window with alignment is not supported yet.")
+              }
+            case FlinkSqlOperatorTable.SESSION =>
+              if (call.getOperands.size() == 2) {
+                true
+              } else {
+                throw new TableException("SESSION window with alignment is not supported yet.")
+              }
+            case _ => false
+          }
+        case _ => false
+      }
+    }.map(w => (w._1.asInstanceOf[RexCall], w._2))
+  }
+
+  /** Returns the expression that replaces the window expression before the aggregation. */
+  private[table] def getInAggregateGroupExpression(
+      rexBuilder: RexBuilder,
+      windowExpression: RexCall): RexNode
+
+  /** Returns the expression that replaces the window expression after the aggregation. */
+  private[table] def getOutAggregateGroupExpression(
+      rexBuilder: RexBuilder,
+      windowExpression: RexCall): RexNode
+
+  /** translate the group window expression in to a Flink Table window. */
+  private[table] def translateWindow(
+      windowExpr: RexCall,
+      rowType: RelDataType): LogicalWindow
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/common/WindowPropertiesRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/common/WindowPropertiesRule.scala
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.common
+
+import org.apache.flink.table.api.{TableException, Types, ValidationException}
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.expressions._
+import org.apache.flink.table.functions.sql.FlinkSqlOperatorTable
+import org.apache.flink.table.plan.logical.LogicalWindow
+import org.apache.flink.table.plan.nodes.calcite.LogicalWindowAggregate
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.logical.{LogicalFilter, LogicalProject}
+import org.apache.calcite.rex.{RexCall, RexNode}
+import org.apache.calcite.tools.RelBuilder
+
+import scala.collection.JavaConversions._
+
+class WindowPropertiesRule extends RelOptRule(
+  RelOptRule.operand(classOf[LogicalProject],
+      RelOptRule.operand(classOf[LogicalProject],
+        RelOptRule.operand(classOf[LogicalWindowAggregate], RelOptRule.none()))),
+    "WindowPropertiesRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val project = call.rel(0).asInstanceOf[LogicalProject]
+    // project includes at least on group auxiliary function
+    project.getProjects.exists(WindowPropertiesRules.hasGroupAuxiliaries)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+      val project = call.rel(0).asInstanceOf[LogicalProject]
+      val innerProject = call.rel(1).asInstanceOf[LogicalProject]
+      val agg = call.rel(2).asInstanceOf[LogicalWindowAggregate]
+
+      val converted = WindowPropertiesRules.convertWindowNodes(
+        call.builder(), project, None, innerProject, agg)
+
+      call.transformTo(converted)
+    }
+}
+
+class WindowPropertiesHavingRule extends RelOptRule(
+  RelOptRule.operand(classOf[LogicalProject],
+    RelOptRule.operand(classOf[LogicalFilter],
+      RelOptRule.operand(classOf[LogicalProject],
+        RelOptRule.operand(classOf[LogicalWindowAggregate], RelOptRule.none())))),
+  "WindowPropertiesHavingRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val project = call.rel(0).asInstanceOf[LogicalProject]
+    val filter = call.rel(1).asInstanceOf[LogicalFilter]
+
+    project.getProjects.exists(WindowPropertiesRules.hasGroupAuxiliaries) ||
+        WindowPropertiesRules.hasGroupAuxiliaries(filter.getCondition)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val project = call.rel(0).asInstanceOf[LogicalProject]
+    val filter = call.rel(1).asInstanceOf[LogicalFilter]
+    val innerProject = call.rel(2).asInstanceOf[LogicalProject]
+    val agg = call.rel(3).asInstanceOf[LogicalWindowAggregate]
+
+    val converted = WindowPropertiesRules.convertWindowNodes(
+      call.builder(), project, Some(filter), innerProject, agg)
+
+    call.transformTo(converted)
+  }
+}
+
+object WindowPropertiesRules {
+
+  val WINDOW_PROPERTIES_HAVING_RULE = new WindowPropertiesHavingRule
+
+  val WINDOW_PROPERTIES_RULE = new WindowPropertiesRule
+
+  def convertWindowNodes(
+      builder: RelBuilder,
+      project: LogicalProject,
+      filter: Option[LogicalFilter],
+      innerProject: LogicalProject,
+      agg: LogicalWindowAggregate): RelNode = {
+    val w = agg.getWindow
+    val windowType = getWindowType(w)
+
+    val startEndProperties = Seq(
+      NamedWindowProperty(propertyName(w, "start"), WindowStart(w.aliasAttribute)),
+      NamedWindowProperty(propertyName(w, "end"), WindowEnd(w.aliasAttribute)))
+
+    // allow rowtime/proctime for rowtime windows and proctime for proctime windows
+    val timeProperties = windowType match {
+      case 'streamRowtime =>
+        Seq(
+          NamedWindowProperty(propertyName(w, "rowtime"), RowtimeAttribute(w.aliasAttribute)),
+          NamedWindowProperty(propertyName(w, "proctime"), ProctimeAttribute(w.aliasAttribute)))
+      case 'streamProctime =>
+        Seq(NamedWindowProperty(propertyName(w, "proctime"), ProctimeAttribute(w.aliasAttribute)))
+      case 'batchRowtime =>
+        Seq(NamedWindowProperty(propertyName(w, "rowtime"), RowtimeAttribute(w.aliasAttribute)))
+      case _ =>
+        throw new TableException("Unknown window type encountered. Please report this bug.")
+    }
+
+    val properties = startEndProperties ++ timeProperties
+
+    // retrieve window start and end properties
+    builder.push(agg.copy(properties))
+
+    // forward window start and end properties
+    builder.project(
+      innerProject.getProjects ++ properties.map(np => builder.field(np.name)))
+
+    // replace window auxiliary function in filter by access to window properties
+    filter.foreach { f =>
+      builder.filter(
+        f.getChildExps.map(expr => replaceGroupAuxiliaries(expr, w, builder))
+      )
+    }
+
+    // replace window auxiliary unctions in projection by access to window properties
+    builder.project(
+      project.getProjects.map(expr => replaceGroupAuxiliaries(expr, w, builder)),
+      project.getRowType.getFieldNames
+    )
+
+    builder.build()
+  }
+
+  private def getWindowType(window: LogicalWindow): Symbol = {
+    if (window.timeAttribute.getResultType == TimeIndicatorTypeInfo.ROWTIME_INDICATOR) {
+      'streamRowtime
+    } else if (window.timeAttribute.getResultType == TimeIndicatorTypeInfo.PROCTIME_INDICATOR) {
+      'streamProctime
+    } else if (window.timeAttribute.getResultType == Types.SQL_TIMESTAMP) {
+      'batchRowtime
+    } else {
+      throw new TableException("Unknown window type encountered. Please report this bug.")
+    }
+  }
+
+  /** Generates a property name for a window. */
+  private def propertyName(window: LogicalWindow, name: String): String =
+    window.aliasAttribute.asInstanceOf[WindowReference].name + name
+
+  /** Replace group auxiliaries with field references. */
+  def replaceGroupAuxiliaries(
+    node: RexNode,
+    window: LogicalWindow,
+    builder: RelBuilder): RexNode = {
+    val rexBuilder = builder.getRexBuilder
+    val windowType = getWindowType(window)
+
+    node match {
+      case c: RexCall if isWindowStart(c) =>
+        // replace expression by access to window start
+        rexBuilder.makeCast(c.getType, builder.field(propertyName(window, "start")), false)
+
+      case c: RexCall if isWindowEnd(c) =>
+        // replace expression by access to window end
+        rexBuilder.makeCast(c.getType, builder.field(propertyName(window, "end")), false)
+
+      case c: RexCall if isWindowRowtime(c) =>
+        windowType match {
+          case 'streamRowtime | 'batchRowtime =>
+            // replace expression by access to window rowtime
+            rexBuilder.makeCast(c.getType, builder.field(propertyName(window, "rowtime")), false)
+          case 'streamProctime =>
+            throw new ValidationException("A proctime window cannot provide a rowtime attribute.")
+          case _ =>
+            throw new TableException("Unknown window type encountered. Please report this bug.")
+        }
+
+      case c: RexCall if isWindowProctime(c) =>
+        windowType match {
+          case 'streamProctime | 'streamRowtime =>
+            // replace expression by access to window proctime
+            rexBuilder.makeCast(c.getType, builder.field(propertyName(window, "proctime")), false)
+          case 'batchRowtime =>
+            throw new ValidationException(
+              "PROCTIME window property is not supported in batch queries.")
+          case _ =>
+            throw new TableException("Unknown window type encountered. Please report this bug.")
+        }
+
+      case c: RexCall =>
+        // replace expressions in children
+        val newOps = c.getOperands.map(replaceGroupAuxiliaries(_, window, builder))
+        c.clone(c.getType, newOps)
+
+      case x =>
+        // preserve expression
+        x
+    }
+  }
+
+  /** Checks if a RexNode is a window start auxiliary function. */
+  private def isWindowStart(node: RexNode): Boolean = {
+    node match {
+      case n: RexCall if n.getOperator.isGroupAuxiliary =>
+        n.getOperator match {
+          case FlinkSqlOperatorTable.TUMBLE_START |
+               FlinkSqlOperatorTable.HOP_START |
+               FlinkSqlOperatorTable.SESSION_START
+          => true
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
+  /** Checks if a RexNode is a window end auxiliary function. */
+  private def isWindowEnd(node: RexNode): Boolean = {
+    node match {
+      case n: RexCall if n.getOperator.isGroupAuxiliary =>
+        n.getOperator match {
+          case FlinkSqlOperatorTable.TUMBLE_END |
+               FlinkSqlOperatorTable.HOP_END |
+               FlinkSqlOperatorTable.SESSION_END
+          => true
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
+  /** Checks if a RexNode is a window rowtime auxiliary function. */
+  private def isWindowRowtime(node: RexNode): Boolean = {
+    node match {
+      case n: RexCall if n.getOperator.isGroupAuxiliary =>
+        n.getOperator match {
+          case FlinkSqlOperatorTable.TUMBLE_ROWTIME |
+               FlinkSqlOperatorTable.HOP_ROWTIME |
+               FlinkSqlOperatorTable.SESSION_ROWTIME
+            => true
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
+  /** Checks if a RexNode is a window proctime auxiliary function. */
+  private def isWindowProctime(node: RexNode): Boolean = {
+    node match {
+      case n: RexCall if n.getOperator.isGroupAuxiliary =>
+        n.getOperator match {
+          case FlinkSqlOperatorTable.TUMBLE_PROCTIME |
+               FlinkSqlOperatorTable.HOP_PROCTIME |
+               FlinkSqlOperatorTable.SESSION_PROCTIME
+            => true
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
+  def hasGroupAuxiliaries(node: RexNode): Boolean = {
+    node match {
+      case c: RexCall if c.getOperator.isGroupAuxiliary => true
+      case c: RexCall =>
+        c.operands.exists(hasGroupAuxiliaries)
+      case _ => false
+    }
+  }
+
+  def hasGroupFunction(node: RexNode): Boolean = {
+    node match {
+      case c: RexCall if c.getOperator.isGroup => true
+      case c: RexCall => c.operands.exists(hasGroupFunction)
+      case _ => false
+    }
+  }
+
+}
+

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecLogicalWindowAggregateRule.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.`type`.TypeConverters.{createExternalTypeInfoFromInternalType, createInternalTypeFromTypeInfo}
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.calcite.FlinkTypeFactory.toInternalType
+import org.apache.flink.table.expressions.{FieldReferenceExpression, ValueLiteralExpression, WindowReference}
+import org.apache.flink.table.functions.sql.FlinkSqlOperatorTable
+import org.apache.flink.table.plan.logical.{LogicalWindow, SessionGroupWindow, SlidingGroupWindow, TumblingGroupWindow}
+import org.apache.flink.table.plan.rules.common.LogicalWindowAggregateRule
+import org.apache.flink.table.typeutils.TimeIntervalTypeInfo.INTERVAL_MILLIS
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rex._
+
+import java.math.BigDecimal
+
+class BatchExecLogicalWindowAggregateRule
+    extends LogicalWindowAggregateRule("BatchExecLogicalWindowAggregateRule") {
+
+  /** Returns the operand of the group window function. */
+  override private[table] def getInAggregateGroupExpression(
+      rexBuilder: RexBuilder,
+      windowExpression: RexCall): RexNode = windowExpression.getOperands.get(0)
+
+  /** Returns a zero literal of the correct type. */
+  override private[table] def getOutAggregateGroupExpression(
+      rexBuilder: RexBuilder,
+      windowExpression: RexCall): RexNode = {
+
+    val literalType = windowExpression.getOperands.get(0).getType
+    rexBuilder.makeZeroLiteral(literalType)
+  }
+
+  override private[table] def translateWindow(
+      windowExpr: RexCall,
+      rowType: RelDataType): LogicalWindow = {
+    def getOperandAsLong(call: RexCall, idx: Int): Long =
+      call.getOperands.get(idx) match {
+        case v: RexLiteral => v.getValue.asInstanceOf[BigDecimal].longValue()
+        case _ => throw new TableException("Only constant window descriptors are supported")
+      }
+
+    def getFieldReference(operand: RexNode): FieldReferenceExpression = {
+      operand match {
+        case ref: RexInputRef =>
+          // resolve field name of window attribute
+          val fieldName = rowType.getFieldList.get(ref.getIndex).getName
+          val fieldType = rowType.getFieldList.get(ref.getIndex).getType
+          new FieldReferenceExpression(
+            fieldName,
+            createExternalTypeInfoFromInternalType(toInternalType(fieldType)),
+            ref.getIndex,
+            ref.getIndex)
+      }
+    }
+
+    val timeField = getFieldReference(windowExpr.getOperands.get(0))
+    val resultType = Some(createInternalTypeFromTypeInfo(timeField.getResultType))
+    val windowRef = WindowReference("w$", resultType)
+    windowExpr.getOperator match {
+      case FlinkSqlOperatorTable.TUMBLE =>
+        val interval = getOperandAsLong(windowExpr, 1)
+        TumblingGroupWindow(
+          windowRef,
+          timeField,
+          new ValueLiteralExpression(interval, INTERVAL_MILLIS))
+
+      case FlinkSqlOperatorTable.HOP =>
+        val (slide, size) = (getOperandAsLong(windowExpr, 1), getOperandAsLong(windowExpr, 2))
+        SlidingGroupWindow(
+          windowRef,
+          timeField,
+          new ValueLiteralExpression(size, INTERVAL_MILLIS),
+          new ValueLiteralExpression(slide, INTERVAL_MILLIS))
+
+      case FlinkSqlOperatorTable.SESSION =>
+        val gap = getOperandAsLong(windowExpr, 1)
+        SessionGroupWindow(
+          windowRef,
+          timeField,
+          new ValueLiteralExpression(gap, INTERVAL_MILLIS))
+    }
+  }
+}
+
+object BatchExecLogicalWindowAggregateRule {
+  val INSTANCE = new BatchExecLogicalWindowAggregateRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecWindowAggregateRule.scala
@@ -1,0 +1,418 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.`type`.TypeConverters.createInternalTypeFromTypeInfo
+import org.apache.flink.table.`type`.{InternalType, InternalTypes}
+import org.apache.flink.table.api.{TableConfig, TableException}
+import org.apache.flink.table.calcite.{FlinkContext, FlinkTypeFactory}
+import org.apache.flink.table.functions.aggfunctions.DeclarativeAggregateFunction
+import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
+import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
+import org.apache.flink.table.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalWindowAggregate
+import org.apache.flink.table.plan.nodes.physical.batch.{BatchExecHashWindowAggregate, BatchExecLocalHashWindowAggregate, BatchExecLocalSortWindowAggregate, BatchExecSortWindowAggregate}
+import org.apache.flink.table.plan.util.AggregateUtil
+import org.apache.flink.table.typeutils.TimeIntervalTypeInfo.INTERVAL_MILLIS
+
+import org.apache.calcite.plan.RelOptRule._
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.Aggregate.Group
+import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
+import org.apache.calcite.rel.{RelCollations, RelNode}
+import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.commons.math3.util.ArithmeticUtils
+
+import scala.collection.JavaConversions._
+
+class BatchExecWindowAggregateRule
+    extends RelOptRule(
+      operand(classOf[FlinkLogicalWindowAggregate],
+        operand(classOf[RelNode], any)),
+      "BatchExecWindowAggregateRule")
+        with BatchExecAggRuleBase {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val agg: FlinkLogicalWindowAggregate = call.rel(0).asInstanceOf[FlinkLogicalWindowAggregate]
+
+    // check if we have distinct aggregates
+    val distinctAggs = agg.containsDistinctCall()
+    if (distinctAggs) {
+      throw new TableException("DISTINCT aggregates are currently not supported.")
+    }
+
+    // check if we have grouping sets
+    val groupSets = agg.getGroupType != Group.SIMPLE
+    if (groupSets || agg.indicator) {
+      throw new TableException("GROUPING SETS are currently not supported.")
+    }
+
+    !distinctAggs && !groupSets && !agg.indicator
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val tableConfig = call.getPlanner.getContext.unwrap(classOf[TableConfig])
+    val input = call.rels(1)
+    val agg = call.rels(0).asInstanceOf[FlinkLogicalWindowAggregate]
+    val window = agg.getWindow
+
+    val (auxGroupSet, aggCallsWithoutAuxGroupCalls) = AggregateUtil.checkAndSplitAggCalls(agg)
+
+    val (_, aggBufferTypes, aggregates) = AggregateUtil.transformToBatchAggregateFunctions(
+      aggCallsWithoutAuxGroupCalls, input.getRowType)
+    val aggCallToAggFunction = aggCallsWithoutAuxGroupCalls.zip(aggregates)
+    val internalAggBufferTypes = aggBufferTypes.map(_.map(createInternalTypeFromTypeInfo))
+
+    window match {
+      case TumblingGroupWindow(_, _, size) if size.getType == INTERVAL_MILLIS =>
+        val sizeInLong = size.getValue.asInstanceOf[java.lang.Long]
+        transformTimeSlidingWindow(
+          call,
+          input,
+          agg,
+          window.asInstanceOf[TumblingGroupWindow],
+          auxGroupSet,
+          aggCallToAggFunction,
+          internalAggBufferTypes,
+          useHashExec(agg),
+          enableAssignPane = false,
+          supportLocalWindowAgg(call, tableConfig, aggregates, sizeInLong, sizeInLong))
+
+      case SlidingGroupWindow(_, _, size, slide) if size.getType == INTERVAL_MILLIS =>
+        val (sizeInLong, slideInLong) = (
+            size.getValue.asInstanceOf[java.lang.Long],
+            slide.getValue.asInstanceOf[java.lang.Long])
+        transformTimeSlidingWindow(
+          call,
+          input,
+          agg,
+          window.asInstanceOf[SlidingGroupWindow],
+          auxGroupSet,
+          aggCallToAggFunction,
+          internalAggBufferTypes,
+          useHashExec(agg),
+          useAssignPane(aggregates, sizeInLong, slideInLong),
+          supportLocalWindowAgg(call, tableConfig, aggregates, sizeInLong, slideInLong))
+
+      case _ => // sliding & tumbling count window and session window not supported
+        throw new UnsupportedOperationException(s"Window $window is not supported right now.")
+    }
+  }
+
+  private def transformTimeSlidingWindow(
+      call: RelOptRuleCall,
+      input: RelNode,
+      agg: FlinkLogicalWindowAggregate,
+      window: LogicalWindow,
+      auxGroupSet: Array[Int],
+      aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
+      aggBufferTypes: Array[Array[InternalType]],
+      preferHashExec: Boolean,
+      enableAssignPane: Boolean,
+      supportLocalAgg: Boolean): Unit = {
+    val groupSet = agg.getGroupSet.toArray
+    val aggregates = aggCallToAggFunction.map(_._2).toArray
+
+    // TODO aggregate include projection now, so do not provide new trait will be safe
+    val aggProvidedTraitSet = input.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+    val inputTimeFieldIndex = AggregateUtil.timeFieldIndex(
+      input.getRowType, call.builder(), window.timeAttribute)
+    val inputTimeFieldType = agg.getInput.getRowType.getFieldList.get(inputTimeFieldIndex).getType
+    val inputTimeIsDate = inputTimeFieldType.getSqlTypeName == SqlTypeName.DATE
+    // local-agg output order: groupset | assignTs | aucGroupSet | aggCalls
+    val newInputTimeFieldIndexFromLocal = groupSet.length
+
+    val config = input.getCluster.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig
+    if (!isEnforceOnePhaseAgg(config) && supportLocalAgg) {
+      val windowType = if (inputTimeIsDate) InternalTypes.INT else InternalTypes.LONG
+      // local
+      var localRequiredTraitSet = input.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+      // local win-agg output order: groupSet + assignTs + auxGroupSet + aggCalls
+      val localAggRelType = inferLocalWindowAggType(enableAssignPane, input.getRowType, agg,
+        groupSet, auxGroupSet, windowType, aggregates, aggBufferTypes)
+
+      val localAgg = if (preferHashExec) {
+        // hash
+        val newLocalInput = RelOptRule.convert(input, localRequiredTraitSet)
+        val localProvidedTraitSet = localRequiredTraitSet
+
+        new BatchExecLocalHashWindowAggregate(
+          window,
+          inputTimeFieldIndex,
+          inputTimeIsDate,
+          agg.getNamedProperties,
+          agg.getCluster,
+          call.builder(),
+          localProvidedTraitSet,
+          newLocalInput,
+          aggCallToAggFunction,
+          localAggRelType,
+          newLocalInput.getRowType,
+          groupSet,
+          auxGroupSet,
+          enableAssignPane)
+      } else {
+        // sort
+        localRequiredTraitSet = localRequiredTraitSet.replace(createRelCollation(
+          groupSet :+ inputTimeFieldIndex))
+
+        val newLocalInput = RelOptRule.convert(input, localRequiredTraitSet)
+        val localProvidedTraitSet = localRequiredTraitSet
+
+        new BatchExecLocalSortWindowAggregate(
+          window,
+          inputTimeFieldIndex,
+          inputTimeIsDate,
+          agg.getNamedProperties,
+          agg.getCluster,
+          call.builder(),
+          localProvidedTraitSet,
+          newLocalInput,
+          aggCallToAggFunction,
+          localAggRelType,
+          newLocalInput.getRowType,
+          groupSet,
+          auxGroupSet,
+          enableAssignPane)
+      }
+
+      // global
+      var globalRequiredTraitSet = localAgg.getTraitSet
+      // distribute by grouping keys or single plus assigned pane
+      val distributionFields = if (agg.getGroupCount != 0) {
+        // global agg should use groupSet's indices as distribution fields
+        val globalGroupSet = groupSet.indices
+        FlinkRelDistribution.hash(globalGroupSet.map(Integer.valueOf), requireStrict = false)
+      } else {
+        FlinkRelDistribution.SINGLETON
+      }
+      globalRequiredTraitSet = globalRequiredTraitSet.replace(distributionFields)
+
+      val globalAgg = if (preferHashExec) {
+        // hash
+        val newGlobalAggInput = RelOptRule.convert(localAgg, globalRequiredTraitSet)
+
+        new BatchExecHashWindowAggregate(
+          window,
+          newInputTimeFieldIndexFromLocal,
+          inputTimeIsDate,
+          agg.getNamedProperties,
+          agg.getCluster,
+          call.builder(),
+          aggProvidedTraitSet,
+          newGlobalAggInput,
+          aggCallToAggFunction,
+          agg.getRowType,
+          newGlobalAggInput.getRowType,
+          input.getRowType,
+          groupSet.indices.toArray,
+          // auxGroupSet starts from `size of groupSet + 1(assignTs)`
+          (groupSet.length + 1 until groupSet.length + 1 + auxGroupSet.length).toArray,
+          enableAssignPane,
+          isMerge = true)
+      } else {
+        // sort
+        globalRequiredTraitSet = globalRequiredTraitSet
+            .replace(RelCollations.EMPTY)
+            .replace(createRelCollation(groupSet.indices.toArray :+ groupSet.length))
+        val newGlobalAggInput = RelOptRule.convert(localAgg, globalRequiredTraitSet)
+
+        new BatchExecSortWindowAggregate(
+          window,
+          newInputTimeFieldIndexFromLocal,
+          inputTimeIsDate,
+          agg.getNamedProperties,
+          agg.getCluster,
+          call.builder(),
+          aggProvidedTraitSet,
+          newGlobalAggInput,
+          aggCallToAggFunction,
+          agg.getRowType,
+          newGlobalAggInput.getRowType,
+          input.getRowType,
+          groupSet.indices.toArray,
+          // auxGroupSet starts from `size of groupSet + 1(assignTs)`
+          (groupSet.length + 1 until groupSet.length + 1 + auxGroupSet.length).toArray,
+          enableAssignPane,
+          isMerge = true)
+      }
+
+      call.transformTo(globalAgg)
+    }
+    // disable one-phase agg if prefer two-phase agg
+    if (!isEnforceTwoPhaseAgg(config) || !supportLocalAgg) {
+      var requiredTraitSet = agg.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+      // distribute by grouping keys
+      requiredTraitSet = if (agg.getGroupCount != 0) {
+        requiredTraitSet.replace(
+          FlinkRelDistribution.hash(groupSet.map(Integer.valueOf).toList, requireStrict = false))
+      } else {
+        requiredTraitSet.replace(FlinkRelDistribution.SINGLETON)
+      }
+
+      val windowAgg = if (preferHashExec && !enableAssignPane) {
+        // case 1: Tumbling window, Sliding window windowSize >= slideSize
+        // case 2: Sliding window without pane optimization
+        val newInput = RelOptRule.convert(input, requiredTraitSet)
+
+        new BatchExecHashWindowAggregate(
+          window,
+          inputTimeFieldIndex,
+          inputTimeIsDate,
+          agg.getNamedProperties,
+          agg.getCluster,
+          call.builder(),
+          aggProvidedTraitSet,
+          newInput,
+          aggCallToAggFunction,
+          agg.getRowType,
+          newInput.getRowType,
+          newInput.getRowType,
+          groupSet,
+          auxGroupSet,
+          enableAssignPane,
+          isMerge = false)
+      } else {
+        // sort by grouping keys and time field in ascending direction
+        requiredTraitSet = requiredTraitSet.replace(createRelCollation(
+          groupSet :+ inputTimeFieldIndex))
+        val newInput = RelOptRule.convert(input, requiredTraitSet)
+
+        new BatchExecSortWindowAggregate(
+          window,
+          inputTimeFieldIndex,
+          inputTimeIsDate,
+          agg.getNamedProperties,
+          agg.getCluster,
+          call.builder(),
+          aggProvidedTraitSet,
+          newInput,
+          aggCallToAggFunction,
+          agg.getRowType,
+          newInput.getRowType,
+          newInput.getRowType,
+          groupSet,
+          auxGroupSet,
+          enableAssignPane,
+          isMerge = false)
+      }
+
+      call.transformTo(windowAgg)
+    }
+  }
+
+  /**
+    * Return true when sliding window with slideSize < windowSize && gcd(windowSize, slideSize) > 1.
+    * Otherwise return false, including the cases of tumbling window,
+    * sliding window with slideSize >= windowSize and
+    * sliding window with slideSize < windowSize but gcd(windowSize, slideSize) == 1.
+    */
+  private def useAssignPane(
+      aggregateList: Array[UserDefinedFunction],
+      windowSize: Long,
+      slideSize: Long): Boolean = {
+    doAllSupportMerge(aggregateList) &&
+        slideSize < windowSize && isEffectiveAssigningPane(windowSize, slideSize)
+  }
+
+  /**
+    * In the case of sliding window without the optimization of assigning pane which means
+    * slideSize < windowSize && ArithmeticUtils.gcd(windowSize, slideSize) == 1, we will disable the
+    * local aggregate.
+    * Otherwise, we use the same way as the group aggregate to make the decision whether
+    * to use a local aggregate or not.
+    */
+  private def supportLocalWindowAgg(
+      call: RelOptRuleCall,
+      tableConfig: TableConfig,
+      aggregateList: Array[UserDefinedFunction],
+      windowSize: Long,
+      slideSize: Long): Boolean = {
+    if (slideSize < windowSize && !isEffectiveAssigningPane(windowSize, slideSize)) {
+      false
+    } else {
+      doAllSupportMerge(aggregateList)
+    }
+  }
+
+  private def useHashExec(agg: Aggregate): Boolean = {
+    isAggBufferFixedLength(agg)
+  }
+
+  private def isEffectiveAssigningPane(windowSize: Long, slideSize: Long) =
+    ArithmeticUtils.gcd(windowSize, slideSize) > 1
+
+  def inferLocalWindowAggType(
+      enableAssignPane: Boolean,
+      inputType: RelDataType,
+      agg: Aggregate,
+      groupSet: Array[Int],
+      auxGroupSet: Array[Int],
+      windowType: InternalType,
+      aggregates: Array[UserDefinedFunction],
+      aggBufferTypes: Array[Array[InternalType]]): RelDataType = {
+    val aggNames = agg.getNamedAggCalls.map(_.right)
+
+    val aggBufferFieldNames = new Array[Array[String]](aggregates.length)
+    var index = -1
+    aggregates.zipWithIndex.foreach{ case (udf, aggIndex) =>
+      aggBufferFieldNames(aggIndex) = udf match {
+        case _: AggregateFunction[_, _] =>
+          Array(aggNames(aggIndex))
+        case agf: DeclarativeAggregateFunction =>
+          agf.aggBufferAttributes.map { attr =>
+            index += 1
+            s"${attr.getName}$$$index"}
+        case _: UserDefinedFunction =>
+          throw new TableException(s"Don't get localAgg merge name")
+      }
+    }
+
+    // local win-agg output order: groupSet + assignTs + auxGroupSet + aggCalls
+    val typeFactory = agg.getCluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    val aggBufferSqlTypes = aggBufferTypes.flatten.map { t =>
+      val nullable = !FlinkTypeFactory.isTimeIndicatorType(t)
+      typeFactory.createTypeFromInternalType(t, nullable)
+    }
+
+    val localAggFieldTypes = (
+        groupSet.map(inputType.getFieldList.get(_).getType) ++ // groupSet
+            // assignTs
+            Array(typeFactory.createTypeFromInternalType(windowType, isNullable = true)) ++
+            auxGroupSet.map(inputType.getFieldList.get(_).getType) ++ // auxGroupSet
+            aggBufferSqlTypes // aggCalls
+        ).toList
+
+    val assignTsFieldName = if (enableAssignPane) "assignedPane$" else "assignedWindow$"
+    val localAggFieldNames = (
+        groupSet.map(inputType.getFieldList.get(_).getName) ++ // groupSet
+            Array(assignTsFieldName) ++ // assignTs
+            auxGroupSet.map(inputType.getFieldList.get(_).getName) ++ // auxGroupSet
+            aggBufferFieldNames.flatten.toArray[String] // aggCalls
+        ).toList
+
+    typeFactory.createStructType(localAggFieldTypes, localAggFieldNames)
+  }
+}
+
+object BatchExecWindowAggregateRule {
+  val INSTANCE: RelOptRule = new BatchExecWindowAggregateRule
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/runtime/utils/BatchAbstractTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/runtime/utils/BatchAbstractTestBase.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+
+/**
+ * Batch test base to use {@link ClassRule}.
+ */
+public class BatchAbstractTestBase {
+
+	public static final int DEFAULT_PARALLELISM = 3;
+
+	@ClassRule
+	public static MiniClusterWithClientResource miniClusterResource = new MiniClusterWithClientResource(
+			new MiniClusterResourceConfiguration.Builder()
+					.setConfiguration(getConfiguration())
+					.setNumberTaskManagers(1)
+					.setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+					.build());
+
+	@ClassRule
+	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+	private static Configuration getConfiguration() {
+		Configuration config = new Configuration();
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "100m");
+		return config;
+	}
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/GroupWindowTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/GroupWindowTest.xml
@@ -22,8 +22,8 @@ limitations under the License.
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(EXPR$0=[$1], EXPR$1=[$0])
-+- LogicalFilter(condition=[AND(>($2, 0), =(EXTRACT(FLAG(QUARTER), $0), 1))])
+LogicalProject(EXPR$0=[$1], EXPR$1=[HOP_START($0)])
++- LogicalFilter(condition=[AND(>($2, 0), =(EXTRACT(FLAG(QUARTER), HOP_START($0)), 1))])
    +- LogicalAggregate(group=[{0}], EXPR$0=[COUNT()], agg#1=[SUM($1)])
       +- LogicalProject($f0=[HOP($3, 900000, 60000)], a=[$0])
          +- LogicalTableScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]])
@@ -31,8 +31,8 @@ LogicalProject(EXPR$0=[$1], EXPR$1=[$0])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[EXPR$0, CAST(1970-01-01 00:00:00) AS EXPR$1], where=[>($f1, 0)])
-+- HashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 60000.millis, 900000.millis)], select=[COUNT(*) AS EXPR$0, SUM(a) AS $f1])
+Calc(select=[EXPR$0, w$start AS EXPR$1], where=[AND(>($f1, 0), =(EXTRACT(FLAG(QUARTER), w$start), 1))])
++- HashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 60000.millis, 900000.millis)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[COUNT(*) AS EXPR$0, SUM(a) AS $f1])
    +- Exchange(distribution=[single])
       +- Calc(select=[ts, a])
          +- TableSourceScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]], fields=[a, b, c, ts])
@@ -89,7 +89,7 @@ HashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 5400000.millis, 900000.m
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(EXPR$0=[+($0, 240000)])
+LogicalProject(EXPR$0=[TUMBLE_END($0)])
 +- LogicalAggregate(group=[{0, 1}])
    +- LogicalProject($f0=[TUMBLE($3, 240000)], c=[$2])
       +- LogicalTableScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]])
@@ -97,8 +97,8 @@ LogicalProject(EXPR$0=[+($0, 240000)])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[+(CAST(1970-01-01 00:00:00), 240000) AS EXPR$0])
-+- HashWindowAggregate(groupBy=[c], window=[TumblingGroupWindow], select=[c])
+Calc(select=[w$end AS EXPR$0])
++- HashWindowAggregate(groupBy=[c], window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime, w$proctime], select=[c])
    +- Exchange(distribution=[hash[c]])
       +- Calc(select=[ts, c])
          +- TableSourceScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]], fields=[a, b, c, ts])

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/GroupWindowTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/GroupWindowTest.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testExpressionOnWindowHavingFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT   COUNT(*),   HOP_START(ts, INTERVAL '15' MINUTE, INTERVAL '1' MINUTE) FROM T GROUP BY HOP(ts, INTERVAL '15' MINUTE, INTERVAL '1' MINUTE) HAVING   SUM(a) > 0 AND   QUARTER(HOP_START(ts, INTERVAL '15' MINUTE, INTERVAL '1' MINUTE)) = 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$0])
++- LogicalFilter(condition=[AND(>($2, 0), =(EXTRACT(FLAG(QUARTER), $0), 1))])
+   +- LogicalAggregate(group=[{0}], EXPR$0=[COUNT()], agg#1=[SUM($1)])
+      +- LogicalProject($f0=[HOP($3, 900000, 60000)], a=[$0])
+         +- LogicalTableScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0, CAST(1970-01-01 00:00:00) AS EXPR$1], where=[>($f1, 0)])
++- HashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 60000.millis, 900000.millis)], select=[COUNT(*) AS EXPR$0, SUM(a) AS $f1])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[ts, a])
+         +- TableSourceScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]], fields=[a, b, c, ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTumbleWindowWithUdAgg">
+    <Resource name="sql">
+      <![CDATA[SELECT weightedAvg(b, a) AS wAvg FROM T GROUP BY TUMBLE(ts, INTERVAL '4' MINUTE)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(wAvg=[$1])
++- LogicalAggregate(group=[{0}], wAvg=[weightedAvg($1, $2)])
+   +- LogicalProject($f0=[TUMBLE($3, 240000)], b=[$1], a=[$0])
+      +- LogicalTableScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortWindowAggregate(window=[TumblingGroupWindow], select=[weightedAvg(b, a) AS wAvg])
++- Sort(orderBy=[ts ASC])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[ts, b, a])
+         +- TableSourceScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]], fields=[a, b, c, ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonPartitionedHopWindow">
+    <Resource name="sql">
+      <![CDATA[SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM T GROUP BY HOP(ts, INTERVAL '15' MINUTE, INTERVAL '90' MINUTE)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(sumA=[$1], cntB=[$2])
++- LogicalAggregate(group=[{0}], sumA=[SUM($1)], cntB=[COUNT($2)])
+   +- LogicalProject($f0=[HOP($3, 900000, 5400000)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 5400000.millis, 900000.millis)], select=[Final_SUM(sum$0) AS sumA, Final_COUNT(count$1) AS cntB])
++- Exchange(distribution=[single])
+   +- LocalHashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 5400000.millis, 900000.millis)], select=[Partial_SUM(a) AS sum$0, Partial_COUNT(b) AS count$1])
+      +- Calc(select=[ts, a, b])
+         +- TableSourceScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]], fields=[a, b, c, ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWindowEndOnly">
+    <Resource name="sql">
+      <![CDATA[SELECT   TUMBLE_END(ts, INTERVAL '4' MINUTE)FROM T GROUP BY TUMBLE(ts, INTERVAL '4' MINUTE), c]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[+($0, 240000)])
++- LogicalAggregate(group=[{0, 1}])
+   +- LogicalProject($f0=[TUMBLE($3, 240000)], c=[$2])
+      +- LogicalTableScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[+(CAST(1970-01-01 00:00:00), 240000) AS EXPR$0])
++- HashWindowAggregate(groupBy=[c], window=[TumblingGroupWindow], select=[c])
+   +- Exchange(distribution=[hash[c]])
+      +- Calc(select=[ts, c])
+         +- TableSourceScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]], fields=[a, b, c, ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonPartitionedTumbleWindow">
+    <Resource name="sql">
+      <![CDATA[SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM T GROUP BY TUMBLE(ts, INTERVAL '2' HOUR)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(sumA=[$1], cntB=[$2])
++- LogicalAggregate(group=[{0}], sumA=[SUM($1)], cntB=[COUNT($2)])
+   +- LogicalProject($f0=[TUMBLE($3, 7200000)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashWindowAggregate(window=[TumblingGroupWindow], select=[SUM(a) AS sumA, COUNT(b) AS cntB])
++- Exchange(distribution=[single])
+   +- Calc(select=[ts, a, b])
+      +- TableSourceScan(table=[[T, source: [TestTableSource(a, b, c, ts)]]], fields=[a, b, c, ts])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/join/WindowJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/join/WindowJoinTest.xml
@@ -16,36 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testProcTimeFullOuterJoin">
-    <Resource name="sql">
-      <![CDATA[
-SELECT t1.a, t2.b
-FROM MyTable t1 Full OUTER JOIN MyTable2 t2 ON
-  t1.a = t2.a AND
-  t1.proctime BETWEEN t2.proctime - INTERVAL '1' HOUR AND t2.proctime + INTERVAL '1' HOUR
-      ]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$6])
-+- LogicalJoin(condition=[AND(=($0, $5), >=($3, -($8, 3600000)), <=($3, +($8, 3600000)))], joinType=[full])
-   :- LogicalTableScan(table=[[MyTable]])
-   +- LogicalTableScan(table=[[MyTable2]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[a, b])
-+- WindowJoin(joinType=[FullOuterJoin], windowBounds=[isRowTime=false, leftLowerBound=-3600000, leftUpperBound=3600000, leftTimeIndex=1, rightTimeIndex=2], where=[AND(=(a, a0), >=(proctime, -(proctime0, 3600000)), <=(proctime, +(proctime0, 3600000)))], select=[a, proctime, a0, b, proctime0])
-   :- Exchange(distribution=[hash[a]])
-   :  +- Calc(select=[a, proctime])
-   :     +- DataStreamScan(table=[[_DataStreamTable_0]], fields=[a, b, c, proctime, rowtime])
-   +- Exchange(distribution=[hash[a]])
-      +- Calc(select=[a, b, proctime])
-         +- DataStreamScan(table=[[_DataStreamTable_1]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testJoinWithEquiProcTime">
     <Resource name="sql">
       <![CDATA[
@@ -224,6 +194,73 @@ Calc(select=[a, b])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testRowTimeInnerJoinAndWindowAggregationOnFirst">
+    <Resource name="sql">
+      <![CDATA[
+SELECT t1.b, SUM(t2.a) AS aSum, COUNT(t2.b) AS bCnt
+FROM MyTable t1, MyTable2 t2
+WHERE t1.a = t2.a AND
+  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' MINUTE AND t2.rowtime + INTERVAL '1' HOUR
+GROUP BY TUMBLE(t1.rowtime, INTERVAL '6' HOUR), t1.b
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$1], aSum=[$2], bCnt=[$3])
++- LogicalAggregate(group=[{0, 1}], aSum=[SUM($2)], bCnt=[COUNT($3)])
+   +- LogicalProject($f0=[TUMBLE($4, 21600000)], b=[$1], a0=[$5], b0=[$6])
+      +- LogicalFilter(condition=[AND(=($0, $5), >=($4, -($9, 600000)), <=($4, +($9, 3600000)))])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalTableScan(table=[[MyTable]])
+            +- LogicalTableScan(table=[[MyTable2]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[b, aSum, bCnt])
++- GroupAggregate(groupBy=[$f0, b], select=[$f0, b, SUM(a0) AS aSum, COUNT(b0) AS bCnt])
+   +- Exchange(distribution=[hash[$f0, b]])
+      +- Calc(select=[TUMBLE(rowtime, 21600000) AS $f0, b, a0, b0])
+         +- WindowJoin(joinType=[InnerJoin], windowBounds=[isRowTime=true, leftLowerBound=-600000, leftUpperBound=3600000, leftTimeIndex=2, rightTimeIndex=2], where=[AND(=(a, a0), >=(rowtime, -(rowtime0, 600000)), <=(rowtime, +(rowtime0, 3600000)))], select=[a, b, rowtime, a0, b0, rowtime0])
+            :- Exchange(distribution=[hash[a]])
+            :  +- Calc(select=[a, b, rowtime])
+            :     +- DataStreamScan(table=[[_DataStreamTable_0]], fields=[a, b, c, proctime, rowtime])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, b, rowtime])
+                  +- DataStreamScan(table=[[_DataStreamTable_1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProcTimeFullOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT t1.a, t2.b
+FROM MyTable t1 Full OUTER JOIN MyTable2 t2 ON
+  t1.a = t2.a AND
+  t1.proctime BETWEEN t2.proctime - INTERVAL '1' HOUR AND t2.proctime + INTERVAL '1' HOUR
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$6])
++- LogicalJoin(condition=[AND(=($0, $5), >=($3, -($8, 3600000)), <=($3, +($8, 3600000)))], joinType=[full])
+   :- LogicalTableScan(table=[[MyTable]])
+   +- LogicalTableScan(table=[[MyTable2]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b])
++- WindowJoin(joinType=[FullOuterJoin], windowBounds=[isRowTime=false, leftLowerBound=-3600000, leftUpperBound=3600000, leftTimeIndex=1, rightTimeIndex=2], where=[AND(=(a, a0), >=(proctime, -(proctime0, 3600000)), <=(proctime, +(proctime0, 3600000)))], select=[a, proctime, a0, b, proctime0])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, proctime])
+   :     +- DataStreamScan(table=[[_DataStreamTable_0]], fields=[a, b, c, proctime, rowtime])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, proctime])
+         +- DataStreamScan(table=[[_DataStreamTable_1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProcTimeRightOuterJoin">
     <Resource name="sql">
       <![CDATA[
@@ -341,6 +378,43 @@ Calc(select=[a, b])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, b, rowtime])
          +- DataStreamScan(table=[[_DataStreamTable_1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRowTimeInnerJoinAndWindowAggregationOnSecond">
+    <Resource name="sql">
+      <![CDATA[
+SELECT t2.b, SUM(t1.a) AS aSum, COUNT(t1.b) AS bCnt
+FROM MyTable t1, MyTable2 t2
+WHERE t1.a = t2.a AND
+  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' MINUTE AND t2.rowtime + INTERVAL '1' HOUR
+GROUP BY TUMBLE(t2.rowtime, INTERVAL '6' HOUR), t2.b
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$1], aSum=[$2], bCnt=[$3])
++- LogicalAggregate(group=[{0, 1}], aSum=[SUM($2)], bCnt=[COUNT($3)])
+   +- LogicalProject($f0=[TUMBLE($9, 21600000)], b=[$6], a=[$0], $f3=[$1])
+      +- LogicalFilter(condition=[AND(=($0, $5), >=($4, -($9, 600000)), <=($4, +($9, 3600000)))])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalTableScan(table=[[MyTable]])
+            +- LogicalTableScan(table=[[MyTable2]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[b, aSum, bCnt])
++- GroupAggregate(groupBy=[$f0, b], select=[$f0, b, SUM(a) AS aSum, COUNT($f3) AS bCnt])
+   +- Exchange(distribution=[hash[$f0, b]])
+      +- Calc(select=[TUMBLE(rowtime0, 21600000) AS $f0, b0 AS b, a, b AS $f3])
+         +- WindowJoin(joinType=[InnerJoin], windowBounds=[isRowTime=true, leftLowerBound=-600000, leftUpperBound=3600000, leftTimeIndex=2, rightTimeIndex=2], where=[AND(=(a, a0), >=(rowtime, -(rowtime0, 600000)), <=(rowtime, +(rowtime0, 3600000)))], select=[a, b, rowtime, a0, b0, rowtime0])
+            :- Exchange(distribution=[hash[a]])
+            :  +- Calc(select=[a, b, rowtime])
+            :     +- DataStreamScan(table=[[_DataStreamTable_0]], fields=[a, b, c, proctime, rowtime])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, b, rowtime])
+                  +- DataStreamScan(table=[[_DataStreamTable_1]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/GroupWindowTest.scala
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.plan.util.JavaUserDefinedAggFunctions.WeightedAvgWithMerge
+import org.apache.flink.table.util.TableTestBase
+
+import org.junit.{Ignore, Test}
+
+import java.sql.Timestamp
+
+class GroupWindowTest extends TableTestBase {
+
+  @Test
+  def testNonPartitionedTumbleWindow(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Timestamp)]("T", 'a, 'b, 'c, 'ts)
+
+    val sqlQuery =
+      "SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM T GROUP BY TUMBLE(ts, INTERVAL '2' HOUR)"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  //TODO to support.
+  @Ignore
+  @Test
+  def testPartitionedTumbleWindow(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Timestamp)]("T", 'a, 'b, 'c, 'ts)
+
+    val sqlQuery =
+      "SELECT " +
+        "  TUMBLE_START(ts, INTERVAL '4' MINUTE), " +
+        "  TUMBLE_END(ts, INTERVAL '4' MINUTE), " +
+        "  TUMBLE_ROWTIME(ts, INTERVAL '4' MINUTE), " +
+        "  c, " +
+        "  SUM(a) AS sumA, " +
+        "  MIN(b) AS minB " +
+        "FROM T " +
+        "GROUP BY TUMBLE(ts, INTERVAL '4' MINUTE), c"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testTumbleWindowWithUdAgg(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Timestamp)]("T", 'a, 'b, 'c, 'ts)
+
+    val weightedAvg = new WeightedAvgWithMerge
+    util.tableEnv.registerFunction("weightedAvg", weightedAvg)
+
+    val sql = "SELECT weightedAvg(b, a) AS wAvg " +
+      "FROM T " +
+      "GROUP BY TUMBLE(ts, INTERVAL '4' MINUTE)"
+
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testNonPartitionedHopWindow(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Timestamp)]("T", 'a, 'b, 'c, 'ts)
+
+    val sqlQuery =
+      "SELECT SUM(a) AS sumA, COUNT(b) AS cntB " +
+        "FROM T " +
+        "GROUP BY HOP(ts, INTERVAL '15' MINUTE, INTERVAL '90' MINUTE)"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  //TODO to support.
+  @Ignore
+  @Test
+  def testPartitionedHopWindow(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Long, Timestamp)]("T", 'a, 'b, 'c, 'd, 'ts)
+
+    val sqlQuery =
+      "SELECT " +
+        "  c, " +
+        "  HOP_END(ts, INTERVAL '1' HOUR, INTERVAL '3' HOUR), " +
+        "  HOP_START(ts, INTERVAL '1' HOUR, INTERVAL '3' HOUR), " +
+        "  HOP_ROWTIME(ts, INTERVAL '1' HOUR, INTERVAL '3' HOUR), " +
+        "  SUM(a) AS sumA, " +
+        "  AVG(b) AS avgB " +
+        "FROM T " +
+        "GROUP BY HOP(ts, INTERVAL '1' HOUR, INTERVAL '3' HOUR), d, c"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  //TODO to support.
+  @Ignore
+  @Test
+  def testNonPartitionedSessionWindow(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Timestamp)]("T", 'a, 'b, 'c, 'ts)
+
+    val sqlQuery =
+      "SELECT COUNT(*) AS cnt FROM T GROUP BY SESSION(ts, INTERVAL '30' MINUTE)"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  //TODO to support.
+  @Ignore
+  @Test
+  def testPartitionedSessionWindow(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Int, Timestamp)]("T", 'a, 'b, 'c, 'd, 'ts)
+
+    val sqlQuery =
+      "SELECT " +
+        "  c, d, " +
+        "  SESSION_START(ts, INTERVAL '12' HOUR), " +
+        "  SESSION_END(ts, INTERVAL '12' HOUR), " +
+        "  SESSION_ROWTIME(ts, INTERVAL '12' HOUR), " +
+        "  SUM(a) AS sumA, " +
+        "  MIN(b) AS minB " +
+        "FROM T " +
+        "GROUP BY SESSION(ts, INTERVAL '12' HOUR), c, d"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testWindowEndOnly(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Timestamp)]("T", 'a, 'b, 'c, 'ts)
+
+    val sqlQuery =
+      "SELECT " +
+        "  TUMBLE_END(ts, INTERVAL '4' MINUTE)" +
+        "FROM T " +
+        "GROUP BY TUMBLE(ts, INTERVAL '4' MINUTE), c"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testExpressionOnWindowHavingFunction(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, Long, String, Timestamp)]("T", 'a, 'b, 'c, 'ts)
+
+    val sql =
+      "SELECT " +
+        "  COUNT(*), " +
+        "  HOP_START(ts, INTERVAL '15' MINUTE, INTERVAL '1' MINUTE) " +
+        "FROM T " +
+        "GROUP BY HOP(ts, INTERVAL '15' MINUTE, INTERVAL '1' MINUTE) " +
+        "HAVING " +
+        "  SUM(a) > 0 AND " +
+        "  QUARTER(HOP_START(ts, INTERVAL '15' MINUTE, INTERVAL '1' MINUTE)) = 1"
+
+    util.verifyPlan(sql)
+  }
+
+  @Ignore // TODO support VAR_POP etc..
+  @Test
+  def testDecomposableAggFunctions(): Unit = {
+    val util = batchTestUtil()
+    util.addTableSource[(Int, String, Long, Timestamp)]("MyTable", 'a, 'b, 'c, 'ts)
+
+    val sql =
+      "SELECT " +
+        "  VAR_POP(c), VAR_SAMP(c), STDDEV_POP(c), STDDEV_SAMP(c), " +
+        "  TUMBLE_START(ts, INTERVAL '15' MINUTE), " +
+        "  TUMBLE_END(ts, INTERVAL '15' MINUTE)" +
+        "FROM MyTable " +
+        "GROUP BY TUMBLE(ts, INTERVAL '15' MINUTE)"
+
+    util.verifyPlan(sql)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/join/WindowJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/join/WindowJoinTest.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.plan.stream.sql.join
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.{TableException, TableImpl, ValidationException}
+import org.apache.flink.table.api.{TableException, TableImpl}
 import org.apache.flink.table.plan.util.WindowJoinUtil
 import org.apache.flink.table.util.{StreamTableTestUtil, TableTestBase}
 
@@ -170,8 +170,7 @@ class WindowJoinTest extends TableTestBase {
     util.verifyPlan(sqlQuery)
   }
 
-  @Test(expected = classOf[ValidationException])
-  // FIXME remove expected exception after TUMBLE added
+  @Test
   def testRowTimeInnerJoinAndWindowAggregationOnFirst(): Unit = {
     val sqlQuery =
       """
@@ -185,8 +184,7 @@ class WindowJoinTest extends TableTestBase {
     util.verifyPlan(sqlQuery)
   }
 
-  @Test(expected = classOf[ValidationException])
-  // FIXME remove expected exception after TUMBLE added
+  @Test
   def testRowTimeInnerJoinAndWindowAggregationOnSecond(): Unit = {
     val sqlQuery =
       """

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/DistinctAggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/DistinctAggregateITCaseBase.scala
@@ -38,8 +38,6 @@ abstract class DistinctAggregateITCaseBase extends BatchTestBase {
 
   @Before
   def before(): Unit = {
-    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 1)
-
     registerCollection("SmallTable3", smallData3, type3, "a, b, c", nullablesOfSmallData3)
     registerCollection("SmallTable5", smallData5, type5, "a, b, c, d, e", nullablesOfSmallData5)
     registerCollection("EmptyTable3", Seq(), type3, "a, b, c")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/DistinctAggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/DistinctAggregateITCaseBase.scala
@@ -38,8 +38,7 @@ abstract class DistinctAggregateITCaseBase extends BatchTestBase {
 
   @Before
   def before(): Unit = {
-    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 3)
-    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_HASH_AGG_TABLE_MEM, 4)
+    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 1)
 
     registerCollection("SmallTable3", smallData3, type3, "a, b, c", nullablesOfSmallData3)
     registerCollection("SmallTable5", smallData5, type5, "a, b, c, d, e", nullablesOfSmallData5)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/GroupWindowITCase.scala
@@ -1,0 +1,719 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.sql.agg
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO}
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIMESTAMP
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.io.CollectionInputFormat
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+import scala.collection.JavaConversions._
+import org.apache.flink.table.api.{TableSchema, _}
+import org.apache.flink.table.runtime.utils.BatchTestBase
+import org.apache.flink.table.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.runtime.utils.TestData._
+import org.apache.flink.table.sources.BatchTableSource
+import org.apache.flink.table.util.DateTimeTestUtil.UTCTimestamp
+import org.apache.flink.table.util.{CountAggFunction, IntAvgAggFunction, IntSumAggFunction}
+import org.apache.flink.types.Row
+
+import org.junit.{Before, Ignore, Test}
+
+class GroupWindowITCase extends BatchTestBase {
+
+  @Before
+  def before(): Unit = {
+    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 3)
+    // common case
+    registerCollection("Table3WithTimestamp", data3WithTimestamp, type3WithTimestamp,
+      "a, b, c, ts", nullablesOfData3WithTimestamp)
+    // for udagg
+    registerFunction("countFun", new CountAggFunction())
+    registerFunction("sumFun", new IntSumAggFunction())
+    registerFunction("avgFun", new IntAvgAggFunction())
+    // time unit
+    registerCollection("Table6", data6, type6, "a, b, c, d, e, f", nullablesOfData6)
+  }
+
+  @Test
+  def testTumblingWindow(): Unit = {
+    // SORT; keyed; 2-phase; pre-accumulate without paned optimization; single row group
+    checkResult(
+      "SELECT a, countFun(a), TUMBLE_START(ts, INTERVAL '3' SECOND)" +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY a, TUMBLE(ts, INTERVAL '3' SECOND)",
+      Seq(
+        row(1, 1, "1970-01-01 00:00:00.0"),
+        row(2, 1, "1970-01-01 00:00:00.0"),
+        row(3, 1, "1970-01-01 00:00:03.0"),
+        row(4, 1, "1970-01-01 00:00:03.0"),
+        row(5, 1, "1970-01-01 00:00:03.0"),
+        row(6, 1, "1970-01-01 00:00:06.0"),
+        row(7, 1, "1970-01-01 00:00:06.0"),
+        row(8, 1, "1970-01-01 00:00:06.0"),
+        row(9, 1, "1970-01-01 00:00:09.0"),
+        row(10, 1, "1970-01-01 00:00:09.0"),
+        row(11, 1, "1970-01-01 00:00:09.0"),
+        row(12, 1, "1970-01-01 00:00:12.0"),
+        row(13, 1, "1970-01-01 00:00:12.0"),
+        row(14, 1, "1970-01-01 00:00:12.0"),
+        row(15, 1, "1970-01-01 00:00:15.0"),
+        row(16, 1, "1970-01-01 00:00:15.0"),
+        row(17, 1, "1970-01-01 00:00:15.0"),
+        row(18, 1, "1970-01-01 00:00:18.0"),
+        row(19, 1, "1970-01-01 00:00:18.0"),
+        row(20, 1, "1970-01-01 00:00:18.0"),
+        row(21, 1, "1970-01-01 00:00:21.0")
+      )
+    )
+
+    // SORT; keyed; 2-phase keyed; single row group
+    checkResult(
+      "SELECT a, countFun(a), TUMBLE_START(ts, INTERVAL '3' SECOND), b " +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY a, TUMBLE(ts, INTERVAL '3' SECOND), b",
+      Seq(
+        row(1, 1, "1970-01-01 00:00:00.0", 1),
+        row(2, 1, "1970-01-01 00:00:00.0", 2),
+        row(3, 1, "1970-01-01 00:00:03.0", 2),
+        row(4, 1, "1970-01-01 00:00:03.0", 3),
+        row(5, 1, "1970-01-01 00:00:03.0", 3),
+        row(6, 1, "1970-01-01 00:00:06.0", 3),
+        row(7, 1, "1970-01-01 00:00:06.0", 4),
+        row(8, 1, "1970-01-01 00:00:06.0", 4),
+        row(9, 1, "1970-01-01 00:00:09.0", 4),
+        row(10, 1, "1970-01-01 00:00:09.0", 4),
+        row(11, 1, "1970-01-01 00:00:09.0", 5),
+        row(12, 1, "1970-01-01 00:00:12.0", 5),
+        row(13, 1, "1970-01-01 00:00:12.0", 5),
+        row(14, 1, "1970-01-01 00:00:12.0", 5),
+        row(15, 1, "1970-01-01 00:00:15.0", 5),
+        row(16, 1, "1970-01-01 00:00:15.0", 6),
+        row(17, 1, "1970-01-01 00:00:15.0", 6),
+        row(18, 1, "1970-01-01 00:00:18.0", 6),
+        row(19, 1, "1970-01-01 00:00:18.0", 6),
+        row(20, 1, "1970-01-01 00:00:18.0", 6),
+        row(21, 1, "1970-01-01 00:00:21.0", 6)
+      )
+    )
+
+    // HASH 2-phase; sparse inputs
+    checkResult(
+      "SELECT a, avg(b), min(b), TUMBLE_START(f, INTERVAL '10' SECOND) " +
+          "FROM Table6 " +
+          "GROUP BY a, TUMBLE(f, INTERVAL '10' SECOND)",
+      Seq(
+        row(1, 1.1, 1.1, "2015-05-20 10:00:00.0"),
+        row(2, -2.4, -2.4, "2016-09-01 23:07:00.0"),
+        row(2, 2.5, 2.5, "2019-09-19 08:03:00.0"),
+        row(3, -4.885, -9.77, "1999-12-12 10:00:00.0"),
+        row(3, 0.08, 0.08, "1999-12-12 10:03:00.0"),
+        row(4, 3.14, 3.14, "2017-11-20 09:00:00.0"),
+        row(4, 3.145, 3.14, "2015-11-19 10:00:00.0"),
+        row(4, 3.16, 3.16, "2015-11-20 08:59:50.0"),
+        row(5, -5.9, -5.9, "1989-06-04 10:00:00.0"),
+        row(5, -2.8, -2.8, "1937-07-07 08:08:00.0"),
+        row(5, 0.7, 0.7, "2010-06-01 10:00:00.0"),
+        row(5, 2.71, 2.71, "1997-07-01 09:00:00.0"),
+        row(5, 3.9, 3.9, "2000-01-01 00:00:00.0")
+      )
+    )
+  }
+
+  @Test
+  def testSlidingWindow(): Unit = {
+    // keyed; 2-phase; pre-accumulate with paned optimization;
+    checkResult(
+      "SELECT b, sumFun(a), HOP_START(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND) " +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY b, HOP(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND)",
+      Seq(
+        row(1, 1, "1969-12-31 23:59:55.0"),
+        row(1, 1, "1970-01-01 00:00:00.0"),
+        row(2, 5, "1969-12-31 23:59:55.0"),
+        row(2, 5, "1970-01-01 00:00:00.0"),
+        row(3, 11, "1970-01-01 00:00:05.0"),
+        row(3, 15, "1970-01-01 00:00:00.0"),
+        row(4, 10, "1970-01-01 00:00:10.0"),
+        row(4, 15, "1970-01-01 00:00:00.0"),
+        row(4, 34, "1970-01-01 00:00:05.0"),
+        row(5, 15, "1970-01-01 00:00:15.0"),
+        row(5, 36, "1970-01-01 00:00:05.0"),
+        row(5, 65, "1970-01-01 00:00:10.0"),
+        row(6, 111, "1970-01-01 00:00:15.0"),
+        row(6, 41, "1970-01-01 00:00:20.0"),
+        row(6, 51, "1970-01-01 00:00:10.0")
+      )
+    )
+
+    checkResult(
+      "SELECT b, sum(a), HOP_START(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND) " +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY b, HOP(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND)",
+      Seq(
+        row(1, 1, "1969-12-31 23:59:55.0"),
+        row(1, 1, "1970-01-01 00:00:00.0"),
+        row(2, 5, "1969-12-31 23:59:55.0"),
+        row(2, 5, "1970-01-01 00:00:00.0"),
+        row(3, 11, "1970-01-01 00:00:05.0"),
+        row(3, 15, "1970-01-01 00:00:00.0"),
+        row(4, 10, "1970-01-01 00:00:10.0"),
+        row(4, 15, "1970-01-01 00:00:00.0"),
+        row(4, 34, "1970-01-01 00:00:05.0"),
+        row(5, 15, "1970-01-01 00:00:15.0"),
+        row(5, 36, "1970-01-01 00:00:05.0"),
+        row(5, 65, "1970-01-01 00:00:10.0"),
+        row(6, 111, "1970-01-01 00:00:15.0"),
+        row(6, 41, "1970-01-01 00:00:20.0"),
+        row(6, 51, "1970-01-01 00:00:10.0")
+      )
+    )
+
+    // keyed; 2-phase; pre-accumulate with windowSize = slideSize
+    checkResult(
+      "SELECT b, sumFun(a) FROM Table3WithTimestamp " +
+          "GROUP BY b, HOP(ts, INTERVAL '3' SECOND, INTERVAL '3' SECOND)",
+      Seq(
+        row(1, 1),
+        row(2, 2),
+        row(2, 3),
+        row(3, 6),
+        row(3, 9),
+        row(4, 15),
+        row(4, 19),
+        row(5, 11),
+        row(5, 15),
+        row(5, 39),
+        row(6, 21),
+        row(6, 33),
+        row(6, 57)
+      )
+    )
+
+    checkResult(
+      "SELECT b, sum(a) FROM Table3WithTimestamp " +
+          "GROUP BY b, HOP(ts, INTERVAL '3' SECOND, INTERVAL '3' SECOND)",
+      Seq(
+        row(1, 1),
+        row(2, 2),
+        row(2, 3),
+        row(3, 6),
+        row(3, 9),
+        row(4, 15),
+        row(4, 19),
+        row(5, 11),
+        row(5, 15),
+        row(5, 39),
+        row(6, 21),
+        row(6, 33),
+        row(6, 57)
+      )
+    )
+
+    // keyed; 2-phase; pre-accumulate without pane optimization
+    checkResult(
+      "SELECT b, sumFun(a), HOP_START(ts, INTERVAL '5.111' SECOND(1,3), INTERVAL '9' SECOND) " +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY b, HOP(ts, INTERVAL '5.111' SECOND(1,3), INTERVAL '9' SECOND)",
+      Seq(
+        row(1, 1, "1969-12-31 23:59:54.889"),
+        row(1, 1, "1970-01-01 00:00:00.0"),
+        row(2, 5, "1969-12-31 23:59:54.889"),
+        row(2, 5, "1970-01-01 00:00:00.0"),
+        row(3, 6, "1970-01-01 00:00:05.111"),
+        row(3, 15, "1970-01-01 00:00:00.0"),
+        row(4, 15, "1970-01-01 00:00:00.0"),
+        row(4, 34, "1970-01-01 00:00:05.111"),
+        row(5, 50, "1970-01-01 00:00:05.111"),
+        row(5, 65, "1970-01-01 00:00:10.222"),
+        row(6, 111, "1970-01-01 00:00:15.333"),
+        row(6, 21, "1970-01-01 00:00:20.444"),
+        row(6, 70, "1970-01-01 00:00:10.222")
+      )
+    )
+
+    checkResult(
+      "SELECT b, sum(a), HOP_START(ts, INTERVAL '5.111' SECOND(1,3), INTERVAL '9' SECOND) " +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY b, HOP(ts, INTERVAL '5.111' SECOND(1,3), INTERVAL '9' SECOND)",
+      Seq(
+        row(1, 1, "1969-12-31 23:59:54.889"),
+        row(1, 1, "1970-01-01 00:00:00.0"),
+        row(2, 5, "1969-12-31 23:59:54.889"),
+        row(2, 5, "1970-01-01 00:00:00.0"),
+        row(3, 6, "1970-01-01 00:00:05.111"),
+        row(3, 15, "1970-01-01 00:00:00.0"),
+        row(4, 15, "1970-01-01 00:00:00.0"),
+        row(4, 34, "1970-01-01 00:00:05.111"),
+        row(5, 50, "1970-01-01 00:00:05.111"),
+        row(5, 65, "1970-01-01 00:00:10.222"),
+        row(6, 111, "1970-01-01 00:00:15.333"),
+        row(6, 21, "1970-01-01 00:00:20.444"),
+        row(6, 70, "1970-01-01 00:00:10.222")
+      )
+    )
+
+    // all group; 2-phase; pre-accumulate with windowSize = slideSize
+    checkResult(
+      "SELECT sumFun(a), " +
+          "HOP_START(ts, INTERVAL '3' SECOND, INTERVAL '3' SECOND), " +
+          "HOP_END(ts, INTERVAL '3' SECOND, INTERVAL '3' SECOND)" +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY HOP(ts, INTERVAL '3' SECOND, INTERVAL '3' SECOND)",
+      Seq(
+        row(12, "1970-01-01 00:00:03.0", "1970-01-01 00:00:06.0"),
+        row(21, "1970-01-01 00:00:06.0", "1970-01-01 00:00:09.0"),
+        row(21, "1970-01-01 00:00:21.0", "1970-01-01 00:00:24.0"),
+        row(3, "1970-01-01 00:00:00.0", "1970-01-01 00:00:03.0"),
+        row(30, "1970-01-01 00:00:09.0", "1970-01-01 00:00:12.0"),
+        row(39, "1970-01-01 00:00:12.0", "1970-01-01 00:00:15.0"),
+        row(48, "1970-01-01 00:00:15.0", "1970-01-01 00:00:18.0"),
+        row(57, "1970-01-01 00:00:18.0", "1970-01-01 00:00:21.0")
+      )
+    )
+
+    checkResult(
+      "SELECT SUM(a), " +
+          "HOP_START(ts, INTERVAL '3' SECOND, INTERVAL '3' SECOND), " +
+          "HOP_END(ts, INTERVAL '3' SECOND, INTERVAL '3' SECOND)" +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY HOP(ts, INTERVAL '3' SECOND, INTERVAL '3' SECOND)",
+      Seq(
+        row(12, "1970-01-01 00:00:03.0", "1970-01-01 00:00:06.0"),
+        row(21, "1970-01-01 00:00:06.0", "1970-01-01 00:00:09.0"),
+        row(21, "1970-01-01 00:00:21.0", "1970-01-01 00:00:24.0"),
+        row(3, "1970-01-01 00:00:00.0", "1970-01-01 00:00:03.0"),
+        row(30, "1970-01-01 00:00:09.0", "1970-01-01 00:00:12.0"),
+        row(39, "1970-01-01 00:00:12.0", "1970-01-01 00:00:15.0"),
+        row(48, "1970-01-01 00:00:15.0", "1970-01-01 00:00:18.0"),
+        row(57, "1970-01-01 00:00:18.0", "1970-01-01 00:00:21.0")
+      )
+    )
+
+    // all group; 2-phase; pre-accumulate with paned optimization
+    checkResult(
+      "SELECT avgFun(a), sumFun(a), HOP_START(ts, INTERVAL '2' SECOND, INTERVAL '3' SECOND) " +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY HOP(ts, INTERVAL '2' SECOND, INTERVAL '3' SECOND)",
+      Seq(
+        row(1.5, 3, "1970-01-01 00:00:00.0"),
+        row(11.0, 33, "1970-01-01 00:00:10.0"),
+        row(13.0, 39, "1970-01-01 00:00:12.0"),
+        row(15.0, 45, "1970-01-01 00:00:14.0"),
+        row(17.0, 51, "1970-01-01 00:00:16.0"),
+        row(19.0, 57, "1970-01-01 00:00:18.0"),
+        row(20.5, 41, "1970-01-01 00:00:20.0"),
+        row(3.0, 9, "1970-01-01 00:00:02.0"),
+        row(5.0, 15, "1970-01-01 00:00:04.0"),
+        row(7.0, 21, "1970-01-01 00:00:06.0"),
+        row(9.0, 27, "1970-01-01 00:00:08.0")
+      )
+    )
+
+    checkResult(
+      "SELECT AVG(a), SUM(a), HOP_START(ts, INTERVAL '2' SECOND, INTERVAL '3' SECOND) " +
+          "FROM Table3WithTimestamp " +
+          "GROUP BY HOP(ts, INTERVAL '2' SECOND, INTERVAL '3' SECOND)",
+      Seq(
+        row(1.5, 3, "1970-01-01 00:00:00.0"),
+        row(11.0, 33, "1970-01-01 00:00:10.0"),
+        row(13.0, 39, "1970-01-01 00:00:12.0"),
+        row(15.0, 45, "1970-01-01 00:00:14.0"),
+        row(17.0, 51, "1970-01-01 00:00:16.0"),
+        row(19.0, 57, "1970-01-01 00:00:18.0"),
+        row(20.5, 41, "1970-01-01 00:00:20.0"),
+        row(3.0, 9, "1970-01-01 00:00:02.0"),
+        row(5.0, 15, "1970-01-01 00:00:04.0"),
+        row(7.0, 21, "1970-01-01 00:00:06.0"),
+        row(9.0, 27, "1970-01-01 00:00:08.0")
+      )
+    )
+
+    // millisecond precision sliding windows
+    val data = Seq(
+      row(UTCTimestamp("2016-03-27 09:00:00.41"), 3),
+      row(UTCTimestamp("2016-03-27 09:00:00.62"), 6),
+      row(UTCTimestamp("2016-03-27 09:00:00.715"), 8)
+    )
+    registerCollection(
+      "T2", data, new RowTypeInfo(TIMESTAMP, INT_TYPE_INFO),
+      "ts, v")
+    checkResult(
+      """
+        |SELECT
+        |HOP_START(ts, INTERVAL '0.04' SECOND(1,2), INTERVAL '0.2' SECOND(1,1)),
+        |HOP_END(ts, INTERVAL '0.04' SECOND(1,2), INTERVAL '0.2' SECOND(1,1)),
+        |count(*)
+        |FROM T2
+        |GROUP BY HOP(ts, INTERVAL '0.04' SECOND(1,2), INTERVAL '0.2' SECOND(1,1))
+      """.stripMargin,
+      Seq(row("2016-03-27 09:00:00.24", "2016-03-27 09:00:00.44", 1),
+        row("2016-03-27 09:00:00.28", "2016-03-27 09:00:00.48", 1),
+        row("2016-03-27 09:00:00.32", "2016-03-27 09:00:00.52", 1),
+        row("2016-03-27 09:00:00.36", "2016-03-27 09:00:00.56", 1),
+        row("2016-03-27 09:00:00.4", "2016-03-27 09:00:00.6", 1),
+        row("2016-03-27 09:00:00.44", "2016-03-27 09:00:00.64", 1),
+        row("2016-03-27 09:00:00.48", "2016-03-27 09:00:00.68", 1),
+        row("2016-03-27 09:00:00.52", "2016-03-27 09:00:00.72", 2),
+        row("2016-03-27 09:00:00.56", "2016-03-27 09:00:00.76", 2),
+        row("2016-03-27 09:00:00.6", "2016-03-27 09:00:00.8", 2),
+        row("2016-03-27 09:00:00.64", "2016-03-27 09:00:00.84", 1),
+        row("2016-03-27 09:00:00.68", "2016-03-27 09:00:00.88", 1))
+    )
+  }
+
+  @Ignore // TODO support table stats
+  @Test
+  def testSlidingWindow2(): Unit = {
+    // for 1 phase agg
+    val tableSchema = new TableSchema(
+      Array("a", "b", "c", "ts"),
+      Array(
+        Types.INT,
+        Types.LONG,
+        Types.STRING,
+        Types.SQL_TIMESTAMP))
+    //    val colStats = Map[String, ColumnStats](
+    //      "ts" -> new ColumnStats(9000000L, 1L, 8D, 8, null, null),
+    //      "a" -> new ColumnStats(10000000L, 1L, 8D, 8, 5, -5),
+    //      "b" -> new ColumnStats(8000000L, 0L, 4D, 32, 6.1D, 0D),
+    //      "c" -> new ColumnStats(9000000L, 0L, 1024D, 32, 6.1D, 0D))
+    val table = new BatchTableSource[Row] {
+      override def getReturnType: TypeInformation[Row] =
+        new RowTypeInfo(tableSchema.getTypes, tableSchema.getColumnNames)
+
+      //      override def getTableStats: TableStats = new TableStats(10000000L, colStats)
+
+      override def getBoundedStream(streamEnv: StreamExecutionEnvironment): DataStream[Row] = {
+        streamEnv.createInput(
+          new CollectionInputFormat[Row](data3WithTimestamp,
+            type3WithTimestamp.createSerializer(env.getConfig)),
+          type3WithTimestamp)
+      }
+
+      override def getTableSchema: TableSchema = tableSchema
+    }
+    tEnv.registerTableSource("Table3WithTimestamp1", table)
+
+    // keyed; 1-phase; pre-accumulate with paned optimization
+    checkResult(
+      "SELECT c, countFun(a), " +
+          "HOP_START(ts, INTERVAL '4' SECOND, INTERVAL '8' SECOND), " +
+          "HOP_END(ts, INTERVAL '4' SECOND, INTERVAL '8' SECOND)" +
+          "FROM Table3WithTimestamp1 GROUP BY c, HOP(ts, INTERVAL '4' SECOND, INTERVAL '8' SECOND)",
+      Seq(
+        row("Comment#1", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Comment#1", 1, "1970-01-01 00:00:04.0", "1970-01-01 00:00:12.0"),
+        row("Comment#10", 1, "1970-01-01 00:00:12.0", "1970-01-01 00:00:20.0"),
+        row("Comment#10", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#11", 1, "1970-01-01 00:00:12.0", "1970-01-01 00:00:20.0"),
+        row("Comment#11", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#12", 1, "1970-01-01 00:00:12.0", "1970-01-01 00:00:20.0"),
+        row("Comment#12", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#13", 1, "1970-01-01 00:00:12.0", "1970-01-01 00:00:20.0"),
+        row("Comment#13", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#14", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#14", 1, "1970-01-01 00:00:20.0", "1970-01-01 00:00:28.0"),
+        row("Comment#15", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#15", 1, "1970-01-01 00:00:20.0", "1970-01-01 00:00:28.0"),
+        row("Comment#2", 1, "1970-01-01 00:00:04.0", "1970-01-01 00:00:12.0"),
+        row("Comment#2", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#3", 1, "1970-01-01 00:00:04.0", "1970-01-01 00:00:12.0"),
+        row("Comment#3", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#4", 1, "1970-01-01 00:00:04.0", "1970-01-01 00:00:12.0"),
+        row("Comment#4", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#5", 1, "1970-01-01 00:00:04.0", "1970-01-01 00:00:12.0"),
+        row("Comment#5", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#6", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#6", 1, "1970-01-01 00:00:12.0", "1970-01-01 00:00:20.0"),
+        row("Comment#7", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#7", 1, "1970-01-01 00:00:12.0", "1970-01-01 00:00:20.0"),
+        row("Comment#8", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#8", 1, "1970-01-01 00:00:12.0", "1970-01-01 00:00:20.0"),
+        row("Comment#9", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#9", 1, "1970-01-01 00:00:12.0", "1970-01-01 00:00:20.0"),
+        row("Hello world, how are you?", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Hello world, how are you?", 1, "1970-01-01 00:00:04.0", "1970-01-01 00:00:12.0"),
+        row("Hello world", 1, "1969-12-31 23:59:56.0", "1970-01-01 00:00:04.0"),
+        row("Hello world", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Hello", 1, "1969-12-31 23:59:56.0", "1970-01-01 00:00:04.0"),
+        row("Hello", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Hi", 1, "1969-12-31 23:59:56.0", "1970-01-01 00:00:04.0"),
+        row("Hi", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("I am fine.", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("I am fine.", 1, "1970-01-01 00:00:04.0", "1970-01-01 00:00:12.0"),
+        row("Luke Skywalker", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Luke Skywalker", 1, "1970-01-01 00:00:04.0", "1970-01-01 00:00:12.0")
+      )
+    )
+
+    // keyed; 1-phase; pre-accumulate with windowSize = slideSize
+    checkResult(
+      "SELECT c, count(a), " +
+          "HOP_START(ts, INTERVAL '8' SECOND, INTERVAL '8' SECOND), " +
+          "HOP_END(ts, INTERVAL '8' SECOND, INTERVAL '8' SECOND)" +
+          "FROM Table3WithTimestamp1 GROUP BY c, HOP(ts, INTERVAL '8' SECOND, INTERVAL '8' SECOND)",
+      Seq(
+        row("Comment#1", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Comment#10", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#11", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#12", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#13", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#14", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#15", 1, "1970-01-01 00:00:16.0", "1970-01-01 00:00:24.0"),
+        row("Comment#2", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#3", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#4", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#5", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#6", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#7", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#8", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Comment#9", 1, "1970-01-01 00:00:08.0", "1970-01-01 00:00:16.0"),
+        row("Hello world, how are you?", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Hello world", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Hello", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Hi", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("I am fine.", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0"),
+        row("Luke Skywalker", 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:08.0")
+      )
+    )
+  }
+
+  @Test
+  def testNullValueInputTimestamp(): Unit = {
+    // Sliding window
+    var data = Seq(
+      row(null, 1),
+      row(null, 2),
+      row(null, 3),
+      row(null, 4)
+    )
+    registerCollection(
+      "T1", data, new RowTypeInfo(TIMESTAMP, INT_TYPE_INFO),
+      "ts, v")
+    checkResult(
+      """
+        |SELECT v
+        |FROM T1
+        |GROUP BY HOP(ts, INTERVAL '2' SECOND, INTERVAL '3' SECOND), v
+      """.stripMargin,
+      // null columns are dropped
+      Seq()
+    )
+
+    // Tumbling window
+    data = Seq(
+      row(UTCTimestamp("2016-03-27 09:00:05"), 1),
+      row(null, 2),
+      row(UTCTimestamp("2016-03-27 09:00:32"), 3),
+      row(null, 4)
+    )
+    registerCollection(
+      "T2", data, new RowTypeInfo(TIMESTAMP, INT_TYPE_INFO),
+      "ts, v")
+    checkResult(
+      """
+        |SELECT TUMBLE_START(ts, INTERVAL '10' SECOND), TUMBLE_END(ts, INTERVAL '10' SECOND), v
+        |FROM T2
+        |GROUP BY TUMBLE(ts, INTERVAL '10' SECOND), v
+      """.stripMargin,
+      // null columns are dropped
+      Seq(
+        row("2016-03-27 09:00:00.0", "2016-03-27 09:00:10.0", 1),
+        row("2016-03-27 09:00:30.0", "2016-03-27 09:00:40.0", 3))
+    )
+    data = Seq(
+      row(null, 1),
+      row(null, 2),
+      row(null, 3),
+      row(null, 4)
+    )
+    registerCollection(
+      "T3", data, new RowTypeInfo(TIMESTAMP, INT_TYPE_INFO),
+      "ts, v")
+    checkResult(
+      """
+        |SELECT TUMBLE_START(ts, INTERVAL '10' SECOND), TUMBLE_END(ts, INTERVAL '10' SECOND), v
+        |FROM T3
+        |GROUP BY TUMBLE(ts, INTERVAL '10' SECOND), v
+      """.stripMargin,
+      // null columns are dropped
+      Seq()
+    )
+  }
+
+  @Test
+  def testNegativeInputTimestamp(): Unit = {
+    // simple tumbling window with record at window start
+    var data = Seq(row(UTCTimestamp("2016-03-27 19:39:30"), 1, "a"))
+    registerCollection(
+      "T1", data, new RowTypeInfo(TIMESTAMP, INT_TYPE_INFO, STRING_TYPE_INFO),
+      "ts, value, id")
+    checkResult(
+      """
+        |SELECT TUMBLE_START(ts, INTERVAL '10' SECOND), TUMBLE_END(ts, INTERVAL '10' SECOND),
+        |count(*)
+        |FROM T1
+        |GROUP BY TUMBLE(ts, INTERVAL '10' SECOND)
+      """.stripMargin,
+      Seq(row("2016-03-27 19:39:30.0", "2016-03-27 19:39:40.0", 1))
+    )
+
+    // simple tumbling window with record at negative timestamp
+    data = Seq(row(UTCTimestamp("1916-03-27 19:39:31"), 1, "a"))
+    registerCollection(
+      "T2", data, new RowTypeInfo(TIMESTAMP, INT_TYPE_INFO, STRING_TYPE_INFO),
+      "ts, value, id")
+    checkResult(
+      """
+        |SELECT TUMBLE_START(ts, INTERVAL '10' SECOND), TUMBLE_END(ts, INTERVAL '10' SECOND),
+        |count(*)
+        |FROM T2
+        |GROUP BY TUMBLE(ts, INTERVAL '10' SECOND)
+      """.stripMargin,
+      Seq(row("1916-03-27 19:39:30.0", "1916-03-27 19:39:40.0", 1))
+    )
+
+    // simple sliding window with record at negative timestamp
+    checkResult(
+      """
+        |SELECT
+        |HOP_START(ts, INTERVAL '10' SECOND, INTERVAL '11' SECOND),
+        |HOP_END(ts, INTERVAL '10' SECOND, INTERVAL '11' SECOND),
+        |count(*)
+        |FROM T2
+        |GROUP BY HOP(ts, INTERVAL '10' SECOND, INTERVAL '11' SECOND)
+      """.stripMargin,
+      Seq(row("1916-03-27 19:39:30.0", "1916-03-27 19:39:41.0", 1))
+    )
+
+    checkResult(
+      """
+        |SELECT
+        |HOP_START(ts, INTERVAL '0.001' SECOND(1,3), INTERVAL '0.002' SECOND(1,3)),
+        |HOP_END(ts, INTERVAL '0.001' SECOND(1,3), INTERVAL '0.002' SECOND(1,3)),
+        |count(*)
+        |FROM T2
+        |GROUP BY HOP(ts, INTERVAL '0.001' SECOND(1,3), INTERVAL '0.002' SECOND(1,3))
+      """.stripMargin,
+      Seq(row("1916-03-27 19:39:30.999", "1916-03-27 19:39:31.001", 1),
+        row("1916-03-27 19:39:31.0", "1916-03-27 19:39:31.002", 1))
+    )
+
+    checkResult(
+      """
+        |SELECT
+        |HOP_START(ts, INTERVAL '0.001' SECOND(1,3), INTERVAL '0.002' SECOND(1,3)),
+        |HOP_END(ts, INTERVAL '0.001' SECOND(1,3), INTERVAL '0.002' SECOND(1,3)),
+        |countFun(ts)
+        |FROM T2
+        |GROUP BY HOP(ts, INTERVAL '0.001' SECOND(1,3), INTERVAL '0.002' SECOND(1,3))
+      """.stripMargin,
+      Seq(row("1916-03-27 19:39:30.999", "1916-03-27 19:39:31.001", 1),
+        row("1916-03-27 19:39:31.0", "1916-03-27 19:39:31.002", 1))
+    )
+  }
+
+  @Test
+  def testTumbleWindowWithProperties(): Unit = {
+    registerCollection(
+      "T",
+      data3WithTimestamp,
+      new RowTypeInfo(INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO, TIMESTAMP),
+      "a, b, c, ts")
+
+    val sqlQuery =
+      "SELECT b, COUNT(a), " +
+        "TUMBLE_START(ts, INTERVAL '5' SECOND), " +
+        "TUMBLE_END(ts, INTERVAL '5' SECOND), " +
+        "TUMBLE_ROWTIME(ts, INTERVAL '5' SECOND)" +
+        "FROM T " +
+        "GROUP BY b, TUMBLE(ts, INTERVAL '5' SECOND)"
+
+    checkResult(sqlQuery, Seq(
+      row(1, 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:05.0", "1970-01-01 00:00:04.999"),
+      row(2, 2, "1970-01-01 00:00:00.0", "1970-01-01 00:00:05.0", "1970-01-01 00:00:04.999"),
+      row(3, 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:05.0", "1970-01-01 00:00:04.999"),
+      row(3, 2, "1970-01-01 00:00:05.0", "1970-01-01 00:00:10.0", "1970-01-01 00:00:09.999"),
+      row(4, 1, "1970-01-01 00:00:10.0", "1970-01-01 00:00:15.0", "1970-01-01 00:00:14.999"),
+      row(4, 3, "1970-01-01 00:00:05.0", "1970-01-01 00:00:10.0", "1970-01-01 00:00:09.999"),
+      row(5, 1, "1970-01-01 00:00:15.0", "1970-01-01 00:00:20.0", "1970-01-01 00:00:19.999"),
+      row(5, 4, "1970-01-01 00:00:10.0", "1970-01-01 00:00:15.0", "1970-01-01 00:00:14.999"),
+      row(6, 2, "1970-01-01 00:00:20.0", "1970-01-01 00:00:25.0", "1970-01-01 00:00:24.999"),
+      row(6, 4, "1970-01-01 00:00:15.0", "1970-01-01 00:00:20.0", "1970-01-01 00:00:19.999")))
+  }
+
+  @Test
+  def testHopWindowWithProperties(): Unit = {
+    registerCollection(
+      "T",
+      data3WithTimestamp,
+      new RowTypeInfo(INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO, TIMESTAMP),
+      "a, b, c, ts")
+
+    val sqlQuery =
+      "SELECT b, COUNT(a), " +
+        "HOP_START(ts, INTERVAL '5' SECOND, INTERVAL '10' SECOND), " +
+        "HOP_END(ts, INTERVAL '5' SECOND, INTERVAL '10' SECOND), " +
+        "HOP_ROWTIME(ts, INTERVAL '5' SECOND, INTERVAL '10' SECOND) " +
+        "FROM T " +
+        "GROUP BY b, HOP(ts, INTERVAL '5' SECOND, INTERVAL '10' SECOND)"
+
+    checkResult(sqlQuery, Seq(
+      row(1, 1, "1969-12-31 23:59:55.0", "1970-01-01 00:00:05.0", "1970-01-01 00:00:04.999"),
+      row(1, 1, "1970-01-01 00:00:00.0", "1970-01-01 00:00:10.0", "1970-01-01 00:00:09.999"),
+      row(2, 2, "1969-12-31 23:59:55.0", "1970-01-01 00:00:05.0", "1970-01-01 00:00:04.999"),
+      row(2, 2, "1970-01-01 00:00:00.0", "1970-01-01 00:00:10.0", "1970-01-01 00:00:09.999"),
+      row(3, 1, "1969-12-31 23:59:55.0", "1970-01-01 00:00:05.0", "1970-01-01 00:00:04.999"),
+      row(3, 2, "1970-01-01 00:00:05.0", "1970-01-01 00:00:15.0", "1970-01-01 00:00:14.999"),
+      row(3, 3, "1970-01-01 00:00:00.0", "1970-01-01 00:00:10.0", "1970-01-01 00:00:09.999"),
+      row(4, 1, "1970-01-01 00:00:10.0", "1970-01-01 00:00:20.0", "1970-01-01 00:00:19.999"),
+      row(4, 3, "1970-01-01 00:00:00.0", "1970-01-01 00:00:10.0", "1970-01-01 00:00:09.999"),
+      row(4, 4, "1970-01-01 00:00:05.0", "1970-01-01 00:00:15.0", "1970-01-01 00:00:14.999"),
+      row(5, 1, "1970-01-01 00:00:15.0", "1970-01-01 00:00:25.0", "1970-01-01 00:00:24.999"),
+      row(5, 4, "1970-01-01 00:00:05.0", "1970-01-01 00:00:15.0", "1970-01-01 00:00:14.999"),
+      row(5, 5, "1970-01-01 00:00:10.0", "1970-01-01 00:00:20.0", "1970-01-01 00:00:19.999"),
+      row(6, 2, "1970-01-01 00:00:20.0", "1970-01-01 00:00:30.0", "1970-01-01 00:00:29.999"),
+      row(6, 4, "1970-01-01 00:00:10.0", "1970-01-01 00:00:20.0", "1970-01-01 00:00:19.999"),
+      row(6, 6, "1970-01-01 00:00:15.0", "1970-01-01 00:00:25.0", "1970-01-01 00:00:24.999")))
+  }
+
+  @Test(expected = classOf[RuntimeException])
+  def testSessionWindowWithProperties(): Unit = {
+    registerCollection(
+      "T",
+      data3WithTimestamp,
+      new RowTypeInfo(INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO, TIMESTAMP),
+      "a, b, c, ts")
+
+    val sqlQuery =
+      "SELECT COUNT(a), " +
+        "SESSION_START(ts, INTERVAL '4' SECOND), " +
+        "SESSION_END(ts, INTERVAL '4' SECOND), " +
+        "SESSION_ROWTIME(ts, INTERVAL '4' SECOND) " +
+        "FROM T " +
+        "GROUP BY SESSION(ts, INTERVAL '4' SECOND)"
+
+    checkResult(sqlQuery, Seq())
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/HashAggITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/HashAggITCase.scala
@@ -28,10 +28,6 @@ class HashAggITCase
     extends AggregateITCaseBase("HashAggregate") {
 
   override def prepareAggOp(): Unit = {
-    // for hash agg fallback test
-    val configuration = new Configuration()
-    configuration.setInteger(TableConfigOptions.SQL_RESOURCE_HASH_AGG_TABLE_MEM, 4)
-    tEnv.getConfig.getConf.addAll(configuration)
     tEnv.getConfig.getConf.setString(
       TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS, "SortAgg")
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/HashDistinctAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/HashDistinctAggregateITCase.scala
@@ -26,8 +26,6 @@ import org.apache.flink.table.api.{OperatorType, TableConfigOptions}
 class HashDistinctAggregateITCase extends DistinctAggregateITCaseBase {
 
   override def prepareAggOp(): Unit = {
-    // for hash agg fallback test
-    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_HASH_AGG_TABLE_MEM, 2)
     tEnv.getConfig.getConf.setString(
       TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS, OperatorType.SortAgg.toString)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/BatchTestBase.scala
@@ -27,11 +27,11 @@ import org.apache.flink.table.`type`.InternalType
 import org.apache.flink.table.api.java.{BatchTableEnvironment => JavaBatchTableEnv}
 import org.apache.flink.table.api.scala.{BatchTableEnvironment => ScalaBatchTableEnv}
 import org.apache.flink.table.api.{SqlParserException, Table, TableConfig, TableConfigOptions, TableEnvironment, TableImpl}
-import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.dataformat.{BinaryRow, BinaryRowWriter}
+import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.plan.util.FlinkRelOptUtil
+import org.apache.flink.table.runtime.utils.BatchAbstractTestBase.DEFAULT_PARALLELISM
 import org.apache.flink.table.util.{BaseRowTestUtil, DiffRepository}
-import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.types.Row
 
 import org.apache.calcite.rel.RelNode
@@ -52,7 +52,7 @@ import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Sorting
 
-class BatchTestBase extends AbstractTestBase {
+class BatchTestBase extends BatchAbstractTestBase {
 
   TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
   val conf: TableConfig = BatchTestBase.initConfigForTest(new TableConfig)
@@ -411,8 +411,6 @@ class BatchTestBase extends AbstractTestBase {
 
 object BatchTestBase {
 
-  val PARALLELISM = 3
-
   def row(args: Any*): Row = {
     val values = args.toArray
     val row = new Row(values.length)
@@ -442,8 +440,9 @@ object BatchTestBase {
 
   def initConfigForTest(conf: TableConfig): TableConfig = {
     // TODO prepare for some resource config
-    conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, PARALLELISM)
-    conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_SORT_BUFFER_MEM, 2)
+    conf.getConf.setInteger(
+      TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, DEFAULT_PARALLELISM)
+    conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_SORT_BUFFER_MEM, 1)
     conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_EXTERNAL_BUFFER_MEM, 1)
     conf.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_HASH_AGG_TABLE_MEM, 2)
     conf

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/util/AvgAggFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/util/AvgAggFunction.scala
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.util
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.api.java.typeutils.TupleTypeInfo
+import org.apache.flink.table.`type`.DecimalType
+import org.apache.flink.table.api.Types
+import org.apache.flink.table.functions.AggregateFunction
+import org.apache.flink.table.typeutils.BigDecimalTypeInfo
+
+import java.lang.{Iterable => JIterable}
+import java.math.{BigDecimal, BigInteger, MathContext}
+
+/** The initial accumulator for Integral Avg aggregate function */
+class IntegralAvgAccumulator extends JTuple2[Long, Long] {
+  f0 = 0L //sum
+  f1 = 0L //count
+}
+
+/**
+  * Base class for built-in Integral Avg aggregate function
+  *
+  * @tparam T the type for the aggregation result
+  */
+// NOTE: T is always scala.Double in subclasses; however it's problematics
+//       if we remove [T] and replace T with Double;
+//       specifically, null.asInstanceOf[Double] == 0.0 !
+abstract class IntegralAvgAggFunction[T] extends AggregateFunction[T, IntegralAvgAccumulator] {
+
+  override def createAccumulator(): IntegralAvgAccumulator = {
+    new IntegralAvgAccumulator
+  }
+
+  def accumulate(acc: IntegralAvgAccumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Number].longValue()
+      acc.f0 += v
+      acc.f1 += 1L
+    }
+  }
+
+  def retract(acc: IntegralAvgAccumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Number].longValue()
+      acc.f0 -= v
+      acc.f1 -= 1L
+    }
+  }
+
+  override def getValue(acc: IntegralAvgAccumulator): T = {
+    if (acc.f1 == 0) {
+      null.asInstanceOf[T]
+    } else {
+      resultTypeConvert(acc.f0.doubleValue() / acc.f1)
+    }
+  }
+
+  def merge(acc: IntegralAvgAccumulator, its: JIterable[IntegralAvgAccumulator]): Unit = {
+    val iter = its.iterator()
+    while (iter.hasNext) {
+      val a = iter.next()
+      acc.f1 += a.f1
+      acc.f0 += a.f0
+    }
+  }
+
+  def resetAccumulator(acc: IntegralAvgAccumulator): Unit = {
+    acc.f0 = 0L
+    acc.f1 = 0L
+  }
+
+  override def getAccumulatorType: TypeInformation[IntegralAvgAccumulator] = {
+    new TupleTypeInfo(classOf[IntegralAvgAccumulator], Types.LONG, Types.LONG)
+  }
+
+  /**
+    * Convert the intermediate result to the expected aggregation result type
+    *
+    * @param value the intermediate result. We use a Long container to save
+    *              the intermediate result to avoid the overflow by sum operation.
+    * @return the result value with the expected aggregation result type
+    */
+  def resultTypeConvert(value: Double): T
+}
+
+/**
+  * Built-in Byte Avg aggregate function
+  */
+class ByteAvgAggFunction extends IntegralAvgAggFunction[Double] {
+  override def resultTypeConvert(value: Double): Double = value
+}
+
+/**
+  * Built-in Short Avg aggregate function
+  */
+class ShortAvgAggFunction extends IntegralAvgAggFunction[Double] {
+  override def resultTypeConvert(value: Double): Double = value
+}
+
+/**
+  * Built-in Int Avg aggregate function
+  */
+class IntAvgAggFunction extends IntegralAvgAggFunction[Double] {
+  override def resultTypeConvert(value: Double): Double = value
+}
+
+/** The initial accumulator for Big Integral Avg aggregate function */
+class BigIntegralAvgAccumulator
+  extends JTuple2[BigInteger, Long] {
+  f0 = BigInteger.ZERO //sum
+  f1 = 0L //count
+}
+
+/**
+  * Base Class for Built-in Big Integral Avg aggregate function
+  *
+  * @tparam T the type for the aggregation result
+  */
+abstract class BigIntegralAvgAggFunction[T]
+  extends AggregateFunction[T, BigIntegralAvgAccumulator] {
+
+  override def createAccumulator(): BigIntegralAvgAccumulator = {
+    new BigIntegralAvgAccumulator
+  }
+
+  def accumulate(acc: BigIntegralAvgAccumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Long]
+      acc.f0 = acc.f0.add(BigInteger.valueOf(v))
+      acc.f1 += 1L
+    }
+  }
+
+  def retract(acc: BigIntegralAvgAccumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Long]
+      acc.f0 = acc.f0.subtract(BigInteger.valueOf(v))
+      acc.f1 -= 1L
+    }
+  }
+
+  override def getValue(acc: BigIntegralAvgAccumulator): T = {
+    if (acc.f1 == 0) {
+      null.asInstanceOf[T]
+    } else {
+      resultTypeConvert(acc.f0.doubleValue() / acc.f1)
+    }
+  }
+
+  def merge(acc: BigIntegralAvgAccumulator, its: JIterable[BigIntegralAvgAccumulator]): Unit = {
+    val iter = its.iterator()
+    while (iter.hasNext) {
+      val a = iter.next()
+      acc.f1 += a.f1
+      acc.f0 = acc.f0.add(a.f0)
+    }
+  }
+
+  def resetAccumulator(acc: BigIntegralAvgAccumulator): Unit = {
+    acc.f0 = BigInteger.ZERO
+    acc.f1 = 0
+  }
+
+  override def getAccumulatorType: TypeInformation[BigIntegralAvgAccumulator] = {
+    new TupleTypeInfo(classOf[BigIntegralAvgAccumulator], Types.INT, Types.LONG)
+  }
+
+  /**
+    * Convert the intermediate result to the expected aggregation result type
+    *
+    * @param value the intermediate result. We use a BigInteger container to
+    *              save the intermediate result to avoid the overflow by sum
+    *              operation.
+    * @return the result value with the expected aggregation result type
+    */
+  def resultTypeConvert(value: Double): T
+}
+
+/**
+  * Built-in Long Avg aggregate function
+  */
+class LongAvgAggFunction extends BigIntegralAvgAggFunction[Double] {
+  override def resultTypeConvert(value: Double): Double = value
+}
+
+/** The initial accumulator for Floating Avg aggregate function */
+class FloatingAvgAccumulator extends JTuple2[Double, Long] {
+  f0 = 0 //sum
+  f1 = 0L //count
+}
+
+/**
+  * Base class for built-in Floating Avg aggregate function
+  *
+  * @tparam T the type for the aggregation result
+  */
+abstract class FloatingAvgAggFunction[T] extends AggregateFunction[T, FloatingAvgAccumulator] {
+
+  override def createAccumulator(): FloatingAvgAccumulator = {
+    new FloatingAvgAccumulator
+  }
+
+  def accumulate(acc: FloatingAvgAccumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Number].doubleValue()
+      acc.f0 += v
+      acc.f1 += 1L
+    }
+  }
+
+  def retract(acc: FloatingAvgAccumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Number].doubleValue()
+      acc.f0 -= v
+      acc.f1 -= 1L
+    }
+  }
+
+  override def getValue(acc: FloatingAvgAccumulator): T = {
+    if (acc.f1 == 0) {
+      null.asInstanceOf[T]
+    } else {
+      resultTypeConvert(acc.f0 / acc.f1)
+    }
+  }
+
+  def merge(acc: FloatingAvgAccumulator, its: JIterable[FloatingAvgAccumulator]): Unit = {
+    val iter = its.iterator()
+    while (iter.hasNext) {
+      val a = iter.next()
+      acc.f1 += a.f1
+      acc.f0 += a.f0
+    }
+  }
+
+  def resetAccumulator(acc: FloatingAvgAccumulator): Unit = {
+    acc.f0 = 0
+    acc.f1 = 0L
+  }
+
+  override def getAccumulatorType: TypeInformation[FloatingAvgAccumulator] = {
+    new TupleTypeInfo(classOf[FloatingAvgAccumulator], Types.DOUBLE, Types.LONG)
+  }
+
+  /**
+    * Convert the intermediate result to the expected aggregation result type
+    *
+    * @param value the intermediate result. We use a Double container to save
+    *              the intermediate result to avoid the overflow by sum operation.
+    * @return the result value with the expected aggregation result type
+    */
+  def resultTypeConvert(value: Double): T
+}
+
+/**
+  * Built-in Float Avg aggregate function
+  */
+class FloatAvgAggFunction extends FloatingAvgAggFunction[Float] {
+  override def resultTypeConvert(value: Double): Float = value.toFloat
+}
+
+/**
+  * Built-in Int Double aggregate function
+  */
+class DoubleAvgAggFunction extends FloatingAvgAggFunction[Double] {
+  override def resultTypeConvert(value: Double): Double = value
+}
+
+/** The initial accumulator for Big Decimal Avg aggregate function */
+class DecimalAvgAccumulator extends JTuple2[BigDecimal, Long] {
+  f0 = BigDecimal.ZERO //sum
+  f1 = 0L //count
+}
+
+/**
+  * Base class for built-in Big Decimal Avg aggregate function
+  */
+class DecimalAvgAggFunction(argType: DecimalType)
+  extends AggregateFunction[BigDecimal, DecimalAvgAccumulator] {
+
+  override def createAccumulator(): DecimalAvgAccumulator = {
+    new DecimalAvgAccumulator
+  }
+
+  def accumulate(acc: DecimalAvgAccumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[BigDecimal]
+      acc.f0 = acc.f0.add(v)
+      acc.f1 += 1L
+    }
+  }
+
+  def retract(acc: DecimalAvgAccumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[BigDecimal]
+      acc.f0 = acc.f0.subtract(v)
+      acc.f1 -= 1L
+    }
+  }
+
+  override def getValue(acc: DecimalAvgAccumulator): BigDecimal = {
+    if (acc.f1 == 0) {
+      null.asInstanceOf[BigDecimal]
+    } else {
+      acc.f0.divide(BigDecimal.valueOf(acc.f1), MathContext.DECIMAL128)
+    }
+  }
+
+  def merge(acc: DecimalAvgAccumulator, its: JIterable[DecimalAvgAccumulator]): Unit = {
+    val iter = its.iterator()
+    while (iter.hasNext) {
+      val a = iter.next()
+      acc.f0 = acc.f0.add(a.f0)
+      acc.f1 += a.f1
+    }
+  }
+
+  def resetAccumulator(acc: DecimalAvgAccumulator): Unit = {
+    acc.f0 = BigDecimal.ZERO
+    acc.f1 = 0L
+  }
+
+  override def getAccumulatorType: TypeInformation[DecimalAvgAccumulator] = {
+    val decimalType = getSumType
+    new TupleTypeInfo(
+      classOf[DecimalAvgAccumulator],
+      new BigDecimalTypeInfo(decimalType.precision(), decimalType.scale()),
+      Types.LONG)
+  }
+
+  def getSumType: DecimalType =
+    DecimalType.inferAggSumType(argType.scale)
+
+  override def getResultType: BigDecimalTypeInfo = {
+    val t = DecimalType.inferAggAvgType(argType.scale)
+    new BigDecimalTypeInfo(t.precision(), t.scale())
+  }
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.runtime.window.grouping.HeapWindowsGrouping;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -132,6 +133,18 @@ public class TableConfigOptions {
 			key("sql.resource.sort.buffer-max-memory-mb")
 					.defaultValue(512)
 					.withDescription("Sets the max buffer memory size for sort. It defines the upper memory for the sort.");
+
+	// ------------------------------------------------------------------------
+	//  Agg Options
+	// ------------------------------------------------------------------------
+
+	/**
+	 * See {@link HeapWindowsGrouping}.
+	 */
+	public static final ConfigOption<Integer> SQL_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT =
+			key("sql.exec.window-agg.buffer-size.limit")
+					.defaultValue(100 * 1000)
+					.withDescription("Sets the window elements buffer limit in size used in group window agg operator.");
 
 	// ------------------------------------------------------------------------
 	//  topN Options

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/aggregate/BytesHashMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/aggregate/BytesHashMap.java
@@ -67,8 +67,8 @@ public class BytesHashMap {
 
 	private static final Logger LOG = LoggerFactory.getLogger(BytesHashMap.class);
 
-	private static final int BUCKET_SIZE = 16;
-	private static final int RECORD_EXTRA_LENGTH = 8;
+	public static final int BUCKET_SIZE = 16;
+	public static final int RECORD_EXTRA_LENGTH = 8;
 	private static final int BUCKET_SIZE_BITS = 4;
 
 	private static final int ELEMENT_POINT_LENGTH = 8;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/grouping/HeapWindowsGrouping.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/grouping/HeapWindowsGrouping.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.grouping;
+
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.runtime.util.RowIterator;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+/**
+ * A jvm heap implementation of {@link WindowsGrouping}, which uses a linked list to buffer
+ * all the inputs of a keyed group belonging to the same window.
+ * It is designed to have a capacity limit to avoid JVM OOM and reduce GC pauses.
+ */
+public class HeapWindowsGrouping extends WindowsGrouping {
+
+	private LinkedList<BinaryRow> buffer;
+
+	private final int maxSizeLimit;
+
+	private int evictLimitIndex;
+
+	private Iterator<BinaryRow> iterator;
+
+	public HeapWindowsGrouping(int maxSizeLimit, long windowSize, long slideSize, int timeIndex, boolean isDate) {
+		this(maxSizeLimit, 0L, windowSize, slideSize, timeIndex, isDate);
+	}
+
+	public HeapWindowsGrouping(
+			int maxSizeLimit, long offset, long windowSize, long slideSize, int timeIndex, boolean isDate) {
+		super(offset, windowSize, slideSize, timeIndex, isDate);
+		this.maxSizeLimit = maxSizeLimit;
+		this.evictLimitIndex = 0;
+		this.buffer = new LinkedList<>();
+	}
+
+	@Override
+	protected void resetBuffer() {
+		buffer.clear();
+		evictLimitIndex = 0;
+		iterator = null;
+	}
+
+	@Override
+	protected void onBufferEvict(int limitIndex) {
+		while (evictLimitIndex < limitIndex) {
+			buffer.removeFirst();
+			evictLimitIndex++;
+		}
+	}
+
+	@Override
+	protected void addIntoBuffer(BinaryRow input) throws IOException {
+		if (buffer.size() >= maxSizeLimit) {
+			throw new IOException("HeapWindowsGrouping out of memory, element size limit " + maxSizeLimit);
+		}
+		buffer.add(input);
+	}
+
+	@Override
+	protected RowIterator<BinaryRow> newBufferIterator(int startIndex) {
+		iterator = buffer.subList(startIndex - evictLimitIndex, buffer.size()).iterator();
+		return new BufferIterator(iterator);
+	}
+
+	@Override
+	public void close() throws IOException {
+		buffer = null;
+	}
+
+	private final class BufferIterator implements RowIterator<BinaryRow> {
+		private final Iterator<BinaryRow> iterator;
+		private BinaryRow next;
+
+		BufferIterator(Iterator<BinaryRow> iterator) {
+			this.iterator = iterator;
+		}
+
+		@Override
+		public boolean advanceNext() {
+			if (iterator.hasNext()) {
+				next = iterator.next();
+				return true;
+			} else {
+				next = null;
+				return false;
+			}
+		}
+
+		@Override
+		public BinaryRow getRow() {
+			return next;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/grouping/WindowsGrouping.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/grouping/WindowsGrouping.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.window.grouping;
+
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.runtime.util.RowIterator;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.avatica.util.DateTimeUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Assigning windows from the sorted input buffers.
+ *
+ * <p>Assign windows and trigger aggregate calculation based on {@link WindowsGrouping}.
+ * It can avoid data expansion in time sliding window case.
+ *
+ * <p>Tumbling window case
+ * Each keyed window corresponds to only one element in the {@link WindowsGrouping} Buffer
+ * (grouping keys, assigned windows, agg buffers).
+ *
+ * <p>Sliding window case
+ * 1. If the assign pane optimization strategy is used, each keyed window corresponding to
+ * {@link WindowsGrouping} buffer contains windowsSize/paneSize number of elements
+ * (assuming 1s/24h window, there are 86400 elements).
+ * 2. Otherwise, the maximum number of elements in {@link WindowsGrouping} buffer is the maximum
+ * number of inputs in a sliding window.
+ *
+ * <p>In most cases, assign pane optimization should be applied, so there should not be much data
+ * in {@link WindowsGrouping}, and {@link HeapWindowsGrouping} is basically okay.
+ */
+public abstract class WindowsGrouping implements Closeable {
+
+	private final long windowStartOffset;
+
+	private final long windowSize;
+
+	private final long slideSize;
+
+	private final int timeIndex;
+
+	private long watermark;
+
+	private TimeWindow nextWindow;
+
+	private TimeWindow currentWindow;
+
+	private int triggerWindowStartIndex;
+
+	private boolean emptyWindowTriggered;
+
+	private boolean isDate;
+
+	WindowsGrouping(long windowSize, long slideSize, int timestampIndex, boolean isDate) {
+		this(0L, windowSize, slideSize, timestampIndex, isDate);
+	}
+
+	WindowsGrouping(
+			long offset, long windowSize, long slideSize, int timeIndex, boolean isDate) {
+		this.windowStartOffset = offset;
+		this.windowSize = windowSize;
+		this.slideSize = slideSize;
+		this.timeIndex = timeIndex;
+		this.isDate = isDate;
+		nextWindow = null;
+		watermark = Long.MIN_VALUE;
+		// index to define
+		triggerWindowStartIndex = 0;
+		emptyWindowTriggered = true;
+	}
+
+	/**
+	 * Reset for next group.
+	 */
+	public void reset() {
+		nextWindow = null;
+		watermark = Long.MIN_VALUE;
+		triggerWindowStartIndex = 0;
+		emptyWindowTriggered = true;
+		resetBuffer();
+	}
+
+	public void addInputToBuffer(BinaryRow input) throws IOException {
+		if (!input.isNullAt(timeIndex)) {
+			addIntoBuffer(input.copy());
+			advanceWatermark(getTimeValue(input));
+		}
+	}
+
+	/**
+	 * Advance the watermark to trigger all the possible windows.
+	 * It is designed to be idempotent.
+	 */
+	public void advanceWatermarkToTriggerAllWindows() {
+		skipEmptyWindow();
+		advanceWatermark(watermark + windowSize);
+	}
+
+	/**
+	 * Check if there are windows could be triggered according to the current watermark.
+	 *
+	 * @return true when there are windows to be triggered.
+	 * It is designed to be idempotent.
+	 */
+	public boolean hasTriggerWindow() {
+		skipEmptyWindow();
+		Preconditions.checkState(watermark == Long.MIN_VALUE || nextWindow != null,
+				"next trigger window cannot be null.");
+		return nextWindow != null && nextWindow.getEnd() <= watermark;
+	}
+
+	/**
+	 * @return the iterator of the next triggerable window's elements.
+	 */
+	public RowIterator<BinaryRow> buildTriggerWindowElementsIterator() {
+		currentWindow = nextWindow;
+		// It is illegal to call this method after [[hasTriggerWindow()]] has returned `false`.
+		Preconditions.checkState(watermark == Long.MIN_VALUE || nextWindow != null,
+				"next trigger window cannot be null.");
+		if (nextWindow.getEnd() > watermark) {
+			throw new IllegalStateException("invalid window triggered " + currentWindow);
+		}
+
+		// advance in the stride of slideSize for hasTriggerWindow
+		nextWindow = TimeWindow.of(currentWindow.getStart() + slideSize,
+				currentWindow.getStart() + slideSize + windowSize);
+		// build trigger window elements' iterator
+		emptyWindowTriggered = true;
+		onBufferEvict(triggerWindowStartIndex);
+		return new WindowsElementsIterator(newBufferIterator(triggerWindowStartIndex));
+	}
+
+	/**
+	 * @return the last triggered window.
+	 */
+	public TimeWindow getTriggerWindow() {
+		return currentWindow;
+	}
+
+	private boolean belongsToCurrentWindow(BinaryRow element) {
+		long currentTimestamp = getTimeValue(element);
+		if (currentTimestamp >= currentWindow.getStart() &&
+				currentTimestamp < currentWindow.getEnd()) {
+			// evict elements for next window
+			evictForWindow(element, nextWindow);
+			return true;
+		}
+		return false;
+	}
+
+	private boolean evictForWindow(BinaryRow element, TimeWindow window) {
+		if (getTimeValue(element) < window.getStart()) {
+			triggerWindowStartIndex++;
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	private void advanceWatermark(long timestamp) {
+		watermark = timestamp;
+	}
+
+	private void skipEmptyWindow() {
+		if (emptyWindowTriggered && watermark != Long.MIN_VALUE) {
+			nextWindow = advanceNextWindowByWatermark(watermark);
+			emptyWindowTriggered = false;
+		}
+	}
+
+	private TimeWindow advanceNextWindowByWatermark(long watermark) {
+		int maxOverlapping = (int) Math.ceil(windowSize * 1.0 / slideSize);
+		long start = getWindowStartWithOffset(watermark, windowStartOffset, slideSize);
+		for (int i = 1; i < maxOverlapping; i++) {
+			long nextStart = start - slideSize;
+			if (nextStart + windowSize > watermark) {
+				start = nextStart;
+			} else {
+				break;
+			}
+		}
+		if (nextWindow == null || start > nextWindow.getStart()) {
+			// This check is used in the case of jumping window.
+			return TimeWindow.of(start, start + windowSize);
+		} else {
+			return nextWindow;
+		}
+	}
+
+	private long getWindowStartWithOffset(long timestamp, long offset, long windowSize) {
+		long remainder = (timestamp - offset) % windowSize;
+		// handle both positive and negative cases
+		if (remainder < 0) {
+			return timestamp - (remainder + windowSize);
+		} else {
+			return timestamp - remainder;
+		}
+	}
+
+	private long getTimeValue(BaseRow row) {
+		if (isDate) {
+			return row.getInt(timeIndex) * DateTimeUtils.MILLIS_PER_DAY;
+		} else {
+			return row.getLong(timeIndex);
+		}
+	}
+
+	/**
+	 * Iterator for a window.
+	 */
+	class WindowsElementsIterator implements RowIterator<BinaryRow> {
+
+		private final RowIterator<BinaryRow> bufferIterator;
+		private BinaryRow next;
+
+		WindowsElementsIterator(RowIterator<BinaryRow> iterator) {
+			this.bufferIterator = iterator;
+		}
+
+		@Override
+		public boolean advanceNext() {
+			// find the first element belongs to the current window,
+			// evict elements from current window, used in the case of jumping window cases.
+			do {
+				if (bufferIterator.advanceNext()) {
+					next = bufferIterator.getRow();
+				} else {
+					next = null;
+					return false;
+				}
+			} while (evictForWindow(next, currentWindow));
+			// Find the last element belongs to the current window.
+			if (belongsToCurrentWindow(next)) {
+				emptyWindowTriggered = false;
+				return true;
+			} else {
+				next = null;
+				return false;
+			}
+		}
+
+		@Override
+		public BinaryRow getRow() {
+			return next;
+		}
+
+	}
+
+	protected abstract void resetBuffer();
+
+	protected abstract void addIntoBuffer(BinaryRow input) throws IOException;
+
+	protected abstract void onBufferEvict(int limitIndex);
+
+	protected abstract RowIterator<BinaryRow> newBufferIterator(int startIndex);
+
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/grouping/HeapWindowsGroupingTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/window/grouping/HeapWindowsGroupingTest.java
@@ -1,0 +1,395 @@
+package org.apache.flink.table.runtime.window.grouping;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.table.api.window.TimeWindow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryRowWriter;
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils;
+import org.apache.flink.table.runtime.util.RowIterator;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link HeapWindowsGrouping}.
+ */
+public class HeapWindowsGroupingTest {
+
+	@Test
+	public void testJumpingWindowCase() throws IOException {
+		Long[] ts = new Long[]{1L, 2L, 3L, 4L, 7L, 8L, 11L, 13L, 81L, 93L};
+		// jumping window(10, 3)
+		List<TimeWindow> expectedWindows = asList(
+				TimeWindow.of(0, 3), TimeWindow.of(10, 13), TimeWindow.of(80, 83));
+		List<List<Long>> expected = new ArrayList<>();
+		expected.add(asList(1L, 2L));
+		expected.add(singletonList(11L));
+		expected.add(singletonList(81L));
+		verify(5000, ts, 3L, 10L, expected, expectedWindows);
+	}
+
+	@Test
+	public void testNegativeCase() throws IOException {
+		Long[] ts = new Long[]{-16L, -6L, -1L, 10L};
+		// tumbling(10)
+		List<TimeWindow> expectedWindows = asList(
+				TimeWindow.of(-20, -10), TimeWindow.of(-10, 0), TimeWindow.of(10, 20));
+		List<List<Long>> expected = new ArrayList<>();
+		expected.add(singletonList(-16L));
+		expected.add(asList(-6L, -1L));
+		expected.add(singletonList(10L));
+		verify(5000, ts, 10L, 10L, expected, expectedWindows);
+
+		// sliding(10, 11)
+		expectedWindows = asList(TimeWindow.of(-20, -9),
+				TimeWindow.of(-10, 1), TimeWindow.of(0, 11), TimeWindow.of(10, 21));
+		expected.clear();
+		expected.add(singletonList(-16L));
+		expected.add(asList(-6L, -1L));
+		expected.add(singletonList(10L));
+		expected.add(singletonList(10L));
+		verify(5000, ts, 11L, 10L, expected, expectedWindows);
+	}
+
+	@Test
+	public void testNullValueCase() throws IOException {
+		Long[] ts = new Long[]{null, 0L, 0L, 0L, 1L, 2L, 3L, 3L,
+				4L, 5L, 6L, 7L, null, 7L, 8L, 9L, 11L, 12L, 12L, 12L, null};
+		// sliding(4, 2)
+		List<TimeWindow> expectedWindows = asList(
+				TimeWindow.of(-2, 2), TimeWindow.of(0, 4), TimeWindow.of(2, 6), TimeWindow.of(4, 8),
+				TimeWindow.of(6, 10), TimeWindow.of(8, 12), TimeWindow.of(10, 14),
+				TimeWindow.of(12, 16));
+		List<List<Long>> expected = new ArrayList<>();
+		expected.add(asList(0L, 0L, 0L, 1L));
+		expected.add(asList(0L, 0L, 0L, 1L, 2L, 3L, 3L));
+		expected.add(asList(2L, 3L, 3L, 4L, 5L));
+		expected.add(asList(4L, 5L, 6L, 7L, 7L));
+		expected.add(asList(6L, 7L, 7L, 8L, 9L));
+		expected.add(asList(8L, 9L, 11L));
+		expected.add(asList(11L, 12L, 12L, 12L));
+		expected.add(asList(12L, 12L, 12L));
+		verify(5000, ts, 4L, 2L, expected, expectedWindows);
+
+		Long[] ts1 = new Long[]{null, null, 1L, 2L, 3L, 3L,
+				4L, 5L, 6L, 7L, null, 7L, 8L, 9L, 11L, 12L, 12L, 12L, null};
+		expectedWindows = asList(
+				TimeWindow.of(-2, 2), TimeWindow.of(0, 4), TimeWindow.of(2, 6), TimeWindow.of(4, 8),
+				TimeWindow.of(6, 10), TimeWindow.of(8, 12), TimeWindow.of(10, 14),
+				TimeWindow.of(12, 16));
+		expected.clear();
+		expected.add(singletonList(1L));
+		expected.add(asList(1L, 2L, 3L, 3L));
+		expected.add(asList(2L, 3L, 3L, 4L, 5L));
+		expected.add(asList(4L, 5L, 6L, 7L, 7L));
+		expected.add(asList(6L, 7L, 7L, 8L, 9L));
+		expected.add(asList(8L, 9L, 11L));
+		expected.add(asList(11L, 12L, 12L, 12L));
+		expected.add(asList(12L, 12L, 12L));
+		verify(5000, ts1, 4L, 2L, expected, expectedWindows);
+	}
+
+	@Test
+	public void testFirstOverlappingWindow() throws IOException {
+		Long[] ts = new Long[]{1L};
+		List<TimeWindow> expectedWindows = asList(
+				TimeWindow.of(-3, 2), TimeWindow.of(-2, 3), TimeWindow.of(-1, 4),
+				TimeWindow.of(0, 5), TimeWindow.of(1, 6));
+		List<List<Long>> expected = new ArrayList<>();
+		expected.add(singletonList(1L));
+		expected.add(singletonList(1L));
+		expected.add(singletonList(1L));
+		expected.add(singletonList(1L));
+		expected.add(singletonList(1L));
+		verify(5000, ts, 5L, 1L, expected, expectedWindows);
+	}
+
+	@Test
+	public void testCommonCase() throws IOException {
+		Long[] ts = new Long[]{
+				0L, 0L, 0L, 1L, 2L, 3L, 3L, 4L, 5L, 6L, 7L, 7L, 8L, 9L, 11L, 12L, 12L, 12L};
+		// sliding(4, 2)
+		List<TimeWindow> expectedWindows = asList(
+				TimeWindow.of(-2, 2), TimeWindow.of(0, 4), TimeWindow.of(2, 6), TimeWindow.of(4, 8),
+				TimeWindow.of(6, 10), TimeWindow.of(8, 12), TimeWindow.of(10, 14),
+				TimeWindow.of(12, 16));
+		List<List<Long>> expected = new ArrayList<>();
+		expected.add(asList(0L, 0L, 0L, 1L));
+		expected.add(asList(0L, 0L, 0L, 1L, 2L, 3L, 3L));
+		expected.add(asList(2L, 3L, 3L, 4L, 5L));
+		expected.add(asList(4L, 5L, 6L, 7L, 7L));
+		expected.add(asList(6L, 7L, 7L, 8L, 9L));
+		expected.add(asList(8L, 9L, 11L));
+		expected.add(asList(11L, 12L, 12L, 12L));
+		expected.add(asList(12L, 12L, 12L));
+		verify(5000, ts, 4L, 2L, expected, expectedWindows);
+
+		// sliding(4, 3)
+		expected.clear();
+		expectedWindows = asList(
+				TimeWindow.of(-3, 1),
+				TimeWindow.of(0, 4), TimeWindow.of(3, 7), TimeWindow.of(6, 10),
+				TimeWindow.of(9, 13), TimeWindow.of(12, 16));
+		expected.add(asList(0L, 0L, 0L));
+		expected.add(asList(0L, 0L, 0L, 1L, 2L, 3L, 3L));
+		expected.add(asList(3L, 3L, 4L, 5L, 6L));
+		expected.add(asList(6L, 7L, 7L, 8L, 9L));
+		expected.add(asList(9L, 11L, 12L, 12L, 12L));
+		expected.add(asList(12L, 12L, 12L));
+		verify(5000, ts, 4L, 3L, expected, expectedWindows);
+
+		// sliding(5, 5) tumbling(5)
+		expected.clear();
+		expectedWindows = asList(TimeWindow.of(0, 5), TimeWindow.of(5, 10),
+				TimeWindow.of(10, 15));
+		expected.add(asList(0L, 0L, 0L, 1L, 2L, 3L, 3L, 4L));
+		expected.add(asList(5L, 6L, 7L, 7L, 8L, 9L));
+		expected.add(asList(11L, 12L, 12L, 12L));
+		verify(5000, ts, 5L, 5L, expected, expectedWindows);
+	}
+
+	@Test
+	public void testSparseCase() throws IOException {
+		Long[] ts = new Long[]{0L, 7L, 33L, 76L, 77L, 77L, 98L, 99L, 100L, 999L};
+		// sliding(4, 2)
+		List<TimeWindow> expectedWindows = asList(
+				TimeWindow.of(-2, 2),
+				TimeWindow.of(0, 4),
+				TimeWindow.of(4, 8), TimeWindow.of(6, 10),
+				TimeWindow.of(30, 34), TimeWindow.of(32, 36),
+				TimeWindow.of(74, 78), TimeWindow.of(76, 80),
+				TimeWindow.of(96, 100), TimeWindow.of(98, 102),
+				TimeWindow.of(100, 104),
+				TimeWindow.of(996, 1000), TimeWindow.of(998, 1002));
+		List<List<Long>> expected = new ArrayList<>();
+		expected.add(singletonList(0L));
+		expected.add(singletonList(0L));
+		expected.add(singletonList(7L));
+		expected.add(singletonList(7L));
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		expected.add(asList(76L, 77L, 77L));
+		expected.add(asList(76L, 77L, 77L));
+		expected.add(asList(98L, 99L));
+		expected.add(asList(98L, 99L, 100L));
+		expected.add(singletonList(100L));
+		expected.add(singletonList(999L));
+		expected.add(singletonList(999L));
+		verify(5000, ts, 4L, 2L, expected, expectedWindows);
+
+		// sliding(9, 3)
+		expectedWindows = asList(
+				TimeWindow.of(-6, 3),
+				TimeWindow.of(-3, 6),
+				TimeWindow.of(0, 9),
+				TimeWindow.of(3, 12), TimeWindow.of(6, 15),
+				TimeWindow.of(27, 36), TimeWindow.of(30, 39), TimeWindow.of(33, 42),
+				TimeWindow.of(69, 78), TimeWindow.of(72, 81), TimeWindow.of(75, 84),
+				TimeWindow.of(90, 99), TimeWindow.of(93, 102), TimeWindow.of(96, 105),
+				TimeWindow.of(99, 108),
+				TimeWindow.of(993, 1002), TimeWindow.of(996, 1005), TimeWindow.of(999, 1008));
+		expected = new ArrayList<>();
+		expected.add(singletonList(0L));
+		expected.add(singletonList(0L));
+		expected.add(asList(0L, 7L));
+		expected.add(singletonList(7L));
+		expected.add(singletonList(7L));
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		expected.add(asList(76L, 77L, 77L));
+		expected.add(asList(76L, 77L, 77L));
+		expected.add(asList(76L, 77L, 77L));
+		expected.add(singletonList(98L));
+		expected.add(asList(98L, 99L, 100L));
+		expected.add(asList(98L, 99L, 100L));
+		expected.add(asList(99L, 100L));
+		expected.add(singletonList(999L));
+		expected.add(singletonList(999L));
+		expected.add(singletonList(999L));
+		verify(5000, ts, 9L, 3L, expected, expectedWindows);
+	}
+
+	@Test
+	public void testSingleInputCase() throws IOException {
+		Long[] ts = new Long[]{33L};
+		// sliding(4, 2)
+		List<TimeWindow> expectedWindows = asList(
+				TimeWindow.of(30, 34), TimeWindow.of(32, 36));
+		List<List<Long>> expected = new ArrayList<>();
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		verify(5000, ts, 4L, 2L, expected, expectedWindows);
+
+		// sliding(19, 3)
+		expectedWindows = asList(
+				TimeWindow.of(15, 34), TimeWindow.of(18, 37),
+				TimeWindow.of(21, 40), TimeWindow.of(24, 43),
+				TimeWindow.of(27, 46), TimeWindow.of(30, 49),
+				TimeWindow.of(33, 52));
+		expected.clear();
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		expected.add(singletonList(33L));
+		verify(5000, ts, 19L, 3L, expected, expectedWindows);
+	}
+
+	@Test(expected = IOException.class)
+	public void testOOM() throws IOException {
+		Long[] ts = new Long[]{33L, 33L, 33L, 33L, 33L, 33L};
+		// sliding(4, 2)
+		verify(5, ts, 4L, 2L, new ArrayList<>(), new ArrayList<>());
+	}
+
+	@Test
+	public void testAdvanceWatermarkFirst() throws IOException {
+		Long[] ts = new Long[]{16L};
+		// sliding(8, 4)
+		List<TimeWindow> expectedWindows = asList(
+				TimeWindow.of(12, 20), TimeWindow.of(16, 24));
+		List<List<Long>> expected = new ArrayList<>();
+		expected.add(singletonList(16L));
+		expected.add(singletonList(16L));
+
+		List<List<Long>> actual = new ArrayList<>();
+		List<TimeWindow> windows = new ArrayList<>();
+		HeapWindowsGrouping grouping = new HeapWindowsGrouping(5000, 0L, 8L, 4L, 0, false);
+		RowIterator<BinaryRow> iterator = new HeapWindowsGroupingTest.TestInputIterator(ts);
+		grouping.addInputToBuffer(iterator.getRow());
+		// watermark to trigger all the windows first
+		grouping.advanceWatermarkToTriggerAllWindows();
+		processTriggerWindow(actual, windows, grouping);
+		assertEquals(expectedWindows, windows);
+		assertEquals(expected, actual);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testInvalidWindowTrigger() throws IOException {
+		Long[] ts = new Long[]{8L};
+		RowIterator<BinaryRow> iterator = new HeapWindowsGroupingTest.TestInputIterator(ts);
+		HeapWindowsGrouping grouping = new HeapWindowsGrouping(5000, 0L, 8L, 4L, 0, false);
+		grouping.addInputToBuffer(iterator.getRow());
+
+		System.out.println("valid window trigger");
+		RowIterator<BinaryRow> iter = grouping.buildTriggerWindowElementsIterator();
+		TimeWindow window = grouping.getTriggerWindow();
+		List<Long> buffer = new ArrayList<>();
+		while (iter.advanceNext()) {
+			buffer.add(iter.getRow().getLong(0));
+		}
+		assertEquals(TimeWindow.of(0, 8L), window);
+		assertEquals(Collections.emptyList(), buffer);
+
+		System.out.println("try invalid window trigger");
+		grouping.buildTriggerWindowElementsIterator();
+	}
+
+	private void verify(
+			int limit, Long[] ts, long windowSize, long slideSize, List<List<Long>> expected,
+			List<TimeWindow> expectedWindows) throws IOException {
+		List<List<Long>> actual = new ArrayList<>();
+		List<TimeWindow> windows = new ArrayList<>();
+		HeapWindowsGrouping grouping = new HeapWindowsGrouping(limit, 0L, windowSize, slideSize, 0, false);
+
+		RowIterator<BinaryRow> iterator = new HeapWindowsGroupingTest.TestInputIterator(ts);
+		while (iterator.advanceNext()) {
+			BinaryRow input = iterator.getRow();
+			grouping.addInputToBuffer(input);
+			processTriggerWindow(actual, windows, grouping);
+		}
+		grouping.advanceWatermarkToTriggerAllWindows();
+		processTriggerWindow(actual, windows, grouping);
+
+		assertEquals(expectedWindows, windows);
+		assertEquals(expected, actual);
+	}
+
+	private void processTriggerWindow(
+			List<List<Long>> actual, List<TimeWindow> windows, HeapWindowsGrouping grouping) {
+		while (grouping.hasTriggerWindow()) {
+			RowIterator<BinaryRow> iter = grouping.buildTriggerWindowElementsIterator();
+			TimeWindow window = grouping.getTriggerWindow();
+			List<Long> buffer = new ArrayList<>();
+			while (iter.advanceNext()) {
+				buffer.add(iter.getRow().getLong(0));
+			}
+			if (!buffer.isEmpty()) {
+				actual.add(buffer);
+				windows.add(window);
+			}
+		}
+	}
+
+	private class TestInputIterator implements RowIterator<BinaryRow> {
+		private BinaryRow row = new BinaryRow(1);
+		private BinaryRowWriter writer = new BinaryRowWriter(row);
+		private List<Long> assignedWindowStart;
+		private int count;
+
+		TestInputIterator(Long[] assignedWindowStart) {
+			this.assignedWindowStart = Arrays.asList(assignedWindowStart);
+			this.assignedWindowStart.sort((o1, o2) -> {
+				if (o1 == null && o2 == null) {
+					return 0;
+				} else {
+					if (o1 == null) {
+						return -1;
+					}
+					if (o2 == null) {
+						return 1;
+					}
+					return (int) (o1 - o2);
+				}
+			});
+			this.count = 0;
+		}
+
+		@Override
+		public boolean advanceNext() {
+			return count < assignedWindowStart.size();
+		}
+
+		@Override
+		public BinaryRow getRow() {
+			writer.reset();
+			if (assignedWindowStart.get(count) == null) {
+				writer.setNullAt(0);
+			} else {
+				writer.writeLong(0, SqlDateTimeUtils.timestampToInternal(new Timestamp(assignedWindowStart.get(count))));
+			}
+			writer.complete();
+			count++;
+			return row;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

1.Add support for generating optimized logical plan for Group window. (Almost same to Legacy runner)
2.Let WindowProperty be independent of Expression.
3.Introduce batch execution sort group window
4.Introduce batch execution hash group window
5.Add REINTERPRET_CAST to BuiltInFunctionDefinitions

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
