### PR TITLE
[FLINK-12175] Change filling of typeHierarchy in analyzePojo, for cor…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1837,8 +1837,8 @@ public class TypeExtractor {
 		if (parameterizedType != null) {
 			getTypeHierarchy(typeHierarchy, parameterizedType, Object.class);
 		}
-		// create a type hierarchy, if the incoming only contains the most bottom one or none.
-		else if (typeHierarchy.size() <= 1) {
+		// create a type hierarchy, for fields types extraction
+		else {
 			getTypeHierarchy(typeHierarchy, clazz, Object.class);
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoParametrizedTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoParametrizedTypeExtractionTest.java
@@ -1,0 +1,101 @@
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+/**
+ *  Tests concerning type extraction of Parametrized Pojo and its superclasses.
+ */
+public class PojoParametrizedTypeExtractionTest {
+
+	@Test
+	public void testCreateTypeInfo(){
+		/// Init
+		final TypeInformation<ParametrizedParentImpl> directTypeInfo = TypeExtractor.createTypeInfo(ParametrizedParentImpl.class);
+
+		/// Check
+		Assert.assertTrue(directTypeInfo instanceof PojoTypeInfo);
+	}
+
+	@Test
+	public void testFieldExtraction(){
+		/// Init
+		final TypeInformation<ParametrizedParentImpl> directTypeInfo = TypeExtractor.createTypeInfo(ParametrizedParentImpl.class);
+
+		// Extract
+		TypeInformation<?> directPojoFieldTypeInfo = ((PojoTypeInfo) directTypeInfo)
+			.getPojoFieldAt(0)
+			.getTypeInformation();
+
+		// Check
+		Assert.assertTrue(directPojoFieldTypeInfo instanceof PojoTypeInfo);
+	}
+
+	@Test
+	public void testMapReturnTypeInfo(){
+		/// Init
+		final TypeInformation<ParametrizedParentImpl> directTypeInfo = TypeExtractor.createTypeInfo(ParametrizedParentImpl.class);
+
+		// Extract
+		TypeInformation<ParametrizedParentImpl> mapReturnTypeInfo = TypeExtractor
+			.getMapReturnTypes(new ConcreteMapFunction(), directTypeInfo);
+
+		// Check
+		Assert.assertTrue(mapReturnTypeInfo instanceof PojoTypeInfo);
+		Assert.assertEquals(directTypeInfo, mapReturnTypeInfo);
+	}
+
+	@Test
+	public void testMapReturnFieldTypeInfo(){
+		/// Init
+		final TypeInformation<ParametrizedParentImpl> directTypeInfo = TypeExtractor.createTypeInfo(ParametrizedParentImpl.class);
+
+		// Extract
+		TypeInformation<ParametrizedParentImpl> mapReturnTypeInfo = TypeExtractor
+			.getMapReturnTypes(new ConcreteMapFunction(), directTypeInfo);
+		TypeInformation<?> mapReturnPojoFieldTypeInfo = ((PojoTypeInfo) mapReturnTypeInfo)
+			.getPojoFieldAt(0)
+			.getTypeInformation();
+
+		// Check
+		Assert.assertTrue(mapReturnPojoFieldTypeInfo instanceof PojoTypeInfo);
+
+	}
+
+	/**
+	 * Representation of Pojo class with 2 fields.
+	 */
+	public static class Pojo implements Serializable {
+		public int digits;
+		public String letters;
+	}
+
+	/**
+	 * Representation of class which is parametrized by some pojo.
+	 */
+	public static class ParameterizedParent<T extends Serializable> implements Serializable {
+		public T pojoField;
+	}
+
+	/**
+	 * Implementation of ParametrizedParent parametrized by Pojo.
+	 */
+	public static class ParametrizedParentImpl extends ParameterizedParent<Pojo> {
+		public double precise;
+	}
+
+	/**
+	 * Representation of map function for type extraction.
+	 */
+	public static class ConcreteMapFunction implements MapFunction<ParametrizedParentImpl, ParametrizedParentImpl> {
+		@Override
+		public ParametrizedParentImpl map(ParametrizedParentImpl value) throws Exception {
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes bug with creating TypeInfo for POJO Classes with generic superclasses which has fields of that genric type. The problem is when we building typeHierarchy for Pojo with generic superclass we already have values in typeHierarchy array, we stopped building typehierahy and coud not extract type for fields later.


## Brief change log

  - Removed condition on if typeHierarchy <= 1. Changed to simple else statement cause we shoudn't stop building type hierarchy.

## Verifying this change

This change added tests and can be verified as follows:

  - Added *PojoParametrizedTypeExtractionTest* test that validates that TypeInfo for generic field correctlly exctracted by TypeExtractor

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no 

## Documentation

  - Does this pull request introduce a new feature?  no