### PR TITLE
[FLINK-12417][table] Unify ReadableCatalog and ReadableWritableCatalog interfaces to Catalog interface

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.catalog.hive;
 
-import org.apache.flink.table.catalog.ReadableWritableCatalog;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
@@ -46,7 +46,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Base class for catalogs backed by Hive metastore.
  */
-public abstract class HiveCatalogBase implements ReadableWritableCatalog {
+public abstract class HiveCatalogBase implements Catalog {
 	private static final Logger LOG = LoggerFactory.getLogger(HiveCatalogBase.class);
 
 	public static final String DEFAULT_DB = "default";

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * A generic catalog implementation that holds all meta objects in memory.
  */
-public class GenericInMemoryCatalog implements ReadableWritableCatalog {
+public class GenericInMemoryCatalog implements Catalog {
 
 	public static final String DEFAULT_DB = "default";
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.catalog;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
@@ -39,6 +40,7 @@ import java.util.List;
  * This interface is responsible for reading and writing metadata such as database/table/views/UDFs
  * from a registered catalog. It connects a registered catalog and Flink's Table API.
  */
+@PublicEvolving
 public interface Catalog {
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -33,12 +33,76 @@ import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 
+import java.util.List;
+
 /**
- * An interface responsible for manipulating catalog metadata.
+ * This interface is responsible for reading and writing metadata such as database/table/views/UDFs
+ * from a registered catalog. It connects a registered catalog and Flink's Table API.
  */
-public interface ReadableWritableCatalog extends ReadableCatalog {
+public interface Catalog {
+
+	/**
+	 * Open the catalog. Used for any required preparation in initialization phase.
+	 *
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	void open() throws CatalogException;
+
+	/**
+	 * Close the catalog when it is no longer needed and release any resource that it might be holding.
+	 *
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	void close() throws CatalogException;
 
 	// ------ databases ------
+
+	/**
+	 * Get the name of the current database of this type of catalog. This is used when users refers an object in the catalog
+	 * without specifying a database. For example, the current db in a Hive Metastore is 'default' by default.
+	 *
+	 * @return the name of the current database
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	String getCurrentDatabase() throws CatalogException;
+
+	/**
+	 * Set the database with the given name as the current database. A current database is used when users refers an object
+	 * in the catalog without specifying a database.
+	 *
+	 * @param databaseName	the name of the database
+	 * @throws DatabaseNotExistException if the given database doesn't exist in the catalog
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	void setCurrentDatabase(String databaseName) throws DatabaseNotExistException, CatalogException;
+
+	/**
+	 * Get the names of all databases in this catalog.
+	 *
+	 * @return a list of the names of all databases
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	List<String> listDatabases() throws CatalogException;
+
+	/**
+	 * Get a database from this catalog.
+	 *
+	 * @param databaseName	Name of the database
+	 * @return The requested database
+	 * @throws DatabaseNotExistException if the database does not exist
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException;
+
+	/**
+	 * Check if a database exists in this catalog.
+	 *
+	 * @param databaseName		Name of the database
+	 * @return true if the given database exists in the catalog
+	 *         false otherwise
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	boolean databaseExists(String databaseName) throws CatalogException;
 
 	/**
 	 * Create a database.
@@ -82,6 +146,45 @@ public interface ReadableWritableCatalog extends ReadableCatalog {
 		throws DatabaseNotExistException, CatalogException;
 
 	// ------ tables and views ------
+
+	/**
+	 * Get names of all tables and views under this database. An empty list is returned if none exists.
+	 *
+	 * @return a list of the names of all tables and views in this database
+	 * @throws DatabaseNotExistException if the database does not exist
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	List<String> listTables(String databaseName) throws DatabaseNotExistException, CatalogException;
+
+	/**
+	 * Get names of all views under this database. An empty list is returned if none exists.
+	 *
+	 * @param databaseName the name of the given database
+	 * @return a list of the names of all views in the given database
+	 * @throws DatabaseNotExistException if the database does not exist
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	List<String> listViews(String databaseName) throws DatabaseNotExistException, CatalogException;
+
+	/**
+	 * Get a CatalogTable or CatalogView identified by tablePath.
+	 *
+	 * @param tablePath		Path of the table or view
+	 * @return The requested table or view
+	 * @throws TableNotExistException if the target does not exist
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException;
+
+	/**
+	 * Check if a table or view exists in this catalog.
+	 *
+	 * @param tablePath    Path of the table or view
+	 * @return true if the given table exists in the catalog
+	 *         false otherwise
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	boolean tableExists(ObjectPath tablePath) throws CatalogException;
 
 	/**
 	 * Drop a table or view.
@@ -143,6 +246,56 @@ public interface ReadableWritableCatalog extends ReadableCatalog {
 	// ------ partitions ------
 
 	/**
+	 * Get CatalogPartitionSpec of all partitions of the table.
+	 *
+	 * @param tablePath	path of the table
+	 * @return a list of CatalogPartitionSpec of the table
+	 *
+	 * @throws TableNotExistException thrown if the table does not exist in the catalog
+	 * @throws TableNotPartitionedException thrown if the table is not partitioned
+	 * @throws CatalogException	in case of any runtime exception
+	 */
+	List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath)
+		throws TableNotExistException, TableNotPartitionedException, CatalogException;
+
+	/**
+	 * Get CatalogPartitionSpec of all partitions that is under the given CatalogPartitionSpec in the table.
+	 *
+	 * @param tablePath	path of the table
+	 * @param partitionSpec the partition spec to list
+	 * @return a list of CatalogPartitionSpec that is under the given CatalogPartitionSpec in the table
+	 *
+	 * @throws TableNotExistException thrown if the table does not exist in the catalog
+	 * @throws TableNotPartitionedException thrown if the table is not partitioned
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+		throws TableNotExistException, TableNotPartitionedException, CatalogException;
+
+	/**
+	 * Get a partition of the given table.
+	 * The given partition spec keys and values need to be matched exactly for a result.
+	 *
+	 * @param tablePath path of the table
+	 * @param partitionSpec partition spec of partition to get
+	 * @return the requested partition
+	 *
+	 * @throws PartitionNotExistException thrown if the partition is not partitioned
+	 * @throws CatalogException	in case of any runtime exception
+	 */
+	CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+		throws PartitionNotExistException, CatalogException;
+
+	/**
+	 * Check whether a partition exists or not.
+	 *
+	 * @param tablePath	path of the table
+	 * @param partitionSpec partition spec of the partition to check
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException;
+
+	/**
 	 * Create a partition.
 	 *
 	 * @param tablePath path of the table.
@@ -195,6 +348,36 @@ public interface ReadableWritableCatalog extends ReadableCatalog {
 	// ------ functions ------
 
 	/**
+	 * List the names of all functions in the given database. An empty list is returned if none is registered.
+	 *
+	 * @param dbName name of the database.
+	 * @return a list of the names of the functions in this database
+	 * @throws DatabaseNotExistException if the database does not exist
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	List<String> listFunctions(String dbName) throws DatabaseNotExistException, CatalogException;
+
+	/**
+	 * Get the function.
+	 *
+	 * @param functionPath path of the function
+	 * @return the requested function
+	 * @throws FunctionNotExistException if the function does not exist in the catalog
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	CatalogFunction getFunction(ObjectPath functionPath) throws FunctionNotExistException, CatalogException;
+
+	/**
+	 * Check whether a function exists or not.
+	 *
+	 * @param functionPath path of the function
+	 * @return true if the function exists in the catalog
+	 *         false otherwise
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	boolean functionExists(ObjectPath functionPath) throws CatalogException;
+
+	/**
 	 * Create a function.
 	 *
 	 * @param functionPath      path of the function
@@ -237,6 +420,56 @@ public interface ReadableWritableCatalog extends ReadableCatalog {
 		throws FunctionNotExistException, CatalogException;
 
 	// ------ statistics ------
+
+	// ------ statistics ------
+
+	/**
+	 * Get the statistics of a table.
+	 *
+	 * @param tablePath path of the table
+	 * @return statistics of the given table
+	 *
+	 * @throws TableNotExistException if the table does not exist in the catalog
+	 * @throws CatalogException	in case of any runtime exception
+	 */
+	CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException;
+
+	/**
+	 * Get the column statistics of a table.
+	 *
+	 * @param tablePath path of the table
+	 * @return column statistics of the given table
+	 *
+	 * @throws TableNotExistException if the table does not exist in the catalog
+	 * @throws CatalogException	in case of any runtime exception
+	 */
+	CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException;
+
+	/**
+	 * Get the statistics of a partition.
+	 *
+	 * @param tablePath path of the table
+	 * @param partitionSpec partition spec of the partition
+	 * @return statistics of the given partition
+	 *
+	 * @throws PartitionNotExistException if the partition does not exist
+	 * @throws CatalogException	in case of any runtime exception
+	 */
+	CatalogTableStatistics getPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+		throws PartitionNotExistException, CatalogException;
+
+	/**
+	 * Get the column statistics of a partition.
+	 *
+	 * @param tablePath path of the table
+	 * @param partitionSpec partition spec of the partition
+	 * @return column statistics of the given partition
+	 *
+	 * @throws PartitionNotExistException if the partition does not exist
+	 * @throws CatalogException	in case of any runtime exception
+	 */
+	CatalogColumnStatistics getPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+		throws PartitionNotExistException, CatalogException;
 
 	/**
 	 * Update the statistics of a table.

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -68,7 +68,7 @@ public abstract class CatalogTestBase {
 
 	protected static final String TEST_COMMENT = "test comment";
 
-	protected static ReadableWritableCatalog catalog;
+	protected static Catalog catalog;
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();


### PR DESCRIPTION
## What is the purpose of the change

This PR unifies `ReadableCatalog` and `ReadableWritableCatalog` interfaces to `Catalog` interface to simplify the architecture and management of catalogs.

## Brief change log

  - Created a new interface `Catalog` that contains exactly the same APIs from `ReadableCatalog` and `ReadableWritableCatalog`. NOTE that there's no change to APIs but only relocating them.
  - Removed `ReadableCatalog` and `ReadableWritableCatalog`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
