### PR TITLE
[hotfix][tests] Replace mock ConsumerRecords with ConsumerRecords.empty

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/HandoverTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/HandoverTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests for the {@link Handover} between Kafka Consumer Thread and the fetcher's main thread.
@@ -285,9 +284,8 @@ public class HandoverTest {
 		producer.sync();
 	}
 
-	@SuppressWarnings("unchecked")
 	private static ConsumerRecords<byte[], byte[]> createTestRecords() {
-		return mock(ConsumerRecords.class);
+		return ConsumerRecords.empty();
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Replace mock `ConsumerRecords` with `ConsumerRecords.empty` in order to reduce usages of mock classes and use a semantically dummy ConsumerRecords.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol @dawidwys 