### PR TITLE
[FLINK-12297]Harden ClosureCleaner to handle the wrapped function

### DIFF
--- a/docs/dev/execution_configuration.md
+++ b/docs/dev/execution_configuration.md
@@ -42,8 +42,9 @@ var executionConfig = env.getConfig
 
 The following configuration options are available: (the default is bold)
 
-- **`enableClosureCleaner()`** / `disableClosureCleaner()`. The closure cleaner is enabled by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
-With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer.
+- `setClosureCleanLevel()`. The closure cleaner level is set to `ClosureCleanerLevel.RECURSIVE` by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
+With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer. The three level
+refers to the different clean action. `NONE`: no clean. `TOP_LEVEL`: clean the top level. `RECURSIVE`: clean all the fields recursively. 
 
 - `getParallelism()` / `setParallelism(int parallelism)` Set the default parallelism for the job.
 

--- a/docs/dev/execution_configuration.md
+++ b/docs/dev/execution_configuration.md
@@ -42,9 +42,9 @@ var executionConfig = env.getConfig
 
 The following configuration options are available: (the default is bold)
 
-- `setClosureCleanLevel()`. The closure cleaner level is set to `ClosureCleanerLevel.RECURSIVE` by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
-With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer. The three level
-refers to the different clean action. `NONE`: no clean. `TOP_LEVEL`: clean the top level. `RECURSIVE`: clean all the fields recursively. 
+- `setClosureCleanerLevel()`. The closure cleaner level is set to `ClosureCleanerLevel.RECURSIVE` by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
+With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer. The settings are:
+`NONE`: disable the closure cleaner completely, `TOP_LEVEL`: clean only the top-level class without recursing into fields, `RECURSIVE`: clean all the fields recursively.
 
 - `getParallelism()` / `setParallelism(int parallelism)` Set the default parallelism for the job.
 

--- a/docs/dev/execution_configuration.zh.md
+++ b/docs/dev/execution_configuration.zh.md
@@ -42,8 +42,9 @@ var executionConfig = env.getConfig
 
 The following configuration options are available: (the default is bold)
 
-- **`enableClosureCleaner()`** / `disableClosureCleaner()`. The closure cleaner is enabled by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
-With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer.
+- `setClosureCleanLevel()`. The closure cleaner level is set to `ClosureCleanerLevel.RECURSIVE` by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
+With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer. The three level
+refers to the different clean action. `NONE`: no clean. `TOP_LEVEL`: clean the top level. `RECURSIVE`: clean all the fields recursively. 
 
 - `getParallelism()` / `setParallelism(int parallelism)` Set the default parallelism for the job.
 

--- a/docs/dev/execution_configuration.zh.md
+++ b/docs/dev/execution_configuration.zh.md
@@ -42,9 +42,9 @@ var executionConfig = env.getConfig
 
 The following configuration options are available: (the default is bold)
 
-- `setClosureCleanLevel()`. The closure cleaner level is set to `ClosureCleanerLevel.RECURSIVE` by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
-With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer. The three level
-refers to the different clean action. `NONE`: no clean. `TOP_LEVEL`: clean the top level. `RECURSIVE`: clean all the fields recursively. 
+- `setClosureCleanerLevel()`. The closure cleaner level is set to `ClosureCleanerLevel.RECURSIVE` by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
+With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer. The settings are:
+`NONE`: disable the closure cleaner completely, `TOP_LEVEL`: clean only the top-level class without recursing into fields, `RECURSIVE`: clean all the fields recursively.
 
 - `getParallelism()` / `setParallelism(int parallelism)` Set the default parallelism for the job.
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraCommitter.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraCommitter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.cassandra;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.streaming.runtime.operators.CheckpointCommitter;
 
