### PR TITLE
[FLINK-12302][runtime] Fixed the wrong finalStatus of yarn application when application finished

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -146,6 +146,6 @@ public class MiniDispatcher extends Dispatcher {
 		super.jobNotFinished(jobId);
 
 		// shut down since we have done our job
-		jobTerminationFuture.complete(ApplicationStatus.UNKNOWN);
+		jobTerminationFuture.complete(ApplicationStatus.FAILED);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

when flink job which was deployed on yarn cluster in detach mode and if some error cause the flink job down. the state of associated yarn application displays `FINISHED`, while the final status of it displays `UNDEFINED`. As we know, these two states are relatively independent and also are not consistent with the state defined in hadoop.

In hadoop system, the `UNDEFINED` means the application has not yet finished. 

[FinalApplicationStatus Enum in Hadoop](https://github.com/apache/hadoop-common/blob/42a61a4fbc88303913c4681f0d40ffcc737e70b5/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/FinalApplicationStatus.java#L32)

```
/**
 * Enumeration of various final states of an <code>Application</code>.
 */
@Public
@Stable
public enum FinalApplicationStatus {

 /** Undefined state when either the application has not yet finished */
  UNDEFINED,

  /** Application which finished successfully. */
  SUCCEEDED,

  /** Application which failed. */
  FAILED,

  /** Application which was terminated by a user or admin. */
  KILLED
}
```

![image](https://user-images.githubusercontent.com/20113411/56714982-e81d3a00-6768-11e9-9838-495df98a7b09.png)


## Brief change log

change the status of flink-job which failed on yarn from `UNKNOWN` to `FAILED`.

## Verifying this change

This change is already covered by existing tests, `MiniDispatcherTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
