### PR TITLE
[FLINK-12339][example] Fix variable name

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/TopSpeedWindowing.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/TopSpeedWindowing.scala
@@ -101,7 +101,7 @@ object TopSpeedWindowing {
         })
       }
 
-    val topSpeed = cars
+    val topSpeeds = cars
       .assignAscendingTimestamps( _.time )
       .keyBy("carId")
       .window(GlobalWindows.create)
@@ -115,10 +115,10 @@ object TopSpeedWindowing {
       .maxBy("speed")
 
     if (params.has("output")) {
-      topSpeed.writeAsText(params.get("output"))
+      topSpeeds.writeAsText(params.get("output"))
     } else {
       println("Printing result to stdout. Use --output to specify output path.")
-      topSpeed.print()
+      topSpeeds.print()
     }
 
     env.execute("TopSpeedWindowing")

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/TopSpeedWindowing.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/TopSpeedWindowing.scala
@@ -101,7 +101,7 @@ object TopSpeedWindowing {
         })
       }
 
-    val topSeed = cars
+    val topSpeed = cars
       .assignAscendingTimestamps( _.time )
       .keyBy("carId")
       .window(GlobalWindows.create)
@@ -115,10 +115,10 @@ object TopSpeedWindowing {
       .maxBy("speed")
 
     if (params.has("output")) {
-      topSeed.writeAsText(params.get("output"))
+      topSpeed.writeAsText(params.get("output"))
     } else {
       println("Printing result to stdout. Use --output to specify output path.")
-      topSeed.print()
+      topSpeed.print()
     }
 
     env.execute("TopSpeedWindowing")


### PR DESCRIPTION
## What is the purpose of the change

This pull request rename topSeed to topSpeed in TopSpeedWindowing.scala. This variable is correct in this TopSpeedWindowing.java

## Verifying this change

*(Please pick either of the following options)*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no =)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
