### PR TITLE
[FLINK-11982] [table] File System Connector's support JSON Format and JSON file BatchTableSource

### DIFF
--- a/flink-connectors/flink-connector-json/pom.xml
+++ b/flink-connectors/flink-connector-json/pom.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connectors</artifactId>
+		<version>1.9-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-connector-json_${scala.binary.version}</artifactId>
+	<name>flink-connector-json</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+
+		<!-- core dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Table ecosystem -->
+		<!-- Projects depending on this project won't depend on flink-table-*. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- A planner dependency won't be necessary once FLIP-32 has been completed. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-json</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+						scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>add-source</goal>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+						 scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Scala Code Style, most of the configuration done via plugin management -->
+			<plugin>
+				<groupId>org.scalastyle</groupId>
+				<artifactId>scalastyle-maven-plugin</artifactId>
+				<configuration>
+					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-connectors/flink-connector-json/src/main/java/org/apache/flink/table/sources/JsonBatchTableSource.java
+++ b/flink-connectors/flink-connector-json/src/main/java/org/apache/flink/table/sources/JsonBatchTableSource.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A [[BatchTableSource]] for simple Json files.
+ */
+public class JsonBatchTableSource implements BatchTableSource<Row>, ProjectableTableSource<Row>{
+
+	// The path to the Json file.
+	private final String path;
+	// The names of the table fields.
+	private final String[] fieldNames;
+	// The types of the table fields.
+	private final TypeInformation[] fieldTypes;
+	// The fields which will be read and returned by the table source.
+	private final int[] selectedFields;
+
+	/**
+	 * A [[BatchTableSource]] for simple JSON files with a
+	 * (logically) unlimited number of fields.
+	 *
+	 * @param path The path to the json file.
+	 * @param fieldNames The names of the table fields.
+	 * @param fieldTypes The types of the table fields.
+	 */
+	public JsonBatchTableSource(String path, String[] fieldNames, TypeInformation[] fieldTypes) {
+		this(path, fieldNames, fieldTypes, null);
+	}
+
+	public JsonBatchTableSource(String path, String[] fieldNames, TypeInformation[] fieldTypes, int[] selectedFields) {
+		Preconditions.checkNotNull(path, "Path must not be null.");
+		this.path = path;
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+		if (null == selectedFields) {
+			selectedFields = new int[fieldNames.length];
+			for (int i = 0; i < fieldNames.length; i++) {
+				selectedFields[i] = i;
+			}
+		}
+		this.selectedFields = selectedFields;
+	}
+
+	@Override
+	public DataSet<Row> getDataSet(ExecutionEnvironment execEnv) {
+		JsonRowInputFormat inputFormat = new JsonRowInputFormat(path, fieldNames, fieldTypes);
+		if (selectedFields != null) {
+			inputFormat.selectFields(selectedFields);
+		}
+		return execEnv.createInput(inputFormat).name(explainSource());
+	}
+
+	@Override
+	public TableSource<Row> projectFields(int[] fields) {
+		// create a copy of the JsonFileBatchTableSource with new selected fields.
+		// If None, all fields are returned.
+		if (null == fields) {
+			fields = this.selectedFields;
+		}
+		return new JsonBatchTableSource(path, fieldNames, fieldTypes, fields);
+	}
+
+	@Override
+	public TypeInformation<Row> getReturnType() {
+		String[] selectedFieldNames = new String[this.selectedFields.length];
+		TypeInformation[] selectedFieldTypes = new TypeInformation[this.selectedFields.length];
+		for (int i = 0; i < this.selectedFields.length; i++) {
+			selectedFieldNames[i] = fieldNames[selectedFields[i]];
+			selectedFieldTypes[i] = fieldTypes[selectedFields[i]];
+		}
+		return new RowTypeInfo(selectedFieldTypes , selectedFieldNames);
+	}
+
+	@Override
+	public TableSchema getTableSchema() {
+		return new TableSchema(fieldNames, fieldTypes);
+	}
+
+	@Override
+	public String explainSource() {
+		return String.format("JsonFileBatchTableSource( read fields: %s)", fieldNames.toString());
+	}
+}

