### PR TITLE
[hotfix] [table] Refactor GenericInMemoryCatalogTest to prepare for moving common tests to CatalogTestBase

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
@@ -80,4 +80,10 @@ public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
 		// TODO: implement this once GenericHiveMetastoreCatalog support table operations
 		return null;
 	}
+
+	@Override
+	public CatalogTable createAnotherTable() {
+		// TODO: implement this once GenericHiveMetastoreCatalog support table operations
+		return null;
+	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.plan.stats.TableStats;
 
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -80,41 +81,38 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	@Test
 	public void testCreateTable_Streaming() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
-		GenericCatalogTable table = createStreamingTable();
+		CatalogTable table = createStreamingTable();
 		catalog.createTable(path1, table, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 	}
 
 	@Test
-	public void testCreateTable_Batch() throws Exception {
+	public void testCreateTable_Batch_nonPartitionedTable() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
-		CatalogDatabase database = catalog.getDatabase(db1);
-		assertTrue(TEST_COMMENT.equals(database.getDescription().get()));
-
-		// Non-partitioned table
-		GenericCatalogTable table = createTable();
+		CatalogTable table = createTable();
 		catalog.createTable(path1, table, false);
 
 		CatalogBaseTable tableCreated = catalog.getTable(path1);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) tableCreated);
+		CatalogTestUtil.checkEquals(table, (CatalogTable) tableCreated);
 		assertEquals(TABLE_COMMENT, tableCreated.getDescription().get());
 
 		List<String> tables = catalog.listTables(db1);
 
 		assertEquals(1, tables.size());
 		assertEquals(path1.getObjectName(), tables.get(0));
+	}
 
-		catalog.dropTable(path1, false);
-
-		// Partitioned table
-		table = createPartitionedTable();
+	@Test
+	public void testCreateTable_Batch_partitionedTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		CatalogTable table = createPartitionedTable();
 		catalog.createTable(path1, table, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 
-		tables = catalog.listTables(db1);
+		List<String> tables = catalog.listTables(db1);
 
 		assertEquals(1, tables.size());
 		assertEquals(path1.getObjectName(), tables.get(0));
@@ -132,7 +130,7 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	@Test
 	public void testCreateTable_TableAlreadyExistException() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
-		catalog.createTable(path1,  CatalogTestUtil.createTable(TABLE_COMMENT), false);
+		catalog.createTable(path1,  createTable(), false);
 
 		exception.expect(TableAlreadyExistException.class);
 		exception.expectMessage("Table (or view) db1.t1 already exists in Catalog");
@@ -143,14 +141,14 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	public void testCreateTable_TableAlreadyExist_ignored() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
 
-		GenericCatalogTable table =  CatalogTestUtil.createTable(TABLE_COMMENT);
+		CatalogTable table = createTable();
 		catalog.createTable(path1, table, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 
 		catalog.createTable(path1, createAnotherTable(), true);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 	}
 
 	@Test
@@ -170,10 +168,8 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	@Test
-	public void testDropTable() throws Exception {
+	public void testDropTable_nonPartitionedTable() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
-
-		// Non-partitioned table
 		catalog.createTable(path1, createTable(), false);
 
 		assertTrue(catalog.tableExists(path1));
@@ -181,8 +177,11 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 		catalog.dropTable(path1, false);
 
 		assertFalse(catalog.tableExists(path1));
+	}
 
-		// Partitioned table
+	@Test
+	public void testDropTable_partitionedTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
 		catalog.createTable(path1, createPartitionedTable(), false);
 		CatalogPartition catalogPartition = createPartition();
 		CatalogPartitionSpec catalogPartitionSpec = createPartitionSpec();
@@ -227,33 +226,32 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	@Test
-	public void testAlterTable() throws Exception {
+	public void testAlterTable_nonPartitionedTable() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
-
-		// Non-partitioned table
-		GenericCatalogTable table = CatalogTestUtil.createTable(TABLE_COMMENT);
+		CatalogTable table = createTable();
 		catalog.createTable(path1, table, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 
-		GenericCatalogTable newTable = createAnotherTable();
+		CatalogTable newTable = createAnotherTable();
 		catalog.alterTable(path1, newTable, false);
 
 		assertNotEquals(table, catalog.getTable(path1));
-		CatalogTestUtil.checkEquals(newTable, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(path1));
+	}
 
-		catalog.dropTable(path1, false);
-
-		// Partitioned table
-		table = createPartitionedTable();
+	@Test
+	public void testAlterTable_partitionedTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		CatalogTable table = createPartitionedTable();
 		catalog.createTable(path1, table, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 
-		newTable = createAnotherPartitionedTable();
+		CatalogTable newTable = createAnotherPartitionedTable();
 		catalog.alterTable(path1, newTable, false);
 
-		CatalogTestUtil.checkEquals(newTable, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(path1));
 	}
 
 	@Test
@@ -272,35 +270,34 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	@Test
-	public void testRenameTable() throws Exception {
+	public void testRenameTable_nonPartitionedTable() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
-
-		// Non-partitioned table
-		GenericCatalogTable table = createTable();
+		CatalogTable table = createTable();
 		catalog.createTable(path1, table, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 
 		catalog.renameTable(path1, t2, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path3));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path3));
 		assertFalse(catalog.tableExists(path1));
+	}
 