@@ -54,7 +55,7 @@ public class CassandraCommitter extends CheckpointCommitter {
 
 	public CassandraCommitter(ClusterBuilder builder) {
 		this.builder = builder;
-		ClosureCleaner.clean(builder, true);
+		ClosureCleaner.clean(builder, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	public CassandraCommitter(ClusterBuilder builder, String keySpace) {

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraRowWriteAheadSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraRowWriteAheadSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.cassandra;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.typeutils.runtime.RowSerializer;
@@ -62,7 +63,7 @@ public class CassandraRowWriteAheadSink extends GenericWriteAheadSink<Row> {
 		super(committer, serializer, UUID.randomUUID().toString().replace("-", "_"));
 		this.insertQuery = insertQuery;
 		this.builder = builder;
-		ClosureCleaner.clean(builder, true);
+		ClosureCleaner.clean(builder, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	public void open() throws Exception {

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.cassandra;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -64,7 +65,7 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 		this.builder = builder;
 		this.config = config;
 		this.failureHandler = Preconditions.checkNotNull(failureHandler);
-		ClosureCleaner.clean(builder, true);
+		ClosureCleaner.clean(builder, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleWriteAheadSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleWriteAheadSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.cassandra;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.tuple.Tuple;
@@ -62,7 +63,7 @@ public class CassandraTupleWriteAheadSink<IN extends Tuple> extends GenericWrite
 		super(committer, serializer, UUID.randomUUID().toString().replace("-", "_"));
 		this.insertQuery = insertQuery;
 		this.builder = builder;
-		ClosureCleaner.clean(builder, true);
+		ClosureCleaner.clean(builder, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	public void open() throws Exception {

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.state.ListState;
@@ -496,7 +497,7 @@ public class FlinkKafkaProducer011<IN>
 		this.kafkaProducersPoolSize = kafkaProducersPoolSize;
 		checkState(kafkaProducersPoolSize > 0, "kafkaProducersPoolSize must be non empty");
 
-		ClosureCleaner.clean(this.flinkKafkaPartitioner, true);
+		ClosureCleaner.clean(this.flinkKafkaPartitioner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 		ClosureCleaner.ensureSerializable(serializationSchema);
 
 		// set the producer configuration properties for kafka record key value serializers.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
@@ -296,7 +297,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 			throw new IllegalStateException("A periodic watermark emitter has already been set.");
 		}
 		try {
-			ClosureCleaner.clean(assigner, true);
+			ClosureCleaner.clean(assigner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 			this.punctuatedWatermarkAssigner = new SerializedValue<>(assigner);
 			return this;
 		} catch (Exception e) {
@@ -331,7 +332,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 			throw new IllegalStateException("A punctuated watermark emitter has already been set.");
 		}
 		try {
-			ClosureCleaner.clean(assigner, true);
+			ClosureCleaner.clean(assigner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 			this.periodicWatermarkAssigner = new SerializedValue<>(assigner);
 			return this;
 		} catch (Exception e) {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.configuration.Configuration;
@@ -143,7 +144,7 @@ public abstract class FlinkKafkaProducerBase<IN> extends RichSinkFunction<IN> im
 		requireNonNull(defaultTopicId, "TopicID not set");
 		requireNonNull(serializationSchema, "serializationSchema not set");
 		requireNonNull(producerConfig, "producerConfig not set");
-		ClosureCleaner.clean(customPartitioner, true);
+		ClosureCleaner.clean(customPartitioner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 		ClosureCleaner.ensureSerializable(serializationSchema);
 
 		this.defaultTopicId = defaultTopicId;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.state.ListState;
@@ -498,7 +499,7 @@ public class FlinkKafkaProducer<IN>
 		this.kafkaProducersPoolSize = kafkaProducersPoolSize;
 		checkState(kafkaProducersPoolSize > 0, "kafkaProducersPoolSize must be non empty");
 
-		ClosureCleaner.clean(this.flinkKafkaPartitioner, true);
+		ClosureCleaner.clean(this.flinkKafkaPartitioner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 		ClosureCleaner.ensureSerializable(serializationSchema);
 
 		// set the producer configuration properties for kafka record key value serializers.

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kinesis;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.state.ListState;
@@ -238,7 +239,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	 */
 	public void setShardAssigner(KinesisShardAssigner shardAssigner) {
 		this.shardAssigner = checkNotNull(shardAssigner, "function can not be null");
-		ClosureCleaner.clean(shardAssigner, true);
+		ClosureCleaner.clean(shardAssigner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	public AssignerWithPeriodicWatermarks<T> getPeriodicWatermarkAssigner() {
@@ -253,7 +254,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	public void setPeriodicWatermarkAssigner(
 		AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner) {
 		this.periodicWatermarkAssigner = periodicWatermarkAssigner;
-		ClosureCleaner.clean(this.periodicWatermarkAssigner, true);
+		ClosureCleaner.clean(this.periodicWatermarkAssigner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	public WatermarkTracker getWatermarkTracker() {
@@ -267,7 +268,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	 */
 	public void setWatermarkTracker(WatermarkTracker watermarkTracker) {
 		this.watermarkTracker = watermarkTracker;
-		ClosureCleaner.clean(this.watermarkTracker, true);
+		ClosureCleaner.clean(this.watermarkTracker, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -90,7 +90,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/** Defines how data exchange happens - batch or pipelined */
 	private ExecutionMode executionMode = ExecutionMode.PIPELINED;
 
-	private ClosureCleanerLevel closureCleanLevel = ClosureCleanerLevel.RECURSIVE;
+	private ClosureCleanerLevel closureCleanerLevel = ClosureCleanerLevel.RECURSIVE;
 
 	private int parallelism = PARALLELISM_DEFAULT;
 
@@ -188,7 +188,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 * User code must be serializable because it needs to be sent to worker nodes.
 	 */
 	public ExecutionConfig enableClosureCleaner() {
-		this.closureCleanLevel = ClosureCleanerLevel.RECURSIVE;
+		this.closureCleanerLevel = ClosureCleanerLevel.RECURSIVE;
 		return this;
 	}
 
@@ -198,7 +198,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 * @see #enableClosureCleaner()
 	 */
 	public ExecutionConfig disableClosureCleaner() {
-		this.closureCleanLevel = ClosureCleanerLevel.NONE;
+		this.closureCleanerLevel = ClosureCleanerLevel.NONE;
 		return this;
 	}
 
@@ -208,28 +208,23 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 * @see #enableClosureCleaner()
 	 */
 	public boolean isClosureCleanerEnabled() {
-		return !(closureCleanLevel == ClosureCleanerLevel.NONE);
+		return !(closureCleanerLevel == ClosureCleanerLevel.NONE);
 	}
 
 	/**
-	 * Sets the level of ClosureCleaner. It has three levels:
-	 * NONE: means disable the clean.
-	 * TOP_LEVEL: means only clean the top level of the class passed by user.
-	 * RECURSIVE: means do the clean recursively with looping over all the needed fields, which is the default clean level.
-	 *
-	 * @param level
-	 * @return
+	 * Configures the closure cleaner. Please see {@link ClosureCleanerLevel} for details on the
+	 * different settings.
 	 */
-	public ExecutionConfig setClosureCleanLevel(ClosureCleanerLevel level) {
-		this.closureCleanLevel = level;
+	public ExecutionConfig setClosureCleanerLevel(ClosureCleanerLevel level) {
+		this.closureCleanerLevel = level;
 		return this;
 	}
 
 	/**
-	 * @return The ClosureClean level.
+	 * Returns the configured {@link ClosureCleanerLevel}.
 	 */
-	public ClosureCleanerLevel getClosureCleanLevel() {
-		return closureCleanLevel;
+	public ClosureCleanerLevel getClosureCleanerLevel() {
+		return closureCleanerLevel;
 	}
 
 	/**
@@ -979,7 +974,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 			return other.canEqual(this) &&
 				Objects.equals(executionMode, other.executionMode) &&
-				closureCleanLevel == other.closureCleanLevel &&
+				closureCleanerLevel == other.closureCleanerLevel &&
 				parallelism == other.parallelism &&
 				((restartStrategyConfiguration == null && other.restartStrategyConfiguration == null) ||
 					(null != restartStrategyConfiguration && restartStrategyConfiguration.equals(other.restartStrategyConfiguration))) &&
@@ -1009,7 +1004,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	public int hashCode() {
 		return Objects.hash(
 			executionMode,
-			closureCleanLevel,
+				closureCleanerLevel,
 			parallelism,
 			restartStrategyConfiguration,
 			forceKryo,
@@ -1078,21 +1073,21 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	}
 
 	/**
-	 * The clean level determines whether need to clean or whether need to clean recursively.
+	 * Configuration settings for the closure cleaner.
 	 */
 	public enum ClosureCleanerLevel {
 		/**
-		 * 	Do not perform clean for closure function.
+		 * Disable the closure cleaner completely.
 		 */
 		NONE,
 
 		/**
-		 * Just clean the top level the closure function.
+		 * Clean only the top-level class without recursing into fields.
 		 */
 		TOP_LEVEL,
 
 		/**
-		 * Try to clean the closure function recursively.
+		 * Clean all the fields recursively.
 		 */
 		RECURSIVE
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -27,11 +28,15 @@ import org.apache.flink.shaded.asm6.org.objectweb.asm.ClassVisitor;
 import org.apache.flink.shaded.asm6.org.objectweb.asm.MethodVisitor;
 import org.apache.flink.shaded.asm6.org.objectweb.asm.Opcodes;
 
+import org.apache.commons.lang3.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Externalizable;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 /**
  * The closure cleaner is a utility that tries to truncate the closure (enclosing instance)
@@ -49,6 +54,7 @@ public class ClosureCleaner {
 	 * class.
 	 *
 	 * @param func The object whose closure should be cleaned.
+	 * @param level the clean up level.
 	 * @param checkSerializable Flag to indicate whether serializability should be checked after
 	 *                          the closure cleaning attempt.
 	 *
@@ -58,12 +64,20 @@ public class ClosureCleaner {
 	 * @throws RuntimeException A RuntimeException may be thrown, if the code of the class could not
 	 *                          be loaded, in order to process during the closure cleaning.
 	 */
-	public static void clean(Object func, boolean checkSerializable) {
+	public static void clean(Object func, ExecutionConfig.ClosureCleanerLevel level, boolean checkSerializable) {
 		if (func == null) {
 			return;
 		}
 
 		final Class<?> cls = func.getClass();
+
+		if (ClassUtils.isPrimitiveOrWrapper(cls)) {
+			return;
+		}
+
+		if (usesCustomSerialization(cls)) {
+			return;
+		}
 
 		// First find the field name of the "this$0" field, this can
 		// be "this$x" depending on the nesting
@@ -73,6 +87,33 @@ public class ClosureCleaner {
 			if (f.getName().startsWith("this$")) {
 				// found a closure referencing field - now try to clean
 				closureAccessed |= cleanThis0(func, cls, f.getName());
+			} else {
+				Object fieldObject;
+				try {
+					f.setAccessible(true);
+					fieldObject = f.get(func);
+				} catch (IllegalAccessException e) {
+					throw new RuntimeException(String.format("Can not access to the %s field in Class %s", f.getName(), func.getClass()));
+				}
+
+				/*
+				 * we should do a deep clean when we encounter an anonymous class, inner class and local class, but should
+				 * skip the class with custom serialize method.
+				 *
+				 * There are five kinds of classes (or interfaces):
+				 * a) Top level classes
+				 * b) Nested classes (static member classes)
+				 * c) Inner classes (non-static member classes)
+				 * d) Local classes (named classes declared within a method)
+				 * e) Anonymous classes
+				 */
+				if (level == ExecutionConfig.ClosureCleanerLevel.RECURSIVE && needsRecursion(f, fieldObject)) {
+					if (LOG.isDebugEnabled()) {
+						LOG.debug("Dig to clean the {}", fieldObject.getClass().getName());
+					}
+
+					clean(fieldObject, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+				}
 			}
 		}
 
@@ -99,6 +140,21 @@ public class ClosureCleaner {
 				throw new InvalidProgramException(msg, e);
 			}
 		}
+	}
+
+	private static boolean needsRecursion(Field f, Object fo) {
+		return (fo != null &&
+				!Modifier.isStatic(f.getModifiers()) &&
+				!Modifier.isTransient(f.getModifiers()));
+	}
+
+	private static boolean usesCustomSerialization(Class<?> cls) {
+		try {
+			cls.getDeclaredMethod("writeObject", ObjectOutputStream.class);
+			return true;
+		} catch (NoSuchMethodException ignored) {}
+
+		return Externalizable.class.isAssignableFrom(cls);
 	}
 
 	public static void ensureSerializable(Object obj) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -183,7 +183,7 @@ public abstract class DataSet<T> {
 
 	public <F> F clean(F f) {
 		if (getExecutionEnvironment().getConfig().isClosureCleanerEnabled()) {
-			ClosureCleaner.clean(f, getExecutionEnvironment().getConfig().getClosureCleanLevel(), true);
+			ClosureCleaner.clean(f, getExecutionEnvironment().getConfig().getClosureCleanerLevel(), true);
 		} else {
 			ClosureCleaner.ensureSerializable(f);
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -183,7 +183,7 @@ public abstract class DataSet<T> {
 
 	public <F> F clean(F f) {
 		if (getExecutionEnvironment().getConfig().isClosureCleanerEnabled()) {
-			ClosureCleaner.clean(f, true);
+			ClosureCleaner.clean(f, getExecutionEnvironment().getConfig().getClosureCleanLevel(), true);
 		} else {
 			ClosureCleaner.ensureSerializable(f);
 		}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.cep.pattern;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.aftermatch.AfterMatchSkipStrategy;
@@ -155,7 +156,7 @@ public class Pattern<T, F extends T> {
 	public Pattern<T, F> where(IterativeCondition<F> condition) {
 		Preconditions.checkNotNull(condition, "The condition cannot be null.");
 
-		ClosureCleaner.clean(condition, true);
+		ClosureCleaner.clean(condition, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 		if (this.condition == null) {
 			this.condition = condition;
 		} else {
@@ -177,7 +178,7 @@ public class Pattern<T, F extends T> {
 	public Pattern<T, F> or(IterativeCondition<F> condition) {
 		Preconditions.checkNotNull(condition, "The condition cannot be null.");
 
-		ClosureCleaner.clean(condition, true);
+		ClosureCleaner.clean(condition, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 
 		if (this.condition == null) {
 			this.condition = condition;
@@ -227,7 +228,7 @@ public class Pattern<T, F extends T> {
 			throw new MalformedPatternException("The until condition is only applicable to looping states.");
 		}
 
-		ClosureCleaner.clean(untilCondition, true);
+		ClosureCleaner.clean(untilCondition, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 		this.untilCondition = untilCondition;
 
 		return this;

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
@@ -40,6 +41,7 @@ import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
 
 import org.junit.Test;
 
@@ -883,5 +885,32 @@ public class CEPITCase extends AbstractTestBase {
 		resultList.sort(String::compareTo);
 
 		assertEquals(Arrays.asList("2,2,2", "3,3,3", "42,42,42"), resultList);
+	}
+
+	@Test
+	public void testFlatSelectSerializationWithAnonymousClass() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements = env.fromElements(1, 2, 3);
+		OutputTag<Integer> outputTag = new OutputTag<Integer>("AAA") {};
+		CEP.pattern(elements, Pattern.begin("A")).flatSelect(
+			outputTag,
+			new PatternFlatTimeoutFunction<Integer, Integer>() {
+				@Override
+				public void timeout(
+					Map<String, List<Integer>> pattern,
+					long timeoutTimestamp,
+					Collector<Integer> out) throws Exception {
+
+				}
+			},
+			new PatternFlatSelectFunction<Integer, Object>() {
+				@Override
+				public void flatSelect(Map<String, List<Integer>> pattern, Collector<Object> out) throws Exception {
+
+				}
+			}
+		);
+
+		env.execute();
 	}
 }

--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -311,7 +311,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
 
   private[flink] def clean[F <: AnyRef](f: F, checkSerializable: Boolean = true): F = {
     if (jgraph.getContext.getConfig.isClosureCleanerEnabled) {
-      ClosureCleaner.clean(f, checkSerializable, jgraph.getContext.getConfig.getClosureCleanLevel)
+      ClosureCleaner.clean(f, checkSerializable, jgraph.getContext.getConfig.getClosureCleanerLevel)
     }
     ClosureCleaner.ensureSerializable(f)
     f

--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -311,7 +311,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
 
   private[flink] def clean[F <: AnyRef](f: F, checkSerializable: Boolean = true): F = {
     if (jgraph.getContext.getConfig.isClosureCleanerEnabled) {
-      ClosureCleaner.clean(f, checkSerializable)
+      ClosureCleaner.clean(f, checkSerializable, jgraph.getContext.getConfig.getClosureCleanLevel)
     }
     ClosureCleaner.ensureSerializable(f)
     f

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcGlobalAggregateManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcGlobalAggregateManager.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.taskexecutor.rpc;
 
 import java.io.IOException;
+
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
@@ -36,7 +38,7 @@ public class RpcGlobalAggregateManager implements GlobalAggregateManager {
 	@Override
 	public <IN, ACC, OUT> OUT updateGlobalAggregate(String aggregateName, Object aggregand, AggregateFunction<IN, ACC, OUT> aggregateFunction)
 		throws IOException {
-		ClosureCleaner.clean(aggregateFunction, true);
+		ClosureCleaner.clean(aggregateFunction, ExecutionConfig.ClosureCleanerLevel.RECURSIVE,true);
 		byte[] serializedAggregateFunction = InstantiationUtil.serializeObject(aggregateFunction);
 		Object result = null;
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1558,7 +1558,7 @@ public class JobMasterTest extends TestLogger {
 
 			AggregateFunction<Integer, Integer, Integer> aggregateFunction = createAggregateFunction();
 
-			ClosureCleaner.clean(aggregateFunction, true);
+			ClosureCleaner.clean(aggregateFunction, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 			byte[] serializedAggregateFunction = InstantiationUtil.serializeObject(aggregateFunction);
 
 			updateAggregateFuture = jobMasterGateway.updateGlobalAggregate("agg1", 1, serializedAggregateFunction);

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
@@ -21,6 +21,7 @@ import java.io._
 import java.lang.invoke.SerializedLambda
 
 import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.ExecutionConfig.ClosureCleanerLevel
 import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.util.{FlinkException, InstantiationUtil}
 import org.slf4j.LoggerFactory
@@ -157,12 +158,13 @@ object ClosureCleaner {
    *
    * @param closure the closure to clean
    * @param checkSerializable whether to verify that the closure is serializable after cleaning
-   * @param cleanTransitively whether to clean enclosing closures transitively
+   * @param cleanLevel whether to clean enclosing closures transitively
    */
   def clean(
       closure: AnyRef,
       checkSerializable: Boolean = true,
-      cleanTransitively: Boolean = true): Unit = {
+      cleanLevel: ClosureCleanerLevel = ClosureCleanerLevel.RECURSIVE): Unit = {
+    val cleanTransitively = if (cleanLevel == ClosureCleanerLevel.RECURSIVE) true else false
     clean(closure, checkSerializable, cleanTransitively, Map.empty)
   }
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -122,7 +122,9 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    */
   private[flink] def clean[F <: AnyRef](f: F, checkSerializable: Boolean = true): F = {
     if (set.getExecutionEnvironment.getConfig.isClosureCleanerEnabled) {
-      ClosureCleaner.clean(f, checkSerializable)
+      ClosureCleaner.clean(f,
+        checkSerializable,
+        set.getExecutionEnvironment.getConfig.getClosureCleanLevel)
     }
     ClosureCleaner.ensureSerializable(f)
     f

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -124,7 +124,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     if (set.getExecutionEnvironment.getConfig.isClosureCleanerEnabled) {
       ClosureCleaner.clean(f,
         checkSerializable,
-        set.getExecutionEnvironment.getConfig.getClosureCleanLevel)
+        set.getExecutionEnvironment.getConfig.getClosureCleanerLevel)
     }
     ClosureCleaner.ensureSerializable(f)
     f

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1536,7 +1536,7 @@ public abstract class StreamExecutionEnvironment {
 	@Internal
 	public <F> F clean(F f) {
 		if (getConfig().isClosureCleanerEnabled()) {
-			ClosureCleaner.clean(f, true);
+			ClosureCleaner.clean(f, getConfig().getClosureCleanLevel(), true);
 		}
 		ClosureCleaner.ensureSerializable(f);
 		return f;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1536,7 +1536,7 @@ public abstract class StreamExecutionEnvironment {
 	@Internal
 	public <F> F clean(F f) {
 		if (getConfig().isClosureCleanerEnabled()) {
-			ClosureCleaner.clean(f, getConfig().getClosureCleanLevel(), true);
+			ClosureCleaner.clean(f, getConfig().getClosureCleanerLevel(), true);
 		}
 		ClosureCleaner.ensureSerializable(f);
 		return f;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.ClosureCleaner;
@@ -138,7 +139,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 	public <K> void configureForKeyedStream(
 			KeySelector<IN, K> keySelector,
 			TypeInformation<K> keyType) {
-		ClosureCleaner.clean(keySelector, false);
+		ClosureCleaner.clean(keySelector, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, false);
 		streamConfig.setStatePartitioner(0, keySelector);
 		streamConfig.setStateKeySerializer(keyType.createSerializer(executionConfig));
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedOneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedOneInputStreamOperatorTestHarness.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -43,7 +44,7 @@ public class KeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 			int subtaskIndex) throws Exception {
 		super(operator, maxParallelism, numSubtasks, subtaskIndex);
 
-		ClosureCleaner.clean(keySelector, false);
+		ClosureCleaner.clean(keySelector, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, false);
 		config.setStatePartitioner(0, keySelector);
 		config.setStateKeySerializer(keyType.createSerializer(executionConfig));
 	}
@@ -63,7 +64,7 @@ public class KeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 
 		super(operator, environment);
 
-		ClosureCleaner.clean(keySelector, false);
+		ClosureCleaner.clean(keySelector, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, false);
 		config.setStatePartitioner(0, keySelector);
 		config.setStateKeySerializer(keyType.createSerializer(executionConfig));
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedTwoInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedTwoInputStreamOperatorTestHarness.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -43,8 +44,8 @@ public class KeyedTwoInputStreamOperatorTestHarness<K, IN1, IN2, OUT>
 			int subtaskIndex) throws Exception {
 		super(operator, maxParallelism, numSubtasks, subtaskIndex);
 
-		ClosureCleaner.clean(keySelector1, false);
-		ClosureCleaner.clean(keySelector2, false);
+		ClosureCleaner.clean(keySelector1, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, false);
+		ClosureCleaner.clean(keySelector2, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, false);
 		config.setStatePartitioner(0, keySelector1);
 		config.setStatePartitioner(1, keySelector2);
 		config.setStateKeySerializer(keyType.createSerializer(executionConfig));

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -683,7 +683,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   private[flink] def scalaClean[F <: AnyRef](f: F): F = {
     if (getConfig.isClosureCleanerEnabled) {
-      ClosureCleaner.clean(f, true, getConfig.getClosureCleanLevel)
+      ClosureCleaner.clean(f, true, getConfig.getClosureCleanerLevel)
     } else {
       ClosureCleaner.ensureSerializable(f)
     }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -683,7 +683,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   private[flink] def scalaClean[F <: AnyRef](f: F): F = {
     if (getConfig.isClosureCleanerEnabled) {
-      ClosureCleaner.clean(f, true)
+      ClosureCleaner.clean(f, true, getConfig.getClosureCleanLevel)
     } else {
       ClosureCleaner.ensureSerializable(f)
     }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/WindowOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/window/WindowOperatorBuilder.java
@@ -168,7 +168,7 @@ public class WindowOperatorBuilder {
 			LogicalType[] accumulatorTypes,
 			LogicalType[] aggResultTypes,
 			LogicalType[] windowPropertyTypes) {
-		ClosureCleaner.clean(aggregateFunction, true);
+		ClosureCleaner.clean(aggregateFunction, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 		this.accumulatorTypes = accumulatorTypes;
 		this.aggResultTypes = aggResultTypes;
 		this.windowPropertyTypes = windowPropertyTypes;


### PR DESCRIPTION
## What is the purpose of the change

ClosureCleaner is used to clean the implicit `this$x` point to the outer class in the user defined function to reduce the case of serialization function failed.

But if the function is wrapped by user or the flink framework, it will escape the clean operation. This pr harden the ClosureCleaner to handle this. And I think it is also a feasible approach for [[FLINK-12113]](https://issues.apache.org/jira/browse/FLINK-12113)

## Brief change log

check the field if need to further clean and apply

## Verifying this change

1. Add the case in the issue to confirm
2. Add the wrapFunction test case in ClosuerCleanerTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)