### PR TITLE
[hotfix][tests] Remove mockito usage in ExecutionGraphTestUtils

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -449,8 +449,6 @@ public class ExecutionGraphTestUtils {
 		return groupVertex;
 	}
 
-	public static final String ERROR_MESSAGE = "test_failure_error_message";
-
 	public static ExecutionJobVertex getExecutionVertex(
 			JobVertexID id, ScheduledExecutorService executor) 
 		throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -27,7 +27,6 @@ import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverRegion;
@@ -38,8 +37,6 @@ import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.instance.SimpleSlot;
-import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -47,7 +44,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
-import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -73,8 +69,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 /**
  * A collection of utility methods for testing the ExecutionGraph and its related classes.
@@ -341,26 +335,6 @@ public class ExecutionGraphTestUtils {
 	}
 
 	// ------------------------------------------------------------------------
-	//  Mocking Slots
-	// ------------------------------------------------------------------------
-
-	public static SimpleSlot createMockSimpleSlot(TaskManagerGateway gateway) {
-		final TaskManagerLocation location = new TaskManagerLocation(
-				ResourceID.generate(), InetAddress.getLoopbackAddress(), 6572);
-
-		final SimpleSlotContext allocatedSlot = new SimpleSlotContext(
-			new AllocationID(),
-			location,
-			0,
-			gateway);
-
-		return new SimpleSlot(
-			allocatedSlot,
-			mock(SlotOwner.class),
-			0);
-	}
-
-	// ------------------------------------------------------------------------
 	//  Mocking ExecutionGraph
 	// ------------------------------------------------------------------------
 
@@ -496,7 +470,7 @@ public class ExecutionGraphTestUtils {
 		throws Exception {
 
 		JobVertex ajv = new JobVertex("TestVertex", id);
-		ajv.setInvokableClass(mock(AbstractInvokable.class).getClass());
+		ajv.setInvokableClass(AbstractInvokable.class);
 
 		ExecutionGraph graph = new ExecutionGraph(
 			executor,
@@ -511,7 +485,7 @@ public class ExecutionGraphTestUtils {
 
 		graph.start(TestingComponentMainThreadExecutorServiceAdapter.forMainThread());
 
-		return spy(new ExecutionJobVertex(graph, ajv, 1, AkkaUtils.getDefaultTimeout()));
+		return new ExecutionJobVertex(graph, ajv, 1, AkkaUtils.getDefaultTimeout());
 	}
 	
 	public static ExecutionJobVertex getExecutionVertex(JobVertexID id) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -222,11 +222,6 @@ public class ExecutionGraphTestUtils {
 		};
 	}
 
-	/**
-	 * Predicate which is true if the given {@link Execution} has a resource assigned.
-	 */
-	static final Predicate<Execution> hasResourceAssigned = (Execution execution) -> execution.getAssignedResource() != null;
-
 	public static Predicate<AccessExecution> isInExecutionState(ExecutionState executionState) {
 		return (AccessExecution execution) -> execution.getState() == executionState;
 	}
@@ -248,15 +243,6 @@ public class ExecutionGraphTestUtils {
 
 		if (System.nanoTime() >= deadline) {
 			throw new TimeoutException();
-		}
-	}
-
-	public static void failExecutionGraph(ExecutionGraph executionGraph, Exception cause) {
-		executionGraph.getAllExecutionVertices().iterator().next().fail(cause);
-		assertEquals(JobStatus.FAILING, executionGraph.getState());
-
-		for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
-			vertex.getCurrentExecutionAttempt().completeCancelling();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.ERROR_MESSAGE;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.getExecutionVertex;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -52,6 +51,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ExecutionVertexDeploymentTest extends TestLogger {
+
+	private static final String ERROR_MESSAGE = "test_failure_error_message";
 
 	@Test
 	public void testDeployCall() {


### PR DESCRIPTION
## What is the purpose of the change

Remove mockito usage in ExecutionGraphTestUtils

... along with code clean up in ExecutionGraphTestUtils

1. remove unused method and field
2. shift down ERROR_MESSAGE to its only referred class

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol @StefanRRichter 