### PR TITLE
[FLINK-11051][table] Add streaming window FlatAggregate to Table API

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2026,7 +2026,7 @@ Table table = input
     
     <tr>
       <td>
-        <strong>GroupBy TableAggregation</strong><br>
+        <strong>FlatAggregate</strong><br>
         <span class="label label-primary">Streaming</span><br>
         <span class="label label-info">Result Updating</span>
       </td>
@@ -2066,14 +2066,35 @@ Table table = input
     }
     
 TableAggregateFunction tableAggFunc = new MyMinMax();
-tableEnv.registerFunction("myTableAggFunc", tableAggFunc);
+tableEnv.registerFunction("tableAggFunc", tableAggFunc);
 Table orders = tableEnv.scan("Orders");
 Table result = orders
     .groupBy("a")
-    .flatAggregate("myTableAggFunc(a) as (x, y)")
+    .flatAggregate("tableAggFunc(b) as (x, y)")
     .select("a, x, y");
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries, the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with a valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
+      </td>
+    </tr>
+    
+    
+    <tr>
+      <td>
+        <strong>Group Window FlatAggregate</strong><br>
+        <span class="label label-primary">Streaming</span><br>
+      </td>
+      <td>
+        <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys. You have to close the "flatAggregate" with a select statement. And the select statement does not support aggregate functions.</p>
+{% highlight java %}
+TableAggregateFunction tableAggFunc = new MyMinMax();
+tableEnv.registerFunction("tableAggFunc", tableAggFunc);
+Table orders = tableEnv.scan("Orders");
+Table result = orders
+    .window(Tumble.over("5.minutes").on("rowtime").as("w")) // define window
+    .groupBy("a, w") // group by key and window
+    .flatAggregate("tableAggFunc(b) as (x, y)")
+    .select("a, w.start, w.end, w.rowtime, x, y"); // access window properties and aggregate results
+{% endhighlight %}
       </td>
     </tr>
   </tbody>
@@ -2194,7 +2215,7 @@ val table = input
     
     <tr>
       <td>
-        <strong>GroupBy TableAggregation</strong><br>
+        <strong>FlatAggregate</strong><br>
         <span class="label label-primary">Streaming</span><br>
         <span class="label label-info">Result Updating</span>
       </td>
