### PR TITLE
[FLINK-12309][JDBC] JDBCOoutputFormat and JDBCAppendTableSink float behavior is not align

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
@@ -156,9 +156,9 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 									upload.setLong(index + 1, (long) row.getField(index));
 									break;
 								case java.sql.Types.REAL:
+								case java.sql.Types.FLOAT:
 									upload.setFloat(index + 1, (float) row.getField(index));
 									break;
-								case java.sql.Types.FLOAT:
 								case java.sql.Types.DOUBLE:
 									upload.setDouble(index + 1, (double) row.getField(index));
 									break;

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormatTest.java
@@ -133,6 +133,32 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 		jdbcOutputFormat.writeRecord(row);
 	}
 
+	@Test
+	public void testCastFloatToDoubleType() throws IOException {
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+			.setDrivername(DRIVER_CLASS)
+			.setDBUrl(DB_URL)
+			.setQuery(String.format(INSERT_TEMPLATE, INPUT_TABLE))
+			.setSqlTypes(new int[] {
+				Types.INTEGER,
+				Types.VARCHAR,
+				Types.VARCHAR,
+				Types.FLOAT,
+				Types.INTEGER})
+			.finish();
+		jdbcOutputFormat.open(0, 1);
+
+		Row row = new Row(5);
+		row.setField(0, 4);
+		row.setField(1, "hello");
+		row.setField(2, "world");
+		row.setField(3, 0.99f);
+		row.setField(4, 1);
+
+		jdbcOutputFormat.writeRecord(row);
+		jdbcOutputFormat.close();
+	}
+
 	@Test(expected = RuntimeException.class)
 	public void testExceptionOnClose() throws IOException {
 


### PR DESCRIPTION
## What is the purpose of the change

JDBCOoutputFormat and JDBCAppendTableSink float behavior is not align
When we use JDBCAppendTableSinkBuilder#setParameterTypes() config the jdbc types, it bind BasicTypeInfo#FLOAT_TYPE_INFO to java.sql.Types#FLOAT.
But JDBCOutputFormat#writeRecord will force cast the float value to double type, it will throw ClassCastException like "java.lang.Float cannot be cast to java.lang.Double".

## Brief change log


## Verifying this change

This change added tests and can be verified as follows:

  - Added a test case org.apache.flink.api.java.io.jdbc.JDBCOutputFormatTest#testCastFloatToDoubleType

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
