### PR TITLE
[FLINK-11921][table] Upgrade to calcite 1.19

### DIFF
--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -136,17 +136,17 @@ under the License.
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
 			<!-- When updating the Calcite version, make sure to update the dependency exclusions -->
-			<version>1.18.0</version>
+			<version>1.19.0</version>
 			<exclusions>
 				<!--
 
 				Dependencies that are not needed for how we use Calcite right now.
 
-				"mvn dependency:tree" as of Calcite 1.18:
+				"mvn dependency:tree" as of Calcite 1.19:
 
-				[INFO] +- org.apache.calcite:calcite-core:jar:1.18.0:compile
+				[INFO] +- org.apache.calcite:calcite-core:jar:1.19.0:compile
 				[INFO] |  +- org.apache.calcite.avatica:avatica-core:jar:1.13.0:compile
-				[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.18.0:compile
+				[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.19.0:compile
 				[INFO] |  +- org.apache.commons:commons-lang3:jar:3.3.2:compile
 				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
 				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.6:compile

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/AuxiliaryConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/AuxiliaryConverter.java
@@ -17,7 +17,7 @@
 package org.apache.calcite.sql2rel;
 
 /*
- * THIS FILE HAS BEEN COPIED FROM THE APACHE CALCITE PROJECT UNTIL CALCITE-1761 IS FIXED.
+ * THIS FILE HAS BEEN COPIED FROM THE APACHE CALCITE PROJECT UNTIL CALCITE-3008 IS FIXED.
  */
 
 import org.apache.calcite.rex.RexBuilder;
@@ -53,25 +53,6 @@ public interface AuxiliaryConverter {
 		public RexNode convert(RexBuilder rexBuilder, RexNode groupCall,
 			RexNode e) {
 			return rexBuilder.makeCall(this.f, e);
-			// FLINK QUICK FIX
-			// we do not use this logic right now
-//      switch (f.getKind()) {
-//      case TUMBLE_START:
-//      case HOP_START:
-//      case SESSION_START:
-//      case SESSION_END: // TODO: ?
-//        return e;
-//      case TUMBLE_END:
-//        return rexBuilder.makeCall(
-//            SqlStdOperatorTable.PLUS, e,
-//            ((RexCall) groupCall).operands.get(1));
-//      case HOP_END:
-//        return rexBuilder.makeCall(
-//            SqlStdOperatorTable.PLUS, e,
-//            ((RexCall) groupCall).operands.get(2));
-//      default:
-//        throw new AssertionError("unknown: " + f);
-//      }
 		}
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/AuxiliaryConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/AuxiliaryConverter.java
@@ -53,6 +53,25 @@ public interface AuxiliaryConverter {
 		public RexNode convert(RexBuilder rexBuilder, RexNode groupCall,
 			RexNode e) {
 			return rexBuilder.makeCall(this.f, e);
+			// FLINK QUICK FIX
+			// we do not use this logic right now
+//      switch (f.getKind()) {
+//      case TUMBLE_START:
+//      case HOP_START:
+//      case SESSION_START:
+//      case SESSION_END: // TODO: ?
+//        return e;
+//      case TUMBLE_END:
+//        return rexBuilder.makeCall(
+//            SqlStdOperatorTable.PLUS, e,
+//            ((RexCall) groupCall).operands.get(1));
+//      case HOP_END:
+//        return rexBuilder.makeCall(
+//            SqlStdOperatorTable.PLUS, e,
+//            ((RexCall) groupCall).operands.get(2));
+//      default:
+//        throw new AssertionError("unknown: " + f);
+//      }
 		}
 	}
 }

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -12,8 +12,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.9.6
 - com.jayway.jsonpath:json-path:2.4.0
 - joda-time:joda-time:2.5
-- org.apache.calcite:calcite-core:1.18.0
-- org.apache.calcite:calcite-linq4j:1.18.0
+- org.apache.calcite:calcite-core:1.19.0
+- org.apache.calcite:calcite-linq4j:1.19.0
 - org.apache.calcite.avatica:avatica-core:1.13.0
 
 This project bundles the following dependencies under the BSD license.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
@@ -100,6 +100,8 @@ class FlinkLogicalTableSourceScan(
       s"Scan($s)"
     }
   }
+
+  override def computeDigest(): String = this.toString
 }
 
 class FlinkLogicalTableSourceScanConverter

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
@@ -235,7 +235,7 @@ class TableSourceTest extends TableTestBase {
         Array("price", "id", "amount"),
         "'amount > 2"),
       term("select", "price", "id", "amount"),
-      term("where", "AND(<(id, 1.2E0), OR(<(amount, 32), >(CAST(amount), 10)))")
+      term("where", "AND(<(id, 1.2E0:DOUBLE), OR(<(amount, 32), >(CAST(amount), 10)))")
     )
     util.verifyTable(result, expected)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/CalcTest.scala
@@ -53,7 +53,8 @@ class CalcTest extends TableTestBase {
     val util = batchTestUtil()
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
 
-    val resultStr = (1 to 30).mkString(", ")
+    val sqlStr = (1 to 30).mkString(", ")
+    val resultStr = (1 to 30).mkString(":BIGINT, ") + ":BIGINT"
     val expected = unaryNode(
       "DataSetCalc",
       batchTableNode(0),
@@ -62,7 +63,7 @@ class CalcTest extends TableTestBase {
     )
 
     util.verifySql(
-      s"SELECT * FROM MyTable WHERE b in ($resultStr)",
+      s"SELECT * FROM MyTable WHERE b in ($sqlStr)",
       expected)
   }
 
@@ -71,7 +72,8 @@ class CalcTest extends TableTestBase {
     val util = batchTestUtil()
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
 
-    val resultStr = (1 to 30).mkString(", ")
+    val sqlStr = (1 to 30).mkString(", ")
+    val resultStr = (1 to 30).mkString(":BIGINT, ") + ":BIGINT"
     val expected = unaryNode(
       "DataSetCalc",
       batchTableNode(0),
@@ -80,7 +82,7 @@ class CalcTest extends TableTestBase {
     )
 
     util.verifySql(
-      s"SELECT * FROM MyTable WHERE b NOT IN ($resultStr)",
+      s"SELECT * FROM MyTable WHERE b NOT IN ($sqlStr)",
       expected)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/GroupWindowTest.scala
@@ -296,7 +296,7 @@ class GroupWindowTest extends TableTestBase {
         term("select", "EXPR$0", "CAST(w$start) AS EXPR$1"),
         term("where",
           "AND(>($f1, 0), " +
-            "=(EXTRACT(FLAG(QUARTER), CAST(w$start)), 1))")
+            "=(EXTRACT(FLAG(QUARTER), w$start), 1:BIGINT))")
       )
 
     util.verifySql(sql, expected)
@@ -336,10 +336,10 @@ class GroupWindowTest extends TableTestBase {
         ),
         term("select",
           "/(-($f0, /(*($f1, $f1), $f2)), $f2) AS EXPR$0",
-          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))) AS EXPR$1",
-          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5)) AS EXPR$2",
-          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
-            "AS EXPR$3",
+          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null:BIGINT, -($f2, 1))) AS EXPR$1",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5:DECIMAL(2, 1))) AS EXPR$2",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null:BIGINT, -($f2, 1)))",
+          "0.5:DECIMAL(2, 1))) AS EXPR$3",
           "CAST(w$start) AS EXPR$4",
           "CAST(w$end) AS EXPR$5")
       )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/GroupingSetsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/GroupingSetsTest.scala
