### PR TITLE
[FLINK-12239][hive] Support table related operations in GenericHiveMetastoreCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -197,10 +197,6 @@ under the License.
 					<artifactId>metrics-json</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>com.github.joshelser</groupId>
 					<artifactId>dropwizard-metrics-hadoop-metrics2-reporter</artifactId>
 				</exclusion>
@@ -387,6 +383,7 @@ under the License.
 									<include>commons-dbcp:commons-dbcp</include>
 									<include>commons-pool:commons-pool</include>
 									<include>commons-beanutils:commons-beanutils</include>
+									<include>com.fasterxml.jackson.core:*</include>
 									<include>com.jolbox:bonecp</include>
 									<include>org.apache.hive:*</include>
 									<include>org.apache.thrift:libthrift</include>

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogUtil.java
@@ -18,17 +18,40 @@
 
 package org.apache.flink.table.catalog.hive;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.GenericCatalogTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.plan.stats.TableStats;
 
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-
+import java.util.stream.Collectors;
 
 /**
  * Utils to convert meta objects between Flink and Hive for GenericHiveMetastoreCatalog.
  */
 public class GenericHiveMetastoreCatalogUtil {
+
+	// Prefix used to distinguish properties created by Hive and Flink,
+	// as Hive metastore has its own properties created upon table creation and migration between different versions of metastore.
+	private static final String FLINK_PROPERTY_PREFIX = "flink.";
+
+	// Flink tables should be stored as 'external' tables in Hive metastore
+	private static final Map<String, String> EXTERNAL_TABLE_PROPERTY = new HashMap<String, String>() {{
+		put("EXTERNAL", "TRUE");
+	}};
 
 	private GenericHiveMetastoreCatalogUtil() {
 	}
@@ -36,14 +59,137 @@ public class GenericHiveMetastoreCatalogUtil {
 	// ------ Utils ------
 
 	/**
-	 * Creates a Hive database from CatalogDatabase.
+	 * Creates a Hive database from a CatalogDatabase.
+	 *
+	 * @param databaseName name of the database
+	 * @param catalogDatabase the CatalogDatabase instance
+	 * @return a Hive database
 	 */
-	public static Database createHiveDatabase(String dbName, CatalogDatabase db) {
-		Map<String, String> props = db.getProperties();
+	public static Database createHiveDatabase(String databaseName, CatalogDatabase catalogDatabase) {
 		return new Database(
-			dbName,
-			db.getDescription().isPresent() ? db.getDescription().get() : null,
+			databaseName,
+			catalogDatabase.getDescription().isPresent() ? catalogDatabase.getDescription().get() : null,
 			null,
-			props);
+			catalogDatabase.getProperties());
+	}
+
+	/**
+	 * Creates a Hive table from a CatalogBaseTable.
+	 * TODO: [FLINK-12240] Support view related operations in GenericHiveMetastoreCatalog
+	 *
+	 * @param tablePath path of the table
+	 * @param table the CatalogBaseTable instance
+	 * @return a Hive table
+	 */
+	public static Table createHiveTable(ObjectPath tablePath, CatalogBaseTable table) {
+		Map<String, String> properties = new HashMap<>(table.getProperties());
+
+		// Table comment
+		properties.put(HiveTableConfig.TABLE_COMMENT, table.getComment());
+
+		Table hiveTable = new Table();
+		hiveTable.setDbName(tablePath.getDatabaseName());
+		hiveTable.setTableName(tablePath.getObjectName());
+		hiveTable.setCreateTime((int) (System.currentTimeMillis() / 1000));
+
+		// Table properties
+		hiveTable.setParameters(buildFlinkProperties(properties));
+		hiveTable.getParameters().putAll(EXTERNAL_TABLE_PROPERTY);
+
+		// Hive table's StorageDescriptor
+		StorageDescriptor sd = new StorageDescriptor();
+		sd.setSerdeInfo(new SerDeInfo(null, null, new HashMap<>()));
+
+		List<FieldSchema> allColumns = createHiveColumns(table.getSchema());
+
+		// Table columns and partition keys
+		if (table instanceof CatalogTable) {
+			CatalogTable catalogTable = (CatalogTable) table;
+
+			if (catalogTable.isPartitioned()) {
+				int partitionKeySize = catalogTable.getPartitionKeys().size();
+				List<FieldSchema> regularColumns = allColumns.subList(0, allColumns.size() - partitionKeySize);
+				List<FieldSchema> partitionColumns = allColumns.subList(allColumns.size() - partitionKeySize, allColumns.size());
+
+				sd.setCols(regularColumns);
+				hiveTable.setPartitionKeys(partitionColumns);
+			} else {
+				sd.setCols(allColumns);
+				hiveTable.setPartitionKeys(new ArrayList<>());
+			}
+
+			hiveTable.setSd(sd);
+		} else {
+			// TODO: [FLINK-12240] Support view related operations in GenericHiveMetastoreCatalog
+			throw new UnsupportedOperationException();
+		}
+
+		return hiveTable;
+	}
+
+	/**
+	 * Creates a CatalogBaseTable from a Hive table.
+	 * TODO: [FLINK-12240] Support view related operations in GenericHiveMetastoreCatalog
+	 *
+	 * @param hiveTable the Hive table
+	 * @return a CatalogBaseTable
+	 */
+	public static CatalogBaseTable createCatalogTable(Table hiveTable) {
+		// Table schema
+		TableSchema tableSchema = HiveCatalogBaseUtil.createTableSchema(
+				hiveTable.getSd().getCols(), hiveTable.getPartitionKeys());
+
+		// Table properties
+		Map<String, String> properties = retrieveFlinkProperties(hiveTable.getParameters());
+
+		// Table comment
+		String comment = properties.remove(HiveTableConfig.TABLE_COMMENT);
+
+		// Partition keys
+		List<String> partitionKeys = new ArrayList<>();
+
+		if (hiveTable.getPartitionKeys() != null && hiveTable.getPartitionKeys().isEmpty()) {
+			partitionKeys = hiveTable.getPartitionKeys().stream()
+								.map(fs -> fs.getName())
+								.collect(Collectors.toList());
+		}
+
+		return new GenericCatalogTable(
+			tableSchema, new TableStats(0), partitionKeys, properties, comment);
+	}
+
+	/**
+	 * Create Hive columns from Flink TableSchema.
+	 */
+	private static List<FieldSchema> createHiveColumns(TableSchema schema) {
+		String[] fieldNames = schema.getFieldNames();
+		TypeInformation[] fieldTypes = schema.getFieldTypes();
+
+		List<FieldSchema> columns = new ArrayList<>(fieldNames.length);
+
+		for (int i = 0; i < fieldNames.length; i++) {
+			columns.add(
+				new FieldSchema(fieldNames[i], HiveTypeUtil.toHiveType(fieldTypes[i]), null));
+		}
+
+		return columns;
+	}
+
+	/**
+	 * Filter out Hive-created properties, and return Flink-created properties.
+	 */
+	private static Map<String, String> retrieveFlinkProperties(Map<String, String> hiveTableParams) {
+		return hiveTableParams.entrySet().stream()
+			.filter(e -> e.getKey().startsWith(FLINK_PROPERTY_PREFIX))
+			.collect(Collectors.toMap(e -> e.getKey().replace(FLINK_PROPERTY_PREFIX, ""), e -> e.getValue()));
+	}
+
+	/**
+	 * Add a prefix to Flink-created properties to distinguish them from Hive-created properties.
+	 */
+	public static Map<String, String> buildFlinkProperties(Map<String, String> properties) {
+		return properties.entrySet().stream()
+			.filter(e -> e.getKey() != null && e.getValue() != null)
+			.collect(Collectors.toMap(e -> FLINK_PROPERTY_PREFIX + e.getKey(), e -> e.getValue()));
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBaseUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBaseUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
+
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared util for catalogs backed by Hive-metastore.
+ */
+public class HiveCatalogBaseUtil {
+
+	/**
+	 * Create a Flink's TableSchema from Hive table's columns and partition keys.
+	 *
+	 * @param cols columns of the Hive table
+	 * @param partitionKeys partition keys of the Hive table
+	 * @return a Flink TableSchema
+	 */
+	public static TableSchema createTableSchema(List<FieldSchema> cols, List<FieldSchema> partitionKeys) {
+		List<FieldSchema> allCols = new ArrayList<>(cols);
+		allCols.addAll(partitionKeys);
+
+		String[] colNames = new String[allCols.size()];
+		TypeInformation[] colTypes = new TypeInformation[allCols.size()];
+
+		for (int i = 0; i < allCols.size(); i++) {
+			FieldSchema fs = allCols.get(i);
+
+			colNames[i] = fs.getName();
+			colTypes[i] = HiveTypeUtil.toFlinkType(TypeInfoUtils.getTypeInfoFromTypeString(fs.getType()));
+		}
+
+		return new TableSchema(colNames, colTypes);
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveTableConfig.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveTableConfig.java
@@ -16,20 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.catalog.exceptions;
+package org.apache.flink.table.catalog.hive;
 
 /**
- * Exception for trying to drop on a database that is not empty.
- *
+ * Configs for Flink tables stored in Hive metastore.
  */
-public class DatabaseNotEmptyException extends Exception {
-	private static final String MSG = "Database %s in catalog %s is not empty.";
+public class HiveTableConfig {
 
-	public DatabaseNotEmptyException(String catalog, String database, Throwable cause) {
-		super(String.format(MSG, database, catalog), cause);
-	}
+	// Description of the Flink table
+	public static final String TABLE_COMMENT = "comment";
 
-	public DatabaseNotEmptyException(String catalog, String database) {
-		this(catalog, database, null);
-	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveTypeUtil.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+/**
+ * Utils to convert data types between Flink and Hive.
+ */
+public class HiveTypeUtil {
+
+	// Note: Need to keep this in sync with BaseSemanticAnalyzer::getTypeStringFromAST
+	private static final String HIVE_ARRAY_TYPE_NAME_FORMAT = serdeConstants.LIST_TYPE_NAME + "<%s>";
+
+	private HiveTypeUtil() {
+	}
+
+	/**
+	 * Convert Flink data type to Hive data type.
+	 * TODO: the following Hive types are not supported in Flink yet, including CHAR, VARCHAR, DECIMAL, MAP, STRUCT
+	 * 		[FLINK-12386] Support complete mapping between Flink and Hive data types
+	 *
+	 * @param type a Flink data type
+	 * @return the corresponding Hive data type
+	 */
+	public static String toHiveType(TypeInformation type) {
+		if (type == BasicTypeInfo.BOOLEAN_TYPE_INFO) {
+			return serdeConstants.BOOLEAN_TYPE_NAME;
+		} else if (type == BasicTypeInfo.BYTE_TYPE_INFO) {
+			return serdeConstants.TINYINT_TYPE_NAME;
+		} else if (type == BasicTypeInfo.SHORT_TYPE_INFO) {
+			return serdeConstants.SMALLINT_TYPE_NAME;
+		} else if (type == BasicTypeInfo.INT_TYPE_INFO) {
+			return serdeConstants.INT_TYPE_NAME;
+		} else if (type == BasicTypeInfo.LONG_TYPE_INFO) {
+			return serdeConstants.BIGINT_TYPE_NAME;
+		} else if (type == BasicTypeInfo.FLOAT_TYPE_INFO) {
+			return serdeConstants.FLOAT_TYPE_NAME;
+		} else if (type == BasicTypeInfo.DOUBLE_TYPE_INFO) {
+			return serdeConstants.DOUBLE_TYPE_NAME;
+		} else if (type == BasicTypeInfo.STRING_TYPE_INFO) {
+			return serdeConstants.STRING_TYPE_NAME;
+		} else if (type == BasicTypeInfo.DATE_TYPE_INFO) {
+			return serdeConstants.DATE_TYPE_NAME;
+		} else if (type == BasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO) {
+			return serdeConstants.BINARY_TYPE_NAME;
+		} else if (type instanceof SqlTimeTypeInfo) {
+			return serdeConstants.TIMESTAMP_TYPE_NAME;
+		} else if (type instanceof BasicArrayTypeInfo) {
+			return toHiveArrayType((BasicArrayTypeInfo) type);
+		} else {
+			throw new UnsupportedOperationException(
+				String.format("Flink doesn't support converting type %s to Hive type yet.", type.toString()));
+		}
+	}
+
+	private static String toHiveArrayType(BasicArrayTypeInfo arrayTypeInfo) {
+		return String.format(HIVE_ARRAY_TYPE_NAME_FORMAT, toHiveType(arrayTypeInfo.getComponentInfo()));
+	}
+
+	/**
+	 * Convert Hive data type to a Flink data type.
+	 * TODO: the following Hive types are not supported in Flink yet, including CHAR, VARCHAR, DECIMAL, MAP, STRUCT
+	 *      [FLINK-12386] Support complete mapping between Flink and Hive data types
+	 *
+	 * @param hiveType a Hive data type
+	 * @return the corresponding Flink data type
+	 */
+	public static TypeInformation toFlinkType(TypeInfo hiveType) {
+		switch (hiveType.getCategory()) {
+			case PRIMITIVE:
+				return toFlinkPrimitiveType((PrimitiveTypeInfo) hiveType);
+			case LIST:
+				ListTypeInfo listTypeInfo = (ListTypeInfo) hiveType;
+				return BasicArrayTypeInfo.getInfoFor(toFlinkType(listTypeInfo.getListElementTypeInfo()).getTypeClass());
+			default:
+				throw new UnsupportedOperationException(
+					String.format("Flink doesn't support Hive data type %s yet.", hiveType));
+		}
+	}
+
+	// TODO: the following Hive types are not supported in Flink yet, including CHAR, VARCHAR, DECIMAL, MAP, STRUCT
+	//    [FLINK-12386] Support complete mapping between Flink and Hive data types
+	private static TypeInformation toFlinkPrimitiveType(PrimitiveTypeInfo hiveType) {
+		switch (hiveType.getPrimitiveCategory()) {
+			// For CHAR(p) and VARCHAR(p) types, map them to String for now because Flink doesn't yet support them.
+			case CHAR:
+			case VARCHAR:
+			case STRING:
+				return BasicTypeInfo.STRING_TYPE_INFO;
+			case BOOLEAN:
+				return BasicTypeInfo.BOOLEAN_TYPE_INFO;
+			case BYTE:
+				return BasicTypeInfo.BYTE_TYPE_INFO;
+			case SHORT:
+				return BasicTypeInfo.SHORT_TYPE_INFO;
+			case INT:
+				return BasicTypeInfo.INT_TYPE_INFO;
+			case LONG:
+				return BasicTypeInfo.LONG_TYPE_INFO;
+			case FLOAT:
+				return BasicTypeInfo.FLOAT_TYPE_INFO;
+			case DOUBLE:
+				return BasicTypeInfo.DOUBLE_TYPE_INFO;
+			case DATE:
+				return BasicTypeInfo.DATE_TYPE_INFO;
+			case TIMESTAMP:
+				return SqlTimeTypeInfo.TIMESTAMP;
+			case BINARY:
+				return BasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO;
+			default:
+				throw new UnsupportedOperationException(
+					String.format("Flink doesn't support Hive primitive type %s yet", hiveType));
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
@@ -8,6 +8,9 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - commons-dbcp:commons-dbcp:1.4
 - commons-pool:commons-pool:1.5.4
+- com.fasterxml.jackson.core:jackson-annotations:2.6.0
+- com.fasterxml.jackson.core:jackson-core:2.6.5
+- com.fasterxml.jackson.core:jackson-databind:2.6.5
 - com.jolbox:bonecp:0.8.0.RELEASE
 - org.apache.hive:hive-common:2.3.4
 - org.apache.hive:hive-metastore:2.3.4

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
@@ -18,10 +18,18 @@
 
 package org.apache.flink.table.catalog.hive;
 
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTestBase;
+import org.apache.flink.table.catalog.CatalogTestUtil;
 import org.apache.flink.table.catalog.GenericCatalogDatabase;
+import org.apache.flink.table.catalog.GenericCatalogTable;
+import org.apache.flink.table.plan.stats.TableStats;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,14 +48,47 @@ public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
 		catalog.open();
 	}
 
-	// =====================
-	// GenericHiveMetastoreCatalog doesn't support table operation yet
-	// Thus, overriding the following tests which involve table operation in CatalogTestBase so they won't run against GenericHiveMetastoreCatalog
-	// =====================
+	// ------ data types ------
 
-	// TODO: re-enable this test once GenericHiveMetastoreCatalog support table operations
 	@Test
-	public void testDropDb_DatabaseNotEmptyException() throws Exception {
+	public void testDataTypes() throws Exception {
+		// TODO: the following Hive types are not supported in Flink yet, including CHAR, VARCHAR, DECIMAL, MAP, STRUCT
+		//	  [FLINK-12386] Support complete mapping between Flink and Hive data types
+		TypeInformation[] types = new TypeInformation[] {
+			BasicTypeInfo.BYTE_TYPE_INFO,
+			BasicTypeInfo.SHORT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.LONG_TYPE_INFO,
+			BasicTypeInfo.FLOAT_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO,
+			BasicTypeInfo.BOOLEAN_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO,
+			BasicTypeInfo.DATE_TYPE_INFO,
+			SqlTimeTypeInfo.TIMESTAMP
+		};
+
+		verifyDataTypes(types);
+	}
+
+	private void verifyDataTypes(TypeInformation[] types) throws Exception {
+		String[] colNames = new String[types.length];
+
+		for (int i = 0; i < types.length; i++) {
+			colNames[i] = types[i].toString().toLowerCase() + "_col";
+		}
+
+		CatalogTable table = new GenericCatalogTable(
+			new TableSchema(colNames, types),
+			new TableStats(0),
+			getBatchTableProperties(),
+			TEST_COMMENT
+		);
+
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.createTable(path1, table, false);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 	}
 
 	// ------ utils ------
@@ -77,13 +118,48 @@ public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
 
 	@Override
 	public CatalogTable createTable() {
-		// TODO: implement this once GenericHiveMetastoreCatalog support table operations
-		return null;
+		return new GenericCatalogTable(
+			createTableSchema(),
+			new TableStats(0),
+			getBatchTableProperties(),
+			TEST_COMMENT);
 	}
 
 	@Override
 	public CatalogTable createAnotherTable() {
-		// TODO: implement this once GenericHiveMetastoreCatalog support table operations
-		return null;
+		return new GenericCatalogTable(
+			createAnotherTableSchema(),
+			new TableStats(0),
+			getBatchTableProperties(),
+			TEST_COMMENT);
+	}
+
+	@Override
+	public CatalogTable createStreamingTable() {
+		return new GenericCatalogTable(
+			createTableSchema(),
+			new TableStats(0),
+			getStreamingTableProperties(),
+			TEST_COMMENT);
+	}
+
+	@Override
+	public CatalogTable createPartitionedTable() {
+		return new GenericCatalogTable(
+			createTableSchema(),
+			new TableStats(0),
+			createPartitionKeys(),
+			getBatchTableProperties(),
+			TEST_COMMENT);
+	}
+
+	@Override
+	public CatalogTable createAnotherPartitionedTable() {
+		return new GenericCatalogTable(
+			createAnotherTableSchema(),
+			new TableStats(0),
+			createPartitionKeys(),
+			getBatchTableProperties(),
+			TEST_COMMENT);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.catalog.hive;
 
+import org.apache.flink.table.catalog.CatalogTestBase;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.rules.TemporaryFolder;
 
@@ -35,7 +37,7 @@ public class HiveTestUtils {
 	 * Create a GenericHiveMetastoreCatalog with an embedded Hive Metastore.
 	 */
 	public static GenericHiveMetastoreCatalog createGenericHiveMetastoreCatalog() throws IOException {
-		return new GenericHiveMetastoreCatalog("test", getHiveConf());
+		return new GenericHiveMetastoreCatalog(CatalogTestBase.TEST_CATALOG_NAME, getHiveConf());
 	}
 
 	private static HiveConf getHiveConf() throws IOException {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogTable.java
@@ -61,8 +61,8 @@ public class GenericCatalogTable implements CatalogTable {
 			TableSchema tableSchema,
 			TableStats tableStats,
 			Map<String, String> properties,
-			String comment) {
-		this(tableSchema, tableStats, new ArrayList<>(), properties, comment);
+			String description) {
+		this(tableSchema, tableStats, new ArrayList<>(), properties, description);
 	}
 
 	@Override
@@ -91,6 +91,11 @@ public class GenericCatalogTable implements CatalogTable {
 	}
 
 	@Override
+	public String getComment() {
+		return comment;
+	}
+
+	@Override
 	public GenericCatalogTable copy() {
 		return new GenericCatalogTable(
 			this.tableSchema.copy(), this.tableStats.copy(), new ArrayList<>(partitionKeys), new HashMap<>(this.properties), comment);
@@ -104,14 +109,6 @@ public class GenericCatalogTable implements CatalogTable {
 	@Override
 	public Optional<String> getDetailedDescription() {
 		return Optional.of("This is a catalog table in an im-memory catalog");
-	}
-
-	public String getComment() {
-		return this.comment;
-	}
-
-	public void setComment(String comment) {
-		this.comment = comment;
 	}
 
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.table.catalog;
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
@@ -40,7 +37,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -62,123 +58,12 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 	@After
 	public void close() throws Exception {
-		if (catalog.tableExists(path1)) {
-			catalog.dropTable(path1, true);
-		}
-		if (catalog.tableExists(path2)) {
-			catalog.dropTable(path2, true);
-		}
-		if (catalog.tableExists(path3)) {
-			catalog.dropTable(path3, true);
-		}
 		if (catalog.functionExists(path1)) {
 			catalog.dropFunction(path1, true);
 		}
 	}
 
 	// ------ tables ------
-
-	@Test
-	public void testCreateTable_Streaming() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		CatalogTable table = createStreamingTable();
-		catalog.createTable(path1, table, false);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
-	}
-
-	@Test
-	public void testCreateTable_Batch() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-
-		// Non-partitioned table
-		CatalogTable table = createTable();
-		catalog.createTable(path1, table, false);
-
-		CatalogBaseTable tableCreated = catalog.getTable(path1);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) tableCreated);
-		assertEquals(TABLE_COMMENT, tableCreated.getDescription().get());
-
-		List<String> tables = catalog.listTables(db1);
-
-		assertEquals(1, tables.size());
-		assertEquals(path1.getObjectName(), tables.get(0));
-
-		catalog.dropTable(path1, false);
-
-		// Partitioned table
-		table = createPartitionedTable();
-		catalog.createTable(path1, table, false);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
-
-		tables = catalog.listTables(db1);
-
-		assertEquals(1, tables.size());
-		assertEquals(path1.getObjectName(), tables.get(0));
-	}
-
-	@Test
-	public void testCreateTable_DatabaseNotExistException() throws Exception {
-		assertFalse(catalog.databaseExists(db1));
-
-		exception.expect(DatabaseNotExistException.class);
-		exception.expectMessage("Database db1 does not exist in Catalog");
-		catalog.createTable(nonExistObjectPath, createTable(), false);
-	}
-
-	@Test
-	public void testCreateTable_TableAlreadyExistException() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.createTable(path1,  createTable(), false);
-
-		exception.expect(TableAlreadyExistException.class);
-		exception.expectMessage("Table (or view) db1.t1 already exists in Catalog");
-		catalog.createTable(path1, createTable(), false);
-	}
-
-	@Test
-	public void testCreateTable_TableAlreadyExist_ignored() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-
-		CatalogTable table = createTable();
-		catalog.createTable(path1, table, false);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
-
-		catalog.createTable(path1, createAnotherTable(), true);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
-	}
-
-	@Test
-	public void testGetTable_TableNotExistException() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-
-		exception.expect(TableNotExistException.class);
-		exception.expectMessage("Table (or view) db1.nonexist does not exist in Catalog");
-		catalog.getTable(nonExistObjectPath);
-	}
-
-	@Test
-	public void testGetTable_TableNotExistException_NoDb() throws Exception {
-		exception.expect(TableNotExistException.class);
-		exception.expectMessage("Table (or view) db1.nonexist does not exist in Catalog");
-		catalog.getTable(nonExistObjectPath);
-	}
-
-	@Test
-	public void testDropTable_nonPartitionedTable() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.createTable(path1, createTable(), false);
-
-		assertTrue(catalog.tableExists(path1));
-
-		catalog.dropTable(path1, false);
-
-		assertFalse(catalog.tableExists(path1));
-	}
 
 	@Test
 	public void testDropTable_partitionedTable() throws Exception {
@@ -214,78 +99,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	@Test
-	public void testDropTable_TableNotExistException() throws Exception {
-		exception.expect(TableNotExistException.class);
-		exception.expectMessage("Table (or view) non.exist does not exist in Catalog");
-		catalog.dropTable(nonExistDbPath, false);
-	}
-
-	@Test
-	public void testDropTable_TableNotExist_ignored() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.dropTable(nonExistObjectPath, true);
-	}
-
-	@Test
-	public void testAlterTable() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-
-		// Non-partitioned table
-		CatalogTable table = createTable();
-		catalog.createTable(path1, table, false);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
-
-		CatalogTable newTable = createAnotherTable();
-		catalog.alterTable(path1, newTable, false);
-
-		assertNotEquals(table, catalog.getTable(path1));
-		CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(path1));
-
-		catalog.dropTable(path1, false);
-
-		// Partitioned table
-		table = createPartitionedTable();
-		catalog.createTable(path1, table, false);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
-
-		newTable = createAnotherPartitionedTable();
-		catalog.alterTable(path1, newTable, false);
-
-		CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(path1));
-	}
-
-	@Test
-	public void testAlterTable_TableNotExistException() throws Exception {
-		exception.expect(TableNotExistException.class);
-		exception.expectMessage("Table (or view) non.exist does not exist in Catalog");
-		catalog.alterTable(nonExistDbPath, createTable(), false);
-	}
-
-	@Test
-	public void testAlterTable_TableNotExist_ignored() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.alterTable(nonExistObjectPath, createTable(), true);
-
-		assertFalse(catalog.tableExists(nonExistObjectPath));
-	}
-
-	@Test
-	public void testRenameTable_nonPartitionedTable() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		CatalogTable table = createTable();
-		catalog.createTable(path1, table, false);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
-
-		catalog.renameTable(path1, t2, false);
-
-		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path3));
-		assertFalse(catalog.tableExists(path1));
-	}
-
-	@Test
 	public void testRenameTable_partitionedTable() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
 		CatalogTable table = createPartitionedTable();
@@ -303,44 +116,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 		assertTrue(catalog.partitionExists(path3, catalogPartitionSpec));
 		assertFalse(catalog.tableExists(path1));
 		assertFalse(catalog.partitionExists(path1, catalogPartitionSpec));
-	}
-
-	@Test
-	public void testRenameTable_TableNotExistException() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-
-		exception.expect(TableNotExistException.class);
-		exception.expectMessage("Table (or view) db1.t1 does not exist in Catalog");
-		catalog.renameTable(path1, t2, false);
-	}
-
-	@Test
-	public void testRenameTable_TableNotExistException_ignored() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.renameTable(path1, t2, true);
-	}
-
-	@Test
-	public void testRenameTable_TableAlreadyExistException() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		CatalogTable table = createTable();
-		catalog.createTable(path1, table, false);
-		catalog.createTable(path3, createAnotherTable(), false);
-
-		exception.expect(TableAlreadyExistException.class);
-		exception.expectMessage("Table (or view) db1.t2 already exists in Catalog");
-		catalog.renameTable(path1, t2, false);
-	}
-
-	@Test
-	public void testTableExists() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-
-		assertFalse(catalog.tableExists(path1));
-
-		catalog.createTable(path1, createTable(), false);
-
-		assertTrue(catalog.tableExists(path1));
 	}
 
 	// ------ views ------
