### PR TITLE
[FLINK-12447][Build] Enforce maven version 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Prerequisites for building Flink:
 
 * Unix-like environment (we use Linux, Mac OS X, Cygwin)
 * git
-* Maven (we recommend version 3.2.5)
+* Maven (we recommend version 3.2.5 and require at least 3.1.1)
 * Java 8 (Java 9 and 10 are not yet supported)
 
 ```
@@ -80,7 +80,7 @@ mvn clean package -DskipTests # this will take up to 10 minutes
 
 Flink is now installed in `build-target`
 
-*NOTE: Maven 3.3.x can build Flink, but will not properly shade away certain dependencies. Maven 3.0.3 creates the libraries properly.
+*NOTE: Maven 3.3.x can build Flink, but will not properly shade away certain dependencies. Maven 3.1.1 creates the libraries properly.
 To build unit tests with Java 8, use Java 8u51 or above to prevent failures in unit tests that use the PowerMock runner.*
 
 ## Developing Flink

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -64,7 +64,7 @@ Flink [shades away](https://maven.apache.org/plugins/maven-shade-plugin/) some o
 
 The dependency shading mechanism was recently changed in Maven and requires users to build Flink slightly differently, depending on their Maven version:
 
-**Maven 3.0.x, 3.1.x, and 3.2.x**
+**Maven 3.1.x and 3.2.x**
 It is sufficient to call `mvn clean install -DskipTests` in the root directory of Flink code base.
 
 **Maven 3.3.x**

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -64,7 +64,7 @@ Flink [shades away](https://maven.apache.org/plugins/maven-shade-plugin/) some o
 
 The dependency shading mechanism was recently changed in Maven and requires users to build Flink slightly differently, depending on their Maven version:
 
-**Maven 3.0.x, 3.1.x, and 3.2.x**
+**Maven 3.1.x and 3.2.x**
 It is sufficient to call `mvn clean install -DskipTests` in the root directory of Flink code base.
 
 **Maven 3.3.x**

--- a/pom.xml
+++ b/pom.xml
@@ -1502,8 +1502,8 @@ under the License.
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<!-- enforce at least mvn version 3.0.3 -->
-									<version>[3.0.3,)</version>
+									<!-- enforce at least mvn version 3.1.1 (see FLINK-12447) -->
+									<version>[3.1.1,)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>${java.version}</version>


### PR DESCRIPTION
## Contribution Checklist

## What is the purpose of the change

The `frontend-maven-plugin` introduced in https://github.com/apache/flink/pull/8016 requires at least Maven 3.1.
With this change, we enforce the the latest stable release of Maven 3.1.