@@ -48,7 +48,7 @@ class GroupingSetsTest extends TableTestBase {
           term("groupBy", "b"),
           term("select", "b", "AVG(a) AS a")
         ),
-        term("select", "b", "null AS c", "a", "1 AS g")
+        term("select", "b", "null:INTEGER AS c", "a", "1:BIGINT AS g")
       ),
       unaryNode(
         "DataSetCalc",
@@ -62,7 +62,7 @@ class GroupingSetsTest extends TableTestBase {
           term("groupBy", "c"),
           term("select", "c", "AVG(a) AS a")
         ),
-        term("select", "null AS b", "c", "a", "2 AS g")
+        term("select", "null:BIGINT AS b", "c", "a", "2:BIGINT AS g")
       ),
       term("all", "true"),
       term("union", "b", "c", "a", "g")
@@ -91,8 +91,8 @@ class GroupingSetsTest extends TableTestBase {
         term("groupBy", "b", "c"),
         term("select", "b", "c", "AVG(a) AS a")
       ),
-      term("select", "b", "c", "a", "3 AS g", "1 AS gb", "1 AS gc",
-        "1 AS gib", "1 AS gic", "3 AS gid")
+      term("select", "b", "c", "a", "3:BIGINT AS g", "1:BIGINT AS gb",
+        "1:BIGINT AS gc", "1:BIGINT AS gib", "1:BIGINT AS gic", "3:BIGINT AS gid")
     )
 
     val group2 = unaryNode(
@@ -107,8 +107,8 @@ class GroupingSetsTest extends TableTestBase {
         term("groupBy", "b"),
         term("select", "b", "AVG(a) AS a")
       ),
-      term("select", "b", "null AS c", "a", "1 AS g", "1 AS gb", "0 AS gc",
-        "1 AS gib", "0 AS gic", "2 AS gid")
+      term("select", "b", "null:INTEGER AS c", "a", "1:BIGINT AS g", "1:BIGINT AS gb",
+        "0:BIGINT AS gc", "1:BIGINT AS gib", "0:BIGINT AS gic", "2:BIGINT AS gid")
     )
 
     val group3 = unaryNode(
@@ -123,8 +123,8 @@ class GroupingSetsTest extends TableTestBase {
         term("groupBy", "c"),
         term("select", "c", "AVG(a) AS a")
       ),
-      term("select", "null AS b", "c", "a", "2 AS g", "0 AS gb", "1 AS gc",
-        "0 AS gib", "1 AS gic", "1 AS gid")
+      term("select", "null:BIGINT AS b", "c", "a", "2:BIGINT AS g", "0:BIGINT AS gb",
+        "1:BIGINT AS gc", "0:BIGINT AS gib", "1:BIGINT AS gic", "1:BIGINT AS gid")
     )
 
     val group4 = unaryNode(
@@ -139,8 +139,9 @@ class GroupingSetsTest extends TableTestBase {
         term("select", "AVG(a) AS a")
       ),
       term(
-        "select", "null AS b", "null AS c", "a", "0 AS g", "0 AS gb", "0 AS gc",
-        "0 AS gib", "0 AS gic", "0 AS gid")
+        "select", "null:BIGINT AS b", "null:INTEGER AS c", "a",
+        "0:BIGINT AS g", "0:BIGINT AS gb", "0:BIGINT AS gc",
+        "0:BIGINT AS gib", "0:BIGINT AS gic", "0:BIGINT AS gid")
     )
 
     val union = binaryNode(
@@ -185,8 +186,8 @@ class GroupingSetsTest extends TableTestBase {
         term("groupBy", "b", "c"),
         term("select", "b", "c", "AVG(a) AS a")
       ),
-      term("select", "b", "c", "a", "3 AS g", "1 AS gb", "1 AS gc",
-        "1 AS gib", "1 AS gic", "3 AS gid")
+      term("select", "b", "c", "a", "3:BIGINT AS g", "1:BIGINT AS gb",
+        "1:BIGINT AS gc", "1:BIGINT AS gib", "1:BIGINT AS gic", "3:BIGINT AS gid")
     )
 
     val group2 = unaryNode(
@@ -201,8 +202,8 @@ class GroupingSetsTest extends TableTestBase {
         term("groupBy", "b"),
         term("select", "b", "AVG(a) AS a")
       ),
-      term("select", "b", "null AS c", "a", "1 AS g", "1 AS gb", "0 AS gc",
-        "1 AS gib", "0 AS gic", "2 AS gid")
+      term("select", "b", "null:INTEGER AS c", "a", "1:BIGINT AS g", "1:BIGINT AS gb",
+        "0:BIGINT AS gc", "1:BIGINT AS gib", "0:BIGINT AS gic", "2:BIGINT AS gid")
     )
 
     val group3 = unaryNode(
@@ -217,8 +218,8 @@ class GroupingSetsTest extends TableTestBase {
         term("select", "AVG(a) AS a")
       ),
       term(
-        "select", "null AS b", "null AS c", "a", "0 AS g", "0 AS gb", "0 AS gc",
-        "0 AS gib", "0 AS gic", "0 AS gid")
+        "select", "null:BIGINT AS b", "null:INTEGER AS c", "a", "0:BIGINT AS g",
+        "0:BIGINT AS gb", "0:BIGINT AS gc", "0:BIGINT AS gib", "0:BIGINT AS gic", "0:BIGINT AS gid")
     )
 
     val union = binaryNode(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
@@ -105,7 +105,7 @@ class SetOperatorsTest extends TableTestBase {
                 "DataSetCalc",
                 batchTableNode(0),
                 term("select", "b"),
-                term("where", "OR(=(b, 6), =(b, 1))")
+                term("where", "OR(=(b, 6:BIGINT), =(b, 1:BIGINT))")
               ),
               term("select", "COUNT(*) AS $f0", "COUNT(b) AS $f1")
             ),
