### PR TITLE
 [FLINK-8640][build][travis] Enable japicmp on Java 9 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,39 +189,39 @@ jobs:
       jdk: "openjdk9"
       stage: compile
       script: ./tools/travis_controller.sh compile
-      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: compile - jdk 9
     - if: type = cron
       jdk: "openjdk9"
       stage: test
       script: ./tools/travis_controller.sh core
-      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: core - jdk 9
     - if: type = cron
       jdk: "openjdk9"
       script: ./tools/travis_controller.sh libraries
-      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: libraries - jdk 9
     - if: type = cron
       jdk: "openjdk9"
       script: ./tools/travis_controller.sh connectors
-      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: connectors - jdk 9
     - if: type = cron
       jdk: "openjdk9"
       script: ./tools/travis_controller.sh tests
-      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: tests - jdk 9
     - if: type = cron
       jdk: "openjdk9"
       script: ./tools/travis_controller.sh misc
-      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: misc
     - if: type = cron
       jdk: "openjdk9"
       stage: cleanup
       script: ./tools/travis_controller.sh cleanup
-      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: cleanup - jdk 9
     # Documentation 404 check
     - if: type = cron

--- a/pom.xml
+++ b/pom.xml
@@ -748,6 +748,7 @@ under the License.
 					<dependency>
 						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-common</artifactId>
+						<version>${hadoop.version}</version>
 						<exclusions>
 							<exclusion>
 								<!-- This dependency is not available with java 9.-->
@@ -760,7 +761,21 @@ under the License.
 					<dependency>
 						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-common</artifactId>
+						<version>${hadoop.version}</version>
 						<type>test-jar</type>
+						<exclusions>
+							<exclusion>
+								<!-- This dependency is not available with java 9.-->
+								<groupId>jdk.tools</groupId>
+								<artifactId>jdk.tools</artifactId>
+							</exclusion>
+						</exclusions>
+					</dependency>
+
+					<dependency>
+						<groupId>org.apache.hadoop</groupId>
+						<artifactId>hadoop-annotations</artifactId>
+						<version>${hadoop.version}</version>
 						<exclusions>
 							<exclusion>
 								<!-- This dependency is not available with java 9.-->

--- a/pom.xml
+++ b/pom.xml
@@ -780,6 +780,32 @@ under the License.
 							<artifactId>maven-shade-plugin</artifactId>
 							<version>3.1.1</version>
 						</plugin>
+						<plugin>
+							<groupId>com.github.siom79.japicmp</groupId>
+							<artifactId>japicmp-maven-plugin</artifactId>
+							<dependencies>
+								<dependency>
+									<groupId>javax.xml.bind</groupId>
+									<artifactId>jaxb-api</artifactId>
+									<version>2.2.12</version>
+								</dependency>
+								<dependency>
+									<groupId>com.sun.xml.bind</groupId>
+									<artifactId>jaxb-impl</artifactId>
+									<version>2.2.11</version>
+								</dependency>
+								<dependency>
+									<groupId>com.sun.xml.bind</groupId>
+									<artifactId>jaxb-core</artifactId>
+									<version>2.2.11</version>
+								</dependency>
+								<dependency>
+									<groupId>javax.activation</groupId>
+									<artifactId>activation</artifactId>
+									<version>1.1.1</version>
+								</dependency>
+							</dependencies>
+						</plugin>
 					</plugins>
 				</pluginManagement>
 


### PR DESCRIPTION
## What is the purpose of the change

The `japicmp-plugin` is usable again on java 9+.

## Brief change log

* add explicit Java EE dependencies that the plugin requires, which are no longer available by default on Java 9+
* modify `hadoop-common` `jdk.tools` exclusion; this (system-provided) dependency is no longer available on java 9+ and thus has to be excluded. Defining the dependencies in the `dependencyManagement` section without a version lead to build failures (for _some_ reason), so we now also specify the hadoop version which just works out. Also adds such an exclusion for `hadoop-annotations`, which was simply missing. Note that this is an issue during **compile**  time; there are no repercussions on the runtime (by virtue of being about system dependencies).
* enable japicmp in our java 9 builds

## Verifying this change

Run plugin locally or on travis on java 9.