-		catalog.dropTable(path3, false);
-
-		// Partitioned table
-		table = createPartitionedTable();
+	@Test
+	public void testRenameTable_partitionedTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		CatalogTable table = createPartitionedTable();
 		catalog.createTable(path1, table, false);
 		CatalogPartition catalogPartition = createPartition();
 		CatalogPartitionSpec catalogPartitionSpec = createPartitionSpec();
 		catalog.createPartition(path1, catalogPartitionSpec, catalogPartition, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 		assertTrue(catalog.partitionExists(path1, catalogPartitionSpec));
 
 		catalog.renameTable(path1, t2, false);
 
-		CatalogTestUtil.checkEquals(table, (GenericCatalogTable) catalog.getTable(path3));
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path3));
 		assertTrue(catalog.partitionExists(path3, catalogPartitionSpec));
 		assertFalse(catalog.tableExists(path1));
 		assertFalse(catalog.partitionExists(path1, catalogPartitionSpec));
@@ -962,35 +959,44 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	private GenericCatalogTable createStreamingTable() {
-		return CatalogTestUtil.createTable(
+		return new GenericCatalogTable(
 			createTableSchema(),
-			getStreamingTableProperties(), TABLE_COMMENT);
+			new TableStats(0),
+			getStreamingTableProperties(),
+			TABLE_COMMENT);
 	}
 
 	@Override
