### PR TITLE
[FLINK-12111][tests] Harden AbstractTaskManagerProcessFailureRecoveryTest

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -171,6 +171,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 
 			// kill one of the previous TaskManagers, triggering a failure and recovery
 			taskManagerProcess1.destroy();
+			waitForShutdown("TaskManager 1", taskManagerProcess1);
 
 			// we create the marker file which signals the program functions tasks that they can complete
 			touchFile(new File(coordinateTempDir, PROCEED_MARKER_FILE));

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -70,7 +70,6 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 
 	protected static final String READY_MARKER_FILE_PREFIX = "ready_";
 	protected static final String PROCEED_MARKER_FILE = "proceed";
-	protected static final String FINISH_MARKER_FILE_PREFIX = "finish_";
 
 	protected static final int PARALLELISM = 4;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -172,7 +172,6 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 
 			// kill one of the previous TaskManagers, triggering a failure and recovery
 			taskManagerProcess1.destroy();
-			taskManagerProcess1 = null;
 
 			// we create the marker file which signals the program functions tasks that they can complete
 			touchFile(new File(coordinateTempDir, PROCEED_MARKER_FILE));

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -68,7 +68,7 @@ public class TaskManagerProcessFailureBatchRecoveryITCase extends AbstractTaskMa
 
 		ExecutionEnvironment env = ExecutionEnvironment.createRemoteEnvironment("localhost", 1337, configuration);
 		env.setParallelism(PARALLELISM);
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0L));
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(2, 0L));
 		env.getConfig().setExecutionMode(executionMode);
 		env.getConfig().disableSysoutLogging();
 


### PR DESCRIPTION
## What is the purpose of the change

Assortment of changes to improve/harden the `AbstractTaskManagerProcessFailureRecoveryTest`

## Brief change log

* removed unused field
* no longer sets `taskManagerProcess1` to null so that the process output is printed on failure
* wait until destroyed process has actually shut down
Prevents theoretical scenarios where the job can finish because the destroy() command takes a while to take effect.
* reduce number of initial TMs to 1,
The batch test could still succeed (if ExecutionMode == BATCH) even if the new TM was never used.
Reduce the number of initial TMs to 1 so that once that TM crashes all tasks MUST be moved to the new TM.
Doubled number of slots to compensate the loss of a TM.
* allow 2 restarts
For some reason this test could fail multiple times, instead of just once.

## Verifying this change

The issue with the BATCH execution mode could be reproduced easily (just skip the start of the third TM), and the change should fix this in an obvious way.

The restart fix is basically a shot in the dark + band-aid; ideally we would find the underlying cause.
