### PR TITLE
[FLINK-12316][jdbc] Relax assertions

### DIFF
--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
@@ -35,6 +35,8 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.sql.Types;
 
+import static org.hamcrest.core.StringContains.containsString;
+
 /**
  * Tests using both {@link JDBCInputFormat} and {@link JDBCOutputFormat}.
  */
@@ -53,8 +55,7 @@ public class JDBCFullTest extends JDBCTestBase {
 	@Test
 	public void testEnrichedClassCastException() throws Exception {
 		exception.expect(ClassCastException.class);
-		exception.expectMessage(
-			"java.lang.String cannot be cast to java.lang.Double, field index: 3, field value: 11.11.");
+		exception.expectMessage(containsString("field index: 3, field value: 11.11."));
 
 		JDBCOutputFormat jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
 			.setDrivername(JDBCTestBase.DRIVER_CLASS)


### PR DESCRIPTION
## What is the purpose of the change

Relaxes the exception message assertion in `JDBCFullTest#testEnrichedClassCastException` such that it works under java 8 and 9+. The test was failing since the class names for Strings, Doubles etc. are different under Java 9.

The assertion now only checks for the part of the exception that we actually control.