### PR TITLE
[FLINK-12453][table-planner-blink] Simplify constructor of AggsHandlerCodeGenerator

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecOverAggregate.scala
@@ -286,11 +286,12 @@ class BatchExecOverAggregate(
           codeGenCtx,
           relBuilder,
           inputType.getFieldTypes,
-          needRetract = false,
           copyInputField = false)
         // over agg code gen must pass the constants
-        generator.withConstants(constants).generateAggsHandler(
-          "BoundedOverAggregateHelper", aggInfoList)
+        generator
+          .needAccumulate()
+          .withConstants(constants)
+          .generateAggsHandler("BoundedOverAggregateHelper", aggInfoList)
       }.toArray
 
       val resetAccumulators =
@@ -344,12 +345,14 @@ class BatchExecOverAggregate(
               CodeGeneratorContext(config),
               relBuilder,
               inputType.getFieldTypes,
-              needRetract = true,
               copyInputField = false)
 
             // over agg code gen must pass the constants
-            val genAggsHandler = generator.withConstants(constants)
-                .generateAggsHandler("BoundedOverAggregateHelper", aggInfoList)
+            val genAggsHandler = generator
+              .needAccumulate()
+              .needRetract()
+              .withConstants(constants)
+              .generateAggsHandler("BoundedOverAggregateHelper", aggInfoList)
 
             // LEAD is behind the currentRow, so we need plus offset.
             // LAG is in front of the currentRow, so we need minus offset.
@@ -414,11 +417,12 @@ class BatchExecOverAggregate(
             codeGenCtx,
             relBuilder,
             inputType.getFieldTypes,
-            needRetract = false,
             copyInputField = false)
 
           // over agg code gen must pass the constants
