### PR TITLE
[FLINK-12271][table] Display input field name list when throw Cannot resolve field exception

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 
 import java.util.List;
@@ -74,7 +75,14 @@ final class ReferenceResolverRule implements ResolverRule {
 		}
 
 		private ValidationException failForField(UnresolvedReferenceExpression fieldReference) {
-			return new ValidationException(format("Cannot resolve field [%s]", fieldReference.getName()));
+			return new ValidationException(format("Cannot resolve field [%s], input field list:[%s].",
+				fieldReference.getName(),
+				String.join(
+					", ",
+					resolutionContext.referenceLookup().getAllInputFields()
+						.stream().map(FieldReferenceExpression::getName)
+						.collect(Collectors.toList())))
+			);
 		}
 
 		@Override

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/CalcValidationTest.scala
@@ -28,8 +28,10 @@ import org.junit._
 
 class CalcValidationTest extends TableTestBase {
 
-  @Test(expected = classOf[ValidationException])
+  @Test
   def testSelectInvalidFieldFields(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Cannot resolve field [foo], input field list:[a, b, c].")
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
       // must fail. Field 'foo does not exist


### PR DESCRIPTION

## What is the purpose of the change

This pull request displays the input field list to indicate existing fields when throw Cannot resolve field exception.


## Brief change log

  - Display input field name list when throw Cannot resolve field exception


## Verifying this change


This change is already covered by existing tests, such as `CalcValidationTest`. Furthermore, I added logic to check the error message in the test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
