### PR TITLE
[FLINK-12469][table] Clean up catalog API on default/current database

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
@@ -67,6 +67,10 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 
 	public GenericHiveMetastoreCatalog(String catalogName, HiveConf hiveConf) {
 		super(catalogName, hiveConf);
+	}
+
+	public GenericHiveMetastoreCatalog(String catalogName, String defaultDatabase, HiveConf hiveConf) {
+		super(catalogName, defaultDatabase, hiveConf);
 
 		LOG.info("Created GenericHiveMetastoreCatalog '{}'", catalogName);
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -48,23 +48,26 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public abstract class HiveCatalogBase implements Catalog {
 	private static final Logger LOG = LoggerFactory.getLogger(HiveCatalogBase.class);
-
-	public static final String DEFAULT_DB = "default";
+	private static final String DEFAULT_DB = "default";
 
 	protected final String catalogName;
 	protected final HiveConf hiveConf;
 
-	protected String currentDatabase = DEFAULT_DB;
+	private final String defaultDatabase;
 	protected IMetaStoreClient client;
 
 	public HiveCatalogBase(String catalogName, String hivemetastoreURI) {
-		this(catalogName, getHiveConf(hivemetastoreURI));
+		this(catalogName, DEFAULT_DB, getHiveConf(hivemetastoreURI));
 	}
 
 	public HiveCatalogBase(String catalogName, HiveConf hiveConf) {
+		this(catalogName, DEFAULT_DB, hiveConf);
+	}
+
+	public HiveCatalogBase(String catalogName, String defaultDatabase, HiveConf hiveConf) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "catalogName cannot be null or empty");
 		this.catalogName = catalogName;
-
+		this.defaultDatabase = checkNotNull(defaultDatabase, "defaultDatabase cannot be null");
 		this.hiveConf = checkNotNull(hiveConf, "hiveConf cannot be null");
 	}
 
@@ -109,19 +112,8 @@ public abstract class HiveCatalogBase implements Catalog {
 	// ------ databases ------
 
 	@Override
-	public String getCurrentDatabase() throws CatalogException {
-		return currentDatabase;
-	}
-
-	@Override
-	public void setCurrentDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
-		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));
-
-		if (!databaseExists(databaseName)) {
-			throw new DatabaseNotExistException(catalogName, databaseName);
-		}
-
-		currentDatabase = databaseName;
+	public String getDefaultDatabase() throws CatalogException {
+		return defaultDatabase;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -99,6 +99,11 @@ public abstract class HiveCatalogBase implements Catalog {
 			client = getMetastoreClient(hiveConf);
 			LOG.info("Connected to Hive metastore");
 		}
+
+		if (!databaseExists(defaultDatabase)) {
+			throw new CatalogException(String.format("Configured default database %s doesn't exist in catalog %s.",
+				defaultDatabase, catalogName));
+		}
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -66,6 +66,7 @@ public abstract class HiveCatalogBase implements Catalog {
 
 	public HiveCatalogBase(String catalogName, String defaultDatabase, HiveConf hiveConf) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "catalogName cannot be null or empty");
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(defaultDatabase), "defaultDatabase cannot be null or empty");
 		this.catalogName = catalogName;
 		this.defaultDatabase = checkNotNull(defaultDatabase, "defaultDatabase cannot be null");
 		this.hiveConf = checkNotNull(hiveConf, "hiveConf cannot be null");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -68,7 +68,7 @@ public abstract class HiveCatalogBase implements Catalog {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "catalogName cannot be null or empty");
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(defaultDatabase), "defaultDatabase cannot be null or empty");
 		this.catalogName = catalogName;
-		this.defaultDatabase = checkNotNull(defaultDatabase, "defaultDatabase cannot be null");
+		this.defaultDatabase = defaultDatabase;
 		this.hiveConf = checkNotNull(hiveConf, "hiveConf cannot be null");
 	}
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
@@ -91,13 +91,6 @@ public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
 		CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(path1));
 	}
 
