### PR TITLE
[FLINK-12395][table] Add more detailed javadoc for getDescription() and getDetailedDescription() in catalog object interfaces

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
@@ -48,6 +48,7 @@ public interface CatalogBaseTable {
 
 	/**
 	 * Get a brief description of the table or view.
+	 * It is shown to users when they run "DESCRIBE" in SQL.
 	 *
 	 * @return an optional short description of the table/view
 	 */
@@ -55,6 +56,7 @@ public interface CatalogBaseTable {
 
 	/**
 	 * Get a detailed description of the table or view.
+	 * It is shown to users when they run "DESCRIBE EXTENDED" in SQL.
 	 *
 	 * @return an optional long description of the table/view
 	 */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogDatabase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogDatabase.java
@@ -39,6 +39,7 @@ public interface CatalogDatabase {
 
 	/**
 	 * Get a brief description of the database.
+	 * It is shown to users when they run "DESCRIBE DATABASE" in SQL.
 	 *
 	 * @return an optional short description of the database
 	 */
@@ -46,6 +47,7 @@ public interface CatalogDatabase {
 
 	/**
 	 * Get a detailed description of the database.
+	 * It is shown to users when they run "DESCRIBE DATABASE EXTENDED" in SQL.
 	 *
 	 * @return an optional long description of the database
 	 */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -49,6 +49,7 @@ public interface CatalogFunction {
 
 	/**
 	 * Get a brief description of the function.
+	 * It is shown to users when they run "DESCRIBE FUNCTION" in SQL.
 	 *
 	 * @return an optional short description of the function
 	 */
@@ -56,6 +57,7 @@ public interface CatalogFunction {
 
 	/**
 	 * Get a detailed description of the function.
+	 * It is shown to users when they run "DESCRIBE FUNCTION EXTENDED" in SQL.
 	 *
 	 * @return an optional long description of the function
 	 */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPartition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPartition.java
@@ -41,16 +41,18 @@ public interface CatalogPartition {
 	CatalogPartition copy();
 
 	/**
-	 * Get a brief description of the database.
+	 * Get a brief description of the partition.
+	 * It will be shown to users when they run "DESCRIBE PARTITION" in SQL.
 	 *
-	 * @return an optional short description of the database
+	 * @return an optional short description of the partition
 	 */
 	Optional<String> getDescription();
 
 	/**
-	 * Get a detailed description of the database.
+	 * Get a detailed description of the partition.
+	 * It will be shown to users when they run "DESCRIBE EXTENDED PARTITION" in SQL.
 	 *
-	 * @return an optional long description of the database
+	 * @return an optional long description of the partition
 	 */
 	Optional<String> getDetailedDescription();
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR adds more detailed javadoc  for getDescription() and getDetailedDescription() in catalog object interfaces, to help developers better understand when these APIs are expected to be called.

## Brief change log

  - Add more detailed javadoc for getDescription() and getDetailedDescription() in catalog object interfaces

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
