### PR TITLE
[FLINK-12411][table-planner][tests] Workaround limited support of not nullable fields in window aggregation

### DIFF
--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -106,7 +106,9 @@ public class StreamSQLTestProgram {
 		String tumbleQuery = String.format(
 			"SELECT " +
 			"  key, " +
-			"  CASE SUM(cnt) / COUNT(*) WHEN 101 THEN 1 ELSE 99 END AS correct, " +
+			//TODO: The "WHEN -1 THEN NULL" part is a temporary workaround, to make the test pass, for
+			// https://issues.apache.org/jira/browse/FLINK-12249. We should remove it once the issue is fixed.
+			"  CASE SUM(cnt) / COUNT(*) WHEN 101 THEN 1 WHEN -1 THEN NULL ELSE 99 END AS correct, " +
 			"  TUMBLE_START(rowtime, INTERVAL '%d' SECOND) AS wStart, " +
 			"  TUMBLE_ROWTIME(rowtime, INTERVAL '%d' SECOND) AS rowtime " +
 			"FROM (%s) " +


### PR DESCRIPTION
## What is the purpose of the change

This does not fix the problem. It just makes the e2e test pass. For a
proper fix of the underlying problem see [FLINK-12249](https://issues.apache.org/jira/browse/FLINK-12249).


## Brief change log

  - Produce nullable type in `CASE ... WHEN` statement. The added `NULL` value will never be generated. It's sole purpose is to deceive the planner.


## Verifying this change

It changes only `test_streaming_sql.sh`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no /** don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
