### PR TITLE
[FLINK-12164][runtime] Harden JobMasterTest against timeouts

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -200,7 +200,7 @@ public class JobMasterTest extends TestLogger {
 	private static final Time testingTimeout = Time.seconds(10L);
 
 	private static final long fastHeartbeatInterval = 1L;
-	private static final long fastHeartbeatTimeout = 5L;
+	private static final long fastHeartbeatTimeout = 10L;
 
 	private static final long heartbeatInterval = 1000L;
 	private static final long heartbeatTimeout = 5_000_000L;


### PR DESCRIPTION
Hardens `JobMasterTest#testJobFailureWhenTaskExecutorHeartbeatTimeout`

The reported failure occurred when offering slots, indicating that at this time the TM was no longer registered at the JM. However, the TM is being registered right before the slot offer.

The only explanation I could find is that due so some freak timing thing a heartbeat times out in between these 2 calls. `testJobFailureWhenTaskExecutorHeartbeatTimeout` uses a very small heartbeat interval (1ms) and timeout (5ms).
I was only able to reproduce the issue locally after reducing the timeout to 2ms.

This PR doubles the timeout to reduce the likely-hood of this happening again.