### PR TITLE
[FLINK-12436][hive] Differentiate Flink database properties from Hive database properties

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
-import org.apache.flink.table.catalog.GenericCatalogDatabase;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
@@ -41,7 +40,6 @@ import org.apache.flink.table.catalog.hive.util.GenericHiveMetastoreCatalogUtil;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
-import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
@@ -73,9 +71,7 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 
 	@Override
 	public CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
-		Database hiveDb = getHiveDatabase(databaseName);
-
-		return new GenericCatalogDatabase(hiveDb.getParameters(), hiveDb.getDescription());
+		return GenericHiveMetastoreCatalogUtil.createCatalogDatabase(getHiveDatabase(databaseName));
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/GenericHiveMetastoreCatalogUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/GenericHiveMetastoreCatalogUtil.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogView;
+import org.apache.flink.table.catalog.GenericCatalogDatabase;
 import org.apache.flink.table.catalog.GenericCatalogTable;
 import org.apache.flink.table.catalog.GenericCatalogView;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -74,9 +75,22 @@ public class GenericHiveMetastoreCatalogUtil {
 	public static Database createHiveDatabase(String databaseName, CatalogDatabase catalogDatabase) {
 		return new Database(
 			databaseName,
-			catalogDatabase.getDescription().isPresent() ? catalogDatabase.getDescription().get() : null,
+			catalogDatabase.getComment(),
 			null,
-			catalogDatabase.getProperties());
+			buildFlinkProperties(catalogDatabase.getProperties()));
+	}
+
+	/**
+	 * Creates a CatalogDatabase from a Hive database.
+	 *
+	 * @param hiveDatabase the Hive database
+	 * @return a CatalogDatabase
+	 */
+	public static CatalogDatabase createCatalogDatabase(Database hiveDatabase) {
+		return new GenericCatalogDatabase(
+			retrieveFlinkProperties(hiveDatabase.getParameters()),
+			hiveDatabase.getDescription()
+		);
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -104,13 +104,6 @@ public abstract class CatalogTestBase {
 	// ------ databases ------
 
 	@Test
-	public void testCreateDb() throws Exception {
-		catalog.createDatabase(db2, createDb(), false);
-
-		assertEquals(2, catalog.listDatabases().size());
-	}
-
-	@Test
 	public void testSetCurrentDatabase() throws Exception {
 		assertEquals(getBuiltInDefaultDatabase(), catalog.getCurrentDatabase());
 
@@ -134,6 +127,17 @@ public abstract class CatalogTestBase {
 	}
 
 	@Test
+	public void testCreateDb() throws Exception {
+		assertFalse(catalog.databaseExists(db1));
+
+		CatalogDatabase cd = createDb();
+		catalog.createDatabase(db1, cd, false);
+
+		assertTrue(catalog.databaseExists(db1));
+		CatalogTestUtil.checkEquals(cd, catalog.getDatabase(db1));
+	}
+
+	@Test
 	public void testCreateDb_DatabaseAlreadyExistException() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
 
@@ -148,13 +152,13 @@ public abstract class CatalogTestBase {
 		catalog.createDatabase(db1, cd1, false);
 		List<String> dbs = catalog.listDatabases();
 
-		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(cd1.getProperties().entrySet()));
+		CatalogTestUtil.checkEquals(cd1, catalog.getDatabase(db1));
 		assertEquals(2, dbs.size());
 		assertEquals(new HashSet<>(Arrays.asList(db1, catalog.getCurrentDatabase())), new HashSet<>(dbs));
 
 		catalog.createDatabase(db1, createAnotherDb(), true);
 
-		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(cd1.getProperties().entrySet()));
+		CatalogTestUtil.checkEquals(cd1, catalog.getDatabase(db1));
 		assertEquals(2, dbs.size());
 		assertEquals(new HashSet<>(Arrays.asList(db1, catalog.getCurrentDatabase())), new HashSet<>(dbs));
 	}
@@ -170,11 +174,11 @@ public abstract class CatalogTestBase {
 	public void testDropDb() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
 
-		assertTrue(catalog.listDatabases().contains(db1));
+		assertTrue(catalog.databaseExists(db1));
 
 		catalog.dropDatabase(db1, false);
 
-		assertFalse(catalog.listDatabases().contains(db1));
+		assertFalse(catalog.databaseExists(db1));
 	}
 
 	@Test
@@ -204,13 +208,11 @@ public abstract class CatalogTestBase {
 		CatalogDatabase db = createDb();
 		catalog.createDatabase(db1, db, false);
 
-		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(db.getProperties().entrySet()));
-
 		CatalogDatabase newDb = createAnotherDb();
 		catalog.alterDatabase(db1, newDb, false);
 
 		assertFalse(catalog.getDatabase(db1).getProperties().entrySet().containsAll(db.getProperties().entrySet()));
-		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(newDb.getProperties().entrySet()));
+		CatalogTestUtil.checkEquals(newDb, catalog.getDatabase(db1));
 	}
 
 	@Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -50,6 +50,7 @@ public class CatalogTestUtil {
 	}
 
 	public static void checkEquals(CatalogDatabase d1, CatalogDatabase d2) {
+		assertEquals(d1.getComment(), d2.getComment());
 		assertEquals(d1.getProperties(), d2.getProperties());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support to differentiate Flink database properties from Hive database properties by using a Flink specific prefix for each property key, similar to how we differentiate Flink table properties from Hive table properties.

## Brief change log

  - Using a 'flink.' prefix for each Flink database config key stored in Hive metastore
  - Updated test util and a few unit tests

## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as GenericHiveMetastoreCatalogTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