--- a/flink-connectors/flink-connector-json/src/main/java/org/apache/flink/table/sources/JsonRowInputFormat.java
+++ b/flink-connectors/flink-connector-json/src/main/java/org/apache/flink/table/sources/JsonRowInputFormat.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.json.JsonRowDeserializationSchema;
+import org.apache.flink.types.Row;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+/**
+ * InputFormat that reads json files.
+ *
+ */
+@Internal
+public class JsonRowInputFormat extends FileInputFormat<Row> implements ResultTypeQueryable<Row> {
+
+	private String[] fieldNames;
+	private TypeInformation[] fieldTypes;
+	private int[] selectedFields;
+
+	private transient boolean hasLine;
+	private transient Scanner sc;
+	private transient RowTypeInfo rowType;
+	private transient FSDataInputStream inputStream;
+
+	private transient JsonRowDeserializationSchema schema;
+
+	public JsonRowInputFormat(String filePath, String[] fieldNames, TypeInformation[] fieldTypes) {
+		super(new Path(filePath));
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+		// set default selection mask, i.e., all fields.
+		this.selectedFields = new int[fieldNames.length];
+		for (int i = 0; i < selectedFields.length; i++) {
+			this.selectedFields[i] = i;
+		}
+	}
+
+	@Override
+	public boolean reachedEnd() throws IOException {
+		return !hasLine;
+	}
+
+	@Override
+	public void open(FileInputSplit fileSplit) throws IOException {
+		Path path = fileSplit.getPath();
+		FileSystem fs = FileSystem.get(path.toUri());
+		inputStream = fs.open(path);
+		sc = new Scanner(inputStream, StandardCharsets.UTF_8.name());
+		hasLine = sc.hasNextLine();
+
+		setRowType();
+		schema = new JsonRowDeserializationSchema(this.rowType);
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (null != inputStream) {
+			inputStream.close();
+		}
+
+		if (null != sc) {
+			sc.close();
+		}
+	}
+
+	@Override
+	public Row nextRecord(Row row) throws IOException {
+		if (!hasLine) {
+			return null;
+		}
+
+		String line = sc.nextLine();
+		row = schema.deserialize(line.getBytes());
+
+		hasLine = sc.hasNextLine();
+		return row;
+	}
+
+	@Override
+	public TypeInformation<Row> getProducedType() {
+		return this.rowType;
+	}
+
+	public void selectFields(int... selectedFields) {
+		// set field mapping
+		if (null != selectedFields) {
+			this.selectedFields = selectedFields;
+		}
+
+		// adapt result type
+		setRowType();
+	}
+
+	private void setRowType() {
+		if (null == this.rowType) {
+			this.rowType = new RowTypeInfo(fieldTypes , fieldNames);
+			this.rowType = RowTypeInfo.projectFields(this.rowType, this.selectedFields);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-json/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-connectors/flink-connector-json/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.sources.JsonBatchTableSourceFactory

--- a/flink-connectors/flink-connector-json/src/main/scala/org/apache/flink/table/sources/JsonBatchTableSourceFactory.scala
+++ b/flink-connectors/flink-connector-json/src/main/scala/org/apache/flink/table/sources/JsonBatchTableSourceFactory.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources
+
+import java.util
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.formats.json.JsonRowSchemaConverter
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR_PROPERTY_VERSION, CONNECTOR_TYPE}
+import org.apache.flink.table.descriptors._
+import org.apache.flink.table.descriptors.FileSystemValidator.{CONNECTOR_PATH, CONNECTOR_TYPE_VALUE}
+import org.apache.flink.table.descriptors.FormatDescriptorValidator.{FORMAT_PROPERTY_VERSION, FORMAT_TYPE}
+import org.apache.flink.table.factories.BatchTableSourceFactory
+import org.apache.flink.types.Row
+
+/**
+  * Factory for creating configured instances of [[JsonBatchTableSource]] in a batch environment.
+  */
+class JsonBatchTableSourceFactory extends BatchTableSourceFactory[Row] {
+
+  val SCHEMA = "schema"
+  val FORMAT_TYPE_VALUE = "json"
+  val FORMAT_FIELDS = "format.fields"
+
+  /**
+    * Creates and configures a [[org.apache.flink.table.sources.BatchTableSource]]
+    * using the given properties.
+    *
+    * @param properties normalized properties describing a batch table source.
+    * @return the configured batch table source.
+    */
+  override def createBatchTableSource(properties: util.Map[String, String])
+    : BatchTableSource[Row] = {
+      val params = new DescriptorProperties()
+      params.putProperties(properties)
+
+      // validate
+      new FileSystemValidator().validate(params)
+      new JsonValidator().validate(params)
+
+      var fieldNames : Array[String] = null
+      var fieldTypes : Array[TypeInformation[_]] = null
+      if (params.containsKey(JsonValidator.FORMAT_SCHEMA)) {
+        val rowTypeInfo : RowTypeInfo = params.getType(JsonValidator.FORMAT_SCHEMA)
+          .asInstanceOf[RowTypeInfo]
+        fieldNames = rowTypeInfo.getFieldNames
+        fieldTypes = rowTypeInfo.getFieldTypes
+      } else if (params.containsKey(JsonValidator.FORMAT_JSON_SCHEMA)) {
+        val rowTypeInfo : RowTypeInfo = JsonRowSchemaConverter.convert(
+          params.getString(JsonValidator.FORMAT_JSON_SCHEMA)).asInstanceOf[RowTypeInfo]
+        fieldNames = rowTypeInfo.getFieldNames
+        fieldTypes = rowTypeInfo.getFieldTypes
+      } else {
+        val tableSchema = params.getTableSchema(SCHEMA)
+        fieldNames = tableSchema.getFieldNames
+        fieldTypes = tableSchema.getFieldTypes
+      }
+
+      val path = params.getString(CONNECTOR_PATH)
+      if (path == null) throw new IllegalArgumentException("Path must be defined.")
+
+      new JsonBatchTableSource(path, fieldNames, fieldTypes)
+  }
+
+  /**
+    * Specifies the context that this factory has been implemented for. The framework guarantees to
+    * only match for this factory if the specified set of properties and values are met.
+    *
+    * <p>Typical properties might be:
+    *   - connector.type
+    *   - format.type
+    *
+    * <p>Specified property versions allow the framework to provide backwards compatible properties
+    * in case of string format changes:
+    *   - connector.property-version
+    *   - format.property-version
+    *
+    * <p>An empty context means that the factory matches for all requests.
+    */
+  override def requiredContext(): util.Map[String, String] = {
+    val context = new util.HashMap[String, String]()
+    context.put(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE)
+    context.put(FORMAT_TYPE, FORMAT_TYPE_VALUE)
+    context.put(CONNECTOR_PROPERTY_VERSION, "1")
+    context.put(FORMAT_PROPERTY_VERSION, "1")
+    context
+  }
+
+  /**
+    * List of property keys that this factory can handle. This method will be used for validation.
+    * If a property is passed that this factory cannot handle, an exception will be thrown. The
+    * list must not contain the keys that are specified by the context.
+    *
+    * <p>Example properties might be:
+    *   - schema.#.type
+    *   - schema.#.name
+    *   - connector.path
+    *   - format.schema
+    *   - format.json-schema
+    *   - format.fail-on-missing-field
+    *   - format.fields.#.type
+    *   - format.fields.#.name
+    *
+    * <p>Note: Use "#" to denote an array of values where "#" represents one or more digits.
+    * Property versions like "format.property-version"
+    * must not be part of the supported properties.
+    *
+    * <p>In some cases it might be useful to declare wildcards "*". Wildcards
+    * can only be declared at the end of a property key.
+    *
+    * <p>For example, if an arbitrary format should be supported:
+    *   - format.*
+    *
+    * <p>Note: Wildcards should be used with caution as they might swallow unsupported properties
+    * and thus might lead to undesired behavior.
+    */
+  override def supportedProperties(): util.List[String] = {
+    val properties = new util.ArrayList[String]()
+    // connector
+    properties.add(CONNECTOR_PATH)
+    // format
+    properties.add(s"$FORMAT_FIELDS.#.${DescriptorProperties.TABLE_SCHEMA_TYPE}")
+    properties.add(s"$FORMAT_FIELDS.#.${DescriptorProperties.TABLE_SCHEMA_NAME}")
+    properties.add(JsonValidator.FORMAT_SCHEMA)
+    properties.add(JsonValidator.FORMAT_JSON_SCHEMA)
+    properties.add(JsonValidator.FORMAT_FAIL_ON_MISSING_FIELD)
+    properties.add(FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA)
+    properties.add(CONNECTOR_PATH)
+    // schema
+    properties.add(s"$SCHEMA.#.${DescriptorProperties.TABLE_SCHEMA_TYPE}")
+    properties.add(s"$SCHEMA.#.${DescriptorProperties.TABLE_SCHEMA_NAME}")
+    properties
+  }
+}

--- a/flink-connectors/flink-connector-json/src/test/java/org/apache/flink/table/sources/JsonBatchTableSourceFactoryTest.java
+++ b/flink-connectors/flink-connector-json/src/test/java/org/apache/flink/table/sources/JsonBatchTableSourceFactoryTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.table.descriptors.FileSystem;
+import org.apache.flink.table.descriptors.Json;
+import org.apache.flink.table.descriptors.Schema;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link JsonBatchTableSourceFactory}.
+ */
+public class JsonBatchTableSourceFactoryTest extends MultipleProgramsTestBase {
+
+	private static final String[] FIELD_NAMES =  {"author", "title", "price", "zip_code"};
+	private static final TypeInformation[] FIELD_TYPES =  {BasicTypeInfo.STRING_TYPE_INFO,
+		BasicTypeInfo.STRING_TYPE_INFO,
+		BasicTypeInfo.DOUBLE_TYPE_INFO,
+		BasicTypeInfo.STRING_TYPE_INFO
+	};
+
+	private String basePath;
+	private BatchTableEnvironment tEnv;
+	private FileSystem connector;
+
+	public JsonBatchTableSourceFactoryTest() {
+		super(TestExecutionMode.COLLECTION);
+	}
+
+	@Before
+	public void create() throws IOException {
+		basePath = JsonFileUtils.createJsonFile();
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		tEnv = BatchTableEnvironment.create(env);
+		connector = new FileSystem().path(basePath);
+	}
+
+	@Test
+	public void testWithFormatSchema() throws Exception {
+		tEnv.connect(connector)
+			.withFormat(new Json()
+				.schema(new RowTypeInfo(FIELD_TYPES, FIELD_NAMES))
+				.failOnMissingField(true)
+			)
+			.registerTableSource("jsonTable");
+
+		String fullSql = "select author, title, price, zip_code FROM jsonTable";
+		Table fullTable = tEnv.sqlQuery(fullSql);
+
+		DataSet<Row> fullDS = tEnv.toDataSet(fullTable, Row.class);
+		List<Row> full = fullDS.collect();
+		assertEquals(1, full.size());
+		assertEquals(
+			"J. R. R. Tolkien,The Lord of the Rings,22.99,94025",
+			full.get(0).toString());
+
+		String countSql =
+			"SELECT author, count(price) FROM jsonTable group by author";
+		Table countTable = tEnv.sqlQuery(countSql);
+		DataSet<Row> countDS = tEnv.toDataSet(countTable, Row.class);
+		List<Row> count = countDS.collect();
+		assertEquals(1, count.size());
+		assertEquals(
+			"J. R. R. Tolkien,1",
+			count.get(0).toString());
+	}
+
+	@Test
+	public void testWithFormatJsonSchema() throws Exception {
+		tEnv.connect(connector)
+			.withFormat(new Json()
+				.jsonSchema("{\"type\":\"object\",\"properties\":{" +
+				"\"author\":{\"type\":\"string\"}," +
+				"\"title\":{\"type\":\"string\"}," +
+				"\"price\":{\"type\":\"number\"}," +
+				"\"zip_code\":{\"type\":\"string\"}" +
+				"}}")
+				.failOnMissingField(true))
+			.registerTableSource("jsonTable");
+
+		String fullSql = "select author, title, price, zip_code FROM jsonTable";
+		Table fullTable = tEnv.sqlQuery(fullSql);
+
+		DataSet<Row> fullDS = tEnv.toDataSet(fullTable, Row.class);
+		List<Row> full = fullDS.collect();
+		assertEquals(1, full.size());
+		assertEquals(
+			"J. R. R. Tolkien,The Lord of the Rings,22.99,94025",
+			full.get(0).toString());
+
+		String countSql =
+			"SELECT author, count(price) FROM jsonTable group by author";
+		Table countTable = tEnv.sqlQuery(countSql);
+		DataSet<Row> countDS = tEnv.toDataSet(countTable, Row.class);
+		List<Row> count = countDS.collect();
+		assertEquals(1, count.size());
+		assertEquals(
+			"J. R. R. Tolkien,1",
+			count.get(0).toString());
+	}
+
+	@Test
+	public void testWithSchema() throws Exception {
+		tEnv.connect(connector)
+			.withFormat(new Json().failOnMissingField(true).deriveSchema())
+			.withSchema(
+				new Schema()
+					.field("author", Types.STRING())
+					.field("title", Types.STRING())
+					.field("price", Types.DOUBLE())
+					.field("zip_code", Types.STRING())
+			)
+			.registerTableSource("jsonTable");
+
+		String fullSql = "select author, title, price, zip_code FROM jsonTable";
+		Table fullTable = tEnv.sqlQuery(fullSql);
+
+		DataSet<Row> fullDS = tEnv.toDataSet(fullTable, Row.class);
+		List<Row> full = fullDS.collect();
+		assertEquals(1, full.size());
+		assertEquals(
+			"J. R. R. Tolkien,The Lord of the Rings,22.99,94025",
+			full.get(0).toString());
+
+		String countSql =
+			"SELECT author, count(price) FROM jsonTable group by author";
+		Table countTable = tEnv.sqlQuery(countSql);
+		DataSet<Row> countDS = tEnv.toDataSet(countTable, Row.class);
+		List<Row> count = countDS.collect();
+		assertEquals(1, count.size());
+		assertEquals(
+			"J. R. R. Tolkien,1",
+			count.get(0).toString());
+	}
+
+	@After
+	public void delete() {
+		if (basePath != null) {
+			new File(basePath).delete();
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-json/src/test/java/org/apache/flink/table/sources/JsonBatchTableSourceTest.java
+++ b/flink-connectors/flink-connector-json/src/test/java/org/apache/flink/table/sources/JsonBatchTableSourceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link JsonBatchTableSource}.
+ */
+public class JsonBatchTableSourceTest extends MultipleProgramsTestBase {
+
+	private static final String[] FIELD_NAMES =  {"author", "title", "price", "zip_code"};
+	private static final TypeInformation[] FIELD_TYPES =  {BasicTypeInfo.STRING_TYPE_INFO,
+		BasicTypeInfo.STRING_TYPE_INFO,
+		BasicTypeInfo.DOUBLE_TYPE_INFO,
+		BasicTypeInfo.STRING_TYPE_INFO
+	};
+
+	private String basePath = null;
+
+	public JsonBatchTableSourceTest() {
+		super(TestExecutionMode.COLLECTION);
+	}
+
+	@Before
+	public void create() throws IOException {
+		basePath = JsonFileUtils.createJsonFile();
+	}
+
+	@Test
+	public void testFullScan() throws Exception {
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
+
+		JsonBatchTableSource json = new JsonBatchTableSource(basePath, FIELD_NAMES, FIELD_TYPES);
+		tEnv.registerTableSource("jsonTable", json);
+
+		String query =
+			"SELECT author, title, price, zip_code FROM jsonTable";
+		Table t = tEnv.sqlQuery(query);
+
+		DataSet<Row> dataSet = tEnv.toDataSet(t, Row.class);
+		List<Row> result = dataSet.collect();
+
+		assertEquals(1, result.size());
+		assertEquals(
+			"J. R. R. Tolkien,The Lord of the Rings,22.99,94025",
+			result.get(0).toString());
+	}
+
+	@Test
+	public void testScanWithProjection() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
+
+		JsonBatchTableSource json = new JsonBatchTableSource(basePath, FIELD_NAMES, FIELD_TYPES);
+		json.projectFields(new int[] {0, 2});
+		tEnv.registerTableSource("jsonTable", json);
+
+		String query =
+			"SELECT author, sum(price) FROM jsonTable group by author";
+		Table t = tEnv.sqlQuery(query);
+
+		DataSet<Row> dataSet = tEnv.toDataSet(t, Row.class);
+		List<Row> result = dataSet.collect();
+
+		assertEquals(1, result.size());
+		assertEquals(
+			"J. R. R. Tolkien,22.99",
+			result.get(0).toString());
+	}
+
+	@After
+	public void delete() {
+		if (basePath != null) {
+			new File(basePath).delete();
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-json/src/test/java/org/apache/flink/table/sources/JsonFileUtils.java
+++ b/flink-connectors/flink-connector-json/src/test/java/org/apache/flink/table/sources/JsonFileUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources;
+
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ *  use json data create file.
+ */
+public class JsonFileUtils {
+
+	private static final String JSON_DATA = "{\"fruit\":[{\"weight\":8,\"type\":\"apple\"},{\"weight\":9,\"type\":\"pear\"}]," +
+		"\"author\":\"J. R. R. Tolkien\",\"title\":\"The Lord of the Rings\",\"category\":\"fiction\",\"price\":22.99,\"isbn\":\"0-395-19395-8\"," +
+		"\"email\":\"amy@only_for_json_udf_test.net\",\"owner\":\"amy\",\"zip_code\":\"94025\",\"fb_id\":\"1234\"}";
+	private static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	public static String createJsonFile() throws IOException {
+		temporaryFolder.create();
+		File output = temporaryFolder.newFile("test-data.json");
+		FileWriter fileWriter = new FileWriter(output);
+		fileWriter.write(JSON_DATA);
+		fileWriter.close();
+		return output.getPath();
+	}
+
+}

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -56,6 +56,7 @@ under the License.
 		<module>flink-connector-cassandra</module>
 		<module>flink-connector-filesystem</module>
 		<module>flink-connector-kafka</module>
+		<module>flink-connector-json</module>
 	</modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up


### PR DESCRIPTION
## What is the purpose of the change

fix [ISSUE #11982](https://issues.apache.org/jira/browse/FLINK-11982) 

## Brief change log

-  [flink-connector-json] module to support File System Connector's JSON Format.
-  JsonBatchTableSourceFactory is a BatchTableSourceFactory
-  JsonBatchTableSource is a BatchTableSource

## Verifying this change

Unit tests for add java class.

*[**flink json format doc**](https://ci.apache.org/projects/flink/flink-docs-release-1.8/dev/table/connect.html#json-format) : File system connector use JSON Format example:*
```java
FileSystem connector = new FileSystem().path(path);

// or withFormatSchema
tEnv.connect(connector)
       .withFormat(new Json()
				.schema(new RowTypeInfo(FIELD_TYPES, FIELD_NAMES))
				.failOnMissingField(true)
      )
      .registerTableSource("jsonTable");

// or withFormatJsonSchema
tEnv.connect(connector)
	.withFormat(new Json()
				.jsonSchema("{\"type\":\"object\",\"properties\":{" +
				"\"author\":{\"type\":\"string\"}," +
				"\"title\":{\"type\":\"string\"}," +
				"\"price\":{\"type\":\"number\"}," +
				"\"zip_code\":{\"type\":\"string\"}" +
				"}}")
				.failOnMissingField(true)
        )
	.registerTableSource("jsonTable");

//or withScheam
tEnv.connect(connector)
	.withFormat(new Json().failOnMissingField(true).deriveSchema())
	.withSchema(
				new Schema()
					.field("author", Types.STRING())
					.field("title", Types.STRING())
					.field("price", Types.DOUBLE())
					.field("zip_code", Types.STRING())
          )
	.registerTableSource("jsonTable");

String fullSql = "select * FROM jsonTable";
Table fullTable = tEnv.sqlQuery(fullSql);
``` 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (example)
