### PR TITLE
[FLINK-11732] [docs] Add a language switch to the sidebar for Flink documents

### DIFF
--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -148,7 +148,12 @@ level is determined by 'nav-pos'.
 
 <div class="sidenav-versions">
   <div class="dropdown">
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">Pick Docs Version
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+      {% if page.is_default_language %}
+        Pick Docs Version
+      {% else %}
+        选择文档版本
+      {% endif %}
     <span class="caret"></span></button>
     <ul class="dropdown-menu">
       {% for d in site.previous_docs %}
@@ -156,4 +161,17 @@ level is determined by 'nav-pos'.
       {% endfor %}
     </ul>
   </div>
+</div>
+
+<div class="sidenav-languages">
+  {% if page.is_default_language %}
+    <!-- link to the Chinese home page when current is blog page -->
+    <a href="{{ site.baseurl }}/zh{{ page.url }}">
+      <button type="submit" class="btn btn-default">中文版</button>
+    </a>
+  {% else %}
+    <a href="{{ site.baseurl }}{{ page.url | remove_first: 'zh/' }}">
+      <button type="submit" class="btn btn-default">English</button>
+    </a>
+  {% endif %}
 </div>

--- a/docs/_layouts/plain.html
+++ b/docs/_layouts/plain.html
@@ -65,8 +65,14 @@ under the License.
 
 {{ content }}
 
-{% if page.language == "zh" %}
-  <div class="footer">
-    <a href="https://cwiki.apache.org/confluence/display/FLINK/Flink+Translation+Specifications" target="_blank">想参与贡献翻译？</a>
-  </div>
-{% endif %}
+
+<div class="footer">
+  <a href="https://cwiki.apache.org/confluence/display/FLINK/Flink+Translation+Specifications" target="_blank">
+    {% if page.language == "zh" %}
+      想参与贡献翻译？
+    {% else if page.language == "en" %}
+      Want to contribute translation?
+    {% endif %}
+  </a>
+</div>
+

--- a/docs/_layouts/plain.html
+++ b/docs/_layouts/plain.html
@@ -64,3 +64,9 @@ under the License.
 {% endif %}
 
 {{ content }}
+
+{% if page.language == "zh" %}
+  <div class="footer">
+    <a href="https://cwiki.apache.org/confluence/display/FLINK/Flink+Translation+Specifications" target="_blank">想参与贡献翻译？</a>
+  </div>
+{% endif %}

--- a/docs/page/css/flink.css
+++ b/docs/page/css/flink.css
@@ -30,6 +30,14 @@ body {
 	background: #f8f8f8;
 }
 
+.footer {
+	color: #7f8c8d;
+	margin-top: 4em;
+	padding-top: 1em;
+	border-top: 1px solid #e5e5e5;
+	font-size: .9em;
+}
+
 @media (min-width: 992px) and (max-width: 1200px) {
     #contentcol { float: left; width: 70%; }
     #sidenavcol { float: left; width: 30%; }
@@ -296,5 +304,13 @@ ul#sidenav {
 }
 
 .sidenav-versions button {
+	width: 100%;
+}
+
+.sidenav-languages {
+	padding: 10px;
+}
+
+.sidenav-languages button {
 	width: 100%;
 }


### PR DESCRIPTION

## What is the purpose of the change

Add a language switch to the sidebar for Flink documents.

## Brief change log

1. Add a language switch to the sidebar for Flink documents. The language switch links to the same page in the opposite language.

![image](https://user-images.githubusercontent.com/5378924/56499954-6dbba280-653b-11e9-8c12-9dcefed8017b.png)

![image](https://user-images.githubusercontent.com/5378924/56499876-04d42a80-653b-11e9-98d1-1208bb7bb8b8.png)


2. Add a ["Want to contribute translation?"](https://cwiki.apache.org/confluence/display/FLINK/Flink+Translation+Specifications) link at the bottom of every Chinese pages.

![image](https://user-images.githubusercontent.com/5378924/56499926-449b1200-653b-11e9-992e-aab6b39e4672.png)




## Verifying this change

N/A

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
