### PR TITLE
[FLINK-12354] [table] Add REVERSE function for table/sql API

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -2689,6 +2689,18 @@ TO_BASE64(string)
         <p>E.g., <code>TO_BASE64('hello world')</code> returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
+     
+    <tr>
+        <td>
+          {% highlight text %}
+REVERSE(string)
+{% endhighlight %}
+        </td>
+        <td>
+          <p>Returns the string with the order of characters reversed; returns NULL if <i>string</i> is NULL. </p>
+          <p>E.g.,<code>REVERSE('hello world')</code> returns "dlrow olleh".</p>
+        </td>
+    </tr>
   </tbody>
 </table>
 </div>
@@ -2954,6 +2966,18 @@ STRING.toBase64()
          <p>E.g., <code>'hello world'.toBase64()</code> returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
+     
+    <tr>
+      <td>
+        {% highlight java %}
+STRING.reverse()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the string with the order of characters reversed; returns NULL if <i>string</i> is NULL. </p>
+        <p>E.g., <code>"hello world".reverse()</code> returns "dlrow olleh".</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>
@@ -3217,6 +3241,18 @@ STRING.toBase64()
         <p>Returns the base64-encoded result from <i>STRING</i>; returns NULL if <i>STRING</i> is NULL.</p>
          <p>E.g., <code>"hello world".toBase64()</code> returns "aGVsbG8gd29ybGQ=".</p>
       </td>
+    </tr>
+    
+    <tr>
+        <td>
+          {% highlight scala %}
+STRING.reverse()
+{% endhighlight %}
+        </td>
+        <td>
+          <p>Returns the string with the order of characters reversed; returns NULL if <i>string</i> is NULL. </p>
+          <p>E.g., <code>"hello world".reverse()</code> returns "dlrow olleh".</p>
+        </td>
     </tr>
   </tbody>
 </table>

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/BuiltInFunctionDefinitions.java
@@ -152,6 +152,8 @@ public final class BuiltInFunctionDefinitions {
 		new FunctionDefinition("repeat", SCALAR_FUNCTION);
 	public static final FunctionDefinition REGEXP_REPLACE =
 		new FunctionDefinition("regexpReplace", SCALAR_FUNCTION);
+	public static final FunctionDefinition REVERSE =
+		new FunctionDefinition("reverse", SCALAR_FUNCTION);
 
 	// math functions
 	public static final FunctionDefinition PLUS =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -678,6 +678,11 @@ trait ImplicitExpressionOperations {
     */
   def repeat(n: Expression): Expression = call(REPEAT, expr, n)
 
+  /**
+    * Returns the string with the order of the characters reversed.
+    */
+  def reverse(): Expression = call(REVERSE, expr)
+
   // Temporal operations
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -177,6 +177,8 @@ object BuiltInMethods {
     classOf[String],
     classOf[Int])
 
+  val REVERSE = Types.lookupMethod(classOf[ScalarFunctions], "reverse", classOf[String])
+
   val TRUNCATE_DOUBLE_ONE = Types.lookupMethod(classOf[SqlFunctions], "struncate",
     classOf[Double])
   val TRUNCATE_INT_ONE = Types.lookupMethod(classOf[SqlFunctions], "struncate",

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -207,6 +207,13 @@ object FunctionGenerator {
     STRING_TYPE_INFO,
     BuiltInMethods.REPEAT)
 
+  addSqlFunctionMethod(
+    REVERSE,
+    Seq(STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethods.REVERSE
+  )
+
   // ----------------------------------------------------------------------------------------------
   // Arithmetic functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -358,6 +358,10 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             assert(args.size == 3)
             RegexpReplace(args.head, args(1), args.last)
 
+          case REVERSE =>
+            assert(args.size == 1)
+            Reverse(args.head)
+
           case PLUS =>
             assert(args.size == 2)
             Plus(args.head, args.last)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -584,3 +584,28 @@ case class Replace(
     relBuilder.call(SqlStdOperatorTable.REPLACE, children.map(_.toRexNode))
   }
 }
+
+/**
+  * Returns the string with the order of the characters reversed.
+  */
+case class Reverse(child: PlannerExpression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = Seq(STRING_TYPE_INFO)
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (child.resultType == STRING_TYPE_INFO) {
+      ValidationSuccess
+    } else {
+      ValidationFailure(s"Reverse operator requires a String input, " +
+        s"but $child is of type ${child.resultType}")
+    }
+  }
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.REVERSE, child.toRexNode)
+  }
+
+  override def toString: String = s"($child).reverse"
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -276,4 +276,12 @@ object ScalarSqlFunctions {
     OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER),
     SqlFunctionCategory.STRING)
 