-	public GenericCatalogTable createTable() {
-		return CatalogTestUtil.createTable(
+	public CatalogTable createTable() {
+		return new GenericCatalogTable(
 			createTableSchema(),
-			getBatchTableProperties(), TABLE_COMMENT);
+			new TableStats(0),
+			getBatchTableProperties(),
+			TABLE_COMMENT);
 	}
 
-	private GenericCatalogTable createAnotherTable() {
-		return CatalogTestUtil.createTable(
+	@Override
+	public CatalogTable createAnotherTable() {
+		return new GenericCatalogTable(
 			createAnotherTableSchema(),
-			getBatchTableProperties(), TABLE_COMMENT);
+			new TableStats(0),
+			getBatchTableProperties(),
+			TABLE_COMMENT);
 	}
 
-	protected GenericCatalogTable createPartitionedTable() {
-		return CatalogTestUtil.createPartitionedTable(
+	protected CatalogTable createPartitionedTable() {
+		return new GenericCatalogTable(
 			createTableSchema(),
+			new TableStats(0),
 			createPartitionKeys(),
 			getBatchTableProperties(),
 			TABLE_COMMENT);
 	}
 
-	protected GenericCatalogTable createAnotherPartitionedTable() {
-		return CatalogTestUtil.createPartitionedTable(
+	protected CatalogTable createAnotherPartitionedTable() {
+		return new GenericCatalogTable(
 			createAnotherTableSchema(),
+			new TableStats(0),
 			createPartitionKeys(),
 			getBatchTableProperties(),
 			TABLE_COMMENT);

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -88,8 +88,10 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	@Test
-	public void testCreateTable_Batch_nonPartitionedTable() throws Exception {
+	public void testCreateTable_Batch() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
+
+		// Non-partitioned table
 		CatalogTable table = createTable();
 		catalog.createTable(path1, table, false);
 
@@ -102,17 +104,16 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 		assertEquals(1, tables.size());
 		assertEquals(path1.getObjectName(), tables.get(0));
-	}
 
-	@Test
-	public void testCreateTable_Batch_partitionedTable() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		CatalogTable table = createPartitionedTable();
+		catalog.dropTable(path1, false);
+
+		// Partitioned table
+		table = createPartitionedTable();
 		catalog.createTable(path1, table, false);
 
 		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 
-		List<String> tables = catalog.listTables(db1);
+		tables = catalog.listTables(db1);
 
 		assertEquals(1, tables.size());
 		assertEquals(path1.getObjectName(), tables.get(0));
@@ -226,8 +227,10 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	@Test
-	public void testAlterTable_nonPartitionedTable() throws Exception {
+	public void testAlterTable() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
+
+		// Non-partitioned table
 		CatalogTable table = createTable();
 		catalog.createTable(path1, table, false);
 
@@ -238,17 +241,16 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 		assertNotEquals(table, catalog.getTable(path1));
 		CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(path1));
-	}
 
-	@Test
-	public void testAlterTable_partitionedTable() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		CatalogTable table = createPartitionedTable();
+		catalog.dropTable(path1, false);
+
+		// Partitioned table
+		table = createPartitionedTable();
 		catalog.createTable(path1, table, false);
 
 		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 
-		CatalogTable newTable = createAnotherPartitionedTable();
+		newTable = createAnotherPartitionedTable();
 		catalog.alterTable(path1, newTable, false);
 
 		CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(path1));

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -238,4 +238,11 @@ public abstract class CatalogTestBase {
 	 * @return a CatalogTable instance
 	 */
 	public abstract CatalogTable createTable();
+
+	/**
+	 * Create another CatalogTable instance by specific catalog implementation.
+	 *
+	 * @return another CatalogTable instance
+	 */
+	public abstract CatalogTable createAnotherTable();
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -18,15 +18,7 @@
 
 package org.apache.flink.table.catalog;
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.plan.stats.TableStats;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -35,42 +27,10 @@ import static org.junit.Assert.assertEquals;
  */
 public class CatalogTestUtil {
 
-	public static GenericCatalogTable createTable(String comment) {
-		TableSchema tableSchema = TableSchema.fromTypeInfo(getRowTypeInfo());
-		return new GenericCatalogTable(tableSchema, createTableStats(), new HashMap<>(), comment);
-	}
-
-	public static RowTypeInfo getRowTypeInfo() {
-		return new RowTypeInfo(
-			new TypeInformation[] {BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO},
-			new String[] {"a", "b"});
-	}
-
-	public static TableStats createTableStats() {
-		return new TableStats(2);
-	}
-
-	public static GenericCatalogTable createTable(
-		TableSchema schema,
-		Map<String, String> tableProperties,
-		String comment) {
-
-		return new GenericCatalogTable(schema, new TableStats(0), tableProperties, comment);
-	}
-
-	public static GenericCatalogTable createPartitionedTable(
-		TableSchema schema,
-		List<String> partitionKeys,
-		Map<String, String> tableProperties,
-		String comment) {
-
-		return new GenericCatalogTable(schema, new TableStats(0), partitionKeys, tableProperties, comment);
-	}
-
-	public static void checkEquals(GenericCatalogTable t1, GenericCatalogTable t2) {
+	public static void checkEquals(CatalogTable t1, CatalogTable t2) {
 		assertEquals(t1.getSchema(), t2.getSchema());
 		checkEquals(t1.getStatistics(), t2.getStatistics());
-		assertEquals(t1.getComment(), t2.getComment());
+		assertEquals(t1.getDescription(), t2.getDescription());
 	}
 
 	protected static void checkEquals(TableStats ts1, TableStats ts2) {


### PR DESCRIPTION
## What is the purpose of the change

This PR refactors existing GenericInMemoryCatalogTest as preparation for moving common tests to CatalogTestBase. Since the unit test logic for different catalog's API implementations are the mostly the same, CatalogTestBase should hold all those common tests so we can reuse them for different catalog test class rather than writing duplicated tests.

## Brief change log

- Split a couple unit tests for partitioned table and non-partitioned table to ease the migration later
- Moved CatalogTestUtil from flink-table-api-java to flink-table-common
- Removed some redundant utils from CatalogTestUtil

## Verifying this change

This change is already covered by existing tests, such as *GenericInMemoryCatalogTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