-	// ------ utils ------
-
-	@Override
-	public String getBuiltInDefaultDatabase() {
-		return HiveCatalogBase.DEFAULT_DB;
-	}
-
 	@Override
 	public CatalogDatabase createDb() {
 		return new GenericCatalogDatabase(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -137,11 +137,6 @@ public class HiveCatalogTest extends CatalogTestBase {
 	// ------ utils ------
 
 	@Override
-	public String getBuiltInDefaultDatabase() {
-		return HiveCatalogBase.DEFAULT_DB;
-	}
-
-	@Override
 	public CatalogDatabase createDb() {
 		return new HiveCatalogDatabase(
 			new HashMap<String, String>() {{

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -69,6 +69,7 @@ public class GenericInMemoryCatalog implements Catalog {
 
 	public GenericInMemoryCatalog(String name, String defaultDatabase) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(name), "name cannot be null or empty");
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(defaultDatabase), "defaultDatabase cannot be null or empty");
 
 		this.catalogName = name;
 		this.defaultDatabase = defaultDatabase;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -85,8 +85,11 @@ public class GenericInMemoryCatalog implements Catalog {
 	}
 
 	@Override
-	public void open() {
-
+	public void open() throws CatalogException {
+		if (!databaseExists(defaultDatabase)) {
+			throw new CatalogException(String.format("Configured default database %s doesn't exist in catalog %s.",
+				defaultDatabase, catalogName));
+		}
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -48,10 +48,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A generic catalog implementation that holds all meta objects in memory.
  */
 public class GenericInMemoryCatalog implements Catalog {
+	private static final String DEFAULT_DB = "default";
 
-	public static final String DEFAULT_DB = "default";
-
-	private String currentDatabase = DEFAULT_DB;
+	private final String defaultDatabase;
 
 	private final String catalogName;
 	private final Map<String, CatalogDatabase> databases;
@@ -65,9 +64,14 @@ public class GenericInMemoryCatalog implements Catalog {
 	private final Map<ObjectPath, Map<CatalogPartitionSpec, CatalogColumnStatistics>> partitionColumnStats;
 
 	public GenericInMemoryCatalog(String name) {
+		this(name, DEFAULT_DB);
+	}
+
+	public GenericInMemoryCatalog(String name, String defaultDatabase) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(name), "name cannot be null or empty");
 
 		this.catalogName = name;
+		this.defaultDatabase = defaultDatabase;
 		this.databases = new LinkedHashMap<>();
 		this.databases.put(DEFAULT_DB, new GenericCatalogDatabase(new HashMap<>()));
 		this.tables = new LinkedHashMap<>();
@@ -92,19 +96,8 @@ public class GenericInMemoryCatalog implements Catalog {
 	// ------ databases ------
 
 	@Override
-	public String getCurrentDatabase() {
-		return currentDatabase;
-	}
-
-	@Override
-	public void setCurrentDatabase(String databaseName) throws DatabaseNotExistException {
-		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));
-
-		if (!databaseExists(databaseName)) {
-			throw new DatabaseNotExistException(catalogName, databaseName);
-		}
-
-		currentDatabase = databaseName;
+	public String getDefaultDatabase() {
+		return defaultDatabase;
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -74,7 +74,7 @@ public class GenericInMemoryCatalog implements Catalog {
 		this.catalogName = name;
 		this.defaultDatabase = defaultDatabase;
 		this.databases = new LinkedHashMap<>();
-		this.databases.put(DEFAULT_DB, new GenericCatalogDatabase(new HashMap<>()));
+		this.databases.put(defaultDatabase, new GenericCatalogDatabase(new HashMap<>()));
 		this.tables = new LinkedHashMap<>();
 		this.functions = new LinkedHashMap<>();
 		this.partitions = new LinkedHashMap<>();
@@ -85,11 +85,7 @@ public class GenericInMemoryCatalog implements Catalog {
 	}
 
 	@Override
-	public void open() throws CatalogException {
-		if (!databaseExists(defaultDatabase)) {
-			throw new CatalogException(String.format("Configured default database %s doesn't exist in catalog %s.",
-				defaultDatabase, catalogName));
-		}
+	public void open() {
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -628,11 +628,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	// ------ utilities ------
 
 	@Override
-	public String getBuiltInDefaultDatabase() {
-		return GenericInMemoryCatalog.DEFAULT_DB;
-	}
-
-	@Override
 	public CatalogDatabase createDb() {
 		return new GenericCatalogDatabase(
 			new HashMap<String, String>() {{

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.catalog;
 
+import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
@@ -71,6 +72,17 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	// ------ tables ------
+
+	@Test
+	public void testDefaultDatabase_notExist() {
+		String catName = "inMemoryCatalog";
+		String dbName = "non-existing-db";
+		Catalog inMemoryCatalog = new GenericInMemoryCatalog(catName, dbName);
+		exception.expect(CatalogException.class);
+		exception.expectMessage(
+			String.format("Configured default database %s doesn't exist in catalog %s.", dbName, catName));
+		inMemoryCatalog.open();
+	}
 
 	@Test
 	public void testDropTable_partitionedTable() throws Exception {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.catalog;
 
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
@@ -72,17 +71,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	}
 
 	// ------ tables ------
-
-	@Test
-	public void testDefaultDatabase_notExist() {
-		String catName = "inMemoryCatalog";
-		String dbName = "non-existing-db";
-		Catalog inMemoryCatalog = new GenericInMemoryCatalog(catName, dbName);
-		exception.expect(CatalogException.class);
-		exception.expectMessage(
-			String.format("Configured default database %s doesn't exist in catalog %s.", dbName, catName));
-		inMemoryCatalog.open();
-	}
 
 	@Test
 	public void testDropTable_partitionedTable() throws Exception {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -60,23 +60,14 @@ public interface Catalog {
 	// ------ databases ------
 
 	/**
-	 * Get the name of the current database of this type of catalog. This is used when users refers an object in the catalog
-	 * without specifying a database. For example, the current db in a Hive Metastore is 'default' by default.
+	 * Get the name of the default database for this catalog. The default database will be the current database for
+	 * the catalog when user's session doesn't specify a current database. The value probably comes from configuration,
+	 * will not change for the life time of the catalog instance.
 	 *
 	 * @return the name of the current database
 	 * @throws CatalogException in case of any runtime exception
 	 */
-	String getCurrentDatabase() throws CatalogException;
-
-	/**
-	 * Set the database with the given name as the current database. A current database is used when users refers an object
-	 * in the catalog without specifying a database.
-	 *
-	 * @param databaseName	the name of the database
-	 * @throws DatabaseNotExistException if the given database doesn't exist in the catalog
-	 * @throws CatalogException in case of any runtime exception
-	 */
-	void setCurrentDatabase(String databaseName) throws DatabaseNotExistException, CatalogException;
+	String getDefaultDatabase() throws CatalogException;
 
 	/**
 	 * Get the names of all databases in this catalog.

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -111,29 +111,6 @@ public abstract class CatalogTestBase {
 	}
 
 	@Test
-	public void testSetCurrentDatabase() throws Exception {
-		assertEquals(getBuiltInDefaultDatabase(), catalog.getCurrentDatabase());
-
-		catalog.createDatabase(db2, createDb(), true);
-		catalog.setCurrentDatabase(db2);
-
-		assertEquals(db2, catalog.getCurrentDatabase());
-
-		catalog.setCurrentDatabase(getBuiltInDefaultDatabase());
-
-		assertEquals(getBuiltInDefaultDatabase(), catalog.getCurrentDatabase());
-
-		catalog.dropDatabase(db2, false);
-	}
-
-	@Test
-	public void testSetCurrentDatabaseNegative() throws Exception {
-		exception.expect(DatabaseNotExistException.class);
-		exception.expectMessage("Database " + this.nonExistentDatabase + " does not exist in Catalog");
-		catalog.setCurrentDatabase(this.nonExistentDatabase);
-	}
-
-	@Test
 	public void testCreateDb_DatabaseAlreadyExistException() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
 
@@ -150,13 +127,13 @@ public abstract class CatalogTestBase {
 
 		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(cd1.getProperties().entrySet()));
 		assertEquals(2, dbs.size());
-		assertEquals(new HashSet<>(Arrays.asList(db1, catalog.getCurrentDatabase())), new HashSet<>(dbs));
+		assertEquals(new HashSet<>(Arrays.asList(db1, catalog.getDefaultDatabase())), new HashSet<>(dbs));
 
 		catalog.createDatabase(db1, createAnotherDb(), true);
 
 		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(cd1.getProperties().entrySet()));
 		assertEquals(2, dbs.size());
-		assertEquals(new HashSet<>(Arrays.asList(db1, catalog.getCurrentDatabase())), new HashSet<>(dbs));
+		assertEquals(new HashSet<>(Arrays.asList(db1, catalog.getDefaultDatabase())), new HashSet<>(dbs));
 	}
 
 	@Test
@@ -584,13 +561,6 @@ public abstract class CatalogTestBase {
 	}
 
 	// ------ utilities ------
-
-	/**
-	 * Get the built-in default database of the specific catalog implementation.
-	 *
-	 * @return The built-in default database name
-	 */
-	public abstract String getBuiltInDefaultDatabase();
 
 	/**
 	 * Create a CatalogDatabase instance by specific catalog implementation.


### PR DESCRIPTION
## What is the purpose of the change

This PR separates concepts of "current database of a user session" and "default database of a catalog". 

## Brief change log

*(for example:)*
  - Removed get/setCurrentDatabase() from Catalog API
  - Added getDefaultDatabase() in Catalog API
  - Provided implementations in sub classes


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