+  val REVERSE = new SqlFunction(
+    "REVERSE",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE),
+    InferTypes.RETURN_TYPE,
+    OperandTypes.STRING,
+    SqlFunctionCategory.STRING
+  )
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -296,4 +296,10 @@ object ScalarFunctions {
     */
   def repeat(base: String, n: Int): String = EncodingUtils.repeat(base, n)
 
+  /**
+    * Returns the string with the order of characters reversed.
+    */
+  def reverse(base: String): String = {
+    new StringBuffer(base).reverse().toString
+  }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -300,6 +300,6 @@ object ScalarFunctions {
     * Returns the string with the order of characters reversed.
     */
   def reverse(base: String): String = {
-    new StringBuffer(base).reverse().toString
+    new StringBuilder(base).reverse().toString
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -294,6 +294,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.REPEAT,
     ScalarSqlFunctions.REGEXP_REPLACE,
     SqlStdOperatorTable.TRUNCATE,
+    ScalarSqlFunctions.REVERSE,
 
     // MATCH_RECOGNIZE
     SqlStdOperatorTable.FIRST,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -896,6 +896,39 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "")
   }
 
+  @Test
+  def testReverse(): Unit = {
+    testAllApis(
+      'f37.reverse(),
+      "f37.reverse()",
+      "REVERSE(f37)",
+      "")
+
+    testAllApis(
+      'f33.reverse(),
+      "f33.reverse()",
+      "REVERSE(f33)",
+      "null")
+
+    testAllApis(
+      'f0.reverse(),
+      "f0.reverse()",
+      "REVERSE(f0)",
+      ".gnirtS tset a si sihT")
+
+    testAllApis(
+      'f24.reverse(),
+      "f24.reverse()",
+      "REVERSE(f24)",
+      ".gnirtS tset a si sihT_*")
+
+    testAllApis(
+      'f38.reverse(),
+      "f38.reverse()",
+      "REVERSE(f38)",
+      "knilF ehcapA，好你")
+  }
+
   // ----------------------------------------------------------------------------------------------
   // Math functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ScalarTypesTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ScalarTypesTestBase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.types.Row
 class ScalarTypesTestBase extends ExpressionTestBase {
 
   def testData: Row = {
-    val testData = new Row(37)
+    val testData = new Row(39)
     testData.setField(0, "This is a test String.")
     testData.setField(1, true)
     testData.setField(2, 42.toByte)
@@ -66,6 +66,8 @@ class ScalarTypesTestBase extends ExpressionTestBase {
     testData.setField(34, 256)
     testData.setField(35, "aGVsbG8gd29ybGQ=")
     testData.setField(36, BigDecimal("42.345").bigDecimal)
+    testData.setField(37, "")
+    testData.setField(38, "你好，Apache Flink")
     testData
   }
 
@@ -107,6 +109,8 @@ class ScalarTypesTestBase extends ExpressionTestBase {
       Types.STRING,
       Types.INT,
       Types.STRING,
-      Types.DECIMAL).asInstanceOf[TypeInformation[Any]]
+      Types.DECIMAL,
+      Types.STRING,
+      Types.STRING).asInstanceOf[TypeInformation[Any]]
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request add `REVERSE` function for table/sql API

## Brief change log

  -  Add `REVERSE` function for table/sql API 

## Verifying this change

This change added tests and can be verified as follows:

- ScalarFunctionsTest#testReverse

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