@@ -951,24 +726,29 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 	@Override
 	public CatalogDatabase createDb() {
-		return new GenericCatalogDatabase(new HashMap<String, String>() {{
-			put("k1", "v1");
-		}}, TEST_COMMENT);
+		return new GenericCatalogDatabase(
+			new HashMap<String, String>() {{
+				put("k1", "v1");
+			}},
+			TEST_COMMENT);
 	}
 
 	@Override
 	public CatalogDatabase createAnotherDb() {
-		return new GenericCatalogDatabase(new HashMap<String, String>() {{
-			put("k2", "v2");
-		}}, "this is another database.");
+		return new GenericCatalogDatabase(
+			new HashMap<String, String>() {{
+				put("k2", "v2");
+			}},
+			"this is another database.");
 	}
 
-	private GenericCatalogTable createStreamingTable() {
+	@Override
+	public GenericCatalogTable createStreamingTable() {
 		return new GenericCatalogTable(
 			createTableSchema(),
 			new TableStats(0),
 			getStreamingTableProperties(),
-			TABLE_COMMENT);
+			TEST_COMMENT);
 	}
 
 	@Override
@@ -977,7 +757,7 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 			createTableSchema(),
 			new TableStats(0),
 			getBatchTableProperties(),
-			TABLE_COMMENT);
+			TEST_COMMENT);
 	}
 
 	@Override