@@ -2235,10 +2256,30 @@ val tableAggFunc = new MyMinMax
 val orders: Table = tableEnv.scan("Orders")
 val result = orders
     .groupBy('a)
-    .flatAggregate(tableAggFunc('a) as ('x, 'y))
+    .flatAggregate(tableAggFunc('b) as ('x, 'y))
     .select('a, 'x, 'y)
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries, the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with a valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        <strong>Group Window FlatAggregate</strong><br>
+        <span class="label label-primary">Streaming</span><br>
+      </td>
+      <td>
+        <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys. You have to close the "flatAggregate" with a select statement. And the select statement does not support aggregate functions.</p>
+{% highlight scala %}
+val tableAggFunc = new MyMinMax
+val orders: Table = tableEnv.scan("Orders")
+val result = orders
+    .window(Tumble over 5.minutes on 'rowtime as 'w) // define window
+    .groupBy('a, 'w) // group by key and window
+    .flatAggregate(tableAggFunc('b) as ('x, 'y))
+    .select('a, w.start, 'w.end, 'w.rowtime, 'x, 'y) // access window properties and aggregate results
+
+{% endhighlight %}
       </td>
     </tr>
   </tbody>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/FlatAggregateTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/FlatAggregateTable.java
@@ -22,13 +22,14 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.expressions.Expression;
 
 /**
- * A table that performs flatAggregate on a {@link Table} or a {@link GroupedTable}.
+ * A table that performs flatAggregate on a {@link Table}, a {@link GroupedTable} or a
+ * {@link WindowGroupedTable}.
  */
 @PublicEvolving
 public interface FlatAggregateTable {
 
 	/**
-	 * Performs a selection operation on a FlatAggregateTable. Similar to an SQL SELECT
+	 * Performs a selection operation on a FlatAggregateTable. Similar to a SQL SELECT
 	 * statement. The field expressions can contain complex expressions.
 	 *
 	 * <p><b>Note</b>: You have to close the flatAggregate with a select statement. And the select
@@ -49,7 +50,7 @@ public interface FlatAggregateTable {
 	Table select(String fields);
 
 	/**
-	 * Performs a selection operation on a FlatAggregateTable table. Similar to an SQL SELECT
+	 * Performs a selection operation on a FlatAggregateTable table. Similar to a SQL SELECT
 	 * statement. The field expressions can contain complex expressions.
 	 *
 	 * <p><b>Note</b>: You have to close the flatAggregate with a select statement. And the select

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
@@ -54,4 +54,39 @@ public interface WindowGroupedTable {
 	 * </pre>
 	 */
 	Table select(Expression... fields);
+
+	/**
+	 * Performs a flatAggregate operation on a window grouped table. FlatAggregate takes a
+	 * TableAggregateFunction which returns multiple rows. Use a selection after flatAggregate.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction
+	 *   tableEnv.registerFunction("tableAggFunc", tableAggFunc);
+	 *   windowGroupedTable
+	 *     .flatAggregate("tableAggFunc(a, b) as (x, y, z)")
+	 *     .select("key, window.start, x, y, z")
+	 * }
+	 * </pre>
+	 */
+	FlatAggregateTable flatAggregate(String tableAggregateFunction);
+
+	/**
+	 * Performs a flatAggregate operation on a window grouped table. FlatAggregate takes a
+	 * TableAggregateFunction which returns multiple rows. Use a selection after flatAggregate.
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   val tableAggFunc = new MyTableAggregateFunction
+	 *   windowGroupedTable
+	 *     .flatAggregate(tableAggFunc('a, 'b) as ('x, 'y, 'z))
+	 *     .select('key, 'window.start, 'x, 'y, 'z)
+	 * }
+	 * </pre>
+	 */
+	FlatAggregateTable flatAggregate(Expression tableAggregateFunction);
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
@@ -110,7 +110,7 @@ public class AggregateOperationFactory {
 
 		TypeInformation[] fieldTypes = Stream.concat(
 			convertedGroupings.stream().map(PlannerExpression::resultType),
-			convertedAggregates.stream().flatMap(this::getAggregateResultTypes)
+			convertedAggregates.stream().flatMap(this::extractAggregateResultTypes)
 		).toArray(TypeInformation[]::new);
 
 		String[] fieldNames = Stream.concat(
@@ -149,7 +149,7 @@ public class AggregateOperationFactory {
 
 		TypeInformation[] fieldTypes = concat(
 			convertedGroupings.stream().map(PlannerExpression::resultType),
-			convertedAggregates.stream().flatMap(this::getAggregateResultTypes),
+			convertedAggregates.stream().flatMap(this::extractAggregateResultTypes),
 			convertedWindowProperties.stream().map(PlannerExpression::resultType)
 		).toArray(TypeInformation[]::new);
 
@@ -171,10 +171,10 @@ public class AggregateOperationFactory {
 	}
 
 	/**
-	 * Get result types for the aggregate or the table aggregate expression. For a table aggregate,
+	 * Extract result types for the aggregate or the table aggregate expression. For a table aggregate,
 	 * it may return multi result types when the composite return type is flattened.
 	 */
-	private Stream<TypeInformation<?>> getAggregateResultTypes(PlannerExpression plannerExpression) {
+	private Stream<TypeInformation<?>> extractAggregateResultTypes(PlannerExpression plannerExpression) {
 		if (plannerExpression instanceof AggFunctionCall &&
 			((AggFunctionCall) plannerExpression).aggregateFunction() instanceof TableAggregateFunction) {
 			return Stream.of(UserDefinedFunctionUtils.getFieldInfo(plannerExpression.resultType())._3());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
@@ -53,6 +53,7 @@ import org.apache.flink.table.typeutils.RowIntervalTypeInfo;
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo;
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -107,30 +108,14 @@ public class AggregateOperationFactory {
 		List<PlannerExpression> convertedGroupings = bridge(groupings);
 		List<PlannerExpression> convertedAggregates = bridge(aggregates);
 
-		Boolean isTableAggregate = aggregates.size() == 1 && isTableAggFunctionCall(aggregates.get(0));
-
 		TypeInformation[] fieldTypes = Stream.concat(
 			convertedGroupings.stream().map(PlannerExpression::resultType),
-			convertedAggregates.stream().flatMap(expr -> {
-				if (isTableAggregate) {
-					return Stream.of(UserDefinedFunctionUtils.getFieldInfo(expr.resultType())._3());
-				} else {
-					return Stream.of(expr.resultType());
-				}
-			})
+			convertedAggregates.stream().flatMap(this::getAggregateResultTypes)
 		).toArray(TypeInformation[]::new);
 
 		String[] fieldNames = Stream.concat(
 			groupings.stream().map(expr -> extractName(expr).orElseGet(expr::toString)),
-			aggregates.stream().flatMap(expr -> {
-				if (isTableAggregate) {
-					return Stream.of(UserDefinedFunctionUtils.getFieldInfo(
-						((AggregateFunctionDefinition) ((CallExpression) expr).getFunctionDefinition())
-							.getResultTypeInfo())._1());
-				} else {
-					return Stream.of(extractName(expr).orElseGet(expr::toString));
-				}
-			})
+			aggregates.stream().flatMap(this::extractAggregateNames)
 		).toArray(String[]::new);
 
 		TableSchema tableSchema = new TableSchema(fieldNames, fieldTypes);
@@ -163,18 +148,16 @@ public class AggregateOperationFactory {
 		List<PlannerExpression> convertedWindowProperties = bridge(windowProperties);
 
 		TypeInformation[] fieldTypes = concat(
-			convertedGroupings.stream(),
-			convertedAggregates.stream(),
-			convertedWindowProperties.stream()
-		).map(PlannerExpression::resultType)
-			.toArray(TypeInformation[]::new);
+			convertedGroupings.stream().map(PlannerExpression::resultType),
+			convertedAggregates.stream().flatMap(this::getAggregateResultTypes),
+			convertedWindowProperties.stream().map(PlannerExpression::resultType)
+		).toArray(TypeInformation[]::new);
 
 		String[] fieldNames = concat(
-			groupings.stream(),
-			aggregates.stream(),
-			windowProperties.stream()
-		).map(expr -> extractName(expr).orElseGet(expr::toString))
-			.toArray(String[]::new);
+			groupings.stream().map(expr -> extractName(expr).orElseGet(expr::toString)),
+			aggregates.stream().flatMap(this::extractAggregateNames),
+			windowProperties.stream().map(expr -> extractName(expr).orElseGet(expr::toString))
+		).toArray(String[]::new);
 
 		TableSchema tableSchema = new TableSchema(fieldNames, fieldTypes);
 
@@ -185,6 +168,33 @@ public class AggregateOperationFactory {
 			window,
 			child,
 			tableSchema);
+	}
+
+	/**
+	 * Get result types for the aggregate or the table aggregate expression. For a table aggregate,
+	 * it may return multi result types when the composite return type is flattened.
+	 */
+	private Stream<TypeInformation<?>> getAggregateResultTypes(PlannerExpression plannerExpression) {
+		if (plannerExpression instanceof AggFunctionCall &&
+			((AggFunctionCall) plannerExpression).aggregateFunction() instanceof TableAggregateFunction) {
+			return Stream.of(UserDefinedFunctionUtils.getFieldInfo(plannerExpression.resultType())._3());
+		} else {
+			return Stream.of(plannerExpression.resultType());
+		}
+	}
+
+	/**
+	 * Extract names for the aggregate or the table aggregate expression. For a table aggregate, it
+	 * may return multi output names when the composite return type is flattened.
+	 */
+	private Stream<String> extractAggregateNames(Expression expression) {
+		if (isTableAggFunctionCall(expression)) {
+			return Arrays.stream(UserDefinedFunctionUtils.getFieldInfo(
+				((AggregateFunctionDefinition) ((CallExpression) expression).getFunctionDefinition())
+					.getResultTypeInfo())._1());
+		} else {
+			return Stream.of(extractName(expression).orElseGet(expression::toString));
+		}
 	}
 
 	/**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/ExtendedAggregateExtractProjectRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/ExtendedAggregateExtractProjectRule.java
@@ -87,9 +87,9 @@ public class ExtendedAggregateExtractProjectRule extends AggregateExtractProject
 		if (relNode instanceof LogicalAggregate || relNode instanceof LogicalWindowAggregate) {
 			call.transformTo(performExtract((Aggregate) relNode, input, relBuilder));
 		} else if (relNode instanceof LogicalTableAggregate) {
-			LogicalAggregate logicalAggregate =
-				LogicalTableAggregate.getCorrespondingAggregate((LogicalTableAggregate) relNode);
-			RelNode newAggregate = performExtract(logicalAggregate, input, relBuilder);
+			Aggregate aggregate =
+				((LogicalTableAggregate) relNode).getCorrespondingAggregate();
+			RelNode newAggregate = performExtract(aggregate, input, relBuilder);
 			call.transformTo(LogicalTableAggregate.create((Aggregate) newAggregate));
 		}
 	}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/ExtendedAggregateExtractProjectRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/ExtendedAggregateExtractProjectRule.java
@@ -22,6 +22,8 @@ import org.apache.flink.table.expressions.ResolvedFieldReference;
 import org.apache.flink.table.plan.logical.LogicalWindow;
 import org.apache.flink.table.plan.logical.rel.LogicalTableAggregate;
 import org.apache.flink.table.plan.logical.rel.LogicalWindowAggregate;
+import org.apache.flink.table.plan.logical.rel.LogicalWindowTableAggregate;
+import org.apache.flink.table.plan.logical.rel.TableAggregate;
 
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
@@ -48,12 +50,12 @@ import java.util.stream.Collectors;
 
 /**
  * Rule to extract a {@link org.apache.calcite.rel.core.Project} from a {@link LogicalAggregate},
- * a {@link LogicalWindowAggregate} or a {@link LogicalTableAggregate} and push it down towards
+ * a {@link LogicalWindowAggregate} or a {@link TableAggregate} and push it down towards
  * the input.
  *
  * <p>Note: Most of the logic in this rule is same with {@link AggregateExtractProjectRule}. The
  * difference is this rule has also taken the {@link LogicalWindowAggregate} and
- * {@link LogicalTableAggregate} into consideration. Furthermore, this rule also creates trivial
+ * {@link TableAggregate} into consideration. Furthermore, this rule also creates trivial
  * {@link Project}s unless the input node is already a {@link Project}.
  */
 public class ExtendedAggregateExtractProjectRule extends AggregateExtractProjectRule {
@@ -75,7 +77,7 @@ public class ExtendedAggregateExtractProjectRule extends AggregateExtractProject
 		final SingleRel relNode = call.rel(0);
 		return relNode instanceof LogicalWindowAggregate ||
 			relNode instanceof LogicalAggregate ||
-			relNode instanceof LogicalTableAggregate;
+			relNode instanceof TableAggregate;
 	}
 
 	@Override
@@ -84,22 +86,31 @@ public class ExtendedAggregateExtractProjectRule extends AggregateExtractProject
 		final RelNode input = call.rel(1);
 		final RelBuilder relBuilder = call.builder().push(input);
 
-		if (relNode instanceof LogicalAggregate || relNode instanceof LogicalWindowAggregate) {
-			call.transformTo(performExtract((Aggregate) relNode, input, relBuilder));
-		} else if (relNode instanceof LogicalTableAggregate) {
-			Aggregate aggregate =
-				((LogicalTableAggregate) relNode).getCorrespondingAggregate();
-			RelNode newAggregate = performExtract(aggregate, input, relBuilder);
-			call.transformTo(LogicalTableAggregate.create((Aggregate) newAggregate));
+		if (relNode instanceof Aggregate) {
+			call.transformTo(performExtractForAggregate((Aggregate) relNode, input, relBuilder));
+		} else if (relNode instanceof TableAggregate) {
+			call.transformTo(performExtractForTableAggregate((TableAggregate) relNode, input, relBuilder));
 		}
 	}
 
 	/**
 	 * Extract a project from the input aggregate and return a new aggregate.
 	 */
-	private RelNode performExtract(Aggregate aggregate, RelNode input, RelBuilder relBuilder) {
+	private RelNode performExtractForAggregate(Aggregate aggregate, RelNode input, RelBuilder relBuilder) {
 		Mapping mapping = extractProjectsAndMapping(aggregate, input, relBuilder);
 		return getNewAggregate(aggregate, relBuilder, mapping);
+	}
+
+	/**
+	 * Extract a project from the input table aggregate and return a new table aggregate.
+	 */
+	private RelNode performExtractForTableAggregate(TableAggregate aggregate, RelNode input, RelBuilder relBuilder) {
+		RelNode newAggregate = performExtractForAggregate(aggregate.getCorrespondingAggregate(), input, relBuilder);
+		if (aggregate instanceof LogicalTableAggregate) {
+			return LogicalTableAggregate.create((Aggregate) newAggregate);
+		} else {
+			return LogicalWindowTableAggregate.create((LogicalWindowAggregate) newAggregate);
+		}
 	}
 
 	/**
@@ -153,7 +164,7 @@ public class ExtendedAggregateExtractProjectRule extends AggregateExtractProject
 		}
 		// 3. window time field if the aggregate is a group window aggregate.
 		if (aggregate instanceof LogicalWindowAggregate) {
-			inputFieldsUsed.set(getWindowTimeFieldIndex((LogicalWindowAggregate) aggregate, input));
+			inputFieldsUsed.set(getWindowTimeFieldIndex(((LogicalWindowAggregate) aggregate).getWindow(), input));
 		}
 		return inputFieldsUsed;
 	}
@@ -195,8 +206,7 @@ public class ExtendedAggregateExtractProjectRule extends AggregateExtractProject
 		}
 	}
 
-	private int getWindowTimeFieldIndex(LogicalWindowAggregate aggregate, RelNode input) {
-		LogicalWindow logicalWindow = aggregate.getWindow();
+	private int getWindowTimeFieldIndex(LogicalWindow logicalWindow, RelNode input) {
 		ResolvedFieldReference timeAttribute = (ResolvedFieldReference) logicalWindow.timeAttribute();
 		return input.getRowType().getFieldNames().indexOf(timeAttribute.name());
 	}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
@@ -640,6 +640,10 @@ class WindowGroupedTableImpl(
         explicitAlias = true
       ))
   }
+
+  override def flatAggregate(tableAggregateFunction: String): FlatAggregateTable = ???
+
+  override def flatAggregate(tableAggregateFunction: Expression): FlatAggregateTable = ???
 }
 
 /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
@@ -641,9 +641,57 @@ class WindowGroupedTableImpl(
       ))
   }
 
-  override def flatAggregate(tableAggregateFunction: String): FlatAggregateTable = ???
+  override def flatAggregate(tableAggregateFunction: String): FlatAggregateTable = {
+    flatAggregate(ExpressionParser.parseExpression(tableAggregateFunction))
+  }
 
-  override def flatAggregate(tableAggregateFunction: Expression): FlatAggregateTable = ???
+  override def flatAggregate(tableAggregateFunction: Expression): FlatAggregateTable = {
+    new WindowFlatAggregateTableImpl(table, groupKeys, tableAggregateFunction, window)
+  }
+}
+
+/**
+  * The implementation of a [[WindowGroupedTable]] that has been windowed and grouped on
+  * [[GroupWindow]]s for table aggregate.
+  */
+class WindowFlatAggregateTableImpl(
+    private[flink] val table: Table,
+    private[flink] val groupKeys: Seq[Expression],
+    private[flink] val tableAggFunction: Expression,
+    private[flink] val window: GroupWindow)
+  extends FlatAggregateTable {
+
+  private val tableImpl = table.asInstanceOf[TableImpl]
+
+  override def select(fields: String): Table = {
+    select(ExpressionParser.parseExpressionList(fields): _*)
+  }
+
+  override def select(fields: Expression*): Table = {
+    val expressionsWithResolvedCalls = fields.map(_.accept(tableImpl.callResolver))
+    val extracted = extractAggregationsAndProperties(
+      expressionsWithResolvedCalls,
+      tableImpl.getUniqueAttributeSupplier)
+
+    if (extracted.getAggregations.nonEmpty) {
+      throw new ValidationException("Aggregate functions cannot be used in the select right " +
+        "after the flatAggregate.")
+    }
+
+    new TableImpl(tableImpl.tableEnv,
+      tableImpl.operationTreeBuilder.project(
+        extracted.getProjections,
+        tableImpl.operationTreeBuilder.windowTableAggregate(
+          groupKeys,
+          window,
+          extracted.getWindowProperties,
+          tableAggFunction,
+          tableImpl.operationTree
+        ),
+        // required for proper resolution of the time attribute in multi-windows
+        explicitAlias = true
+      ))
+  }
 }
 
 /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilder.scala
@@ -34,7 +34,8 @@ import org.apache.flink.table.expressions.{Alias, ExpressionBridge, PlannerExpre
 import org.apache.flink.table.operations.TableOperation
 import org.apache.flink.table.plan.TableOperationConverter
 import org.apache.flink.table.plan.logical.LogicalWindow
-import org.apache.flink.table.plan.logical.rel.{LogicalTableAggregate, LogicalWindowAggregate}
+import org.apache.flink.table.plan.logical.rel.{LogicalTableAggregate, LogicalWindowAggregate, LogicalWindowTableAggregate}
+import org.apache.flink.table.runtime.aggregate.AggregateUtil
 
 import scala.collection.JavaConverters._
 
@@ -64,7 +65,25 @@ class FlinkRelBuilder(
   override def getTypeFactory: FlinkTypeFactory =
     super.getTypeFactory.asInstanceOf[FlinkTypeFactory]
 
-  def aggregate(
+  /**
+    * Build non-window aggregate for either aggregate or table aggregate.
+    */
+  override def aggregate(groupKey: GroupKey, aggCalls: Iterable[AggCall]): RelBuilder = {
+    // build a relNode, the build() may also return a project
+    val relNode = super.aggregate(groupKey, aggCalls).build()
+
+    relNode match {
+      case logicalAggregate: LogicalAggregate
+        if AggregateUtil.isTableAggregate(logicalAggregate.getAggCallList) =>
+        push(LogicalTableAggregate.create(logicalAggregate))
+      case _ => push(relNode)
+    }
+  }
+
+  /**
+    * Build window aggregate for either aggregate or table aggregate.
+    */
+  def windowAggregate(
       window: LogicalWindow,
       groupKey: GroupKey,
       windowProperties: JList[PlannerExpression],
@@ -80,18 +99,11 @@ class FlinkRelBuilder(
     }
 
     // build logical window aggregate from it
-    push(LogicalWindowAggregate.create(window, namedProperties, aggregate))
-    this
-  }
-
-  def tableAggregate(
-    groupKey: GroupKey,
-    aggCalls: Iterable[AggCall]): RelBuilder = {
-
-    // build logical aggregate
-    val aggregate = super.aggregate(groupKey, aggCalls).build().asInstanceOf[LogicalAggregate]
-    // build logical table aggregate from it
-    push(LogicalTableAggregate.create(aggregate))
+    if (AggregateUtil.isTableAggregate(aggregate.getAggCallList)) {
+      push(LogicalWindowTableAggregate.create(window, namedProperties, aggregate))
+    } else {
+      push(LogicalWindowAggregate.create(window, namedProperties, aggregate))
+    }
   }
 
   def tableOperation(tableOperation: TableOperation): RelBuilder= {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
@@ -160,9 +160,8 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
         aggregate.getNamedProperties,
         convAggregate)
 
-    case tableAgg: LogicalTableAggregate =>
-      val correspondAggregate = LogicalTableAggregate.getCorrespondingAggregate(tableAgg)
-      val convAggregate = convertAggregate(correspondAggregate)
+    case tableAggregate: LogicalTableAggregate =>
+      val convAggregate = convertAggregate(tableAggregate.getCorrespondingAggregate)
       LogicalTableAggregate.create(convAggregate)
 
     case temporalTableJoin: LogicalTemporalTableJoin =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
@@ -30,7 +30,7 @@ import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.calcite.FlinkTypeFactory.{isRowtimeIndicatorType, _}
 import org.apache.flink.table.functions.sql.ProctimeSqlFunction
-import org.apache.flink.table.plan.logical.rel.{LogicalTableAggregate, LogicalTemporalTableJoin, LogicalWindowAggregate}
+import org.apache.flink.table.plan.logical.rel._
 import org.apache.flink.table.plan.schema.TimeIndicatorRelDataType
 import org.apache.flink.table.validate.BasicOperatorTable
 
@@ -158,6 +158,13 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
       LogicalWindowAggregate.create(
         aggregate.getWindow,
         aggregate.getNamedProperties,
+        convAggregate)
+
+    case windowTableAggregate: LogicalWindowTableAggregate =>
+      val convAggregate = convertAggregate(windowTableAggregate.getCorrespondingAggregate)
+      LogicalWindowTableAggregate.create(
+        windowTableAggregate.getWindow,
+        windowTableAggregate.getNamedProperties,
         convAggregate)
 
     case tableAggregate: LogicalTableAggregate =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/generated.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/generated.scala
@@ -62,7 +62,7 @@ case class GeneratedFunction[F <: Function, T <: Any](
   code: String)
 
 /**
-  * Describes a generated aggregate helper function
+  * Describes a generated aggregate or table aggregate helper function
   *
   * @param name class name of the generated Function.
   * @param code code of the generated Function.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/logical/rel/LogicalTableAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/logical/rel/LogicalTableAggregate.scala
@@ -21,12 +21,9 @@ package org.apache.flink.table.plan.logical.rel
 import java.util
 
 import org.apache.calcite.plan.{Convention, RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
-import org.apache.calcite.rel.logical.LogicalAggregate
-import org.apache.calcite.rel.{RelNode, SingleRel}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.util.ImmutableBitSet
-import org.apache.flink.table.plan.nodes.CommonTableAggregate
 
 /**
   * Logical Node for TableAggregate.
@@ -34,19 +31,14 @@ import org.apache.flink.table.plan.nodes.CommonTableAggregate
 class LogicalTableAggregate(
   cluster: RelOptCluster,
   traitSet: RelTraitSet,
-  child: RelNode,
-  val indicator: Boolean,
-  val groupSet: ImmutableBitSet,
-  val groupSets: util.List[ImmutableBitSet],
-  val aggCalls: util.List[AggregateCall])
-  extends SingleRel(cluster, traitSet, child)
-    with CommonTableAggregate {
+  input: RelNode,
+  indicator: Boolean,
+  groupSet: ImmutableBitSet,
+  groupSets: util.List[ImmutableBitSet],
+  aggCalls: util.List[AggregateCall])
+  extends TableAggregate(cluster, traitSet, input, indicator, groupSet, groupSets, aggCalls) {
 
-  override def deriveRowType(): RelDataType = {
-    deriveTableAggRowType(cluster, child, groupSet, aggCalls)
-  }
-
-  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): TableAggregate = {
     new LogicalTableAggregate(
       cluster,
       traitSet,
@@ -71,17 +63,5 @@ object LogicalTableAggregate {
       aggregate.getGroupSet,
       aggregate.getGroupSets,
       aggregate.getAggCallList)
-  }
-
-  def getCorrespondingAggregate(tableAgg: LogicalTableAggregate): LogicalAggregate = {
-    new LogicalAggregate(
-      tableAgg.getCluster,
-      tableAgg.getTraitSet,
-      tableAgg.getInput,
-      tableAgg.indicator,
-      tableAgg.groupSet,
-      tableAgg.groupSets,
-      tableAgg.aggCalls
-    )
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/logical/rel/LogicalWindowTableAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/logical/rel/LogicalWindowTableAggregate.scala
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.logical.rel
+
+import java.util
+
+import org.apache.calcite.plan.{Convention, RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
+import org.apache.calcite.rel.{RelNode, RelShuttle, RelWriter}
+import org.apache.calcite.util.ImmutableBitSet
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.logical.LogicalWindow
+
+class LogicalWindowTableAggregate(
+    window: LogicalWindow,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    indicatorFlag: Boolean,
+    groupSet: ImmutableBitSet,
+    groupSets: util.List[ImmutableBitSet],
+    aggCalls: util.List[AggregateCall])
+  extends TableAggregate(cluster, traitSet, input, indicatorFlag, groupSet, groupSets, aggCalls) {
+
+  def getWindow: LogicalWindow = window
+
+  def getNamedProperties: Seq[NamedWindowProperty] = namedProperties
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+    for (property <- namedProperties) {
+      pw.item(property.name, property.property)
+    }
+    pw
+  }
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): TableAggregate = {
+    new LogicalWindowTableAggregate(
+      window,
+      namedProperties,
+      cluster,
+      traitSet,
+      inputs.get(0),
+      indicatorFlag,
+      groupSet,
+      groupSets,
+      aggCalls)
+  }
+
+  override def accept(shuttle: RelShuttle): RelNode = shuttle.visit(this)
+
+  override def deriveRowType(): RelDataType = {
+    val aggregateRowType = super.deriveRowType()
+    val typeFactory = getCluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    val builder = typeFactory.builder
+    builder.addAll(aggregateRowType.getFieldList)
+    namedProperties.foreach { namedProp =>
+      builder.add(
+        namedProp.name,
+        typeFactory.createTypeFromTypeInfo(namedProp.property.resultType, isNullable = false)
+      )
+    }
+    builder.build()
+  }
+
+  override private[flink] def getCorrespondingAggregate: Aggregate = {
+    new LogicalWindowAggregate(
+      window,
+      namedProperties,
+      cluster,
+      traitSet,
+      getInput,
+      indicatorFlag,
+      groupSet,
+      groupSets,
+      aggCalls
+    )
+  }
+}
+
+object LogicalWindowTableAggregate {
+
+  def create(
+    window: LogicalWindow,
+    namedProperties: Seq[NamedWindowProperty],
+    aggregate: Aggregate)
+  : LogicalWindowTableAggregate = {
+
+    val cluster: RelOptCluster = aggregate.getCluster
+    val traitSet: RelTraitSet = cluster.traitSetOf(Convention.NONE)
+    new LogicalWindowTableAggregate(
+      window,
+      namedProperties,
+      cluster,
+      traitSet,
+      aggregate.getInput,
+      aggregate.indicator,
+      aggregate.getGroupSet,
+      aggregate.getGroupSets,
+      aggregate.getAggCallList)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/logical/rel/TableAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/logical/rel/TableAggregate.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.logical.rel
+
+import java.util
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
+import org.apache.calcite.rel.logical.LogicalAggregate
+import org.apache.calcite.rel.{RelNode, SingleRel}
+import org.apache.calcite.util.{ImmutableBitSet, Pair}
+import org.apache.flink.table.plan.nodes.CommonTableAggregate
+
+/**
+  * Relational operator that represents a table aggregate. A TableAggregate is similar to the
+  * [[org.apache.calcite.rel.core.Aggregate]] but may output 0 or more records for a group.
+  */
+abstract class TableAggregate(
+  cluster: RelOptCluster,
+  traitSet: RelTraitSet,
+  input: RelNode,
+  indicator: Boolean,
+  groupSet: ImmutableBitSet,
+  groupSets: util.List[ImmutableBitSet],
+  val aggCalls: util.List[AggregateCall])
+  extends SingleRel(cluster, traitSet, input)
+    with CommonTableAggregate {
+
+  private[flink] def getIndicator: Boolean = indicator
+
+  private[flink] def getGroupSet: ImmutableBitSet = groupSet
+
+  private[flink] def getGroupSets: util.List[ImmutableBitSet] = groupSets
+
+  private[flink] def getAggCallList: util.List[AggregateCall] = aggCalls
+
+  private[flink] def getNamedAggCalls: util.List[Pair[AggregateCall, String]] = {
+    super.getNamedAggCalls(aggCalls, deriveRowType(), indicator, groupSet)
+  }
+
+  override def deriveRowType(): RelDataType = {
+    deriveTableAggRowType(cluster, input, groupSet, aggCalls)
+  }
+
+  private[flink] def getCorrespondingAggregate: Aggregate = {
+    new LogicalAggregate(
+      cluster,
+      traitSet,
+      getInput,
+      indicator,
+      groupSet,
+      groupSets,
+      aggCalls
+    )
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
@@ -20,13 +20,8 @@ package org.apache.flink.table.plan.nodes.datastream
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rel.RelNode
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction
-import org.apache.flink.table.api.{StreamQueryConfig, TableConfig}
-import org.apache.flink.table.plan.rules.datastream.DataStreamRetractionRules
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.aggregate.AggregateUtil.CalcitePair
-import org.apache.flink.table.runtime.aggregate._
-import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.util.Logging
 
 /**
@@ -71,24 +66,6 @@ class DataStreamGroupAggregate(
       schema,
       inputSchema,
       groupings)
-  }
-
-  override def createKeyedProcessFunction[K](
-    tableConfig: TableConfig,
-    queryConfig: StreamQueryConfig): KeyedProcessFunction[K, CRow, CRow] = {
-
-    AggregateUtil.createGroupAggregateFunction[K](
-      tableConfig,
-      false,
-      inputSchema.typeInfo,
-      None,
-      namedAggregates,
-      inputSchema.relDataType,
-      inputSchema.fieldTypeInfos,
-      groupings,
-      queryConfig,
-      DataStreamRetractionRules.isAccRetract(this),
-      DataStreamRetractionRules.isAccRetract(getInput))
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupTableAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupTableAggregate.scala
@@ -20,15 +20,9 @@ package org.apache.flink.table.plan.nodes.datastream
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rel.RelNode
-import org.apache.flink.api.java.typeutils.RowTypeInfo
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction
-import org.apache.flink.table.api.{StreamQueryConfig, TableConfig}
 import org.apache.flink.table.plan.nodes.CommonTableAggregate
-import org.apache.flink.table.plan.rules.datastream.DataStreamRetractionRules
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.aggregate.AggregateUtil.CalcitePair
-import org.apache.flink.table.runtime.aggregate._
-import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.util.Logging
 
 /**
@@ -73,29 +67,6 @@ class DataStreamGroupTableAggregate(
       inputSchema,
       namedAggregates,
       groupings)
-  }
-
-  override def createKeyedProcessFunction[K](
-    tableConfig: TableConfig,
-    queryConfig: StreamQueryConfig): KeyedProcessFunction[K, CRow, CRow] = {
-
-    val tableAggOutputRowType = new RowTypeInfo(
-      schema.fieldTypeInfos.drop(groupings.length).toArray,
-      schema.fieldNames.drop(groupings.length).toArray)
-
-    AggregateUtil.createGroupTableAggregateFunction[K](
-      tableConfig,
-      false,
-      inputSchema.typeInfo,
-      None,
-      namedAggregates,
-      inputSchema.relDataType,
-      inputSchema.fieldTypeInfos,
-      tableAggOutputRowType,
-      groupings,
-      queryConfig,
-      DataStreamRetractionRules.isAccRetract(this),
-      DataStreamRetractionRules.isAccRetract(getInput))
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregateBase.scala
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.flink.streaming.api.datastream.{AllWindowedStream, DataStream, KeyedStream, WindowedStream}
+import org.apache.flink.streaming.api.windowing.assigners._
+import org.apache.flink.streaming.api.windowing.triggers.PurgingTrigger
+import org.apache.flink.streaming.api.windowing.windows.{Window => DataStreamWindow}
+import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvImpl, TableException}
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.expressions.PlannerExpressionUtils._
+import org.apache.flink.table.expressions.ResolvedFieldReference
+import org.apache.flink.table.plan.logical._
+import org.apache.flink.table.plan.nodes.CommonAggregate
+import org.apache.flink.table.plan.nodes.datastream.DataStreamGroupWindowAggregateBase._
+import org.apache.flink.table.plan.rules.datastream.DataStreamRetractionRules
+import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.runtime.aggregate.AggregateUtil._
+import org.apache.flink.table.runtime.aggregate._
+import org.apache.flink.table.runtime.triggers.StateCleaningCountTrigger
+import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
+import org.apache.flink.table.runtime.{CRowKeySelector, RowtimeProcessFunction}
+import org.apache.flink.table.typeutils.TypeCheckUtils.isTimeInterval
+import org.apache.flink.table.util.Logging
+import org.apache.flink.types.Row
+
+abstract class DataStreamGroupWindowAggregateBase(
+    window: LogicalWindow,
+    namedProperties: Seq[NamedWindowProperty],
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputNode: RelNode,
+    namedAggregates: Seq[CalcitePair[AggregateCall, String]],
+    schema: RowSchema,
+    inputSchema: RowSchema,
+    grouping: Array[Int],
+    aggType: String)
+  extends SingleRel(cluster, traitSet, inputNode)
+    with CommonAggregate
+    with DataStreamRel
+    with Logging {
+
+  override def deriveRowType(): RelDataType = schema.relDataType
+
+  override def needsUpdatesAsRetraction = true
+
+  override def consumesRetractions = true
+
+  def getGroupings: Array[Int] = grouping
+
+  def getWindowProperties: Seq[NamedWindowProperty] = namedProperties
+
+  override def toString: String = {
+    s"$aggType(${
+      if (!grouping.isEmpty) {
+        s"groupBy: (${groupingToString(inputSchema.relDataType, grouping)}), "
+      } else {
+        ""
+      }
+    }window: ($window), " +
+      s"select: (${
+        aggregationToString(
+          inputSchema.relDataType,
+          grouping,
+          getRowType,
+          namedAggregates,
+          namedProperties)
+      }))"
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+      .itemIf("groupBy", groupingToString(inputSchema.relDataType, grouping), grouping.nonEmpty)
+      .item("window", window)
+      .item(
+        "select", aggregationToString(
+          inputSchema.relDataType,
+          grouping,
+          schema.relDataType,
+          namedAggregates,
+          namedProperties))
+  }
+
+  override def translateToPlan(
+      tableEnv: StreamTableEnvImpl,
+      queryConfig: StreamQueryConfig): DataStream[CRow] = {
+
+    val inputDS = input.asInstanceOf[DataStreamRel].translateToPlan(tableEnv, queryConfig)
+
+    val inputIsAccRetract = DataStreamRetractionRules.isAccRetract(input)
+
+    if (inputIsAccRetract) {
+      throw new TableException(
+        "Retraction on windowed GroupBy aggregation is not supported yet. " +
+          "Note: Windowed GroupBy aggregation should not follow a " +
+          "non-windowed GroupBy aggregation.")
+    }
+
+    val isCountWindow = window match {
+      case TumblingGroupWindow(_, _, size) if isRowCountLiteral(size) => true
+      case SlidingGroupWindow(_, _, size, _) if isRowCountLiteral(size) => true
+      case _ => false
+    }
+
+    if (isCountWindow && grouping.length > 0 && queryConfig.getMinIdleStateRetentionTime < 0) {
+      LOG.warn(
+        "No state retention interval configured for a query which accumulates state. " +
+        "Please provide a query configuration with valid retention interval to prevent excessive " +
+        "state size. You may specify a retention time of 0 to not clean up the state.")
+    }
+
+    val timestampedInput = if (isRowtimeAttribute(window.timeAttribute)) {
+      // copy the window rowtime attribute into the StreamRecord timestamp field
+      val timeAttribute = window.timeAttribute.asInstanceOf[ResolvedFieldReference].name
+      val timeIdx = inputSchema.fieldNames.indexOf(timeAttribute)
+      if (timeIdx < 0) {
+        throw new TableException("Time attribute could not be found. This is a bug.")
+      }
+
+      inputDS
+        .process(
+          new RowtimeProcessFunction(timeIdx, CRowTypeInfo(inputSchema.typeInfo)))
+        .setParallelism(inputDS.getParallelism)
+        .name(s"time attribute: ($timeAttribute)")
+    } else {
+      inputDS
+    }
+
+    val outRowType = CRowTypeInfo(schema.typeInfo)
+
+    val aggString = aggregationToString(
+      inputSchema.relDataType,
+      grouping,
+      schema.relDataType,
+      namedAggregates,
+      namedProperties)
+
+    val keyedAggOpName = s"groupBy: (${groupingToString(inputSchema.relDataType, grouping)}), " +
+      s"window: ($window), " +
+      s"select: ($aggString)"
+    val nonKeyedAggOpName = s"window: ($window), select: ($aggString)"
+
+    val needMerge = window match {
+      case SessionGroupWindow(_, _, _) => true
+      case _ => false
+    }
+    // grouped / keyed aggregation
+    if (grouping.length > 0) {
+      val windowFunction = AggregateUtil.createAggregationGroupWindowFunction(
+        window,
+        grouping.length,
+        namedAggregates.size,
+        schema.arity,
+        namedProperties)
+
+      val keySelector = new CRowKeySelector(grouping, inputSchema.projectedTypeInfo(grouping))
+
+      val keyedStream = timestampedInput.keyBy(keySelector)
+      val windowedStream =
+        createKeyedWindowedStream(queryConfig, window, keyedStream)
+          .asInstanceOf[WindowedStream[CRow, Row, DataStreamWindow]]
+
+      val (aggFunction, accumulatorRowType) =
+        AggregateUtil.createDataStreamAggregateFunction(
+          tableEnv.getConfig,
+          false,
+          inputSchema.typeInfo,
+          None,
+          namedAggregates,
+          inputSchema.relDataType,
+          inputSchema.fieldTypeInfos,
+          schema.relDataType,
+          grouping,
+          needMerge,
+          tableEnv.getConfig)
+
+      windowedStream
+        .aggregate(aggFunction, windowFunction, accumulatorRowType, outRowType)
+        .name(keyedAggOpName)
+    }
+    // global / non-keyed aggregation
+    else {
+      val windowFunction = AggregateUtil.createAggregationAllWindowFunction(
+        window,
+        schema.arity,
+        namedProperties)
+
+      val windowedStream =
+        createNonKeyedWindowedStream(queryConfig, window, timestampedInput)
+          .asInstanceOf[AllWindowedStream[CRow, DataStreamWindow]]
+
+      val (aggFunction, accumulatorRowType) =
+        AggregateUtil.createDataStreamAggregateFunction(
+          tableEnv.getConfig,
+          false,
+          inputSchema.typeInfo,
+          None,
+          namedAggregates,
+          inputSchema.relDataType,
+          inputSchema.fieldTypeInfos,
+          schema.relDataType,
+          Array[Int](),
+          needMerge,
+          tableEnv.getConfig)
+
+      windowedStream
+        .aggregate(aggFunction, windowFunction, accumulatorRowType, outRowType)
+        .name(nonKeyedAggOpName)
+    }
+  }
+}
+
+
+object DataStreamGroupWindowAggregateBase {
+
+  private def createKeyedWindowedStream(
+    queryConfig: StreamQueryConfig,
+    groupWindow: LogicalWindow,
+    stream: KeyedStream[CRow, Row]):
+  WindowedStream[CRow, Row, _ <: DataStreamWindow] = groupWindow match {
+
+    case TumblingGroupWindow(_, timeField, size)
+      if isProctimeAttribute(timeField) && isTimeIntervalLiteral(size)=>
+      stream.window(TumblingProcessingTimeWindows.of(toTime(size)))
+
+    case TumblingGroupWindow(_, timeField, size)
+      if isProctimeAttribute(timeField) && isRowCountLiteral(size)=>
+      stream.countWindow(toLong(size))
+        .trigger(PurgingTrigger.of(StateCleaningCountTrigger.of(queryConfig, toLong(size))));
+
+    case TumblingGroupWindow(_, timeField, size)
+      if isRowtimeAttribute(timeField) && isTimeIntervalLiteral(size) =>
+      stream.window(TumblingEventTimeWindows.of(toTime(size)))
+
+    case TumblingGroupWindow(_, _, size) =>
+      // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
+      // before applying the  windowing logic. Otherwise, this would be the same as a
+      // ProcessingTimeTumblingGroupWindow
+      throw new UnsupportedOperationException(
+        "Event-time grouping windows on row intervals are currently not supported.")
+
+    case SlidingGroupWindow(_, timeField, size, slide)
+      if isProctimeAttribute(timeField) && isTimeIntervalLiteral(slide) =>
+      stream.window(SlidingProcessingTimeWindows.of(toTime(size), toTime(slide)))
+
+    case SlidingGroupWindow(_, timeField, size, slide)
+      if isProctimeAttribute(timeField) && isRowCountLiteral(size) =>
+      stream.countWindow(toLong(size), toLong(slide))
+        .trigger(StateCleaningCountTrigger.of(queryConfig, toLong(slide)));
+
+    case SlidingGroupWindow(_, timeField, size, slide)
+      if isRowtimeAttribute(timeField) && isTimeIntervalLiteral(size)=>
+      stream.window(SlidingEventTimeWindows.of(toTime(size), toTime(slide)))
+
+    case SlidingGroupWindow(_, _, size, slide) =>
+      // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
+      // before applying the  windowing logic. Otherwise, this would be the same as a
+      // ProcessingTimeTumblingGroupWindow
+      throw new UnsupportedOperationException(
+        "Event-time grouping windows on row intervals are currently not supported.")
+
+    case SessionGroupWindow(_, timeField, gap)
+      if isProctimeAttribute(timeField) =>
+      stream.window(ProcessingTimeSessionWindows.withGap(toTime(gap)))
+
+    case SessionGroupWindow(_, timeField, gap)
+      if isRowtimeAttribute(timeField) =>
+      stream.window(EventTimeSessionWindows.withGap(toTime(gap)))
+  }
+
+  private def createNonKeyedWindowedStream(
+    queryConfig: StreamQueryConfig,
+    groupWindow: LogicalWindow,
+    stream: DataStream[CRow]):
+  AllWindowedStream[CRow, _ <: DataStreamWindow] = groupWindow match {
+
+    case TumblingGroupWindow(_, timeField, size)
+      if isProctimeAttribute(timeField) && isTimeIntervalLiteral(size) =>
+      stream.windowAll(TumblingProcessingTimeWindows.of(toTime(size)))
+
+    case TumblingGroupWindow(_, timeField, size)
+      if isProctimeAttribute(timeField) && isRowCountLiteral(size)=>
+      stream.countWindowAll(toLong(size))
+        .trigger(PurgingTrigger.of(StateCleaningCountTrigger.of(queryConfig, toLong(size))));
+
+    case TumblingGroupWindow(_, _, size) if isTimeInterval(size.resultType) =>
+      stream.windowAll(TumblingEventTimeWindows.of(toTime(size)))
+
+    case TumblingGroupWindow(_, _, size) =>
+      // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
+      // before applying the  windowing logic. Otherwise, this would be the same as a
+      // ProcessingTimeTumblingGroupWindow
+      throw new UnsupportedOperationException(
+        "Event-time grouping windows on row intervals are currently not supported.")
+
+    case SlidingGroupWindow(_, timeField, size, slide)
+      if isProctimeAttribute(timeField) && isTimeIntervalLiteral(size) =>
+      stream.windowAll(SlidingProcessingTimeWindows.of(toTime(size), toTime(slide)))
+
+    case SlidingGroupWindow(_, timeField, size, slide)
+      if isProctimeAttribute(timeField) && isRowCountLiteral(size)=>
+      stream.countWindowAll(toLong(size), toLong(slide))
+        .trigger(StateCleaningCountTrigger.of(queryConfig, toLong(slide)));
+
+    case SlidingGroupWindow(_, timeField, size, slide)
+      if isRowtimeAttribute(timeField) && isTimeIntervalLiteral(size)=>
+      stream.windowAll(SlidingEventTimeWindows.of(toTime(size), toTime(slide)))
+
+    case SlidingGroupWindow(_, _, size, slide) =>
+      // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
+      // before applying the  windowing logic. Otherwise, this would be the same as a
+      // ProcessingTimeTumblingGroupWindow
+      throw new UnsupportedOperationException(
+        "Event-time grouping windows on row intervals are currently not supported.")
+
+    case SessionGroupWindow(_, timeField, gap)
+      if isProctimeAttribute(timeField) && isTimeIntervalLiteral(gap) =>
+      stream.windowAll(ProcessingTimeSessionWindows.withGap(toTime(gap)))
+
+    case SessionGroupWindow(_, timeField, gap)
+      if isRowtimeAttribute(timeField) && isTimeIntervalLiteral(gap) =>
+      stream.windowAll(EventTimeSessionWindows.withGap(toTime(gap)))
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregateBase.scala
@@ -44,6 +44,9 @@ import org.apache.flink.table.typeutils.TypeCheckUtils.isTimeInterval
 import org.apache.flink.table.util.Logging
 import org.apache.flink.types.Row
 
+/**
+  * Base RelNode for data stream group window aggregate and table aggregate.
+  */
 abstract class DataStreamGroupWindowAggregateBase(
     window: LogicalWindow,
     namedProperties: Seq[NamedWindowProperty],
@@ -171,6 +174,7 @@ abstract class DataStreamGroupWindowAggregateBase(
         grouping.length,
         namedAggregates.size,
         schema.arity,
+        namedAggregates,
         namedProperties)
 
       val keySelector = new CRowKeySelector(grouping, inputSchema.projectedTypeInfo(grouping))
@@ -181,12 +185,13 @@ abstract class DataStreamGroupWindowAggregateBase(
           .asInstanceOf[WindowedStream[CRow, Row, DataStreamWindow]]
 
       val (aggFunction, accumulatorRowType) =
-        AggregateUtil.createDataStreamAggregateFunction(
+        AggregateUtil.createDataStreamGroupWindowAggregateFunction(
           tableEnv.getConfig,
           false,
           inputSchema.typeInfo,
           None,
           namedAggregates,
+          namedProperties,
           inputSchema.relDataType,
           inputSchema.fieldTypeInfos,
           schema.relDataType,
@@ -203,6 +208,7 @@ abstract class DataStreamGroupWindowAggregateBase(
       val windowFunction = AggregateUtil.createAggregationAllWindowFunction(
         window,
         schema.arity,
+        namedAggregates,
         namedProperties)
 
       val windowedStream =
@@ -210,12 +216,13 @@ abstract class DataStreamGroupWindowAggregateBase(
           .asInstanceOf[AllWindowedStream[CRow, DataStreamWindow]]
 
       val (aggFunction, accumulatorRowType) =
-        AggregateUtil.createDataStreamAggregateFunction(
+        AggregateUtil.createDataStreamGroupWindowAggregateFunction(
           tableEnv.getConfig,
           false,
           inputSchema.typeInfo,
           None,
           namedAggregates,
+          namedProperties,
           inputSchema.relDataType,
           inputSchema.fieldTypeInfos,
           schema.relDataType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowTableAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowTableAggregate.scala
@@ -19,16 +19,16 @@
 package org.apache.flink.table.plan.nodes.datastream
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core.AggregateCall
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.plan.logical._
-import org.apache.flink.table.plan.nodes.CommonAggregate
+import org.apache.flink.table.plan.nodes.CommonTableAggregate
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.aggregate.AggregateUtil._
 import org.apache.flink.table.util.Logging
 
-class DataStreamGroupWindowAggregate(
+class DataStreamGroupWindowTableAggregate(
     window: LogicalWindow,
     namedProperties: Seq[NamedWindowProperty],
     cluster: RelOptCluster,
@@ -48,13 +48,13 @@ class DataStreamGroupWindowAggregate(
     schema,
     inputSchema,
     grouping,
-    "Aggregate")
-    with CommonAggregate
+    "TableAggregate")
+    with CommonTableAggregate
     with DataStreamRel
     with Logging {
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
-    new DataStreamGroupWindowAggregate(
+    new DataStreamGroupWindowTableAggregate(
       window,
       namedProperties,
       cluster,
@@ -66,4 +66,3 @@ class DataStreamGroupWindowAggregate(
       grouping)
   }
 }
-

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableAggregate.scala
@@ -22,25 +22,23 @@ import java.util
 import java.util.{List => JList}
 
 import org.apache.calcite.plan._
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.{RelNode, SingleRel}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.util.ImmutableBitSet
-import org.apache.flink.table.plan.logical.rel.LogicalTableAggregate
-import org.apache.flink.table.plan.nodes.{CommonTableAggregate, FlinkConventions}
+import org.apache.flink.table.plan.logical.rel.{LogicalTableAggregate, TableAggregate}
+import org.apache.flink.table.plan.nodes.FlinkConventions
 
 class FlinkLogicalTableAggregate(
   cluster: RelOptCluster,
   traitSet: RelTraitSet,
-  child: RelNode,
-  val indicator: Boolean,
-  val groupSet: ImmutableBitSet,
+  input: RelNode,
+  indicator: Boolean,
+  groupSet: ImmutableBitSet,
   groupSets: util.List[ImmutableBitSet],
-  val aggCalls: util.List[AggregateCall])
-  extends SingleRel(cluster, traitSet, child)
-    with FlinkLogicalRel
-    with CommonTableAggregate {
+  aggCalls: util.List[AggregateCall])
+  extends TableAggregate(cluster, traitSet, input, indicator, groupSet, groupSets, aggCalls)
+    with FlinkLogicalRel {
 
   override def copy(traitSet: RelTraitSet, inputs: JList[RelNode]): RelNode = {
     new FlinkLogicalTableAggregate(
@@ -52,10 +50,6 @@ class FlinkLogicalTableAggregate(
       groupSets,
       aggCalls
     )
-  }
-
-  override def deriveRowType(): RelDataType = {
-    deriveTableAggRowType(cluster, child, groupSet, aggCalls)
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableAggregate.scala
@@ -75,9 +75,9 @@ private class FlinkLogicalTableAggregateConverter
       rel.getCluster,
       traitSet,
       newInput,
-      agg.indicator,
-      agg.groupSet,
-      agg.groupSets,
+      agg.getIndicator,
+      agg.getGroupSet,
+      agg.getGroupSets,
       agg.aggCalls)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -141,7 +141,8 @@ object FlinkRuleSets {
     FlinkLogicalTableFunctionScan.CONVERTER,
     FlinkLogicalNativeTableScan.CONVERTER,
     FlinkLogicalMatch.CONVERTER,
-    FlinkLogicalTableAggregate.CONVERTER
+    FlinkLogicalTableAggregate.CONVERTER,
+    FlinkLogicalWindowTableAggregate.CONVERTER
   )
 
   /**
@@ -233,7 +234,8 @@ object FlinkRuleSets {
     DataStreamTemporalTableJoinRule.INSTANCE,
     StreamTableSourceScanRule.INSTANCE,
     DataStreamMatchRule.INSTANCE,
-    DataStreamTableAggregateRule.INSTANCE
+    DataStreamTableAggregateRule.INSTANCE,
+    DataStreamGroupWindowTableAggregateRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/TableAggregateCollector.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/TableAggregateCollector.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime
+
+import org.apache.flink.types.Row
+
+/**
+  * The collector is used to concat group keys and table aggregate function output.
+  */
+class TableAggregateCollector(val groupKeySize: Int) extends CRowWrappingCollector {
+
+  // reused output row
+  var resultRow: Row = _
+
+  def setResultRow(row: Row): Unit = {
+    resultRow = row
+  }
+
+  def getResultRow: Row = {
+    resultRow
+  }
+
+  override def collect(record: Row): Unit = {
+    var i = 0
+    val offset = groupKeySize
+    while (i < record.getArity) {
+      resultRow.setField(i + offset, record.getField(i))
+      i += 1
+    }
+    super.collect(resultRow)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateAggFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateAggFunction.scala
@@ -25,15 +25,19 @@ import org.apache.flink.table.util.Logging
 import org.apache.flink.types.Row
 
 /**
-  * Aggregate Function used for the aggregate operator in
-  * [[org.apache.flink.streaming.api.datastream.WindowedStream]]
+  * Aggregate Function used for the aggregate or table aggregate operator in
+  * [[org.apache.flink.streaming.api.datastream.WindowedStream]].
   *
-  * @param genAggregations Generated aggregate helper function
+  * @param genAggregations Generated aggregate or table aggregate helper function
+  * @param isTableAggregate Whether it is table aggregate.
   */
-class AggregateAggFunction(genAggregations: GeneratedAggregationsFunction)
-  extends AggregateFunction[CRow, Row, Row] with Compiler[GeneratedAggregations] with Logging {
+class AggregateAggFunction[F <: AggregationsFunction](
+    genAggregations: GeneratedAggregationsFunction,
+    isTableAggregate: Boolean)
+  extends AggregateFunction[CRow, Row, Row]
+    with Compiler[F] with Logging {
 
-  private var function: GeneratedAggregations = _
+  private var function: F = _
 
   override def createAccumulator(): Row = {
     if (function == null) {
@@ -54,9 +58,15 @@ class AggregateAggFunction(genAggregations: GeneratedAggregationsFunction)
     if (function == null) {
       initFunction()
     }
-    val output = function.createOutputRow()
-    function.setAggregationResults(accumulatorRow, output)
-    output
+
+    if (isTableAggregate) {
+      // pass both accumulator and function to the window function and emit value in it.
+      Row.of(accumulatorRow, function)
+    } else {
+      val output = function.createOutputRow()
+      function.asInstanceOf[GeneratedAggregations].setAggregationResults(accumulatorRow, output)
+      output
+    }
   }
 
   override def merge(aAccumulatorRow: Row, bAccumulatorRow: Row): Row = {
@@ -68,7 +78,7 @@ class AggregateAggFunction(genAggregations: GeneratedAggregationsFunction)
 
   def initFunction(): Unit = {
     LOG.debug(s"Compiling AggregateHelper: $genAggregations.name \n\n " +
-                s"Code:\n$genAggregations.code")
+      s"Code:\n$genAggregations.code")
     val clazz = compile(
       Thread.currentThread().getContextClassLoader,
       genAggregations.name,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateAllTimeWindowFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateAllTimeWindowFunction.scala
@@ -27,20 +27,23 @@ import org.apache.flink.util.Collector
 
 /**
   *
-  * Computes the final aggregate value from incrementally computed aggregates.
+  * Computes the final (table)aggregate value from incrementally computed aggregates.
   *
   * @param windowStartOffset the offset of the window start property
   * @param windowEndOffset   the offset of the window end property
   * @param windowRowtimeOffset the offset of the window rowtime property
   * @param finalRowArity  The arity of the final output row.
+  * @param isTableAggregate Whether it is table aggregate.
   */
 class IncrementalAggregateAllTimeWindowFunction(
     private val windowStartOffset: Option[Int],
     private val windowEndOffset: Option[Int],
     private val windowRowtimeOffset: Option[Int],
-    private val finalRowArity: Int)
+    private val finalRowArity: Int,
+    private val isTableAggregate: Boolean)
   extends IncrementalAggregateAllWindowFunction[TimeWindow](
-    finalRowArity) {
+    finalRowArity,
+    isTableAggregate) {
 
   private var collector: DataStreamTimeWindowPropertyCollector = _
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateTimeWindowFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateTimeWindowFunction.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.util.Collector
 
 /**
-  * Computes the final aggregate value from incrementally computed aggregates.
+  * Computes the final (table)aggregate value from incrementally computed aggregates.
   *
   * @param numGroupingKey the number of grouping keys
   * @param numAggregates the number of aggregates
@@ -34,6 +34,7 @@ import org.apache.flink.util.Collector
   * @param windowEndOffset   the offset of the window end property
   * @param windowRowtimeOffset the offset of the window rowtime property
   * @param finalRowArity  The arity of the final output row.
+  * @param isTableAggregate Whether it is table aggregate.
   */
 class IncrementalAggregateTimeWindowFunction(
     private val numGroupingKey: Int,
@@ -41,11 +42,13 @@ class IncrementalAggregateTimeWindowFunction(
     private val windowStartOffset: Option[Int],
     private val windowEndOffset: Option[Int],
     private val windowRowtimeOffset: Option[Int],
-    private val finalRowArity: Int)
+    private val finalRowArity: Int,
+    private val isTableAggregate: Boolean)
   extends IncrementalAggregateWindowFunction[TimeWindow](
     numGroupingKey,
     numAggregates,
-    finalRowArity) {
+    finalRowArity,
+    isTableAggregate) {
 
   private var collector: DataStreamTimeWindowPropertyCollector = _
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/GroupWindowTableAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/GroupWindowTableAggregateTest.scala
@@ -1,0 +1,520 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.stream.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.{Session, Slide, Tumble}
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.{EmptyTableAggFunc, TableTestBase}
+import org.apache.flink.table.utils.TableTestUtil._
+import org.junit.Test
+
+class GroupWindowTableAggregateTest extends TableTestBase {
+
+  val util = streamTestUtil()
+  val table = util.addTable[(Long, Int, Long, Long)]('a, 'b, 'c, 'd.rowtime, 'e.proctime)
+  val emptyFunc = new EmptyTableAggFunc
+
+  @Test
+  def testMultiWindow(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 50.milli on 'e as 'w1)
+      .groupBy('w1, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('w1.proctime as 'proctime, 'c, 'f0, 'f1 + 1 as 'f1)
+      .window(Slide over 20.milli every 10.milli on 'proctime as 'w2)
+      .groupBy('w2)
+      .flatAggregate(emptyFunc('f0))
+      .select('w2.start, 'f1)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          unaryNode(
+            "DataStreamGroupWindowTableAggregate",
+            unaryNode(
+              "DataStreamCalc",
+              streamTableNode(0),
+              term("select", "a", "b", "c", "e")
+            ),
+            term("groupBy", "c"),
+            term("window", "TumblingGroupWindow('w1, 'e, 50.millis)"),
+            term("select", "c", "EmptyTableAggFunc(a, b) AS (f0, f1)", "proctime('w1) AS TMP_0")
+          ),
+          term("select", "TMP_0 AS proctime", "f0")
+        ),
+        term("window", "SlidingGroupWindow('w2, 'proctime, 20.millis, 10.millis)"),
+        term("select", "EmptyTableAggFunc(f0) AS (f0, f1)", "start('w2) AS TMP_1")
+      ),
+      term("select", "TMP_1", "f1")
+    )
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testProcessingTimeTumblingGroupWindowOverTime(): Unit = {
+
+    val windowedTable = table
+      .window(Tumble over 50.milli on 'e as 'w1)
+      .groupBy('w1, 'b % 5 as 'bb)
+      .flatAggregate(emptyFunc('a, 'b) as ('x, 'y))
+      .select('w1.proctime as 'proctime, 'bb, 'x + 1, 'y)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupWindowTableAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "b", "e", "MOD(b, 5) AS bb")
+          ),
+          term("groupBy", "bb"),
+          term("window", "TumblingGroupWindow('w1, 'e, 50.millis)"),
+          term("select", "bb", "EmptyTableAggFunc(a, b) AS (f0, f1)", "proctime('w1) AS TMP_0")
+        ),
+        term("select", "PROCTIME(TMP_0) AS proctime", "bb", "+(f0, 1) AS _c2", "f1 AS y")
+      )
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testProcessingTimeTumblingGroupWindowOverCount(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 2.rows on 'e as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('c, 'f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "c", "e")
+        ),
+        term("groupBy", "c"),
+        term("window", "TumblingGroupWindow('w, 'e, 2.rows)"),
+        term("select",  "c", "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testEventTimeTumblingGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 5.milli on 'd as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('c, 'f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "c", "d")
+        ),
+        term("groupBy", "c"),
+        term("window", "TumblingGroupWindow('w, 'd, 5.millis)"),
+        term("select",  "c", "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testProcessingTimeSlidingGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Slide over 50.milli every 50.milli on 'e as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('w.proctime as 'proctime, 'c, 'f0, 'f1 + 1)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupWindowTableAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "b", "c", "e")
+          ),
+          term("groupBy", "c"),
+          term("window", "SlidingGroupWindow('w, 'e, 50.millis, 50.millis)"),
+          term("select",  "c", "EmptyTableAggFunc(a, b) AS (f0, f1)", "proctime('w) AS TMP_0")
+        ),
+        term("select", "PROCTIME(TMP_0) AS proctime", "c", "f0", "+(f1, 1) AS _c3")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testProcessingTimeSlidingGroupWindowOverCount(): Unit = {
+    val windowedTable = table
+      .window(Slide over 2.rows every 1.rows on 'e as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('c, 'f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "c", "e")
+        ),
+        term("groupBy", "c"),
+        term("window", "SlidingGroupWindow('w, 'e, 2.rows, 1.rows)"),
+        term("select",  "c", "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testEventTimeSlidingGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Slide over 8.milli every 10.milli on 'd as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('c, 'f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "c", "d")
+        ),
+        term("groupBy", "c"),
+        term("window", "SlidingGroupWindow('w, 'd, 8.millis, 10.millis)"),
+        term("select",  "c", "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testEventTimeSessionGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Session withGap 7.milli on 'd as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('c, 'f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "c", "d")
+        ),
+        term("groupBy", "c"),
+        term("window", "SessionGroupWindow('w, 'd, 7.millis)"),
+        term("select",  "c", "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testAllProcessingTimeTumblingGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 50.milli on 'e as 'w)
+      .groupBy('w)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "e")
+        ),
+        term("window", "TumblingGroupWindow('w, 'e, 50.millis)"),
+        term("select",  "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testAllProcessingTimeTumblingGroupWindowOverCount(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 2.rows on 'e as 'w)
+      .groupBy('w)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "e")
+        ),
+        term("window", "TumblingGroupWindow('w, 'e, 2.rows)"),
+        term("select",  "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testAllEventTimeTumblingGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 5.milli on 'd as 'w)
+      .groupBy('w)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "d")
+        ),
+        term("window", "TumblingGroupWindow('w, 'd, 5.millis)"),
+        term("select",  "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testAllProcessingTimeSlidingGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Slide over 50.milli every 50.milli on 'e as 'w)
+      .groupBy('w)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "e")
+        ),
+        term("window", "SlidingGroupWindow('w, 'e, 50.millis, 50.millis)"),
+        term("select",  "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testAllProcessingTimeSlidingGroupWindowOverCount(): Unit = {
+    val windowedTable = table
+      .window(Slide over 2.rows every 1.rows on 'e as 'w)
+      .groupBy('w)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "e")
+        ),
+        term("window", "SlidingGroupWindow('w, 'e, 2.rows, 1.rows)"),
+        term("select",  "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testAllEventTimeSlidingGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Slide over 8.milli every 10.milli on 'd as 'w)
+      .groupBy('w)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "d")
+        ),
+        term("window", "SlidingGroupWindow('w, 'd, 8.millis, 10.millis)"),
+        term("select",  "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testAllEventTimeSlidingGroupWindowOverCount(): Unit = {
+    val windowedTable = table
+      .window(Slide over 8.milli every 10.milli on 'd as 'w)
+      .groupBy('w)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "d")
+        ),
+        term("window", "SlidingGroupWindow('w, 'd, 8.millis, 10.millis)"),
+        term("select",  "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testAllEventTimeSessionGroupWindowOverTime(): Unit = {
+    val windowedTable = table
+      .window(Session withGap 7.milli on 'd as 'w)
+      .groupBy('w)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupWindowTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "d")
+        ),
+        term("window", "SessionGroupWindow('w, 'd, 7.millis)"),
+        term("select",  "EmptyTableAggFunc(a, b) AS (f0, f1)")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testTumbleWindowStartEnd(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 5.milli on 'd as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1 + 1, 'w.start, 'w.end)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupWindowTableAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "b", "c", "d")
+          ),
+          term("groupBy", "c"),
+          term("window", "TumblingGroupWindow('w, 'd, 5.millis)"),
+          term("select",
+            "c", "EmptyTableAggFunc(a, b) AS (f0, f1)", "start('w) AS TMP_0", "end('w) AS TMP_1")
+        ),
+        term("select", "f0", "+(f1, 1) AS _c1", "TMP_0", "TMP_1")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testSlideWindowStartEnd(): Unit = {
+    val windowedTable = table
+      .window(Slide over 10.milli every 5.milli on 'd as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1 + 1, 'w.start, 'w.end)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupWindowTableAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "b", "c", "d")
+          ),
+          term("groupBy", "c"),
+          term("window", "SlidingGroupWindow('w, 'd, 10.millis, 5.millis)"),
+          term("select",
+            "c", "EmptyTableAggFunc(a, b) AS (f0, f1)", "start('w) AS TMP_0", "end('w) AS TMP_1")
+        ),
+        term("select", "f0", "+(f1, 1) AS _c1", "TMP_0", "TMP_1")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+
+  @Test
+  def testSessionWindowStartWithTwoEnd(): Unit = {
+    val windowedTable = table
+      .window(Session withGap 3.milli on 'd as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('w.end as 'we1, 'f0, 'f1 + 1, 'w.start, 'w.end)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupWindowTableAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "b", "c", "d")
+          ),
+          term("groupBy", "c"),
+          term("window", "SessionGroupWindow('w, 'd, 3.millis)"),
+          term("select",
+            "c", "EmptyTableAggFunc(a, b) AS (f0, f1)", "end('w) AS TMP_0", "start('w) AS TMP_1")
+        ),
+        term("select", "TMP_0 AS we1", "f0", "+(f1, 1) AS _c2", "TMP_1", "TMP_0")
+      )
+
+    util.verifyTable(windowedTable, expected)
+  }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/GroupWindowTableAggregateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/GroupWindowTableAggregateStringExpressionTest.scala
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.stream.table.stringexpr
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{Session, Slide, Tumble}
+import org.apache.flink.table.utils.{TableTestBase, Top3}
+import org.junit.Test
+
+class GroupWindowTableAggregateStringExpressionTest extends TableTestBase {
+
+  @Test
+  def testRowTimeSlide(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]('int, 'long, 'string, 'rowtime.rowtime)
+
+    val top3 = new Top3
+    util.tableEnv.registerFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Slide over 4.hours every 2.hours on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'string,
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Slide.over("4.hours").every("2.hours").on("rowtime").as("w"))
+      .groupBy("w, string")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "string, " +
+        "x, " +
+        "y + 1, " +
+        "start(w)," +
+        "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testRowTimeTumble(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, Long, String)]('int, 'long, 'rowtime.rowtime, 'string)
+
+    val top3 = new Top3
+    util.tableEnv.registerFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Tumble over 4.hours on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'string,
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Tumble.over("4.hours").on("rowtime").as("w"))
+      .groupBy("w, string")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "string, " +
+          "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testRowTimeSession(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]('int, 'long, 'string, 'rowtime.rowtime)
+
+    val top3 = new Top3
+    util.tableEnv.registerFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Session withGap 4.hours on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'string,
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Session.withGap("4.hours").on("rowtime").as("w"))
+      .groupBy("w, string")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "string, " +
+          "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+  @Test
+  def testProcTimeSlide(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]('int, 'long, 'string, 'proctime.proctime)
+
+    val top3 = new Top3
+    util.tableEnv.registerFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Slide over 4.hours every 2.hours on 'proctime as 'w)
+      .groupBy('w)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Slide.over("4.hours").every("2.hours").on("proctime").as("w"))
+      .groupBy("w")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+          "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testProcTimeTumble(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]('int, 'long,'string, 'proctime.proctime)
+
+    val top3 = new Top3
+    util.tableEnv.registerFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Tumble over 4.hours on 'proctime as 'w)
+      .groupBy('w)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Tumble.over("4.hours").on("proctime").as("w"))
+      .groupBy("w")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testProcTimeSession(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]('int, 'long, 'string, 'proctime.proctime)
+
+    val top3 = new Top3
+    util.tableEnv.registerFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Session withGap 4.hours on 'proctime as 'w)
+      .groupBy('w)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Session.withGap("4.hours").on("proctime").as("w"))
+      .groupBy("w")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/GroupWindowTableAggregateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/GroupWindowTableAggregateValidationTest.scala
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.api.stream.table.validation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.{Session, Slide, Tumble, ValidationException}
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.WeightedAvgWithMerge
+import org.apache.flink.table.utils.{TableTestBase, Top3}
+import org.junit.Test
+
+class GroupWindowTableAggregateValidationTest extends TableTestBase {
+
+  val top3 = new Top3
+  val weightedAvg = new WeightedAvgWithMerge
+
+  val util = streamTestUtil()
+  val table = util.addTable[(Long, Int, String)](
+    'long, 'int, 'string, 'rowtime.rowtime, 'proctime.proctime)
+
+  @Test
+  def testGroupByWithoutWindowAlias(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("GroupBy must contain exactly one window alias.")
+
+    table
+      .window(Tumble over 5.milli on 'rowtime as 'w)
+      .groupBy('string)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testInvalidRowTimeRef(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage(
+      "Cannot resolve field [int], input field list:[string, TMP_0].")
+
+    table
+      .window(Tumble over 5.milli on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .select('string, 'int.count)
+      .window(Slide over 5.milli every 1.milli on 'int as 'w2) // 'Int  does not exist in input.
+      .groupBy('string, 'w2)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testInvalidTumblingSize(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("A tumble window expects a size value literal")
+
+    table
+      .window(Tumble over "WRONG" on 'rowtime as 'w) // string is not a valid interval
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testInvalidTumblingSizeType(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Tumbling window expects size literal of type Interval of " +
+      "Milliseconds or Interval of Rows.")
+
+    table
+      // row interval is not valid for session windows
+      .window(Tumble over 10 on 'rowtime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testTumbleUdAggWithInvalidArgs(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Given parameters do not match any signature. \n" +
+      "Actual: (java.lang.Long) \nExpected: (int)")
+
+    table
+      .window(Tumble over 2.hours on 'rowtime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('long)) // invalid args
+      .select('string, 'f0)
+  }
+
+  @Test
+  def testInvalidSlidingSize(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("A sliding window expects a size value literal")
+
+    table
+      // field reference is not a valid interval
+      .window(Slide over "WRONG" every "WRONG" on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testInvalidSlidingSlide(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("A sliding window expects the same type of size and slide.")
+
+    table
+      // row and time intervals may not be mixed
+      .window(Slide over 12.rows every 1.minute on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testInvalidSlidingSizeType(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("A sliding window expects size literal of type Interval of " +
+      "Milliseconds or Interval of Rows.")
+
+    table
+      // row and time intervals may not be mixed
+      .window(Slide over 10 every 10.milli  on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testSlideUdAggWithInvalidArgs(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Given parameters do not match any signature. \n" +
+      "Actual: (java.lang.Long) \nExpected: (int)")
+
+    table
+      .window(Slide over 2.hours every 30.minutes on 'rowtime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('long)) // invalid args
+      .select('string, 'f0)
+  }
+
+  @Test
+  def testInvalidSessionGap(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("A session window expects gap literal of type " +
+      "Interval of Milliseconds.")
+
+    table
+      // row interval is not valid for session windows
+      .window(Session withGap 10.rows on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testInvalidSessionGapType(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("A session window expects gap literal of type " +
+      "Interval of Milliseconds.")
+
+    table
+      // row interval is not valid for session windows
+      .window(Session withGap 10 on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testInvalidWindowAliasWithExpression(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Only unresolved reference supported for alias of a " +
+      "group window.")
+
+    table
+      // expression instead of a symbol
+      .window(Session withGap 100.milli on 'proctime as concat("A", "B"))
+      .groupBy(concat("A", "B"))
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+  }
+
+  @Test
+  def testInvalidWindowAlias(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Cannot resolve field [string], input field list:[f0, f1].")
+
+    val util = streamTestUtil()
+    val table = util.addTable[(Long, Int, String)]('long.rowtime, 'int, 'string)
+
+    table
+      .window(Session withGap 100.milli on 'long as 'string)
+      .groupBy('string)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1)
+  }
+
+  @Test
+  def testSessionUdAggWithInvalidArgs(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Given parameters do not match any signature. \n" +
+      "Actual: (java.lang.Long) \nExpected: (int)")
+
+    table
+      .window(Session withGap 2.hours on 'rowtime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('long)) // invalid args
+      .select('string, 'f1)
+  }
+
+  @Test
+  def testInvalidWindowPropertyOnRowCountsWindow(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Window start and Window end cannot be selected " +
+      "for a row-count tumble window.")
+
+    val util = streamTestUtil()
+    val table = util.addTable[(Long, Int, String)]('long, 'int, 'string, 'proctime.proctime)
+
+    table
+      .window(Tumble over 2.rows on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'w.start, 'w.end) // invalid start/end on rows-count window
+  }
+
+  @Test
+  def testInvalidAggregateInSelection(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Aggregate functions cannot be used in the select " +
+      "right after the flatAggregate.")
+
+    val util = streamTestUtil()
+    val table = util.addTable[(Long, Int, String)]('long, 'int, 'string, 'proctime.proctime)
+
+    table
+      .window(Tumble over 2.rows on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('string, 'f0.count)
+  }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowTableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowTableAggregateITCase.scala
@@ -23,27 +23,24 @@ import java.math.BigDecimal
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.TimeCharacteristic
-import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.streaming.api.watermark.Watermark
-import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{Session, Slide, StreamQueryConfig, Tumble}
-import org.apache.flink.table.functions.aggfunctions.CountAggFunction
+import org.apache.flink.table.api.scala.{StreamTableEnvironment, _}
+import org.apache.flink.table.api._
 import org.apache.flink.table.runtime.stream.table.GroupWindowITCase._
-import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, CountDistinctWithMerge, WeightedAvg, WeightedAvgWithMerge}
-import org.apache.flink.table.runtime.utils.StreamITCase
+import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData}
+import org.apache.flink.table.utils.Top3
 import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.types.Row
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.collection.mutable
+import _root_.scala.collection.mutable
 
 /**
   * We only test some aggregations until better testing of constructed DataStream
   * programs is possible.
   */
-class GroupWindowITCase extends AbstractTestBase {
+class GroupWindowTableAggregateITCase extends AbstractTestBase {
   private val queryConfig = new StreamQueryConfig()
   queryConfig.withIdleStateRetentionTime(Time.hours(1), Time.hours(2))
 
@@ -71,26 +68,23 @@ class GroupWindowITCase extends AbstractTestBase {
     val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
-    val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'proctime.proctime)
-
-    val countFun = new CountAggFunction
-    val weightAvgFun = new WeightedAvg
-    val countDistinct = new CountDistinct
+    val top3 = new Top3
+    val stream = StreamTestData.get3TupleDataStream(env)
+    val table = stream.toTable(tEnv, 'int, 'long, 'string, 'proctime.proctime)
 
     val windowedTable = table
-      .window(Slide over 2.rows every 1.rows on 'proctime as 'w)
-      .groupBy('w, 'string)
-      .select('string, countFun('int), 'int.avg,
-        weightAvgFun('long, 'int), weightAvgFun('int, 'int),
-        countDistinct('long))
+      .window(Slide over 4.rows every 2.rows on 'proctime as 'w)
+      .groupBy('w, 'long)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select('long, 'x, 'y)
 
     val results = windowedTable.toAppendStream[Row](queryConfig)
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
-    val expected = Seq("Hello world,1,3,8,3,1", "Hello world,2,3,12,3,2", "Hello,1,2,2,2,1",
-      "Hello,2,2,3,2,2", "Hi,1,1,1,1,1")
+    val expected = Seq("2,2,2", "2,3,3", "3,4,4", "3,5,5", "4,7,7", "4,8,8", "4,8,8", "4,9,9",
+      "4,10,10", "5,11,11", "5,12,12", "5,12,12", "5,13,13", "5,14,14", "6,16,16", "6,17,17",
+      "6,17,17", "6,18,18", "6,19,19", "6,19,19", "6,20,20", "6,21,21")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -113,27 +107,24 @@ class GroupWindowITCase extends AbstractTestBase {
     val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
-    val countFun = new CountAggFunction
-    val weightAvgFun = new WeightedAvgWithMerge
-    val countDistinct = new CountDistinctWithMerge
-
     val stream = env
       .fromCollection(sessionWindowTestdata)
-      .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Long, Int, String)](10L))
+      .assignTimestampsAndWatermarks(
+   new TimestampAndWatermarkWithOffset[(Long, Int, String)](10L))
     val table = stream.toTable(tEnv, 'long, 'int, 'string, 'rowtime.rowtime)
 
+    val top3 = new Top3
     val windowedTable = table
       .window(Session withGap 5.milli on 'rowtime as 'w)
       .groupBy('w, 'string)
-      .select('string, countFun('int), 'int.avg,
-        weightAvgFun('long, 'int), weightAvgFun('int, 'int),
-        countDistinct('long))
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
-    val expected = Seq("Hello World,1,9,9,9,1", "Hello,1,16,16,16,1", "Hello,4,3,5,5,4")
+    val expected = Seq("Hello,2,2", "Hello,4,4", "Hello,8,8", "Hello World,9,9", "Hello,16,16")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -144,25 +135,21 @@ class GroupWindowITCase extends AbstractTestBase {
     val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
-    val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'proctime.proctime)
-    val countFun = new CountAggFunction
-    val weightAvgFun = new WeightedAvg
-    val countDistinct = new CountDistinct
+    val stream = StreamTestData.get3TupleDataStream(env)
+    val table = stream.toTable(tEnv, 'int, 'long, 'string, 'proctime.proctime)
+    val top3 = new Top3
 
     val windowedTable = table
-      .window(Tumble over 2.rows on 'proctime as 'w)
+      .window(Tumble over 7.rows on 'proctime as 'w)
       .groupBy('w)
-      .select(countFun('string), 'int.avg,
-        weightAvgFun('long, 'int), weightAvgFun('int, 'int),
-        countDistinct('long)
-      )
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
 
     val results = windowedTable.toAppendStream[Row](queryConfig)
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
-    val expected = Seq("2,1,1,1,2", "2,2,6,2,2")
+    val expected = Seq("5,5", "6,6", "7,7", "12,12", "13,13", "14,14", "19,19", "20,20", "21,21")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -173,30 +160,40 @@ class GroupWindowITCase extends AbstractTestBase {
     val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
-    val stream = env
-      .fromCollection(data)
-      .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Long, Int, String)](0L))
-    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'rowtime.rowtime)
-    val countFun = new CountAggFunction
-    val weightAvgFun = new WeightedAvg
-    val countDistinct = new CountDistinct
+    val stream = StreamTestData.get3TupleDataStream(env)
+      .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Int, Long, String)](0L))
+    val table = stream.toTable(tEnv, 'int, 'long, 'string, 'rowtime.rowtime)
 
+    val top3 = new Top3
     val windowedTable = table
-      .window(Tumble over 5.milli on 'rowtime as 'w)
-      .groupBy('w, 'string)
-      .select('string, countFun('string), 'int.avg, weightAvgFun('long, 'int),
-        weightAvgFun('int, 'int), 'int.min, 'int.max, 'int.sum, 'w.start, 'w.end,
-        countDistinct('long))
+      .window(Tumble over 10.milli on 'rowtime as 'w)
+      .groupBy('w, 'long)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select('w.start, 'w.end, 'long, 'x, 'y + 1)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
-      "Hello world,1,3,8,3,3,3,3,1970-01-01 00:00:00.005,1970-01-01 00:00:00.01,1",
-      "Hello world,1,3,16,3,3,3,3,1970-01-01 00:00:00.015,1970-01-01 00:00:00.02,1",
-      "Hello,2,2,3,2,2,2,4,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005,2",
-      "Hi,1,1,1,1,1,1,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005,1")
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,1,1,2",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,2,2,3",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,2,3,4",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,3,4,5",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,3,5,6",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,3,6,7",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,4,7,8",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,4,8,9",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:00.01,4,9,10",
+      "1970-01-01 00:00:00.01,1970-01-01 00:00:00.02,4,10,11",
+      "1970-01-01 00:00:00.01,1970-01-01 00:00:00.02,5,13,14",
+      "1970-01-01 00:00:00.01,1970-01-01 00:00:00.02,5,14,15",
+      "1970-01-01 00:00:00.01,1970-01-01 00:00:00.02,5,15,16",
+      "1970-01-01 00:00:00.01,1970-01-01 00:00:00.02,6,17,18",
+      "1970-01-01 00:00:00.01,1970-01-01 00:00:00.02,6,18,19",
+      "1970-01-01 00:00:00.01,1970-01-01 00:00:00.02,6,19,20",
+      "1970-01-01 00:00:00.02,1970-01-01 00:00:00.03,6,21,22",
+      "1970-01-01 00:00:00.02,1970-01-01 00:00:00.03,6,20,21")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -217,19 +214,18 @@ class GroupWindowITCase extends AbstractTestBase {
     val stream = env.fromCollection(data)
     val table = stream.toTable(tEnv, 'long, 'int, 'string, 'int2, 'int3, 'proctime.proctime)
 
-    val weightAvgFun = new WeightedAvg
-    val countDistinct = new CountDistinct
-
+    val top3 = new Top3
     val windowedTable = table
       .window(Slide over 2.rows every 1.rows on 'proctime as 'w)
       .groupBy('w, 'int2, 'int3, 'string)
-      .select(weightAvgFun('long, 'int), countDistinct('long))
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
-    val expected = Seq("12,2", "8,1", "2,1", "3,2", "1,1")
+    val expected = Seq("1,1", "2,2", "2,2", "2,2", "3,3", "3,3", "3,3")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -251,28 +247,38 @@ class GroupWindowITCase extends AbstractTestBase {
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
     val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
+    val top3 = new Top3
     val windowedTable = table
       .window(Slide over 5.milli every 2.milli on 'long as 'w)
       .groupBy('w)
-      .select('int.count, 'w.start, 'w.end, 'w.rowtime)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1, 'w.start, 'w.end, 'w.rowtime)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
-      "1,1970-01-01 00:00:00.008,1970-01-01 00:00:00.013,1970-01-01 00:00:00.012",
-      "1,1970-01-01 00:00:00.012,1970-01-01 00:00:00.017,1970-01-01 00:00:00.016",
-      "1,1970-01-01 00:00:00.014,1970-01-01 00:00:00.019,1970-01-01 00:00:00.018",
-      "1,1970-01-01 00:00:00.016,1970-01-01 00:00:00.021,1970-01-01 00:00:00.02",
-      "2,1969-12-31 23:59:59.998,1970-01-01 00:00:00.003,1970-01-01 00:00:00.002",
-      "2,1970-01-01 00:00:00.006,1970-01-01 00:00:00.011,1970-01-01 00:00:00.01",
-      "3,1970-01-01 00:00:00.002,1970-01-01 00:00:00.007,1970-01-01 00:00:00.006",
-      "3,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009,1970-01-01 00:00:00.008",
-      "4,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005,1970-01-01 00:00:00.004",
-      "1,1970-01-01 00:00:00.028,1970-01-01 00:00:00.033,1970-01-01 00:00:00.032",
-      "1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.035,1970-01-01 00:00:00.034",
-      "1,1970-01-01 00:00:00.032,1970-01-01 00:00:00.037,1970-01-01 00:00:00.036")
+      "1,1,1969-12-31 23:59:59.998,1970-01-01 00:00:00.003,1970-01-01 00:00:00.002",
+      "2,2,1969-12-31 23:59:59.998,1970-01-01 00:00:00.003,1970-01-01 00:00:00.002",
+      "2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005,1970-01-01 00:00:00.004",
+      "5,5,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005,1970-01-01 00:00:00.004",
+      "2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005,1970-01-01 00:00:00.004",
+      "2,2,1970-01-01 00:00:00.002,1970-01-01 00:00:00.007,1970-01-01 00:00:00.006",
+      "2,2,1970-01-01 00:00:00.002,1970-01-01 00:00:00.007,1970-01-01 00:00:00.006",
+      "5,5,1970-01-01 00:00:00.002,1970-01-01 00:00:00.007,1970-01-01 00:00:00.006",
+      "3,3,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009,1970-01-01 00:00:00.008",
+      "3,3,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009,1970-01-01 00:00:00.008",
+      "5,5,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009,1970-01-01 00:00:00.008",
+      "3,3,1970-01-01 00:00:00.006,1970-01-01 00:00:00.011,1970-01-01 00:00:00.01",
+      "3,3,1970-01-01 00:00:00.006,1970-01-01 00:00:00.011,1970-01-01 00:00:00.01",
+      "3,3,1970-01-01 00:00:00.008,1970-01-01 00:00:00.013,1970-01-01 00:00:00.012",
+      "4,4,1970-01-01 00:00:00.012,1970-01-01 00:00:00.017,1970-01-01 00:00:00.016",
+      "4,4,1970-01-01 00:00:00.014,1970-01-01 00:00:00.019,1970-01-01 00:00:00.018",
+      "4,4,1970-01-01 00:00:00.016,1970-01-01 00:00:00.021,1970-01-01 00:00:00.02",
+      "4,4,1970-01-01 00:00:00.028,1970-01-01 00:00:00.033,1970-01-01 00:00:00.032",
+      "4,4,1970-01-01 00:00:00.03,1970-01-01 00:00:00.035,1970-01-01 00:00:00.034",
+      "4,4,1970-01-01 00:00:00.032,1970-01-01 00:00:00.037,1970-01-01 00:00:00.036")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -290,29 +296,35 @@ class GroupWindowITCase extends AbstractTestBase {
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
     val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
+    val top3 = new Top3
     val windowedTable = table
       .window(Slide over 10.milli every 5.milli on 'long as 'w)
       .groupBy('w, 'string)
-      .select('string, 'int.count, 'w.start, 'w.end)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
-      "Hallo,1,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
-      "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
-      "Hello world,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
-      "Hello world,1,1970-01-01 00:00:00.005,1970-01-01 00:00:00.015",
-      "Hello world,1,1970-01-01 00:00:00.01,1970-01-01 00:00:00.02",
-      "Hello world,1,1970-01-01 00:00:00.015,1970-01-01 00:00:00.025",
-      "Hello,1,1970-01-01 00:00:00.005,1970-01-01 00:00:00.015",
-      "Hello,2,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
-      "Hello,3,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
-      "Hi,1,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
-      "null,1,1970-01-01 00:00:00.025,1970-01-01 00:00:00.035",
-      "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.04")
+      "Hallo,2,2,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
+      "Hallo,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
+      "Hello world,3,3,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
+      "Hello world,3,3,1970-01-01 00:00:00.005,1970-01-01 00:00:00.015",
+      "Hello world,4,4,1970-01-01 00:00:00.01,1970-01-01 00:00:00.02",
+      "Hello world,4,4,1970-01-01 00:00:00.015,1970-01-01 00:00:00.025",
+      "Hello,2,2,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
+      "Hello,5,5,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
+      "Hello,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
+      "Hello,3,3,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
+      "Hello,5,5,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
+      "Hello,3,3,1970-01-01 00:00:00.005,1970-01-01 00:00:00.015",
+      "Hi,1,1,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
+      "Hi,1,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
+      "null,4,4,1970-01-01 00:00:00.025,1970-01-01 00:00:00.035",
+      "null,4,4,1970-01-01 00:00:00.03,1970-01-01 00:00:00.04")
+
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -324,6 +336,7 @@ class GroupWindowITCase extends AbstractTestBase {
     val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
+    val top3 = new Top3
     val stream = env
       .fromCollection(data2)
       .assignTimestampsAndWatermarks(
@@ -333,23 +346,27 @@ class GroupWindowITCase extends AbstractTestBase {
     val windowedTable = table
       .window(Slide over 5.milli every 4.milli on 'long as 'w)
       .groupBy('w, 'string)
-      .select('string, 'int.count, 'w.start, 'w.end)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
-      "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
-      "Hello world,1,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009",
-      "Hello world,1,1970-01-01 00:00:00.008,1970-01-01 00:00:00.013",
-      "Hello world,1,1970-01-01 00:00:00.012,1970-01-01 00:00:00.017",
-      "Hello world,1,1970-01-01 00:00:00.016,1970-01-01 00:00:00.021",
-      "Hello,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
-      "Hello,2,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
-      "null,1,1970-01-01 00:00:00.028,1970-01-01 00:00:00.033",
-      "null,1,1970-01-01 00:00:00.032,1970-01-01 00:00:00.037")
+      "Hello,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "Hello,5,5,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "Hallo,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "Hello world,3,3,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009",
+      "Hello world,3,3,1970-01-01 00:00:00.008,1970-01-01 00:00:00.013",
+      "Hello,3,3,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009",
+      "Hi,1,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "Hello,5,5,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009",
+      "Hello world,4,4,1970-01-01 00:00:00.012,1970-01-01 00:00:00.017",
+      "null,4,4,1970-01-01 00:00:00.028,1970-01-01 00:00:00.033",
+      "Hello world,4,4,1970-01-01 00:00:00.016,1970-01-01 00:00:00.021",
+      "null,4,4,1970-01-01 00:00:00.032,1970-01-01 00:00:00.037")
+
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -367,20 +384,23 @@ class GroupWindowITCase extends AbstractTestBase {
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
     val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
+    val top3 = new Top3
     val windowedTable = table
       .window(Slide over 5.milli every 10.milli on 'long as 'w)
       .groupBy('w, 'string)
-      .select('string, 'int.count, 'w.start, 'w.end)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
-      "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
-      "Hello,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
-      "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.035")
+      "Hallo,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "Hello,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "Hello,5,5,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "Hi,1,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "null,4,4,1970-01-01 00:00:00.03,1970-01-01 00:00:00.035")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -398,19 +418,21 @@ class GroupWindowITCase extends AbstractTestBase {
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
     val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
+    val top3 = new Top3
     val windowedTable = table
       .window(Slide over 3.milli every 10.milli on 'long as 'w)
       .groupBy('w, 'string)
-      .select('string, 'int.count, 'w.start, 'w.end)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
-      "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
-      "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.033")
+      "null,4,4,1970-01-01 00:00:00.03,1970-01-01 00:00:00.033",
+      "Hallo,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
+      "Hi,1,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -428,37 +450,20 @@ class GroupWindowITCase extends AbstractTestBase {
       .map(t => (t._2, t._6))
     val table = stream.toTable(tEnv, 'int, 'string, 'rowtime.rowtime)
 
+    val top3 = new Top3
     val windowedTable = table
       .window(Slide over 3.milli every 10.milli on 'rowtime as 'w)
       .groupBy('w, 'string)
-      .select('string, 'int.count, 'w.start, 'w.end)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
     val expected = Seq(
-      "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
-      "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.033")
+      "Hallo,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
+      "Hi,1,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
+      "null,4,4,1970-01-01 00:00:00.03,1970-01-01 00:00:00.033")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
-  }
-}
-
-object GroupWindowITCase {
-
-  class TimestampAndWatermarkWithOffset[T <: Product](
-    offset: Long) extends AssignerWithPunctuatedWatermarks[T] {
-
-    override def checkAndGetNextWatermark(
-        lastElement: T,
-        extractedTimestamp: Long): Watermark = {
-      new Watermark(extractedTimestamp - offset)
-    }
-
-    override def extractTimestamp(
-        element: T,
-        previousElementTimestamp: Long): Long = {
-      element.productElement(0).asInstanceOf[Number].longValue()
-    }
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

### Goal
This PR supports (streaming, window) flatAggregate on Table API.

### Background
FLINK-10977 add streaming non-window flatAggregate on TableAPI. The behavior of table aggregates is most like GroupReduceFunction did, which computed for a group of elements, and output a group of elements. The TableAggregateFunction can be applied on Table/GroupedTable.

### Motivation
For group window cases, it would be nice if we can also support flatAggregate. This means we can perform flatAggregate on Tumble/Slide/Session Windows. The API looks like:
```
table.window(Tumble.over("5.minutes").on("rowtime").as("w")) // define window
    .groupBy("a, w") // group by key and window
    .flatAggregate("tableAggFunc(b) as (x, y)")
```

### Solution
This PR adds flatAggregate API on `WindowGroupedTable` and adds window table aggregate logical node for the plan optimization. For the runtime code, window table aggregate reused most of the code with window aggregate and non-window table aggregate.

The difference between window aggregate and window table aggregate is, for window table aggregate, the runtime aggregate function(org.apache.flink.table.runtime.aggregate.AggregateAggFunction) returns both accumulator and function to the window function and emit value in it while for window aggregate, the runtime aggregate function returns the final results to the window function. This is because we can't emit results in the runtime aggregate function for table aggregate as there is no collector to be used.

## Brief change log

- [494d356](https://github.com/apache/flink/pull/8359/commits/5000809f100bfdad70edc2efa7c2c1c9dc1e88e5) Add flatAggregate API on WindowGroupedTable. Add java and scala API. In this commit, the implementation has not been implemented.
- [9990a47](https://github.com/apache/flink/pull/8359/commits/e1a8a3b0433512720d18672b3d1bca3084daeca0) Resolve expression and build LogicalWindowTableAggregate. `TableAggregate` is added to make it different from `Aggregate`. The two kinds of RelNode contain different semantics. For `Aggregate`, it represents a relational operator that eliminates duplicates and computes totals while for `TableAggregate`, it can output 0 or more records for a group.
- [3b2e2bb](https://github.com/apache/flink/pull/8359/commits/352800704b2e965fe158077a76220225afca0b90) Add Plan support for window table aggregate. Logical&Physical nodes and rules are added in the commit. 
- [e1a3ed4](https://github.com/apache/flink/pull/8359/commits/f3622aff211af70f01131380ea800eb4e4ab70bb) Add runtime support for window table aggregate. This commit reuses the code of window aggregate and adds support for window table aggregate.
- [031a6e7](https://github.com/apache/flink/pull/8359/commits/f1a68bededf08451416b90febc589044d0ea810b) Add docs for window table aggregate. Also rename `Table Aggregate` to `FlatAggregate` as it is more consistent with the API for users. 


## Verifying this change


This change added tests and can be verified as follows:

 - Added plan test(GroupWindowTableAggregateTest) to verify plan
 - Add IT case(GroupWindowTableAggregateITCase) to verify code gen and runtime logic
 - Add GropuWindowTableAggregateStringExpressionTest to test java.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)