### PR TITLE
[FLINK-11638][docs-zh] Translate Savepoints page into Chinese

### DIFF
--- a/docs/ops/state/savepoints.zh.md
+++ b/docs/ops/state/savepoints.zh.md
@@ -25,32 +25,22 @@ under the License.
 * toc
 {:toc}
 
-## What is a Savepoint? How is a Savepoint different from a Checkpoint?
+## 什么是 Savepoint ？ Savepoint 与 Checkpoint 有什么不同？
 
-A Savepoint is a consistent image of the execution state of a streaming job, created via Flink's [checkpointing mechanism]({{ site.baseurl }}/internals/stream_checkpointing.html). You can use Savepoints to stop-and-resume, fork,
-or update your Flink jobs. Savepoints consist of two parts: a directory with (typically large) binary files on stable storage (e.g. HDFS, S3, ...) and a (relatively small) meta data file. The files on stable storage represent the net data of the job's execution state
-image. The meta data file of a Savepoint contains (primarily) pointers to all files on stable storage that are part of the Savepoint, in form of absolute paths.
+Savepoint 是依据 Flink [checkpointing 机制]({{ site.baseurl }}/internals/stream_checkpointing.html)所创建的流作业执行状态的一致镜像。 你可以使用 Savepoint 进行 Flink 作业的停止与重启、fork或者更新。 Savepoint 由两部分组成：稳定存储（列入 HDFS，S3，...) 上包含二进制文件的目录（通常很大），和元数据文件（相对较小）。 稳定存储上的文件表示作业执行状态的数据镜像。 Savepoint 的元数据文件以（绝对路径）的形式包含（主要）指向作为 Savepoint 一部分的稳定存储上的所有文件的指针。
 
 <div class="alert alert-warning">
-<strong>Attention:</strong> In order to allow upgrades between programs and Flink versions, it is important to check out the following section about <a href="#assigning-operator-ids">assigning IDs to your operators</a>.
+<strong>注意:</strong> 为了允许程序和 Flink 版本之间的升级，请务必查看以下有关<a href="#assigning-operator-ids">分配算子 ID </a>的部分 。
 </div>
+从概念上讲， Flink 的 Savepoint 与 Checkpoint 的不同之处类似于传统数据库中的备份与恢复日志之间的差异。 Checkpoint 的主要目的是为意外失败的作为提供恢复机制。 Checkpoint 的生命周期由 Flink 管理，即 Flink 创建，管理和删除 Checkpoint - 无需用户交互。 作为一种恢复和定期触发的方法，Checkpoint 实现有两个设计目标：i）轻量级创建和 ii）尽可能快地恢复。 可能会利用某些特定的属性来达到这个，例如， 工作代码在执行尝试之间不会改变。 在用户终止作业后，通常会删除 Checkpoint（除非明确配置为保留的 Checkpoint）。
 
-Conceptually, Flink's Savepoints are different from Checkpoints in a similar way that backups are different from recovery logs in traditional database systems. The primary purpose of Checkpoints is to provide a recovery mechanism in case of
-unexpected job failures. A Checkpoint's lifecycle is managed by Flink, i.e. a Checkpoint is created, owned, and released by Flink - without user interaction. As a method of recovery and being periodically triggered, two main
-design goals for the Checkpoint implementation are i) being as lightweight to create and ii) being as fast to restore from as possible. Optimizations towards those goals can exploit certain properties, e.g. that the job code
-doesn't change between the execution attempts. Checkpoints are usually dropped after the job was terminated by the user (except if explicitly configured as retained Checkpoints).
+ 与此相反、Savepoint 由用户创建，拥有和删除。 他们的用例是计划的，手动备份和恢复。 例如，升级 Flink 版本，调整用户逻辑，改变并行度，以及进行红蓝部署等。 当然，Savepoint 必须在终止工作后继续存在。 从概念上讲，Savepoint 的生成，恢复成本可能更高一些，Savepoint 更多地关注可移植性和对前面提到的作业更改的支持。
 
-In contrast to all this, Savepoints are created, owned, and deleted by the user. Their use-case is for planned, manual backup and resume. For example, this could be an update of your Flink version, changing your job graph,
-changing parallelism, forking a second job like for a red/blue deployment, and so on. Of course, Savepoints must survive job termination. Conceptually, Savepoints can be a bit more expensive to produce and restore and focus
-more on portability and support for the previously mentioned changes to the job.
+除去这些概念上的差异，Checkpoint 和 Savepoint 的当前实现基本上使用相同的代码并生成相同的格式。然而，目前有一个例外，我们可能会在未来引入更多的差异。例外情况是使用 RocksDB 状态后端的增量 Checkpoint。他们使用了一些 RocksDB 内部格式，而不是 Flink 的本机 Savepoint 格式。这使他们成为了与 Savepoint 相比，更轻量级的 Checkpoint 机制的第一个实例。
 
