### PR TITLE
[FLINK-12297]Harden ClosureCleaner to handle the wrapped function

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -73,6 +73,21 @@ public class ClosureCleaner {
 			if (f.getName().startsWith("this$")) {
 				// found a closure referencing field - now try to clean
 				closureAccessed |= cleanThis0(func, cls, f.getName());
+			} else {
+				Object fo;
+				try {
+					f.setAccessible(true);
+					fo = f.get(func);
+				} catch (IllegalAccessException e) {
+					throw new RuntimeException(String.format("Can not access to the %s field in Class %s", f.getName(), func.getClass()));
+				}
+				// we should make a deep clean when we encounter an anonymous class or a inner class
+				if (fo != null && (fo.getClass().isAnonymousClass() || fo.getClass().getName().contains("$"))) {
+					if (LOG.isDebugEnabled()) {
+						LOG.debug("Dig to clean the {} class", fo.getClass().getName());
+					}
+					clean(fo, true);
+				}
 			}
 		}
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/functions/ClosureCleanerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/functions/ClosureCleanerTest.java
@@ -90,10 +90,37 @@ public class ClosureCleanerTest {
 		int result = map.map(3);
 		Assert.assertEquals(result, 4);
 	}
+
+	@Test
+	public void testWrapperClass() throws Exception {
+		MapCreator creator = new NonSerializableMapCreator();
+		MapFunction<Integer, Integer> map = creator.getMap();
+
+		WrapperMapFunction wrapped = new WrapperMapFunction(map);
+		ClosureCleaner.clean(wrapped, true);
+
+		ClosureCleaner.ensureSerializable(wrapped);
+
+		int result = wrapped.map(3);
+		Assert.assertEquals(result, 4);
+	}
 }
 
 interface MapCreator {
 	MapFunction<Integer, Integer> getMap();
+}
+
+class WrapperMapFunction implements MapFunction<Integer, Integer> {
+
+	MapFunction<Integer, Integer> innerMapFuc;
+	public WrapperMapFunction(MapFunction<Integer, Integer> mapFunction) {
+		innerMapFuc = mapFunction;
+	}
+
+	@Override
+	public Integer map(Integer value) throws Exception {
+		return innerMapFuc.map(value);
+	}
 }
 
 @SuppressWarnings("serial")

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
@@ -40,6 +41,7 @@ import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
 
 import org.junit.Test;
 
@@ -883,5 +885,65 @@ public class CEPITCase extends AbstractTestBase {
 		resultList.sort(String::compareTo);
 
 		assertEquals(Arrays.asList("2,2,2", "3,3,3", "42,42,42"), resultList);
+	}
+
+	@Test
+	public void testFlatSelectSerializationWithAnonymousClass() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements = env.fromElements(1, 2, 3);
+		OutputTag<Integer> outputTag = new OutputTag<Integer>("AAA") {};
+		CEP.pattern(elements, Pattern.begin("A")).flatSelect(
+			outputTag,
+			new PatternFlatTimeoutFunction<Integer, Integer>() {
+				@Override
+				public void timeout(
+					Map<String, List<Integer>> pattern,
+					long timeoutTimestamp,
+					Collector<Integer> out) throws Exception {
+
+				}
+			},
+			new PatternFlatSelectFunction<Integer, Object>() {
+				@Override
+				public void flatSelect(Map<String, List<Integer>> pattern, Collector<Object> out) throws Exception {
+
+				}
+			}
+		);
+
+		env.execute();
+	}
+
+	@Test
+	public void testFlatSelectSerializationWithInnerClass() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements = env.fromElements(1, 2, 3);
+		OutputTag<Integer> outputTag = new SubOutPutTag("AAA");
+		CEP.pattern(elements, Pattern.begin("A")).flatSelect(
+			outputTag,
+			new PatternFlatTimeoutFunction<Integer, Integer>() {
+				@Override
+				public void timeout(
+					Map<String, List<Integer>> pattern,
+					long timeoutTimestamp,
+					Collector<Integer> out) throws Exception {
+
+				}
+			},
+			new PatternFlatSelectFunction<Integer, Object>() {
+				@Override
+				public void flatSelect(Map<String, List<Integer>> pattern, Collector<Object> out) throws Exception {
+
+				}
+			}
+		);
+
+		env.execute();
+	}
+
+	class SubOutPutTag extends OutputTag<Integer> {
+		public SubOutPutTag(String id) {
+			super(id);
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

ClosureCleaner is used to clean the implicit `this$x` point to the outer class in the user defined function to reduce the case of serialization function failed.

But if the function is wrapped by user or the flink framework, it will escape the clean operation. This pr harden the ClosureCleaner to handle this. And I think it is also a feasible approach for [[FLINK-12113]](https://issues.apache.org/jira/browse/FLINK-12113)

## Brief change log

check the field if need to further clean and apply

## Verifying this change

1. Add the case in the issue to confirm
2. Add the wrapFunction test case in ClosuerCleanerTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)
