### PR TITLE
[FLINK-12247][runtime] fix NPE when writing the archive json file to FileSystem

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandler.java
@@ -100,13 +100,15 @@ public class SubtaskExecutionAttemptAccumulatorsHandler
 
 				for (int x = 0; x < subtask.getCurrentExecutionAttempt().getAttemptNumber(); x++) {
 					AccessExecution attempt = subtask.getPriorExecutionAttempt(x);
-					ResponseBody json = createAccumulatorInfo(attempt);
-					String path = getMessageHeaders().getTargetRestEndpointURL()
-						.replace(':' + JobIDPathParameter.KEY, graph.getJobID().toString())
-						.replace(':' + JobVertexIdPathParameter.KEY, task.getJobVertexId().toString())
-						.replace(':' + SubtaskIndexPathParameter.KEY, String.valueOf(subtask.getParallelSubtaskIndex()))
-						.replace(':' + SubtaskAttemptPathParameter.KEY, String.valueOf(attempt.getAttemptNumber()));
-					archive.add(new ArchivedJson(path, json));
+					if (attempt != null){
+						ResponseBody json = createAccumulatorInfo(attempt);
+						String path = getMessageHeaders().getTargetRestEndpointURL()
+							.replace(':' + JobIDPathParameter.KEY, graph.getJobID().toString())
+							.replace(':' + JobVertexIdPathParameter.KEY, task.getJobVertexId().toString())
+							.replace(':' + SubtaskIndexPathParameter.KEY, String.valueOf(subtask.getParallelSubtaskIndex()))
+							.replace(':' + SubtaskAttemptPathParameter.KEY, String.valueOf(attempt.getAttemptNumber()));
+						archive.add(new ArchivedJson(path, json));
+					}
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandler.java
@@ -114,13 +114,15 @@ public class SubtaskExecutionAttemptDetailsHandler
 
 				for (int x = 0; x < subtask.getCurrentExecutionAttempt().getAttemptNumber(); x++) {
 					AccessExecution attempt = subtask.getPriorExecutionAttempt(x);
-					ResponseBody json = createDetailsInfo(attempt, graph.getJobID(), task.getJobVertexId(), null);
-					String path = getMessageHeaders().getTargetRestEndpointURL()
-						.replace(':' + JobIDPathParameter.KEY, graph.getJobID().toString())
-						.replace(':' + JobVertexIdPathParameter.KEY, task.getJobVertexId().toString())
-						.replace(':' + SubtaskIndexPathParameter.KEY, String.valueOf(subtask.getParallelSubtaskIndex()))
-						.replace(':' + SubtaskAttemptPathParameter.KEY, String.valueOf(attempt.getAttemptNumber()));
-					archive.add(new ArchivedJson(path, json));
+					if (attempt != null){
+						ResponseBody json = createDetailsInfo(attempt, graph.getJobID(), task.getJobVertexId(), null);
+						String path = getMessageHeaders().getTargetRestEndpointURL()
+							.replace(':' + JobIDPathParameter.KEY, graph.getJobID().toString())
+							.replace(':' + JobVertexIdPathParameter.KEY, task.getJobVertexId().toString())
+							.replace(':' + SubtaskIndexPathParameter.KEY, String.valueOf(subtask.getParallelSubtaskIndex()))
+							.replace(':' + SubtaskAttemptPathParameter.KEY, String.valueOf(attempt.getAttemptNumber()));
+						archive.add(new ArchivedJson(path, json));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

if a flink-job reaches the max attempt count, the flink job will write an archive file to FileSystem and shut down.but when `SubtaskExecutionAttemptDetailsHandler` handle the detail attempt info of subtask, met NEP.

for more detail, please see [FLINK-12247](https://issues.apache.org/jira/browse/FLINK-12247).


## Brief change log

  - `SubtaskExecutionAttemptAccumulatorsHandler` add judgment null condition for `AccessExecution`.
  - `SubtaskExecutionAttemptDetailsHandler` add judgment null condition for `AccessExecution`.


## Verifying this change

This change is already covered by existing tests
- *SubtaskExecutionAttemptAccumulatorsHandlerTest*.
- *SubtaskExecutionAttemptDetailsHandlerTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