@@ -121,7 +121,7 @@ class SetOperatorsTest extends TableTestBase {
             "DataSetCalc",
             batchTableNode(0),
             term("select", "b", "true AS $f1"),
-            term("where", "OR(=(b, 6), =(b, 1))")
+            term("where", "OR(=(b, 6:BIGINT), =(b, 1:BIGINT))")
           ),
           term("groupBy", "b"),
           term("select", "b", "MIN($f1) AS $f1")
@@ -131,7 +131,7 @@ class SetOperatorsTest extends TableTestBase {
         term("joinType", "LeftOuterJoin")
       ),
       term("select", "a", "c"),
-      term("where", "OR(=($f0, 0), AND(IS NULL($f10), >=($f1, $f0), IS NOT NULL(b0)))")
+      term("where", "OR(=($f0, 0:BIGINT), AND(IS NULL($f10), >=($f1, $f0), IS NOT NULL(b0)))")
     )
 
     util.verifySql(
@@ -188,7 +188,9 @@ class SetOperatorsTest extends TableTestBase {
       unaryNode(
         "DataSetCalc",
         batchTableNode(0),
-        term("select", "CASE(>(c, 0), b, null) AS EXPR$0")
+        term("select", "CASE(>(c, 0), b",
+          "null:RecordType:peek_no_expand(" +
+            "INTEGER _1, VARCHAR(65536) CHARACTER SET \"UTF-16LE\" _2)) AS EXPR$0")
       ),
       term("all", "true"),
       term("union", "a")
@@ -238,17 +240,17 @@ class SetOperatorsTest extends TableTestBase {
           values("DataSetValues",
             tuples(List("0")),
             "values=[ZERO]"),
-          term("select", "1 AS EXPR$0, 1 AS EXPR$1")),
+          term("select", "1 AS EXPR$0, 1:BIGINT AS EXPR$1")),
         unaryNode("DataSetCalc",
           values("DataSetValues",
             tuples(List("0")),
             "values=[ZERO]"),
-          term("select", "2 AS EXPR$0, 2 AS EXPR$1")),
+          term("select", "2 AS EXPR$0, 2:BIGINT AS EXPR$1")),
         unaryNode("DataSetCalc",
           values("DataSetValues",
             tuples(List("0")),
             "values=[ZERO]"),
-          term("select", "3 AS EXPR$0, 3 AS EXPR$1"))
+          term("select", "3 AS EXPR$0, 3:BIGINT AS EXPR$1"))
       ),
       term("all", "true"),
       term("union", "EXPR$0, EXPR$1")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/SingleRowJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/SingleRowJoinTest.scala
@@ -344,7 +344,7 @@ class SingleRowJoinTest extends TableTestBase {
             ),
             term("select", "SUM(a1) AS $f0")
           ),
-          term("select", "*($f0, 0.1) AS EXPR$0")
+          term("select", "*($f0, 0.1:DECIMAL(2, 1)) AS EXPR$0")
         )
 
     util.verifySql(query, expected)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/GroupWindowTest.scala
@@ -474,10 +474,10 @@ class GroupWindowTest extends TableTestBase {
         ),
         term("select",
           "/(-($f0, /(*($f1, $f1), $f2)), $f2) AS TMP_0",
-          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))) AS TMP_1",
-          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5)) AS TMP_2",
-          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
-            "AS TMP_3",
+          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null:BIGINT, -($f2, 1))) AS TMP_1",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5:DECIMAL(2, 1))) AS TMP_2",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null:BIGINT, -($f2, 1)))",
+            "0.5:DECIMAL(2, 1))) AS TMP_3",
           "TMP_4",
           "TMP_5")
       )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
@@ -74,7 +74,7 @@ class SetOperatorsTest extends TableTestBase {
     val expected = unaryNode(
       "DataSetCalc",
       batchTableNode(0),
-      term("select", "IN(b, 1972-02-22 07:12:00.333) AS b2")
+      term("select", "IN(b, 1972-02-22 07:12:00.333:TIMESTAMP(3)) AS b2")
     )
 
     util.verifyTable(in, expected)
@@ -99,7 +99,9 @@ class SetOperatorsTest extends TableTestBase {
       unaryNode(
         "DataSetCalc",
         batchTableNode(0),
-        term("select", "CASE(>(c, 0), b, null) AS _c0")
+        term("select", "CASE(>(c, 0), b",
+          "null:RecordType:peek_no_expand(" +
+            "INTEGER _1, VARCHAR(65536) CHARACTER SET \"UTF-16LE\" _2)) AS _c0")
       ),
       term("all", "true"),
       term("union", "a")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/SetOperatorsTest.scala
@@ -71,7 +71,7 @@ class SetOperatorsTest extends TableTestBase {
     val expected = unaryNode(
       "DataSetCalc",
       batchTableNode(0),
-      term("select", "IN(b, CAST('1972-02-22 07:12:00.333')) AS b2")
+      term("select", "IN(b, 1972-02-22 07:12:00.333:TIMESTAMP(3)) AS b2")
     )
 
     util.verifyTable(in, expected)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/GroupWindowTest.scala
@@ -160,7 +160,7 @@ class GroupWindowTest extends TableTestBase {
             "rowtime('w$) AS w$rowtime",
             "proctime('w$) AS w$proctime")
         ),
-        term("select", "EXPR$0", "+(w$end, 60000) AS EXPR$1")
+        term("select", "EXPR$0", "+(w$end, 60000:INTERVAL MINUTE) AS EXPR$1")
       )
 
     streamUtil.verifySql(sql, expected)
@@ -200,7 +200,7 @@ class GroupWindowTest extends TableTestBase {
         term("select", "EXPR$0", "w$start AS EXPR$1"),
         term("where",
           "AND(>($f1, 0), " +
-            "=(EXTRACT(FLAG(QUARTER), w$start), 1))")
+            "=(EXTRACT(FLAG(QUARTER), w$start), 1:BIGINT))")
       )
 
     streamUtil.verifySql(sql, expected)
