### PR TITLE
[FLINK-12141] [API/Type Serialization System] Allow @TypeInfo annotation on POJO field declarations

### DIFF
--- a/docs/content/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
@@ -522,8 +522,8 @@ env.getConfig().disableGenericTypes();
 
 A type information factory allows for plugging-in user-defined type information into the Flink type system.
 You have to implement `org.apache.flink.api.common.typeinfo.TypeInfoFactory` to return your custom type information. 
-The factory is called during the type extraction phase if the corresponding type has been annotated 
-with the `@org.apache.flink.api.common.typeinfo.TypeInfo` annotation. 
+The factory is called during the type extraction phase if either the corresponding type or a POJO's field using
+this type has been annotated with the `@org.apache.flink.api.common.typeinfo.TypeInfo` annotation.
 
 Type information factories can be used in both the Java and Scala API.
 
@@ -550,6 +550,17 @@ public class MyTupleTypeInfoFactory extends TypeInfoFactory<MyTuple> {
   public TypeInformation<MyTuple> createTypeInfo(Type t, Map<String, TypeInformation<?>> genericParameters) {
     return new MyTupleTypeInfo(genericParameters.get("T0"), genericParameters.get("T1"));
   }
+}
+```
+
+Instead of annotating the type itself, which may not be possible for third-party code, you can also
+annotate the usage of this type inside a valid Flink POJO like this:
+```java
+public class MyPojo {
+  public int id;
+
+  @TypeInfo(MyTupleTypeInfoFactory.class)
+  public MyTuple<Integer, String> tuple;
 }
 ```
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInfo.java
@@ -35,7 +35,7 @@ import java.lang.reflect.Type;
  * has highest precedence (see {@link TypeExtractor#registerFactory(Type, Class)}).
  */
 @Documented
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Public
 public @interface TypeInfo {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1308,6 +1308,19 @@ public class TypeExtractor {
         }
         final Type factoryDefiningType = factoryHierarchy.get(factoryHierarchy.size() - 1);
 
+        return createTypeInfoFromFactory(
+                t, in1Type, in2Type, factoryHierarchy, factory, factoryDefiningType);
+    }
+
+    /** Creates type information using a given factory. */
+    @SuppressWarnings("unchecked")
+    private <IN1, IN2, OUT> TypeInformation<OUT> createTypeInfoFromFactory(
+            Type t,
+            TypeInformation<IN1> in1Type,
+            TypeInformation<IN2> in2Type,
+            List<Type> factoryHierarchy,
+            TypeInfoFactory<? super OUT> factory,
+            Type factoryDefiningType) {
         // infer possible type parameters from input
         final Map<String, TypeInformation<?>> genericParams;
         if (factoryDefiningType instanceof ParameterizedType) {
@@ -1689,6 +1702,23 @@ public class TypeExtractor {
         return (TypeInfoFactory<OUT>) InstantiationUtil.instantiate(factoryClass);
     }
 
+    /** Returns the type information factory for an annotated field. */
+    @Internal
+    @SuppressWarnings("unchecked")
+    public static <OUT> TypeInfoFactory<OUT> getTypeInfoFactory(Field field) {
+        if (!isClassType(field.getType()) || !field.isAnnotationPresent(TypeInfo.class)) {
+            return null;
+        }
+
+        Class<?> factoryClass = field.getAnnotation(TypeInfo.class).value();
+        // check for valid factory class
+        if (!TypeInfoFactory.class.isAssignableFrom(factoryClass)) {
+            throw new InvalidTypesException(
+                    "TypeInfo annotation does not specify a valid TypeInfoFactory.");
+        }
+        return (TypeInfoFactory<OUT>) InstantiationUtil.instantiate(factoryClass);
+    }
+
     /** @return number of items with equal type or same raw type */
     private static int countTypeInHierarchy(List<Type> typeHierarchy, Type type) {
         int count = 0;
@@ -2043,47 +2073,25 @@ public class TypeExtractor {
                 return null;
             }
             try {
-                if (field.isAnnotationPresent(TypeInfo.class)) {
-                    Class<?> factoryClass = field.getAnnotation(TypeInfo.class).value();
-                    if (TypeInfoFactory.class.isAssignableFrom(factoryClass)) {
-                        TypeInfoFactory factory =
-                                (TypeInfoFactory<?>) InstantiationUtil.instantiate(factoryClass);
-                        final Map<String, TypeInformation<?>> genericParams;
-                        if (fieldType instanceof ParameterizedType) {
-                            genericParams = new HashMap<>();
-                            final ParameterizedType paramDefiningType =
-                                    (ParameterizedType) fieldType;
-                            final Type[] args = typeToClass(paramDefiningType).getTypeParameters();
-
-                            final TypeInformation<?>[] subtypeInfo =
-                                    createSubTypesInfo(
-                                            fieldType,
-                                            paramDefiningType,
-                                            new ArrayList<Type>(typeHierarchy),
-                                            in1Type,
-                                            in2Type,
-                                            true);
-                            assert subtypeInfo != null;
-                            for (int i = 0; i < subtypeInfo.length; i++) {
-                                genericParams.put(args[i].toString(), subtypeInfo[i]);
-                            }
-                        } else {
-                            genericParams = Collections.emptyMap();
-                        }
-
-                        final TypeInformation<?> createdTypeInfo =
-                                (TypeInformation<?>)
-                                        factory.createTypeInfo(fieldType, genericParams);
-                        pojoFields.add(new PojoField(field, createdTypeInfo));
-                        continue;
-                    }
-                }
+                final TypeInformation<?> typeInfo;
                 List<Type> fieldTypeHierarchy = new ArrayList<>(typeHierarchy);
-                fieldTypeHierarchy.add(fieldType);
-                TypeInformation<?> ti =
-                        createTypeInfoWithTypeHierarchy(
-                                fieldTypeHierarchy, fieldType, in1Type, in2Type);
-                pojoFields.add(new PojoField(field, ti));
+                TypeInfoFactory factory = getTypeInfoFactory(field);
+                if (factory != null) {
+                    typeInfo =
+                            createTypeInfoFromFactory(
+                                    fieldType,
+                                    in1Type,
+                                    in2Type,
+                                    fieldTypeHierarchy,
+                                    factory,
+                                    fieldType);
+                } else {
+                    fieldTypeHierarchy.add(fieldType);
+                    typeInfo =
+                            createTypeInfoWithTypeHierarchy(
+                                    fieldTypeHierarchy, fieldType, in1Type, in2Type);
+                }
+                pojoFields.add(new PojoField(field, typeInfo));
             } catch (InvalidTypesException e) {
                 Class<?> genericClass = Object.class;
                 if (isClassType(fieldType)) {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeInfoFactoryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeInfoFactoryTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java.typeutils;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -127,6 +128,32 @@ public class TypeInfoFactoryTest {
         MyTupleTypeInfo mtti = (MyTupleTypeInfo) tti.getTypeAt(0);
         assertEquals(new TupleTypeInfo<>(FLOAT_TYPE_INFO, STRING_TYPE_INFO), mtti.getField0());
         assertEquals(BOOLEAN_TYPE_INFO, mtti.getField1());
+    }
+
+    @Test
+    public void testWithFieldTypeInfoAnnotation() {
+        TypeInformation<WithFieldTypeInfoAnnotation<Double, String>> typeWithAnnotation =
+                TypeInformation.of(new TypeHint<WithFieldTypeInfoAnnotation<Double, String>>() {});
+        TypeInformation<WithoutFieldTypeInfoAnnotation<Double, String>> typeWithoutAnnotation =
+                TypeInformation.of(
+                        new TypeHint<WithoutFieldTypeInfoAnnotation<Double, String>>() {});
+
+        assertTrue(typeWithAnnotation instanceof PojoTypeInfo);
+        assertTrue(typeWithoutAnnotation instanceof PojoTypeInfo);
+
+        assertTrue(((PojoTypeInfo<?>) typeWithAnnotation).getTypeAt(1) instanceof EitherTypeInfo);
+        assertTrue(
+                ((PojoTypeInfo<?>) typeWithoutAnnotation).getTypeAt(1) instanceof GenericTypeInfo);
+
+        MapFunction<Boolean, WithFieldTypeInfoAnnotation<Boolean, String>> f =
+                new WithFieldTypeInfoAnnotationMapper<>();
+        TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(f, BOOLEAN_TYPE_INFO);
+        assertTrue(ti instanceof PojoTypeInfo);
+        PojoTypeInfo<?> tiPojo = (PojoTypeInfo<?>) ti;
+        assertTrue(tiPojo.getTypeAt(1) instanceof EitherTypeInfo);
+        EitherTypeInfo eti = (EitherTypeInfo) tiPojo.getTypeAt(1);
+        assertEquals(BOOLEAN_TYPE_INFO, eti.getLeftType());
+        assertEquals(STRING_TYPE_INFO, eti.getRightType());
     }
 
     @Test(expected = InvalidTypesException.class)
@@ -482,6 +509,31 @@ public class TypeInfoFactoryTest {
         public TypeInformation<IntLike> createTypeInfo(
                 Type t, Map<String, TypeInformation<?>> genericParams) {
             return (TypeInformation) INT_TYPE_INFO;
+        }
+    }
+
+    // hypothesis:from out package not in the project
+    public static class OuterEither<A, B> {
+        // empty
+    }
+
+    public static class WithFieldTypeInfoAnnotation<A, B> {
+        @TypeInfo(MyEitherTypeInfoFactory.class)
+        public OuterEither<A, B> outerEither;
+
+        public String id;
+    }
+
+    public static class WithoutFieldTypeInfoAnnotation<A, B> {
+        public OuterEither<A, B> outerEither;
+        public String id;
+    }
+
+    public static class WithFieldTypeInfoAnnotationMapper<T>
+            implements MapFunction<T, WithFieldTypeInfoAnnotation<T, String>> {
+        @Override
+        public WithFieldTypeInfoAnnotation<T, String> map(T value) throws Exception {
+            return null;
         }
     }
 }


### PR DESCRIPTION


## What is the purpose of the change

*Allow @TypeInfo annotation on POJO field declarations.*


## Brief change log

  - *allow @TypeInfo annotation on POJO field *
  - *add a testcase in TypeInfoFactoryTest.java*
  - *change the function analyzePojo to make it can analyze POJO field  with @TypeInfo annotation*


## Verifying this change


This change is already covered by existing tests, such as *TypeInfoFactoryTest*.

This change added tests and can be verified as follows:

*testWithFieldTypeInfoAnnotation*
 - *Added unit test for POJO field declarations with @TypeInfo annotation*
  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? JavaDocs 