-          val genAggsHandler = generator.withConstants(constants)
+          val genAggsHandler = generator
+              .needAccumulate()
+              .withConstants(constants)
               .generateAggsHandler("BoundedOverAggregateHelper", aggInfoList)
 
           mode match {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGlobalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGlobalGroupAggregate.scala
@@ -212,12 +212,11 @@ class StreamExecGlobalGroupAggregate(
       CodeGeneratorContext(config),
       relBuilder,
       FlinkTypeFactory.toInternalRowType(inputRowType).getFieldTypes,
-      needRetract = false,
-      config.getNullCheck,
       inputFieldCopy)
 
     generator
-      .withMerging(mergedAccOffset, mergedAccOnHeap, mergedAccExternalTypes)
+      .needAccumulate()
+      .needMerge(mergedAccOffset, mergedAccOnHeap, mergedAccExternalTypes)
       .generateAggsHandler(name, aggInfoList)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGroupAggregate.scala
@@ -146,13 +146,18 @@ class StreamExecGroupAggregate(
       CodeGeneratorContext(tableConfig),
       tableEnv.getRelBuilder,
       inputRowType.getFieldTypes,
-      needRetraction,
       // TODO: heap state backend do not copy key currently, we have to copy input field
       // TODO: copy is not need when state backend is rocksdb, improve this in future
       // TODO: but other operators do not copy this input field.....
       copyInputField = true)
 
-    val aggsHandler = generator.generateAggsHandler("GroupAggsHandler", aggInfoList)
+    if (needRetraction) {
+      generator.needRetract()
+    }
+
+    val aggsHandler = generator
+      .needAccumulate()
+      .generateAggsHandler("GroupAggsHandler", aggInfoList)
     val accTypes = aggInfoList.getAccTypes.map(createInternalTypeFromTypeInfo)
     val aggValueTypes = aggInfoList.getActualValueTypes.map(createInternalTypeFromTypeInfo)
     val recordEqualiser = new EqualiserCodeGenerator(aggValueTypes)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecIncrementalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecIncrementalGroupAggregate.scala
@@ -208,12 +208,11 @@ class StreamExecIncrementalGroupAggregate(
       CodeGeneratorContext(config),
       relBuilder,
       FlinkTypeFactory.toInternalRowType(inputRowType).getFieldTypes,
-      needRetract = false,
-      config.getNullCheck,
       inputFieldCopy)
 
     generator
-      .withMerging(mergedAccOffset, mergedAccOnHeap = true, mergedAccExternalTypes)
+      .needAccumulate()
+      .needMerge(mergedAccOffset, mergedAccOnHeap = true, mergedAccExternalTypes)
       .generateAggsHandler(name, aggInfoList)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecLocalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecLocalGroupAggregate.scala
@@ -120,10 +120,16 @@ class StreamExecLocalGroupAggregate(
       CodeGeneratorContext(tableEnv.getConfig),
       tableEnv.getRelBuilder,
       inRowType.getFieldTypes,
-      needRetraction,
       // the local aggregate result will be buffered, so need copy
       copyInputField = true)
-    generator.withMerging(mergedAccOffset = 0, mergedAccOnHeap = true)
+
+    generator
+      .needAccumulate()
+      .needMerge(mergedAccOffset = 0, mergedAccOnHeap = true)
+
+    if (needRetraction) {
+      generator.needRetract()
+    }
 
     val aggsHandler = generator.generateAggsHandler("GroupAggsHandler", aggInfoList)
     val aggFunction = new MiniBatchLocalGroupAggFunction(aggsHandler)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/codegen/agg/AggsHandlerCodeGeneratorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/codegen/agg/AggsHandlerCodeGeneratorTest.scala
@@ -82,12 +82,17 @@ class AggsHandlerCodeGeneratorTest extends AggTestBase {
   }
 
   private def getHandler(needRetract: Boolean, needMerge: Boolean): AggsHandleFunction = {
-    val generator = new AggsHandlerCodeGenerator(ctx, relBuilder, inputTypes, needRetract, true)
+    val generator = new AggsHandlerCodeGenerator(ctx, relBuilder, inputTypes, true)
+    if (needRetract) {
+      generator.needRetract()
+    }
     if (needMerge) {
-      generator.withMerging(1, mergedAccOnHeap = true, Array(Types.LONG, Types.LONG,
+      generator.needMerge(1, mergedAccOnHeap = true, Array(Types.LONG, Types.LONG,
         Types.DOUBLE, Types.LONG, imperativeAggFunc.getAccumulatorType))
     }
-    val handler = generator.generateAggsHandler("Test", aggInfoList).newInstance(classLoader)
+    val handler = generator
+      .needAccumulate()
+      .generateAggsHandler("Test", aggInfoList).newInstance(classLoader)
     handler.open(new PerKeyStateDataViewStore(context.getRuntimeContext))
     handler
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/AggregateITCase.scala
@@ -24,7 +24,6 @@ import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.dataformat.Decimal
 import org.apache.flink.table.functions.aggfunctions.{ConcatWithRetractAggFunction, ConcatWsWithRetractAggFunction}
 import org.apache.flink.table.plan.util.JavaUserDefinedAggFunctions.VarSumAggFunction
 import org.apache.flink.table.runtime.batch.sql.agg.{MyPojoAggFunction, VarArgsAggFunction}
@@ -33,7 +32,7 @@ import org.apache.flink.table.runtime.utils.StreamingWithMiniBatchTestBase.MiniB
 import org.apache.flink.table.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.runtime.utils.UserDefinedFunctionTestUtils._
 import org.apache.flink.table.runtime.utils.{StreamTestData, StreamingWithAggTestBase, TestingRetractSink}
-import org.apache.flink.table.typeutils.{BigDecimalTypeInfo, DecimalTypeInfo}
+import org.apache.flink.table.typeutils.BigDecimalTypeInfo
 import org.apache.flink.table.util.DateTimeTestUtil._
 import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
@@ -741,7 +740,6 @@ class AggregateITCase(
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
 
-  @Ignore("[FLINK-12208] LIMIT is not supported")
   @Test
   def testDifferentTypesSumWithRetract(): Unit = {
     val data = List(
@@ -1203,7 +1201,6 @@ class AggregateITCase(
 
   @Test
   def testCountDistinctWithBinaryRowSource(): Unit = {
-    System.setProperty("org.codehaus.janino.source_debugging.enable", "true")
     // this case is failed before, because of object reuse problem
     val data = (0 until 100).map {i => ("1", "1", s"${i%50}", "1")}.toList
     // use BinaryRow source here for BinaryString reuse


### PR DESCRIPTION

## What is the purpose of the change

Currently, the constructor of `AggsHandlerCodeGenerator` contains several boolean flag to indicate which methods should be generated. It is error-prone that it's easy to pass wrong parameters.

This pull request simplify the constructor of `AggsHandlerCodeGenerator` to avoid this problem.


## Brief change log

  - add a `needAccumulate` and `needRetract` and `needMerge` methods into `AggsHandlerCodeGenerator`.


## Verifying this change

All the existing integration tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
