### PR TITLE
[FLINK-12343] [flink-yarn] add file replication config for yarn configuration

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -79,8 +79,8 @@
         </tr>
         <tr>
             <td><h5>yarn.file-replication</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Number of file replication of each local resource file.</td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Number of file replication of each local resource file. If it is not configured, Flink will use the default replication value in hadoop configuration.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -77,5 +77,10 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>A comma-separated list of tags to apply to the Flink YARN application.</td>
         </tr>
+        <tr>
+            <td><h5>yarn.file-replication</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Number of file replication of each local resource file.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -120,7 +120,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 		YARN_CONFIGURATION.setClass(YarnConfiguration.RM_SCHEDULER, CapacityScheduler.class, ResourceScheduler.class);
 		YARN_CONFIGURATION.set(YarnTestBase.TEST_CLUSTER_NAME_KEY, LOG_DIR);
 		YARN_CONFIGURATION.setInt(YarnConfiguration.NM_PMEM_MB, 4096);
-		startYARNWithConfig(YARN_CONFIGURATION);
+		startYARNWithConfig(YARN_CONFIGURATION, false);
 	}
 
 	@AfterClass

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -63,7 +63,7 @@ public class YARNITCase extends YarnTestBase {
 	@BeforeClass
 	public static void setup() {
 		YARN_CONFIGURATION.set(YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-per-job");
-		startYARNWithConfig(YARN_CONFIGURATION);
+		startYARNWithConfig(YARN_CONFIGURATION, true);
 	}
 
 	@Test
@@ -123,7 +123,7 @@ public class YARNITCase extends YarnTestBase {
 		runTest(() -> {
 			Configuration configuration = new Configuration();
 			configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
-			configuration.setString(YarnConfigOptions.FILE_REPLICATION, "4");
+			configuration.setInteger(YarnConfigOptions.FILE_REPLICATION, 4);
 			final YarnClient yarnClient = getYarnClient();
 
 			try (final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -119,14 +119,14 @@ public class YARNITCase extends YarnTestBase {
 
 					assertThat(jobResult, is(notNullValue()));
 					assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
-					
+
 					final FileSystem fs = FileSystem.get(getYarnConfiguration());
 					String suffix = ".flink/" + applicationId.toString() + "/" + flinkUberjar.getName();
 
 					Path uberJarHDFSPath = new Path(fs.getHomeDirectory(), suffix);
 					FileStatus fsStatus = fs.getFileStatus(uberJarHDFSPath);
 					Assert.assertEquals(5, fsStatus.getReplication());
-					
+
 					Path appPath = uberJarHDFSPath.getParent();
 					FileStatus[] fileStatuses = fs.listStatus(appPath, new PathFilter() {
 						@Override

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -179,7 +179,8 @@ public class YARNITCase extends YarnTestBase {
 						Assert.assertEquals(replication, fileStatus.getReplication());
 					}
 
-					waitApplicationFinishedElseKillIt(applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor);
+					// Longer timeout for testing file replication
+					waitApplicationFinishedElseKillIt(applicationId, Duration.ofSeconds(60), yarnClusterDescriptor);
 				}
 			}
 		});

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -120,7 +120,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		YARN_CONFIGURATION.setInt("yarn.scheduler.capacity.root.default.capacity", 40);
 		YARN_CONFIGURATION.setInt("yarn.scheduler.capacity.root.qa-team.capacity", 60);
 		YARN_CONFIGURATION.set(YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-capacityscheduler");
-		startYARNWithConfig(YARN_CONFIGURATION);
+		startYARNWithConfig(YARN_CONFIGURATION, false);
 
 		restClientExecutor = Executors.newSingleThreadExecutor();
 		restClient = new RestClient(RestClientConfiguration.fromConfiguration(new Configuration()), restClientExecutor);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -69,7 +69,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		YARN_CONFIGURATION.setInt(YarnConfiguration.NM_PMEM_MB, 768);
 		YARN_CONFIGURATION.setInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 512);
 		YARN_CONFIGURATION.set(YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-fifo");
-		startYARNWithConfig(YARN_CONFIGURATION);
+		startYARNWithConfig(YARN_CONFIGURATION, false);
 	}
 
 	@After

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnPrioritySchedulingITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnPrioritySchedulingITCase.java
@@ -42,7 +42,7 @@ public class YarnPrioritySchedulingITCase extends YarnTestBase {
 			isHadoopVersionGreaterThanOrEquals(2, 8));
 
 		YARN_CONFIGURATION.setStrings("yarn.cluster.max-application-priority", "10");
-		startYARNWithConfig(YARN_CONFIGURATION);
+		startYARNWithConfig(YARN_CONFIGURATION, false);
 	}
 
 	@Test

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -740,10 +740,15 @@ public abstract class YarnTestBase extends TestLogger {
 
 			Configuration hdfsConfiguration = new Configuration();
 			hdfsConfiguration.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tmpHDFS.getRoot().getAbsolutePath());
+			// As we need three data nodes, free random ports are needed here
+			hdfsConfiguration.set("dfs.datanode.https.address",	"0.0.0.0:0");
 			if (principal != null && keytab != null) {
 				populateHDFSSecureConfigurations(hdfsConfiguration, principal, keytab);
 			}
-			miniDFSCluster = new MiniDFSCluster.Builder(hdfsConfiguration).numDataNodes(3).build();
+			miniDFSCluster = new MiniDFSCluster
+				.Builder(hdfsConfiguration)
+				.numDataNodes(2)
+				.build();
 			miniDFSCluster.waitClusterUp();
 
 			hdfsConfiguration = miniDFSCluster.getConfiguration(0);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -715,20 +715,7 @@ public abstract class YarnTestBase extends TestLogger {
 			writeYarnSiteConfigXML(conf, targetTestClassesFolder);
 
 			LOG.info("Starting up MiniDFSCluster");
-			if (miniDFSCluster == null) {
-
-				Configuration hdfsConfiguration = new Configuration();
-				hdfsConfiguration.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tmpHDFS.getRoot().getAbsolutePath());
-				if (principal != null && keytab != null) {
-					populateHDFSSecureConfigurations(hdfsConfiguration, principal, keytab);
-				}
-				miniDFSCluster = new MiniDFSCluster.Builder(hdfsConfiguration).numDataNodes(3).build();
-				miniDFSCluster.waitClusterUp();
-
-				hdfsConfiguration = miniDFSCluster.getConfiguration(0);
-				writeHDFSCoreSiteConfigXML(hdfsConfiguration, targetTestClassesFolder);
-				YARN_CONFIGURATION.addResource(hdfsConfiguration);
-			}
+			setMiniDFSCluster(principal, keytab, targetTestClassesFolder);
 
 			map.put("IN_TESTS", "yes we are in tests"); // see YarnClusterDescriptor() for more infos
 			map.put("YARN_CONF_DIR", targetTestClassesFolder.getAbsolutePath());
@@ -746,6 +733,23 @@ public abstract class YarnTestBase extends TestLogger {
 			Assert.fail();
 		}
 
+	}
+
+	private static void setMiniDFSCluster(String principal, String keytab, File targetTestClassesFolder) throws Exception {
+		if (miniDFSCluster == null) {
+
+			Configuration hdfsConfiguration = new Configuration();
+			hdfsConfiguration.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tmpHDFS.getRoot().getAbsolutePath());
+			if (principal != null && keytab != null) {
+				populateHDFSSecureConfigurations(hdfsConfiguration, principal, keytab);
+			}
+			miniDFSCluster = new MiniDFSCluster.Builder(hdfsConfiguration).numDataNodes(3).build();
+			miniDFSCluster.waitClusterUp();
+
+			hdfsConfiguration = miniDFSCluster.getConfiguration(0);
+			writeHDFSCoreSiteConfigXML(hdfsConfiguration, targetTestClassesFolder);
+			YARN_CONFIGURATION.addResource(hdfsConfiguration);
+		}
 	}
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -746,15 +746,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		StringBuilder envShipFileList = new StringBuilder();
 
 		int fileReplication = yarnConfiguration.getInt(DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);
-		if (flinkConfiguration.contains(YarnConfigOptions.FILE_REPLICATION)) {
-			try {
-				final String replication = flinkConfiguration.getString(YarnConfigOptions.FILE_REPLICATION);
-				fileReplication = Integer.parseInt(replication);
-			} catch (NumberFormatException e) {
-				throw new RuntimeException(
-					"The yarn configuration yarn.file-replication has to be a positive integer", e);
-			}
-		}
+		fileReplication = flinkConfiguration.getInteger(YarnConfigOptions.FILE_REPLICATION, fileReplication);
 
 		// upload and register ship files
 		List<String> systemClassPaths = uploadAndRegisterFiles(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -1184,37 +1184,10 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 					public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs) {
 						localPaths.add(new Path(file.toUri()));
 						relativePaths.add(new Path(parentPath.relativize(file).toString()));
-					public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
-						throws IOException {
-						String fileName = file.getFileName().toString();
-						if (!(fileName.startsWith("flink-dist") &&
-								fileName.endsWith("jar"))) {
-
-							java.nio.file.Path relativePath = parentPath.relativize(file);
-
-							String key = relativePath.toString();
-							try {
-								Path remotePath = setupSingleLocalResource(
-									key,
-									fs,
-									appId,
-									new Path(file.toUri()),
-									localResources,
-									targetHomeDir,
-									relativePath.getParent().toString(),
-									replication);
-								remotePaths.add(remotePath);
-								envShipFileList.append(key).append("=")
-									.append(remotePath).append(",");
-
-								// add files to the classpath
-								classPaths.add(key);
-							} catch (URISyntaxException e) {
-								throw new IOException(e);
-							}
-						}
+						return FileVisitResult.CONTINUE;
 					}
-				}
+				});
+			} else {
 				localPaths.add(new Path(shipFile.toURI()));
 				relativePaths.add(new Path(shipFile.getName()));
 			}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -44,13 +44,13 @@ import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.ShutdownHookUtil;
-import org.apache.flink.util.StringUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;
@@ -745,10 +745,10 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		// ship list that enables reuse of resources for task manager containers
 		StringBuilder envShipFileList = new StringBuilder();
 
-		int fileReplication = yarnConfiguration.getInt("dfs.replication", 3);
-		final String replication = flinkConfiguration.getString(YarnConfigOptions.FILE_REPLICATION);
-		if (!StringUtils.isNullOrWhitespaceOnly(replication)) {
+		int fileReplication = yarnConfiguration.getInt(DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);
+		if (flinkConfiguration.contains(YarnConfigOptions.FILE_REPLICATION)) {
 			try {
+				final String replication = flinkConfiguration.getString(YarnConfigOptions.FILE_REPLICATION);
 				fileReplication = Integer.parseInt(replication);
 			} catch (NumberFormatException e) {
 				throw new RuntimeException(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -513,7 +513,8 @@ public final class Utils {
 					appId,
 					new Path(taskManagerConfigFile.toURI()),
 					homeDirPath,
-					"", replication).f1;
+					"",
+					replication).f1;
 
 				log.debug("Prepared local resource for modified yaml: {}", flinkConf);
 			} finally {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.security.TokenCache;
@@ -500,7 +501,7 @@ public final class Utils {
 			log.debug("Writing TaskManager configuration to {}", taskManagerConfigFile.getAbsolutePath());
 			BootstrapTools.writeConfiguration(taskManagerConfig, taskManagerConfigFile);
 
-			final int replication = yarnConfig.getInt("dfs.replication", 3);
+			final int replication = yarnConfig.getInt(DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);
 
 			try {
 				Path homeDirPath = new Path(clientHomeDir);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -501,7 +501,8 @@ public final class Utils {
 			log.debug("Writing TaskManager configuration to {}", taskManagerConfigFile.getAbsolutePath());
 			BootstrapTools.writeConfiguration(taskManagerConfig, taskManagerConfigFile);
 
-			final int replication = yarnConfig.getInt(DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);
+			final int replication = yarnConfig.getInt(DFSConfigKeys.DFS_REPLICATION_KEY,
+				DFSConfigKeys.DFS_REPLICATION_DEFAULT);
 
 			try {
 				Path homeDirPath = new Path(clientHomeDir);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -204,6 +204,17 @@ public class YarnConfigOptions {
 		.defaultValue("")
 		.withDescription("A comma-separated list of tags to apply to the Flink YARN application.");
 
+	/**
+	 * Yarn session client uploads flink jar and user libs to file system (hdfs/s3) as local resource for yarn
+	 * application context. The replication number changes the how many replica of each of these files in hdfs/s3.
+	 * It is useful to accelerate this container bootstrap time, when a Flink application needs more one hundred
+	 * of containers.
+	 */
+	public static final ConfigOption<String> FILE_REPLICATION =
+		key("yarn.file-replication")
+		.noDefaultValue()
+		.withDescription("Number of file replication of each local resource file.");
+
 	// ------------------------------------------------------------------------
 
 	/** This class is not meant to be instantiated. */

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -208,13 +208,12 @@ public class YarnConfigOptions {
 	 * Yarn session client uploads flink jar and user libs to file system (hdfs/s3) as local resource for yarn
 	 * application context. The replication number changes the how many replica of each of these files in hdfs/s3.
 	 * It is useful to accelerate this container bootstrap, when a Flink application needs more than one hundred
-	 * of containers. If yarn.file-replication is configured, Flink will use the default replication value in
-	 * hadoop configuration.
+	 * of containers. If it is configured, Flink will use the default replication value in hadoop configuration.
 	 */
 	public static final ConfigOption<Integer> FILE_REPLICATION =
 		key("yarn.file-replication")
 		.defaultValue(-1)
-		.withDescription("Number of file replication of each local resource file.");
+		.withDescription("Number of file replication of each local resource file. If it is not configured, Flink will use the default replication value in hadoop configuration.");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -208,11 +208,12 @@ public class YarnConfigOptions {
 	 * Yarn session client uploads flink jar and user libs to file system (hdfs/s3) as local resource for yarn
 	 * application context. The replication number changes the how many replica of each of these files in hdfs/s3.
 	 * It is useful to accelerate this container bootstrap, when a Flink application needs more than one hundred
-	 * of containers.
+	 * of containers. If yarn.file-replication is configured, Flink will use the default replication value in
+	 * hadoop configuration.
 	 */
-	public static final ConfigOption<String> FILE_REPLICATION =
+	public static final ConfigOption<Integer> FILE_REPLICATION =
 		key("yarn.file-replication")
-		.noDefaultValue()
+		.defaultValue(-1)
 		.withDescription("Number of file replication of each local resource file.");
 
 	// ------------------------------------------------------------------------

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -207,7 +207,7 @@ public class YarnConfigOptions {
 	/**
 	 * Yarn session client uploads flink jar and user libs to file system (hdfs/s3) as local resource for yarn
 	 * application context. The replication number changes the how many replica of each of these files in hdfs/s3.
-	 * It is useful to accelerate this container bootstrap time, when a Flink application needs more one hundred
+	 * It is useful to accelerate this container bootstrap, when a Flink application needs more than one hundred
 	 * of containers.
 	 */
 	public static final ConfigOption<String> FILE_REPLICATION =

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -186,7 +186,8 @@ public class YarnFileStageTest extends TestLogger {
 				ApplicationId.newInstance(0, 0),
 				remotePaths,
 				localResources,
-				new StringBuilder());
+				new StringBuilder(),
+				3 /* HDFS default replications */);
 
 			assertThat(
 				classpath,


### PR DESCRIPTION
## What is the purpose of the change
This pull request add file replication config for Flink yarn configuration. This is helpful to accelerate the bootstrap time of containers when Flink applications needs 100+ containers by changing the default replication number (such 3 for hdfs).

## Brief change log
  - Add a file-replication in YarnConfigOptions
  - Apply the file-replication  value for each of  application master local resources
  - Apply the default file replication value 3 for task manager local resources


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
