### PR TITLE
[FLINK-12390][build] Fully migrate to flink-shaded-asm-6

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -49,7 +49,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-asm</artifactId>
+			<artifactId>flink-shaded-asm-6</artifactId>
 		</dependency>
 
 		<!-- standard utilities -->

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
@@ -35,8 +35,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.shaded.asm5.org.objectweb.asm.Type.getConstructorDescriptor;
-import static org.apache.flink.shaded.asm5.org.objectweb.asm.Type.getMethodDescriptor;
+import static org.apache.flink.shaded.asm6.org.objectweb.asm.Type.getConstructorDescriptor;
+import static org.apache.flink.shaded.asm6.org.objectweb.asm.Type.getMethodDescriptor;
 
 @Internal
 public class TypeExtractionUtils {

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -43,11 +43,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-asm</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-asm-6</artifactId>
 		</dependency>
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -176,7 +176,7 @@ class This0AccessFinder extends ClassVisitor {
 	private boolean isThis0Accessed;
 
 	public This0AccessFinder(String this0Name) {
-		super(Opcodes.ASM5);
+		super(Opcodes.ASM6);
 		this.this0Name = this0Name;
 	}
 
@@ -186,7 +186,7 @@ class This0AccessFinder extends ClassVisitor {
 
 	@Override
 	public MethodVisitor visitMethod(int access, String name, String desc, String sig, String[] exceptions) {
-		return new MethodVisitor(Opcodes.ASM5) {
+		return new MethodVisitor(Opcodes.ASM6) {
 
 			@Override
 			public void visitFieldInsn(int op, String owner, String name, String desc) {

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -90,7 +90,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-asm</artifactId>
+			<artifactId>flink-shaded-asm-6</artifactId>
 		</dependency>
 
 		<dependency>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/DependencyVisitor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/DependencyVisitor.java
@@ -18,16 +18,16 @@
 
 package org.apache.flink.runtime.util;
 
-import org.apache.flink.shaded.asm5.org.objectweb.asm.AnnotationVisitor;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.ClassVisitor;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.Opcodes;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.FieldVisitor;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.MethodVisitor;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.Type;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.TypePath;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.Label;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.signature.SignatureReader;
-import org.apache.flink.shaded.asm5.org.objectweb.asm.signature.SignatureVisitor;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.AnnotationVisitor;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.ClassVisitor;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.Opcodes;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.FieldVisitor;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.MethodVisitor;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.Type;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.TypePath;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.Label;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.signature.SignatureReader;
+import org.apache.flink.shaded.asm6.org.objectweb.asm.signature.SignatureVisitor;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -66,7 +66,7 @@ public class DependencyVisitor extends ClassVisitor {
 	@Override
 	public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
 		addDesc(desc);
-		return new AnnotationVisitorImpl(Opcodes.ASM5);
+		return new AnnotationVisitorImpl(Opcodes.ASM6);
 	}
 
 	@Override
@@ -79,7 +79,7 @@ public class DependencyVisitor extends ClassVisitor {
 		if (value instanceof Type) {
 			addType((Type) value);
 		}
-		return new FieldVisitorImpl(Opcodes.ASM5);
+		return new FieldVisitorImpl(Opcodes.ASM6);
 	}
 
 	@Override
@@ -90,7 +90,7 @@ public class DependencyVisitor extends ClassVisitor {
 			addSignature(signature);
 		}
 		addInternalNames(exceptions);
-		return new MethodVisitorImpl(Opcodes.ASM5);
+		return new MethodVisitorImpl(Opcodes.ASM6);
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -154,13 +154,13 @@ public class DependencyVisitor extends ClassVisitor {
 
 	private void addSignature(String signature) {
 		if (signature != null) {
-			new SignatureReader(signature).accept(new SignatureVisitorImpl(Opcodes.ASM5));
+			new SignatureReader(signature).accept(new SignatureVisitorImpl(Opcodes.ASM6));
 		}
 	}
 
 	private void addTypeSignature(String signature) {
 		if (signature != null) {
-			new SignatureReader(signature).acceptType(new SignatureVisitorImpl(Opcodes.ASM5));
+			new SignatureReader(signature).acceptType(new SignatureVisitorImpl(Opcodes.ASM6));
 		}
 	}
 
@@ -173,7 +173,7 @@ public class DependencyVisitor extends ClassVisitor {
 		@Override
 		public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
 			addDesc(desc);
-			return new AnnotationVisitorImpl(Opcodes.ASM5);
+			return new AnnotationVisitorImpl(Opcodes.ASM6);
 		}
 
 		@Override
@@ -222,13 +222,13 @@ public class DependencyVisitor extends ClassVisitor {
 
 		@Override
 		public AnnotationVisitor visitAnnotationDefault() {
-			return new AnnotationVisitorImpl(Opcodes.ASM5);
+			return new AnnotationVisitorImpl(Opcodes.ASM6);
 		}
 
 		@Override
 		public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
 			addDesc(desc);
-			return new AnnotationVisitorImpl(Opcodes.ASM5);
+			return new AnnotationVisitorImpl(Opcodes.ASM6);
 		}
 
 		@Override
@@ -277,7 +277,7 @@ public class DependencyVisitor extends ClassVisitor {
 		@Override
 		public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
 			addDesc(desc);
-			return new AnnotationVisitorImpl(Opcodes.ASM5);
+			return new AnnotationVisitorImpl(Opcodes.ASM6);
 		}
 	}
 

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -47,11 +47,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-asm</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-asm-6</artifactId>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,12 +241,6 @@ under the License.
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-shaded-asm</artifactId>
-				<version>5.0.4-${flink.shaded.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-asm-6</artifactId>
 				<version>6.2.1-${flink.shaded.version}</version>
 			</dependency>


### PR DESCRIPTION
## What is the purpose of the change

Migrates the remaining usages of asm5 to version 6.

IIRC, when we introduced asm6 initially we only touched scala-related code.

## Verifying this change

https://travis-ci.org/zentol/flink/builds/516207673