### PR TITLE
[FLINK-12391][travis] Limit transfer.sh upload to 1 minute

### DIFF
--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -110,7 +110,7 @@ upload_artifacts_s3() {
 
 	# upload to https://transfer.sh
 	echo "Uploading to transfer.sh"
-	curl --upload-file $ARTIFACTS_FILE https://transfer.sh
+	curl --upload-file $ARTIFACTS_FILE --max-time 60 https://transfer.sh
 }
 
 print_stacktraces () {


### PR DESCRIPTION
This PR adds a 1 minute timeout to the curl `transfer.sh` upload. We usually spend between 10-20 seconds on the upload; anything going beyond 1 minute usually meant that the upload was broken and would never finish.