### PR TITLE
[hotfix][docs] mention kryo in serialization and link to page

### DIFF
--- a/docs/dev/api_concepts.md
+++ b/docs/dev/api_concepts.md
@@ -694,7 +694,12 @@ Java and Scala classes are treated by Flink as a special POJO data type if they 
 
 - All fields are either public or must be accessible through getter and setter functions. For a field called `foo` the getter and setter methods must be named `getFoo()` and `setFoo()`.
 
-- The type of a field must be supported by Flink. At the moment, Flink uses [Avro](http://avro.apache.org) to serialize arbitrary objects (such as `Date`).
+- The type of a field must be supported by a registered serializer.
+
+POJOs are generally represented with a `PojoTypeInfo` and serialized with the `PojoSerializer` (using [Kryo](https://github.com/EsotericSoftware/kryo) as configurable fallback).
+The exception is when the POJOs are actually Avro types (Avro Specific Records) or produced as "Avro Reflect Types". 
+In that case the POJO's are represented by an `AvroTypeInfo` and serialized with the `AvroSerializer`.
+You can also register your own custom serializer if required; see [Serialization](https://ci.apache.org/projects/flink/flink-docs-stable/dev/types_serialization.html#serialization-of-pojo-types) for further information.
 
 Flink analyzes the structure of POJO types, i.e., it learns about the fields of a POJO. As a result POJO types are easier to use than general types. Moreover, Flink can process POJOs more efficiently than general types.
 

--- a/docs/dev/execution_configuration.md
+++ b/docs/dev/execution_configuration.md
@@ -57,7 +57,7 @@ With the closure cleaner disabled, it might happen that an anonymous user functi
 
 - `enableForceKryo()` / **`disableForceKryo`**. Kryo is not forced by default. Forces the GenericTypeInformation to use the Kryo serializer for POJOs even though we could analyze them as a POJO. In some cases this might be preferable. For example, when Flink's internal serializers fail to handle a POJO properly.
 
-- `enableForceAvro()` / **`disableForceAvro()`**. Avro is not forced by default. Forces the Flink AvroTypeInformation to use the Avro serializer instead of Kryo for serializing Avro POJOs.
+- `enableForceAvro()` / **`disableForceAvro()`**. Avro is not forced by default. Forces the Flink AvroTypeInfo to use the Avro serializer instead of Kryo for serializing Avro POJOs.
 
 - `enableObjectReuse()` / **`disableObjectReuse()`** By default, objects are not reused in Flink. Enabling the object reuse mode will instruct the runtime to reuse user objects for better performance. Keep in mind that this can lead to bugs when the user-code function of an operation is not aware of this behavior.
 

--- a/docs/dev/execution_configuration.zh.md
+++ b/docs/dev/execution_configuration.zh.md
@@ -57,7 +57,7 @@ With the closure cleaner disabled, it might happen that an anonymous user functi
 
 - `enableForceKryo()` / **`disableForceKryo`**. Kryo is not forced by default. Forces the GenericTypeInformation to use the Kryo serializer for POJOs even though we could analyze them as a POJO. In some cases this might be preferable. For example, when Flink's internal serializers fail to handle a POJO properly.
 
-- `enableForceAvro()` / **`disableForceAvro()`**. Avro is not forced by default. Forces the Flink AvroTypeInformation to use the Avro serializer instead of Kryo for serializing Avro POJOs.
+- `enableForceAvro()` / **`disableForceAvro()`**. Avro is not forced by default. Forces the Flink AvroTypeInfo to use the Avro serializer instead of Kryo for serializing Avro POJOs.
 
 - `enableObjectReuse()` / **`disableObjectReuse()`** By default, objects are not reused in Flink. Enabling the object reuse mode will instruct the runtime to reuse user objects for better performance. Keep in mind that this can lead to bugs when the user-code function of an operation is not aware of this behavior.
 

--- a/docs/dev/types_serialization.md
+++ b/docs/dev/types_serialization.md
@@ -281,11 +281,11 @@ by all compilers (as of writing this document only reliably by the Eclipse JDT c
 
 #### Serialization of POJO types
 
-The PojoTypeInformation is creating serializers for all the fields inside the POJO. Standard types such as
+The `PojoTypeInfo` is creating serializers for all the fields inside the POJO. Standard types such as
 int, long, String etc. are handled by serializers we ship with Flink.
-For all other types, we fall back to Kryo.
+For all other types, we fall back to [Kryo](https://github.com/EsotericSoftware/kryo).
 
-If Kryo is not able to handle the type, you can ask the PojoTypeInfo to serialize the POJO using Avro.
+If Kryo is not able to handle the type, you can ask the `PojoTypeInfo` to serialize the POJO using [Avro](https://avro.apache.org).
 To do so, you have to call
 
 {% highlight java %}

--- a/docs/dev/types_serialization.zh.md
+++ b/docs/dev/types_serialization.zh.md
@@ -255,7 +255,7 @@ Flink 目前试图找出实现 lambda 的方法，并使用 Java 的泛型签名
 
 #### POJO 类型的序列化
 
-PojoTypeInformation 为 POJO 中的所有字段创建序列化器。Flink 标准类型如 int、long、String 等由 Flink 序列化器处理。
+PojoTypeInfo 为 POJO 中的所有字段创建序列化器。Flink 标准类型如 int、long、String 等由 Flink 序列化器处理。
 对于所有其他类型，我们回退到 Kryo。
 
 对于 Kryo 不能处理的类型，你可以要求 PojoTypeInfo 使用 Avro 对 POJO 进行序列化。


### PR DESCRIPTION
## What is the purpose of the change
improve documentation

## Brief change log
I am new to flink so maybe I misunderstood something. As far as I am get Avro is only used if the POJO comes from a source which was deserialised with Avro. Otherwise Kryo is used. Thus I changed the text, mentioning Kryo as well and added a link to the `Serialization of POJO types` section  (I guess the link to the other page makes sense in all cases).

## Verifying this change
- This change is a trivial rework / code cleanup without any test coverage.

## Documentation
  - Does this pull request introduce a new feature? => no
