### PR TITLE
[FLINK-12181][Tests] Port ExecutionGraphRestartTest to new codebase

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -536,9 +536,9 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 			final List<SlotOffer> slotOffers = new ArrayList<>(NUM_TASKS);
 			for (int i = 0; i < NUM_TASKS; i++) {
-				final AllocationID expiredAllocationId = new AllocationID();
-				final SlotOffer slotToExpire = new SlotOffer(expiredAllocationId, 0, ResourceProfile.UNKNOWN);
-				slotOffers.add(slotToExpire);
+				final AllocationID allocationId = new AllocationID();
+				final SlotOffer slotOffer = new SlotOffer(allocationId, 0, ResourceProfile.UNKNOWN);
+				slotOffers.add(slotOffer);
 			}
 
 			slotPool.offerSlots(taskManagerLocation, taskManagerGateway, slotOffers);
@@ -860,9 +860,9 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		final List<SlotOffer> slotOffers = new ArrayList<>(NUM_TASKS);
 		for (int i = 0; i < NUM_TASKS; i++) {
-			final AllocationID expiredAllocationId = new AllocationID();
-			final SlotOffer slotToExpire = new SlotOffer(expiredAllocationId, 0, ResourceProfile.UNKNOWN);
-			slotOffers.add(slotToExpire);
+			final AllocationID allocationId = new AllocationID();
+			final SlotOffer slotOffer = new SlotOffer(allocationId, 0, ResourceProfile.UNKNOWN);
+			slotOffers.add(slotOffer);
 		}
 
 		slotPool.offerSlots(taskManagerLocation, taskManagerGateway, slotOffers);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -785,7 +785,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	private static Scheduler setupScheduler(
 		SlotPool slotPool,
 		ComponentMainThreadExecutor mainThreadExecutable) {
-		Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
+		final Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
 		scheduler.start(mainThreadExecutable);
 		return scheduler;
 	}


### PR DESCRIPTION


## What is the purpose of the change

Port ExecutionGraphRestartTest to new codebase.

## Brief change log

*(for example:)*
  - *Use TaskManagerLocation, SimpleAckingTaskManagerGateway and TestingResourceManagerGateway in repalce of Instance.*
  - *Use SlotPool#releaseTaskManager in replace of Instrance#markDead *


## Verifying this change

This change is a trivial rework.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