@@ -292,10 +292,10 @@ class GroupWindowTest extends TableTestBase {
         ),
         term("select",
           "/(-($f0, /(*($f1, $f1), $f2)), $f2) AS EXPR$0",
-          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))) AS EXPR$1",
-          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5)) AS EXPR$2",
-          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
-            "AS EXPR$3",
+          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null:BIGINT, -($f2, 1))) AS EXPR$1",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5:DECIMAL(2, 1))) AS EXPR$2",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null:BIGINT, -($f2, 1)))",
+          "0.5:DECIMAL(2, 1))) AS EXPR$3",
           "w$start AS EXPR$4",
           "w$end AS EXPR$5")
       )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/JoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/JoinTest.scala
@@ -64,8 +64,9 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "proctime")
           ),
           term("where",
-            "AND(=(a, a0), >=(PROCTIME(proctime), -(PROCTIME(proctime0), 3600000)), " +
-              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000)))"),
+            "AND(=(a, a0), >=(PROCTIME(proctime), " +
+              "-(PROCTIME(proctime0), 3600000:INTERVAL HOUR)), " +
+              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, proctime, a0, b, proctime0"),
           term("joinType", "InnerJoin")
         ),
@@ -102,8 +103,8 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "c")
           ),
           term("where",
-            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000)), " +
-              "<=(CAST(c), +(CAST(c0), 3600000)))"),
+            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000:INTERVAL SECOND)), " +
+              "<=(CAST(c), +(CAST(c0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, c, a0, b, c0"),
           term("joinType", "InnerJoin")
         ),
@@ -140,8 +141,9 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "proctime")
           ),
           term("where",
-            "AND(=(a, a0), >=(PROCTIME(proctime), -(PROCTIME(proctime0), 3600000)), " +
-              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000)))"),
+            "AND(=(a, a0), >=(PROCTIME(proctime), " +
+              "-(PROCTIME(proctime0), 3600000:INTERVAL HOUR)), " +
+              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, proctime, a0, b, proctime0"),
           term("joinType", "InnerJoin")
         ),
@@ -178,8 +180,8 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "c")
           ),
           term("where",
-            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 600000)), " +
-              "<=(CAST(c), +(CAST(c0), 3600000)))"),
+            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 600000:INTERVAL MINUTE)), " +
+              "<=(CAST(c), +(CAST(c0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, c, a0, b, c0"),
           term("joinType", "InnerJoin")
         ),
@@ -276,14 +278,15 @@ class JoinTest extends TableTestBase {
         binaryNode("DataStreamWindowJoin",
           unaryNode("DataStreamCalc",
             streamTableNode(0),
-            term("select", "a", "c", "proctime", "null AS nullField")
+            term("select", "a", "c", "proctime", "null:BIGINT AS nullField")
           ),
           unaryNode("DataStreamCalc",
             streamTableNode(1),
-            term("select", "a", "c", "proctime", "12 AS nullField")
+            term("select", "a", "c", "proctime", "12:BIGINT AS nullField")
           ),
           term("where", "AND(=(a, a0), =(nullField, nullField0), >=(PROCTIME(proctime), " +
-            "-(PROCTIME(proctime0), 5000)), <=(PROCTIME(proctime), +(PROCTIME(proctime0), 5000)))"),
+            "-(PROCTIME(proctime0), 5000:INTERVAL SECOND)), <=(PROCTIME(proctime), " +
+            "+(PROCTIME(proctime0), 5000:INTERVAL SECOND)))"),
           term("join", "a", "c", "proctime", "nullField", "a0", "c0", "proctime0", "nullField0"),
           term("joinType", "InnerJoin")
         ),
@@ -322,8 +325,8 @@ class JoinTest extends TableTestBase {
               term("select", "a", "b", "c")
             ),
             term("where",
-              "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 600000)), " +
-                "<=(CAST(c), +(CAST(c0), 3600000)))"),
+              "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 600000:INTERVAL MINUTE)), " +
+                "<=(CAST(c), +(CAST(c0), 3600000:INTERVAL HOUR)))"),
             term("join", "a, b, c, a0, b0, c0"),
             term("joinType", "InnerJoin")
           ),
@@ -367,8 +370,8 @@ class JoinTest extends TableTestBase {
               term("select", "a", "b", "c")
             ),
             term("where",
-              "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 600000)), " +
-                "<=(CAST(c), +(CAST(c0), 3600000)))"),
+              "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 600000:INTERVAL MINUTE)), " +
+                "<=(CAST(c), +(CAST(c0), 3600000:INTERVAL HOUR)))"),
             term("join", "a, b, c, a0, b0, c0"),
             term("joinType", "InnerJoin")
           ),
@@ -410,8 +413,9 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "proctime")
           ),
           term("where",
-            "AND(=(a, a0), >=(PROCTIME(proctime), -(PROCTIME(proctime0), 3600000)), " +
-              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000)))"),
+            "AND(=(a, a0), >=(PROCTIME(proctime), " +
+              "-(PROCTIME(proctime0), 3600000:INTERVAL HOUR)), " +
+              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, proctime, a0, b, proctime0"),
           term("joinType", "LeftOuterJoin")
         ),
@@ -448,8 +452,8 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "c")
           ),
           term("where",
-            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000)), " +
-              "<=(CAST(c), +(CAST(c0), 3600000)))"),
+            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000:INTERVAL SECOND)), " +
+              "<=(CAST(c), +(CAST(c0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, c, a0, b, c0"),
           term("joinType", "LeftOuterJoin")
         ),
@@ -487,8 +491,9 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "proctime")
           ),
           term("where",
-            "AND(=(a, a0), >=(PROCTIME(proctime), -(PROCTIME(proctime0), 3600000)), " +
-              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000)))"),
+            "AND(=(a, a0), >=(PROCTIME(proctime), " +
+              "-(PROCTIME(proctime0), 3600000:INTERVAL HOUR)), " +
+              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, proctime, a0, b, proctime0"),
           term("joinType", "RightOuterJoin")
         ),
@@ -525,8 +530,8 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "c")
           ),
           term("where",
-            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000)), " +
-              "<=(CAST(c), +(CAST(c0), 3600000)))"),
+            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000:INTERVAL SECOND)), " +
+              "<=(CAST(c), +(CAST(c0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, c, a0, b, c0"),
           term("joinType", "RightOuterJoin")
         ),
@@ -564,8 +569,9 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "proctime")
           ),
           term("where",
-            "AND(=(a, a0), >=(PROCTIME(proctime), -(PROCTIME(proctime0), 3600000)), " +
-              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000)))"),
+            "AND(=(a, a0), >=(PROCTIME(proctime), " +
+              "-(PROCTIME(proctime0), 3600000:INTERVAL HOUR)), " +
+              "<=(PROCTIME(proctime), +(PROCTIME(proctime0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, proctime, a0, b, proctime0"),
           term("joinType", "FullOuterJoin")
         ),