@@ -986,29 +766,27 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 			createAnotherTableSchema(),
 			new TableStats(0),
 			getBatchTableProperties(),
-			TABLE_COMMENT);
+			TEST_COMMENT);
 	}
 
-	protected CatalogTable createPartitionedTable() {
+	@Override
+	public CatalogTable createPartitionedTable() {
 		return new GenericCatalogTable(
 			createTableSchema(),
 			new TableStats(0),
 			createPartitionKeys(),
 			getBatchTableProperties(),
-			TABLE_COMMENT);
+			TEST_COMMENT);
 	}
 
-	protected CatalogTable createAnotherPartitionedTable() {
+	@Override
+	public CatalogTable createAnotherPartitionedTable() {
 		return new GenericCatalogTable(
 			createAnotherTableSchema(),
 			new TableStats(0),
 			createPartitionKeys(),
 			getBatchTableProperties(),
-			TABLE_COMMENT);
-	}
-
-	private List<String> createPartitionKeys() {
-		return Arrays.asList("second", "third");
+			TEST_COMMENT);
 	}
 
 	private CatalogPartitionSpec createPartitionSpec() {
@@ -1051,40 +829,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 	private CatalogPartition createPartition(Map<String, String> props) {
 		return new GenericCatalogPartition(props);
-	}
-
-	private Map<String, String> getBatchTableProperties() {
-		return new HashMap<String, String>() {{
-			put(IS_STREAMING, "false");
-		}};
-	}
-
-	private Map<String, String> getStreamingTableProperties() {
-		return new HashMap<String, String>() {{
-			put(IS_STREAMING, "true");
-		}};
-	}
-
-	private TableSchema createTableSchema() {
-		return new TableSchema(
-			new String[] {"first", "second", "third"},
-			new TypeInformation[] {
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.INT_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO,
-			}
-		);
-	}
-
-	private TableSchema createAnotherTableSchema() {
-		return new TableSchema(
-			new String[] {"first2", "second", "third"},
-			new TypeInformation[] {
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO
-			}
-		);
 	}
 
 	private CatalogView createView() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
@@ -30,18 +30,28 @@ import java.util.Optional;
 public interface CatalogBaseTable {
 	/**
 	 * Get the properties of the table.
-	 * @return table property map
+	 *
+	 * @return property map of the table/view
 	 */
 	Map<String, String> getProperties();
 
 	/**
 	 * Get the schema of the table.
-	 * @return schema of the table
+	 *
+	 * @return schema of the table/view.
 	 */
 	TableSchema getSchema();
 
 	/**
+	 * Get comment of the table or view.
+	 *
+	 * @return comment of the table/view.
+	 */
+	String getComment();
+
+	/**
 	 * Get a deep copy of the CatalogBaseTable instance.
+	 *
 	 * @return a copy of the CatalogBaseTable instance
 	 */
 	CatalogBaseTable copy();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ReadableCatalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ReadableCatalog.java
@@ -96,6 +96,8 @@ public interface ReadableCatalog {
 	 */
 	boolean databaseExists(String databaseName) throws CatalogException;
 
+	// ------ tables and views ------
+
 	/**
 	 * Get names of all tables and views under this database. An empty list is returned if none exists.
 	 *
@@ -116,24 +118,24 @@ public interface ReadableCatalog {
 	List<String> listViews(String databaseName) throws DatabaseNotExistException, CatalogException;
 
 	/**
-	 * Get a CatalogTable or CatalogView identified by objectPath.
+	 * Get a CatalogTable or CatalogView identified by tablePath.
 	 *
-	 * @param objectPath		Path of the table or view
+	 * @param tablePath		Path of the table or view
 	 * @return The requested table or view
 	 * @throws TableNotExistException if the target does not exist
 	 * @throws CatalogException in case of any runtime exception
 	 */
-	CatalogBaseTable getTable(ObjectPath objectPath) throws TableNotExistException, CatalogException;
+	CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException;
 
 	/**
 	 * Check if a table or view exists in this catalog.
 	 *
-	 * @param objectPath    Path of the table or view
+	 * @param tablePath    Path of the table or view
 	 * @return true if the given table exists in the catalog
 	 *         false otherwise
 	 * @throws CatalogException in case of any runtime exception
 	 */
-	boolean tableExists(ObjectPath objectPath) throws CatalogException;
+	boolean tableExists(ObjectPath tablePath) throws CatalogException;
 
 	// ------ partitions ------
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ReadableWritableCatalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ReadableWritableCatalog.java
@@ -102,11 +102,10 @@ public interface ReadableWritableCatalog extends ReadableCatalog {
 	 *                          if set to false, throw an exception,
 	 *                          if set to true, do nothing.
 	 * @throws TableNotExistException if the table does not exist
-	 * @throws DatabaseNotExistException if the database in tablePath to doesn't exist
 	 * @throws CatalogException in case of any runtime exception
 	 */
 	void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
-		throws TableNotExistException, TableAlreadyExistException, DatabaseNotExistException, CatalogException;
+		throws TableNotExistException, TableAlreadyExistException, CatalogException;
 
 	/**
 	 * Create a new table or view.
@@ -128,7 +127,7 @@ public interface ReadableWritableCatalog extends ReadableCatalog {
 	 * Note that the new and old CatalogBaseTable must be of the same type. For example, this doesn't
 	 * allow alter a regular table to partitioned table, or alter a view to a table, and vice versa.
 	 *
-	 * @param tableName path of the table or view to be modified
+	 * @param tablePath path of the table or view to be modified
 	 * @param newTable the new table definition
 	 * @param ignoreIfNotExists flag to specify behavior when the table or view does not exist:
 	 *                          if set to false, throw an exception,
@@ -136,7 +135,7 @@ public interface ReadableWritableCatalog extends ReadableCatalog {
 	 * @throws TableNotExistException if the table does not exist
 	 * @throws CatalogException in case of any runtime exception
 	 */
-	void alterTable(ObjectPath tableName, CatalogBaseTable newTable, boolean ignoreIfNotExists)
+	void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
 		throws TableNotExistException, CatalogException;
 
 	// ------ partitions ------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -18,9 +18,14 @@
 
 package org.apache.flink.table.catalog;
 
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -29,11 +34,14 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -55,9 +63,9 @@ public abstract class CatalogTestBase {
 	protected final ObjectPath nonExistDbPath = ObjectPath.fromString("non.exist");
 	protected final ObjectPath nonExistObjectPath = ObjectPath.fromString("db1.nonexist");
 
-	protected static final String TEST_CATALOG_NAME = "test-catalog";
+	public static final String TEST_CATALOG_NAME = "test-catalog";
+
 	protected static final String TEST_COMMENT = "test comment";
-	protected static final String TABLE_COMMENT = "This is my batch table";
 
 	protected static ReadableWritableCatalog catalog;
 
@@ -66,6 +74,16 @@ public abstract class CatalogTestBase {
 
 	@After
 	public void cleanup() throws Exception {
+		if (catalog.tableExists(path1)) {
+			catalog.dropTable(path1, true);
+		}
+		if (catalog.tableExists(path2)) {
+			catalog.dropTable(path2, true);
+		}
+		if (catalog.tableExists(path3)) {
+			catalog.dropTable(path3, true);
+		}
+
 		if (catalog.databaseExists(db1)) {
 			catalog.dropDatabase(db1, true);
 		}
@@ -168,7 +186,7 @@ public abstract class CatalogTestBase {
 		catalog.createTable(path1, createTable(), false);
 
 		exception.expect(DatabaseNotEmptyException.class);
-		exception.expectMessage("Database db1 in Catalog test-catalog is not empty");
+		exception.expectMessage("Database db1 in catalog test-catalog is not empty");
 		catalog.dropDatabase(db1, true);
 	}
 
@@ -209,6 +227,220 @@ public abstract class CatalogTestBase {
 		assertTrue(catalog.databaseExists(db1));
 	}
 
+	// ------ tables ------
+
+	@Test
+	public void testCreateTable_Streaming() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		CatalogTable table = createStreamingTable();
+		catalog.createTable(path1, table, false);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
+	}
+
+	@Test
+	public void testCreateTable_Batch() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		// Non-partitioned table
+		CatalogTable table = createTable();
+		catalog.createTable(path1, table, false);
+
+		CatalogBaseTable tableCreated = catalog.getTable(path1);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) tableCreated);
+		assertEquals(TEST_COMMENT, tableCreated.getDescription().get());
+
+		List<String> tables = catalog.listTables(db1);
+
+		assertEquals(1, tables.size());
+		assertEquals(path1.getObjectName(), tables.get(0));
+
+		catalog.dropTable(path1, false);
+
+		// Partitioned table
+		table = createPartitionedTable();
+		catalog.createTable(path1, table, false);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
+
+		tables = catalog.listTables(db1);
+
+		assertEquals(1, tables.size());
+		assertEquals(path1.getObjectName(), tables.get(0));
+	}
+
+	@Test
+	public void testCreateTable_DatabaseNotExistException() throws Exception {
+		assertFalse(catalog.databaseExists(db1));
+
+		exception.expect(DatabaseNotExistException.class);
+		exception.expectMessage("Database db1 does not exist in Catalog");
+		catalog.createTable(nonExistObjectPath, createTable(), false);
+	}
+
+	@Test
+	public void testCreateTable_TableAlreadyExistException() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.createTable(path1,  createTable(), false);
+
+		exception.expect(TableAlreadyExistException.class);
+		exception.expectMessage("Table (or view) db1.t1 already exists in Catalog");
+		catalog.createTable(path1, createTable(), false);
+	}
+
+	@Test
+	public void testCreateTable_TableAlreadyExist_ignored() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		CatalogTable table = createTable();
+		catalog.createTable(path1, table, false);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
+
+		catalog.createTable(path1, createAnotherTable(), true);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
+	}
+
+	@Test
+	public void testGetTable_TableNotExistException() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		exception.expect(TableNotExistException.class);
+		exception.expectMessage("Table (or view) db1.nonexist does not exist in Catalog");
+		catalog.getTable(nonExistObjectPath);
+	}
+
+	@Test
+	public void testGetTable_TableNotExistException_NoDb() throws Exception {
+		exception.expect(TableNotExistException.class);
+		exception.expectMessage("Table (or view) db1.nonexist does not exist in Catalog");
+		catalog.getTable(nonExistObjectPath);
+	}
+
+	@Test
+	public void testDropTable_nonPartitionedTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.createTable(path1, createTable(), false);
+
+		assertTrue(catalog.tableExists(path1));
+
+		catalog.dropTable(path1, false);
+
+		assertFalse(catalog.tableExists(path1));
+	}
+
+	@Test
+	public void testDropTable_TableNotExistException() throws Exception {
+		exception.expect(TableNotExistException.class);
+		exception.expectMessage("Table (or view) non.exist does not exist in Catalog");
+		catalog.dropTable(nonExistDbPath, false);
+	}
+
+	@Test
+	public void testDropTable_TableNotExist_ignored() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.dropTable(nonExistObjectPath, true);
+	}
+
+	@Test
+	public void testAlterTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		// Non-partitioned table
+		CatalogTable table = createTable();
+		catalog.createTable(path1, table, false);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
+
+		CatalogTable newTable = createAnotherTable();
+		catalog.alterTable(path1, newTable, false);
+
+		assertNotEquals(table, catalog.getTable(path1));
+		CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(path1));
+
+		catalog.dropTable(path1, false);
+
+		// Partitioned table
+		table = createPartitionedTable();
+		catalog.createTable(path1, table, false);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
+
+		newTable = createAnotherPartitionedTable();
+		catalog.alterTable(path1, newTable, false);
+
+		CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(path1));
+	}
+
+	@Test
+	public void testAlterTable_TableNotExistException() throws Exception {
+		exception.expect(TableNotExistException.class);
+		exception.expectMessage("Table (or view) non.exist does not exist in Catalog");
+		catalog.alterTable(nonExistDbPath, createTable(), false);
+	}
+
+	@Test
+	public void testAlterTable_TableNotExist_ignored() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.alterTable(nonExistObjectPath, createTable(), true);
+
+		assertFalse(catalog.tableExists(nonExistObjectPath));
+	}
+
+	@Test
+	public void testRenameTable_nonPartitionedTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		CatalogTable table = createTable();
+		catalog.createTable(path1, table, false);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
+
+		catalog.renameTable(path1, t2, false);
+
+		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path3));
+		assertFalse(catalog.tableExists(path1));
+	}
+
+	@Test
+	public void testRenameTable_TableNotExistException() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		exception.expect(TableNotExistException.class);
+		exception.expectMessage("Table (or view) db1.t1 does not exist in Catalog");
+		catalog.renameTable(path1, t2, false);
+	}
+
+	@Test
+	public void testRenameTable_TableNotExistException_ignored() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.renameTable(path1, t2, true);
+	}
+
+	@Test
+	public void testRenameTable_TableAlreadyExistException() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		CatalogTable table = createTable();
+		catalog.createTable(path1, table, false);
+		catalog.createTable(path3, createAnotherTable(), false);
+
+		exception.expect(TableAlreadyExistException.class);
+		exception.expectMessage("Table (or view) db1.t2 already exists in Catalog");
+		catalog.renameTable(path1, t2, false);
+	}
+
+	@Test
+	public void testTableExists() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		assertFalse(catalog.tableExists(path1));
+
+		catalog.createTable(path1, createTable(), false);
+
+		assertTrue(catalog.tableExists(path1));
+	}
+
 	// ------ utilities ------
 
 	/**
@@ -245,4 +477,63 @@ public abstract class CatalogTestBase {
 	 * @return another CatalogTable instance
 	 */
 	public abstract CatalogTable createAnotherTable();
