### PR TITLE
[FLINK-12201][network,metrics] Introduce InputGateWithMetrics in Task to increment numBytesIn metric

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -248,8 +247,7 @@ public class NetworkEnvironment {
 			Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
 			MetricGroup parentGroup,
 			MetricGroup inputGroup,
-			MetricGroup buffersGroup,
-			Counter numBytesInCounter) {
+			MetricGroup buffersGroup) {
 		synchronized (lock) {
 			Preconditions.checkState(!isShutdown, "The NetworkEnvironment has already been shut down.");
 
@@ -261,8 +259,7 @@ public class NetworkEnvironment {
 					taskName,
 					igdd,
 					partitionProducerStateProvider,
-					inputChannelMetrics,
-					numBytesInCounter);
+					inputChannelMetrics);
 				InputGateID id = new InputGateID(igdd.getConsumedResultId(), executionId);
 				inputGatesById.put(id, inputGate);
 				inputGate.getCloseFuture().thenRun(() -> inputGatesById.remove(id));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
@@ -159,17 +159,6 @@ public interface Buffer {
 	void setReaderIndex(int readerIndex) throws IndexOutOfBoundsException;
 
 	/**
-	 * Returns the size of the written data, i.e. the <tt>writer index</tt>, of this buffer in an
-	 * non-synchronized fashion.
-	 *
-	 * <p>This is where writable bytes start in the backing memory segment.
-	 *
-	 * @return writer index (from 0 (inclusive) to the size of the backing {@link MemorySegment}
-	 * (inclusive))
-	 */
-	int getSizeUnsafe();
-
-	/**
 	 * Returns the size of the written data, i.e. the <tt>writer index</tt>, of this buffer.
 	 *
 	 * <p>This is where writable bytes start in the backing memory segment.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBuffer.java
@@ -291,11 +291,6 @@ public class NetworkBuffer extends AbstractReferenceCountedByteBuf implements Bu
 	}
 
 	@Override
-	public int getSizeUnsafe() {
-		return writerIndex();
-	}
-
-	@Override
 	public int getSize() {
 		return writerIndex();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
@@ -153,11 +153,6 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 	}
 
 	@Override
-	public int getSizeUnsafe() {
-		return writerIndex();
-	}
-
-	@Override
 	public int getSize() {
 		return writerIndex();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferOrEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferOrEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
@@ -43,26 +44,32 @@ public class BufferOrEvent {
 
 	private int channelIndex;
 
-	BufferOrEvent(Buffer buffer, int channelIndex, boolean moreAvailable) {
+	private final int size;
+
+	public BufferOrEvent(Buffer buffer, int channelIndex, boolean moreAvailable) {
 		this.buffer = checkNotNull(buffer);
 		this.event = null;
 		this.channelIndex = channelIndex;
 		this.moreAvailable = moreAvailable;
+		this.size = buffer.getSize();
 	}
 
-	BufferOrEvent(AbstractEvent event, int channelIndex, boolean moreAvailable) {
+	public BufferOrEvent(AbstractEvent event, int channelIndex, boolean moreAvailable, int size) {
 		this.buffer = null;
 		this.event = checkNotNull(event);
 		this.channelIndex = channelIndex;
 		this.moreAvailable = moreAvailable;
+		this.size = size;
 	}
 
+	@VisibleForTesting
 	public BufferOrEvent(Buffer buffer, int channelIndex) {
 		this(buffer, channelIndex, true);
 	}
 
+	@VisibleForTesting
 	public BufferOrEvent(AbstractEvent event, int channelIndex) {
-		this(event, channelIndex, true);
+		this(event, channelIndex, true, 0);
 	}
 
 	public boolean isBuffer() {
@@ -96,11 +103,15 @@ public class BufferOrEvent {
 
 	@Override
 	public String toString() {
-		return String.format("BufferOrEvent [%s, channelIndex = %d]",
-				isBuffer() ? buffer : event, channelIndex);
+		return String.format("BufferOrEvent [%s, channelIndex = %d, size = %d]",
+				isBuffer() ? buffer : event, channelIndex, size);
 	}
 
 	public void setMoreAvailable(boolean moreAvailable) {
 		this.moreAvailable = moreAvailable;
+	}
+
+	public int getSize() {
+		return size;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -193,7 +193,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 			}
 		}
 
-		numBytesIn.inc(next.buffer().getSizeUnsafe());
+		numBytesIn.inc(next.buffer().getSize());
 		numBuffersIn.inc();
 		return Optional.of(new BufferAndAvailability(next.buffer(), next.isMoreAvailable(), next.buffersInBacklog()));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -201,7 +201,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 			moreAvailable = !receivedBuffers.isEmpty();
 		}
 
-		numBytesIn.inc(next.getSizeUnsafe());
+		numBytesIn.inc(next.getSize());
 		numBuffersIn.inc();
 		return Optional.of(new BufferAndAvailability(next, moreAvailable, getSenderBacklog()));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
@@ -99,8 +98,7 @@ public class SingleInputGateFactory {
 			@Nonnull String owningTaskName,
 			@Nonnull InputGateDeploymentDescriptor igdd,
 			@Nonnull PartitionProducerStateProvider partitionProducerStateProvider,
-			@Nonnull InputChannelMetrics metrics,
-			@Nonnull Counter numBytesInCounter) {
+			@Nonnull InputChannelMetrics metrics) {
 		final IntermediateDataSetID consumedResultId = checkNotNull(igdd.getConsumedResultId());
 		final ResultPartitionType consumedPartitionType = checkNotNull(igdd.getConsumedPartitionType());
 
@@ -116,7 +114,6 @@ public class SingleInputGateFactory {
 			consumedSubpartitionIndex,
 			icdd.length,
 			partitionProducerStateProvider,
-			numBytesInCounter,
 			isCreditBased,
 			createBufferPoolFactory(icdd.length, consumedPartitionType));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class wraps {@link InputGate} provided by shuffle service and it is mainly
+ * used for increasing general input metrics from {@link TaskIOMetricGroup}.
+ */
+public class InputGateWithMetrics extends InputGate {
+
+	private final InputGate inputGate;
+
+	private final Counter numBytesIn;
+
+	public InputGateWithMetrics(InputGate inputGate, Counter numBytesIn) {
+		this.inputGate = checkNotNull(inputGate);
+		this.numBytesIn = checkNotNull(numBytesIn);
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return inputGate.isAvailable();
+	}
+
+	@Override
+	public int getNumberOfInputChannels() {
+		return inputGate.getNumberOfInputChannels();
+	}
+
+	@Override
+	public String getOwningTaskName() {
+		return inputGate.getOwningTaskName();
+	}
+
+	@Override
+	public boolean isFinished() {
+		return inputGate.isFinished();
+	}
+
+	@Override
+	public void setup() throws IOException {
+		inputGate.setup();
+	}
+
+	@Override
+	public void requestPartitions() throws IOException, InterruptedException {
+		inputGate.requestPartitions();
+	}
+
+	@Override
+	public Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException {
+		return updateMetrics(inputGate.getNextBufferOrEvent());
+	}
+
+	@Override
+	public Optional<BufferOrEvent> pollNextBufferOrEvent() throws IOException, InterruptedException {
+		return updateMetrics(inputGate.pollNextBufferOrEvent());
+	}
+
+	@Override
+	public void sendTaskEvent(TaskEvent event) throws IOException {
+		inputGate.sendTaskEvent(event);
+	}
+
+	@Override
+	public int getPageSize() {
+		return inputGate.getPageSize();
+	}
+
+	@Override
+	public void close() throws Exception {
+		inputGate.close();
+	}
+
+	private Optional<BufferOrEvent> updateMetrics(Optional<BufferOrEvent> bufferOrEvent) {
+		bufferOrEvent.ifPresent(b -> numBytesIn.inc(b.getSize()));
+		return bufferOrEvent;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferTest.java
@@ -216,7 +216,6 @@ public class NetworkBufferTest extends AbstractByteBufTest {
 
 		assertEquals(0, slice.getReaderIndex());
 		assertEquals(10, slice.getSize());
-		assertEquals(10, slice.getSizeUnsafe());
 		assertSame(buffer, slice.unwrap().unwrap());
 
 		// slice indices should be independent:
@@ -224,7 +223,6 @@ public class NetworkBufferTest extends AbstractByteBufTest {
 		buffer.setReaderIndex(2);
 		assertEquals(0, slice.getReaderIndex());
 		assertEquals(10, slice.getSize());
-		assertEquals(10, slice.getSizeUnsafe());
 	}
 
 	@Test
@@ -244,7 +242,6 @@ public class NetworkBufferTest extends AbstractByteBufTest {
 
 		assertEquals(0, slice.getReaderIndex());
 		assertEquals(10, slice.getSize());
-		assertEquals(10, slice.getSizeUnsafe());
 		assertSame(buffer, slice.unwrap().unwrap());
 
 		// slice indices should be independent:
@@ -252,7 +249,6 @@ public class NetworkBufferTest extends AbstractByteBufTest {
 		buffer.setReaderIndex(2);
 		assertEquals(0, slice.getReaderIndex());
 		assertEquals(10, slice.getSize());
-		assertEquals(10, slice.getSizeUnsafe());
 	}
 
 	@Test
@@ -312,13 +308,11 @@ public class NetworkBufferTest extends AbstractByteBufTest {
 		NetworkBuffer buffer = newBuffer(1024, 1024, isBuffer);
 
 		assertEquals(0, buffer.getSize()); // initially 0
-		assertEquals(0, buffer.getSizeUnsafe());
 		assertEquals(buffer.writerIndex(), buffer.getSize());
 		assertEquals(0, buffer.readerIndex()); // initially 0
 
 		buffer.setSize(10);
 		assertEquals(10, buffer.getSize());
-		assertEquals(10, buffer.getSizeUnsafe());
 		assertEquals(buffer.writerIndex(), buffer.getSize());
 		assertEquals(0, buffer.readerIndex()); // independent
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedBufferTest.java
@@ -233,8 +233,7 @@ public class ReadOnlySlicedBufferTest {
 	/**
 	 * Tests the independence of the writer index via
 	 * {@link ReadOnlySlicedNetworkBuffer#setSize(int)},
-	 * {@link ReadOnlySlicedNetworkBuffer#getSize()}, and
-	 * {@link ReadOnlySlicedNetworkBuffer#getSizeUnsafe()}.
+	 * {@link ReadOnlySlicedNetworkBuffer#getSize()}.
 	 */
 	@Test
 	public void testGetSetSize1() {
@@ -244,8 +243,7 @@ public class ReadOnlySlicedBufferTest {
 	/**
 	 * Tests the independence of the writer index via
 	 * {@link ReadOnlySlicedNetworkBuffer#setSize(int)},
-	 * {@link ReadOnlySlicedNetworkBuffer#getSize()}, and
-	 * {@link ReadOnlySlicedNetworkBuffer#getSizeUnsafe()}.
+	 * {@link ReadOnlySlicedNetworkBuffer#getSize()}.
 	 */
 	@Test
 	public void testGetSetSize2() {
@@ -254,14 +252,10 @@ public class ReadOnlySlicedBufferTest {
 
 	private void testGetSetSize(ReadOnlySlicedNetworkBuffer slice, int sliceSize) {
 		assertEquals(DATA_SIZE, buffer.getSize());
-		assertEquals(DATA_SIZE, buffer.getSizeUnsafe());
 		assertEquals(sliceSize, slice.getSize());
-		assertEquals(sliceSize, slice.getSizeUnsafe());
 		buffer.setSize(DATA_SIZE + 1);
 		assertEquals(DATA_SIZE + 1, buffer.getSize());
-		assertEquals(DATA_SIZE + 1, buffer.getSizeUnsafe());
 		assertEquals(sliceSize, slice.getSize());
-		assertEquals(sliceSize, slice.getSizeUnsafe());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
@@ -331,7 +330,6 @@ public class InputGateFairnessTest {
 				consumedSubpartitionIndex,
 				numberOfInputChannels,
 				SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
-				new SimpleCounter(),
 				isCreditBased,
 				STUB_BUFFER_POOL_FACTORY);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
@@ -50,8 +48,6 @@ public class SingleInputGateBuilder {
 	private int numberOfChannels = 1;
 
 	private final PartitionProducerStateProvider partitionProducerStateProvider = NO_OP_PRODUCER_CHECKER;
-
-	private final Counter numBytesInCounter = new SimpleCounter();
 
 	private boolean isCreditBased = true;
 
@@ -99,7 +95,6 @@ public class SingleInputGateBuilder {
 			consumedSubpartitionIndex,
 			numberOfChannels,
 			partitionProducerStateProvider,
-			numBytesInCounter,
 			isCreditBased,
 			bufferPoolFactory);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.core.memory.MemorySegmentFactory;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -347,8 +346,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 				"TestTask",
 				gateDesc,
 				SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
-				InputChannelTestUtils.newUnregisteredInputChannelMetrics(),
-				new SimpleCounter());
+				InputChannelTestUtils.newUnregisteredInputChannelMetrics());
 
 		try {
 			assertEquals(gateDesc.getConsumedPartitionType(), gate.getConsumedPartitionType());
@@ -599,8 +597,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 			Arrays.asList(gateDescs),
 			new UnregisteredMetricsGroup(),
 			new UnregisteredMetricsGroup(),
-			new UnregisteredMetricsGroup(),
-			new SimpleCounter());
+			new UnregisteredMetricsGroup());
 		Map<InputGateID, SingleInputGate> inputGatesById = new HashMap<>();
 		for (int i = 0; i < numberOfGates; i++) {
 			inputGatesById.put(new InputGateID(ids[i], consumerID), gates[i]);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferSpiller.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferSpiller.java
@@ -374,7 +374,7 @@ public class BufferSpiller implements BufferBlocker {
 				Buffer buf = new NetworkBuffer(seg, FreeingBufferRecycler.INSTANCE);
 				buf.setSize(length);
 
-				return new BufferOrEvent(buf, channel);
+				return new BufferOrEvent(buf, channel, true);
 			}
 			else {
 				// deserialize event
@@ -399,7 +399,7 @@ public class BufferSpiller implements BufferBlocker {
 				AbstractEvent evt = EventSerializer.fromSerializedEvent(buffer, getClass().getClassLoader());
 				buffer.limit(oldLimit);
 
-				return new BufferOrEvent(evt, channel);
+				return new BufferOrEvent(evt, channel, true, length);
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

* Incrementing of `numBytesIn` metric in `SingleInputGate` does not depend on shuffle service and can be moved out of network internals into `Task`. `Task` could wrap `InputGate` provided by `ShuffleService` with `InputGateWithMetrics` which would increment numBytesIn metric.*

## Brief change log

  - *Introduce `InputGateWithMetrics` to wrap `InputGate` from `ShuffleService` in `Task`*
  - *Remove the counter from `SingleInputGate` and related creation.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)