### PR TITLE
[FLINK-12350] [State Backends] RocksDBStateBackendTest doesn't cover the incremental checkpoint code path

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -217,7 +217,9 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 			AbstractStateBackend.getCompressionDecorator(env.getExecutionConfig()),
 			spy(db),
 			defaultCFHandle,
-			new CloseableRegistry()).build();
+			new CloseableRegistry())
+			.setEnableIncrementalCheckpointing(enableIncrementalCheckpointing)
+			.build();
 
 		testState1 = keyedStateBackend.getPartitionedState(
 				VoidNamespace.INSTANCE,
@@ -294,7 +296,9 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 				AbstractStateBackend.getCompressionDecorator(executionConfig),
 				db,
 				defaultCFHandle,
-				new CloseableRegistry()).build();
+				new CloseableRegistry())
+				.setEnableIncrementalCheckpointing(enableIncrementalCheckpointing)
+				.build();
 			ValueStateDescriptor<String> stubState1 =
 				new ValueStateDescriptor<>("StubState-1", StringSerializer.INSTANCE);
 			test.createInternalState(StringSerializer.INSTANCE, stubState1);


### PR DESCRIPTION
## What is the purpose of the change

Fix `RocksDBStateBackendTest` to cover the incremental checkpoint/restore code path.


## Brief change log

Invoke `setEnableIncrementalCheckpointing` before building the rocksdb backend to respect the `enableIncrementalCheckpointing` parameterized field.


## Verifying this change

This change is a fix on existing test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
