### PR TITLE
[FLINK-12399][table] Fix FilterableTableSource does not change after applyPredicate

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.schema.TableSourceSinkTable
-import org.apache.flink.table.sources.{FilterableTableSource, TableSource, TableSourceUtil}
+import org.apache.flink.table.sources.{FilterableTableSource, ProjectableTableSource, TableSource, TableSourceUtil}
 
 import scala.collection.JavaConverters._
 
@@ -81,7 +81,13 @@ class FlinkLogicalTableSourceScan(
     val terms = super.explainTerms(pw)
         .item("fields", tableSource.getTableSchema.getFieldNames.mkString(", "))
 
-    val sourceDesc = tableSource.explainSource()
+    val auxiliarySourceDesc = tableSource match {
+      case fts: FilterableTableSource[_] =>
+        s"FilterPushDown=${fts.isFilterPushedDown.toString}"
+      case _ => ""
+    }
+
+    val sourceDesc = tableSource.explainSource() + auxiliarySourceDesc
     if (sourceDesc.nonEmpty) {
       terms.item("source", sourceDesc)
     } else {


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the problem: FilterableTableSource does not generate a new digest after the predicate push down, unless `explainSource()` API is explicitly override. 

## Brief change log


  - Changed the `explainTerm` API from `FlinkLogicalTableSourceScan` to include auxiliary source description.
  - Changed the `TestFilterableTableSource` to include both the none explainSource and with explainSource version.
  - Added test to both stream and batch cases.

## Verifying this change

  - Tests for both stream and batch cases for predicate push down without explainSource override.
  - Others are covered for current tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
