### PR TITLE
[FLINK-12253][table-common] Setup a class hierarchy for the new logical type system

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/AnyType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/AnyType.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of an arbitrary serialized type. This type is a black box within the table ecosystem
+ * and is only deserialized at the edges. The any type is an extension to the SQL standard.
+ *
+ * <p>The serialized string representation is {@code ANY(c, s)} where {@code s} is the originating
+ * class and {@code s} is the serialized {@link TypeSerializerSnapshot} in Base64 encoding.
+ *
+ * @param <T> originating class for this type
+ */
+@PublicEvolving
+public final class AnyType<T> extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "ANY(%s, %s)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		byte[].class.getName(),
+		"org.apache.flink.table.dataformat.BinaryGeneric");
+
+	private final Class<T> clazz;
+
+	private final TypeSerializer<T> serializer;
+
+	private transient String serializerString;
+
+	public AnyType(boolean isNullable, Class<T> clazz, TypeSerializer<T> serializer) {
+		super(isNullable, LogicalTypeRoot.ANY);
+		this.clazz = Preconditions.checkNotNull(clazz, "Class must not be null.");
+		this.serializer = Preconditions.checkNotNull(serializer, "Serializer must not be null.");
+	}
+
+	public AnyType(Class<T> clazz, TypeSerializer<T> serializer) {
+		this(true, clazz, serializer);
+	}
+
+	public Class<T> getOriginatingClass() {
+		return clazz;
+	}
+
+	public TypeSerializer<T> getTypeSerializer() {
+		return serializer;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new AnyType<>(isNullable, clazz, serializer.duplicate());
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(DEFAULT_FORMAT, clazz.getName(), "...");
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, clazz.getName(), getOrCreateSerializerString());
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return this.clazz.isAssignableFrom(clazz) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return clazz.isAssignableFrom(this.clazz) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return clazz;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		AnyType<?> anyType = (AnyType<?>) o;
+		return clazz.equals(anyType.clazz) && serializer.equals(anyType.serializer);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), clazz, serializer);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private String getOrCreateSerializerString() {
+		if (serializerString == null) {
+			final DataOutputSerializer outputSerializer = new DataOutputSerializer(128);
+			try {
+				serializer.snapshotConfiguration().writeSnapshot(outputSerializer);
+				serializerString = EncodingUtils.encodeBytesToBase64(outputSerializer.getCopyOfBuffer());
+				return serializerString;
+			} catch (Exception e) {
+				throw new TableException(String.format(
+					"Unable to generate a string representation of the serializer snapshot of '%s' " +
+						"describing the class '%s' for the any type.",
+					serializer.getClass().getName(),
+					clazz.toString()));
+			}
+		}
+		return serializerString;
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ArrayType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ArrayType.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import java.lang.reflect.Array;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of an array of elements with same subtype. Compared to the SQL standard, the maximum
+ * cardinality of an array cannot be specified but is fixed at {@link Integer#MAX_VALUE}. Also, any
+ * valid type is supported as a subtype.
+ *
+ * <p>The serialized string representation is {@code ARRAY<t>} where {@code t} is the type of
+ * the contained elements.
+ */
+@PublicEvolving
+public final class ArrayType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "ARRAY<%s>";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		"org.apache.flink.table.dataformat.BinaryArray");
+
+	private final LogicalType elementType;
+
+	public ArrayType(boolean isNullable, LogicalType elementType) {
+		super(isNullable, LogicalTypeRoot.ARRAY);
+		this.elementType = Preconditions.checkNotNull(elementType, "Element type must not be null.");
+	}
+
+	public ArrayType(LogicalType elementType) {
+		this(true, elementType);
+	}
+
+	public LogicalType getElementType() {
+		return elementType;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new ArrayType(isNullable, elementType.copy());
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(DEFAULT_FORMAT, elementType.asSummaryString());
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, elementType.asSerializableString());
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		if (INPUT_OUTPUT_CONVERSION.contains(clazz.getName())) {
+			return true;
+		}
+		if (!clazz.isArray()) {
+			return false;
+		}
+		return elementType.supportsInputConversion(clazz.getComponentType());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (INPUT_OUTPUT_CONVERSION.contains(clazz.getName())) {
+			return true;
+		}
+		if (!clazz.isArray()) {
+			return false;
+		}
+		return elementType.supportsOutputConversion(clazz.getComponentType());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return Array.newInstance(elementType.getDefaultOutputConversion(), 0).getClass();
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.singletonList(elementType);
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		ArrayType arrayType = (ArrayType) o;
+		return elementType.equals(arrayType.elementType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), elementType);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BigIntType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BigIntType.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Logical type of an 8-byte signed integer with values from -9,223,372,036,854,775,808 to
+ * 9,223,372,036,854,775,807.
+ *
+ * <p>The serialized string representation is {@code BIGINT}.
+ */
+@PublicEvolving
+public final class BigIntType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "BIGINT";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		Long.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		Long.class.getName(),
+		long.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = Long.class;
+
+	public BigIntType(boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.BIGINT);
+	}
+
+	public BigIntType() {
+		this(true);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new BigIntType(isNullable);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BinaryType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BinaryType.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a fixed-length binary string (=a sequence of bytes).
+ *
+ * <p>The serialized string representation is {@code BINARY(n)} where {@code n} is the number of
+ * bytes. {@code n} must have a value between 1 and {@link Integer#MAX_VALUE} (both inclusive). If
+ * no length is specified, {@code n} is equal to 1.
+ */
+@PublicEvolving
+public final class BinaryType extends LogicalType {
+
+	private static final int MIN_LENGTH = 1;
+
+	private static final int MAX_LENGTH = Integer.MAX_VALUE;
+
+	private static final int DEFAULT_LENGTH = 1;
+
+	private static final String DEFAULT_FORMAT = "BINARY(%d)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		byte[].class.getName(),
+		"org.apache.flink.table.dataformat.BinaryArray");
+
+	private static final Class<?> DEFAULT_CONVERSION = byte[].class;
+
+	private final int length;
+
+	public BinaryType(boolean isNullable, int length) {
+		super(isNullable, LogicalTypeRoot.BINARY);
+		if (length < MIN_LENGTH) {
+			throw new ValidationException(
+				String.format(
+					"Binary string length must be between %d and %d (both inclusive).",
+					MIN_LENGTH,
+					MAX_LENGTH));
+		}
+		this.length = length;
+	}
+
+	public BinaryType(int length) {
+		this(true, length);
+	}
+
+	public BinaryType() {
+		this(DEFAULT_LENGTH);
+	}
+
+	public int getLength() {
+		return length;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new BinaryType(isNullable, length);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, length);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		BinaryType that = (BinaryType) o;
+		return length == that.length;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), length);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BooleanType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BooleanType.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Logical type of a boolean with a (possibly) three-valued logic of {@code TRUE, FALSE, UNKNOWN}.
+ *
+ * <p>The serialized string representation is {@code BOOLEAN}.
+ */
+@PublicEvolving
+public final class BooleanType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "BOOLEAN";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		Boolean.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		Boolean.class.getName(),
+		boolean.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = Boolean.class;
+
+	public BooleanType(boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.BOOLEAN);
+	}
+
+	public BooleanType() {
+		this(true);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new BooleanType(isNullable);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/CharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/CharType.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a fixed-length character string.
+ *
+ * <p>The serialized string representation is {@code CHAR(n)} where {@code n} is the number of
+ * code points. {@code n} must have a value between 1 and 255 (both inclusive). If no length is
+ * specified, {@code n} is equal to 1.
+ */
+@PublicEvolving
+public final class CharType extends LogicalType {
+
+	private static final int MIN_LENGTH = 1;
+
+	private static final int MAX_LENGTH = 255;
+
+	private static final int DEFAULT_LENGTH = 1;
+
+	private static final String DEFAULT_FORMAT = "CHAR(%d)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		String.class.getName(),
+		byte[].class.getName(),
+		"org.apache.flink.table.dataformat.BinaryString");
+
+	private static final Class<?> DEFAULT_CONVERSION = String.class;
+
+	private final int length;
+
+	public CharType(boolean isNullable, int length) {
+		super(isNullable, LogicalTypeRoot.CHAR);
+		if (length < MIN_LENGTH || length > MAX_LENGTH) {
+			throw new ValidationException(
+				String.format(
+					"Character string length must be between %d and %d (both inclusive).",
+					MIN_LENGTH,
+					MAX_LENGTH));
+		}
+		this.length = length;
+	}
+
+	public CharType(int length) {
+		this(true, length);
+	}
+
+	public CharType() {
+		this(DEFAULT_LENGTH);
+	}
+
+	public int getLength() {
+		return length;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new CharType(isNullable, length);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, length);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		CharType charType = (CharType) o;
+		return length == charType.length;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), length);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DateType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DateType.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Logical type of a date consisting of {@code year-month-day} with values ranging from {@code 0000-01-01}
+ * to {@code 9999-12-31}.
+ *
+ * <p>The serialized string representation is {@code DATE}.
+ *
+ * <p>A conversion from and to {@code int} describes the number of days since epoch.
+ */
+@PublicEvolving
+public final class DateType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "DATE";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		java.sql.Date.class.getName(),
+		java.time.LocalDate.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		java.sql.Date.class.getName(),
+		java.time.LocalDate.class.getName(),
+		int.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = java.time.LocalDate.class;
+
+	public DateType(boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.DATE);
+	}
+
+	public DateType() {
+		this(true);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new DateType(isNullable);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DayTimeIntervalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DayTimeIntervalType.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type for a group of day-time interval types. The type must be parameterized to one of
+ * the following resolutions with up to nanosecond precision: interval of days, interval of days to
+ * hours, interval of days to minutes, interval of days to seconds, interval of hours, interval of
+ * hours to minutes, interval of hours to seconds, interval of minutes, interval of minutes to seconds,
+ * or interval of seconds.
+ *
+ * <p>An interval of day-time consists of {@code +days hours:months:seconds.fractional} with values
+ * ranging from {@code -999999 23:59:59.999999999} to {@code +999999 23:59:59.999999999}. The value
+ * is the same for all resolutions of this group (for example, an interval of seconds of 70 leads to
+ * {@code +00 00:01:10.000000}).
+ *
+ * <p>The serialized string representation is {@code INTERVAL DAY(p1)}, {@code INTERVAL DAY(p1) TO HOUR},
+ * {@code INTERVAL DAY(p1) TO MINUTE}, {@code INTERVAL DAY(p1) TO SECOND(p2)}, {@code INTERVAL HOUR},
+ * {@code INTERVAL HOUR TO MINUTE}, {@code INTERVAL HOUR TO SECOND(p2)}, {@code INTERVAL  MINUTE},
+ * {@code INTERVAL  MINUTE TO SECOND(p2)}, or {@code INTERVAL SECOND(p2)} where {@code p1} is the number
+ * of digits of days (=day precision) and {@code p2} is the number of digits of fractional seconds
+ * (=fractional precision). {@code p1} must have a value between 1 and 6 (both inclusive). {@code p2}
+ * must have a value between 0 and 9 (both inclusive). If no {@code p1} is specified, it is equal to 2 by
+ * default. If no {@code p2} is specified, it is equal to 6 by default.
+ *
+ * <p>A conversion from and to {@code long} describes the number of milliseconds.
+ */
+@PublicEvolving
+public final class DayTimeIntervalType extends LogicalType {
+
+	private static final int MIN_DAY_PRECISION = 1;
+
+	private static final int MAX_DAY_PRECISION = 6;
+
+	private static final int DEFAULT_DAY_PRECISION = 2;
+
+	private static final int MIN_FRACTIONAL_PRECISION = 0;
+
+	private static final int MAX_FRACTIONAL_PRECISION = 9;
+
+	private static final int DEFAULT_FRACTIONAL_PRECISION = 6;
+
+	private static final String DEFAULT_DAY_FORMAT = "INTERVAL DAY(%1$d)";
+
+	private static final String DEFAULT_DAY_TO_HOUR_FORMAT = "INTERVAL DAY(%1$d) TO HOUR";
+
+	private static final String DEFAULT_DAY_TO_MINUTE_FORMAT = "INTERVAL DAY(%1$d) TO MINUTE";
+
+	private static final String DEFAULT_DAY_TO_SECOND_FORMAT = "INTERVAL DAY(%1$d) TO SECOND(%2$d)";
+
+	private static final String DEFAULT_HOUR_FORMAT = "INTERVAL HOUR";
+
+	private static final String DEFAULT_HOUR_TO_MINUTE_FORMAT = "INTERVAL HOUR TO MINUTE";
+
+	private static final String DEFAULT_HOUR_TO_SECOND_FORMAT = "INTERVAL HOUR TO SECOND(%2$d)";
+
+	private static final String DEFAULT_MINUTE_FORMAT = "INTERVAL MINUTE";
+
+	private static final String DEFAULT_MINUTE_TO_SECOND_FORMAT = "INTERVAL MINUTE TO SECOND(%2$d)";
+
+	private static final String DEFAULT_SECOND_FORMAT = "INTERVAL SECOND(%2$d)";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		java.time.Duration.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		java.time.Duration.class.getName(),
+		long.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = java.time.Duration.class;
+
+	/**
+	 * Supported resolution of this type.
+	 */
+	public enum DayTimeResolution {
+		DAY,
+		DAY_TO_HOUR,
+		DAY_TO_MINUTE,
+		DAY_TO_SECOND,
+		HOUR,
+		HOUR_TO_MINUTE,
+		HOUR_TO_SECOND,
+		MINUTE,
+		MINUTE_TO_SECOND,
+		SECOND
+	}
+
+	private final DayTimeResolution resolution;
+
+	private final int dayPrecision;
+
+	private final int fractionalPrecision;
+
+	public DayTimeIntervalType(
+			boolean isNullable,
+			DayTimeResolution resolution,
+			int dayPrecision,
+			int fractionalPrecision) {
+		super(isNullable, LogicalTypeRoot.INTERVAL_DAY_TIME);
+		Preconditions.checkNotNull(resolution);
+		if (needsDefaultDayPrecision(resolution) && dayPrecision != DEFAULT_DAY_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Day precision of sub-day intervals must be equal to the default precision %d.",
+					DEFAULT_DAY_PRECISION));
+		}
+		if (needsDefaultFractionalPrecision(resolution) && fractionalPrecision != DEFAULT_FRACTIONAL_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Fractional precision of super-second intervals must be equal to the default precision %d.",
+					DEFAULT_FRACTIONAL_PRECISION));
+		}
+		if (dayPrecision < MIN_DAY_PRECISION || dayPrecision > MAX_DAY_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Day precision of day-time intervals must be between %d and %d (both inclusive).",
+					MIN_DAY_PRECISION,
+					MAX_DAY_PRECISION));
+		}
+		if (fractionalPrecision < MIN_FRACTIONAL_PRECISION || fractionalPrecision > MAX_FRACTIONAL_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Fractional precision of day-time intervals must be between %d and %d (both inclusive).",
+					MIN_FRACTIONAL_PRECISION,
+					MAX_FRACTIONAL_PRECISION));
+		}
+		this.resolution = resolution;
+		this.dayPrecision = dayPrecision;
+		this.fractionalPrecision = fractionalPrecision;
+	}
+
+	public DayTimeIntervalType(DayTimeResolution resolution, int dayPrecision, int fractionalPrecision) {
+		this(true, resolution, dayPrecision, fractionalPrecision);
+	}
+
+	public DayTimeIntervalType(DayTimeResolution resolution) {
+		this(resolution, DEFAULT_DAY_PRECISION, DEFAULT_FRACTIONAL_PRECISION);
+	}
+
+	public DayTimeResolution getResolution() {
+		return resolution;
+	}
+
+	public int getDayPrecision() {
+		return dayPrecision;
+	}
+
+	public int getFractionalPrecision() {
+		return fractionalPrecision;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new DayTimeIntervalType(isNullable, resolution, dayPrecision, fractionalPrecision);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(getResolutionFormat(), dayPrecision, fractionalPrecision);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		DayTimeIntervalType that = (DayTimeIntervalType) o;
+		return dayPrecision == that.dayPrecision &&
+			fractionalPrecision == that.fractionalPrecision &&
+			resolution == that.resolution;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), resolution, dayPrecision, fractionalPrecision);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private boolean needsDefaultDayPrecision(DayTimeResolution resolution) {
+		switch (resolution) {
+			case HOUR:
+			case HOUR_TO_MINUTE:
+			case HOUR_TO_SECOND:
+			case MINUTE:
+			case MINUTE_TO_SECOND:
+			case SECOND:
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private boolean needsDefaultFractionalPrecision(DayTimeResolution resolution) {
+		switch (resolution) {
+			case DAY:
+			case DAY_TO_HOUR:
+			case DAY_TO_MINUTE:
+			case HOUR:
+			case HOUR_TO_MINUTE:
+			case MINUTE:
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private String getResolutionFormat() {
+		switch (resolution) {
+			case DAY:
+				return DEFAULT_DAY_FORMAT;
+			case DAY_TO_HOUR:
+				return DEFAULT_DAY_TO_HOUR_FORMAT;
+			case DAY_TO_MINUTE:
+				return DEFAULT_DAY_TO_MINUTE_FORMAT;
+			case DAY_TO_SECOND:
+				return DEFAULT_DAY_TO_SECOND_FORMAT;
+			case HOUR:
+				return DEFAULT_HOUR_FORMAT;
+			case HOUR_TO_MINUTE:
+				return DEFAULT_HOUR_TO_MINUTE_FORMAT;
+			case HOUR_TO_SECOND:
+				return DEFAULT_HOUR_TO_SECOND_FORMAT;
+			case MINUTE:
+				return DEFAULT_MINUTE_FORMAT;
+			case MINUTE_TO_SECOND:
+				return DEFAULT_MINUTE_TO_SECOND_FORMAT;
+			case SECOND:
+				return DEFAULT_SECOND_FORMAT;
+			default:
+				throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DecimalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DecimalType.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a decimal number with fixed precision and scale.
+ *
+ * <p>The serialized string representation is {@code DECIMAL(p, s)} where {@code p} is the number of
+ * digits in a number (=precision) and {@code s} is the number of digits to the right of the decimal
+ * point in a number (=scale). {@code p} must have a value between 1 and 38 (both inclusive). {@code s}
+ * must have a value between 0 and {@code p} (both inclusive). The default value for {@code p} is 10.
+ * The default value for {@code s} is 0.
+ */
+@PublicEvolving
+public final class DecimalType extends LogicalType {
+
+	private static final int MIN_PRECISION = 1;
+
+	private static final int MAX_PRECISION = 38;
+
+	private static final int DEFAULT_PRECISION = 10;
+
+	private static final int MIN_SCALE = 0;
+
+	private static final int DEFAULT_SCALE = 0;
+
+	private static final String DEFAULT_FORMAT = "DECIMAL(%d, %d)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		BigDecimal.class.getName(),
+		"org.apache.flink.table.dataformat.Decimal");
+
+	private static final Class<?> DEFAULT_CONVERSION = BigDecimal.class;
+
+	private final int precision;
+
+	private final int scale;
+
+	public DecimalType(boolean isNullable, int precision, int scale) {
+		super(isNullable, LogicalTypeRoot.DECIMAL);
+		if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Decimal precision must be between %d and %d (both inclusive).",
+					MIN_PRECISION,
+					MAX_PRECISION));
+		}
+		if (scale < MIN_SCALE || scale > precision) {
+			throw new ValidationException(
+				String.format(
+					"Decimal scale must be between %d and %d (both inclusive).",
+					MIN_SCALE,
+					precision));
+		}
+		this.precision = precision;
+		this.scale = scale;
+	}
+
+	public DecimalType(int precision, int scale) {
+		this(true, precision, scale);
+	}
+
+	public DecimalType(int precision) {
+		this(precision, DEFAULT_SCALE);
+	}
+
+	public DecimalType() {
+		this(DEFAULT_PRECISION);
+	}
+
+	public int getPrecision() {
+		return precision;
+	}
+
+	public int getScale() {
+		return scale;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new DecimalType(isNullable, precision, scale);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, precision, scale);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		DecimalType that = (DecimalType) o;
+		return precision == that.precision && scale == that.scale;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), precision, scale);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DistinctType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DistinctType.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Logical type of a user-defined distinct type. A distinct type specifies an identifier and is backed
+ * by a source type. A distinct types has the same internal representation as a source type, but is
+ * considered to be a separate and incompatible data type for most operations. Compared to the SQL
+ * standard, every non-user-defined type can be used as a source type.
+ *
+ * <p>A distinct type can always be cast to its source type and vice versa.
+ *
+ * <p>Distinct types are implicitly final and do not support super types.
+ *
+ * <p>Most other properties are forwarded from the source type. Thus, ordering and comparision among
+ * the same distinct types are supported.
+ *
+ * <p>The serialized string representation is the fully qualified name of this type which means that
+ * the type must have been registered in a catalog.
+ */
+@PublicEvolving
+public final class DistinctType extends UserDefinedType {
+
+	/**
+	 * A builder for a {@link DistinctType}. Intended for future extensibility.
+	 */
+	public static final class Builder {
+
+		private final TypeIdentifier typeIdentifier;
+
+		private final LogicalType sourceType;
+
+		private @Nullable String description;
+
+		public Builder(TypeIdentifier typeIdentifier, LogicalType sourceType) {
+			this.typeIdentifier = Preconditions.checkNotNull(typeIdentifier, "Type identifier must not be null.");
+			this.sourceType = Preconditions.checkNotNull(sourceType, "Source type must not be null.");
+
+			Preconditions.checkArgument(
+				!sourceType.getTypeRoot().getFamilies().contains(LogicalTypeFamily.USER_DEFINED),
+				"Source type must not be a user-defined type.");
+		}
+
+		public Builder setDescription(String description) {
+			this.description = Preconditions.checkNotNull(description, "Description must not be null");
+			return this;
+		}
+
+		public DistinctType build() {
+			return new DistinctType(typeIdentifier, sourceType, description);
+		}
+	}
+
+	private final LogicalType sourceType;
+
+	private DistinctType(
+			TypeIdentifier typeIdentifier,
+			LogicalType sourceType,
+			@Nullable String description) {
+		super(
+			sourceType.isNullable(),
+			LogicalTypeRoot.DISTINCT_TYPE,
+			typeIdentifier,
+			true,
+			description);
+		this.sourceType = Preconditions.checkNotNull(sourceType, "Source type must not be null.");
+	}
+
+	public LogicalType getSourceType() {
+		return sourceType;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new DistinctType(
+			getTypeIdentifier(),
+			sourceType.copy(isNullable),
+			getDescription().orElse(null));
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return sourceType.supportsInputConversion(clazz);
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return sourceType.supportsOutputConversion(clazz);
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return sourceType.getDefaultOutputConversion();
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.singletonList(sourceType);
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		DistinctType that = (DistinctType) o;
+		return sourceType.equals(that.sourceType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), sourceType);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Logical type of an 8-byte double precision floating point number.
+ *
+ * <p>The serialized string representation is {@code DOUBLE}.
+ */
+@PublicEvolving
+public final class DoubleType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "DOUBLE";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		Double.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		Double.class.getName(),
+		double.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = Double.class;
+
+	public DoubleType(boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.DOUBLE);
+	}
+
+	public DoubleType() {
+		this(true);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new DoubleType(isNullable);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/FloatType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/FloatType.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Logical type of a 4-byte single precision floating point number.
+ *
+ * <p>The serialized string representation is {@code FLOAT}.
+ */
+@PublicEvolving
+public final class FloatType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "FLOAT";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		Float.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		Float.class.getName(),
+		float.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = Float.class;
+
+	public FloatType(boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.FLOAT);
+	}
+
+	public FloatType() {
+		this(true);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new FloatType(isNullable);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/IntType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/IntType.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Logical type of a 4-byte signed integer with values from -2,147,483,648 to 2,147,483,647.
+ *
+ * <p>The serialized string representation is {@code INT}.
+ */
+@PublicEvolving
+public final class IntType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "INT";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		Integer.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		Integer.class.getName(),
+		int.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = Integer.class;
+
+	public IntType(boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.INTEGER);
+	}
+
+	public IntType() {
+		this(true);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new IntType(isNullable);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a timestamp WITH LOCAL timezone consisting of {@code year-month-day hour:minute:second[.fractional] zone}
+ * with up to nanosecond precision and values ranging from {@code 0000-01-01 00:00:00.000000000 +14:59} to
+ * {@code 9999-12-31 23:59:59.999999999 -14:59}. Leap seconds (23:59:60 and 23:59:61) are not
+ * supported as the semantics are closer to {@link java.time.OffsetDateTime}.
+ *
+ * <p>The serialized string representation is {@code TIMESTAMP(p) WITH LOCAL TIME ZONE} where {@code p} is
+ * the number of digits of fractional seconds (=precision). {@code p} must have a value between 0 and
+ * 9 (both inclusive). If no precision is specified, {@code p} is equal to 6.
+ *
+ * <p>Compared to {@link ZonedTimestampType}, the time zone offset information is not stored physically
+ * in ever datum. Instead, the type assumes {@link java.time.Instant} semantics in UTC time zone at
+ * the edges of the table ecosystem. Every datum is interpreted in the local time zone configured in
+ * the current session for computation and visualization.
+ *
+ * <p>This type fills the gap between timezone-free and timezone-mandatory timestamp types by allowing
+ * the interpretation of UTC timestamps according to the configured session timezone. A conversion
+ * from and to {@code int} describes the number of seconds since epoch. A conversion from and to {@code long}
+ * describes the number of milliseconds since epoch.
+ *
+ * @see TimestampType
+ * @see ZonedTimestampType
+ */
+@PublicEvolving
+public final class LocalZonedTimestampType extends LogicalType {
+
+	private static final int MIN_PRECISION = 0;
+
+	private static final int MAX_PRECISION = 9;
+
+	private static final int DEFAULT_PRECISION = 6;
+
+	private static final String DEFAULT_FORMAT = "TIMESTAMP(%d) WITH LOCAL TIME ZONE";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		java.time.Instant.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		java.time.Instant.class.getName(),
+		int.class.getName(),
+		long.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = java.time.Instant.class;
+
+	/**
+	 * Internal timestamp kind for time attribute metadata.
+	 */
+	@Internal
+	public enum TimestampKind {
+		REGULAR,
+		ROWTIME,
+		PROCTIME
+	}
+
+	private final TimestampKind kind;
+
+	private final int precision;
+
+	/**
+	 * Internal constructor that allows attaching additional metadata about time attribute
+	 * properties. The additional metadata does not affect equality or serializability.
+	 *
+	 * <p>Use {@link #getKind()} for comparing this metadata.
+	 */
+	@Internal
+	public LocalZonedTimestampType(boolean isNullable, TimestampKind kind, int precision) {
+		super(isNullable, LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+		if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Timestamp with local time zone precision must be between %d and %d (both inclusive).",
+					MIN_PRECISION,
+					MAX_PRECISION));
+		}
+		this.kind = kind;
+		this.precision = precision;
+	}
+
+	public LocalZonedTimestampType(boolean isNullable, int precision) {
+		this(isNullable, TimestampKind.REGULAR, precision);
+	}
+
+	public LocalZonedTimestampType(int precision) {
+		this(true, precision);
+	}
+
+	public LocalZonedTimestampType() {
+		this(DEFAULT_PRECISION);
+	}
+
+	@Internal
+	public TimestampKind getKind() {
+		return kind;
+	}
+
+	public int getPrecision() {
+		return precision;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new LocalZonedTimestampType(isNullable, kind, precision);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, precision);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		LocalZonedTimestampType that = (LocalZonedTimestampType) o;
+		return precision == that.precision;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), precision);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalType.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A logical type that describes the data type of a value. It does not imply a concrete physical
+ * representation for transmission or storage but defines the boundaries between JVM-based languages
+ * and the table ecosystem.
+ *
+ * <p>The definition of a logical type is similar to the SQL standard's "data type" terminology but
+ * also contains information about the nullability of a value for efficient handling of scalar
+ * expressions.
+ *
+ * <p>Subclasses of this class define characteristics of built-in or user-defined types.
+ *
+ * <p>Instances of this class describe the fully parameterized, immutable type with additional
+ * information such as numeric precision or expected length.
+ *
+ * <p>NOTE: A logical type is just a description of a type, a planner or runtime might not support
+ * every type in every logical precision yet!
+ */
+@PublicEvolving
+public abstract class LogicalType implements Serializable {
+
+	private final boolean isNullable;
+
+	private final LogicalTypeRoot typeRoot;
+
+	public LogicalType(boolean isNullable, LogicalTypeRoot typeRoot) {
+		this.isNullable = isNullable;
+		this.typeRoot = Preconditions.checkNotNull(typeRoot);
+	}
+
+	/**
+	 * Returns whether a value of this type can be {@code null}.
+	 */
+	public boolean isNullable() {
+		return isNullable;
+	}
+
+	/**
+	 * Returns the root of this type. It is an essential description without additional parameters.
+	 */
+	public LogicalTypeRoot getTypeRoot() {
+		return typeRoot;
+	}
+
+	/**
+	 * Returns a deep copy of this type with possibly different nullability.
+	 *
+	 * @param isNullable the intended nullability of the copied type
+	 * @return a deep copy
+	 */
+	public abstract LogicalType copy(boolean isNullable);
+
+	/**
+	 * Returns a deep copy of this type.
+	 *
+	 * @return a deep copy
+	 */
+	public LogicalType copy() {
+		return copy(isNullable);
+	}
+
+	/**
+	 * Returns a string that fully serializes this instance. The serialized string can be used for
+	 * transmitting or persisting a type.
+	 *
+	 * @return detailed string for transmission or persistence
+	 */
+	public abstract String asSerializableString();
+
+	/**
+	 * Returns a string that summarizes this type for printing to a console. An implementation might
+	 * shorten long names or skips very specific properties.
+	 *
+	 * <p>Use {@link #asSerializableString()} for a type string that fully serializes
+	 * this instance.
+	 *
+	 * @return summary string of this type for debugging purposes
+	 */
+	public String asSummaryString() {
+		return asSerializableString();
+	}
+
+	/**
+	 * Returns whether an instance of the given class can be represented as a value of this logical
+	 * type when entering the table ecosystem. This method helps for the interoperability between
+	 * JVM-based languages and the relational type system.
+	 *
+	 * <p>A supported conversion directly maps an input class to a logical type without loss of
+	 * precision or type widening.
+	 *
+	 * <p>For example, {@code java.lang.Long} or {@code long} can be used as input for {@code BIGINT}
+	 * independent of the set nullability.
+	 *
+	 * @param clazz input class to be converted into this logical type
+	 * @return flag that indicates if instances of this class can be used as input into the table
+	 * ecosystem
+	 */
+	public abstract boolean supportsInputConversion(Class<?> clazz);
+
+	/**
+	 * Returns whether a value of this logical type can be represented as an instance of the given
+	 * class when leaving the table ecosystem. This method helps for the interoperability between
+	 * JVM-based languages and the relational type system.
+	 *
+	 * <p>A supported conversion directly maps a logical type to an output class without loss of
+	 * precision or type widening.
+	 *
+	 * <p>For example, {@code java.lang.Long} or {@code long} can be used as output for {@code BIGINT}
+	 * if the type is not nullable. If the type is nullable, only {@code java.lang.Long} can represent
+	 * this.
+	 *
+	 * @param clazz output class to be converted from this logical type
+	 * @return flag that indicates if instances of this class can be used as output from the table
+	 * ecosystem
+	 * @see #getDefaultOutputConversion()
+	 */
+	public abstract boolean supportsOutputConversion(Class<?> clazz);
+
+	/**
+	 * Returns the default output conversion class. A value of this logical type will be represented
+	 * as an instance of the given class when leaving the table ecosystem if no other conversion
+	 * has been specified.
+	 *
+	 * <p>For example, {@code java.lang.Long} is the default output for {@code BIGINT}.
+	 *
+	 * @return output class to be converted from this logical type
+	 * @see #supportsOutputConversion(Class)
+	 */
+	public abstract Class<?> getDefaultOutputConversion();
+
+	public abstract List<LogicalType> getChildren();
+
+	public abstract <R> R accept(LogicalTypeVisitor<R> visitor);
+
+	@Override
+	public String toString() {
+		return asSummaryString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		LogicalType that = (LogicalType) o;
+		return isNullable == that.isNullable && typeRoot == that.typeRoot;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(isNullable, typeRoot);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	protected String withNullability(String format, Object... params) {
+		if (!isNullable) {
+			return String.format(format + " NOT NULL", params);
+		}
+		return String.format(format, params);
+	}
+
+	protected static Set<String> conversionSet(String... elements) {
+		return new HashSet<>(Arrays.asList(elements));
+	}
+
+	protected static String escapeBackticks(String s) {
+		return s.replace("`", "``");
+	}
+
+	protected static String escapeSingleQuotes(String s) {
+		return s.replace("'", "''");
+	}
+
+	protected static String escapeIdentifier(String s) {
+		return "`" + escapeBackticks(s) + "`";
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeFamily.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeFamily.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * An enumeration of logical type families for clustering {@link LogicalTypeRoot}s into categories.
+ *
+ * <p>The enumeration is very close to the SQL standard in terms of naming and completeness. However,
+ * it reflects just a subset of the evolving standard and contains some extensions (indicated
+ * by {@code EXTENSION}).
+ */
+@PublicEvolving
+public enum LogicalTypeFamily {
+
+	PREDEFINED,
+
+	CONSTRUCTED,
+
+	USER_DEFINED,
+
+	CHARACTER_STRING,
+
+	BINARY_STRING,
+
+	NUMERIC,
+
+	EXACT_NUMERIC,
+
+	APPROXIMATE_NUMERIC,
+
+	DATETIME,
+
+	TIME,
+
+	TIMESTAMP,
+
+	INTERVAL,
+
+	COLLECTION,
+
+	EXTENSION
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * An enumeration of logical type roots containing static information about logical data types.
+ *
+ * <p>A root is an essential description of a {@link LogicalType} without additional parameters. For
+ * example, a parameterized logical type {@code DECIMAL(12,3)} possesses all characteristics of its
+ * root {@code DECIMAL}. Additionally, a logical type root enables efficient comparision during the
+ * evaluation of types.
+ *
+ * <p>The enumeration is very close to the SQL standard in terms of naming and completeness. However,
+ * it reflects just a subset of the evolving standard and contains some extensions (such as {@code NULL}
+ * or {@code ANY}).
+ *
+ * <p>See the type-implementing classes for a more detailed description of each type.
+ */
+@PublicEvolving
+public enum LogicalTypeRoot {
+
+	CHAR(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.CHARACTER_STRING),
+
+	VARCHAR(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.CHARACTER_STRING),
+
+	BOOLEAN(
+		LogicalTypeFamily.PREDEFINED),
+
+	BINARY(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.BINARY_STRING),
+
+	VARBINARY(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.BINARY_STRING),
+
+	DECIMAL(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.NUMERIC,
+		LogicalTypeFamily.EXACT_NUMERIC),
+
+	TINYINT(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.NUMERIC,
+		LogicalTypeFamily.EXACT_NUMERIC),
+
+	SMALLINT(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.NUMERIC,
+		LogicalTypeFamily.EXACT_NUMERIC),
+
+	INTEGER(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.NUMERIC,
+		LogicalTypeFamily.EXACT_NUMERIC),
+
+	BIGINT(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.NUMERIC,
+		LogicalTypeFamily.EXACT_NUMERIC),
+
+	FLOAT(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.NUMERIC,
+		LogicalTypeFamily.APPROXIMATE_NUMERIC),
+
+	DOUBLE(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.NUMERIC,
+		LogicalTypeFamily.APPROXIMATE_NUMERIC),
+
+	DATE(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.DATETIME),
+
+	TIME_WITHOUT_TIME_ZONE(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.DATETIME),
+
+	TIMESTAMP_WITHOUT_TIME_ZONE(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.DATETIME,
+		LogicalTypeFamily.TIMESTAMP),
+
+	TIMESTAMP_WITH_TIME_ZONE(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.DATETIME,
+		LogicalTypeFamily.TIMESTAMP),
+
+	TIMESTAMP_WITH_LOCAL_TIME_ZONE(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.DATETIME,
+		LogicalTypeFamily.TIMESTAMP,
+		LogicalTypeFamily.EXTENSION),
+
+	INTERVAL_YEAR_MONTH(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.INTERVAL),
+
+	INTERVAL_DAY_TIME(
+		LogicalTypeFamily.PREDEFINED,
+		LogicalTypeFamily.INTERVAL),
+
+	ARRAY(
+		LogicalTypeFamily.CONSTRUCTED,
+		LogicalTypeFamily.COLLECTION),
+
+	MULTISET(
+		LogicalTypeFamily.CONSTRUCTED,
+		LogicalTypeFamily.COLLECTION),
+
+	MAP(
+		LogicalTypeFamily.CONSTRUCTED,
+		LogicalTypeFamily.COLLECTION,
+		LogicalTypeFamily.EXTENSION),
+
+	ROW(
+		LogicalTypeFamily.CONSTRUCTED),
+
+	DISTINCT_TYPE(
+		LogicalTypeFamily.USER_DEFINED),
+
+	STRUCTURED_TYPE(
+		LogicalTypeFamily.USER_DEFINED),
+
+	NULL(
+		LogicalTypeFamily.EXTENSION),
+
+	ANY(
+		LogicalTypeFamily.EXTENSION);
+
+	private final Set<LogicalTypeFamily> families;
+
+	LogicalTypeRoot(LogicalTypeFamily... families) {
+		this.families = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(families)));
+	}
+
+	public Set<LogicalTypeFamily> getFamilies() {
+		return families;
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -73,5 +73,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(MapType mapType);
 
+	R visit(RowType rowType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -41,5 +41,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(DecimalType decimalType);
 
+	R visit(TinyIntType tinyIntType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -53,5 +53,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(DoubleType doubleType);
 
+	R visit(DateType dateType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -75,5 +75,9 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(RowType rowType);
 
+	R visit(DistinctType distinctType);
+
+	R visit(StructuredType structuredType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -33,5 +33,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(VarCharType varCharType);
 
+	R visit(BooleanType booleanType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -43,5 +43,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(TinyIntType tinyIntType);
 
+	R visit(SmallIntType smallIntType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -61,5 +61,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(ZonedTimestampType zonedTimestampType);
 
+	R visit(LocalZonedTimestampType localZonedTimestampType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -71,5 +71,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(MultisetType multisetType);
 
+	R visit(MapType mapType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -45,5 +45,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(SmallIntType smallIntType);
 
+	R visit(IntType intType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -69,5 +69,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(ArrayType arrayType);
 
+	R visit(MultisetType multisetType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -67,5 +67,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(DayTimeIntervalType dayTimeIntervalType);
 
+	R visit(ArrayType arrayType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -65,5 +65,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(YearMonthIntervalType yearMonthIntervalType);
 
+	R visit(DayTimeIntervalType dayTimeIntervalType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -57,5 +57,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(TimeType timeType);
 
+	R visit(TimestampType timestampType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -39,5 +39,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(VarBinaryType varBinaryType);
 
+	R visit(DecimalType decimalType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * The visitor definition of {@link LogicalType}. The visitor transforms a logical type into
+ * instances of {@code R}.
+ *
+ * @param <R> result type
+ */
+@PublicEvolving
+public interface LogicalTypeVisitor<R> {
+
+	R visit(LogicalType other);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -35,5 +35,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(BooleanType booleanType);
 
+	R visit(BinaryType binaryType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -47,5 +47,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(IntType intType);
 
+	R visit(BigIntType bigIntType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -24,6 +24,9 @@ import org.apache.flink.annotation.PublicEvolving;
  * The visitor definition of {@link LogicalType}. The visitor transforms a logical type into
  * instances of {@code R}.
  *
+ * <p>Incomplete types such as the {@link TypeInformationAnyType} are visited through the generic
+ * {@link #visit(LogicalType)}.
+ *
  * @param <R> result type
  */
 @PublicEvolving
@@ -80,6 +83,8 @@ public interface LogicalTypeVisitor<R> {
 	R visit(StructuredType structuredType);
 
 	R visit(NullType nullType);
+
+	R visit(AnyType anyType);
 
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -79,5 +79,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(StructuredType structuredType);
 
+	R visit(NullType nullType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -29,5 +29,7 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public interface LogicalTypeVisitor<R> {
 
+	R visit(CharType charType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -63,5 +63,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(LocalZonedTimestampType localZonedTimestampType);
 
+	R visit(YearMonthIntervalType yearMonthIntervalType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -59,5 +59,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(TimestampType timestampType);
 
+	R visit(ZonedTimestampType zonedTimestampType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -55,5 +55,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(DateType dateType);
 
+	R visit(TimeType timeType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -51,5 +51,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(FloatType floatType);
 
+	R visit(DoubleType doubleType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -37,5 +37,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(BinaryType binaryType);
 
+	R visit(VarBinaryType varBinaryType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -31,5 +31,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(CharType charType);
 
+	R visit(VarCharType varCharType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -49,5 +49,7 @@ public interface LogicalTypeVisitor<R> {
 
 	R visit(BigIntType bigIntType);
 
+	R visit(FloatType floatType);
+
 	R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MapType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MapType.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of an associative array that maps keys (including {@code NULL}) to values (including
+ * {@code NULL}). A map cannot contain duplicate keys; each key can map to at most one value. There
+ * is no restriction of key types; it is the responsibility of the user to ensure uniqueness. The map
+ * type is an extension to the SQL standard.
+ *
+ * <p>The serialized string representation is {@code MAP<kt, vt>} where {@code kt} is the type
+ * of the key elements and {@code vt} is the type of the value elements.
+ */
+@PublicEvolving
+public final class MapType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "MAP<%s, %s>";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		Map.class.getName(),
+		"org.apache.flink.table.dataformat.BinaryMap");
+
+	private static final Class<?> DEFAULT_CONVERSION = Map.class;
+
+	private final LogicalType keyType;
+
+	private final LogicalType valueType;
+
+	public MapType(boolean isNullable, LogicalType keyType, LogicalType valueType) {
+		super(isNullable, LogicalTypeRoot.MAP);
+		this.keyType = Preconditions.checkNotNull(keyType, "Key type must not be null.");
+		this.valueType = Preconditions.checkNotNull(valueType, "Value type must not be null.");
+	}
+
+	public MapType(LogicalType keyType, LogicalType valueType) {
+		this(true, keyType, valueType);
+	}
+
+	public LogicalType getKeyType() {
+		return keyType;
+	}
+
+	public LogicalType getValueType() {
+		return valueType;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new MapType(isNullable, keyType.copy(), valueType.copy());
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(
+			DEFAULT_FORMAT,
+			keyType.asSummaryString(),
+			valueType.asSummaryString());
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(
+			DEFAULT_FORMAT,
+			keyType.asSerializableString(),
+			valueType.asSerializableString());
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.unmodifiableList(Arrays.asList(keyType, valueType));
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MapType mapType = (MapType) o;
+		return keyType.equals(mapType.keyType) && valueType.equals(mapType.valueType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), keyType, valueType);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MultisetType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MultisetType.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a multiset (=bag). Unlike a set, it allows for multiple instances for each of its
+ * elements with a common subtype. Each unique value (including {@code NULL}) is mapped to some
+ * multiplicity. There is no restriction of element types; it is the responsibility of the user to
+ * ensure uniqueness.
+ *
+ * <p>The serialized string representation is {@code MULTISET<t>} where {@code t} is the type
+ * of the contained elements.
+ *
+ * <p>A conversion is possible through a map that assigns each value to an integer multiplicity
+ * ({@code Map<t, Integer>}).
+ */
+@PublicEvolving
+public final class MultisetType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "MULTISET<%s>";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		Map.class.getName(),
+		"org.apache.flink.table.dataformat.BinaryMap");
+
+	private static final Class<?> DEFAULT_CONVERSION = Map.class;
+
+	private final LogicalType elementType;
+
+	public MultisetType(boolean isNullable, LogicalType elementType) {
+		super(isNullable, LogicalTypeRoot.MULTISET);
+		this.elementType = Preconditions.checkNotNull(elementType, "Element type must not be null.");
+	}
+
+	public MultisetType(LogicalType elementType) {
+		this(true, elementType);
+	}
+
+	public LogicalType getElementType() {
+		return elementType;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new MultisetType(isNullable, elementType.copy());
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(DEFAULT_FORMAT, elementType.asSummaryString());
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, elementType.asSerializableString());
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.singletonList(elementType);
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MultisetType that = (MultisetType) o;
+		return elementType.equals(that.elementType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), elementType);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/NullType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/NullType.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Logical type for representing untyped {@code NULL} values. The null type is an extension to the
+ * SQL standard. A null type has no other value except {@code NULL}, thus, it can be cast to any
+ * nullable type similar to JVM semantics.
+ *
+ * <p>This type helps in representing unknown types in API calls that use a {@code NULL} literal as
+ * well as bridging to formats such as JSON or Avro that define such a type as well.
+ *
+ * <p>The serialized string representation is {@code NULL}.
+ */
+@PublicEvolving
+public final class NullType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "NULL";
+
+	private static final Class<?> INPUT_CONVERSION = Object.class;
+
+	private static final Class<?> DEFAULT_CONVERSION = Object.class;
+
+	public NullType() {
+		super(true, LogicalTypeRoot.NULL);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		if (!isNullable) {
+			throw new TableException(
+				"The nullability of a null type cannot be disabled because the type must always " +
+					"be able to contain a null value.");
+		}
+		return new NullType();
+	}
+
+	@Override
+	public String asSerializableString() {
+		return DEFAULT_FORMAT;
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_CONVERSION.equals(clazz);
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		// any nullable class is supported
+		return !clazz.isPrimitive();
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RowType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RowType.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Logical type of a sequence of fields. A field consists of a field name, field type, and an optional
+ * description. The most specific type of a row of a table is a row type. In this case, each column
+ * of the row corresponds to the field of the row type that has the same ordinal position as the
+ * column. Compared to the SQL standard, an optional field description simplifies the handling with
+ * complex structures.
+ *
+ * <p>The serialized string representation is {@code ROW<n0 t0 'd0', n1 t1 'd1', ...>} where
+ * {@code n} is the name of a field, {@code t} is the type of a field, {@code d} is the description
+ * of a field.
+ */
+@PublicEvolving
+public final class RowType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "ROW<%s>";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		Row.class.getName(),
+		"org.apache.flink.table.dataformat.BaseRow");
+
+	private static final Class<?> DEFAULT_CONVERSION = Row.class;
+
+	/**
+	 * Describes a field of a {@link RowType}.
+	 */
+	public static final class RowField implements Serializable {
+
+		private static final String DEFAULT_FIELD_FORMAT_WITH_DESCRIPTION = "%s %s '%s'";
+
+		private static final String DEFAULT_FIELD_FORMAT_NO_DESCRIPTION = "%s %s";
+
+		private final String name;
+
+		private final LogicalType type;
+
+		private final @Nullable String description;
+
+		public RowField(String name, LogicalType type, @Nullable String description) {
+			this.name = Preconditions.checkNotNull(name, "Field name must not be null.");
+			this.type = Preconditions.checkNotNull(type, "Field type must not be null.");
+			this.description = description;
+		}
+
+		public RowField(String name, LogicalType type) {
+			this(name, type, null);
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public LogicalType getType() {
+			return type;
+		}
+
+		public Optional<String> getDescription() {
+			return Optional.ofNullable(description);
+		}
+
+		public RowField copy() {
+			return new RowField(name, type.copy(), description);
+		}
+
+		public String asSummaryString() {
+			return formatString(type.asSummaryString());
+		}
+
+		public String asSerializableString() {
+			return formatString(type.asSerializableString());
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			RowField rowField = (RowField) o;
+			return name.equals(rowField.name) &&
+				type.equals(rowField.type) &&
+				Objects.equals(description, rowField.description);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name, type, description);
+		}
+
+		private String formatString(String typeString) {
+			if (description == null) {
+				return String.format(
+					DEFAULT_FIELD_FORMAT_NO_DESCRIPTION,
+					escapeIdentifier(name),
+					typeString);
+			} else {
+				return String.format(
+					DEFAULT_FIELD_FORMAT_WITH_DESCRIPTION,
+					escapeIdentifier(name),
+					typeString,
+					escapeSingleQuotes(description));
+			}
+		}
+	}
+
+	private final List<RowField> fields;
+
+	public RowType(boolean isNullable, List<RowField> fields) {
+		super(isNullable, LogicalTypeRoot.ROW);
+		this.fields = Collections.unmodifiableList(
+			new ArrayList<>(
+				Preconditions.checkNotNull(fields, "Fields must not be null.")));
+	}
+
+	public RowType(List<RowField> fields) {
+		this(true, fields);
+	}
+
+	public List<RowField> getFields() {
+		return fields;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new RowType(
+			isNullable,
+			fields.stream().map(RowField::copy).collect(Collectors.toList()));
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(
+			DEFAULT_FORMAT,
+			fields.stream()
+				.map(RowField::asSummaryString)
+				.collect(Collectors.joining(", ")));
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(
+			DEFAULT_FORMAT,
+			fields.stream()
+				.map(RowField::asSerializableString)
+				.collect(Collectors.joining(", ")));
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.unmodifiableList(
+			fields.stream()
+				.map(RowField::getType)
+				.collect(Collectors.toList()));
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		RowType rowType = (RowType) o;
+		return fields.equals(rowType.fields);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), fields);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SmallIntType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SmallIntType.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Logical type of a 2-byte signed integer with values from -32,768 to 32,767.
+ *
+ * <p>The serialized string representation is {@code SMALLINT}.
+ */
+@PublicEvolving
+public final class SmallIntType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "SMALLINT";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		Short.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		Short.class.getName(),
+		short.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = Short.class;
+
+	public SmallIntType(boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.SMALLINT);
+	}
+
+	public SmallIntType() {
+		this(true);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new SmallIntType(isNullable);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Logical type of a user-defined object structured type. Structured types contain one or more
+ * attributes. Each attribute consists of a name and a type. A type cannot be defined so that one of
+ * its attribute types (transitively) uses itself.
+ *
+ * <p>A structured type can declare a super type and allows single inheritance for more complex type
+ * hierarchies, similar to JVM-based languages.
+ *
+ * <p>A structured type must be declared {@code final} for preventing further inheritance (default
+ * behavior) or {@code not final} for allowing subtypes.
+ *
+ * <p>A structured type must be declared {@code not instantiable} if a more specific type is
+ * required or {@code instantiable} if instances can be created from this type (default behavior).
+ *
+ * <p>A structured type declares comparision properties of either {@code none} (no equality),
+ * {@code equals} (only equality and inequality), or {@code full} (greater, equals, less).
+ *
+ * <p>NOTE: Compared to the SQL standard, this class is incomplete. We might add new features such
+ * as method declarations in the future. Also ordering is not supported yet.
+ */
+@PublicEvolving
+public final class StructuredType extends UserDefinedType {
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		Row.class.getName(),
+		"org.apache.flink.table.dataformat.BaseRow");
+
+	private static final Class<?> FALLBACK_CONVERSION = Row.class;
+
+	/**
+	 * Defines an attribute of a {@link StructuredType}.
+	 */
+	public static final class StructuredAttribute implements Serializable {
+
+		private final String name;
+
+		private final LogicalType type;
+
+		public StructuredAttribute(String name, LogicalType type) {
+			this.name = Preconditions.checkNotNull(name, "Attribute name must not be null.");
+			this.type = Preconditions.checkNotNull(type, "Attribute type must not be null.");
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public LogicalType getType() {
+			return type;
+		}
+
+		public StructuredAttribute copy() {
+			return new StructuredAttribute(name, type.copy());
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			StructuredAttribute that = (StructuredAttribute) o;
+			return name.equals(that.name) && type.equals(that.type);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name, type);
+		}
+	}
+
+	/**
+	 * Defines equality properties for scalar evaluation.
+	 */
+	public enum StructuredComparision {
+		EQUALS,
+		FULL,
+		NONE
+	}
+
+	/**
+	 * A builder for a {@link StructuredType}. Intended for future extensibility.
+	 */
+	public static class Builder {
+
+		private final TypeIdentifier typeIdentifier;
+
+		private final List<StructuredAttribute> attributes;
+
+		private boolean isNullable = true;
+
+		private boolean isFinal = true;
+
+		private boolean isInstantiable = true;
+
+		private StructuredComparision comparision = StructuredComparision.NONE;
+
+		private @Nullable StructuredType superType;
+
+		private @Nullable String description;
+
+		private @Nullable Class<?> implementationClass;
+
+		public Builder(TypeIdentifier typeIdentifier, List<StructuredAttribute> attributes) {
+			this.typeIdentifier = Preconditions.checkNotNull(typeIdentifier, "Type identifier must not be null.");
+			this.attributes = Collections.unmodifiableList(
+				new ArrayList<>(
+					Preconditions.checkNotNull(attributes, "Attributes must not be null.")));
+
+			Preconditions.checkArgument(
+				attributes.size() > 0,
+				"Attribute list must not be empty.");
+		}
+
+		public Builder setNullable(boolean isNullable) {
+			this.isNullable = isNullable;
+			return this;
+		}
+
+		public Builder setDescription(String description) {
+			this.description = Preconditions.checkNotNull(description, "Description must not be null.");
+			return this;
+		}
+
+		public Builder setFinal(boolean isFinal) {
+			this.isFinal = isFinal;
+			return this;
+		}
+
+		public Builder setInstantiable(boolean isInstantiable) {
+			this.isInstantiable = isInstantiable;
+			return this;
+		}
+
+		public Builder setComparision(StructuredComparision comparision) {
+			this.comparision = Preconditions.checkNotNull(comparision, "Comparision must not be null.");
+			return this;
+		}
+
+		public Builder setSuperType(@Nullable StructuredType superType) {
+			this.superType = Preconditions.checkNotNull(superType, "Super type must not be null.");
+			return this;
+		}
+
+		public Builder setImplementationClass(Class<?> implementationClass) {
+			this.implementationClass = Preconditions.checkNotNull(implementationClass, "Implementation class must not null.");
+			return this;
+		}
+
+		public StructuredType build() {
+			return new StructuredType(
+				isNullable,
+				typeIdentifier,
+				attributes,
+				isFinal,
+				isInstantiable,
+				comparision,
+				superType,
+				description,
+				implementationClass);
+		}
+	}
+
+	private final List<StructuredAttribute> attributes;
+
+	private final boolean isInstantiable;
+
+	private final StructuredComparision comparision;
+
+	private final @Nullable StructuredType superType;
+
+	private final @Nullable Class<?> implementationClass;
+
+	private StructuredType(
+			boolean isNullable,
+			TypeIdentifier typeIdentifier,
+			List<StructuredAttribute> attributes,
+			boolean isFinal,
+			boolean isInstantiable,
+			StructuredComparision comparision,
+			@Nullable StructuredType superType,
+			@Nullable String description,
+			@Nullable Class<?> implementationClass) {
+		super(
+			isNullable,
+			LogicalTypeRoot.STRUCTURED_TYPE,
+			typeIdentifier,
+			isFinal,
+			description);
+
+		this.attributes = attributes;
+		this.isInstantiable = isInstantiable;
+		this.comparision = comparision;
+		this.superType = superType;
+		this.implementationClass = implementationClass;
+	}
+
+	public List<StructuredAttribute> getAttributes() {
+		return attributes;
+	}
+
+	public boolean isInstantiable() {
+		return isInstantiable;
+	}
+
+	public StructuredComparision getComparision() {
+		return comparision;
+	}
+
+	public Optional<StructuredType> getSuperType() {
+		return Optional.ofNullable(superType);
+	}
+
+	public Optional<Class<?>> getImplementationClass() {
+		return Optional.ofNullable(implementationClass);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new StructuredType(
+			isNullable,
+			getTypeIdentifier(),
+			attributes.stream().map(StructuredAttribute::copy).collect(Collectors.toList()),
+			isFinal(),
+			isInstantiable,
+			comparision,
+			superType == null ? null : (StructuredType) superType.copy(),
+			getDescription().orElse(null),
+			implementationClass);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return (implementationClass != null && implementationClass.isAssignableFrom(clazz)) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		StructuredType currentType = this;
+		while (currentType != null) {
+			if (currentType.implementationClass != null && clazz.isAssignableFrom(currentType.implementationClass)) {
+				return true;
+			}
+			currentType = currentType.superType;
+		}
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		if (implementationClass != null) {
+			return implementationClass;
+		}
+		return FALLBACK_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		final ArrayList<LogicalType> children = new ArrayList<>();
+		StructuredType currentType = this;
+		while (currentType != null) {
+			children.addAll(
+				currentType.attributes.stream()
+					.map(StructuredAttribute::getType)
+					.collect(Collectors.toList()));
+			currentType = currentType.superType;
+		}
+		Collections.reverse(children);
+		return Collections.unmodifiableList(children);
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		StructuredType that = (StructuredType) o;
+		return isInstantiable == that.isInstantiable &&
+			attributes.equals(that.attributes) &&
+			comparision == that.comparision &&
+			Objects.equals(superType, that.superType) &&
+			Objects.equals(implementationClass, that.implementationClass);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+			super.hashCode(),
+			attributes,
+			isInstantiable,
+			comparision,
+			superType,
+			implementationClass);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a time WITHOUT timezone consisting of {@code hour:minute:second[.fractional]} with up
+ * to nanosecond precision and values ranging from {@code 00:00:00.000000000} to
+ * {@code 23:59:59.999999999}. Compared to the SQL standard, leap seconds (23:59:60 and 23:59:61) are
+ * not supported as the semantics are closer to {@link java.time.LocalTime}.
+ *
+ * <p>The serialized string representation is {@code TIME(p)} where {@code p} is the number of digits
+ * of fractional seconds (=precision). {@code p} must have a value between 0 and 9 (both inclusive).
+ * If no precision is specified, {@code p} is equal to 0.
+ *
+ * <p>A conversion from and to {@code int} describes the number of milliseconds of the day. A
+ * conversion from and to {@code long} describes the number of nanoseconds of the day.
+ */
+@PublicEvolving
+public final class TimeType extends LogicalType {
+
+	private static final int MIN_PRECISION = 0;
+
+	private static final int MAX_PRECISION = 9;
+
+	private static final int DEFAULT_PRECISION = 0;
+
+	private static final String DEFAULT_FORMAT = "TIME(%d)";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		java.sql.Time.class.getName(),
+		java.time.LocalTime.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		java.sql.Time.class.getName(),
+		java.time.LocalTime.class.getName(),
+		int.class.getName(),
+		long.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = java.time.LocalTime.class;
+
+	private final int precision;
+
+	public TimeType(boolean isNullable, int precision) {
+		super(isNullable, LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE);
+		if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Time precision must be between %d and %d (both inclusive).",
+					MIN_PRECISION,
+					MAX_PRECISION));
+		}
+		this.precision = precision;
+	}
+
+	public TimeType(int precision) {
+		this(true, precision);
+	}
+
+	public TimeType() {
+		this(DEFAULT_PRECISION);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new TimeType(isNullable, precision);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, precision);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TimeType timeType = (TimeType) o;
+		return precision == timeType.precision;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), precision);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a timestamp WITHOUT timezone consisting of {@code year-month-day hour:minute:second[.fractional]}
+ * with up to nanosecond precision and values ranging from {@code 0000-01-01 00:00:00.000000000} to
+ * {@code 9999-12-31 23:59:59.999999999}. Compared to the SQL standard, leap seconds (23:59:60 and 23:59:61) are
+ * not supported as the semantics are closer to {@link java.time.LocalDateTime}.
+ *
+ * <p>The serialized string representation is {@code TIMESTAMP(p)} where {@code p} is the number of digits
+ * of fractional seconds (=precision). {@code p} must have a value between 0 and 9 (both inclusive).
+ * If no precision is specified, {@code p} is equal to 6.
+ *
+ * <p>A conversion from and to {@code long} is not supported as this would imply a timezone. However,
+ * this type is timezone-free. For more {@link java.time.Instant}-like semantics use
+ * {@link LocalZonedTimestampType}.
+ *
+ * @see ZonedTimestampType
+ * @see LocalZonedTimestampType
+ */
+@PublicEvolving
+public final class TimestampType extends LogicalType {
+
+	private static final int MIN_PRECISION = 0;
+
+	private static final int MAX_PRECISION = 9;
+
+	private static final int DEFAULT_PRECISION = 6;
+
+	private static final String DEFAULT_FORMAT = "TIMESTAMP(%d)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		java.sql.Timestamp.class.getName(),
+		java.time.LocalDateTime.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = java.time.LocalDateTime.class;
+
+	/**
+	 * Internal timestamp kind for time attribute metadata.
+	 */
+	@Internal
+	public enum TimestampKind {
+		REGULAR,
+		ROWTIME,
+		PROCTIME
+	}
+
+	private final TimestampKind kind;
+
+	private final int precision;
+
+	/**
+	 * Internal constructor that allows attaching additional metadata about time attribute
+	 * properties. The additional metadata does not affect equality or serializability.
+	 *
+	 * <p>Use {@link #getKind()} for comparing this metadata.
+	 */
+	@Internal
+	public TimestampType(boolean isNullable, TimestampKind kind, int precision) {
+		super(isNullable, LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE);
+		if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Timestamp precision must be between %d and %d (both inclusive).",
+					MIN_PRECISION,
+					MAX_PRECISION));
+		}
+		this.kind = kind;
+		this.precision = precision;
+	}
+
+	public TimestampType(boolean isNullable, int precision) {
+		this(isNullable, TimestampKind.REGULAR, precision);
+	}
+
+	public TimestampType(int precision) {
+		this(true, precision);
+	}
+
+	public TimestampType() {
+		this(DEFAULT_PRECISION);
+	}
+
+	@Internal
+	public TimestampKind getKind() {
+		return kind;
+	}
+
+	public int getPrecision() {
+		return precision;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new TimestampType(isNullable, kind, precision);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, precision);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TimestampType that = (TimestampType) o;
+		return precision == that.precision;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), precision);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TinyIntType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TinyIntType.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Logical type of a 1-byte signed integer with values from -128 to 127.
+ *
+ * <p>The serialized string representation is {@code TINYINT}.
+ */
+@PublicEvolving
+public final class TinyIntType extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "TINYINT";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		Byte.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		Byte.class.getName(),
+		byte.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = Byte.class;
+
+	public TinyIntType(boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.TINYINT);
+	}
+
+	public TinyIntType() {
+		this(true);
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new TinyIntType(isNullable);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TypeInformationAnyType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TypeInformationAnyType.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Placeholder type of an arbitrary serialized type backed by {@link TypeInformation}. This type is
+ * a black box within the table ecosystem and is only deserialized at the edges. The any type is an
+ * extension to the SQL standard.
+ *
+ * <p>Compared to an {@link AnyType}, this type does not contain a {@link TypeSerializer} yet. The
+ * serializer will be generated from the enclosed {@link TypeInformation} but needs access to the
+ * {@link ExecutionConfig} of the current execution environment. Thus, this type is just a placeholder
+ * for the fully resolved {@link AnyType} returned by {@link #resolve(ExecutionConfig)}.
+ *
+ * <p>This type has no serializable string representation.
+ *
+ * <p>If no type information is supplied, generic type serialization for {@link Object} is used.
+ */
+@PublicEvolving
+public final class TypeInformationAnyType<T> extends LogicalType {
+
+	private static final String DEFAULT_FORMAT = "ANY(%s, ?)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		byte[].class.getName(),
+		"org.apache.flink.table.dataformat.BinaryGeneric");
+
+	private static final TypeInformation<?> DEFAULT_TYPE_INFO = Types.GENERIC(Object.class);
+
+	private final TypeInformation<T> typeInfo;
+
+	public TypeInformationAnyType(boolean isNullable, TypeInformation<T> typeInfo) {
+		super(isNullable, LogicalTypeRoot.ANY);
+		this.typeInfo = Preconditions.checkNotNull(typeInfo, "Type information must not be null.");
+	}
+
+	public TypeInformationAnyType(TypeInformation<T> typeInfo) {
+		this(true, typeInfo);
+	}
+
+	@SuppressWarnings("unchecked")
+	public TypeInformationAnyType() {
+		this(true, (TypeInformation<T>) DEFAULT_TYPE_INFO);
+	}
+
+	public TypeInformation<T> getTypeInformation() {
+		return typeInfo;
+	}
+
+	@Internal
+	public AnyType<T> resolve(ExecutionConfig config) {
+		return new AnyType<>(isNullable(), typeInfo.getTypeClass(), typeInfo.createSerializer(config));
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new TypeInformationAnyType<>(isNullable, typeInfo); // we must assume immutability here
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(DEFAULT_FORMAT, typeInfo.getTypeClass().getName());
+	}
+
+	@Override
+	public String asSerializableString() {
+		throw new TableException(
+			"An any type backed by type information has no serializable string representation. It " +
+				"needs to be resolved into a proper any type.");
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return typeInfo.getTypeClass().isAssignableFrom(clazz) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return clazz.isAssignableFrom(typeInfo.getTypeClass()) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return typeInfo.getTypeClass();
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TypeInformationAnyType<?> that = (TypeInformationAnyType<?>) o;
+		return typeInfo.equals(that.typeInfo);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), typeInfo);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UserDefinedType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UserDefinedType.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Logical type of a user-defined representation for one or more built-in types. A user-defined
+ * type is either a distinct type or a structured type.
+ *
+ * <p>A {@link UserDefinedType} instance is the result of a catalog lookup or an explicit definition.
+ * Therefore, the serialized string representation is a unique {@link TypeIdentifier}.
+ *
+ * <p>NOTE: Compared to the SQL standard, this class and subclasses are incomplete. We might add new
+ * features such as method declarations in the future.
+ *
+ * @see DistinctType
+ * @see StructuredType
+ */
+@PublicEvolving
+public abstract class UserDefinedType extends LogicalType {
+
+	/**
+	 * Fully qualifies a user-defined type. Two user-defined types are considered equal if they
+	 * share the same type identifier.
+	 */
+	public static final class TypeIdentifier implements Serializable {
+
+		private @Nullable String catalogName;
+
+		private @Nullable String databaseName;
+
+		private String typeName;
+
+		public TypeIdentifier(
+				@Nullable String catalogName,
+				@Nullable String databaseName,
+				String typeName) {
+			this.catalogName = catalogName;
+			this.databaseName = databaseName;
+			this.typeName = Preconditions.checkNotNull(typeName, "Type name must not be null.");
+		}
+
+		public TypeIdentifier(@Nullable String databaseName, String typeName) {
+			this(null, databaseName, typeName);
+		}
+
+		public TypeIdentifier(String typeName) {
+			this(null, null, typeName);
+		}
+
+		public Optional<String> getCatalogName() {
+			return Optional.ofNullable(catalogName);
+		}
+
+		public Optional<String> getDatabaseName() {
+			return Optional.ofNullable(databaseName);
+		}
+
+		public String getTypeName() {
+			return typeName;
+		}
+
+		@Override
+		public String toString() {
+			final StringBuilder sb = new StringBuilder();
+			if (catalogName != null) {
+				sb.append(escapeIdentifier(catalogName));
+				sb.append('.');
+			}
+			if (databaseName != null) {
+				sb.append(escapeIdentifier(databaseName));
+				sb.append('.');
+			}
+			sb.append(escapeIdentifier(typeName));
+			return sb.toString();
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			TypeIdentifier that = (TypeIdentifier) o;
+			return Objects.equals(catalogName, that.catalogName) &&
+				Objects.equals(databaseName, that.databaseName) &&
+				typeName.equals(that.typeName);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(catalogName, databaseName, typeName);
+		}
+	}
+
+	private final TypeIdentifier typeIdentifier;
+
+	private final boolean isFinal;
+
+	private final @Nullable String description;
+
+	UserDefinedType(
+			boolean isNullable,
+			LogicalTypeRoot typeRoot,
+			TypeIdentifier typeIdentifier,
+			boolean isFinal,
+			@Nullable String description) {
+		super(isNullable, typeRoot);
+		this.typeIdentifier = Preconditions.checkNotNull(typeIdentifier, "Type identifier must not be null.");
+		this.isFinal = isFinal;
+		this.description = description;
+	}
+
+	public TypeIdentifier getTypeIdentifier() {
+		return typeIdentifier;
+	}
+
+	public boolean isFinal() {
+		return isFinal;
+	}
+
+	public Optional<String> getDescription() {
+		return Optional.ofNullable(description);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(typeIdentifier.toString());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		UserDefinedType that = (UserDefinedType) o;
+		return isFinal == that.isFinal &&
+			typeIdentifier.equals(that.typeIdentifier) &&
+			Objects.equals(description, that.description);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), typeIdentifier, isFinal, description);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarBinaryType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarBinaryType.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a variable-length binary string (=a sequence of bytes).
+ *
+ * <p>The serialized string representation is {@code VARBINARY(n)} where {@code n} is the maximum
+ * number of bytes. {@code n} must have a value between 1 and {@link Integer#MAX_VALUE} (both
+ * inclusive). If no length is specified, {@code n} is equal to 1.
+ */
+@PublicEvolving
+public final class VarBinaryType extends LogicalType {
+
+	private static final int MIN_LENGTH = 1;
+
+	private static final int MAX_LENGTH = Integer.MAX_VALUE;
+
+	private static final int DEFAULT_LENGTH = 1;
+
+	private static final String DEFAULT_FORMAT = "VARBINARY(%d)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		byte[].class.getName(),
+		"org.apache.flink.table.dataformat.BinaryArray");
+
+	private static final Class<?> DEFAULT_CONVERSION = byte[].class;
+
+	private final int length;
+
+	public VarBinaryType(boolean isNullable, int length) {
+		super(isNullable, LogicalTypeRoot.VARBINARY);
+		if (length < MIN_LENGTH) {
+			throw new ValidationException(
+				String.format(
+					"Variable binary string length must be between %d and %d (both inclusive).",
+					MIN_LENGTH,
+					MAX_LENGTH));
+		}
+		this.length = length;
+	}
+
+	public VarBinaryType(int length) {
+		this(true, length);
+	}
+
+	public VarBinaryType() {
+		this(DEFAULT_LENGTH);
+	}
+
+	public int getLength() {
+		return length;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new VarBinaryType(isNullable, length);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, length);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		VarBinaryType that = (VarBinaryType) o;
+		return length == that.length;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), length);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a variable-length character string.
+ *
+ * <p>The serialized string representation is {@code VARCHAR(n)} where {@code n} is the maximum
+ * number of code points. {@code n} must have a value between 1 and {@link Integer#MAX_VALUE} (both
+ * inclusive). If no length is specified, {@code n} is equal to 1.
+ */
+@PublicEvolving
+public final class VarCharType extends LogicalType {
+
+	private static final int MIN_LENGTH = 1;
+
+	private static final int MAX_LENGTH = Integer.MAX_VALUE;
+
+	private static final int DEFAULT_LENGTH = 1;
+
+	private static final String DEFAULT_FORMAT = "VARCHAR(%d)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		String.class.getName(),
+		byte[].class.getName(),
+		"org.apache.flink.table.dataformat.BinaryString");
+
+	private static final Class<?> DEFAULT_CONVERSION = String.class;
+
+	private final int length;
+
+	public VarCharType(boolean isNullable, int length) {
+		super(isNullable, LogicalTypeRoot.VARCHAR);
+		if (length < MIN_LENGTH) {
+			throw new ValidationException(
+				String.format(
+					"Variable character string length must be between %d and %d (both inclusive).",
+					MIN_LENGTH,
+					MAX_LENGTH));
+		}
+		this.length = length;
+	}
+
+	public VarCharType(int length) {
+		this(true, length);
+	}
+
+	public VarCharType() {
+		this(DEFAULT_LENGTH);
+	}
+
+	public int getLength() {
+		return length;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new VarCharType(isNullable, length);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, length);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		VarCharType that = (VarCharType) o;
+		return length == that.length;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), length);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/YearMonthIntervalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/YearMonthIntervalType.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type for a group of year-month interval types. The type must be parameterized to one of
+ * the following resolutions: interval of years, interval of years to months, or interval of months.
+ *
+ * <p>An interval of year-month consists of {@code +years-months} with values ranging from {@code -9999-11}
+ * to {@code +9999-11}. The value is the same for all resolutions of this group (for example, an
+ * interval of months of 50 leads to {@code +04-02}).
+ *
+ * <p>The serialized string representation is {@code INTERVAL YEAR(p)}, {@code INTERVAL YEAR(p) TO MONTH},
+ * or {@code INTERVAL YEAR(p)} where {@code p} is the number of digits of years (=year precision).
+ * {@code p} must have a value between 1 and 4 (both inclusive). If no year precision is specified,
+ * {@code p} is equal to 2.
+ *
+ * <p>A conversion from and to {@code int} describes the number of months. A conversion from
+ * {@link java.time.Period} ignores the {@code days} part.
+ */
+@PublicEvolving
+public final class YearMonthIntervalType extends LogicalType {
+
+	private static final int MIN_PRECISION = 1;
+
+	private static final int MAX_PRECISION = 4;
+
+	private static final int DEFAULT_PRECISION = 2;
+
+	private static final String DEFAULT_YEAR_FORMAT = "INTERVAL YEAR(%d)";
+
+	private static final String DEFAULT_YEAR_TO_MONTH_FORMAT = "INTERVAL YEAR(%d) TO MONTH";
+
+	private static final String DEFAULT_MONTH_FORMAT = "INTERVAL MONTH";
+
+	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
+		java.time.Period.class.getName());
+
+	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
+		java.time.Period.class.getName(),
+		int.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = java.time.Period.class;
+
+	/**
+	 * Supported resolution of this type.
+	 */
+	public enum YearMonthResolution {
+		YEAR,
+		MONTH,
+		YEAR_TO_MONTH
+	}
+
+	private final YearMonthResolution resolution;
+
+	private final int yearPrecision;
+
+	public YearMonthIntervalType(boolean isNullable, YearMonthResolution resolution, int yearPrecision) {
+		super(isNullable, LogicalTypeRoot.INTERVAL_YEAR_MONTH);
+		Preconditions.checkNotNull(resolution);
+		if (resolution == YearMonthResolution.MONTH && yearPrecision != DEFAULT_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Year precision of sub-year intervals must be equal to the default precision %d.",
+					DEFAULT_PRECISION));
+		}
+		if (yearPrecision < MIN_PRECISION || yearPrecision > MAX_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Year precision of year-month intervals must be between %d and %d (both inclusive).",
+					MIN_PRECISION,
+					MAX_PRECISION));
+		}
+		this.resolution = resolution;
+		this.yearPrecision = yearPrecision;
+	}
+
+	public YearMonthIntervalType(YearMonthResolution resolution, int yearPrecision) {
+		this(true, resolution, yearPrecision);
+	}
+
+	public YearMonthIntervalType(YearMonthResolution resolution) {
+		this(resolution, DEFAULT_PRECISION);
+	}
+
+	public YearMonthResolution getResolution() {
+		return resolution;
+	}
+
+	public int getYearPrecision() {
+		return yearPrecision;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new YearMonthIntervalType(isNullable, resolution, yearPrecision);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(getResolutionFormat(), yearPrecision);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		if (isNullable()) {
+			return NULL_OUTPUT_CONVERSION.contains(clazz.getName());
+		}
+		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		YearMonthIntervalType that = (YearMonthIntervalType) o;
+		return yearPrecision == that.yearPrecision && resolution == that.resolution;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), resolution, yearPrecision);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private String getResolutionFormat() {
+		switch (resolution) {
+			case YEAR:
+				return DEFAULT_YEAR_FORMAT;
+			case YEAR_TO_MONTH:
+				return DEFAULT_YEAR_TO_MONTH_FORMAT;
+			case MONTH:
+				return DEFAULT_MONTH_FORMAT;
+			default:
+				throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ZonedTimestampType.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of a timestamp WITH timezone consisting of {@code year-month-day hour:minute:second[.fractional] zone}
+ * with up to nanosecond precision and values ranging from {@code 0000-01-01 00:00:00.000000000 +14:59} to
+ * {@code 9999-12-31 23:59:59.999999999 -14:59}. Compared to the SQL standard, leap seconds (23:59:60 and
+ * 23:59:61) are not supported as the semantics are closer to {@link java.time.OffsetDateTime}.
+ *
+ * <p>The serialized string representation is {@code TIMESTAMP(p) WITH TIME ZONE} where {@code p} is
+ * the number of digits of fractional seconds (=precision). {@code p} must have a value between 0 and
+ * 9 (both inclusive). If no precision is specified, {@code p} is equal to 6.
+ *
+ * <p>Compared to {@link LocalZonedTimestampType}, the time zone offset information is physically
+ * stored in every datum. It is used individually for every computation, visualization, or communication
+ * to external systems.
+ *
+ * <p>A conversion from {@link java.time.ZonedDateTime} ignores the zone ID.
+ *
+ * @see TimestampType
+ * @see LocalZonedTimestampType
+ */
+@PublicEvolving
+public final class ZonedTimestampType extends LogicalType {
+
+	private static final int MIN_PRECISION = 0;
+
+	private static final int MAX_PRECISION = 9;
+
+	private static final int DEFAULT_PRECISION = 6;
+
+	private static final String DEFAULT_FORMAT = "TIMESTAMP(%d) WITH TIME ZONE";
+
+	private static final Set<String> INPUT_CONVERSION = conversionSet(
+		java.time.ZonedDateTime.class.getName(),
+		java.time.OffsetDateTime.class.getName());
+
+	private static final Set<String> OUTPUT_CONVERSION = conversionSet(
+		java.time.OffsetDateTime.class.getName());
+
+	private static final Class<?> DEFAULT_CONVERSION = java.time.OffsetDateTime.class;
+
+	/**
+	 * Internal timestamp kind for time attribute metadata.
+	 */
+	@Internal
+	public enum TimestampKind {
+		REGULAR,
+		ROWTIME,
+		PROCTIME
+	}
+
+	private final TimestampKind kind;
+
+	private final int precision;
+
+	/**
+	 * Internal constructor that allows attaching additional metadata about time attribute
+	 * properties. The additional metadata does not affect equality or serializability.
+	 *
+	 * <p>Use {@link #getKind()} for comparing this metadata.
+	 */
+	@Internal
+	public ZonedTimestampType(boolean isNullable, TimestampKind kind, int precision) {
+		super(isNullable, LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE);
+		if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+			throw new ValidationException(
+				String.format(
+					"Timestamp with time zone precision must be between %d and %d (both inclusive).",
+					MIN_PRECISION,
+					MAX_PRECISION));
+		}
+		this.kind = kind;
+		this.precision = precision;
+	}
+
+	public ZonedTimestampType(boolean isNullable, int precision) {
+		this(isNullable, TimestampKind.REGULAR, precision);
+	}
+
+	public ZonedTimestampType(int precision) {
+		this(true, precision);
+	}
+
+	public ZonedTimestampType() {
+		this(DEFAULT_PRECISION);
+	}
+
+	@Internal
+	public TimestampKind getKind() {
+		return kind;
+	}
+
+	public int getPrecision() {
+		return precision;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new ZonedTimestampType(isNullable, kind, precision);
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(DEFAULT_FORMAT, precision);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return INPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultOutputConversion() {
+		return DEFAULT_CONVERSION;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		ZonedTimestampType that = (ZonedTimestampType) o;
+		return precision == that.precision;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), precision);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
@@ -93,8 +93,12 @@ public abstract class EncodingUtils {
 		return loadClass(qualifiedName, Thread.currentThread().getContextClassLoader());
 	}
 
+	public static String encodeBytesToBase64(byte[] bytes) {
+		return new String(java.util.Base64.getEncoder().encode(bytes), UTF_8);
+	}
+
 	public static String encodeStringToBase64(String string) {
-		return new String(java.util.Base64.getEncoder().encode(string.getBytes(UTF_8)), UTF_8);
+		return encodeBytesToBase64(string.getBytes(UTF_8));
 	}
 
 	public static String decodeBase64ToString(String base64) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.types;
 
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -282,6 +283,27 @@ public class LogicalTypesTest {
 			new Class[]{java.time.Duration.class},
 			new LogicalType[]{},
 			new DayTimeIntervalType(DayTimeIntervalType.DayTimeResolution.DAY_TO_SECOND, 2, 7)
+		);
+	}
+
+	@Test
+	public void testArrayType() {
+		testAll(
+			new ArrayType(new TimestampType()),
+			"ARRAY<TIMESTAMP(6)>",
+			new Class[]{java.sql.Timestamp[].class, java.time.LocalDateTime[].class},
+			new Class[]{java.sql.Timestamp[].class, java.time.LocalDateTime[].class},
+			new LogicalType[]{new TimestampType()},
+			new ArrayType(new SmallIntType())
+		);
+
+		testAll(
+			new ArrayType(new ArrayType(new TimestampType())),
+			"ARRAY<ARRAY<TIMESTAMP(6)>>",
+			new Class[]{java.sql.Timestamp[][].class, java.time.LocalDateTime[][].class},
+			new Class[]{java.sql.Timestamp[][].class, java.time.LocalDateTime[][].class},
+			new LogicalType[]{new ArrayType(new TimestampType())},
+			new ArrayType(new ArrayType(new SmallIntType()))
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -126,6 +127,18 @@ public class LogicalTypesTest {
 			new Class[]{Byte.class},
 			new LogicalType[]{},
 			new TinyIntType(false)
+		);
+	}
+
+	@Test
+	public void testSmallIntType() {
+		testAll(
+			new SmallIntType(),
+			"SMALLINT",
+			new Class[]{Short.class},
+			new Class[]{Short.class},
+			new LogicalType[]{},
+			new SmallIntType(false)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -178,6 +179,18 @@ public class LogicalTypesTest {
 			new Class[]{Float.class},
 			new LogicalType[]{},
 			new FloatType(false)
+		);
+	}
+
+	@Test
+	public void testDoubleType() {
+		testAll(
+			new DoubleType(),
+			"DOUBLE",
+			new Class[]{Double.class},
+			new Class[]{Double.class},
+			new LogicalType[]{},
+			new DoubleType(false)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -41,6 +42,7 @@ import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
+import org.apache.flink.types.Row;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.junit.Assert;
@@ -49,6 +51,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -331,6 +334,24 @@ public class LogicalTypesTest {
 			new Class[]{Map.class},
 			new LogicalType[]{new VarCharType(20), new TimestampType()},
 			new MapType(new VarCharType(99), new TimestampType())
+		);
+	}
+
+	@Test
+	public void testRowType() {
+		testAll(
+			new RowType(
+				Arrays.asList(
+					new RowType.RowField("a", new VarCharType(), "Someone's desc."),
+					new RowType.RowField("b`", new TimestampType()))),
+			"ROW<`a` VARCHAR(1) 'Someone''s desc.', `b``` TIMESTAMP(6)>",
+			new Class[]{Row.class},
+			new Class[]{Row.class},
+			new LogicalType[]{new VarCharType(), new TimestampType()},
+			new RowType(
+				Arrays.asList(
+					new RowType.RowField("a", new VarCharType(), "Different desc."),
+					new RowType.RowField("b`", new TimestampType())))
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
@@ -191,6 +192,18 @@ public class LogicalTypesTest {
 			new Class[]{Double.class},
 			new LogicalType[]{},
 			new DoubleType(false)
+		);
+	}
+
+	@Test
+	public void testDateType() {
+		testAll(
+			new DateType(),
+			"DATE",
+			new Class[]{java.sql.Date.class, java.time.LocalDate.class, int.class},
+			new Class[]{java.time.LocalDate.class},
+			new LogicalType[]{},
+			new DateType(false)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.junit.Assert;
@@ -230,6 +231,18 @@ public class LogicalTypesTest {
 			new Class[]{java.time.LocalDateTime.class},
 			new LogicalType[]{},
 			new TimestampType(3)
+		);
+	}
+
+	@Test
+	public void testZonedTimestampType() {
+		testAll(
+			new ZonedTimestampType(9),
+			"TIMESTAMP(9) WITH TIME ZONE",
+			new Class[]{java.time.ZonedDateTime.class, java.time.OffsetDateTime.class},
+			new Class[]{java.time.OffsetDateTime.class},
+			new LogicalType[]{},
+			new ZonedTimestampType(3)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
@@ -243,6 +244,18 @@ public class LogicalTypesTest {
 			new Class[]{java.time.OffsetDateTime.class},
 			new LogicalType[]{},
 			new ZonedTimestampType(3)
+		);
+	}
+
+	@Test
+	public void testLocalZonedTimestampType() {
+		testAll(
+			new LocalZonedTimestampType(9),
+			"TIMESTAMP(9) WITH LOCAL TIME ZONE",
+			new Class[]{java.time.Instant.class, long.class, int.class},
+			new Class[]{java.time.Instant.class},
+			new LogicalType[]{},
+			new LocalZonedTimestampType(3)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -18,6 +18,12 @@
 
 package org.apache.flink.table.types;
 
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.table.types.logical.AnyType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
@@ -41,6 +47,7 @@ import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.TypeInformationAnyType;
 import org.apache.flink.table.types.logical.UserDefinedType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -410,6 +417,40 @@ public class LogicalTypesTest {
 		assertTrue(nullType.supportsOutputConversion(Integer.class));
 
 		assertFalse(nullType.supportsOutputConversion(int.class));
+	}
+
+	@Test
+	public void testTypeInformationAnyType() {
+		final TypeInformationAnyType<?> anyType = new TypeInformationAnyType<>(Types.TUPLE(Types.STRING, Types.INT));
+
+		testEquality(anyType, new TypeInformationAnyType<>(Types.TUPLE(Types.STRING, Types.LONG)));
+
+		testNullability(anyType);
+
+		testJavaSerializability(anyType);
+
+		testConversions(anyType, new Class[]{Tuple2.class}, new Class[]{Tuple.class});
+	}
+
+	@Test
+	public void testAnyType() {
+		testAll(
+			new AnyType<>(Human.class, new KryoSerializer<>(Human.class, new ExecutionConfig())),
+				"ANY(org.apache.flink.table.types.LogicalTypesTest$Human, " +
+					"ADNvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLnR5cGVzLkxvZ2ljYWxUeXBlc1Rlc3QkSHVtYW4AAATyxpo9cAA" +
+					"AAAIAM29yZy5hcGFjaGUuZmxpbmsudGFibGUudHlwZXMuTG9naWNhbFR5cGVzVGVzdCRIdW1hbgEAAAA1AD" +
+					"NvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLnR5cGVzLkxvZ2ljYWxUeXBlc1Rlc3QkSHVtYW4BAAAAOQAzb3JnL" +
+					"mFwYWNoZS5mbGluay50YWJsZS50eXBlcy5Mb2dpY2FsVHlwZXNUZXN0JEh1bWFuAAAAAAApb3JnLmFwYWNo" +
+					"ZS5hdnJvLmdlbmVyaWMuR2VuZXJpY0RhdGEkQXJyYXkBAAAAKwApb3JnLmFwYWNoZS5hdnJvLmdlbmVyaWM" +
+					"uR2VuZXJpY0RhdGEkQXJyYXkBAAAAtgBVb3JnLmFwYWNoZS5mbGluay5hcGkuamF2YS50eXBldXRpbHMucn" +
+					"VudGltZS5rcnlvLlNlcmlhbGl6ZXJzJER1bW15QXZyb1JlZ2lzdGVyZWRDbGFzcwAAAAEAWW9yZy5hcGFja" +
+					"GUuZmxpbmsuYXBpLmphdmEudHlwZXV0aWxzLnJ1bnRpbWUua3J5by5TZXJpYWxpemVycyREdW1teUF2cm9L" +
+					"cnlvU2VyaWFsaXplckNsYXNzAAAE8saaPXAAAAAAAAAE8saaPXAAAAAA)",
+			new Class[]{Human.class, User.class}, // every User is Human
+			new Class[]{Human.class},
+			new LogicalType[]{},
+			new AnyType<>(User.class, new KryoSerializer<>(User.class, new ExecutionConfig()))
+		);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types;
+
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.junit.Assert;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for subclasses of {@link org.apache.flink.table.types.logical.LogicalType}.
+ */
+public class LogicalTypesTest {
+
+	// --------------------------------------------------------------------------------------------
+
+	private static void testAll(
+		LogicalType nullableType,
+		String typeString,
+		Class[] input,
+		Class[] output,
+		LogicalType[] children,
+		LogicalType otherType) {
+
+		testEquality(nullableType, otherType);
+
+		testNullability(nullableType);
+
+		testJavaSerializability(nullableType);
+
+		testStringSerializability(nullableType, typeString);
+
+		testConversions(nullableType, input, output);
+
+		testChildren(nullableType, children);
+	}
+
+	private static void testEquality(LogicalType nullableType, LogicalType otherType) {
+		assertTrue(nullableType.isNullable());
+
+		assertEquals(nullableType, nullableType);
+		assertEquals(nullableType.hashCode(), nullableType.hashCode());
+
+		assertEquals(nullableType, nullableType.copy());
+
+		assertNotEquals(nullableType, otherType);
+		assertNotEquals(nullableType.hashCode(), otherType.hashCode());
+	}
+
+	private static void testNullability(LogicalType nullableType) {
+		final LogicalType notNullInstance = nullableType.copy(false);
+
+		assertNotEquals(nullableType, notNullInstance);
+
+		assertFalse(notNullInstance.isNullable());
+	}
+
+	private static void testJavaSerializability(LogicalType serializableType) {
+		try {
+			final LogicalType deserializedInstance = InstantiationUtil.deserializeObject(
+				InstantiationUtil.serializeObject(serializableType),
+				LogicalTypesTest.class.getClassLoader());
+
+			assertEquals(serializableType, deserializedInstance);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static void testStringSerializability(LogicalType serializableType, String typeString) {
+		Assert.assertEquals(typeString, serializableType.asSerializableString());
+	}
+
+	private static void testConversions(LogicalType type, Class[] inputs, Class[] outputs) {
+		for (Class<?> clazz : inputs) {
+			assertTrue(type.supportsInputConversion(clazz));
+		}
+
+		for (Class<?> clazz : outputs) {
+			assertTrue(type.supportsOutputConversion(clazz));
+		}
+
+		assertTrue(type.supportsOutputConversion(type.getDefaultOutputConversion()));
+
+		assertFalse(type.supportsOutputConversion(LogicalTypesTest.class));
+
+		assertFalse(type.supportsInputConversion(LogicalTypesTest.class));
+	}
+
+	private static void testChildren(LogicalType type, LogicalType[] children) {
+		assertEquals(Arrays.asList(children), type.getChildren());
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -256,6 +257,18 @@ public class LogicalTypesTest {
 			new Class[]{java.time.Instant.class},
 			new LogicalType[]{},
 			new LocalZonedTimestampType(3)
+		);
+	}
+
+	@Test
+	public void testYearMonthIntervalType() {
+		testAll(
+			new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.YEAR_TO_MONTH, 2),
+			"INTERVAL YEAR(2) TO MONTH",
+			new Class[]{java.time.Period.class, int.class},
+			new Class[]{java.time.Period.class},
+			new LogicalType[]{},
+			new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.MONTH)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
@@ -269,6 +270,18 @@ public class LogicalTypesTest {
 			new Class[]{java.time.Period.class},
 			new LogicalType[]{},
 			new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.MONTH)
+		);
+	}
+
+	@Test
+	public void testDayTimeIntervalType() {
+		testAll(
+			new DayTimeIntervalType(DayTimeIntervalType.DayTimeResolution.DAY_TO_SECOND, 2, 6),
+			"INTERVAL DAY(2) TO SECOND(6)",
+			new Class[]{java.time.Duration.class, long.class},
+			new Class[]{java.time.Duration.class},
+			new LogicalType[]{},
+			new DayTimeIntervalType(DayTimeIntervalType.DayTimeResolution.DAY_TO_SECOND, 2, 7)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -47,6 +48,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -304,6 +306,18 @@ public class LogicalTypesTest {
 			new Class[]{java.sql.Timestamp[][].class, java.time.LocalDateTime[][].class},
 			new LogicalType[]{new ArrayType(new TimestampType())},
 			new ArrayType(new ArrayType(new SmallIntType()))
+		);
+	}
+
+	@Test
+	public void testMultisetType() {
+		testAll(
+			new MultisetType(new TimestampType()),
+			"MULTISET<TIMESTAMP(6)>",
+			new Class[]{Map.class},
+			new Class[]{Map.class},
+			new LogicalType[]{new TimestampType()},
+			new MultisetType(new SmallIntType())
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.StructuredType;
@@ -390,6 +391,25 @@ public class LogicalTypesTest {
 
 		// User is not implementing SpecialHuman
 		assertFalse(createHumanType(true).supportsInputConversion(User.class));
+	}
+
+	@Test
+	public void testNullType() {
+		final NullType nullType = new NullType();
+
+		testEquality(nullType, new TimeType());
+
+		testJavaSerializability(nullType);
+
+		testStringSerializability(nullType, "NULL");
+
+		assertTrue(nullType.supportsInputConversion(Object.class));
+
+		assertTrue(nullType.supportsOutputConversion(Object.class));
+
+		assertTrue(nullType.supportsOutputConversion(Integer.class));
+
+		assertFalse(nullType.supportsOutputConversion(int.class));
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -85,6 +86,18 @@ public class LogicalTypesTest {
 			new Class[]{byte[].class},
 			new LogicalType[]{},
 			new BinaryType()
+		);
+	}
+
+	@Test
+	public void testVarBinaryType() {
+		testAll(
+			new VarBinaryType(22),
+			"VARBINARY(22)",
+			new Class[]{byte[].class},
+			new Class[]{byte[].class},
+			new LogicalType[]{},
+			new VarBinaryType()
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.types;
 
+import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -72,6 +73,18 @@ public class LogicalTypesTest {
 			new Class[]{Boolean.class},
 			new LogicalType[]{},
 			new BooleanType(false)
+		);
+	}
+
+	@Test
+	public void testBinaryType() {
+		testAll(
+			new BinaryType(22),
+			"BINARY(22)",
+			new Class[]{byte[].class},
+			new Class[]{byte[].class},
+			new LogicalType[]{},
+			new BinaryType()
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.types;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -30,6 +31,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+
+import java.math.BigDecimal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -98,6 +101,18 @@ public class LogicalTypesTest {
 			new Class[]{byte[].class},
 			new LogicalType[]{},
 			new VarBinaryType()
+		);
+	}
+
+	@Test
+	public void testDecimalType() {
+		testAll(
+			new DecimalType(10, 2),
+			"DECIMAL(10, 2)",
+			new Class[]{BigDecimal.class},
+			new Class[]{BigDecimal.class},
+			new LogicalType[]{},
+			new DecimalType()
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -139,6 +140,18 @@ public class LogicalTypesTest {
 			new Class[]{Short.class},
 			new LogicalType[]{},
 			new SmallIntType(false)
+		);
+	}
+
+	@Test
+	public void testIntType() {
+		testAll(
+			new IntType(),
+			"INT",
+			new Class[]{Integer.class},
+			new Class[]{Integer.class},
+			new LogicalType[]{},
+			new IntType(false)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
@@ -318,6 +319,18 @@ public class LogicalTypesTest {
 			new Class[]{Map.class},
 			new LogicalType[]{new TimestampType()},
 			new MultisetType(new SmallIntType())
+		);
+	}
+
+	@Test
+	public void testMapType() {
+		testAll(
+			new MapType(new VarCharType(20), new TimestampType()),
+			"MAP<VARCHAR(20), TIMESTAMP(6)>",
+			new Class[]{Map.class},
+			new Class[]{Map.class},
+			new LogicalType[]{new VarCharType(20), new TimestampType()},
+			new MapType(new VarCharType(99), new TimestampType())
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -204,6 +205,18 @@ public class LogicalTypesTest {
 			new Class[]{java.time.LocalDate.class},
 			new LogicalType[]{},
 			new DateType(false)
+		);
+	}
+
+	@Test
+	public void testTimeType() {
+		testAll(
+			new TimeType(9),
+			"TIME(9)",
+			new Class[]{java.sql.Time.class, java.time.LocalTime.class, long.class},
+			new Class[]{java.time.LocalTime.class},
+			new LogicalType[]{},
+			new TimeType()
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.util.InstantiationUtil;
@@ -113,6 +114,18 @@ public class LogicalTypesTest {
 			new Class[]{BigDecimal.class},
 			new LogicalType[]{},
 			new DecimalType()
+		);
+	}
+
+	@Test
+	public void testTinyIntType() {
+		testAll(
+			new TinyIntType(),
+			"TINYINT",
+			new Class[]{Byte.class},
+			new Class[]{Byte.class},
+			new LogicalType[]{},
+			new TinyIntType(false)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -217,6 +218,18 @@ public class LogicalTypesTest {
 			new Class[]{java.time.LocalTime.class},
 			new LogicalType[]{},
 			new TimeType()
+		);
+	}
+
+	@Test
+	public void testTimestampType() {
+		testAll(
+			new TimestampType(9),
+			"TIMESTAMP(9)",
+			new Class[]{java.sql.Timestamp.class, java.time.LocalDateTime.class},
+			new Class[]{java.time.LocalDateTime.class},
+			new LogicalType[]{},
+			new TimestampType(3)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.types;
 
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.junit.Assert;
@@ -46,6 +47,18 @@ public class LogicalTypesTest {
 			new Class[]{String.class, byte[].class},
 			new LogicalType[]{},
 			new CharType(12)
+		);
+	}
+
+	@Test
+	public void testVarCharType() {
+		testAll(
+			new VarCharType(33),
+			"VARCHAR(33)",
+			new Class[]{String.class, byte[].class},
+			new Class[]{String.class, byte[].class},
+			new LogicalType[]{},
+			new VarCharType(12)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.SmallIntType;
@@ -165,6 +166,18 @@ public class LogicalTypesTest {
 			new Class[]{Long.class},
 			new LogicalType[]{},
 			new BigIntType(false)
+		);
+	}
+
+	@Test
+	public void testFloatType() {
+		testAll(
+			new FloatType(),
+			"FLOAT",
+			new Class[]{Float.class},
+			new Class[]{Float.class},
+			new LogicalType[]{},
+			new FloatType(false)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.types;
 
+import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
@@ -152,6 +153,18 @@ public class LogicalTypesTest {
 			new Class[]{Integer.class},
 			new LogicalType[]{},
 			new IntType(false)
+		);
+	}
+
+	@Test
+	public void testBigIntType() {
+		testAll(
+			new BigIntType(),
+			"BIGINT",
+			new Class[]{Long.class},
+			new Class[]{Long.class},
+			new LogicalType[]{},
+			new BigIntType(false)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.types;
 
+import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -59,6 +60,18 @@ public class LogicalTypesTest {
 			new Class[]{String.class, byte[].class},
 			new LogicalType[]{},
 			new VarCharType(12)
+		);
+	}
+
+	@Test
+	public void testBooleanType() {
+		testAll(
+			new BooleanType(),
+			"BOOLEAN",
+			new Class[]{Boolean.class},
+			new Class[]{Boolean.class},
+			new LogicalType[]{},
+			new BooleanType(false)
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.table.types;
 
+import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.Arrays;
 
@@ -34,6 +36,18 @@ import static org.junit.Assert.assertTrue;
  * Test for subclasses of {@link org.apache.flink.table.types.logical.LogicalType}.
  */
 public class LogicalTypesTest {
+
+	@Test
+	public void testCharType() {
+		testAll(
+			new CharType(33),
+			"CHAR(33)",
+			new Class[]{String.class, byte[].class},
+			new Class[]{String.class, byte[].class},
+			new LogicalType[]{},
+			new CharType(12)
+		);
+	}
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
@@ -35,9 +36,11 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UserDefinedType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
@@ -48,10 +51,9 @@ import org.apache.flink.util.InstantiationUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
-
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -355,6 +357,41 @@ public class LogicalTypesTest {
 		);
 	}
 
+	@Test
+	public void testDistinctType() {
+		testAll(
+			createDistinctType("Money"),
+			"`cat`.`db`.`Money`",
+			new Class[]{BigDecimal.class},
+			new Class[]{BigDecimal.class},
+			new LogicalType[]{new DecimalType(10, 2)},
+			createDistinctType("Monetary")
+		);
+	}
+
+	@Test
+	public void testStructuredType() {
+		testAll(
+			createUserType(true),
+			"`cat`.`db`.`User`",
+			new Class[]{Row.class, User.class},
+			new Class[]{Row.class, Human.class, User.class},
+			new LogicalType[]{UDT_NAME_TYPE, UDT_SETTING_TYPE},
+			createUserType(false)
+		);
+
+		testConversions(
+			createHumanType(false),
+			new Class[]{Row.class, Human.class, User.class}, // every User is Human
+			new Class[]{Row.class, Human.class});
+
+		// not every Human is User
+		assertFalse(createUserType(true).supportsInputConversion(Human.class));
+
+		// User is not implementing SpecialHuman
+		assertFalse(createHumanType(true).supportsInputConversion(User.class));
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	private static void testAll(
@@ -432,5 +469,54 @@ public class LogicalTypesTest {
 
 	private static void testChildren(LogicalType type, LogicalType[] children) {
 		assertEquals(Arrays.asList(children), type.getChildren());
+	}
+
+	private DistinctType createDistinctType(String typeName) {
+		return new DistinctType.Builder(
+				new UserDefinedType.TypeIdentifier("cat", "db", typeName),
+				new DecimalType(10, 2))
+			.setDescription("Money type desc.")
+			.build();
+	}
+
+	private static final LogicalType UDT_NAME_TYPE = new VarCharType();
+
+	private static final LogicalType UDT_SETTING_TYPE = new IntType();
+
+	private StructuredType createHumanType(boolean useDifferentImplementation) {
+		return new StructuredType.Builder(
+				new UserDefinedType.TypeIdentifier("cat", "db", "Human"),
+				Collections.singletonList(
+					new StructuredType.StructuredAttribute("name", UDT_NAME_TYPE)))
+			.setDescription("Human type desc.")
+			.setFinal(false)
+			.setInstantiable(false)
+			.setImplementationClass(useDifferentImplementation ? SpecialHuman.class : Human.class)
+			.build();
+	}
+
+	private StructuredType createUserType(boolean isFinal) {
+		return new StructuredType.Builder(
+				new UserDefinedType.TypeIdentifier("cat", "db", "User"),
+				Collections.singletonList(
+					new StructuredType.StructuredAttribute("setting", UDT_SETTING_TYPE)))
+			.setDescription("User type desc.")
+			.setFinal(isFinal)
+			.setInstantiable(true)
+			.setImplementationClass(User.class)
+			.setSuperType(createHumanType(false))
+			.build();
+	}
+
+	private abstract static class SpecialHuman {
+		public String name;
+	}
+
+	private abstract static class Human {
+		public String name;
+	}
+
+	private static final class User extends Human {
+		public int setting;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR implements all logical types that Flink's type system should support in the near future. As the name indicates, these type classes are purely logical to allow declarations and intentions across modules and in the API. Planners/runtime can still decide which type and precision is supported physically.

An exact listing can be found in FLIP-37: https://docs.google.com/document/d/1a9HUb6OaBIoj9IRfbILcMFPrOL7ALeZ3rVI66dvA2_U/edit#

The most important content of this PR are the JavaDoc comments that clearly define each type and should avoid ambiguity. Catalogs/connectors/planners should adapt to those definitions.

## Brief change log

- 27 logical types added

## Verifying this change

- `org.apache.flink.table.types.LogicalTypesTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
