### PR TITLE
[FLINK-12475][tests] Include timestamp in generated log4j config

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -147,7 +147,7 @@ public class CommonTestUtils {
 			writer.println("log4j.appender.console=org.apache.log4j.ConsoleAppender");
 			writer.println("log4j.appender.console.target = System.err");
 			writer.println("log4j.appender.console.layout=org.apache.log4j.PatternLayout");
-			writer.println("log4j.appender.console.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n");
+			writer.println("log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-4r [%t] %-5p %c %x - %m%n");
 			writer.println("log4j.logger.org.eclipse.jetty.util.log=OFF");
 			writer.println("log4j.logger.org.apache.zookeeper=OFF");
 			writer.flush();


### PR DESCRIPTION
Small modification to include a timestamp in `CommonTestUtils#printLog4jDebugConfig`, so it's easier to order events between different processes.