### PR TITLE
[FLINK-12232][hive] Create HiveCatalog and support database related operations in HiveCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
@@ -71,45 +71,21 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 
 	@Override
 	public CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
-		Database hiveDb;
-
-		try {
-			hiveDb = client.getDatabase(databaseName);
-		} catch (NoSuchObjectException e) {
-			throw new DatabaseNotExistException(catalogName, databaseName);
-		} catch (TException e) {
-			throw new CatalogException(
-				String.format("Failed to get database %s from %s", databaseName, catalogName), e);
-		}
+		Database hiveDb = getHiveDatabase(databaseName);
 
 		return new GenericCatalogDatabase(hiveDb.getParameters(), hiveDb.getDescription());
 	}
 
 	@Override
-	public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists) throws DatabaseAlreadyExistException, CatalogException {
-
-		try {
-			client.createDatabase(GenericHiveMetastoreCatalogUtil.createHiveDatabase(name, database));
-		} catch (AlreadyExistsException e) {
-			if (!ignoreIfExists) {
-				throw new DatabaseAlreadyExistException(catalogName, name);
-			}
-		} catch (TException e) {
-			throw new CatalogException(String.format("Failed to create database %s", name), e);
-		}
+	public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
+			throws DatabaseAlreadyExistException, CatalogException {
+		createHiveDatabase(GenericHiveMetastoreCatalogUtil.createHiveDatabase(name, database), ignoreIfExists);
 	}
 
 	@Override
-	public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists) throws DatabaseNotExistException, CatalogException {
-		try {
-			if (databaseExists(name)) {
-				client.alterDatabase(name, GenericHiveMetastoreCatalogUtil.createHiveDatabase(name, newDatabase));
-			} else if (!ignoreIfNotExists) {
-				throw new DatabaseNotExistException(catalogName, name);
-			}
-		} catch (TException e) {
-			throw new CatalogException(String.format("Failed to alter database %s", name), e);
-		}
+	public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists)
+			throws DatabaseNotExistException, CatalogException {
+		alterHiveDatabase(name, GenericHiveMetastoreCatalogUtil.createHiveDatabase(name, newDatabase), ignoreIfNotExists);
 	}
 
 	// ------ tables and views------

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
-import org.apache.flink.table.catalog.GenericCatalogDatabase;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
@@ -41,8 +40,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
-import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,27 +47,28 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 /**
- * A catalog that persists all Flink streaming and batch metadata by using Hive metastore as a persistent storage.
+ * A catalog implementation for Hive.
  */