@@ -602,8 +608,8 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "c")
           ),
           term("where",
-            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000)), " +
-              "<=(CAST(c), +(CAST(c0), 3600000)))"),
+            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000:INTERVAL SECOND)), " +
+              "<=(CAST(c), +(CAST(c0), 3600000:INTERVAL HOUR)))"),
           term("join", "a, c, a0, b, c0"),
           term("joinType", "FullOuterJoin")
         ),
@@ -642,8 +648,8 @@ class JoinTest extends TableTestBase {
             term("select", "a", "b", "c")
           ),
           term("where",
-            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000)), " +
-              "<=(CAST(c), +(CAST(c0), 3600000)), LIKE(b, b0))"),
+            "AND(=(a, a0), >=(CAST(c), -(CAST(c0), 10000:INTERVAL SECOND)), " +
+              "<=(CAST(c), +(CAST(c0), 3600000:INTERVAL HOUR)), LIKE(b, b0))"),
           term("join", "a, b, c, a0, b0, c0"),
           // Since we filter on attributes b and b0 after the join, the full outer join
           // will be automatically optimized to inner join.

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
@@ -71,8 +71,9 @@ class OverWindowTest extends TableTestBase {
           term("select", "a", "b", "c", "proctime", "COUNT(a) AS w0$o0, $SUM0(a) AS w0$o1, " +
             "COUNT(DISTINCT a) AS w0$o2, COUNT(DISTINCT c) AS w0$o3, $SUM0(DISTINCT c) AS w0$o4")
         ),
-        term("select", "b", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), w0$o1, null) AS sum1, " +
-          "w0$o2 AS cnt2, CASE(>(w0$o3, 0), w0$o4, null) AS sum2")
+        term("select", "b",
+          "w0$o0 AS cnt1, CASE(>(w0$o0, 0:BIGINT), w0$o1, null:INTEGER) AS sum1, " +
+          "w0$o2 AS cnt2, CASE(>(w0$o3, 0:BIGINT), w0$o4, null:BIGINT) AS sum2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -112,7 +113,7 @@ class OverWindowTest extends TableTestBase {
           term("select", "a", "c", "proctime",
             "COUNT(DISTINCT a) AS w0$o0, $SUM0(DISTINCT a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), w0$o1, null) AS sum1")
+        term("select", "c", "w0$o0 AS cnt1, CASE(>(w0$o0, 0:BIGINT), w0$o1, null:INTEGER) AS sum1")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -151,7 +152,7 @@ class OverWindowTest extends TableTestBase {
           term("rows", "BETWEEN 2 PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "proctime", "COUNT(a) AS w0$o0, $SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), w0$o1, null) AS sum1")
+        term("select", "c", "w0$o0 AS cnt1, CASE(>(w0$o0, 0:BIGINT), w0$o1, null:INTEGER) AS sum1")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -195,7 +196,7 @@ class OverWindowTest extends TableTestBase {
             "$SUM0(c) AS w0$o1"
           )
         ),
-        term("select", "a", "/(CASE(>(w0$o0, 0)", "CAST(w0$o1), null), w0$o0) AS avgA")
+        term("select", "a", "/(CASE(>(w0$o0, 0:BIGINT)", "w0$o1, null:BIGINT), w0$o0) AS avgA")
       )
 
     streamUtil.verifySql(sqlQuery, expected)
@@ -312,7 +313,8 @@ class OverWindowTest extends TableTestBase {
           term("range", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "proctime", "COUNT(a) AS w0$o0", "$SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "w0$o1, null) AS cnt2")
+        term("select", "c",
+          "w0$o0 AS cnt1", "CASE(>(w0$o0, 0:BIGINT)", "w0$o1, null:INTEGER) AS cnt2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -378,7 +380,8 @@ class OverWindowTest extends TableTestBase {
           term("range", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "proctime", "COUNT(a) AS w0$o0", "$SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "w0$o1, null) AS cnt2")
+        term("select", "c",
+          "w0$o0 AS cnt1", "CASE(>(w0$o0, 0:BIGINT)", "w0$o1, null:INTEGER) AS cnt2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -553,7 +556,8 @@ class OverWindowTest extends TableTestBase {
           term("range", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "rowtime", "COUNT(a) AS w0$o0", "$SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "w0$o1, null) AS cnt2")
+        term("select", "c",
+          "w0$o0 AS cnt1", "CASE(>(w0$o0, 0:BIGINT)", "w0$o1, null:INTEGER) AS cnt2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -592,8 +596,8 @@ class OverWindowTest extends TableTestBase {
           "select",
           "c",
           "w0$o0 AS cnt1",
-          "CASE(>(w0$o0, 0)",
-          "w0$o1, null) AS cnt2"
+          "CASE(>(w0$o0, 0:BIGINT)",
+          "w0$o1, null:INTEGER) AS cnt2"
         )
       )
     streamUtil.verifySql(sql, expected)
@@ -621,7 +625,8 @@ class OverWindowTest extends TableTestBase {
           term("range", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "rowtime", "COUNT(a) AS w0$o0", "$SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "w0$o1, null) AS cnt2")
+        term("select", "c",
+          "w0$o0 AS cnt1", "CASE(>(w0$o0, 0:BIGINT)", "w0$o1, null:INTEGER) AS cnt2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -659,8 +664,8 @@ class OverWindowTest extends TableTestBase {
           "select",
           "c",
           "w0$o0 AS cnt1",
-          "CASE(>(w0$o0, 0)",
-          "w0$o1, null) AS cnt2"
+          "CASE(>(w0$o0, 0:BIGINT)",
+          "w0$o1, null:INTEGER) AS cnt2"
         )
       )
     streamUtil.verifySql(sql, expected)
@@ -699,7 +704,8 @@ class OverWindowTest extends TableTestBase {
           term("select", "a", "c", "proctime", "COUNT(c) AS w0$o0",
             "$SUM0(c) AS w0$o1")
         ),
-        term("select", "a", "CASE(>(w0$o0, 0)", "w0$o1, null) AS EXPR$1", "w1$o0 AS EXPR$2")
+        term("select", "a",
+          "CASE(>(w0$o0, 0:BIGINT)", "w0$o1, null:BIGINT) AS EXPR$1", "w1$o0 AS EXPR$2")
       )
 
     streamUtil.verifySql(sql, expected)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
@@ -30,7 +30,8 @@ class SetOperatorsTest extends TableTestBase {
     val util = streamTestUtil()
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
 
-    val resultStr = (1 to 30).mkString(", ")
+    val sqlStr = (1 to 30).mkString(", ")
+    val resultStr = (1 to 30).mkString(":BIGINT, ") + ":BIGINT"
     val expected = unaryNode(
       "DataStreamCalc",
       streamTableNode(0),
@@ -39,7 +40,7 @@ class SetOperatorsTest extends TableTestBase {
     )
 
     util.verifySql(
-      s"SELECT * FROM MyTable WHERE b in ($resultStr)",
+      s"SELECT * FROM MyTable WHERE b in ($sqlStr)",
       expected)
   }
 
@@ -48,7 +49,8 @@ class SetOperatorsTest extends TableTestBase {
     val util = streamTestUtil()
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
 
-    val resultStr = (1 to 30).mkString(", ")
+    val sqlStr = (1 to 30).mkString(", ")
+    val resultStr = (1 to 30).mkString(":BIGINT, ") + ":BIGINT"
     val expected = unaryNode(
       "DataStreamCalc",
       streamTableNode(0),
@@ -57,7 +59,7 @@ class SetOperatorsTest extends TableTestBase {
     )
 
     util.verifySql(
-      s"SELECT * FROM MyTable WHERE b NOT IN ($resultStr)",
+      s"SELECT * FROM MyTable WHERE b NOT IN ($sqlStr)",
       expected)
   }
 
@@ -217,15 +219,15 @@ class SetOperatorsTest extends TableTestBase {
         unaryNode("DataStreamCalc",
           values("DataStreamValues",
             tuples(List("0"))),
-          term("select", "1 AS EXPR$0, 1 AS EXPR$1")),
+          term("select", "1 AS EXPR$0, 1:BIGINT AS EXPR$1")),
         unaryNode("DataStreamCalc",
           values("DataStreamValues",
             tuples(List("0"))),
-          term("select", "2 AS EXPR$0, 2 AS EXPR$1")),
+          term("select", "2 AS EXPR$0, 2:BIGINT AS EXPR$1")),
         unaryNode("DataStreamCalc",
           values("DataStreamValues",
             tuples(List("0"))),
-          term("select", "3 AS EXPR$0, 3 AS EXPR$1"))
+          term("select", "3 AS EXPR$0, 3:BIGINT AS EXPR$1"))
       ),
       term("all", "true"),
       term("union all", "EXPR$0, EXPR$1")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/UnionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/UnionTest.scala
