### PR TITLE
[FLINK-12333][docs] Add documentation for all async operations through REST API

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -2131,7 +2131,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">Triggers the rescaling of a job.</td>
+      <td colspan="2">Triggers the rescaling of a job. This async operation would return a 'triggerid' for further query identifier.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2261,7 +2261,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td class="text-left">Response code: <code>202 Accepted</code></td>
     </tr>
     <tr>
-      <td colspan="2">Triggers a savepoint, and optionally cancels the job afterwards.</td>
+      <td colspan="2">Triggers a savepoint, and optionally cancels the job afterwards. This async operation would return a 'triggerid' for further query identifier.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2392,7 +2392,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td class="text-left">Response code: <code>202 Accepted</code></td>
     </tr>
     <tr>
-      <td colspan="2">Stops a job with a savepoint. Optionally, it can also emit a MAX_WATERMARK before taking the savepoint to flush out any state waiting for timers to fire.</td>
+      <td colspan="2">Stops a job with a savepoint. Optionally, it can also emit a MAX_WATERMARK before taking the savepoint to flush out any state waiting for timers to fire. This async operation would return a 'triggerid' for further query identifier.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -3581,7 +3581,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">Triggers the desposal of a savepoint.</td>
+      <td colspan="2">Triggers the desposal of a savepoint. This async operation would return a 'triggerid' for further query identifier.</td>
     </tr>
     <tr>
       <td colspan="2">

--- a/docs/monitoring/rest_api.md
+++ b/docs/monitoring/rest_api.md
@@ -61,6 +61,8 @@ If no version is specified Flink will default to the *oldest* version supporting
 
 Querying unsupported/non-existing versions will return a 404 error.
 
+There exist several async operations among these APIs, e.g. `trigger savepoint`, `rescale a job`. They would return a `triggerid` to identify the operation you just POST and then you need to use that `triggerid` to query for the status of the operation.
+
 <div class="codetabs" markdown="1">
 
 <div data-lang="v1" markdown="1">

--- a/docs/monitoring/rest_api.zh.md
+++ b/docs/monitoring/rest_api.zh.md
@@ -61,6 +61,8 @@ If no version is specified Flink will default to the *oldest* version supporting
 
 Querying unsupported/non-existing versions will return a 404 error.
 
+There exist several async operations among these APIs, e.g. `trigger savepoint`, `rescale a job`. They would return a `triggerid` to identify the operation you just POST and then you need to use that `triggerid` to query for the status of the operation.
+
 <div class="codetabs" markdown="1">
 
 <div data-lang="v1" markdown="1">

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AsynchronousOperationTriggerMessageHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AsynchronousOperationTriggerMessageHeaders.java
@@ -35,4 +35,16 @@ public abstract class AsynchronousOperationTriggerMessageHeaders<R extends Reque
 	public Class<TriggerResponse> getResponseClass() {
 		return TriggerResponse.class;
 	}
+
+	@Override
+	public String getDescription() {
+		return getAsyncOperationDescription() + " This async operation would return a 'triggerid' for further query identifier.";
+	}
+
+	/**
+	 * Returns the description for this async operation header.
+	 *
+	 * @return the description for this async operation header.
+	 */
+	protected abstract String getAsyncOperationDescription();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingTriggerHeaders.java
@@ -69,7 +69,7 @@ public class RescalingTriggerHeaders extends
 	}
 
 	@Override
-	public String getDescription() {
+	protected String getAsyncOperationDescription() {
 		return "Triggers the rescaling of a job.";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalTriggerHeaders.java
@@ -66,7 +66,7 @@ public class SavepointDisposalTriggerHeaders extends AsynchronousOperationTrigge
 	}
 
 	@Override
-	public String getDescription() {
+	protected String getAsyncOperationDescription() {
 		return "Triggers the desposal of a savepoint.";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerHeaders.java
@@ -78,7 +78,7 @@ public class SavepointTriggerHeaders
 	}
 
 	@Override
-	public String getDescription() {
+	protected String getAsyncOperationDescription() {
 		return "Triggers a savepoint, and optionally cancels the job afterwards.";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointTriggerHeaders.java
@@ -79,8 +79,8 @@ public class StopWithSavepointTriggerHeaders
 	}
 
 	@Override
-	public String getDescription() {
+	protected String getAsyncOperationDescription() {
 		return "Stops a job with a savepoint. Optionally, it can also emit a MAX_WATERMARK before taking" +
-				" the savepoint to flush out any state waiting for timers to fire.";
+			" the savepoint to flush out any state waiting for timers to fire.";
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
@@ -265,6 +265,11 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 		}
 
 		@Override
+		protected String getAsyncOperationDescription() {
+			return "";
+		}
+
+		@Override
 		public Class<EmptyRequestBody> getRequestClass() {
 			return EmptyRequestBody.class;
 		}


### PR DESCRIPTION


## What is the purpose of the change

Improve the description for all async-operations through REST API. `Trigger savepoint` and `rescaling` operations are all async-operations which would return a request-id for further query identifier. However, current REST documentation does not describe this clearly and users might be confused to use these REST APIs


## Brief change log

  - Add description for all async operation headers.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