+
+	/**
+	 * Create a streaming CatalogTable instance by specific catalog implementation.
+	 *
+	 * @return a streaming CatalogTable instance
+	 */
+	public abstract CatalogTable createStreamingTable();
+
+	/**
+	 * Create a partitioned CatalogTable instance by specific catalog implementation.
+	 *
+	 * @return a streaming CatalogTable instance
+	 */
+	public abstract CatalogTable createPartitionedTable();
+
+	/**
+	 * Create another partitioned CatalogTable instance by specific catalog implementation.
+	 *
+	 * @return another partitioned CatalogTable instance
+	 */
+	public abstract CatalogTable createAnotherPartitionedTable();
+
+	protected TableSchema createTableSchema() {
+		return new TableSchema(
+			new String[] {"first", "second", "third"},
+			new TypeInformation[] {
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+			}
+		);
+	}
+
+	protected TableSchema createAnotherTableSchema() {
+		return new TableSchema(
+			new String[] {"first2", "second", "third"},
+			new TypeInformation[] {
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO
+			}
+		);
+	}
+
+	protected List<String> createPartitionKeys() {
+		return Arrays.asList("second", "third");
+	}
+
+	protected Map<String, String> getBatchTableProperties() {
+		return new HashMap<String, String>() {{
+			put(IS_STREAMING, "false");
+		}};
+	}
+
+	protected Map<String, String> getStreamingTableProperties() {
+		return new HashMap<String, String>() {{
+			put(IS_STREAMING, "true");
+		}};
+	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -33,26 +33,26 @@ public class CatalogTestUtil {
 		assertEquals(t1.getDescription(), t2.getDescription());
 	}
 
-	protected static void checkEquals(TableStats ts1, TableStats ts2) {
+	public static void checkEquals(TableStats ts1, TableStats ts2) {
 		assertEquals(ts1.getRowCount(), ts2.getRowCount());
 		assertEquals(ts1.getColumnStats().size(), ts2.getColumnStats().size());
 	}
 
-	protected static void checkEquals(CatalogView v1, CatalogView v2) {
+	public static void checkEquals(CatalogView v1, CatalogView v2) {
 		assertEquals(v1.getOriginalQuery(), v2.getOriginalQuery());
 		assertEquals(v1.getExpandedQuery(), v2.getExpandedQuery());
 	}
 
-	protected static void checkEquals(CatalogDatabase d1, CatalogDatabase d2) {
+	public static void checkEquals(CatalogDatabase d1, CatalogDatabase d2) {
 		assertEquals(d1.getProperties(), d2.getProperties());
 	}
 
-	protected static void checkEquals(CatalogFunction f1, CatalogFunction f2) {
+	public static void checkEquals(CatalogFunction f1, CatalogFunction f2) {
 		assertEquals(f1.getClassName(), f2.getClassName());
 		assertEquals(f1.getProperties(), f2.getProperties());
 	}
 
-	protected static void checkEquals(CatalogPartition p1, CatalogPartition p2) {
+	public static void checkEquals(CatalogPartition p1, CatalogPartition p2) {
 		assertEquals(p1.getProperties(), p2.getProperties());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR enables GenericHiveMetastoreCatalog to operate Flink tables by using Hive metastore as a storage. Flink tables will be stored as Hive tables in metastore, and GenericHiveMetastoreCatalog can convert between Flink and Hive tables upon read and write.

Currently due to the limitation of type system, several Hive data types cannot be mapped to Flink types. I've opened [FLINK-12386](https://issues.apache.org/jira/browse/FLINK-12386) to add complete 1:1 mapping between Flink and Hive data types when the rework of Flink type system is finished

## Brief change log

  - implemented Table APIs in GenericHiveMetastoreCatalog
  - reused unit tests in GenericInMemoryCatalog, and moved them to CatalogTestBase

## Verifying this change

This change added tests and can be verified as follows:

  - reused unit tests in GenericInMemoryCatalog, and moved them to CatalogTestBase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)

This PR depends on https://github.com/apache/flink/pull/8325