@@ -44,7 +44,9 @@ class UnionTest extends TableTestBase {
       unaryNode(
         "DataStreamCalc",
         streamTableNode(0),
-        term("select", "CASE(>(c, 0), b, null) AS EXPR$0")
+        term("select", "CASE(>(c, 0), b",
+          "null:RecordType:peek_no_expand(" +
+            "INTEGER _1, VARCHAR(65536) CHARACTER SET \"UTF-16LE\" _2)) AS EXPR$0")
       ),
       term("all", "true"),
       term("union all", "a")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/GroupWindowTest.scala
@@ -734,10 +734,10 @@ class GroupWindowTest extends TableTestBase {
         ),
         term("select",
           "/(-($f0, /(*($f1, $f1), $f2)), $f2) AS TMP_0",
-          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))) AS TMP_1",
-          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5)) AS TMP_2",
-          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
-            "AS TMP_3",
+          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null:BIGINT, -($f2, 1))) AS TMP_1",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5:DECIMAL(2, 1))) AS TMP_2",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null:BIGINT, -($f2, 1)))",
+          "0.5:DECIMAL(2, 1))) AS TMP_3",
           "TMP_4",
           "TMP_5")
       )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/JoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/JoinTest.scala
@@ -57,8 +57,9 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
-          term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
-            " <(CAST(lrtime), +(CAST(rrtime), 3000)))"),
+          term("where", "AND(=(a, d), >=(CAST(lrtime)," +
+            " -(CAST(rrtime), 300000:INTERVAL DAY TO SECOND))," +
+            " <(CAST(lrtime), +(CAST(rrtime), 3000:INTERVAL DAY TO SECOND)))"),
           term("join", "a", "lrtime", "d", "e", "rrtime"),
           term("joinType", "InnerJoin")
         ),
@@ -92,7 +93,8 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rptime")
           ),
-          term("where", "AND(=(a, d), >=(PROCTIME(lptime), -(PROCTIME(rptime), 1000)), " +
+          term("where", "AND(=(a, d), >=(PROCTIME(lptime), " +
+            "-(PROCTIME(rptime), 1000:INTERVAL DAY TO SECOND)), " +
             "<(PROCTIME(lptime), PROCTIME(rptime)))"),
           term("join", "a", "lptime", "d", "e", "rptime"),
           term("joinType", "InnerJoin")
@@ -154,7 +156,7 @@ class JoinTest extends TableTestBase {
         streamTableNode(0),
         streamTableNode(1),
         term("where",
-          "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000)), " +
+          "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000:INTERVAL DAY TO SECOND)), " +
             "<(CAST(lrtime), CAST(rrtime)), >(CAST(lrtime), f))"),
         term("join", "a", "b", "c", "lrtime", "d", "e", "f", "rrtime"),
         term("joinType", "InnerJoin")
@@ -190,8 +192,9 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
-          term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
-            " <(CAST(lrtime), +(CAST(rrtime), 3000)))"),
+          term("where", "AND(=(a, d), >=(CAST(lrtime)," +
+            " -(CAST(rrtime), 300000:INTERVAL DAY TO SECOND))," +
+            " <(CAST(lrtime), +(CAST(rrtime), 3000:INTERVAL DAY TO SECOND)))"),
           term("join", "a", "lrtime", "d", "e", "rrtime"),
           term("joinType", "LeftOuterJoin")
         ),
@@ -225,7 +228,8 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rptime")
           ),
-          term("where", "AND(=(a, d), >=(PROCTIME(lptime), -(PROCTIME(rptime), 1000)), " +
+          term("where", "AND(=(a, d), >=(PROCTIME(lptime), " +
+            "-(PROCTIME(rptime), 1000:INTERVAL DAY TO SECOND)), " +
             "<(PROCTIME(lptime), PROCTIME(rptime)))"),
           term("join", "a", "lptime", "d", "e", "rptime"),
           term("joinType", "LeftOuterJoin")
@@ -263,8 +267,9 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
-          term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
-            " <(CAST(lrtime), +(CAST(rrtime), 3000)))"),
+          term("where", "AND(=(a, d), >=(CAST(lrtime)," +
+            " -(CAST(rrtime), 300000:INTERVAL DAY TO SECOND))," +
+            " <(CAST(lrtime), +(CAST(rrtime), 3000:INTERVAL DAY TO SECOND)))"),
           term("join", "a", "lrtime", "d", "e", "rrtime"),
           term("joinType", "RightOuterJoin")
         ),