-public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
-	private static final Logger LOG = LoggerFactory.getLogger(GenericHiveMetastoreCatalog.class);
+public class HiveCatalog extends HiveCatalogBase {
+	private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
-	public GenericHiveMetastoreCatalog(String catalogName, String hivemetastoreURI) {
+	public HiveCatalog(String catalogName, String hivemetastoreURI) {
 		super(catalogName, hivemetastoreURI);
 
-		LOG.info("Created GenericHiveMetastoreCatalog '{}'", catalogName);
+		LOG.info("Created HiveCatalog '{}'", catalogName);
 	}
 
-	public GenericHiveMetastoreCatalog(String catalogName, HiveConf hiveConf) {
+	public HiveCatalog(String catalogName, HiveConf hiveConf) {
 		super(catalogName, hiveConf);
 
-		LOG.info("Created GenericHiveMetastoreCatalog '{}'", catalogName);
+		LOG.info("Created HiveCatalog '{}'", catalogName);
 	}
 
 	// ------ databases ------
 
 	@Override
-	public CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
+	public CatalogDatabase getDatabase(String databaseName)
+			throws DatabaseNotExistException, CatalogException {
 		Database hiveDb;
 
 		try {
@@ -82,14 +80,15 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 				String.format("Failed to get database %s from %s", databaseName, catalogName), e);
 		}
 
-		return new GenericCatalogDatabase(hiveDb.getParameters(), hiveDb.getDescription());
+		return new HiveCatalogDatabase(
+			hiveDb.getParameters(), hiveDb.getLocationUri(), hiveDb.getDescription());
 	}
 
 	@Override
-	public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists) throws DatabaseAlreadyExistException, CatalogException {
-
+	public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
+			throws DatabaseAlreadyExistException, CatalogException {
 		try {
-			client.createDatabase(GenericHiveMetastoreCatalogUtil.createHiveDatabase(name, database));
+			client.createDatabase(HiveCatalogUtil.createHiveDatabase(name, database));
 		} catch (AlreadyExistsException e) {
 			if (!ignoreIfExists) {
 				throw new DatabaseAlreadyExistException(catalogName, name);
@@ -103,7 +102,7 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 	public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists) throws DatabaseNotExistException, CatalogException {
 		try {
 			if (databaseExists(name)) {
-				client.alterDatabase(name, GenericHiveMetastoreCatalogUtil.createHiveDatabase(name, newDatabase));
+				client.alterDatabase(name, HiveCatalogUtil.createHiveDatabase(name, newDatabase));
 			} else if (!ignoreIfNotExists) {
 				throw new DatabaseNotExistException(catalogName, name);
 			}
@@ -117,97 +116,31 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 	@Override
 	public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
 			throws TableNotExistException, CatalogException {
-		try {
-			client.dropTable(
-				tablePath.getDatabaseName(),
-				tablePath.getObjectName(),
-				// Indicate whether associated data should be deleted.
-				// Set to 'true' for now because Flink tables shouldn't have data in Hive. Can be changed later if necessary
-				true,
-				ignoreIfNotExists);
-		} catch (NoSuchObjectException e) {
-			if (!ignoreIfNotExists) {
-				throw new TableNotExistException(catalogName, tablePath);
-			}
-		} catch (TException e) {
-			throw new CatalogException(
-				String.format("Failed to drop table %s", tablePath.getFullName()), e);
-		}
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
-			throws TableNotExistException, TableAlreadyExistException, CatalogException {
-		try {
-			// alter_table() doesn't throw a clear exception when target table doesn't exist. Thus, check the table existence explicitly
-			if (tableExists(tablePath)) {
-				ObjectPath newPath = new ObjectPath(tablePath.getDatabaseName(), newTableName);
-				// alter_table() doesn't throw a clear exception when new table already exists. Thus, check the table existence explicitly
-				if (tableExists(newPath)) {
-					throw new TableAlreadyExistException(catalogName, newPath);
-				} else {
-					Table table = getHiveTable(tablePath);
-					table.setTableName(newTableName);
-					client.alter_table(tablePath.getDatabaseName(), tablePath.getObjectName(), table);
-				}
-			} else if (!ignoreIfNotExists) {
-				throw new TableNotExistException(catalogName, tablePath);
-			}
-		} catch (TException e) {
-			throw new CatalogException(
-				String.format("Failed to rename table %s", tablePath.getFullName()), e);
-		}
+			throws TableNotExistException, TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
 			throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
-		if (!databaseExists(tablePath.getDatabaseName())) {
-			throw new DatabaseNotExistException(catalogName, tablePath.getDatabaseName());
-		} else {
-			try {
-				client.createTable(GenericHiveMetastoreCatalogUtil.createHiveTable(tablePath, table));
-			} catch (AlreadyExistsException e) {
-				if (!ignoreIfExists) {
-					throw new TableAlreadyExistException(catalogName, tablePath);
-				}
-			} catch (TException e) {
-				throw new CatalogException(String.format("Failed to create table %s", tablePath.getFullName()), e);
-			}
-		}
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
+	public void alterTable(ObjectPath tableName, CatalogBaseTable newTable, boolean ignoreIfNotExists)
 			throws TableNotExistException, CatalogException {
-		if (!tableExists(tablePath)) {
-			if (!ignoreIfNotExists) {
-				throw new TableNotExistException(catalogName, tablePath);
-			}
-		} else {
-			// IMetastoreClient.alter_table() requires the table to have a valid location, which it doesn't in this case
-			// Thus we have to translate alterTable() into (dropTable() + createTable())
-			dropTable(tablePath, false);
-			try {
-				createTable(tablePath, newTable, false);
-			} catch (TableAlreadyExistException | DatabaseNotExistException e) {
-				// These exceptions wouldn't be thrown, unless a concurrent operation is triggered in Hive
-				throw new CatalogException(
-					String.format("Failed to alter table %s", tablePath), e);
-			}
-		}
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public List<String> listTables(String databaseName) throws DatabaseNotExistException, CatalogException {
-		try {
-			return client.getAllTables(databaseName);
-		} catch (UnknownDBException e) {
-			throw new DatabaseNotExistException(catalogName, databaseName);
-		} catch (TException e) {
-			throw new CatalogException(
-				String.format("Failed to list tables in database %s", databaseName), e);
-		}
+	public List<String> listTables(String databaseName)
+			throws DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -216,33 +149,13 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 	}
 
 	@Override
-	public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
-		Table hiveTable = getHiveTable(tablePath);
-
-		return GenericHiveMetastoreCatalogUtil.createCatalogTable(hiveTable);
-	}
-
-	protected Table getHiveTable(ObjectPath tablePath) throws TableNotExistException {
-		try {
-			return client.getTable(tablePath.getDatabaseName(), tablePath.getObjectName());
-		} catch (NoSuchObjectException e) {
-			throw new TableNotExistException(catalogName, tablePath);
-		} catch (TException e) {
-			throw new CatalogException(
-				String.format("Failed to get table %s from Hive metastore", tablePath.getFullName()), e);
-		}
+	public CatalogBaseTable getTable(ObjectPath objectPath) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public boolean tableExists(ObjectPath tablePath) throws CatalogException {
-		try {
-			return client.tableExists(tablePath.getDatabaseName(), tablePath.getObjectName());
-		} catch (UnknownDBException e) {
-			return false;
-		} catch (TException e) {
-			throw new CatalogException(
-				String.format("Failed to check whether table %s exists or not.", tablePath.getFullName()), e);
-		}
+	public boolean tableExists(ObjectPath objectPath) throws CatalogException {
+		throw new UnsupportedOperationException();
 	}
 
 	// ------ partitions ------
@@ -255,13 +168,13 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 
 	@Override
 	public void dropPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists)
-			throws PartitionNotExistException, CatalogException {
+			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionNotExistException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void alterPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition newPartition, boolean ignoreIfNotExists)
-			throws PartitionNotExistException, CatalogException {
+			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionNotExistException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 
@@ -273,19 +186,18 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 
 	@Override
 	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-			throws TableNotExistException, TableNotPartitionedException, CatalogException {
+			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-			throws PartitionNotExistException, CatalogException {
+			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionNotExistException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-			throws CatalogException {
+	public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -93,7 +93,7 @@ public class HiveCatalog extends HiveCatalogBase {
 
 	@Override
 	public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
-			throws TableNotExistException, TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+			throws TableNotExistException, TableAlreadyExistException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 
@@ -140,13 +140,13 @@ public class HiveCatalog extends HiveCatalogBase {
 
 	@Override
 	public void dropPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists)
-			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionNotExistException, CatalogException {
+			throws PartitionNotExistException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void alterPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition newPartition, boolean ignoreIfNotExists)
-			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionNotExistException, CatalogException {
+			throws PartitionNotExistException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 
@@ -158,13 +158,13 @@ public class HiveCatalog extends HiveCatalogBase {
 
 	@Override
 	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, CatalogException {
+			throws TableNotExistException, TableNotPartitionedException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionNotExistException, CatalogException {
+			throws PartitionNotExistException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.catalog.hive;
 
-import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.ReadableWritableCatalog;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.table.catalog.ReadableWritableCatalog;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.util.StringUtils;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Base class for catalogs backed by Hive metastore.
+ */
+public abstract class HiveCatalogBase implements ReadableWritableCatalog {
+	private static final Logger LOG = LoggerFactory.getLogger(HiveCatalogBase.class);
+
+	public static final String DEFAULT_DB = "default";
+
+	protected final String catalogName;
+	protected final HiveConf hiveConf;
+
+	protected String currentDatabase = DEFAULT_DB;
+	protected IMetaStoreClient client;
+
+	public HiveCatalogBase(String catalogName, String hivemetastoreURI) {
+		this(catalogName, getHiveConf(hivemetastoreURI));
+	}
+
+	public HiveCatalogBase(String catalogName, HiveConf hiveConf) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "catalogName cannot be null or empty");
+		this.catalogName = catalogName;
+
+		this.hiveConf = checkNotNull(hiveConf, "hiveConf cannot be null");
+	}
+
+	private static HiveConf getHiveConf(String hiveMetastoreURI) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(hiveMetastoreURI), "hiveMetastoreURI cannot be null or empty");
+
+		HiveConf hiveConf = new HiveConf();
+		hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, hiveMetastoreURI);
+		return hiveConf;
+	}
+
+	private static IMetaStoreClient getMetastoreClient(HiveConf hiveConf) {
+		try {
+			return RetryingMetaStoreClient.getProxy(
+				hiveConf,
+				null,
+				null,
+				HiveMetaStoreClient.class.getName(),
+				true);
+		} catch (MetaException e) {
+			throw new CatalogException("Failed to create Hive metastore client", e);
+		}
+	}
+
+	@Override
+	public void open() throws CatalogException {
+		if (client == null) {
+			client = getMetastoreClient(hiveConf);
+			LOG.info("Connected to Hive metastore");
+		}
+	}
+
+	@Override
+	public void close() throws CatalogException {
+		if (client != null) {
+			client.close();
+			client = null;
+			LOG.info("Close connection to Hive metastore");
+		}
+	}
+
+	// ------ databases ------
+
+	@Override
+	public String getCurrentDatabase() throws CatalogException {
+		return currentDatabase;
+	}
+
+	@Override
+	public void setCurrentDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));
+
+		if (!databaseExists(databaseName)) {
+			throw new DatabaseNotExistException(catalogName, databaseName);
+		}
+
+		currentDatabase = databaseName;
+	}
+
+	@Override
+	public List<String> listDatabases() throws CatalogException {
+		try {
+			return client.getAllDatabases();
+		} catch (TException e) {
+			throw new CatalogException(
+				String.format("Failed to list all databases in %s", catalogName), e);
+		}
+	}
+
+	@Override
+	public boolean databaseExists(String databaseName) throws CatalogException {
+		try {
+			return client.getDatabase(databaseName) != null;
+		} catch (NoSuchObjectException e) {
+			return false;
+		} catch (TException e) {
+			throw new CatalogException(
+				String.format("Failed to determine whether database %s exists or not", databaseName), e);
+		}
+	}
+
+	@Override
+	public void dropDatabase(String name, boolean ignoreIfNotExists) throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+		try {
+			client.dropDatabase(name, true, ignoreIfNotExists);
+		} catch (NoSuchObjectException e) {
+			if (!ignoreIfNotExists) {
+				throw new DatabaseNotExistException(catalogName, name);
+			}
+		} catch (InvalidOperationException e) {
+			throw new DatabaseNotEmptyException(catalogName, name);
+		} catch (TException e) {
+			throw new CatalogException(String.format("Failed to drop database %s", name), e);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogDatabase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogDatabase.java
@@ -37,7 +37,11 @@ public class HiveCatalogDatabase implements CatalogDatabase {
 	// HDFS path of the database
 	private String location;
 	// Comment of the database
-	private String comment = "This is a generic catalog database.";
+	private String comment = "This is a hive catalog database.";
+
+	public HiveCatalogDatabase() {
+		properties = new HashMap<>();
+	}
 
 	public HiveCatalogDatabase(Map<String, String> properties) {
 		this.properties = checkNotNull(properties, "properties cannot be null");
@@ -58,6 +62,11 @@ public class HiveCatalogDatabase implements CatalogDatabase {
 	@Override
 	public Map<String, String> getProperties() {
 		return properties;
+	}
+
+	@Override
+	public String getComment() {
+		return comment;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogDatabase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogDatabase.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A hive catalog database implementation.
+ */
+public class HiveCatalogDatabase implements CatalogDatabase {
+	// Property of the database
+	private final Map<String, String> properties;
+	// HDFS path of the database
+	private String location;
+	// Comment of the database
+	private String comment = "This is a generic catalog database.";
+
+	public HiveCatalogDatabase(Map<String, String> properties) {
+		this.properties = checkNotNull(properties, "properties cannot be null");
+	}
+
+	public HiveCatalogDatabase(Map<String, String> properties, String comment) {
+		this(properties);
+		this.comment = checkNotNull(comment, "comment cannot be null");
+	}
+
+	public HiveCatalogDatabase(Map<String, String> properties, String location, String comment) {
+		this(properties, comment);
+
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(location), "location cannot be null or empty");
+		this.location = location;
+	}
+
+	@Override
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	@Override
+	public HiveCatalogDatabase copy() {
+		return new HiveCatalogDatabase(new HashMap<>(properties), location, comment);
+	}
+
+	@Override
+	public Optional<String> getDescription() {
+		return Optional.of(comment);
+	}
+
+	@Override
+	public Optional<String> getDetailedDescription() {
+		return Optional.of("This is a Hive catalog database stored in memory only");
+	}
+
+	public String getLocation() {
+		return location;
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+
+import org.apache.hadoop.hive.metastore.api.Database;
+
+/**
+ * Utils to convert meta objects between Flink and Hive for HiveCatalog.
+ */
+public class HiveCatalogUtil {
+
+	private HiveCatalogUtil() {
+	}
+
+	// ------ Utils ------
+
+	/**
+	 * Creates a Hive database from CatalogDatabase.
+	 */
+	public static Database createHiveDatabase(String dbName, CatalogDatabase db) {
+		HiveCatalogDatabase hiveCatalogDatabase = (HiveCatalogDatabase) db;
+
+		return new Database(
+			dbName,
+			db.getDescription().isPresent() ? db.getDescription().get() : null,
+			hiveCatalogDatabase.getLocation(),
+			hiveCatalogDatabase.getProperties());
+
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogUtil.java
@@ -40,7 +40,7 @@ public class HiveCatalogUtil {
 
 		return new Database(
 			dbName,
-			db.getDescription().isPresent() ? db.getDescription().get() : null,
+			db.getComment(),
 			hiveCatalogDatabase.getLocation(),
 			hiveCatalogDatabase.getProperties());
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
@@ -95,7 +95,7 @@ public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
 
 	@Override
 	public String getBuiltInDefaultDatabase() {
-		return GenericHiveMetastoreCatalog.DEFAULT_DB;
+		return HiveCatalogBase.DEFAULT_DB;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogTestBase;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+/**
+ * Test for HiveCatalog.
+ */
+public class HiveCatalogTest extends CatalogTestBase {
+	@BeforeClass
+	public static void init() throws IOException {
+		catalog = HiveTestUtils.createGenericHiveMetastoreCatalog();
+		catalog.open();
+	}
+
+	// =====================
+	// HiveCatalog doesn't support table operation yet
+	// Thus, overriding the following tests which involve table operation in CatalogTestBase so they won't run against HiveCatalog
+	// =====================
+
+	// TODO: re-enable this test once HiveCatalog support table operations
+	@Test
+	public void testDropDb_DatabaseNotEmptyException() throws Exception {
+	}
+
+	// ------ utils ------
+
+	@Override
+	public String getBuiltInDefaultDatabase() {
+		return HiveCatalogBase.DEFAULT_DB;
+	}
+
+	@Override
+	public CatalogDatabase createDb() {
+		return new HiveCatalogDatabase(
+			new HashMap<String, String>() {{
+				put("k1", "v1");
+			}},
+			TEST_COMMENT
+		);
+	}
+
+	@Override
+	public CatalogDatabase createAnotherDb() {
+		return new HiveCatalogDatabase(
+			new HashMap<String, String>() {{
+				put("k2", "v2");
+			}},
+			TEST_COMMENT
+		);
+	}
+
+	@Override
+	public CatalogTable createTable() {
+		// TODO: implement this once HiveCatalog support table operations
+		return null;
+	}
+
+	@Override
+	public CatalogTable createAnotherTable() {
+		// TODO: implement this once HiveCatalog support table operations
+		return null;
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -43,9 +43,81 @@ public class HiveCatalogTest extends CatalogTestBase {
 	// Thus, overriding the following tests which involve table operation in CatalogTestBase so they won't run against HiveCatalog
 	// =====================
 
-	// TODO: re-enable this test once HiveCatalog support table operations
+	// TODO: re-enable these tests once HiveCatalog support table operations
 	@Test
 	public void testDropDb_DatabaseNotEmptyException() throws Exception {
+	}
+
+	@Test
+	public void testCreateTable_Streaming() throws Exception {
+	}
+
+	@Test
+	public void testCreateTable_Batch() throws Exception {
+	}
+
+	@Test
+	public void testCreateTable_DatabaseNotExistException() throws Exception {
+	}
+
+	@Test
+	public void testCreateTable_TableAlreadyExistException() throws Exception {
+	}
+
+	@Test
+	public void testCreateTable_TableAlreadyExist_ignored() throws Exception {
+	}
+
+	@Test
+	public void testGetTable_TableNotExistException() throws Exception {
+	}
+
+	@Test
+	public void testGetTable_TableNotExistException_NoDb() throws Exception {
+	}
+
+	@Test
+	public void testDropTable_nonPartitionedTable() throws Exception {
+	}
+
+	@Test
+	public void testDropTable_TableNotExistException() throws Exception {
+	}
+
+	@Test
+	public void testDropTable_TableNotExist_ignored() throws Exception {
+	}
+
+	@Test
+	public void testAlterTable() throws Exception {
+	}
+
+	@Test
+	public void testAlterTable_TableNotExistException() throws Exception {
+	}
+
+	@Test
+	public void testAlterTable_TableNotExist_ignored() throws Exception {
+	}
+
+	@Test
+	public void testRenameTable_nonPartitionedTable() throws Exception {
+	}
+
+	@Test
+	public void testRenameTable_TableNotExistException() throws Exception {
+	}
+
+	@Test
+	public void testRenameTable_TableNotExistException_ignored() throws Exception {
+	}
+
+	@Test
+	public void testRenameTable_TableAlreadyExistException() throws Exception {
+	}
+
+	@Test
+	public void testTableExists() throws Exception {
 	}
 
 	// ------ utils ------
@@ -83,6 +155,24 @@ public class HiveCatalogTest extends CatalogTestBase {
 
 	@Override
 	public CatalogTable createAnotherTable() {
+		// TODO: implement this once HiveCatalog support table operations
+		return null;
+	}
+
+	@Override
+	public CatalogTable createStreamingTable() {
+		// TODO: implement this once HiveCatalog support table operations
+		return null;
+	}
+
+	@Override
+	public CatalogTable createPartitionedTable() {
+		// TODO: implement this once HiveCatalog support table operations
+		return null;
+	}
+
+	@Override
+	public CatalogTable createAnotherPartitionedTable() {
 		// TODO: implement this once HiveCatalog support table operations
 		return null;
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogDatabase.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogDatabase.java
@@ -29,8 +29,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class GenericCatalogDatabase implements CatalogDatabase {
 	private final Map<String, String> properties;
-	// Comment of the database
 	private String comment = "This is a generic catalog database.";
+
+	public GenericCatalogDatabase() {
+		this.properties = new HashMap<>();
+	}
 
 	public GenericCatalogDatabase(Map<String, String> properties) {
 		this.properties = checkNotNull(properties, "properties cannot be null");
@@ -41,8 +44,14 @@ public class GenericCatalogDatabase implements CatalogDatabase {
 		this.comment = checkNotNull(comment, "comment cannot be null");
 	}
 
+	@Override
 	public Map<String, String> getProperties() {
 		return properties;
+	}
+
+	@Override
+	public String getComment() {
+		return this.comment;
 	}
 
 	@Override
@@ -59,13 +68,4 @@ public class GenericCatalogDatabase implements CatalogDatabase {
 	public Optional<String> getDetailedDescription() {
 		return Optional.of("This is a generic catalog database stored in memory only");
 	}
-
-	public String getComment() {
-		return this.comment;
-	}
-
-	public void setComment(String comment) {
-		this.comment = comment;
-	}
-
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogDatabase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogDatabase.java
@@ -31,6 +31,13 @@ public interface CatalogDatabase {
 	Map<String, String> getProperties();
 
 	/**
+	 * Get comment of the database.
+	 *
+	 * @return comment of the database
+	 */
+	String getComment();
+
+	/**
 	 * Get a deep copy of the CatalogDatabase instance.
 	 *
 	 * @return a copy of CatalogDatabase instance

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -109,11 +109,16 @@ public abstract class CatalogTestBase {
 	@Test
 	public void testSetCurrentDatabase() throws Exception {
 		assertEquals(getBuiltInDefaultDatabase(), catalog.getCurrentDatabase());
+
 		catalog.createDatabase(db2, createDb(), true);
 		catalog.setCurrentDatabase(db2);
+
 		assertEquals(db2, catalog.getCurrentDatabase());
+
 		catalog.setCurrentDatabase(getBuiltInDefaultDatabase());
+
 		assertEquals(getBuiltInDefaultDatabase(), catalog.getCurrentDatabase());
+
 		catalog.dropDatabase(db2, false);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR creates HiveCatalog in flink-connector-hive module and implements database related APIs for HiveCatalog.

## Brief change log

  - Created HiveCatalog and HiveCatalogDatabase
  - Abstracted common part between HiveCatalog and GenericHiveMetastoreCatalog to HiveCatalogBase

## Verifying this change

This change added tests and can be verified as follows:

  - Added tests HiveCatalogTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)
## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

Documentation will be added later