### PR TITLE
[FLINK-12412] [API / Type Serialization System] Allow ListTypeInfo us…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1669,6 +1669,27 @@ public class TypeExtractor {
 			return new GenericTypeInfo<>(clazz);
 		}
 
+		if (clazz.equals(java.util.List.class)) {
+			if (parameterizedType != null
+					&& parameterizedType.getActualTypeArguments().length > 0) {
+				Type type = parameterizedType.getActualTypeArguments()[0];
+				// type must be a Class not can be ParameterizedType
+				if (type instanceof Class) {
+					return new ListTypeInfo(typeToClass(type));
+				}
+			}
+		}
+
+		if (clazz.equals(java.util.Map.class)) {
+			if (parameterizedType != null
+					&& parameterizedType.getActualTypeArguments().length > 1) {
+				Type typeK = parameterizedType.getActualTypeArguments()[0];
+				Type typeV = parameterizedType.getActualTypeArguments()[1];
+				if (typeK instanceof Class && typeV instanceof Class) {
+					return new MapTypeInfo(typeToClass(typeK), typeToClass(typeV));
+				}
+			}
+		}
 		// check for arrays
 		if (clazz.isArray()) {
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/ListTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/ListTypeInfoTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.java.typeutils;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for {@link ListTypeInfo}.
@@ -34,4 +36,16 @@ public class ListTypeInfoTest extends TypeInformationTestBase<ListTypeInfo<?>> {
 			new ListTypeInfo<>(Object.class),
 		};
 	}
+
+	@Test
+	public void testPojoWithJavaList() {
+		PojoTypeInfo<PojoWithList> pojoType = (PojoTypeInfo<PojoWithList>) TypeExtractor.createTypeInfo(PojoWithList.class);
+		assertTrue(pojoType.getTypeAt(1) instanceof ListTypeInfo);
+	}
+
+	public static class PojoWithList {
+		public Double id;
+		public java.util.List<String> scores;
+	}
+
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MapTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MapTypeInfoTest.java
@@ -20,6 +20,9 @@ package org.apache.flink.api.java.typeutils;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for {@link MapTypeInfo}.
@@ -34,4 +37,16 @@ public class MapTypeInfoTest extends TypeInformationTestBase<MapTypeInfo<?, ?>> 
 			new MapTypeInfo<>(String.class, Boolean.class)
 		};
 	}
+
+	@Test
+	public void testPojoWithJavaMap() {
+		PojoTypeInfo<PojoWithMap> pojoType = (PojoTypeInfo<PojoWithMap>) TypeExtractor.createTypeInfo(PojoWithMap.class);
+		assertTrue(pojoType.getTypeAt(1) instanceof MapTypeInfo);
+	}
+
+	public static class PojoWithMap {
+		public Double id;
+		public java.util.Map<String, Double> scores;
+	}
+
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -407,7 +407,7 @@ public class PojoTypeExtractionTest {
 					Assert.fail("already seen");
 				}
 				collectionSeen = true;
-				Assert.assertEquals(new GenericTypeInfo(List.class), field.getTypeInformation());
+				Assert.assertEquals(new ListTypeInfo<>(String.class), field.getTypeInformation());
 
 			} else {
 				Assert.fail("field "+field+" is not expected");

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
@@ -1922,6 +1922,7 @@ public class TypeExtractorTest {
 		inputMap.put("a", "b");
 		TypeInformation<?> inputType = TypeExtractor.createTypeInfo(inputMap.getClass());
 
+
 		MapFunction<?, ?> function = new MapFunction<Map<String, Object>,Map<String, Object>>(){
 
 			@Override
@@ -1931,7 +1932,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) inputType);
-		TypeInformation<?> expected = TypeExtractor.createTypeInfo(Map.class);
+		TypeInformation<?> expected = new MapTypeInfo(String.class, Object.class);
 		Assert.assertEquals(expected, ti);
 	}
 


### PR DESCRIPTION
…ed for java.util.List and MapTypeInfo used for java.util.Map

## What is the purpose of the change

*Allow ListTypeInfo used for java.util.List and MapTypeInfo used for java.util.Map*

## Brief change log

  - *Allow ListTypeInfo used for java.util.List *
  - *Allow  MapTypeInfo used for java.util.Map*
  - *change the test case:PojoTypeExtractionTest.testPojoWC*
  - *change the test case:TypeExtractorTest.testGenericTypeWithSubclassInput*


## Verifying this change

This change is already covered by existing tests, such as MapTypeInfoTest,ListTypeInfoTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive):  no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented?  not documented)