@@ -298,7 +303,8 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rptime")
           ),
-          term("where", "AND(=(a, d), >=(PROCTIME(lptime), -(PROCTIME(rptime), 1000)), " +
+          term("where", "AND(=(a, d), >=(PROCTIME(lptime), " +
+            "-(PROCTIME(rptime), 1000:INTERVAL DAY TO SECOND)), " +
             "<(PROCTIME(lptime), PROCTIME(rptime)))"),
           term("join", "a", "lptime", "d", "e", "rptime"),
           term("joinType", "RightOuterJoin")
@@ -336,8 +342,9 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
-          term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
-            " <(CAST(lrtime), +(CAST(rrtime), 3000)))"),
+          term("where", "AND(=(a, d), >=(CAST(lrtime)," +
+            " -(CAST(rrtime), 300000:INTERVAL DAY TO SECOND))," +
+            " <(CAST(lrtime), +(CAST(rrtime), 3000:INTERVAL DAY TO SECOND)))"),
           term("join", "a", "lrtime", "d", "e", "rrtime"),
           term("joinType", "FullOuterJoin")
         ),
@@ -371,7 +378,8 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rptime")
           ),
-          term("where", "AND(=(a, d), >=(PROCTIME(lptime), -(PROCTIME(rptime), 1000)), " +
+          term("where", "AND(=(a, d), >=(PROCTIME(lptime), " +
+            "-(PROCTIME(rptime), 1000:INTERVAL DAY TO SECOND)), " +
             "<(PROCTIME(lptime), PROCTIME(rptime)))"),
           term("join", "a", "lptime", "d", "e", "rptime"),
           term("joinType", "FullOuterJoin")
@@ -407,8 +415,9 @@ class JoinTest extends TableTestBase {
             streamTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
-          term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
-            " <(CAST(lrtime), +(CAST(rrtime), 3000)))"),
+          term("where", "AND(=(a, d), >=(CAST(lrtime)," +
+            " -(CAST(rrtime), 300000:INTERVAL DAY TO SECOND))," +
+            " <(CAST(lrtime), +(CAST(rrtime), 3000:INTERVAL DAY TO SECOND)))"),
           term("join", "a", "lrtime", "d", "e", "rrtime"),
           // Since we filter on attributes of the left table after the join, the left outer join
           // will be automatically optimized to inner join.

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/OverWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/OverWindowTest.scala
@@ -53,13 +53,12 @@ class OverWindowTest extends TableTestBase {
           unaryNode(
             "DataStreamCalc",
             streamTableNode(0),
-            // RexSimplify didn't simplify "CAST(1):BIGINT NOT NULL", see [CALCITE-2862]
-            term("select", "a", "b", "c", "proctime", "1 AS $4")
+            term("select", "a", "b", "c", "proctime")
           ),
           term("partitionBy", "b"),
           term("orderBy", "proctime"),
           term("rows", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
-          term("select", "a", "b", "c", "proctime", "$4",
+          term("select", "a", "b", "c", "proctime",
                "SUM(a) AS w0$o0",
                "COUNT(a) AS w0$o1",
                "WeightedAvgWithRetract(c, a) AS w0$o2")
@@ -67,7 +66,7 @@ class OverWindowTest extends TableTestBase {
         term("select",
              s"Func1$$(w0$$o0) AS d",
              "EXP(CAST(w0$o1)) AS _c1",
-             "+(w0$o2, $4) AS _c2",
+             "+(w0$o2, 1:BIGINT) AS _c2",
              "||('AVG:', CAST(w0$o2)) AS _c3",
              "ARRAY(w0$o2, w0$o1) AS _c4")
       )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
@@ -234,7 +234,7 @@ object TemporalTableJoinTest {
             "DataStreamCalc",
             streamTableNode(2),
             term("select", "rowtime, currency, rate, secondary_key"),
-            term("where", ">(rate, 110)")
+            term("where", ">(rate, 110:BIGINT)")
           ),
           term("where",
             "AND(" +

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
@@ -56,16 +56,16 @@ class ExpressionReductionRulesTest extends TableTestBase {
         "+(7, a) AS EXPR$0",
         "+(b, 3) AS EXPR$1",
         "'b' AS EXPR$2",
-        "'STRING' AS EXPR$3",
+        "'STRING':VARCHAR(8) CHARACTER SET \"UTF-16LE\" AS EXPR$3",
         "'teststring' AS EXPR$4",
-        "null AS EXPR$5",
-        "1990-10-24 23:00:01.123 AS EXPR$6",
-        "19 AS EXPR$7",
+        "null:INTEGER AS EXPR$5",
+        "1990-10-24 23:00:01.123:TIMESTAMP(3) AS EXPR$6",
+        "19:BIGINT AS EXPR$7",
         "false AS EXPR$8",
         "true AS EXPR$9",
-        "2 AS EXPR$10",
+        "2:DECIMAL(2, 0) AS EXPR$10",
         "true AS EXPR$11",
-        "'trueX' AS EXPR$12"
+        "'trueX':VARCHAR(65536) CHARACTER SET \"UTF-16LE\" AS EXPR$12"
       ),
       term("where", ">(a, 8)")
     )
@@ -101,16 +101,16 @@ class ExpressionReductionRulesTest extends TableTestBase {
         "+(7, a) AS EXPR$0",
         "+(b, 3) AS EXPR$1",
         "'b' AS EXPR$2",
-        "'STRING' AS EXPR$3",
+        "'STRING':VARCHAR(8) CHARACTER SET \"UTF-16LE\" AS EXPR$3",
         "'teststring' AS EXPR$4",
-        "null AS EXPR$5",
-        "1990-10-24 23:00:01.123 AS EXPR$6",
-        "19 AS EXPR$7",
+        "null:INTEGER AS EXPR$5",
+        "1990-10-24 23:00:01.123:TIMESTAMP(3) AS EXPR$6",
+        "19:BIGINT AS EXPR$7",
         "false AS EXPR$8",
         "true AS EXPR$9",
-        "2 AS EXPR$10",
+        "2:DECIMAL(2, 0) AS EXPR$10",
         "true AS EXPR$11",
-        "'trueX' AS EXPR$12"
+        "'trueX':VARCHAR(65536) CHARACTER SET \"UTF-16LE\" AS EXPR$12"
       )
     )
 
@@ -161,11 +161,11 @@ class ExpressionReductionRulesTest extends TableTestBase {
         "'b' AS _c1",
         "'STRING' AS _c2",
         "'teststring' AS _c3",
-        "1990-10-24 23:00:01.123 AS _c4",
+        "1990-10-24 23:00:01.123:TIMESTAMP(3) AS _c4",
         "false AS _c5",
         "true AS _c6",
-        "2E0 AS _c7",
-        "'trueX' AS _c8"
+        "2E0:DOUBLE AS _c7",
+        "'trueX':VARCHAR(65536) CHARACTER SET \"UTF-16LE\" AS _c8"
       ),
       term("where", ">(a, 8)")
     )
@@ -197,11 +197,11 @@ class ExpressionReductionRulesTest extends TableTestBase {
         "'b' AS _c1",
         "'STRING' AS _c2",
         "'teststring' AS _c3",
-        "1990-10-24 23:00:01.123 AS _c4",
+        "1990-10-24 23:00:01.123:TIMESTAMP(3) AS _c4",
         "false AS _c5",
         "true AS _c6",
-        "2E0 AS _c7",
-        "'trueX' AS _c8"
+        "2E0:DOUBLE AS _c7",
+        "'trueX':VARCHAR(65536) CHARACTER SET \"UTF-16LE\" AS _c8"
       )
     )
 
@@ -254,16 +254,16 @@ class ExpressionReductionRulesTest extends TableTestBase {
         "+(7, a) AS EXPR$0",
         "+(b, 3) AS EXPR$1",
         "'b' AS EXPR$2",
-        "'STRING' AS EXPR$3",
+        "'STRING':VARCHAR(8) CHARACTER SET \"UTF-16LE\" AS EXPR$3",
         "'teststring' AS EXPR$4",
-        "null AS EXPR$5",
-        "1990-10-24 23:00:01.123 AS EXPR$6",
-        "19 AS EXPR$7",
+        "null:INTEGER AS EXPR$5",
+        "1990-10-24 23:00:01.123:TIMESTAMP(3) AS EXPR$6",
+        "19:BIGINT AS EXPR$7",
         "false AS EXPR$8",
         "true AS EXPR$9",
-        "2 AS EXPR$10",
+        "2:DECIMAL(2, 0) AS EXPR$10",
         "true AS EXPR$11",
-        "'trueX' AS EXPR$12"
+        "'trueX':VARCHAR(65536) CHARACTER SET \"UTF-16LE\" AS EXPR$12"
       ),
       term("where", ">(a, 8)")
     )
