### PR TITLE
[FLINK-12317][runtime] Ensure maximum size is larger than core size 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -279,7 +279,7 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
 						result = rpcMethod.invoke(rpcEndpoint, rpcInvocation.getArgs());
 					}
 					catch (InvocationTargetException e) {
-						log.trace("Reporting back error thrown in remote procedure {}", rpcMethod, e);
+						log.debug("Reporting back error thrown in remote procedure {}", rpcMethod, e);
 
 						// tell the sender about the failure
 						getSender().tell(new Status.Failure(e.getTargetException()), getSelf());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/BlockingCallMonitoringThreadPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/BlockingCallMonitoringThreadPool.java
@@ -86,8 +86,14 @@ public class BlockingCallMonitoringThreadPool {
 		// ** a new thread will be created ONLY IF THE QUEUE IS FULL **.
 		// ``
 
-		executor.setCorePoolSize(newPoolSize);
-		executor.setMaximumPoolSize(newPoolSize);
+		// ensure that regardless of whether we increase/reduce the pool size, maximum is always >= core
+		if (newPoolSize < executor.getCorePoolSize()) {
+			executor.setCorePoolSize(newPoolSize);
+			executor.setMaximumPoolSize(newPoolSize);
+		} else {
+			executor.setMaximumPoolSize(newPoolSize);
+			executor.setCorePoolSize(newPoolSize);
+		}
 	}
 
 	public void shutdown() {


### PR DESCRIPTION
## What is the purpose of the change

Fixes an issue in the `BlockingCallMonitoringThreadPool` where the pool core size may be set to a value exceeding the current maximum pool size. This is no longer allowed under Java 9 (rightfully so).

This PR also contains a hotfix for the `AkkaRpcActor` to log failures under DEBUG instead of TRACE. This change would've made this easier to debug.

@pnowojski Do you know whether we purposefully set the pool size first?
