### PR TITLE
[FLINK-12299] ExecutionConfig#setAutoWatermarkInterval should check param(interval should not less than zero)

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -220,6 +220,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 */
 	@PublicEvolving
 	public ExecutionConfig setAutoWatermarkInterval(long interval) {
+		Preconditions.checkArgument(interval >= 0, "Auto watermark interval must not be negative.");
 		this.autoWatermarkInterval = interval;
 		return this;
 	}


### PR DESCRIPTION
## What is the purpose of the change
We should check autowatermarkinterval field.

In any scenario, `autoWatermarkInterval` should not be less than or equal to zero.

First of all, this does not correspond to the meaning of `autoWatermarkInterval`.

Second, in the case where `autoWatermarkInterval` is less than 0, we will not be able to register ourselves in `TimestampsAndPeriodicWatermarksOperator#open`, which will result in the water level of this stream being kept at the lowest level.


## Brief change log
add check to ExecutionConfig#setAutoWatermarkInterval's param


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

no

## Documentation

  - Does this pull request introduce a new feature? ( no)