@@ -299,16 +299,16 @@ class ExpressionReductionRulesTest extends TableTestBase {
         "+(7, a) AS EXPR$0",
         "+(b, 3) AS EXPR$1",
         "'b' AS EXPR$2",
-        "'STRING' AS EXPR$3",
+        "'STRING':VARCHAR(8) CHARACTER SET \"UTF-16LE\" AS EXPR$3",
         "'teststring' AS EXPR$4",
-        "null AS EXPR$5",
-        "1990-10-24 23:00:01.123 AS EXPR$6",
-        "19 AS EXPR$7",
+        "null:INTEGER AS EXPR$5",
+        "1990-10-24 23:00:01.123:TIMESTAMP(3) AS EXPR$6",
+        "19:BIGINT AS EXPR$7",
         "false AS EXPR$8",
         "true AS EXPR$9",
-        "2 AS EXPR$10",
+        "2:DECIMAL(2, 0) AS EXPR$10",
         "true AS EXPR$11",
-        "'trueX' AS EXPR$12"
+        "'trueX':VARCHAR(65536) CHARACTER SET \"UTF-16LE\" AS EXPR$12"
       )
     )
 
@@ -359,11 +359,11 @@ class ExpressionReductionRulesTest extends TableTestBase {
         "'b' AS _c1",
         "'STRING' AS _c2",
         "'teststring' AS _c3",
-        "1990-10-24 23:00:01.123 AS _c4",
+        "1990-10-24 23:00:01.123:TIMESTAMP(3) AS _c4",
         "false AS _c5",
         "true AS _c6",
-        "2E0 AS _c7",
-        "'trueX' AS _c8"
+        "2E0:DOUBLE AS _c7",
+        "'trueX':VARCHAR(65536) CHARACTER SET \"UTF-16LE\" AS _c8"
       ),
       term("where", ">(a, 8)")
     )
@@ -395,11 +395,11 @@ class ExpressionReductionRulesTest extends TableTestBase {
         "'b' AS _c1",
         "'STRING' AS _c2",
         "'teststring' AS _c3",
-        "1990-10-24 23:00:01.123 AS _c4",
+        "1990-10-24 23:00:01.123:TIMESTAMP(3) AS _c4",
         "false AS _c5",
         "true AS _c6",
-        "2E0 AS _c7",
-        "'trueX' AS _c8"
+        "2E0:DOUBLE AS _c7",
+        "'trueX':VARCHAR(65536) CHARACTER SET \"UTF-16LE\" AS _c8"
       )
     )
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
@@ -85,7 +85,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
       "DataStreamCalc",
       streamTableNode(0),
       term("select", "rowtime"),
-      term("where", ">(CAST(rowtime), 1990-12-02 12:11:11)")
+      term("where", ">(CAST(rowtime), 1990-12-02 12:11:11:TIMESTAMP(3))")
     )
 
     util.verifyTable(result, expected)


### PR DESCRIPTION
## What is the purpose of the change

This change upgrades apache calcite dependencies to 1.19.0 release.

## Brief change log

  - Updated pom.xml file to include calcite 1.19.0
  - Updated all test cases that includes literals which now includes type in digest.
  - Updated the 2 pull-in files `DateTimeUtils` and `AuxiliaryConverter` and updated the depending calcite JIRAs which will eventually allow us to remove these two pull-ins.
  - Updated the `FlinkLogicalTableSourceScan` to include a new computeDigest override, this allows predicator push-down rules like `PushFilterIntoTableSourceScanRule` and `PushProjectIntoTableSourceScanRule` to find correct entry in digestToRelMap (see CALCITE-2454, and CALCITE PR [#1002](https://github.com/apache/calcite/pull/1002))


## Verifying this change

  - This change is already covered by existing tests
  - Verified via `mvn dependeny:tree` that no extra dependencies were pulled in.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
