### PR TITLE
[BP-1.6][FLINK-12296][StateBackend] Fix local state directory collision with state loss for chained keyed operators

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -25,7 +25,10 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
+import org.apache.flink.runtime.state.LocalRecoveryConfig;
+import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.function.Function;
 
@@ -56,16 +59,48 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 
 	/**
 	 * Creates a test harness with the specified number of input gates and specified number
-	 * of channels per input gate.
+	 * of channels per input gate and local recovery disabled.
+	 */
+	public OneInputStreamTaskTestHarness(
+		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		int numInputGates,
+		int numInputChannelsPerGate,
+		TypeInformation<IN> inputType,
+		TypeInformation<OUT> outputType) {
+		this(taskFactory, numInputGates, numInputChannelsPerGate, inputType, outputType, TestLocalRecoveryConfig.disabled());
+	}
+
+	public OneInputStreamTaskTestHarness(
+		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		int numInputGates,
+		int numInputChannelsPerGate,
+		TypeInformation<IN> inputType,
+		TypeInformation<OUT> outputType,
+		File localRootDir) {
+		super(taskFactory, outputType, localRootDir);
+
+		this.inputType = inputType;
+		inputSerializer = inputType.createSerializer(executionConfig);
+
+		this.numInputGates = numInputGates;
+		this.numInputChannelsPerGate = numInputChannelsPerGate;
+
+		streamConfig.setStateKeySerializer(inputSerializer);
+	}
+
+	/**
+	 * Creates a test harness with the specified number of input gates and specified number
+	 * of channels per input gate and specified localRecoveryConfig.
 	 */
 	public OneInputStreamTaskTestHarness(
 			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
 			int numInputGates,
 			int numInputChannelsPerGate,
 			TypeInformation<IN> inputType,
-			TypeInformation<OUT> outputType) {
+			TypeInformation<OUT> outputType,
+			LocalRecoveryConfig localRecoveryConfig) {
 
-		super(taskFactory, outputType);
+		super(taskFactory, outputType, localRecoveryConfig);
 
 		this.inputType = inputType;
 		inputSerializer = inputType.createSerializer(executionConfig);
@@ -82,7 +117,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 			TypeInformation<IN> inputType,
 			TypeInformation<OUT> outputType) {
 
-		this(taskFactory, 1, 1, inputType, outputType);
+		this(taskFactory, 1, 1, inputType, outputType, TestLocalRecoveryConfig.disabled());
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -67,11 +67,28 @@ public class StreamConfigChainer {
 		return chain(operatorID, operator, typeSerializer, typeSerializer);
 	}
 
+	public <T> StreamConfigChainer chain(
+		OperatorID operatorID,
+		OneInputStreamOperator<T, T> operator,
+		TypeSerializer<T> typeSerializer,
+		boolean createKeyedStateBackend) {
+		return chain(operatorID, operator, typeSerializer, typeSerializer, createKeyedStateBackend);
+	}
+
+	public <IN, OUT> StreamConfigChainer chain(
+		OperatorID operatorID,
+		OneInputStreamOperator<IN, OUT> operator,
+		TypeSerializer<IN> inputSerializer,
+		TypeSerializer<OUT> outputSerializer) {
+		return chain(operatorID, operator, inputSerializer, outputSerializer, false);
+	}
+
 	public <IN, OUT> StreamConfigChainer chain(
 			OperatorID operatorID,
 			OneInputStreamOperator<IN, OUT> operator,
 			TypeSerializer<IN> inputSerializer,
-			TypeSerializer<OUT> outputSerializer) {
+			TypeSerializer<OUT> outputSerializer,
+			boolean createKeyedStateBackend) {
 		chainIndex++;
 
 		tailConfig.setChainedOutputs(Collections.singletonList(
@@ -88,6 +105,10 @@ public class StreamConfigChainer {
 		tailConfig.setTypeSerializerIn1(inputSerializer);
 		tailConfig.setTypeSerializerOut(outputSerializer);
 		tailConfig.setChainIndex(chainIndex);
+		if (createKeyedStateBackend) {
+			// used to test multiple stateful operators chained in a single task.
+			tailConfig.setStateKeySerializer(inputSerializer);
+		}
 
 		chainedConfigs.put(chainIndex, tailConfig);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -102,6 +102,8 @@ public class StreamMockEnvironment implements Environment {
 
 	private TaskEventDispatcher taskEventDispatcher = mock(TaskEventDispatcher.class);
 
+	private TaskManagerRuntimeInfo taskManagerRuntimeInfo = new TestingTaskManagerRuntimeInfo();
+
 	public StreamMockEnvironment(
 		Configuration jobConfig,
 		Configuration taskConfig,
@@ -322,7 +324,11 @@ public class StreamMockEnvironment implements Environment {
 
 	@Override
 	public TaskManagerRuntimeInfo getTaskManagerInfo() {
-		return new TestingTaskManagerRuntimeInfo();
+		return this.taskManagerRuntimeInfo;
+	}
+
+	public void setTaskManagerInfo(TaskManagerRuntimeInfo taskManagerRuntimeInfo) {
+		this.taskManagerRuntimeInfo = taskManagerRuntimeInfo;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
@@ -26,10 +27,14 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.LocalRecoveryConfig;
+import org.apache.flink.runtime.state.LocalRecoveryDirectoryProviderImpl;
+import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
@@ -47,6 +52,7 @@ import org.apache.flink.util.Preconditions;
 
 import org.junit.Assert;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -109,7 +115,20 @@ public class StreamTaskTestHarness<OUT> {
 	public StreamTaskTestHarness(
 			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
 			TypeInformation<OUT> outputType) {
+		this(taskFactory, outputType, TestLocalRecoveryConfig.disabled());
+	}
 
+	public StreamTaskTestHarness(
+		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		TypeInformation<OUT> outputType,
+		File localRootDir) {
+		this(taskFactory, outputType, new LocalRecoveryConfig(true, new LocalRecoveryDirectoryProviderImpl(localRootDir, new JobID(), new JobVertexID(), 0)));
+	}
+
+	public StreamTaskTestHarness(
+		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		TypeInformation<OUT> outputType,
+		LocalRecoveryConfig localRecoveryConfig) {
 		this.taskFactory = checkNotNull(taskFactory);
 		this.memorySize = DEFAULT_MEMORY_MANAGER_SIZE;
 		this.bufferSize = DEFAULT_NETWORK_BUFFER_SIZE;
@@ -123,7 +142,7 @@ public class StreamTaskTestHarness<OUT> {
 		outputSerializer = outputType.createSerializer(executionConfig);
 		outputStreamRecordSerializer = new StreamElementSerializer<OUT>(outputSerializer);
 
-		this.taskStateManager = new TestTaskStateManager();
+		this.taskStateManager = new TestTaskStateManager(localRecoveryConfig);
 	}
 
 	public ProcessingTimeService getProcessingTimeService() {

--- a/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.state;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
+import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINTS_DIRECTORY;
+import static org.apache.flink.configuration.CheckpointingOptions.INCREMENTAL_CHECKPOINTS;
+import static org.apache.flink.configuration.CheckpointingOptions.STATE_BACKEND;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for StatefulOperatorChainedTaskTest.
+ */
+public class StatefulOperatorChainedTaskTest {
+
+	private static final Set<OperatorID> RESTORED_OPERATORS = ConcurrentHashMap.newKeySet();
+	private TemporaryFolder temporaryFolder;
+
+	@Before
+	public void setup() throws IOException {
+		RESTORED_OPERATORS.clear();
+		temporaryFolder = new TemporaryFolder();
+		temporaryFolder.create();
+	}
+
+	@Test
+	public void testMultipleStatefulOperatorChainedSnapshotAndRestore() throws Exception {
+
+		OperatorID headOperatorID = new OperatorID(42L, 42L);
+		OperatorID tailOperatorID = new OperatorID(44L, 44L);
+
+		JobManagerTaskRestore restore = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new CounterOperator("head"),
+			tailOperatorID,
+			new CounterOperator("tail"),
+			Optional.empty());
+
+		TaskStateSnapshot stateHandles = restore.getTaskStateSnapshot();
+
+		assertEquals(2, stateHandles.getSubtaskStateMappings().size());
+
+		createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new CounterOperator("head"),
+			tailOperatorID,
+			new CounterOperator("tail"),
+			Optional.of(restore));
+
+		assertEquals(new HashSet<>(Arrays.asList(headOperatorID, tailOperatorID)), RESTORED_OPERATORS);
+	}
+
+	private JobManagerTaskRestore createRunAndCheckpointOperatorChain(
+		OperatorID headId,
+		OneInputStreamOperator<String, String> headOperator,
+		OperatorID tailId,
+		OneInputStreamOperator<String, String> tailOperator,
+		Optional<JobManagerTaskRestore> restore) throws Exception {
+
+		File localRootDir = temporaryFolder.newFolder();
+		final OneInputStreamTaskTestHarness<String, String> testHarness =
+			new OneInputStreamTaskTestHarness<>(
+				OneInputStreamTask::new,
+				1, 1,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				localRootDir);
+
+		testHarness.setupOperatorChain(headId, headOperator)
+			.chain(tailId, tailOperator, StringSerializer.INSTANCE, true)
+			.finish();
+
+		if (restore.isPresent()) {
+			JobManagerTaskRestore taskRestore = restore.get();
+			testHarness.setTaskStateSnapshot(
+				taskRestore.getRestoreCheckpointId(),
+				taskRestore.getTaskStateSnapshot());
+		}
+
+		StreamMockEnvironment environment = new StreamMockEnvironment(
+			testHarness.jobConfig,
+			testHarness.taskConfig,
+			testHarness.getExecutionConfig(),
+			testHarness.memorySize,
+			new MockInputSplitProvider(),
+			testHarness.bufferSize,
+			testHarness.getTaskStateManager());
+
+		Configuration configuration = new Configuration();
+		configuration.setString(STATE_BACKEND.key(), "rocksdb");
+		File file = temporaryFolder.newFolder();
+		configuration.setString(CHECKPOINTS_DIRECTORY.key(), file.toURI().toString());
+		configuration.setString(INCREMENTAL_CHECKPOINTS.key(), "true");
+		environment.setTaskManagerInfo(
+			new TestingTaskManagerRuntimeInfo(
+				configuration,
+				System.getProperty("java.io.tmpdir").split(",|" + File.pathSeparator)));
+		testHarness.invoke(environment);
+		testHarness.waitForTaskRunning();
+
+		OneInputStreamTask<String, String> streamTask = testHarness.getTask();
+
+		processRecords(testHarness);
+		triggerCheckpoint(testHarness, streamTask);
+
+		TestTaskStateManager taskStateManager = testHarness.getTaskStateManager();
+
+		JobManagerTaskRestore jobManagerTaskRestore = new JobManagerTaskRestore(
+			taskStateManager.getReportedCheckpointId(),
+			taskStateManager.getLastJobManagerTaskStateSnapshot());
+
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+		return jobManagerTaskRestore;
+	}
+
+	private void triggerCheckpoint(
+		OneInputStreamTaskTestHarness<String, String> testHarness,
+		OneInputStreamTask<String, String> streamTask) throws Exception {
+
+		long checkpointId = 1L;
+		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, 1L);
+
+		testHarness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
+
+		while (!streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation())) {}
+
+		testHarness.getTaskStateManager().getWaitForReportLatch().await();
+		long reportedCheckpointId = testHarness.getTaskStateManager().getReportedCheckpointId();
+
+		assertEquals(checkpointId, reportedCheckpointId);
+	}
+
+	private void processRecords(OneInputStreamTaskTestHarness<String, String> testHarness) throws Exception {
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.processElement(new StreamRecord<>("10"), 0, 0);
+		testHarness.processElement(new StreamRecord<>("20"), 0, 0);
+		testHarness.processElement(new StreamRecord<>("30"), 0, 0);
+
+		testHarness.waitForInputProcessing();
+
+		expectedOutput.add(new StreamRecord<>("10"));
+		expectedOutput.add(new StreamRecord<>("20"));
+		expectedOutput.add(new StreamRecord<>("30"));
+		TestHarnessUtil.assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+	}
+
+	private abstract static class RestoreWatchOperator<IN, OUT>
+		extends AbstractStreamOperator<OUT>
+		implements OneInputStreamOperator<IN, OUT> {
+
+		@Override
+		public void initializeState(StateInitializationContext context) throws Exception {
+			if (context.isRestored()) {
+				RESTORED_OPERATORS.add(getOperatorID());
+			}
+		}
+	}
+
+	/**
+	 * Operator that counts processed messages and keeps result on state.
+	 */
+	private static class CounterOperator extends RestoreWatchOperator<String, String> {
+		private static final long serialVersionUID = 2048954179291813243L;
+
+		private static long snapshotOutData = 0L;
+		private ValueState<Long> counterState;
+		private long counter = 0;
+		private String prefix;
+
+		CounterOperator(String prefix) {
+			this.prefix = prefix;
+		}
+
+		@Override
+		public void processElement(StreamRecord<String> element) throws Exception {
+			counter++;
+			output.collect(element);
+		}
+
+		@Override
+		public void initializeState(StateInitializationContext context) throws Exception {
+			super.initializeState(context);
+
+			counterState = context
+				.getKeyedStateStore()
+				.getState(new ValueStateDescriptor<>(prefix + "counter-state", LongSerializer.INSTANCE));
+
+			// set key manually to make RocksDBListState get the serialized key.
+			setCurrentKey("10");
+
+			if (context.isRestored()) {
+				counter =  counterState.value();
+				assertEquals(snapshotOutData, counter);
+				counterState.clear();
+			}
+		}
+
+		@Override
+		public void snapshotState(StateSnapshotContext context) throws Exception {
+			counterState.update(counter);
+			snapshotOutData = counter;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

cherry-pick #8263 to release-1.6 manually.


## Verifying this change

This change added tests and can be verified as follows:

`flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java#testMultipleStatefulOperatorChainedSnapshotAndRestore`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

@StefanRRichter 