-Those conceptual differences aside, the current implementations of Checkpoints and Savepoints are basically using the same code and produce the same format. However, there is currently one exception from this, and we might
-introduce more differences in the future. The exception are incremental checkpoints with the RocksDB state backend. They are using some RocksDB internal format instead of Flink’s native savepoint format. This makes them the
-first instance of a more lightweight checkpointing mechanism, compared to Savepoints.
+## 分配算子ID
 
-## Assigning Operator IDs
-
-It is **highly recommended** that you adjust your programs as described in this section in order to be able to upgrade your programs in the future. The main required change is to manually specify operator IDs via the **`uid(String)`** method. These IDs are used to scope the state of each operator.
+**强烈建议**你按照本节所述调整你的程序，以便将来能够升级你的程序。主要通过**`uid(String)`**方法手动指定算子 ID 。这些 ID 将用于恢复每个算子的状态。
 
 {% highlight java %}
 DataStream<String> stream = env.
@@ -65,11 +55,11 @@ DataStream<String> stream = env.
   .print(); // Auto-generated ID
 {% endhighlight %}
 
-If you don't specify the IDs manually they will be generated automatically. You can automatically restore from the savepoint as long as these IDs do not change. The generated IDs depend on the structure of your program and are sensitive to program changes. Therefore, it is highly recommended to assign these IDs manually.
+如果不手动指定 ID ，则会自动生成 ID 。只要这些 ID 不变，就可以从 Savepoint 自动恢复。生成的 ID 取决于程序的结构，并且对程序更改很敏感。因此，强烈建议手动分配这些 ID 。
 
-### Savepoint State
+### Savepoint 状态
 
-You can think of a savepoint as holding a map of `Operator ID -> State` for each stateful operator:
+你可以将 Savepoint 想象为为每个有状态的算子保存一个映射“算子 ID  ->状态”:
 
 {% highlight plain %}
 Operator ID | State
@@ -78,160 +68,162 @@ source-id   | State of StatefulSource
 mapper-id   | State of StatefulMapper
 {% endhighlight %}
 
-In the above example, the print sink is stateless and hence not part of the savepoint state. By default, we try to map each entry of the savepoint back to the new program.
+在上面的示例中，print sink 是无状态的，因此不是 Savepoint 状态的一部分。默认情况下，我们尝试将 Savepoint 的每个条目映射回新程序。
 
-## Operations
+## 算子
 
