### PR TITLE
[FLINK-12356][BuildSystem] Optimise version experssion of flink-shaded-hadoop2(-uber)

### DIFF
--- a/flink-shaded-hadoop/flink-shaded-hadoop2-uber/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2-uber/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<name>flink-shaded-hadoop2-uber</name>
 
 	<packaging>jar</packaging>
-	<version>${hadoop.version}-1.9-SNAPSHOT</version>
+	<version>${hadoop.version}-${parent.version}</version>
 
 	<!--
 		the only dependency of the 'flink-shaded-hadoop2' artifact, out

--- a/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<name>flink-shaded-hadoop2</name>
 
 	<packaging>jar</packaging>
-	<version>${hadoop.version}-1.9-SNAPSHOT</version>
+	<version>${hadoop.version}-${parent.version}</version>
 
 	<dependencies>
 


### PR DESCRIPTION
## What is the purpose of the change

Since the new version scheme for hadoop-based modules, we use version literals in `flink-shaded-hadoop` and `flink-shaded-hadoop2`, and it can be replaced by `${parent.version}` variable for better management.

## Brief change log

- Use `${parent.version}` to replace version literals in version expressions.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
