### PR TITLE
[FLINK-12325][metrics] Fix bug in statsd exporter when using negative values

### DIFF
--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/util/TestCounter.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/util/TestCounter.java
@@ -18,35 +18,40 @@
 
 package org.apache.flink.metrics.util;
 
-import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.Counter;
 
 /**
- * A dummy {@link Meter} implementation.
+ * A dummy {@link Counter} implementation.
  */
-public class TestMeter implements Meter {
-	private final long countValue;
-	private final double rateValue;
+public class TestCounter implements Counter {
+	private long countValue;
 
-	public TestMeter() {
-		this(100, 5);
+	public TestCounter() {
+		this.countValue = 0;
 	}
 
-	public TestMeter(long countValue, double rateValue) {
+	public TestCounter(long countValue) {
 		this.countValue = countValue;
-		this.rateValue = rateValue;
 	}
 
 	@Override
-	public void markEvent() {
+	public void inc() {
+		countValue++;
 	}
 
 	@Override
-	public void markEvent(long n) {
+	public void inc(long n) {
+		countValue += n;
 	}
 
 	@Override
-	public double getRate() {
-		return rateValue;
+	public void dec() {
+		countValue--;
+	}
+
+	@Override
+	public void dec(long n) {
+		countValue -= n;
 	}
 
 	@Override

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/util/TestHistogram.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/util/TestHistogram.java
@@ -25,14 +25,19 @@ import org.apache.flink.metrics.HistogramStatistics;
  * Stateless test histogram for which all methods return a static value.
  */
 public class TestHistogram implements Histogram {
-
+	private long count = 1;
+	private int size = 3;
+	private double mean = 4;
+	private double stdDev = 5;
+	private long max = 6;
+	private long min = 7;
 	@Override
 	public void update(long value) {
 	}
 
 	@Override
 	public long getCount() {
-		return 1;
+		return count;
 	}
 
 	@Override
@@ -50,28 +55,52 @@ public class TestHistogram implements Histogram {
 
 			@Override
 			public int size() {
-				return 3;
+				return size;
 			}
 
 			@Override
 			public double getMean() {
-				return 4;
+				return mean;
 			}
 
 			@Override
 			public double getStdDev() {
-				return 5;
+				return stdDev;
 			}
 
 			@Override
 			public long getMax() {
-				return 6;
+				return max;
 			}
 
 			@Override
 			public long getMin() {
-				return 7;
+				return min;
 			}
 		};
+	}
+
+	public void setSize(int size) {
+		this.size = size;
+	}
+
+	public void setMean(double mean) {
+		this.mean = mean;
+	}
+
+	public void setStdDev(double stdDev) {
+		this.stdDev = stdDev;
+	}
+
+	public void setMax(long max) {
+		this.max = max;
+	}
+
+	public void setMin(long min) {
+		this.min = min;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
 	}
 }

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -152,6 +152,36 @@ public class StatsDReporterTest extends TestLogger {
 		testMetricAndAssert(new TestHistogram(), "metric", expectedLines);
 	}
 
+	@Test
+	public void testStatsDHistogramReportingOfNegativeValues() throws Exception {
+		TestHistogram histogram = new TestHistogram();
+		histogram.setCount(-101);
+		histogram.setMean(-104);
+		histogram.setMin(-107);
+		histogram.setMax(-106);
+		histogram.setStdDev(-105);
+
+		Set<String> expectedLines = new HashSet<>();
+		expectedLines.add("metric.count:0|g");
+		expectedLines.add("metric.count:-101|g");
+		expectedLines.add("metric.mean:0|g");
+		expectedLines.add("metric.mean:-104.0|g");
+		expectedLines.add("metric.min:0|g");
+		expectedLines.add("metric.min:-107|g");
+		expectedLines.add("metric.max:0|g");
+		expectedLines.add("metric.max:-106|g");
+		expectedLines.add("metric.stddev:0|g");
+		expectedLines.add("metric.stddev:-105.0|g");
+		expectedLines.add("metric.p75:0.75|g");
+		expectedLines.add("metric.p98:0.98|g");
+		expectedLines.add("metric.p99:0.99|g");
+		expectedLines.add("metric.p999:0.999|g");
+		expectedLines.add("metric.p95:0.95|g");
+		expectedLines.add("metric.p50:0.5|g");
+
+		testMetricAndAssert(histogram, "metric", expectedLines);
+	}
+
 	/**
 	 * Tests that meters are properly reported via the StatsD reporter.
 	 */
@@ -162,6 +192,17 @@ public class StatsDReporterTest extends TestLogger {
 		expectedLines.add("metric.count:100|g");
 
 		testMetricAndAssert(new TestMeter(), "metric", expectedLines);
+	}
+
+	@Test
+	public void testStatsDMetersReportingOfNegativeValues() throws Exception {
+		Set<String> expectedLines = new HashSet<>();
+		expectedLines.add("metric.rate:0|g");
+		expectedLines.add("metric.rate:-5.3|g");
+		expectedLines.add("metric.count:0|g");
+		expectedLines.add("metric.count:-50|g");
+
+		testMetricAndAssert(new TestMeter(-50, -5.3), "metric", expectedLines);
 	}
 
 	/**
@@ -176,11 +217,29 @@ public class StatsDReporterTest extends TestLogger {
 	}
 
 	@Test
+	public void testStatsDCountersReportingOfNegativeValues() throws Exception {
+		Set<String> expectedLines = new HashSet<>();
+		expectedLines.add("metric:0|g");
+		expectedLines.add("metric:-51|g");
+
+		testMetricAndAssert(new TestCounter(-51), "metric", expectedLines);
+	}
+
+	@Test
 	public void testStatsDGaugesReporting() throws Exception {
 		Set<String> expectedLines = new HashSet<>(2);
 		expectedLines.add("metric:75|g");
 
 		testMetricAndAssert((Gauge) () -> 75, "metric", expectedLines);
+	}
+
+	@Test
+	public void testStatsDGaugesReportingOfNegativeValues() throws Exception {
+		Set<String> expectedLines = new HashSet<>();
+		expectedLines.add("metric:0|g");
+		expectedLines.add("metric:-12345|g");
+
+		testMetricAndAssert((Gauge) () -> -12345, "metric", expectedLines);
 	}
 
 	private void testMetricAndAssert(Metric metric, String metricName, Set<String> expectation) throws Exception {

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -24,14 +24,14 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
-import org.apache.flink.metrics.Histogram;
-import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.util.TestCounter;
+import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
@@ -138,10 +138,10 @@ public class StatsDReporterTest extends TestLogger {
 	public void testStatsDHistogramReporting() throws Exception {
 		Set<String> expectedLines = new HashSet<>(6);
 		expectedLines.add("metric.count:1|g");
-		expectedLines.add("metric.mean:3.0|g");
-		expectedLines.add("metric.min:6|g");
-		expectedLines.add("metric.max:5|g");
-		expectedLines.add("metric.stddev:4.0|g");
+		expectedLines.add("metric.mean:4.0|g");
+		expectedLines.add("metric.min:7|g");
+		expectedLines.add("metric.max:6|g");
+		expectedLines.add("metric.stddev:5.0|g");
 		expectedLines.add("metric.p75:0.75|g");
 		expectedLines.add("metric.p98:0.98|g");
 		expectedLines.add("metric.p99:0.99|g");
@@ -149,7 +149,7 @@ public class StatsDReporterTest extends TestLogger {
 		expectedLines.add("metric.p95:0.95|g");
 		expectedLines.add("metric.p50:0.5|g");
 
-		testMetricAndAssert(new TestingHistogram(), "metric", expectedLines);
+		testMetricAndAssert(new TestHistogram(), "metric", expectedLines);
 	}
 
 	/**
@@ -172,10 +172,7 @@ public class StatsDReporterTest extends TestLogger {
 		Set<String> expectedLines = new HashSet<>(2);
 		expectedLines.add("metric:100|g");
 
-		Counter counter = new SimpleCounter();
-		counter.inc(100);
-
-		testMetricAndAssert(counter, "metric", expectedLines);
+		testMetricAndAssert(new TestCounter(100), "metric", expectedLines);
 	}
 
 	@Test
@@ -242,59 +239,6 @@ public class StatsDReporterTest extends TestLogger {
 
 		public Map<Counter, String> getCounters() {
 			return counters;
-		}
-	}
-
-	private static class TestingHistogram implements Histogram {
-
-		@Override
-		public void update(long value) {
-
-		}
-
-		@Override
-		public long getCount() {
-			return 1;
-		}
-
-		@Override
-		public HistogramStatistics getStatistics() {
-			return new HistogramStatistics() {
-				@Override
-				public double getQuantile(double quantile) {
-					return quantile;
-				}
-
-				@Override
-				public long[] getValues() {
-					return new long[0];
-				}
-
-				@Override
-				public int size() {
-					return 2;
-				}
-
-				@Override
-				public double getMean() {
-					return 3;
-				}
-
-				@Override
-				public double getStdDev() {
-					return 4;
-				}
-
-				@Override
-				public long getMax() {
-					return 5;
-				}
-
-				@Override
-				public long getMin() {
-					return 6;
-				}
-			};
 		}
 	}
 

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Metric;
@@ -161,6 +162,28 @@ public class StatsDReporterTest extends TestLogger {
 		expectedLines.add("metric.count:100|g");
 
 		testMetricAndAssert(new TestMeter(), "metric", expectedLines);
+	}
+
+	/**
+	 * Tests that counter are properly reported via the StatsD reporter.
+	 */
+	@Test
+	public void testStatsDCountersReporting() throws Exception {
+		Set<String> expectedLines = new HashSet<>(2);
+		expectedLines.add("metric:100|g");
+
+		Counter counter = new SimpleCounter();
+		counter.inc(100);
+
+		testMetricAndAssert(counter, "metric", expectedLines);
+	}
+
+	@Test
+	public void testStatsDGaugesReporting() throws Exception {
+		Set<String> expectedLines = new HashSet<>(2);
+		expectedLines.add("metric:75|g");
+
+		testMetricAndAssert((Gauge) () -> 75, "metric", expectedLines);
 	}
 
 	private void testMetricAndAssert(Metric metric, String metricName, Set<String> expectation) throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Fix a bug in the statsd reporter. With this PR flink is able to correctly send negative metric values to statsd. See FLINK-12325 for the exact details what is going wrong.

## Brief change log
- * Change in StatsdReporter class. When sending negative values to statsd first reset the metric to 0

## Verifying this change

This change added an unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable