### PR TITLE
[FLINK-12229] [runtime] Implement LazyFromSourcesScheduling Strategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertex.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
+import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
@@ -44,14 +45,18 @@ class DefaultSchedulingExecutionVertex implements SchedulingExecutionVertex {
 
 	private final Supplier<ExecutionState> stateSupplier;
 
+	private final InputDependencyConstraint inputDependencyConstraint;
+
 	DefaultSchedulingExecutionVertex(
 			ExecutionVertexID executionVertexId,
 			List<? extends SchedulingResultPartition> producedPartitions,
-			Supplier<ExecutionState> stateSupplier) {
+			Supplier<ExecutionState> stateSupplier,
+			InputDependencyConstraint constraint) {
 		this.executionVertexId = checkNotNull(executionVertexId);
 		this.consumedPartitions = new ArrayList<>();
 		this.stateSupplier = checkNotNull(stateSupplier);
 		this.producedPartitions = checkNotNull(producedPartitions);
+		this.inputDependencyConstraint = checkNotNull(constraint);
 	}
 
 	@Override
@@ -72,6 +77,11 @@ class DefaultSchedulingExecutionVertex implements SchedulingExecutionVertex {
 	@Override
 	public Collection<SchedulingResultPartition> getProducedResultPartitions() {
 		return Collections.unmodifiableCollection(producedPartitions);
+	}
+
+	@Override
+	public InputDependencyConstraint getInputDependencyConstraint() {
+		return inputDependencyConstraint;
 	}
 
 	<X extends SchedulingResultPartition> void addConsumedPartition(X partition) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/ExecutionGraphToSchedulingTopologyAdapter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/ExecutionGraphToSchedulingTopologyAdapter.java
@@ -109,7 +109,8 @@ public class ExecutionGraphToSchedulingTopologyAdapter implements SchedulingTopo
 		DefaultSchedulingExecutionVertex schedulingVertex = new DefaultSchedulingExecutionVertex(
 			new ExecutionVertexID(vertex.getJobvertexId(), vertex.getParallelSubtaskIndex()),
 			producedPartitions,
-			new ExecutionStateSupplier(vertex));
+			new ExecutionStateSupplier(vertex),
+			vertex.getInputDependencyConstraint());
 
 		producedPartitions.forEach(partition -> partition.setProducer(schedulingVertex));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.api.common.InputDependencyConstraint;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
+import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
+import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.PRODUCING;
+
+/**
+ * A wrapper class for {@link InputDependencyConstraint} checker.
+ */
+public class InputDependencyConstraintChecker {
+	private final SchedulingIntermediateDataSetManager intermediateDataSetManager =
+		new SchedulingIntermediateDataSetManager();
+
+	public boolean check(final SchedulingExecutionVertex schedulingExecutionVertex) {
+		final InputDependencyConstraint inputConstraint = schedulingExecutionVertex.getInputDependencyConstraint();
+		if (schedulingExecutionVertex.getConsumedResultPartitions().isEmpty() || ALL.equals(inputConstraint)) {
+			return checkAll(schedulingExecutionVertex);
+		} else if (ANY.equals(inputConstraint)) {
+			return checkAny(schedulingExecutionVertex);
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	List<SchedulingResultPartition> markSchedulingResultPartitionFinished(SchedulingResultPartition srp) {
+		return intermediateDataSetManager.markSchedulingResultPartitionFinished(srp);
+	}
+
+	void resetSchedulingResultPartition(SchedulingResultPartition srp) {
+		intermediateDataSetManager.resetSchedulingResultPartition(srp);
+	}
+
+	void addSchedulingResultPartition(SchedulingResultPartition srp) {
+		intermediateDataSetManager.addSchedulingResultPartition(srp);
+	}
+
+	private boolean checkAll(final SchedulingExecutionVertex schedulingExecutionVertex) {
+		return schedulingExecutionVertex.getConsumedResultPartitions()
+			.stream()
+			.allMatch(this::partitionConsumable);
+	}
+
+	private boolean checkAny(final SchedulingExecutionVertex schedulingExecutionVertex) {
+		return schedulingExecutionVertex.getConsumedResultPartitions()
+			.stream()
+			.anyMatch(this::partitionConsumable);
+	}
+
+	private boolean partitionConsumable(SchedulingResultPartition partition) {
+		if (BLOCKING.equals(partition.getPartitionType())) {
+			return intermediateDataSetManager.allPartitionsFinished(partition);
+		} else {
+			SchedulingResultPartition.ResultPartitionState state = partition.getState();
+			return PRODUCING.equals(state) || DONE.equals(state);
+		}
+	}
+
+	private static class SchedulingIntermediateDataSetManager {
+
+		private final Map<IntermediateDataSetID, SchedulingIntermediateDataSet> intermediateDataSets = new HashMap<>();
+
+		List<SchedulingResultPartition> markSchedulingResultPartitionFinished(SchedulingResultPartition srp) {
+			SchedulingIntermediateDataSet intermediateDataSet = getSchedulingIntermediateDataSet(srp.getResultId());
+			if (intermediateDataSet.markPartitionFinished(srp.getId())) {
+				return intermediateDataSet.getSchedulingResultPartitions();
+			}
+			return Collections.emptyList();
+		}
+
+		void resetSchedulingResultPartition(SchedulingResultPartition srp) {
+			SchedulingIntermediateDataSet sid = getSchedulingIntermediateDataSet(srp.getResultId());
+			sid.resetPartition(srp.getId());
+		}
+
+		void addSchedulingResultPartition(SchedulingResultPartition srp) {
+			SchedulingIntermediateDataSet sid = getOrCreateSchedulingIntermediateDataSetIfAbsent(srp.getResultId());
+			sid.addSchedulingResultPartition(srp);
+		}
+
+		boolean allPartitionsFinished(SchedulingResultPartition srp) {
+			SchedulingIntermediateDataSet sid = getSchedulingIntermediateDataSet(srp.getResultId());
+			return sid.allPartitionsFinished();
+		}
+
+		private SchedulingIntermediateDataSet getSchedulingIntermediateDataSet(
+				final IntermediateDataSetID intermediateDataSetId) {
+			return getSchedulingIntermediateDataSetInternal(intermediateDataSetId, false);
+		}
+
+		private SchedulingIntermediateDataSet getOrCreateSchedulingIntermediateDataSetIfAbsent(
+				final IntermediateDataSetID intermediateDataSetId) {
+			return getSchedulingIntermediateDataSetInternal(intermediateDataSetId, true);
+		}
+
+		private SchedulingIntermediateDataSet getSchedulingIntermediateDataSetInternal(
+				final IntermediateDataSetID intermediateDataSetId,
+				boolean createIfAbsent) {
+
+			return intermediateDataSets.computeIfAbsent(
+				intermediateDataSetId,
+				(key) -> {
+					if (createIfAbsent) {
+						return new SchedulingIntermediateDataSet();
+					} else {
+						throw new IllegalArgumentException("can not find data set for " + intermediateDataSetId);
+					}
+				});
+		}
+	}
+
+	/**
+	 * Representation of {@link IntermediateDataSet}.
+	 */
+	private static class SchedulingIntermediateDataSet {
+
+		private final List<SchedulingResultPartition> partitions;
+
+		private final Set<IntermediateResultPartitionID> producingPartitionIds;
+
+		SchedulingIntermediateDataSet() {
+			partitions = new ArrayList<>();
+			producingPartitionIds = new HashSet<>();
+		}
+
+		boolean markPartitionFinished(IntermediateResultPartitionID partitionId) {
+			producingPartitionIds.remove(partitionId);
+			return producingPartitionIds.isEmpty();
+		}
+
+		void resetPartition(IntermediateResultPartitionID partitionId) {
+			producingPartitionIds.add(partitionId);
+		}
+
+		boolean allPartitionsFinished() {
+			return producingPartitionIds.isEmpty();
+		}
+
+		void addSchedulingResultPartition(SchedulingResultPartition partition) {
+			partitions.add(partition);
+			producingPartitionIds.add(partition.getId());
+		}
+
+		List<SchedulingResultPartition> getSchedulingResultPartitions() {
+			return Collections.unmodifiableList(partitions);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.scheduler.DeploymentOption;
+import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
+import org.apache.flink.runtime.scheduler.SchedulerOperations;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.apache.flink.runtime.execution.ExecutionState.CREATED;
+import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * {@link SchedulingStrategy} instance for batch job which schedule vertices when input data are ready.
+ */
+public class LazyFromSourcesSchedulingStrategy implements SchedulingStrategy {
+
+	private static final Predicate<SchedulingExecutionVertex> IS_IN_CREATED_EXECUTION_STATE = schedulingExecutionVertex -> CREATED == schedulingExecutionVertex.getState();
+
+	private final SchedulerOperations schedulerOperations;
+
+	private final SchedulingTopology schedulingTopology;
+
+	private final Map<ExecutionVertexID, DeploymentOption> deploymentOptions;
+
+	private final InputDependencyConstraintChecker inputConstraintChecker;
+
+	public LazyFromSourcesSchedulingStrategy(
+			SchedulerOperations schedulerOperations,
+			SchedulingTopology schedulingTopology) {
+
+		this.schedulerOperations = checkNotNull(schedulerOperations);
+		this.schedulingTopology = checkNotNull(schedulingTopology);
+		this.deploymentOptions = new HashMap<>();
+		this.inputConstraintChecker = new InputDependencyConstraintChecker();
+	}
+
+	@Override
+	public void startScheduling() {
+		final DeploymentOption updateOption = new DeploymentOption(true);
+		final DeploymentOption nonUpdateOption = new DeploymentOption(false);
+
+		for (SchedulingExecutionVertex schedulingVertex : schedulingTopology.getVertices()) {
+			DeploymentOption option = nonUpdateOption;
+			for (SchedulingResultPartition srp : schedulingVertex.getProducedResultPartitions()) {
+				if (srp.getPartitionType().isPipelined()) {
+					option = updateOption;
+				}
+				inputConstraintChecker.addSchedulingResultPartition(srp);
+			}
+			deploymentOptions.put(schedulingVertex.getId(), option);
+		}
+
+		allocateSlotsAndDeployExecutionVertexIds(getAllVerticesFromTopology());
+	}
+
+	@Override
+	public void restartTasks(Set<ExecutionVertexID> verticesToRestart) {
+		// increase counter of the dataset first
+		verticesToRestart
+			.stream()
+			.map(this::getSchedulingVertex)
+			.flatMap(vertex -> vertex.getProducedResultPartitions().stream())
+			.forEach(inputConstraintChecker::resetSchedulingResultPartition);
+
+		allocateSlotsAndDeployExecutionVertexIds(verticesToRestart);
+	}
+
+	@Override
+	public void onExecutionStateChange(ExecutionVertexID executionVertexId, ExecutionState executionState) {
+		if (!FINISHED.equals(executionState)) {
+			return;
+		}
+
+		final Set<SchedulingExecutionVertex> verticesToSchedule = getSchedulingVertex(executionVertexId)
+			.getProducedResultPartitions()
+			.stream()
+			.flatMap(partition -> inputConstraintChecker.markSchedulingResultPartitionFinished(partition).stream())
+			.flatMap(partition -> partition.getConsumers().stream())
+			.collect(Collectors.toSet());
+
+		allocateSlotsAndDeployExecutionVertices(verticesToSchedule);
+	}
+
+	@Override
+	public void onPartitionConsumable(ExecutionVertexID executionVertexId, ResultPartitionID resultPartitionId) {
+		final SchedulingResultPartition resultPartition = schedulingTopology
+				.getResultPartition(resultPartitionId.getPartitionId())
+				.orElseThrow(() -> new IllegalStateException("can not find scheduling result partition for "
+						+ resultPartitionId));
+
+		if (!resultPartition.getPartitionType().isPipelined()) {
+			return;
+		}
+
+		final SchedulingExecutionVertex producerVertex = getSchedulingVertex(executionVertexId);
+		if (!producerVertex.getProducedResultPartitions().contains(resultPartition)) {
+			throw new IllegalStateException("partition " + resultPartitionId
+					+ " is not the produced partition of " + executionVertexId);
+		}
+
+		allocateSlotsAndDeployExecutionVertices(resultPartition.getConsumers());
+	}
+
+	private SchedulingExecutionVertex getSchedulingVertex(final ExecutionVertexID executionVertexId) {
+		return schedulingTopology.getVertex(executionVertexId)
+			.orElseThrow(() -> new IllegalStateException("can not find scheduling vertex for " + executionVertexId));
+	}
+
+	private void allocateSlotsAndDeployExecutionVertexIds(Set<ExecutionVertexID> verticesToSchedule) {
+		allocateSlotsAndDeployExecutionVertices(
+			verticesToSchedule
+				.stream()
+				.map(this::getSchedulingVertex)
+				.collect(Collectors.toList()));
+	}
+
+	private void allocateSlotsAndDeployExecutionVertices(final Collection<SchedulingExecutionVertex> schedulingExecutionVertices) {
+		schedulerOperations.allocateSlotsAndDeploy(
+			schedulingExecutionVertices
+				.stream()
+				.filter(isInputConstraintSatisfied().and(IS_IN_CREATED_EXECUTION_STATE))
+				.map(SchedulingExecutionVertex::getId)
+				.map(executionVertexID -> new ExecutionVertexDeploymentOption(
+					executionVertexID,
+					deploymentOptions.get(executionVertexID)))
+				.collect(Collectors.toSet()));
+	}
+
+	private Predicate<SchedulingExecutionVertex> isInputConstraintSatisfied() {
+		return inputConstraintChecker::check;
+	}
+
+	private Set<ExecutionVertexID> getAllVerticesFromTopology() {
+		return StreamSupport
+			.stream(schedulingTopology.getVertices().spliterator(), false)
+			.map(SchedulingExecutionVertex::getId)
+			.collect(Collectors.toSet());
+	}
+
+	/**
+	 * The factory for creating {@link LazyFromSourcesSchedulingStrategy}.
+	 */
+	public static class Factory implements SchedulingStrategyFactory {
+		@Override
+		public SchedulingStrategy createInstance(
+				SchedulerOperations schedulerOperations,
+				SchedulingTopology schedulingTopology,
+				JobGraph jobGraph) {
+			return new LazyFromSourcesSchedulingStrategy(schedulerOperations, schedulingTopology);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingExecutionVertex.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
+import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 
@@ -55,4 +56,11 @@ public interface SchedulingExecutionVertex {
 	 * @return collection of output edges
 	 */
 	Collection<SchedulingResultPartition> getProducedResultPartitions();
+
+	/**
+	 * Get {@link InputDependencyConstraint}.
+	 *
+	 * @return input dependency constraint
+	 */
+	InputDependencyConstraint getInputDependencyConstraint();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertexTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.function.Supplier;
 
+import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 import static org.junit.Assert.assertEquals;
 
@@ -60,12 +61,14 @@ public class DefaultSchedulingExecutionVertexTest extends TestLogger {
 		producerVertex = new DefaultSchedulingExecutionVertex(
 			new ExecutionVertexID(new JobVertexID(), 0),
 			Collections.singletonList(schedulingResultPartition),
-			stateSupplier);
+			stateSupplier,
+			ANY);
 		schedulingResultPartition.setProducer(producerVertex);
 		consumerVertex = new DefaultSchedulingExecutionVertex(
 			new ExecutionVertexID(new JobVertexID(), 0),
 			Collections.emptyList(),
-			stateSupplier);
+			stateSupplier,
+			ANY);
 		consumerVertex.addConsumedPartition(schedulingResultPartition);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingResultPartitionTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.function.Supplier;
 
+import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
 import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.EMPTY;
@@ -60,7 +61,8 @@ public class DefaultSchedulingResultPartitionTest extends TestLogger {
 		DefaultSchedulingExecutionVertex producerVertex = new DefaultSchedulingExecutionVertex(
 			new ExecutionVertexID(new JobVertexID(), 0),
 			Collections.singletonList(resultPartition),
-			stateProvider);
+			stateProvider,
+			ANY);
 		resultPartition.setProducer(producerVertex);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/ExecutionGraphToSchedulingTopologyAdapterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/ExecutionGraphToSchedulingTopologyAdapterTest.java
@@ -183,5 +183,6 @@ public class ExecutionGraphToSchedulingTopologyAdapterTest extends TestLogger {
 		assertEquals(
 			new ExecutionVertexID(originalVertex.getJobvertexId(), originalVertex.getParallelSubtaskIndex()),
 			adaptedVertex.getId());
+		assertEquals(originalVertex.getInputDependencyConstraint(), adaptedVertex.getInputDependencyConstraint());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategyTest.java
@@ -29,8 +29,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.scheduler.strategy.StrategyTestUtil.getExecutionVertexIdsFromDeployOptions;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -110,12 +110,5 @@ public class EagerSchedulingStrategyTest extends TestLogger {
 
 		Collection<ExecutionVertexDeploymentOption> scheduledVertices2 = testingSchedulerOperations.getScheduledVertices().get(1);
 		assertThat(getExecutionVertexIdsFromDeployOptions(scheduledVertices2), containsInAnyOrder(verticesToRestart2.toArray()));
-	}
-
-	private static Collection<ExecutionVertexID> getExecutionVertexIdsFromDeployOptions(
-			Collection<ExecutionVertexDeploymentOption> deploymentOptions) {
-		return deploymentOptions.stream()
-				.map(ExecutionVertexDeploymentOption::getExecutionVertexId)
-				.collect(Collectors.toList());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintCheckerTest.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.api.common.InputDependencyConstraint;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
+import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
+import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.EMPTY;
+import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.PRODUCING;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link InputDependencyConstraintChecker}.
+ */
+public class InputDependencyConstraintCheckerTest extends TestLogger {
+
+	@Test
+	public void testCheckInputVertex() {
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex().finish();
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(Collections.emptyList());
+
+		assertTrue(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckEmptyPipelinedInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withPartitionType(PIPELINED)
+			.withPartitionState(EMPTY)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		assertFalse(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckProducingPipelinedInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withPartitionType(PIPELINED)
+			.withPartitionState(PRODUCING)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		assertTrue(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckDoneBlockingInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withPartitionCntPerDataSet(2)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		for (TestingSchedulingResultPartition srp : partitions) {
+			inputChecker.markSchedulingResultPartitionFinished(srp);
+		}
+
+		assertTrue(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckPartialDoneBlockingInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withPartitionCntPerDataSet(2)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		inputChecker.markSchedulingResultPartitionFinished(partitions.get(0));
+
+		assertFalse(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckResetBlockingInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withPartitionCntPerDataSet(2)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		for (TestingSchedulingResultPartition srp : partitions) {
+			inputChecker.markSchedulingResultPartitionFinished(srp);
+		}
+
+		for (TestingSchedulingResultPartition srp : partitions) {
+			inputChecker.resetSchedulingResultPartition(srp);
+		}
+
+		assertFalse(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckAnyBlockingInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withDataSetCnt(2)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		inputChecker.markSchedulingResultPartitionFinished(partitions.get(0));
+
+		assertTrue(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckAllBlockingInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withDataSetCnt(2)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withInputDependencyConstraint(ALL)
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		for (TestingSchedulingResultPartition srp : partitions) {
+			inputChecker.markSchedulingResultPartitionFinished(srp);
+		}
+
+		assertTrue(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckAllPartialDatasetBlockingInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withDataSetCnt(2)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withInputDependencyConstraint(ALL)
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		inputChecker.markSchedulingResultPartitionFinished(partitions.get(0));
+		assertFalse(inputChecker.check(vertex));
+	}
+
+	@Test
+	public void testCheckAllPartialPartitionBlockingInput() {
+		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
+			.withDataSetCnt(2)
+			.withPartitionCntPerDataSet(2)
+			.finish();
+		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+			.withInputDependencyConstraint(ALL)
+			.withConsumedPartitions(partitions)
+			.finish();
+
+		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
+
+		for (int idx = 0; idx < 3; idx++) {
+			inputChecker.markSchedulingResultPartitionFinished(partitions.get(idx));
+		}
+
+		assertFalse(inputChecker.check(vertex));
+	}
+
+	private static TestingSchedulingExecutionVertexBuilder addSchedulingExecutionVertex() {
+		return new TestingSchedulingExecutionVertexBuilder();
+	}
+
+	private static class TestingSchedulingExecutionVertexBuilder {
+		private static final JobVertexID jobVertexId = new JobVertexID();
+		private InputDependencyConstraint inputDependencyConstraint = ANY;
+		private List<TestingSchedulingResultPartition> partitions = Collections.emptyList();
+
+		TestingSchedulingExecutionVertexBuilder withInputDependencyConstraint(InputDependencyConstraint constraint) {
+			this.inputDependencyConstraint = constraint;
+			return this;
+		}
+
+		TestingSchedulingExecutionVertexBuilder withConsumedPartitions(List<TestingSchedulingResultPartition> partitions) {
+			this.partitions = partitions;
+			return this;
+		}
+
+		TestingSchedulingExecutionVertex finish() {
+			return new TestingSchedulingExecutionVertex(jobVertexId, 0, inputDependencyConstraint, partitions);
+		}
+	}
+
+	private static TestingSchedulingResultPartitionBuilder addResultPartition() {
+		return new TestingSchedulingResultPartitionBuilder();
+	}
+
+	private static InputDependencyConstraintChecker createInputDependencyConstraintChecker(
+		List<TestingSchedulingResultPartition> partitions) {
+
+		InputDependencyConstraintChecker inputChecker = new InputDependencyConstraintChecker();
+		for (SchedulingResultPartition partition : partitions) {
+			inputChecker.addSchedulingResultPartition(partition);
+		}
+		return inputChecker;
+	}
+
+	private static class TestingSchedulingResultPartitionBuilder {
+		private int dataSetCnt = 1;
+		private int partitionCntPerDataSet = 1;
+		private ResultPartitionType partitionType = BLOCKING;
+		private SchedulingResultPartition.ResultPartitionState partitionState = DONE;
+
+		TestingSchedulingResultPartitionBuilder withDataSetCnt(int dataSetCnt) {
+			this.dataSetCnt = dataSetCnt;
+			return this;
+		}
+
+		TestingSchedulingResultPartitionBuilder withPartitionCntPerDataSet(int partitionCnt) {
+			this.partitionCntPerDataSet = partitionCnt;
+			return this;
+		}
+
+		TestingSchedulingResultPartitionBuilder withPartitionType(ResultPartitionType type) {
+			this.partitionType = type;
+			return this;
+		}
+
+		TestingSchedulingResultPartitionBuilder withPartitionState(SchedulingResultPartition.ResultPartitionState state) {
+			this.partitionState = state;
+			return this;
+		}
+
+		List<TestingSchedulingResultPartition> finish() {
+			List<TestingSchedulingResultPartition> partitions = new ArrayList<>(dataSetCnt * partitionCntPerDataSet);
+			for (int dataSetIdx = 0; dataSetIdx < dataSetCnt; dataSetIdx++) {
+				IntermediateDataSetID dataSetId = new IntermediateDataSetID();
+				for (int partitionIdx = 0; partitionIdx < partitionCntPerDataSet; partitionIdx++) {
+					partitions.add(new TestingSchedulingResultPartition(dataSetId, partitionType, partitionState));
+				}
+			}
+
+			return partitions;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
@@ -1,0 +1,382 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.util.TestLogger;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.EMPTY;
+import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.PRODUCING;
+import static org.apache.flink.runtime.scheduler.strategy.StrategyTestUtil.getExecutionVertexIdsFromDeployOptions;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests for {@link LazyFromSourcesSchedulingStrategy}.
+ */
+public class LazyFromSourcesSchedulingStrategyTest extends TestLogger {
+
+	private TestingSchedulerOperations testingSchedulerOperation = new TestingSchedulerOperations();
+
+	/**
+	 * Tests that when start scheduling lazy from sources scheduling strategy will start input vertices in scheduling topology.
+	 */
+	@Test
+	public void testStartScheduling() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices().finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices().finish();
+		testingSchedulingTopology.connectAllToAll(producers, consumers).finish();
+
+		startScheduling(testingSchedulingTopology);
+
+		assertThat(testingSchedulerOperation, hasScheduledVertices(producers));
+	}
+
+	/**
+	 * Tests that when restart tasks will only schedule input ready vertices in given ones.
+	 */
+	@Test
+	public void testRestartBlockingTasks() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices().finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices().finish();
+		testingSchedulingTopology.connectAllToAll(producers, consumers).finish();
+
+		LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		Set<ExecutionVertexID> verticesToRestart = producers.stream().map(TestingSchedulingExecutionVertex::getId)
+			.collect(Collectors.toSet());
+		verticesToRestart.addAll(consumers.stream().map(
+			TestingSchedulingExecutionVertex::getId).collect(Collectors.toSet()));
+
+		schedulingStrategy.restartTasks(verticesToRestart);
+		assertThat(testingSchedulerOperation, hasScheduledVertices(producers));
+	}
+
+	/**
+	 * Tests that when restart tasks will schedule input consumable vertices in given ones.
+	 */
+	@Test
+	public void testRestartConsumableBlockingTasks() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices().finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices().finish();
+		testingSchedulingTopology.connectAllToAll(producers, consumers).finish();
+
+		LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		Set<ExecutionVertexID> verticesToRestart = consumers.stream().map(TestingSchedulingExecutionVertex::getId)
+			.collect(Collectors.toSet());
+
+		for (TestingSchedulingExecutionVertex producer : producers) {
+			schedulingStrategy.onExecutionStateChange(producer.getId(), ExecutionState.FINISHED);
+		}
+
+		schedulingStrategy.restartTasks(verticesToRestart);
+		assertThat(testingSchedulerOperation, hasScheduledVertices(consumers));
+	}
+
+	/**
+	 * Tests that when all the input partitions are ready will start available downstream {@link ResultPartitionType#BLOCKING} vertices.
+	 * vertex#0    vertex#1
+	 *       \     /
+	 *        \   /
+	 *         \ /
+	 *  (BLOCKING, ALL)
+	 *     vertex#2
+	 */
+	@Test
+	public void testRestartBlockingALLExecutionStateChange() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers1 = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> producers2 = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).withInputDependencyConstraint(ALL).finish();
+		testingSchedulingTopology.connectPointwise(producers1, consumers).finish();
+		testingSchedulingTopology.connectPointwise(producers2, consumers).finish();
+
+		final LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		for (TestingSchedulingExecutionVertex producer : producers1) {
+			schedulingStrategy.onExecutionStateChange(producer.getId(), ExecutionState.FINISHED);
+		}
+		for (TestingSchedulingExecutionVertex producer : producers2) {
+			schedulingStrategy.onExecutionStateChange(producer.getId(), ExecutionState.FINISHED);
+		}
+
+		Set<ExecutionVertexID> verticesToRestart = consumers.stream().map(TestingSchedulingExecutionVertex::getId)
+			.collect(Collectors.toSet());
+
+		schedulingStrategy.restartTasks(verticesToRestart);
+		assertThat(testingSchedulerOperation, hasScheduledVertices(consumers));
+	}
+
+	/**
+	 * Tests that when any input dataset finishes will start available downstream {@link ResultPartitionType#BLOCKING} vertices.
+	 * vertex#0    vertex#1
+	 *       \     /
+	 *        \   /
+	 *         \ /
+	 *  (BLOCKING, ANY)
+	 *     vertex#2
+	 */
+	@Test
+	public void testRestartBlockingANYExecutionStateChange() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers1 = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> producers2 = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		testingSchedulingTopology.connectPointwise(producers1, consumers).finish();
+		testingSchedulingTopology.connectPointwise(producers2, consumers).finish();
+
+		final LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		for (TestingSchedulingExecutionVertex producer : producers1) {
+			schedulingStrategy.onExecutionStateChange(producer.getId(), ExecutionState.FINISHED);
+		}
+
+		Set<ExecutionVertexID> verticesToRestart = consumers.stream().map(TestingSchedulingExecutionVertex::getId)
+			.collect(Collectors.toSet());
+
+		schedulingStrategy.restartTasks(verticesToRestart);
+		assertThat(testingSchedulerOperation, hasScheduledVertices(consumers));
+	}
+
+	/**
+	 * Tests that when restart {@link ResultPartitionType#PIPELINED} tasks with {@link SchedulingResultPartition.ResultPartitionState#PRODUCING} will be scheduled.
+	 */
+	@Test
+	public void testRestartProducingPipelinedTasks() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		testingSchedulingTopology.connectAllToAll(producers, consumers).withResultPartitionState(PRODUCING)
+			.withResultPartitionType(PIPELINED).finish();
+
+		LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		Set<ExecutionVertexID> verticesToRestart = producers.stream().map(TestingSchedulingExecutionVertex::getId)
+			.collect(Collectors.toSet());
+		verticesToRestart.addAll(consumers.stream().map(
+			TestingSchedulingExecutionVertex::getId).collect(Collectors.toSet()));
+
+		schedulingStrategy.restartTasks(verticesToRestart);
+		List<TestingSchedulingExecutionVertex> toScheduleVertices = new ArrayList<>(producers.size() + consumers.size());
+		toScheduleVertices.addAll(consumers);
+		toScheduleVertices.addAll(producers);
+		assertThat(testingSchedulerOperation, hasScheduledVertices(toScheduleVertices));
+	}
+
+	/**
+	 * Tests that when restart {@link ResultPartitionType#PIPELINED} tasks with {@link SchedulingResultPartition.ResultPartitionState#EMPTY} will not be scheduled.
+	 */
+	@Test
+	public void testRestartEmptyPipelinedTasks() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		testingSchedulingTopology.connectAllToAll(producers, consumers).withResultPartitionState(EMPTY)
+			.withResultPartitionType(PIPELINED).finish();
+
+		LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		Set<ExecutionVertexID> verticesToRestart = producers.stream().map(TestingSchedulingExecutionVertex::getId)
+			.collect(Collectors.toSet());
+		verticesToRestart.addAll(consumers.stream().map(
+			TestingSchedulingExecutionVertex::getId).collect(Collectors.toSet()));
+
+		schedulingStrategy.restartTasks(verticesToRestart);
+		assertThat(testingSchedulerOperation, hasScheduledVertices(producers));
+	}
+
+	/**
+	 * Tests that when partition consumable notified will start available {@link ResultPartitionType#PIPELINED} downstream vertices.
+	 */
+	@Test
+	public void testPipelinedPartitionConsumable() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		testingSchedulingTopology.connectAllToAll(producers, consumers).withResultPartitionType(PIPELINED).finish();
+
+		final LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		final TestingSchedulingExecutionVertex producer1 = producers.get(0);
+		final SchedulingResultPartition partition1 = producer1.getProducedResultPartitions().iterator().next();
+
+		schedulingStrategy.onExecutionStateChange(producer1.getId(), ExecutionState.RUNNING);
+		schedulingStrategy.onPartitionConsumable(producer1.getId(), new ResultPartitionID(partition1.getId(), new ExecutionAttemptID()));
+
+		assertThat(testingSchedulerOperation, hasScheduledVertices(consumers));
+	}
+
+	/**
+	 * Tests that when partition consumable notified will start available {@link ResultPartitionType#BLOCKING} downstream vertices.
+	 */
+	@Test
+	public void testBlockingPointwiseExecutionStateChange() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).withInputDependencyConstraint(ALL).finish();
+		testingSchedulingTopology.connectPointwise(producers, consumers).finish();
+
+		final LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		for (TestingSchedulingExecutionVertex producer : producers) {
+			schedulingStrategy.onExecutionStateChange(producer.getId(), ExecutionState.FINISHED);
+		}
+
+		assertThat(testingSchedulerOperation, hasScheduledVertices(consumers));
+	}
+
+	/**
+	 * Tests that when all the input partitions are ready will start available downstream {@link ResultPartitionType#BLOCKING} vertices.
+	 * vertex#0    vertex#1
+	 *       \     /
+	 *        \   /
+	 *         \ /
+	 *  (BLOCKING, ALL)
+	 *     vertex#2
+	 */
+	@Test
+	public void testBlockingALLExecutionStateChange() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers1 = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> producers2 = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).withInputDependencyConstraint(ALL).finish();
+		testingSchedulingTopology.connectPointwise(producers1, consumers).finish();
+		testingSchedulingTopology.connectPointwise(producers2, consumers).finish();
+
+		final LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		for (TestingSchedulingExecutionVertex producer : producers1) {
+			schedulingStrategy.onExecutionStateChange(producer.getId(), ExecutionState.FINISHED);
+		}
+		for (TestingSchedulingExecutionVertex producer : producers2) {
+			schedulingStrategy.onExecutionStateChange(producer.getId(), ExecutionState.FINISHED);
+		}
+
+		assertThat(testingSchedulerOperation, hasScheduledVertices(consumers));
+	}
+
+	/**
+	 * Tests that when any input dataset finishes will start available downstream {@link ResultPartitionType#BLOCKING} vertices.
+	 * vertex#0    vertex#1
+	 *       \     /
+	 *        \   /
+	 *         \ /
+	 *  (BLOCKING, ANY)
+	 *     vertex#2
+	 */
+	@Test
+	public void testBlockingANYExecutionStateChange() {
+		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> producers1 = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> producers2 = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
+			.withParallelism(2).finish();
+		testingSchedulingTopology.connectPointwise(producers1, consumers).finish();
+		testingSchedulingTopology.connectPointwise(producers2, consumers).finish();
+
+		final LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
+
+		for (TestingSchedulingExecutionVertex producer : producers1) {
+			schedulingStrategy.onExecutionStateChange(producer.getId(), ExecutionState.FINISHED);
+		}
+
+		assertThat(testingSchedulerOperation, hasScheduledVertices(consumers));
+	}
+
+	private static Matcher<TestingSchedulerOperations> hasScheduledVertices(final List<TestingSchedulingExecutionVertex> consumers) {
+
+		final Matcher<Iterable<? extends ExecutionVertexID>> vertexIdMatcher = containsInAnyOrder(consumers.stream()
+			.map(SchedulingExecutionVertex::getId)
+			.toArray(ExecutionVertexID[]::new));
+
+		return new TypeSafeDiagnosingMatcher<TestingSchedulerOperations>() {
+
+			@Override
+			protected boolean matchesSafely(final TestingSchedulerOperations item, final Description mismatchDescription) {
+				final boolean matches = vertexIdMatcher.matches(getExecutionVertexIdsFromDeployOptions(item.getLatestScheduledVertices()));
+				if (!matches) {
+					vertexIdMatcher.describeMismatch(item.getLatestScheduledVertices(), mismatchDescription);
+				}
+				return matches;
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("to be scheduled vertex id is ").appendDescriptionOf(vertexIdMatcher);
+			}
+		};
+	}
+
+	private LazyFromSourcesSchedulingStrategy startScheduling(TestingSchedulingTopology testingSchedulingTopology) {
+		LazyFromSourcesSchedulingStrategy schedulingStrategy = new LazyFromSourcesSchedulingStrategy(
+			testingSchedulerOperation,
+			testingSchedulingTopology);
+		schedulingStrategy.startScheduling();
+		return schedulingStrategy;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/StrategyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/StrategyTestUtil.java
@@ -19,30 +19,20 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
-import org.apache.flink.runtime.scheduler.SchedulerOperations;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.stream.Collectors;
 
 /**
- * A Simple scheduler operation for testing purposes.
+ * Strategy test utilities.
  */
-public class TestingSchedulerOperations implements SchedulerOperations {
+public class StrategyTestUtil {
 
-	private final List<Collection<ExecutionVertexDeploymentOption>> scheduledVertices = new ArrayList<>();
+	static Collection<ExecutionVertexID> getExecutionVertexIdsFromDeployOptions(
+		Collection<ExecutionVertexDeploymentOption> deploymentOptions) {
 
-	@Override
-	public void allocateSlotsAndDeploy(Collection<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
-		scheduledVertices.add(executionVertexDeploymentOptions);
-	}
-
-	List<Collection<ExecutionVertexDeploymentOption>> getScheduledVertices() {
-		return Collections.unmodifiableList(scheduledVertices);
-	}
-
-	Collection<ExecutionVertexDeploymentOption> getLatestScheduledVertices() {
-		return Collections.unmodifiableCollection(scheduledVertices.get(scheduledVertices.size() - 1));
+		return deploymentOptions.stream()
+			.map(ExecutionVertexDeploymentOption::getExecutionVertexId)
+			.collect(Collectors.toList());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -18,11 +18,15 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
+import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A simple scheduling execution vertex for testing purposes.
@@ -31,8 +35,32 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	private final ExecutionVertexID executionVertexId;
 
+	private final Collection<TestingSchedulingResultPartition> consumedPartitions;
+
+	private final Collection<SchedulingResultPartition> producedPartitions;
+
+	private InputDependencyConstraint inputDependencyConstraint;
+
 	public TestingSchedulingExecutionVertex(JobVertexID jobVertexId, int subtaskIndex) {
+		this(jobVertexId, subtaskIndex, InputDependencyConstraint.ANY);
+	}
+
+	public TestingSchedulingExecutionVertex(JobVertexID jobVertexId, int subtaskIndex,
+		InputDependencyConstraint constraint) {
+
+		this(jobVertexId, subtaskIndex, constraint, new ArrayList<>());
+	}
+
+	public TestingSchedulingExecutionVertex(
+		JobVertexID jobVertexId,
+		int subtaskIndex,
+		InputDependencyConstraint constraint,
+		Collection<TestingSchedulingResultPartition> consumedPartitions) {
+
 		this.executionVertexId = new ExecutionVertexID(jobVertexId, subtaskIndex);
+		this.inputDependencyConstraint = constraint;
+		this.consumedPartitions = checkNotNull(consumedPartitions);
+		this.producedPartitions = new ArrayList<>();
 	}
 
 	@Override
@@ -47,11 +75,24 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	@Override
 	public Collection<SchedulingResultPartition> getConsumedResultPartitions() {
-		return Collections.emptyList();
+		return Collections.unmodifiableCollection(consumedPartitions);
 	}
 
 	@Override
 	public Collection<SchedulingResultPartition> getProducedResultPartitions() {
-		return Collections.emptyList();
+		return Collections.unmodifiableCollection(producedPartitions);
+	}
+
+	@Override
+	public InputDependencyConstraint getInputDependencyConstraint() {
+		return inputDependencyConstraint;
+	}
+
+	void addConsumedPartition(TestingSchedulingResultPartition partition) {
+		consumedPartitions.add(partition);
+	}
+
+	void addProducedPartition(SchedulingResultPartition partition) {
+		producedPartitions.add(partition);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A simple implementation of {@link SchedulingResultPartition} for testing.
+ */
+public class TestingSchedulingResultPartition implements SchedulingResultPartition {
+	private final IntermediateDataSetID intermediateDataSetID;
+
+	private final IntermediateResultPartitionID intermediateResultPartitionID;
+
+	private final ResultPartitionType partitionType;
+
+	private SchedulingExecutionVertex producer;
+
+	private Collection<SchedulingExecutionVertex> consumers;
+
+	private ResultPartitionState state;
+
+	TestingSchedulingResultPartition(IntermediateDataSetID dataSetID, ResultPartitionType type, ResultPartitionState state) {
+		this.intermediateDataSetID = dataSetID;
+		this.partitionType = type;
+		this.state = state;
+		this.intermediateResultPartitionID = new IntermediateResultPartitionID();
+		this.consumers = new ArrayList<>();
+	}
+
+	@Override
+	public IntermediateResultPartitionID getId() {
+		return intermediateResultPartitionID;
+	}
+
+	@Override
+	public IntermediateDataSetID getResultId() {
+		return intermediateDataSetID;
+	}
+
+	@Override
+	public ResultPartitionType getPartitionType() {
+		return partitionType;
+	}
+
+	@Override
+	public ResultPartitionState getState() {
+		return state;
+	}
+
+	@Override
+	public SchedulingExecutionVertex getProducer() {
+		return producer;
+	}
+
+	@Override
+	public Collection<SchedulingExecutionVertex> getConsumers() {
+		return Collections.unmodifiableCollection(consumers);
+	}
+
+	void addConsumer(SchedulingExecutionVertex consumer) {
+		this.consumers.add(consumer);
+	}
+
+	void setProducer(TestingSchedulingExecutionVertex producer) {
+		this.producer = checkNotNull(producer);
+	}
+
+	/**
+	 * Builder for {@link TestingSchedulingResultPartition}.
+	 */
+	public static final class Builder {
+		private IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
+		private ResultPartitionType resultPartitionType = ResultPartitionType.BLOCKING;
+		private ResultPartitionState resultPartitionState = ResultPartitionState.DONE;
+
+		Builder withIntermediateDataSetID(IntermediateDataSetID intermediateDataSetId) {
+			this.intermediateDataSetId = intermediateDataSetId;
+			return this;
+		}
+
+		Builder withResultPartitionState(ResultPartitionState state) {
+			this.resultPartitionState = state;
+			return this;
+		}
+
+		Builder withResultPartitionType(ResultPartitionType type) {
+			this.resultPartitionType = type;
+			return this;
+		}
+
+		TestingSchedulingResultPartition build() {
+			return new TestingSchedulingResultPartition(intermediateDataSetId, resultPartitionType, resultPartitionState);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -18,13 +18,23 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
+import org.apache.flink.api.common.InputDependencyConstraint;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.Preconditions;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
 
 /**
  * A simple scheduling topology for testing purposes.
@@ -48,10 +58,10 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 	@Override
 	public Optional<SchedulingResultPartition> getResultPartition(
 			IntermediateResultPartitionID intermediateResultPartitionId) {
-		return Optional.ofNullable(schedulingResultPartitions.get(intermediateResultPartitionId));
+		return Optional.of(schedulingResultPartitions.get(intermediateResultPartitionId));
 	}
 
-	public void addSchedulingExecutionVertex(SchedulingExecutionVertex schedulingExecutionVertex) {
+	void addSchedulingExecutionVertex(SchedulingExecutionVertex schedulingExecutionVertex) {
 		schedulingExecutionVertices.put(schedulingExecutionVertex.getId(), schedulingExecutionVertex);
 		addSchedulingResultPartitions(schedulingExecutionVertex.getConsumedResultPartitions());
 		addSchedulingResultPartitions(schedulingExecutionVertex.getProducedResultPartitions());
@@ -60,6 +70,184 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 	private void addSchedulingResultPartitions(final Collection<SchedulingResultPartition> resultPartitions) {
 		for (SchedulingResultPartition schedulingResultPartition : resultPartitions) {
 			schedulingResultPartitions.put(schedulingResultPartition.getId(), schedulingResultPartition);
+		}
+	}
+
+	private void addSchedulingExecutionVertices(List<TestingSchedulingExecutionVertex> vertices) {
+		for (TestingSchedulingExecutionVertex vertex : vertices) {
+			addSchedulingExecutionVertex(vertex);
+		}
+	}
+
+	SchedulingExecutionVerticesBuilder addExecutionVertices() {
+		return new SchedulingExecutionVerticesBuilder();
+	}
+
+	ProducerConsumerConnectionBuilder connectPointwise(
+		final List<TestingSchedulingExecutionVertex> producers,
+		final List<TestingSchedulingExecutionVertex> consumers) {
+
+		return new ProducerConsumerPointwiseConnectionBuilder(producers, consumers);
+	}
+
+	ProducerConsumerConnectionBuilder connectAllToAll(
+		final List<TestingSchedulingExecutionVertex> producers,
+		final List<TestingSchedulingExecutionVertex> consumers) {
+
+		return new ProducerConsumerAllToAllConnectionBuilder(producers, consumers);
+	}
+
+	/**
+	 * Builder for {@link TestingSchedulingResultPartition}.
+	 */
+	public abstract class ProducerConsumerConnectionBuilder {
+
+		protected final List<TestingSchedulingExecutionVertex> producers;
+
+		protected final List<TestingSchedulingExecutionVertex> consumers;
+
+		protected ResultPartitionType resultPartitionType = ResultPartitionType.BLOCKING;
+
+		protected SchedulingResultPartition.ResultPartitionState resultPartitionState = DONE;
+
+		protected ProducerConsumerConnectionBuilder(
+			final List<TestingSchedulingExecutionVertex> producers,
+			final List<TestingSchedulingExecutionVertex> consumers) {
+			this.producers = producers;
+			this.consumers = consumers;
+		}
+
+		ProducerConsumerConnectionBuilder withResultPartitionType(final ResultPartitionType resultPartitionType) {
+			this.resultPartitionType = resultPartitionType;
+			return this;
+		}
+
+		ProducerConsumerConnectionBuilder withResultPartitionState(final SchedulingResultPartition.ResultPartitionState state) {
+			this.resultPartitionState = state;
+			return this;
+		}
+
+		public List<TestingSchedulingResultPartition> finish() {
+			final List<TestingSchedulingResultPartition> resultPartitions = connect();
+
+			TestingSchedulingTopology.this.addSchedulingExecutionVertices(producers);
+			TestingSchedulingTopology.this.addSchedulingExecutionVertices(consumers);
+
+			return resultPartitions;
+		}
+
+		TestingSchedulingResultPartition.Builder initTestingSchedulingResultPartitionBuilder() {
+			return new TestingSchedulingResultPartition.Builder()
+				.withResultPartitionType(resultPartitionType);
+		}
+
+		protected abstract List<TestingSchedulingResultPartition> connect();
+
+	}
+
+	/**
+	 * Builder for {@link TestingSchedulingResultPartition} of {@link DistributionPattern#POINTWISE}.
+	 */
+	private class ProducerConsumerPointwiseConnectionBuilder extends ProducerConsumerConnectionBuilder {
+
+		private ProducerConsumerPointwiseConnectionBuilder(
+			final List<TestingSchedulingExecutionVertex> producers,
+			final List<TestingSchedulingExecutionVertex> consumers) {
+			super(producers, consumers);
+			// currently we only support one to one
+			Preconditions.checkState(producers.size() == consumers.size());
+		}
+
+		@Override
+		protected List<TestingSchedulingResultPartition> connect() {
+			final List<TestingSchedulingResultPartition> resultPartitions = new ArrayList<>();
+			final IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
+
+			for (int idx = 0; idx < producers.size(); idx++) {
+				final TestingSchedulingExecutionVertex producer = producers.get(idx);
+				final TestingSchedulingExecutionVertex consumer = consumers.get(idx);
+
+				final TestingSchedulingResultPartition resultPartition = initTestingSchedulingResultPartitionBuilder()
+					.withIntermediateDataSetID(intermediateDataSetId)
+					.withResultPartitionState(resultPartitionState)
+					.build();
+				resultPartition.setProducer(producer);
+				producer.addProducedPartition(resultPartition);
+				consumer.addConsumedPartition(resultPartition);
+				resultPartition.addConsumer(consumer);
+				resultPartitions.add(resultPartition);
+			}
+
+			return resultPartitions;
+		}
+	}
+
+	/**
+	 * Builder for {@link TestingSchedulingResultPartition} of {@link DistributionPattern#ALL_TO_ALL}.
+	 */
+	private class ProducerConsumerAllToAllConnectionBuilder extends ProducerConsumerConnectionBuilder {
+
+		private ProducerConsumerAllToAllConnectionBuilder(
+			final List<TestingSchedulingExecutionVertex> producers,
+			final List<TestingSchedulingExecutionVertex> consumers) {
+			super(producers, consumers);
+		}
+
+		@Override
+		protected List<TestingSchedulingResultPartition> connect() {
+			final List<TestingSchedulingResultPartition> resultPartitions = new ArrayList<>();
+			final IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
+
+			for (TestingSchedulingExecutionVertex producer : producers) {
+
+				final TestingSchedulingResultPartition resultPartition = initTestingSchedulingResultPartitionBuilder()
+					.withIntermediateDataSetID(intermediateDataSetId)
+					.withResultPartitionState(resultPartitionState)
+					.build();
+				resultPartition.setProducer(producer);
+				producer.addProducedPartition(resultPartition);
+
+				for (TestingSchedulingExecutionVertex consumer : consumers) {
+					consumer.addConsumedPartition(resultPartition);
+					resultPartition.addConsumer(consumer);
+					resultPartitions.add(resultPartition);
+				}
+			}
+
+			return resultPartitions;
+		}
+	}
+
+	/**
+	 * Builder for {@link TestingSchedulingExecutionVertex}.
+	 */
+	public class SchedulingExecutionVerticesBuilder {
+
+		private final JobVertexID jobVertexId = new JobVertexID();
+
+		private int parallelism = 1;
+
+		private InputDependencyConstraint inputDependencyConstraint = InputDependencyConstraint.ANY;
+
+		SchedulingExecutionVerticesBuilder withParallelism(final int parallelism) {
+			this.parallelism = parallelism;
+			return this;
+		}
+
+		SchedulingExecutionVerticesBuilder withInputDependencyConstraint(final InputDependencyConstraint inputDependencyConstraint) {
+			this.inputDependencyConstraint = inputDependencyConstraint;
+			return this;
+		}
+
+		public List<TestingSchedulingExecutionVertex> finish() {
+			final List<TestingSchedulingExecutionVertex> vertices = new ArrayList<>();
+			for (int subtaskIndex = 0; subtaskIndex < parallelism; subtaskIndex++) {
+				vertices.add(new TestingSchedulingExecutionVertex(jobVertexId, subtaskIndex, inputDependencyConstraint));
+			}
+
+			TestingSchedulingTopology.this.addSchedulingExecutionVertices(vertices);
+
+			return vertices;
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request implements the LAZY_FROM_SOURCES scheduling strategy based on the new scheduling interface.*


## Brief change log

  - *Implement the LazyFromSourcesSchedulingStrategy which schedules vertices when the input data are available*
  - *Add InputDependencyConstraintChecker class to efficiently check input dependency constraint*
  - *Add getInputDependencyConstraint in SchedulingExecutionVertex interface*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add unit test in LazyFromSourcesSchedulingStrategyTest*
  - *Add unit test in InputDependencyConstraintCheckerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
