### PR TITLE
[hotfix][doc] typo, remove `one` from `value of one two...`

### DIFF
--- a/docs/dev/api_concepts.md
+++ b/docs/dev/api_concepts.md
@@ -783,7 +783,7 @@ defined in the `write()`and `readFields()` methods will be used for serializatio
 
 You can use special types, including Scala's `Either`, `Option`, and `Try`.
 The Java API has its own custom implementation of `Either`.
-Similarly to Scala's `Either`, it represents a value of one two possible types, *Left* or *Right*.
+Similarly to Scala's `Either`, it represents a value of two possible types, *Left* or *Right*.
 `Either` can be useful for error handling or operators that need to output two different types of records.
 
 #### Type Erasure & Type Inference


### PR DESCRIPTION
## What is the purpose of the change
typo

## Brief change log
see changes

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

  - Does this pull request introduce a new feature? (yes / no) => no
