### PR TITLE
[hotfix][runtime] Remove executionCanceled() and executionFailed() from ExecutionVertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1039,12 +1039,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	}
 
 	private void finishCancellation() {
-		try {
-			releaseAssignedResource(new FlinkException("Execution " + this + " was cancelled."));
-			vertex.getExecutionGraph().deregisterExecution(this);
-		} finally {
-			vertex.executionCanceled(this);
-		}
+		releaseAssignedResource(new FlinkException("Execution " + this + " was cancelled."));
+		vertex.getExecutionGraph().deregisterExecution(this);
 	}
 
 	void cachePartitionInfo(PartitionInfo partitionInfo) {
@@ -1101,13 +1097,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 				updateAccumulatorsAndMetrics(userAccumulators, metrics);
 
-				try {
-					releaseAssignedResource(t);
-					vertex.getExecutionGraph().deregisterExecution(this);
-				}
-				finally {
-					vertex.executionFailed(this, t);
-				}
+				releaseAssignedResource(t);
+				vertex.getExecutionGraph().deregisterExecution(this);
 
 				if (!isCallback && (current == RUNNING || current == DEPLOYING)) {
 					if (LOG.isDebugEnabled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -795,14 +795,6 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		getExecutionGraph().vertexFinished();
 	}
 
-	void executionCanceled(Execution execution) {
-		// nothing to do
-	}
-
-	void executionFailed(Execution execution, Throwable cause) {
-		// nothing to do
-	}
-
 	// --------------------------------------------------------------------------------------------
 	//   Miscellaneous
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*Remove empty methods from ExecutionVertex.*


## Brief change log

  - *See commits*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
