### PR TITLE
[FLINK-12402][table] Make validation error message for CallExpression more user friendly

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CalcValidationTest.scala
@@ -148,4 +148,17 @@ class CalcValidationTest extends TableTestBase {
       "MyTable", 'string)
       .map("func(string) as a") // do not support TableFunction as input
   }
+
+  @Test
+  def testInvalidParameterTypes(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("log('long) fails on input type checking: " +
+      "[expecting Double on 0th input, get Long].\nOperand should be casted to proper type")
+
+    val util = streamTestUtil()
+
+    util.tableEnv.registerFunction("func", new TableFunc0)
+    util.addTable[(Int, Long, String)]("MyTable", 'int, 'long, 'string)
+      .select('int, 'long.log as 'long, 'string)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/GroupWindowValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/GroupWindowValidationTest.scala
@@ -104,7 +104,9 @@ class GroupWindowValidationTest extends TableTestBase {
   @Test
   def testTumbleUdAggWithInvalidArgs(): Unit = {
     expectedException.expect(classOf[ValidationException])
-    expectedException.expectMessage("Invalid arguments")
+    expectedException.expectMessage("Given parameters do not match any signature. \n" +
+      "Actual: (java.lang.String, java.lang.Integer) \nExpected: (int, int), (long, int), " +
+      "(long, int, int, java.lang.String)")
 
     val util = streamTestUtil()
     val weightedAvg = new WeightedAvgWithMerge
@@ -165,7 +167,9 @@ class GroupWindowValidationTest extends TableTestBase {
   @Test
   def testSlideUdAggWithInvalidArgs(): Unit = {
     expectedException.expect(classOf[ValidationException])
-    expectedException.expectMessage("Invalid arguments")
+    expectedException.expectMessage("Given parameters do not match any signature. \n" +
+      "Actual: (java.lang.String, java.lang.Integer) \nExpected: (int, int), (long, int), " +
+      "(long, int, int, java.lang.String)")
 
     val util = streamTestUtil()
     val weightedAvg = new WeightedAvgWithMerge
@@ -243,7 +247,9 @@ class GroupWindowValidationTest extends TableTestBase {
   @Test
   def testSessionUdAggWithInvalidArgs(): Unit = {
     expectedException.expect(classOf[ValidationException])
-    expectedException.expectMessage("Invalid arguments")
+    expectedException.expectMessage("Given parameters do not match any signature. \n" +
+      "Actual: (java.lang.String, java.lang.Integer) \nExpected: (int, int), (long, int), " +
+      "(long, int, int, java.lang.String)")
 
     val util = streamTestUtil()
     val weightedAvg = new WeightedAvgWithMerge


### PR DESCRIPTION

## What is the purpose of the change

This pull request makes the validation error message more user friendly. The previous error message for CallExpression validation may not display the root cause which may confuse our users. See more details in the [jira](https://issues.apache.org/jira/browse/FLINK-12402).

## Brief change log

  - Display the truth validation error message.
  - Adjust test cases.

## Verifying this change

This change added tests and can be verified as follows:

  - Add `testInvalidParameterTypes` in `CalcValidationTest` to test the validation error message.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