-You can use the [command line client]({{ site.baseurl }}/ops/cli.html#savepoints) to *trigger savepoints*, *cancel a job with a savepoint*, *resume from savepoints*, and *dispose savepoints*.
+你可以使用[命令行客户端]({{site.baseurl}}/zh/ops/cli.html#Savepoint)来*触发 Savepoint*，*触发 Savepoint 并取消作业*，*从 Savepoint*恢复，以及*删除 Savepoint*。
 
-With Flink >= 1.2.0 it is also possible to *resume from savepoints* using the webui.
+从 Flink 1.2.0 开始，还可以使用 webui *从 Savepoint 恢复*。
 
-### Triggering Savepoints
+### 触发 Savepoint
 
-When triggering a savepoint, a new savepoint directory is created where the data as well as the meta data will be stored. The location of this directory can be controlled by [configuring a default target directory](#configuration) or by specifying a custom target directory with the trigger commands (see the [`:targetDirectory` argument](#trigger-a-savepoint)).
+当触发 Savepoint 时，将创建一个新的 Savepoint 目录，其中存储数据和元数据。可以通过[配置默认目标目录](#configuration)或使用触发器命令指定自定义目标目录(参见[`:targetDirectory `参数](#trigger-a-savepoint)来控制该目录的位置。
 
 <div class="alert alert-warning">
-<strong>Attention:</strong> The target directory has to be a location accessible by both the JobManager(s) and TaskManager(s) e.g. a location on a distributed file-system.
+<strong>注意:</strong>目标目录必须是 JobManager(s) 和 TaskManager(s) 都可以访问的位置，例如分布式文件系统上的位置。
 </div>
 
-For example with a `FsStateBackend` or `RocksDBStateBackend`:
+例如，使用 `FsStateBackend`  或 `RocksDBStateBackend` ：
 
 {% highlight shell %}
-# Savepoint target directory
-/savepoints/
+# Savepoint 目标目录
+/Savepoint/
 
-# Savepoint directory
-/savepoints/savepoint-:shortjobid-:savepointid/
+# Savepoint 目录
+/Savepoint/savepoint-:shortjobid-:savepointid/
 
-# Savepoint file contains the checkpoint meta data
-/savepoints/savepoint-:shortjobid-:savepointid/_metadata
+# Savepoint 文件包含 Checkpoint元数据
+/Savepoint/savepoint-:shortjobid-:savepointid/_metadata
 
-# Savepoint state
-/savepoints/savepoint-:shortjobid-:savepointid/...
+# Savepoint 状态
+/Savepoint/savepoint-:shortjobid-:savepointid/...
 {% endhighlight %}
 
 <div class="alert alert-info">
-  <strong>Note:</strong>
-Although it looks as if the savepoints may be moved, it is currently not possible due to absolute paths in the <code>_metadata</code> file.
-Please follow <a href="https://issues.apache.org/jira/browse/FLINK-5778">FLINK-5778</a> for progress on lifting this restriction.
+  <strong>注意:</strong>
+虽然看起来好像可以移动 Savepoint ，但由于<code> _metadata </ code>中保存的是绝对路径，因此暂时不支持。
+请按照<a href="https://issues.apache.org/jira/browse/FLINK-5778"> FLINK-5778 </a>了解取消此限制的进度。
 </div>
-
-Note that if you use the `MemoryStateBackend`, metadata *and* savepoint state will be stored in the `_metadata` file. Since it is self-contained, you may move the file and restore from any location.
+请注意，如果使用 `MemoryStateBackend`，则元数据*和*  Savepoint 状态将存储在`_metadata`文件中。 由于它是自包含的，你可以移动文件并从任何位置恢复。
 
 <div class="alert alert-warning">
-  <strong>Attention:</strong> It is discouraged to move or delete the last savepoint of a running job, because this might interfere with failure-recovery. Savepoints have side-effects on exactly-once sinks, therefore 
-  to ensure exactly-once semantics, if there is no checkpoint after the last savepoint, the savepoint will be used for recovery. 
+  <strong>注意:</strong> 不建议移动或删除正在运行作业的最后一个 Savepoint ，因为这可能会干扰故障恢复。因此，Savepoint 对精确一次的接收器有副作用，为了确保精确一次的语义，如果在最后一个 Savepoint 之后没有 Checkpoint ，那么将使用 Savepoint 进行恢复。
 </div>
 
-#### Trigger a Savepoint
+
+#### 触发 Savepoint
 
 {% highlight shell %}
 $ bin/flink savepoint :jobId [:targetDirectory]
 {% endhighlight %}
 
-This will trigger a savepoint for the job with ID `:jobId`, and returns the path of the created savepoint. You need this path to restore and dispose savepoints.
+这将触发ID为`：jobId`的作业的Savepoint，并返回创建的 Savepoint 的路径。 你需要此路径来还原和部署 Savepoint 。
 
-#### Trigger a Savepoint with YARN
+#### 使用 YARN 触发 Savepoint
 
 {% highlight shell %}
 $ bin/flink savepoint :jobId [:targetDirectory] -yid :yarnAppId
 {% endhighlight %}
 
-This will trigger a savepoint for the job with ID `:jobId` and YARN application ID `:yarnAppId`, and returns the path of the created savepoint.
+这将触发 ID 为`：jobId` 和 YARN 应用程序 ID `：yarnAppId`的作业的 Savepoint，并返回创建的 Savepoint 的路径。
 
-#### Cancel Job with Savepoint
+#### 使用 Savepoint 取消作业
 
 {% highlight shell %}
 $ bin/flink cancel -s [:targetDirectory] :jobId
 {% endhighlight %}
 
-This will atomically trigger a savepoint for the job with ID `:jobid` and cancel the job. Furthermore, you can specify a target file system directory to store the savepoint in.  The directory needs to be accessible by the JobManager(s) and TaskManager(s).
+这将自动触发 ID 为`:jobid` 的作业的 Savepoint，并取消该作业。此外，你可以指定一个目标文件系统目录来存储 Savepoint 。该目录需要被 JobManager(s) 和 TaskManager(s) 访问。
 
-### Resuming from Savepoints
+### 从 Savepoint 恢复
 
 {% highlight shell %}
 $ bin/flink run -s :savepointPath [:runArgs]
 {% endhighlight %}
 
-This submits a job and specifies a savepoint to resume from. You may give a path to either the savepoint's directory or the `_metadata` file.
+这将提交作业并指定要从中恢复的 Savepoint 。 你可以给出 Savepoint 目录或`_metadata`文件的路径。
 
-#### Allowing Non-Restored State
+#### 允许非恢复状态
 
-By default the resume operation will try to map all state of the savepoint back to the program you are restoring with. If you dropped an operator, you can allow to skip state that cannot be mapped to the new program via `--allowNonRestoredState` (short: `-n`) option:
+默认情况下，resume 操作将尝试将 Savepoint 的所有状态映射回你要还原的程序。 如果删除了运算符，则可以通过`--allowNonRestoredState`（short：`-n`）选项跳过无法映射到新程序的状态：
 
 {% highlight shell %}
 $ bin/flink run -s :savepointPath -n [:runArgs]
 {% endhighlight %}
 
-### Disposing Savepoints
+### 删除 Savepoint
 
 {% highlight shell %}
 $ bin/flink savepoint -d :savepointPath
 {% endhighlight %}
 
-This disposes the savepoint stored in `:savepointPath`.
+这将删除存储在`:savepointPath`中的Savepoint。
 
-Note that it is possible to also manually delete a savepoint via regular file system operations without affecting other savepoints or checkpoints (recall that each savepoint is self-contained). Up to Flink 1.2, this was a more tedious task which was performed with the savepoint command above.
+请注意，还可以通过常规文件系统操作手动删除 Savepoint ，而不会影响其他 Savepoint 或 Checkpoint（请记住，每个 Savepoint 都是自包含的）。 在 Flink 1.2 之前，使用上面的 Savepoint 命令执行是一个更乏味的任务。
 
-### Configuration
+### 配置
 
-You can configure a default savepoint target directory via the `state.savepoints.dir` key. When triggering savepoints, this directory will be used to store the savepoint. You can overwrite the default by specifying a custom target directory with the trigger commands (see the [`:targetDirectory` argument](#trigger-a-savepoint)).
+你可以通过 `state.savepoint.dir` 配置 savepoint 的默认目录。 触发 savepoint 时，将使用此目录来存储 savepoint 。 你可以通过使用触发器命令指定自定义目标目录来覆盖缺省值（请参阅[`：targetDirectory` 参数](＃trigger-a-savepoint)）。
+
 
 {% highlight yaml %}
-# Default savepoint target directory
-state.savepoints.dir: hdfs:///flink/savepoints
+# 默认 Savepoint 目标目录
+state.savepoint.dir: hdfs:///flink/savepoint
 {% endhighlight %}
 
-If you neither configure a default nor specify a custom target directory, triggering the savepoint will fail.
+如果既未配置缺省值也未指定自定义目标目录，则触发 Savepoint 将失败。
 
 <div class="alert alert-warning">
-<strong>Attention:</strong> The target directory has to be a location accessible by both the JobManager(s) and TaskManager(s) e.g. a location on a distributed file-system.
+<strong>注意:</strong>目标目录必须是 JobManager(s) 和 TaskManager(s) 可访问的位置，例如，分布式文件系统上的位置。
 </div>
+
 
 ## F.A.Q
 
-### Should I assign IDs to all operators in my job?
+### 我应该为我作业中的所有算子分配 ID 吗?
 
-As a rule of thumb, yes. Strictly speaking, it is sufficient to only assign IDs via the `uid` method to the stateful operators in your job. The savepoint only contains state for these operators and stateless operator are not part of the savepoint.
+根据经验，是的。 严格来说，仅通过 `uid` 方法给有状态算子分配 ID 就足够了。Savepoint 仅包含这些有状态算子的状态，无状态算子不是 Savepoint 的一部分。
 
-In practice, it is recommended to assign it to all operators, because some of Flink's built-in operators like the Window operator are also stateful and it is not obvious which built-in operators are actually stateful and which are not. If you are absolutely certain that an operator is stateless, you can skip the `uid` method.
 
-### What happens if I add a new operator that requires state to my job?
+在实践中，建议给所有算子分配 ID，因为 Flink 的一些内置算子（如 Window 算子）也是有状态的，而内置算子是否有状态并不很明显。 如果你完全确定算子是无状态的，则可以跳过 `uid` 方法。
 
-When you add a new operator to your job it will be initialized without any state. Savepoints contain the state of each stateful operator. Stateless operators are simply not part of the savepoint. The new operator behaves similar to a stateless operator.
 
-### What happens if I delete an operator that has state from my job?
+### 如果我在作业中添加一个需要状态的新算子，会发生什么？
 
-By default, a savepoint restore will try to match all state back to the restored job. If you restore from a savepoint that contains state for an operator that has been deleted, this will therefore fail. 
+当你向作业添加新算子时，它将在没有任何状态的情况下进行初始化。 Savepoint 包含每个有状态算子的状态。 无状态算子根本不是 Savepoint 的一部分。 新算子的行为类似于无状态算子。
 
-You can allow non restored state by setting the `--allowNonRestoredState` (short: `-n`) with the run command:
+### 如果从作业中删除有状态的算子会发生什么?
+
+默认情况下，从 Savepoint 恢复时将尝试将所有状态分配给新作业。如果有状态算子被删除，则无法从 Savepoint 恢复。
+
+
+你可以通过使用 run 命令设置 `——allowNonRestoredState` (简称：`-n` )来允许删除有状态算子:
 
 {% highlight shell %}
 $ bin/flink run -s :savepointPath -n [:runArgs]
 {% endhighlight %}
 
-### What happens if I reorder stateful operators in my job?
+### 如果我在作业中重新排序有状态算子，会发生什么?
 
-If you assigned IDs to these operators, they will be restored as usual.
+如果给这些算子分配了 ID，它们将像往常一样恢复。
 
-If you did not assign IDs, the auto generated IDs of the stateful operators will most likely change after the reordering. This would result in you not being able to restore from a previous savepoint.
+如果没有分配 ID ，则有状态操作符自动生成的 ID 很可能在重新排序后发生更改。这将导致你无法从以前的 Savepoint 恢复。
 
-### What happens if I add or delete or reorder operators that have no state in my job?
+### 如果我添加、删除或重新排序作业中没有状态的算子，会发生什么?
 
-If you assigned IDs to your stateful operators, the stateless operators will not influence the savepoint restore.
+如果将 ID 分配给有状态操作符，则无状态操作符不会影响 Savepoint 恢复。
 
-If you did not assign IDs, the auto generated IDs of the stateful operators will most likely change after the reordering. This would result in you not being able to restore from a previous savepoint.
+如果没有分配 ID ，则有状态操作符自动生成的 ID 很可能在重新排序后发生更改。这将导致你无法从以前的Savepoint 恢复。
 
-### What happens when I change the parallelism of my program when restoring?
+### 当我在恢复时改变程序的并行度时会发生什么?
 
-If the savepoint was triggered with Flink >= 1.2.0 and using no deprecated state API like `Checkpointed`, you can simply restore the program from a savepoint and specify a new parallelism.
+如果 Savepoint 是用 Flink >= 1.2.0触发的，并且没有使用像 `Checkpointed` 这样的不推荐的状态API，那么你可以简单地从 Savepoint 恢复程序并指定新的并行性。
 
-If you are resuming from a savepoint triggered with Flink < 1.2.0 or using now deprecated APIs you first have to migrate your job and savepoint to Flink >= 1.2.0 before being able to change the parallelism. See the [upgrading jobs and Flink versions guide]({{ site.baseurl }}/ops/upgrading.html).
+如果你正在从Flink < 1.2.0触发的 Savepoint 恢复，或者使用现在已经废弃的 api，那么你首先必须将作业和Savepoint 迁移到 Flink >= 1.2.0，然后才能更改并行性。参见[升级作业和Flink版本指南]({{site.baseurl}}/ops/upgrading.html)。
 
-### Can I move the Savepoint files on stable storage?
+### 我可以将 savepoint 文件移动到稳定存储上吗?
 
-The quick answer to this question is currently "no" because the meta data file references the files on stable storage as absolute paths for technical reasons. The longer answer is: if you MUST move the files for some reason there are two
-potential approaches as workaround. First, simpler but potentially more dangerous, you can use an editor to find the old path in the meta data file and replace them with the new path. Second, you can use the class
-SavepointV2Serializer as starting point to programmatically read, manipulate, and rewrite the meta data file with the new paths.
+这个问题的快速答案目前是“否”，因为元数据文件由于技术原因将稳定存储上的文件作为绝对路径引用。 更长的答案是：如果你因某种原因必须移动文件，那么有两个潜在的方法作为解决方法。 首先，更简单但可能更危险，你可以使用编辑器在元数据文件中查找旧路径并将其替换为新路径。 其次，你可以使用这个类 `SavepointV2Serializer`作为以新路径以编程方式读取，操作和重写元数据文件的起点。
 
 {% top %}

--- a/docs/ops/state/savepoints.zh.md
+++ b/docs/ops/state/savepoints.zh.md
@@ -78,7 +78,7 @@ mapper-id   | State of StatefulMapper
 
 ### 触发 Savepoint
 
-当触发 Savepoint 时，将创建一个新的 Savepoint 目录，其中存储数据和元数据。可以通过[配置默认目标目录](#configuration)或使用触发器命令指定自定义目标目录(参见[`:targetDirectory `参数](#trigger-a-savepoint)来控制该目录的位置。
+当触发 Savepoint 时，将创建一个新的 Savepoint 目录，其中存储数据和元数据。可以通过[配置默认目标目录](#configuration)或使用触发器命令指定自定义目标目录(参见[`:targetDirectory`参数](#trigger-a-savepoint)来控制该目录的位置。
 
 <div class="alert alert-warning">
 <strong>注意:</strong>目标目录必须是 JobManager(s) 和 TaskManager(s) 都可以访问的位置，例如分布式文件系统上的位置。
@@ -198,7 +198,7 @@ state.savepoints.dir: hdfs:///flink/savepoints
 默认情况下，从 Savepoint 恢复时将尝试将所有状态分配给新作业。如果有状态算子被删除，则无法从 Savepoint 恢复。
 
 
-你可以通过使用 run 命令设置 `——allowNonRestoredState` (简称：`-n` )来允许删除有状态算子:
+你可以通过使用 run 命令设置 `--allowNonRestoredState` (简称：`-n` )来允许删除有状态算子:
 
 {% highlight shell %}
 $ bin/flink run -s :savepointPath -n [:runArgs]

--- a/docs/ops/state/savepoints.zh.md
+++ b/docs/ops/state/savepoints.zh.md
@@ -27,20 +27,20 @@ under the License.
 
 ## 什么是 Savepoint ？ Savepoint 与 Checkpoint 有什么不同？
 
-Savepoint 是依据 Flink [checkpointing 机制]({{ site.baseurl }}/internals/stream_checkpointing.html)所创建的流作业执行状态的一致镜像。 你可以使用 Savepoint 进行 Flink 作业的停止与重启、fork或者更新。 Savepoint 由两部分组成：稳定存储（列入 HDFS，S3，...) 上包含二进制文件的目录（通常很大），和元数据文件（相对较小）。 稳定存储上的文件表示作业执行状态的数据镜像。 Savepoint 的元数据文件以（绝对路径）的形式包含（主要）指向作为 Savepoint 一部分的稳定存储上的所有文件的指针。
+Savepoint 是依据 Flink [checkpointing 机制]({{ site.baseurl }}/zh/internals/stream_checkpointing.html)所创建的流作业执行状态的一致镜像。 你可以使用 Savepoint 进行 Flink 作业的停止与重启、fork 或者更新。 Savepoint 由两部分组成：稳定存储（列入 HDFS，S3，...) 上包含二进制文件的目录（通常很大），和元数据文件（相对较小）。 稳定存储上的文件表示作业执行状态的数据镜像。 Savepoint 的元数据文件以（绝对路径）的形式包含（主要）指向作为 Savepoint 一部分的稳定存储上的所有文件的指针。
 
 <div class="alert alert-warning">
 <strong>注意:</strong> 为了允许程序和 Flink 版本之间的升级，请务必查看以下有关<a href="#assigning-operator-ids">分配算子 ID </a>的部分 。
 </div>
-从概念上讲， Flink 的 Savepoint 与 Checkpoint 的不同之处类似于传统数据库中的备份与恢复日志之间的差异。 Checkpoint 的主要目的是为意外失败的作为提供恢复机制。 Checkpoint 的生命周期由 Flink 管理，即 Flink 创建，管理和删除 Checkpoint - 无需用户交互。 作为一种恢复和定期触发的方法，Checkpoint 实现有两个设计目标：i）轻量级创建和 ii）尽可能快地恢复。 可能会利用某些特定的属性来达到这个，例如， 工作代码在执行尝试之间不会改变。 在用户终止作业后，通常会删除 Checkpoint（除非明确配置为保留的 Checkpoint）。
+从概念上讲， Flink 的 Savepoint 与 Checkpoint 的不同之处类似于传统数据库中的备份与恢复日志之间的差异。 Checkpoint 的主要目的是为意外失败的作业提供恢复机制。 Checkpoint 的生命周期由 Flink 管理，即 Flink 创建，管理和删除 Checkpoint - 无需用户交互。 作为一种恢复和定期触发的方法，Checkpoint 实现有两个设计目标：i）轻量级创建和 ii）尽可能快地恢复。 可能会利用某些特定的属性来达到这个，例如， 工作代码在执行尝试之间不会改变。 在用户终止作业后，通常会删除 Checkpoint（除非明确配置为保留的 Checkpoint）。
 
- 与此相反、Savepoint 由用户创建，拥有和删除。 他们的用例是计划的，手动备份和恢复。 例如，升级 Flink 版本，调整用户逻辑，改变并行度，以及进行红蓝部署等。 当然，Savepoint 必须在终止工作后继续存在。 从概念上讲，Savepoint 的生成，恢复成本可能更高一些，Savepoint 更多地关注可移植性和对前面提到的作业更改的支持。
+ 与此相反、Savepoint 由用户创建，拥有和删除。 他们的用例是计划的，手动备份和恢复。 例如，升级 Flink 版本，调整用户逻辑，改变并行度，以及进行红蓝部署等。 当然，Savepoint 必须在作业停止后继续存在。 从概念上讲，Savepoint 的生成，恢复成本可能更高一些，Savepoint 更多地关注可移植性和对前面提到的作业更改的支持。
 
 除去这些概念上的差异，Checkpoint 和 Savepoint 的当前实现基本上使用相同的代码并生成相同的格式。然而，目前有一个例外，我们可能会在未来引入更多的差异。例外情况是使用 RocksDB 状态后端的增量 Checkpoint。他们使用了一些 RocksDB 内部格式，而不是 Flink 的本机 Savepoint 格式。这使他们成为了与 Savepoint 相比，更轻量级的 Checkpoint 机制的第一个实例。
 
-## 分配算子ID
+## 分配算子 ID
 
-**强烈建议**你按照本节所述调整你的程序，以便将来能够升级你的程序。主要通过**`uid(String)`**方法手动指定算子 ID 。这些 ID 将用于恢复每个算子的状态。
+**强烈建议**你按照本节所述调整你的程序，以便将来能够升级你的程序。主要通过 **`uid(String)`** 方法手动指定算子 ID 。这些 ID 将用于恢复每个算子的状态。
 
 {% highlight java %}
 DataStream<String> stream = env.
@@ -59,7 +59,7 @@ DataStream<String> stream = env.
 
 ### Savepoint 状态
 
-你可以将 Savepoint 想象为为每个有状态的算子保存一个映射“算子 ID  ->状态”:
+你可以将 Savepoint 想象为每个有状态的算子保存一个映射“算子 ID  ->状态”:
 
 {% highlight plain %}
 Operator ID | State
@@ -72,7 +72,7 @@ mapper-id   | State of StatefulMapper
 
 ## 算子
 
-你可以使用[命令行客户端]({{site.baseurl}}/zh/ops/cli.html#Savepoint)来*触发 Savepoint*，*触发 Savepoint 并取消作业*，*从 Savepoint*恢复，以及*删除 Savepoint*。
+你可以使用[命令行客户端]({{site.baseurl}}/zh/ops/cli.html#Savepoint)来*触发 Savepoint*，*触发 Savepoint 并取消作业*，*从 Savepoint* 恢复，以及*删除 Savepoint*。
 
 从 Flink 1.2.0 开始，还可以使用 webui *从 Savepoint 恢复*。
 
@@ -84,7 +84,7 @@ mapper-id   | State of StatefulMapper
 <strong>注意:</strong>目标目录必须是 JobManager(s) 和 TaskManager(s) 都可以访问的位置，例如分布式文件系统上的位置。
 </div>
 
-例如，使用 `FsStateBackend`  或 `RocksDBStateBackend` ：
+以 `FsStateBackend`  或 `RocksDBStateBackend` 为例：
 
 {% highlight shell %}
 # Savepoint 目标目录
@@ -102,10 +102,10 @@ mapper-id   | State of StatefulMapper
 
 <div class="alert alert-info">
   <strong>注意:</strong>
-虽然看起来好像可以移动 Savepoint ，但由于<code> _metadata </ code>中保存的是绝对路径，因此暂时不支持。
+虽然看起来好像可以移动 Savepoint ，但由于 <code>_metadata </ code> 中保存的是绝对路径，因此暂时不支持。
 请按照<a href="https://issues.apache.org/jira/browse/FLINK-5778"> FLINK-5778 </a>了解取消此限制的进度。
 </div>
-请注意，如果使用 `MemoryStateBackend`，则元数据*和*  Savepoint 状态将存储在`_metadata`文件中。 由于它是自包含的，你可以移动文件并从任何位置恢复。
+请注意，如果使用 `MemoryStateBackend`，则元数据*和*  Savepoint 状态将存储在 `_metadata` 文件中。 由于它是自包含的，你可以移动文件并从任何位置恢复。
 
 <div class="alert alert-warning">
   <strong>注意:</strong> 不建议移动或删除正在运行作业的最后一个 Savepoint ，因为这可能会干扰故障恢复。因此，Savepoint 对精确一次的接收器有副作用，为了确保精确一次的语义，如果在最后一个 Savepoint 之后没有 Checkpoint ，那么将使用 Savepoint 进行恢复。
@@ -118,7 +118,7 @@ mapper-id   | State of StatefulMapper
 $ bin/flink savepoint :jobId [:targetDirectory]
 {% endhighlight %}
 
-这将触发ID为`：jobId`的作业的Savepoint，并返回创建的 Savepoint 的路径。 你需要此路径来还原和部署 Savepoint 。
+这将触发 ID 为 `:jobId` 的作业的 Savepoint，并返回创建的 Savepoint 路径。 你需要此路径来还原和删除 Savepoint 。
 
 #### 使用 YARN 触发 Savepoint
 
@@ -126,7 +126,7 @@ $ bin/flink savepoint :jobId [:targetDirectory]
 $ bin/flink savepoint :jobId [:targetDirectory] -yid :yarnAppId
 {% endhighlight %}
 
-这将触发 ID 为`：jobId` 和 YARN 应用程序 ID `：yarnAppId`的作业的 Savepoint，并返回创建的 Savepoint 的路径。
+这将触发 ID 为 `:jobId` 和 YARN 应用程序 ID `:yarnAppId` 的作业的 Savepoint，并返回创建的 Savepoint 的路径。
 
 #### 使用 Savepoint 取消作业
 
@@ -134,7 +134,7 @@ $ bin/flink savepoint :jobId [:targetDirectory] -yid :yarnAppId
 $ bin/flink cancel -s [:targetDirectory] :jobId
 {% endhighlight %}
 
-这将自动触发 ID 为`:jobid` 的作业的 Savepoint，并取消该作业。此外，你可以指定一个目标文件系统目录来存储 Savepoint 。该目录需要被 JobManager(s) 和 TaskManager(s) 访问。
+这将自动触发 ID 为 `:jobid` 的作业的 Savepoint，并取消该作业。此外，你可以指定一个目标文件系统目录来存储 Savepoint 。该目录需要能被 JobManager(s) 和 TaskManager(s) 访问。
 
 ### 从 Savepoint 恢复
 
@@ -142,11 +142,11 @@ $ bin/flink cancel -s [:targetDirectory] :jobId
 $ bin/flink run -s :savepointPath [:runArgs]
 {% endhighlight %}
 
-这将提交作业并指定要从中恢复的 Savepoint 。 你可以给出 Savepoint 目录或`_metadata`文件的路径。
+这将提交作业并指定要从中恢复的 Savepoint 。 你可以给出 Savepoint 目录或 `_metadata` 文件的路径。
 
-#### 允许非恢复状态
+#### 跳过无法映射的状态恢复
 
-默认情况下，resume 操作将尝试将 Savepoint 的所有状态映射回你要还原的程序。 如果删除了运算符，则可以通过`--allowNonRestoredState`（short：`-n`）选项跳过无法映射到新程序的状态：
+默认情况下，resume 操作将尝试将 Savepoint 的所有状态映射回你要还原的程序。 如果删除了运算符，则可以通过 `--allowNonRestoredState`（short：`-n`）选项跳过无法映射到新程序的状态：
 
 {% highlight shell %}
 $ bin/flink run -s :savepointPath -n [:runArgs]
@@ -158,18 +158,18 @@ $ bin/flink run -s :savepointPath -n [:runArgs]
 $ bin/flink savepoint -d :savepointPath
 {% endhighlight %}
 
-这将删除存储在`:savepointPath`中的Savepoint。
+这将删除存储在 `:savepointPath` 中的 Savepoint。
 
 请注意，还可以通过常规文件系统操作手动删除 Savepoint ，而不会影响其他 Savepoint 或 Checkpoint（请记住，每个 Savepoint 都是自包含的）。 在 Flink 1.2 之前，使用上面的 Savepoint 命令执行是一个更乏味的任务。
 
 ### 配置
 
-你可以通过 `state.savepoint.dir` 配置 savepoint 的默认目录。 触发 savepoint 时，将使用此目录来存储 savepoint 。 你可以通过使用触发器命令指定自定义目标目录来覆盖缺省值（请参阅[`：targetDirectory` 参数](＃trigger-a-savepoint)）。
+你可以通过 `state.savepoint.dir` 配置 savepoint 的默认目录。 触发 savepoint 时，将使用此目录来存储 savepoint。 你可以通过使用触发器命令指定自定义目标目录来覆盖缺省值（请参阅[`：targetDirectory` 参数](＃trigger-a-savepoint)）。
 
 
 {% highlight yaml %}
 # 默认 Savepoint 目标目录
-state.savepoint.dir: hdfs:///flink/savepoint
+state.savepoints.dir: hdfs:///flink/savepoints
 {% endhighlight %}
 
 如果既未配置缺省值也未指定自定义目标目录，则触发 Savepoint 将失败。
@@ -218,9 +218,9 @@ $ bin/flink run -s :savepointPath -n [:runArgs]
 
 ### 当我在恢复时改变程序的并行度时会发生什么?
 
-如果 Savepoint 是用 Flink >= 1.2.0触发的，并且没有使用像 `Checkpointed` 这样的不推荐的状态API，那么你可以简单地从 Savepoint 恢复程序并指定新的并行性。
+如果 Savepoint 是用 Flink >= 1.2.0 触发的，并且没有使用像 `Checkpointed` 这样的不推荐的状态API，那么你可以简单地从 Savepoint 恢复程序并指定新的并行度。
 
-如果你正在从Flink < 1.2.0触发的 Savepoint 恢复，或者使用现在已经废弃的 api，那么你首先必须将作业和Savepoint 迁移到 Flink >= 1.2.0，然后才能更改并行性。参见[升级作业和Flink版本指南]({{site.baseurl}}/ops/upgrading.html)。
+如果你正在从 Flink < 1.2.0 触发的 Savepoint 恢复，或者使用现在已经废弃的 api，那么你首先必须将作业和 Savepoint 迁移到 Flink >= 1.2.0，然后才能更改并行度。参见[升级作业和Flink版本指南]({{site.baseurl}}/zh/ops/upgrading.html)。
 
 ### 我可以将 savepoint 文件移动到稳定存储上吗?
 

--- a/docs/ops/state/savepoints.zh.md
+++ b/docs/ops/state/savepoints.zh.md
@@ -88,22 +88,22 @@ mapper-id   | State of StatefulMapper
 
 {% highlight shell %}
 # Savepoint 目标目录
-/Savepoint/
+/savepoint/
 
 # Savepoint 目录
-/Savepoint/savepoint-:shortjobid-:savepointid/
+/savepoint/savepoint-:shortjobid-:savepointid/
 
 # Savepoint 文件包含 Checkpoint元数据
-/Savepoint/savepoint-:shortjobid-:savepointid/_metadata
+/savepoint/savepoint-:shortjobid-:savepointid/_metadata
 
 # Savepoint 状态
-/Savepoint/savepoint-:shortjobid-:savepointid/...
+/savepoint/savepoint-:shortjobid-:savepointid/...
 {% endhighlight %}
 
 <div class="alert alert-info">
   <strong>注意:</strong>
-虽然看起来好像可以移动 Savepoint ，但由于 <code>_metadata </ code> 中保存的是绝对路径，因此暂时不支持。
-请按照<a href="https://issues.apache.org/jira/browse/FLINK-5778"> FLINK-5778 </a>了解取消此限制的进度。
+虽然看起来好像可以移动 Savepoint ，但由于 <code>_metadata</code> 中保存的是绝对路径，因此暂时不支持。
+请按照<a href="https://issues.apache.org/jira/browse/FLINK-5778">FLINK-5778</a>了解取消此限制的进度。
 </div>
 请注意，如果使用 `MemoryStateBackend`，则元数据*和*  Savepoint 状态将存储在 `_metadata` 文件中。 由于它是自包含的，你可以移动文件并从任何位置恢复。
 


### PR DESCRIPTION
## What is the purpose of the change

*(This pull request to Translate "Savepoints" page into Chinese.)*


## Brief change log

  - *doc locates in flink/docs/ops/state/savepoints.zh.md*


## Verifying this change

*(Please pick either of the following options)*

no change to test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)