### PR TITLE
[FLINK-12357][api-java][hotfix] Remove useless code in TableConfig

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -19,8 +19,6 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.util.Preconditions;
 
 import java.math.MathContext;
@@ -58,11 +56,6 @@ public class TableConfig {
 	 * maximum method length of 64 KB. This setting allows for finer granularity if necessary.
 	 */
 	private Integer maxGeneratedCodeLength = 64000; // just an estimate
-
-	/**
-	 * Defines user-defined configuration.
-	 */
-	private Configuration userDefinedConfig = GlobalConfiguration.loadConfiguration();
 
 	/**
 	 * Returns the timezone for date/time/timestamp conversions.


### PR DESCRIPTION

## What is the purpose of the change

Remove useless code in TableConfig. It was added accidentally in [FLINK-11067](https://issues.apache.org/jira/browse/FLINK-11067).


## Brief change log

  - Remove `userDefinedConfig` in `TableConfig`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
