### PR TITLE
[FLINK-12240][hive] Support view related operations in GenericHiveMetastoreCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -188,7 +189,18 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 
 	@Override
 	public List<String> listViews(String databaseName) throws DatabaseNotExistException, CatalogException {
-		throw new UnsupportedOperationException();
+		try {
+
+			return client.getTables(
+				databaseName,
+				null, // table pattern
+				TableType.VIRTUAL_VIEW);
+		} catch (UnknownDBException e) {
+			throw new DatabaseNotExistException(catalogName, databaseName);
+		} catch (TException e) {
+			throw new CatalogException(
+				String.format("Failed to list tables in database %s", databaseName), e);
+		}
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
@@ -191,7 +191,6 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 	@Override
 	public List<String> listViews(String databaseName) throws DatabaseNotExistException, CatalogException {
 		try {
-
 			return client.getTables(
 				databaseName,
 				null, // table pattern

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.catalog.exceptions.PartitionSpecInvalidException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
+import org.apache.flink.table.catalog.hive.util.GenericHiveMetastoreCatalogUtil;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
@@ -199,7 +200,7 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 			throw new DatabaseNotExistException(catalogName, databaseName);
 		} catch (TException e) {
 			throw new CatalogException(
-				String.format("Failed to list tables in database %s", databaseName), e);
+				String.format("Failed to list views in database %s", databaseName), e);
 		}
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogUtil.java
@@ -23,10 +23,13 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.GenericCatalogTable;
+import org.apache.flink.table.catalog.GenericCatalogView;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.plan.stats.TableStats;
 
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
@@ -75,7 +78,6 @@ public class GenericHiveMetastoreCatalogUtil {
 
 	/**
 	 * Creates a Hive table from a CatalogBaseTable.
-	 * TODO: [FLINK-12240] Support view related operations in GenericHiveMetastoreCatalog
 	 *
 	 * @param tablePath path of the table
 	 * @param table the CatalogBaseTable instance
@@ -118,18 +120,26 @@ public class GenericHiveMetastoreCatalogUtil {
 				hiveTable.setPartitionKeys(new ArrayList<>());
 			}
 
-			hiveTable.setSd(sd);
+			hiveTable.setTableType(TableType.EXTERNAL_TABLE.name());
 		} else {
-			// TODO: [FLINK-12240] Support view related operations in GenericHiveMetastoreCatalog
-			throw new UnsupportedOperationException();
+			CatalogView view = (CatalogView) table;
+
+			// TODO: [FLINK-12398] Support partitioned view in catalog API
+			sd.setCols(allColumns);
+			hiveTable.setPartitionKeys(new ArrayList<>());
+
+			hiveTable.setViewOriginalText(view.getOriginalQuery());
+			hiveTable.setViewExpandedText(view.getExpandedQuery());
+			hiveTable.setTableType(TableType.VIRTUAL_VIEW.name());
 		}
+
+		hiveTable.setSd(sd);
 
 		return hiveTable;
 	}
 
 	/**
 	 * Creates a CatalogBaseTable from a Hive table.
-	 * TODO: [FLINK-12240] Support view related operations in GenericHiveMetastoreCatalog
 	 *
 	 * @param hiveTable the Hive table
 	 * @return a CatalogBaseTable
@@ -148,14 +158,24 @@ public class GenericHiveMetastoreCatalogUtil {
 		// Partition keys
 		List<String> partitionKeys = new ArrayList<>();
 
-		if (hiveTable.getPartitionKeys() != null && hiveTable.getPartitionKeys().isEmpty()) {
+		if (hiveTable.getPartitionKeys().isEmpty()) {
 			partitionKeys = hiveTable.getPartitionKeys().stream()
 								.map(fs -> fs.getName())
 								.collect(Collectors.toList());
 		}
 
-		return new GenericCatalogTable(
-			tableSchema, new TableStats(0), partitionKeys, properties, comment);
+		if (TableType.valueOf(hiveTable.getTableType()) == TableType.VIRTUAL_VIEW) {
+			return new GenericCatalogView(
+				hiveTable.getViewOriginalText(),
+				hiveTable.getViewExpandedText(),
+				tableSchema,
+				properties,
+				comment
+			);
+		} else {
+			return new GenericCatalogTable(
+				tableSchema, new TableStats(0), partitionKeys, properties, comment);
+		}
 	}
 
 	/**

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/GenericHiveMetastoreCatalogUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/GenericHiveMetastoreCatalogUtil.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.catalog.hive;
+package org.apache.flink.table.catalog.hive.util;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
@@ -27,6 +27,9 @@ import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.GenericCatalogTable;
 import org.apache.flink.table.catalog.GenericCatalogView;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.hive.HiveCatalogBaseUtil;
+import org.apache.flink.table.catalog.hive.HiveTableConfig;
+import org.apache.flink.table.catalog.hive.HiveTypeUtil;
 import org.apache.flink.table.plan.stats.TableStats;
 
 import org.apache.hadoop.hive.metastore.TableType;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/GenericHiveMetastoreCatalogUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/GenericHiveMetastoreCatalogUtil.java
@@ -161,7 +161,7 @@ public class GenericHiveMetastoreCatalogUtil {
 		// Partition keys
 		List<String> partitionKeys = new ArrayList<>();
 
-		if (hiveTable.getPartitionKeys().isEmpty()) {
+		if (!hiveTable.getPartitionKeys().isEmpty()) {
 			partitionKeys = hiveTable.getPartitionKeys().stream()
 								.map(fs -> fs.getName())
 								.collect(Collectors.toList());

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/GenericHiveMetastoreCatalogUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/GenericHiveMetastoreCatalogUtil.java
@@ -124,7 +124,7 @@ public class GenericHiveMetastoreCatalogUtil {
 			}
 
 			hiveTable.setTableType(TableType.EXTERNAL_TABLE.name());
-		} else {
+		} else if (table instanceof CatalogView) {
 			CatalogView view = (CatalogView) table;
 
 			// TODO: [FLINK-12398] Support partitioned view in catalog API
@@ -134,6 +134,9 @@ public class GenericHiveMetastoreCatalogUtil {
 			hiveTable.setViewOriginalText(view.getOriginalQuery());
 			hiveTable.setViewExpandedText(view.getExpandedQuery());
 			hiveTable.setTableType(TableType.VIRTUAL_VIEW.name());
+		} else {
+			throw new IllegalArgumentException(
+				"GenericHiveMetastoreCatalog only supports CatalogTable and CatalogView");
 		}
 
 		hiveTable.setSd(sd);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
@@ -180,7 +180,7 @@ public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
 		return new GenericCatalogView(
 			String.format("select * from %s", t2),
 			String.format("select * from %s.%s", TEST_CATALOG_NAME, path2.getFullName()),
-			createTableSchema(),
+			createAnotherTableSchema(),
 			new HashMap<>(),
 			"This is another view");
 	}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
@@ -27,8 +27,10 @@ import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTestBase;
 import org.apache.flink.table.catalog.CatalogTestUtil;
+import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.GenericCatalogDatabase;
 import org.apache.flink.table.catalog.GenericCatalogTable;
+import org.apache.flink.table.catalog.GenericCatalogView;
 import org.apache.flink.table.plan.stats.TableStats;
 
 import org.junit.BeforeClass;
@@ -161,5 +163,25 @@ public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
 			createPartitionKeys(),
 			getBatchTableProperties(),
 			TEST_COMMENT);
+	}
+
+	@Override
+	public CatalogView createView() {
+		return new GenericCatalogView(
+			String.format("select * from %s", t1),
+			String.format("select * from %s.%s", TEST_CATALOG_NAME, path1.getFullName()),
+			createTableSchema(),
+			new HashMap<>(),
+			"This is a view");
+	}
+
+	@Override
+	public CatalogView createAnotherView() {
+		return new GenericCatalogView(
+			String.format("select * from %s", t2),
+			String.format("select * from %s.%s", TEST_CATALOG_NAME, path2.getFullName()),
+			createTableSchema(),
+			new HashMap<>(),
+			"This is another view");
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.catalog.hive;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTestBase;
+import org.apache.flink.table.catalog.CatalogView;
 
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -44,80 +44,94 @@ public class HiveCatalogTest extends CatalogTestBase {
 	// =====================
 
 	// TODO: re-enable these tests once HiveCatalog support table operations
-	@Test
 	public void testDropDb_DatabaseNotEmptyException() throws Exception {
 	}
 
-	@Test
 	public void testCreateTable_Streaming() throws Exception {
 	}
 
-	@Test
 	public void testCreateTable_Batch() throws Exception {
 	}
 
-	@Test
 	public void testCreateTable_DatabaseNotExistException() throws Exception {
 	}
 
-	@Test
 	public void testCreateTable_TableAlreadyExistException() throws Exception {
 	}
 
-	@Test
 	public void testCreateTable_TableAlreadyExist_ignored() throws Exception {
 	}
 
-	@Test
 	public void testGetTable_TableNotExistException() throws Exception {
 	}
 
-	@Test
 	public void testGetTable_TableNotExistException_NoDb() throws Exception {
 	}
 
-	@Test
 	public void testDropTable_nonPartitionedTable() throws Exception {
 	}
 
-	@Test
 	public void testDropTable_TableNotExistException() throws Exception {
 	}
 
-	@Test
 	public void testDropTable_TableNotExist_ignored() throws Exception {
 	}
 
-	@Test
 	public void testAlterTable() throws Exception {
 	}
 
-	@Test
 	public void testAlterTable_TableNotExistException() throws Exception {
 	}
 
-	@Test
 	public void testAlterTable_TableNotExist_ignored() throws Exception {
 	}
 
-	@Test
 	public void testRenameTable_nonPartitionedTable() throws Exception {
 	}
 
-	@Test
 	public void testRenameTable_TableNotExistException() throws Exception {
 	}
 
-	@Test
 	public void testRenameTable_TableNotExistException_ignored() throws Exception {
 	}
 
-	@Test
 	public void testRenameTable_TableAlreadyExistException() throws Exception {
 	}
 
-	@Test
+	public void testListTables() throws Exception {
+	}
+
 	public void testTableExists() throws Exception {
+	}
+
+	public void testCreateView() throws Exception {
+	}
+
+	public void testCreateView_DatabaseNotExistException() throws Exception {
+	}
+
+	public void testCreateView_TableAlreadyExistException() throws Exception {
+	}
+
+	public void testCreateView_TableAlreadyExist_ignored() throws Exception {
+	}
+
+	public void testDropView() throws Exception {
+	}
+
+	public void testAlterView() throws Exception {
+	}
+
+	public void testAlterView_TableNotExistException() throws Exception {
+	}
+
+	public void testAlterView_TableNotExist_ignored() throws Exception {
+	}
+
+	public void testListView() throws Exception {
+	}
+
+	public void testRenameView() throws Exception {
 	}
 
 	// ------ utils ------
@@ -174,6 +188,18 @@ public class HiveCatalogTest extends CatalogTestBase {
 	@Override
 	public CatalogTable createAnotherPartitionedTable() {
 		// TODO: implement this once HiveCatalog support table operations
+		return null;
+	}
+
+	@Override
+	public CatalogView createView() {
+		// TODO: implement this once HiveCatalog support view operations
+		return null;
+	}
+
+	@Override
+	public CatalogView createAnotherView() {
+		// TODO: implement this once HiveCatalog support view operations
 		return null;
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -647,26 +647,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 			TEST_COMMENT);
 	}
 
-	@Override
-	public CatalogView createView() {
-		return new GenericCatalogView(
-			String.format("select * from %s", t1),
-			String.format("select * from %s.%s", TEST_CATALOG_NAME, path1.getFullName()),
-			createTableSchema(),
-			new HashMap<>(),
-			"This is a view");
-	}
-
-	@Override
-	public CatalogView createAnotherView() {
-		return new GenericCatalogView(
-			String.format("select * from %s", t2),
-			String.format("select * from %s.%s", TEST_CATALOG_NAME, path2.getFullName()),
-			createTableSchema(),
-			new HashMap<>(),
-			"This is another view");
-	}
-
 	private CatalogPartitionSpec createPartitionSpec() {
 		return new CatalogPartitionSpec(
 			new HashMap<String, String>() {{
@@ -707,6 +687,26 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 	private CatalogPartition createPartition(Map<String, String> props) {
 		return new GenericCatalogPartition(props);
+	}
+
+	@Override
+	public CatalogView createView() {
+		return new GenericCatalogView(
+			String.format("select * from %s", t1),
+			String.format("select * from %s.%s", TEST_CATALOG_NAME, path1.getFullName()),
+			createTableSchema(),
+			new HashMap<>(),
+			"This is a view");
+	}
+
+	@Override
+	public CatalogView createAnotherView() {
+		return new GenericCatalogView(
+			String.format("select * from %s", t2),
+			String.format("select * from %s.%s", TEST_CATALOG_NAME, path2.getFullName()),
+			createAnotherTableSchema(),
+			new HashMap<>(),
+			"This is another view");
 	}
 
 	protected CatalogFunction createFunction() {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -32,6 +32,8 @@ public class CatalogTestUtil {
 		checkEquals(t1.getStatistics(), t2.getStatistics());
 		assertEquals(t1.getComment(), t2.getComment());
 		assertEquals(t1.getProperties(), t2.getProperties());
+		assertEquals(t1.getPartitionKeys(), t2.getPartitionKeys());
+		assertEquals(t1.isPartitioned(), t2.isPartitioned());
 	}
 
 	public static void checkEquals(TableStats ts1, TableStats ts2) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -30,7 +30,8 @@ public class CatalogTestUtil {
 	public static void checkEquals(CatalogTable t1, CatalogTable t2) {
 		assertEquals(t1.getSchema(), t2.getSchema());
 		checkEquals(t1.getStatistics(), t2.getStatistics());
-		assertEquals(t1.getDescription(), t2.getDescription());
+		assertEquals(t1.getComment(), t2.getComment());
+		assertEquals(t1.getProperties(), t2.getProperties());
 	}
 
 	public static void checkEquals(TableStats ts1, TableStats ts2) {
@@ -39,6 +40,9 @@ public class CatalogTestUtil {
 	}
 
 	public static void checkEquals(CatalogView v1, CatalogView v2) {
+		assertEquals(v1.getSchema(), v1.getSchema());
+		assertEquals(v1.getProperties(), v2.getProperties());
+		assertEquals(v1.getComment(), v2.getComment());
 		assertEquals(v1.getOriginalQuery(), v2.getOriginalQuery());
 		assertEquals(v1.getExpandedQuery(), v2.getExpandedQuery());
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR added support for views in GenericHiveMetastoreCatalog, operations include create, drop, alter, rename, list.

## Brief change log

- Implemented view related APIs in GenericHiveMetastoreCatalog
- Reused and moved view related unit tests from GenericInMemoryCatalog to CatalogTestBase

## Verifying this change

This change added tests and can be verified as follows:

  - Tests moved to CatalogTestBase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
