### PR TITLE
[FLINK-12331] Introduce partition/gate setup to decouple task registration with NetworkEnvironment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * The provider used for requesting and releasing batch of memory segments.
+ */
+public interface MemorySegmentProvider {
+	Collection<MemorySegment> requestMemorySegments() throws IOException;
+
+	void recycleMemorySegments(Collection<MemorySegment> segments) throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -138,8 +138,8 @@ public class NetworkEnvironment {
 		ResultPartitionFactory resultPartitionFactory =
 			new ResultPartitionFactory(resultPartitionManager, ioManager);
 
-		SingleInputGateFactory singleInputGateFactory =
-			new SingleInputGateFactory(config, connectionManager, resultPartitionManager, taskEventPublisher);
+		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
+			config, connectionManager, resultPartitionManager, taskEventPublisher, networkBufferPool);
 
 		return new NetworkEnvironment(
 			config,
@@ -247,7 +247,7 @@ public class NetworkEnvironment {
 					config.floatingNetworkBuffersPerGate() : Integer.MAX_VALUE;
 
 				// assign exclusive buffers to input channels directly and use the rest for floating buffers
-				gate.assignExclusiveSegments(networkBufferPool);
+				gate.assignExclusiveSegments();
 				bufferPool = networkBufferPool.createBufferPool(0, maxNumberOfMemorySegments);
 			} else {
 				maxNumberOfMemorySegments = gate.getConsumedPartitionType().isBounded() ?

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -129,7 +129,8 @@ public class NetworkEnvironment {
 
 		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
 			config.numNetworkBuffers(),
-			config.networkBufferSize());
+			config.networkBufferSize(),
+			config.networkBuffersPerChannel());
 
 		registerNetworkMetrics(metricGroup, networkBufferPool);
 
@@ -246,7 +247,7 @@ public class NetworkEnvironment {
 					config.floatingNetworkBuffersPerGate() : Integer.MAX_VALUE;
 
 				// assign exclusive buffers to input channels directly and use the rest for floating buffers
-				gate.assignExclusiveSegments(networkBufferPool, config.networkBuffersPerChannel());
+				gate.assignExclusiveSegments(networkBufferPool);
 				bufferPool = networkBufferPool.createBufferPool(0, maxNumberOfMemorySegments);
 			} else {
 				maxNumberOfMemorySegments = gate.getConsumedPartitionType().isBounded() ?

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -57,7 +57,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -135,11 +134,19 @@ public class NetworkEnvironment {
 		registerNetworkMetrics(metricGroup, networkBufferPool);
 
 		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
-		ResultPartitionFactory resultPartitionFactory =
-			new ResultPartitionFactory(resultPartitionManager, ioManager);
+		ResultPartitionFactory resultPartitionFactory = new ResultPartitionFactory(
+			resultPartitionManager,
+			ioManager,
+			networkBufferPool,
+			config.networkBuffersPerChannel(),
+			config.floatingNetworkBuffersPerGate());
 
 		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
-			config, connectionManager, resultPartitionManager, taskEventPublisher, networkBufferPool);
+			config,
+			connectionManager,
+			resultPartitionManager,
+			taskEventPublisher,
+			networkBufferPool);
 
 		return new NetworkEnvironment(
 			config,
@@ -196,43 +203,13 @@ public class NetworkEnvironment {
 			}
 
 			for (final ResultPartition partition : producedPartitions) {
-				setupPartition(partition);
+				partition.setup();
 			}
 
 			// Setup the buffer pool for each buffer reader
 			final SingleInputGate[] inputGates = task.getAllInputGates();
 			for (SingleInputGate gate : inputGates) {
 				setupInputGate(gate);
-			}
-		}
-	}
-
-	@VisibleForTesting
-	public void setupPartition(ResultPartition partition) throws IOException {
-		BufferPool bufferPool = null;
-
-		try {
-			int maxNumberOfMemorySegments = partition.getPartitionType().isBounded() ?
-				partition.getNumberOfSubpartitions() * config.networkBuffersPerChannel() +
-					config.floatingNetworkBuffersPerGate() : Integer.MAX_VALUE;
-			// If the partition type is back pressure-free, we register with the buffer pool for
-			// callbacks to release memory.
-			bufferPool = networkBufferPool.createBufferPool(partition.getNumberOfSubpartitions(),
-				maxNumberOfMemorySegments,
-				partition.getPartitionType().hasBackPressure() ? Optional.empty() : Optional.of(partition));
-
-			partition.registerBufferPool(bufferPool);
-
-			resultPartitionManager.registerResultPartition(partition);
-		} catch (Throwable t) {
-			if (bufferPool != null) {
-				bufferPool.lazyDestroy();
-			}
-
-			if (t instanceof IOException) {
-				throw (IOException) t;
-			} else {
-				throw new IOException(t.getMessage(), t);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -92,31 +92,50 @@ public class NetworkEnvironment {
 
 	private boolean isShutdown;
 
-	public NetworkEnvironment(
+	private NetworkEnvironment(
+			NetworkEnvironmentConfiguration config,
+			NetworkBufferPool networkBufferPool,
+			ConnectionManager connectionManager,
+			ResultPartitionManager resultPartitionManager,
+			TaskEventPublisher taskEventPublisher,
+			IOManager ioManager) {
+		this.config = config;
+		this.networkBufferPool = networkBufferPool;
+		this.connectionManager = connectionManager;
+		this.resultPartitionManager = resultPartitionManager;
+		this.taskEventPublisher = taskEventPublisher;
+		this.ioManager = ioManager;
+		this.isShutdown = false;
+	}
+
+	public static NetworkEnvironment create(
 			NetworkEnvironmentConfiguration config,
 			TaskEventPublisher taskEventPublisher,
 			MetricGroup metricGroup,
 			IOManager ioManager) {
-		this.config = checkNotNull(config);
-
-		this.networkBufferPool = new NetworkBufferPool(config.numNetworkBuffers(), config.networkBufferSize());
+		checkNotNull(ioManager);
+		checkNotNull(taskEventPublisher);
+		checkNotNull(config);
 
 		NettyConfig nettyConfig = config.nettyConfig();
-		if (nettyConfig != null) {
-			this.connectionManager = new NettyConnectionManager(nettyConfig, config.isCreditBased());
-		} else {
-			this.connectionManager = new LocalConnectionManager();
-		}
+		ConnectionManager connectionManager = nettyConfig != null ?
+			new NettyConnectionManager(nettyConfig, config.isCreditBased()) : new LocalConnectionManager();
 
-		this.resultPartitionManager = new ResultPartitionManager();
-
-		this.taskEventPublisher = checkNotNull(taskEventPublisher);
+		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
+			config.numNetworkBuffers(),
+			config.networkBufferSize());
 
 		registerNetworkMetrics(metricGroup, networkBufferPool);
 
-		this.ioManager = checkNotNull(ioManager);
+		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
 
-		isShutdown = false;
+		return new NetworkEnvironment(
+			config,
+			networkBufferPool,
+			connectionManager,
+			resultPartitionManager,
+			taskEventPublisher,
+			ioManager);
 	}
 
 	private static void registerNetworkMetrics(MetricGroup metricGroup, NetworkBufferPool networkBufferPool) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -29,6 +29,11 @@ import java.io.IOException;
  */
 public interface ResultPartitionWriter extends AutoCloseable {
 
+	/**
+	 * Setup partition, potentially heavy-weight, blocking operation comparing to just creation.
+	 */
+	void setup() throws IOException;
+
 	BufferProvider getBufferProvider();
 
 	ResultPartitionID getPartitionId();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.buffer;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.MathUtils;
 
@@ -31,6 +32,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -49,7 +51,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * the buffers for the network data transfer. When new local buffer pools are created, the
  * NetworkBufferPool dynamically redistributes the buffers between the pools.
  */
-public class NetworkBufferPool implements BufferPoolFactory {
+public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvider {
 
 	private static final Logger LOG = LoggerFactory.getLogger(NetworkBufferPool.class);
 
@@ -69,13 +71,18 @@ public class NetworkBufferPool implements BufferPoolFactory {
 
 	private int numTotalRequiredBuffers;
 
+	private final int numberOfSegmentsToRequest;
+
 	/**
 	 * Allocates all {@link MemorySegment} instances managed by this pool.
 	 */
-	public NetworkBufferPool(int numberOfSegmentsToAllocate, int segmentSize) {
+	public NetworkBufferPool(int numberOfSegmentsToAllocate, int segmentSize, int numberOfSegmentsToRequest) {
 
 		this.totalNumberOfMemorySegments = numberOfSegmentsToAllocate;
 		this.memorySegmentSize = segmentSize;
+
+		checkArgument(numberOfSegmentsToRequest > 0, "The number of required buffers should be larger than 0.");
+		this.numberOfSegmentsToRequest = numberOfSegmentsToRequest;
 
 		final long sizeInLong = (long) segmentSize;
 
@@ -126,20 +133,19 @@ public class NetworkBufferPool implements BufferPoolFactory {
 		availableMemorySegments.add(checkNotNull(segment));
 	}
 
-	public List<MemorySegment> requestMemorySegments(int numRequiredBuffers) throws IOException {
-		checkArgument(numRequiredBuffers > 0, "The number of required buffers should be larger than 0.");
-
+	@Override
+	public List<MemorySegment> requestMemorySegments() throws IOException {
 		synchronized (factoryLock) {
 			if (isDestroyed) {
 				throw new IllegalStateException("Network buffer pool has already been destroyed.");
 			}
 
-			if (numTotalRequiredBuffers + numRequiredBuffers > totalNumberOfMemorySegments) {
+			if (numTotalRequiredBuffers + numberOfSegmentsToRequest > totalNumberOfMemorySegments) {
 				throw new IOException(String.format("Insufficient number of network buffers: " +
 								"required %d, but only %d available. The total number of network " +
 								"buffers is currently set to %d of %d bytes each. You can increase this " +
 								"number by setting the configuration keys '%s', '%s', and '%s'.",
-						numRequiredBuffers,
+					numberOfSegmentsToRequest,
 						totalNumberOfMemorySegments - numTotalRequiredBuffers,
 						totalNumberOfMemorySegments,
 						memorySegmentSize,
@@ -148,12 +154,12 @@ public class NetworkBufferPool implements BufferPoolFactory {
 						TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key()));
 			}
 
-			this.numTotalRequiredBuffers += numRequiredBuffers;
+			this.numTotalRequiredBuffers += numberOfSegmentsToRequest;
 
 			try {
 				redistributeBuffers();
 			} catch (Throwable t) {
-				this.numTotalRequiredBuffers -= numRequiredBuffers;
+				this.numTotalRequiredBuffers -= numberOfSegmentsToRequest;
 
 				try {
 					redistributeBuffers();
@@ -164,9 +170,9 @@ public class NetworkBufferPool implements BufferPoolFactory {
 			}
 		}
 
-		final List<MemorySegment> segments = new ArrayList<>(numRequiredBuffers);
+		final List<MemorySegment> segments = new ArrayList<>(numberOfSegmentsToRequest);
 		try {
-			while (segments.size() < numRequiredBuffers) {
+			while (segments.size() < numberOfSegmentsToRequest) {
 				if (isDestroyed) {
 					throw new IllegalStateException("Buffer pool is destroyed.");
 				}
@@ -178,7 +184,7 @@ public class NetworkBufferPool implements BufferPoolFactory {
 			}
 		} catch (Throwable e) {
 			try {
-				recycleMemorySegments(segments, numRequiredBuffers);
+				recycleMemorySegments(segments, numberOfSegmentsToRequest);
 			} catch (IOException inner) {
 				e.addSuppressed(inner);
 			}
@@ -188,11 +194,12 @@ public class NetworkBufferPool implements BufferPoolFactory {
 		return segments;
 	}
 
-	public void recycleMemorySegments(List<MemorySegment> segments) throws IOException {
+	@Override
+	public void recycleMemorySegments(Collection<MemorySegment> segments) throws IOException {
 		recycleMemorySegments(segments, segments.size());
 	}
 
-	private void recycleMemorySegments(List<MemorySegment> segments, int size) throws IOException {
+	private void recycleMemorySegments(Collection<MemorySegment> segments, int size) throws IOException {
 		synchronized (factoryLock) {
 			numTotalRequiredBuffers -= size;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskmanager.TaskActions;
+import org.apache.flink.util.function.FunctionWithException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,7 +123,9 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 
 	private volatile Throwable cause;
 
-	ResultPartition(
+	private final FunctionWithException<BufferPoolOwner, BufferPool, IOException> bufferPoolFactory;
+
+	public ResultPartition(
 		String owningTaskName,
 		TaskActions taskActions, // actions on the owning task
 		JobID jobId,
@@ -132,7 +135,8 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 		int numTargetKeyGroups,
 		ResultPartitionManager partitionManager,
 		ResultPartitionConsumableNotifier partitionConsumableNotifier,
-		boolean sendScheduleOrUpdateConsumersMessage) {
+		boolean sendScheduleOrUpdateConsumersMessage,
+		FunctionWithException<BufferPoolOwner, BufferPool, IOException> bufferPoolFactory) {
 
 		this.owningTaskName = checkNotNull(owningTaskName);
 		this.taskActions = checkNotNull(taskActions);
@@ -144,6 +148,7 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 		this.partitionManager = checkNotNull(partitionManager);
 		this.partitionConsumableNotifier = checkNotNull(partitionConsumableNotifier);
 		this.sendScheduleOrUpdateConsumersMessage = sendScheduleOrUpdateConsumersMessage;
+		this.bufferPoolFactory = bufferPoolFactory;
 	}
 
 	/**
@@ -154,13 +159,16 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	 * <p>The pool is registered with the partition *after* it as been constructed in order to conform
 	 * to the life-cycle of task registrations in the {@link TaskExecutor}.
 	 */
-	public void registerBufferPool(BufferPool bufferPool) {
-		checkArgument(bufferPool.getNumberOfRequiredMemorySegments() >= getNumberOfSubpartitions(),
-				"Bug in result partition setup logic: Buffer pool has not enough guaranteed buffers for this result partition.");
-
+	@Override
+	public void setup() throws IOException {
 		checkState(this.bufferPool == null, "Bug in result partition setup logic: Already registered buffer pool.");
 
-		this.bufferPool = checkNotNull(bufferPool);
+		BufferPool bufferPool = checkNotNull(bufferPoolFactory.apply(this));
+		checkArgument(bufferPool.getNumberOfRequiredMemorySegments() >= getNumberOfSubpartitions(),
+			"Bug in result partition setup logic: Buffer pool has not enough guaranteed buffers for this result partition.");
+
+		this.bufferPool = bufferPool;
+		partitionManager.registerResultPartition(this);
 	}
 
 	public JobID getJobId() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.taskmanager.TaskActions;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+
+/**
+ * Factory for {@link ResultPartition} to use in {@link org.apache.flink.runtime.io.network.NetworkEnvironment}.
+ */
+public class ResultPartitionFactory {
+	private static final Logger LOG = LoggerFactory.getLogger(ResultPartition.class);
+
+	@Nonnull
+	private final ResultPartitionManager partitionManager;
+
+	@Nonnull
+	private final IOManager ioManager;
+
+	public ResultPartitionFactory(@Nonnull ResultPartitionManager partitionManager,  @Nonnull IOManager ioManager) {
+		this.partitionManager = partitionManager;
+		this.ioManager = ioManager;
+	}
+
+	@VisibleForTesting
+	public ResultPartition create(
+		@Nonnull String taskNameWithSubtaskAndId,
+		@Nonnull TaskActions taskActions,
+		@Nonnull JobID jobId,
+		@Nonnull ExecutionAttemptID executionAttemptID,
+		@Nonnull ResultPartitionDeploymentDescriptor desc,
+		@Nonnull ResultPartitionConsumableNotifier partitionConsumableNotifier) {
+
+		return create(
+			taskNameWithSubtaskAndId,
+			taskActions,
+			jobId,
+			new ResultPartitionID(desc.getPartitionId(), executionAttemptID),
+			desc.getPartitionType(),
+			desc.getNumberOfSubpartitions(),
+			desc.getMaxParallelism(),
+			partitionConsumableNotifier,
+			desc.sendScheduleOrUpdateConsumersMessage());
+	}
+
+	public ResultPartition create(
+		@Nonnull String taskNameWithSubtaskAndId,
+		@Nonnull TaskActions taskActions,
+		@Nonnull JobID jobId,
+		@Nonnull ResultPartitionID id,
+		@Nonnull ResultPartitionType type,
+		int numberOfSubpartitions,
+		int maxParallelism,
+		@Nonnull ResultPartitionConsumableNotifier partitionConsumableNotifier,
+		boolean sendScheduleOrUpdateConsumersMessage) {
+
+		ResultSubpartition[] subpartitions = new ResultSubpartition[numberOfSubpartitions];
+
+		ResultPartition partition = new ResultPartition(
+			taskNameWithSubtaskAndId,
+			taskActions,
+			jobId,
+			id,
+			type,
+			subpartitions,
+			maxParallelism,
+			partitionManager,
+			partitionConsumableNotifier,
+			sendScheduleOrUpdateConsumersMessage);
+
+		createSubpartitions(partition, type, subpartitions);
+
+		// Initially, partitions should be consumed once before release.
+		partition.pin();
+
+		LOG.debug("{}: Initialized {}", taskNameWithSubtaskAndId, this);
+
+		return partition;
+	}
+
+	private void createSubpartitions(
+		ResultPartition partition, ResultPartitionType type, ResultSubpartition[] subpartitions) {
+
+		// Create the subpartitions.
+		switch (type) {
+			case BLOCKING:
+				initializeBoundedBlockingPartitions(subpartitions, partition, ioManager);
+				break;
+
+			case PIPELINED:
+			case PIPELINED_BOUNDED:
+				for (int i = 0; i < subpartitions.length; i++) {
+					subpartitions[i] = new PipelinedSubpartition(i, partition);
+				}
+
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unsupported result partition type.");
+		}
+	}
+
+	private static void initializeBoundedBlockingPartitions(
+		ResultSubpartition[] subpartitions,
+		ResultPartition parent,
+		IOManager ioManager) {
+
+		int i = 0;
+		try {
+			for (; i < subpartitions.length; i++) {
+				subpartitions[i] = new BoundedBlockingSubpartition(
+					i, parent, ioManager.createChannel().getPathFile().toPath());
+			}
+		}
+		catch (IOException e) {
+			// undo all the work so that a failed constructor does not leave any resources
+			// in need of disposal
+			releasePartitionsQuietly(subpartitions, i);
+
+			// this is not good, we should not be forced to wrap this in a runtime exception.
+			// the fact that the ResultPartition and Task constructor (which calls this) do not tolerate any exceptions
+			// is incompatible with eager initialization of resources (RAII).
+			throw new FlinkRuntimeException(e);
+		}
+	}
+
+	private static void releasePartitionsQuietly(ResultSubpartition[] partitions, int until) {
+		for (int i = 0; i < until; i++) {
+			final ResultSubpartition subpartition = partitions[i];
+			ExceptionUtils.suppressExceptions(subpartition::release);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -129,4 +129,9 @@ public abstract class InputGate implements AutoCloseable {
 			this.moreAvailable = moreAvailable;
 		}
 	}
+
+	/**
+	 * Setup gate, potentially heavy-weight, blocking operation comparing to just creation.
+	 */
+	public abstract void setup() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -40,6 +40,7 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -122,12 +123,12 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	 * Assigns exclusive buffers to this input channel, and this method should be called only once
 	 * after this input channel is created.
 	 */
-	void assignExclusiveSegments(List<MemorySegment> segments) {
+	void assignExclusiveSegments(Collection<MemorySegment> segments) {
 		checkState(this.initialCredit == 0, "Bug in input channel setup logic: exclusive buffers have " +
 			"already been set for this input channel.");
 
 		checkNotNull(segments);
-		checkArgument(segments.size() > 0, "The number of exclusive buffers per channel should be larger than 0.");
+		checkArgument(!segments.isEmpty(), "The number of exclusive buffers per channel should be larger than 0.");
 
 		this.initialCredit = segments.size();
 		this.numRequiredBuffers = segments.size();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -108,17 +108,6 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		ResultPartitionID partitionId,
 		ConnectionID connectionId,
 		ConnectionManager connectionManager,
-		InputChannelMetrics metrics) {
-
-		this(inputGate, channelIndex, partitionId, connectionId, connectionManager, 0, 0, metrics);
-	}
-
-	public RemoteInputChannel(
-		SingleInputGate inputGate,
-		int channelIndex,
-		ResultPartitionID partitionId,
-		ConnectionID connectionId,
-		ConnectionManager connectionManager,
 		int initialBackOff,
 		int maxBackoff,
 		InputChannelMetrics metrics) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -22,26 +22,21 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
-import org.apache.flink.runtime.io.network.NetworkEnvironment;
-import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.TaskActions;
 
 import org.slf4j.Logger;
@@ -677,96 +672,5 @@ public class SingleInputGate extends InputGate {
 
 	public Map<IntermediateResultPartitionID, InputChannel> getInputChannels() {
 		return inputChannels;
-	}
-
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Creates an input gate and all of its input channels.
-	 */
-	public static SingleInputGate create(
-		String owningTaskName,
-		JobID jobId,
-		InputGateDeploymentDescriptor igdd,
-		NetworkEnvironment networkEnvironment,
-		TaskEventPublisher taskEventPublisher,
-		TaskActions taskActions,
-		InputChannelMetrics metrics,
-		Counter numBytesInCounter) {
-
-		final IntermediateDataSetID consumedResultId = checkNotNull(igdd.getConsumedResultId());
-		final ResultPartitionType consumedPartitionType = checkNotNull(igdd.getConsumedPartitionType());
-
-		final int consumedSubpartitionIndex = igdd.getConsumedSubpartitionIndex();
-		checkArgument(consumedSubpartitionIndex >= 0);
-
-		final InputChannelDeploymentDescriptor[] icdd = checkNotNull(igdd.getInputChannelDeploymentDescriptors());
-
-		final NetworkEnvironmentConfiguration networkConfig = networkEnvironment.getConfiguration();
-
-		final SingleInputGate inputGate = new SingleInputGate(
-			owningTaskName, jobId, consumedResultId, consumedPartitionType, consumedSubpartitionIndex,
-			icdd.length, taskActions, numBytesInCounter, networkConfig.isCreditBased());
-
-		// Create the input channels. There is one input channel for each consumed partition.
-		final InputChannel[] inputChannels = new InputChannel[icdd.length];
-
-		int numLocalChannels = 0;
-		int numRemoteChannels = 0;
-		int numUnknownChannels = 0;
-
-		for (int i = 0; i < inputChannels.length; i++) {
-			final ResultPartitionID partitionId = icdd[i].getConsumedPartitionId();
-			final ResultPartitionLocation partitionLocation = icdd[i].getConsumedPartitionLocation();
-
-			if (partitionLocation.isLocal()) {
-				inputChannels[i] = new LocalInputChannel(inputGate, i, partitionId,
-					networkEnvironment.getResultPartitionManager(),
-					taskEventPublisher,
-					networkConfig.partitionRequestInitialBackoff(),
-					networkConfig.partitionRequestMaxBackoff(),
-					metrics
-				);
-
-				numLocalChannels++;
-			}
-			else if (partitionLocation.isRemote()) {
-				inputChannels[i] = new RemoteInputChannel(inputGate, i, partitionId,
-					partitionLocation.getConnectionId(),
-					networkEnvironment.getConnectionManager(),
-					networkConfig.partitionRequestInitialBackoff(),
-					networkConfig.partitionRequestMaxBackoff(),
-					metrics
-				);
-
-				numRemoteChannels++;
-			}
-			else if (partitionLocation.isUnknown()) {
-				inputChannels[i] = new UnknownInputChannel(inputGate, i, partitionId,
-					networkEnvironment.getResultPartitionManager(),
-					taskEventPublisher,
-					networkEnvironment.getConnectionManager(),
-					networkConfig.partitionRequestInitialBackoff(),
-					networkConfig.partitionRequestMaxBackoff(),
-					metrics
-				);
-
-				numUnknownChannels++;
-			}
-			else {
-				throw new IllegalStateException("Unexpected partition location.");
-			}
-
-			inputGate.setInputChannel(partitionId.getPartitionId(), inputChannels[i]);
-		}
-
-		LOG.debug("{}: Created {} input channels (local: {}, remote: {}, unknown: {}).",
-			owningTaskName,
-			inputChannels.length,
-			numLocalChannels,
-			numRemoteChannels,
-			numUnknownChannels);
-
-		return inputGate;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionLocation;
+import org.apache.flink.runtime.io.network.ConnectionManager;
+import org.apache.flink.runtime.io.network.TaskEventPublisher;
+import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
+import org.apache.flink.runtime.taskmanager.TaskActions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Factory for {@link SingleInputGate} to use in {@link org.apache.flink.runtime.io.network.NetworkEnvironment}.
+ */
+public class SingleInputGateFactory {
+	private static final Logger LOG = LoggerFactory.getLogger(SingleInputGate.class);
+
+	private final boolean isCreditBased;
+
+	private final int partitionRequestInitialBackoff;
+
+	private final int partitionRequestMaxBackoff;
+
+	@Nonnull
+	private final ConnectionManager connectionManager;
+
+	@Nonnull
+	private final ResultPartitionManager partitionManager;
+
+	@Nonnull
+	private final TaskEventPublisher taskEventPublisher;
+
+	public SingleInputGateFactory(
+			@Nonnull NetworkEnvironmentConfiguration networkConfig,
+			@Nonnull ConnectionManager connectionManager,
+			@Nonnull ResultPartitionManager partitionManager,
+			@Nonnull TaskEventPublisher taskEventPublisher) {
+		this.isCreditBased = networkConfig.isCreditBased();
+		this.partitionRequestInitialBackoff = networkConfig.partitionRequestInitialBackoff();
+		this.partitionRequestMaxBackoff = networkConfig.partitionRequestMaxBackoff();
+		this.connectionManager = connectionManager;
+		this.partitionManager = partitionManager;
+		this.taskEventPublisher = taskEventPublisher;
+	}
+
+	/**
+	 * Creates an input gate and all of its input channels.
+	 */
+	public SingleInputGate create(
+			@Nonnull String owningTaskName,
+			@Nonnull JobID jobId,
+			@Nonnull InputGateDeploymentDescriptor igdd,
+			@Nonnull TaskActions taskActions,
+			@Nonnull InputChannelMetrics metrics,
+			@Nonnull Counter numBytesInCounter) {
+		final IntermediateDataSetID consumedResultId = checkNotNull(igdd.getConsumedResultId());
+		final ResultPartitionType consumedPartitionType = checkNotNull(igdd.getConsumedPartitionType());
+
+		final int consumedSubpartitionIndex = igdd.getConsumedSubpartitionIndex();
+		checkArgument(consumedSubpartitionIndex >= 0);
+
+		final InputChannelDeploymentDescriptor[] icdd = checkNotNull(igdd.getInputChannelDeploymentDescriptors());
+
+		final SingleInputGate inputGate = new SingleInputGate(
+			owningTaskName, jobId, consumedResultId, consumedPartitionType, consumedSubpartitionIndex,
+			icdd.length, taskActions, numBytesInCounter, isCreditBased);
+
+		// Create the input channels. There is one input channel for each consumed partition.
+		final InputChannel[] inputChannels = new InputChannel[icdd.length];
+
+		int numLocalChannels = 0;
+		int numRemoteChannels = 0;
+		int numUnknownChannels = 0;
+
+		for (int i = 0; i < inputChannels.length; i++) {
+			final ResultPartitionID partitionId = icdd[i].getConsumedPartitionId();
+			final ResultPartitionLocation partitionLocation = icdd[i].getConsumedPartitionLocation();
+
+			if (partitionLocation.isLocal()) {
+				inputChannels[i] = new LocalInputChannel(inputGate, i, partitionId,
+					partitionManager,
+					taskEventPublisher,
+					partitionRequestInitialBackoff,
+					partitionRequestMaxBackoff,
+					metrics);
+
+				numLocalChannels++;
+			}
+			else if (partitionLocation.isRemote()) {
+				inputChannels[i] = new RemoteInputChannel(inputGate, i, partitionId,
+					partitionLocation.getConnectionId(),
+					connectionManager,
+					partitionRequestInitialBackoff,
+					partitionRequestMaxBackoff,
+					metrics);
+
+				numRemoteChannels++;
+			}
+			else if (partitionLocation.isUnknown()) {
+				inputChannels[i] = new UnknownInputChannel(inputGate, i, partitionId,
+					partitionManager,
+					taskEventPublisher,
+					connectionManager,
+					partitionRequestInitialBackoff,
+					partitionRequestMaxBackoff,
+					metrics);
+
+				numUnknownChannels++;
+			}
+			else {
+				throw new IllegalStateException("Unexpected partition location.");
+			}
+
+			inputGate.setInputChannel(partitionId.getPartitionId(), inputChannels[i]);
+		}
+
+		LOG.debug("{}: Created {} input channels (local: {}, remote: {}, unknown: {}).",
+			owningTaskName,
+			inputChannels.length,
+			numLocalChannels,
+			numRemoteChannels,
+			numUnknownChannels);
+
+		return inputGate;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -62,17 +63,22 @@ public class SingleInputGateFactory {
 	@Nonnull
 	private final TaskEventPublisher taskEventPublisher;
 
+	@Nonnull
+	private final MemorySegmentProvider memorySegmentProvider;
+
 	public SingleInputGateFactory(
 			@Nonnull NetworkEnvironmentConfiguration networkConfig,
 			@Nonnull ConnectionManager connectionManager,
 			@Nonnull ResultPartitionManager partitionManager,
-			@Nonnull TaskEventPublisher taskEventPublisher) {
+			@Nonnull TaskEventPublisher taskEventPublisher,
+			@Nonnull MemorySegmentProvider memorySegmentProvider) {
 		this.isCreditBased = networkConfig.isCreditBased();
 		this.partitionRequestInitialBackoff = networkConfig.partitionRequestInitialBackoff();
 		this.partitionRequestMaxBackoff = networkConfig.partitionRequestMaxBackoff();
 		this.connectionManager = connectionManager;
 		this.partitionManager = partitionManager;
 		this.taskEventPublisher = taskEventPublisher;
+		this.memorySegmentProvider = memorySegmentProvider;
 	}
 
 	/**
@@ -124,7 +130,8 @@ public class SingleInputGateFactory {
 					connectionManager,
 					partitionRequestInitialBackoff,
 					partitionRequestMaxBackoff,
-					metrics);
+					metrics,
+					memorySegmentProvider);
 
 				numRemoteChannels++;
 			}
@@ -135,7 +142,8 @@ public class SingleInputGateFactory {
 					connectionManager,
 					partitionRequestInitialBackoff,
 					partitionRequestMaxBackoff,
-					metrics);
+					metrics,
+					memorySegmentProvider);
 
 				numUnknownChannels++;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -284,6 +284,10 @@ public class UnionInputGate extends InputGate {
 	}
 
 	@Override
+	public void setup() {
+	}
+
+	@Override
 	public void close() throws IOException {
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -25,6 +26,8 @@ import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -50,6 +53,9 @@ class UnknownInputChannel extends InputChannel {
 
 	private final InputChannelMetrics metrics;
 
+	@Nonnull
+	private final MemorySegmentProvider memorySegmentProvider;
+
 	public UnknownInputChannel(
 			SingleInputGate gate,
 			int channelIndex,
@@ -59,7 +65,8 @@ class UnknownInputChannel extends InputChannel {
 			ConnectionManager connectionManager,
 			int initialBackoff,
 			int maxBackoff,
-			InputChannelMetrics metrics) {
+			InputChannelMetrics metrics,
+			@Nonnull MemorySegmentProvider memorySegmentProvider) {
 
 		super(gate, channelIndex, partitionId, initialBackoff, maxBackoff, null, null);
 
@@ -69,6 +76,7 @@ class UnknownInputChannel extends InputChannel {
 		this.metrics = checkNotNull(metrics);
 		this.initialBackoff = initialBackoff;
 		this.maxBackoff = maxBackoff;
+		this.memorySegmentProvider = memorySegmentProvider;
 	}
 
 	@Override
@@ -118,7 +126,8 @@ class UnknownInputChannel extends InputChannel {
 	// ------------------------------------------------------------------------
 
 	public RemoteInputChannel toRemoteInputChannel(ConnectionID producerAddress) {
-		return new RemoteInputChannel(inputGate, channelIndex, partitionId, checkNotNull(producerAddress), connectionManager, initialBackoff, maxBackoff, metrics);
+		return new RemoteInputChannel(inputGate, channelIndex, partitionId, checkNotNull(producerAddress),
+			connectionManager, initialBackoff, maxBackoff, metrics, memorySegmentProvider);
 	}
 
 	public LocalInputChannel toLocalInputChannel() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -246,7 +246,7 @@ public class TaskManagerServices {
 		// start the I/O manager, it will create some temp directories.
 		final IOManager ioManager = new IOManagerAsync(taskManagerServicesConfiguration.getTmpDirPaths());
 
-		final NetworkEnvironment network = new NetworkEnvironment(
+		final NetworkEnvironment network = NetworkEnvironment.create(
 			taskManagerServicesConfiguration.getNetworkConfig(), taskEventDispatcher, taskManagerMetricGroup, ioManager);
 		network.start();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
@@ -216,9 +217,6 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 	/** The cache for user-defined files that the invokable requires. */
 	private final FileCache fileCache;
 
-	/** The gateway to the network stack, which handles inputs and produced results. */
-	private final NetworkEnvironment network;
-
 	/** The service for kvState registration of this task. */
 	private final KvStateService kvStateService;
 
@@ -352,7 +350,6 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		this.blobService = Preconditions.checkNotNull(blobService);
 		this.libraryCache = Preconditions.checkNotNull(libraryCache);
 		this.fileCache = Preconditions.checkNotNull(fileCache);
-		this.network = Preconditions.checkNotNull(networkEnvironment);
 		this.kvStateService = Preconditions.checkNotNull(kvStateService);
 		this.taskManagerConfig = Preconditions.checkNotNull(taskManagerConfig);
 
@@ -436,14 +433,6 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 
 	public Configuration getTaskConfiguration() {
 		return this.taskConfiguration;
-	}
-
-	public SingleInputGate[] getAllInputGates() {
-		return inputGates;
-	}
-
-	public ResultPartition[] getProducedPartitions() {
-		return producedPartitions;
 	}
 
 	public SingleInputGate getInputGateById(IntermediateDataSetID id) {
@@ -607,7 +596,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 
 			LOG.info("Registering task at network: {}.", this);
 
-			network.registerTask(this);
+			setupPartionsAndGates(producedPartitions, inputGates);
 
 			for (ResultPartition partition : producedPartitions) {
 				taskEventDispatcher.registerPartition(partition.getPartitionId());
@@ -833,6 +822,19 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 			catch (Throwable t) {
 				LOG.error("Error during metrics de-registration of task {} ({}).", taskNameWithSubtask, executionId, t);
 			}
+		}
+	}
+
+	@VisibleForTesting
+	public static void setupPartionsAndGates(
+		ResultPartitionWriter[] producedPartitions, InputGate[] inputGates) throws IOException {
+
+		for (ResultPartitionWriter partition : producedPartitions) {
+			partition.setup();
+		}
+
+		for (InputGate gate : inputGates) {
+			gate.setup();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentBuilder.java
@@ -110,7 +110,7 @@ public class NetworkEnvironmentBuilder {
 	}
 
 	public NetworkEnvironment build() {
-		return new NetworkEnvironment(
+		return NetworkEnvironment.create(
 			new NetworkEnvironmentConfiguration(
 				numNetworkBuffers,
 				networkBufferSize,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
-import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
@@ -272,8 +272,11 @@ public class NetworkEnvironmentTest {
 	 */
 	private static ResultPartition createResultPartition(
 			final ResultPartitionType partitionType, final int channels) {
-
-		return PartitionTestUtils.createPartition(partitionType, channels);
+		return new ResultPartitionBuilder()
+			.setResultPartitionType(partitionType)
+			.setNumberOfSubpartitions(channels)
+			.setNumTargetKeyGroups(channels)
+			.build();
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.io.network;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
@@ -39,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createDummyConnectionManager;
+import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -74,10 +74,10 @@ public class NetworkEnvironmentTest {
 			.build();
 
 		// result partitions
-		ResultPartition rp1 = createResultPartition(ResultPartitionType.PIPELINED, 2);
-		ResultPartition rp2 = createResultPartition(ResultPartitionType.BLOCKING, 2);
-		ResultPartition rp3 = createResultPartition(ResultPartitionType.PIPELINED_BOUNDED, 2);
-		ResultPartition rp4 = createResultPartition(ResultPartitionType.PIPELINED_BOUNDED, 8);
+		ResultPartition rp1 = createPartition(network, ResultPartitionType.PIPELINED, 2);
+		ResultPartition rp2 = createPartition(network, ResultPartitionType.BLOCKING, 2);
+		ResultPartition rp3 = createPartition(network, ResultPartitionType.PIPELINED_BOUNDED, 2);
+		ResultPartition rp4 = createPartition(network, ResultPartitionType.PIPELINED_BOUNDED, 8);
 		final ResultPartition[] resultPartitions = new ResultPartition[] {rp1, rp2, rp3, rp4};
 
 		// input gates
@@ -182,10 +182,10 @@ public class NetworkEnvironmentTest {
 		final ConnectionManager connManager = createDummyConnectionManager();
 
 		// result partitions
-		ResultPartition rp1 = createResultPartition(ResultPartitionType.PIPELINED, 2);
-		ResultPartition rp2 = createResultPartition(ResultPartitionType.BLOCKING, 2);
-		ResultPartition rp3 = createResultPartition(ResultPartitionType.PIPELINED_BOUNDED, 2);
-		ResultPartition rp4 = createResultPartition(ResultPartitionType.PIPELINED_BOUNDED, 4);
+		ResultPartition rp1 = createPartition(network, ResultPartitionType.PIPELINED, 2);
+		ResultPartition rp2 = createPartition(network, ResultPartitionType.BLOCKING, 2);
+		ResultPartition rp3 = createPartition(network, ResultPartitionType.PIPELINED_BOUNDED, 2);
+		ResultPartition rp4 = createPartition(network, ResultPartitionType.PIPELINED_BOUNDED, 4);
 		final ResultPartition[] resultPartitions = new ResultPartition[] {rp1, rp2, rp3, rp4};
 
 		// input gates
@@ -256,27 +256,6 @@ public class NetworkEnvironmentTest {
 			ig.close();
 		}
 		network.shutdown();
-	}
-
-	/**
-	 * Helper to create simple {@link ResultPartition} instance for use by a {@link Task} inside
-	 * {@link NetworkEnvironment#registerTask(Task)}.
-	 *
-	 * @param partitionType
-	 * 		the produced partition type
-	 * @param channels
-	 * 		the number of output channels
-	 *
-	 * @return instance with minimal data set and some mocks so that it is useful for {@link
-	 * NetworkEnvironment#registerTask(Task)}
-	 */
-	private static ResultPartition createResultPartition(
-			final ResultPartitionType partitionType, final int channels) {
-		return new ResultPartitionBuilder()
-			.setResultPartitionType(partitionType)
-			.setNumberOfSubpartitions(channels)
-			.setNumTargetKeyGroups(channels)
-			.build();
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
 import org.apache.flink.runtime.taskmanager.Task;
 
 import org.junit.Rule;
@@ -287,7 +288,11 @@ public class NetworkEnvironmentTest {
 	 * @return input gate with some fake settings
 	 */
 	private SingleInputGate createSingleInputGate(ResultPartitionType partitionType, int numberOfChannels) {
-		return spy(InputChannelTestUtils.createSingleInputGate(numberOfChannels, partitionType, enableCreditBasedFlowControl));
+		return spy(new SingleInputGateBuilder()
+			.setNumberOfChannels(numberOfChannels)
+			.setResultPartitionType(partitionType)
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build());
 	}
 
 	private static void createRemoteInputChannel(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -117,10 +117,10 @@ public class NetworkEnvironmentTest {
 		assertEquals(enableCreditBasedFlowControl ? 8 : 8 * 2 + 8, ig4.getBufferPool().getMaxNumberOfMemorySegments());
 
 		int invokations = enableCreditBasedFlowControl ? 1 : 0;
-		verify(ig1, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
-		verify(ig2, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
-		verify(ig3, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
-		verify(ig4, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
+		verify(ig1, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool());
+		verify(ig2, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool());
+		verify(ig3, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool());
+		verify(ig4, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool());
 
 		for (ResultPartition rp : resultPartitions) {
 			rp.release();
@@ -243,10 +243,10 @@ public class NetworkEnvironmentTest {
 		assertEquals(enableCreditBasedFlowControl ? 8 : 4 * 2 + 8, ig4.getBufferPool().getMaxNumberOfMemorySegments());
 
 		int invokations = enableCreditBasedFlowControl ? 1 : 0;
-		verify(ig1, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
-		verify(ig2, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
-		verify(ig3, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
-		verify(ig4, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
+		verify(ig1, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool());
+		verify(ig2, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool());
+		verify(ig3, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool());
+		verify(ig4, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool());
 
 		for (ResultPartition rp : resultPartitions) {
 			rp.release();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -19,11 +19,10 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
-import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -288,7 +287,7 @@ public class NetworkEnvironmentTest {
 	 * @param numberOfChannels
 	 * 		the number of input channels
 	 *
-	 * @return input gate with some fake settings
+	 * @return input gate with some fake settiFngs
 	 */
 	private SingleInputGate createSingleInputGate(ResultPartitionType partitionType, int numberOfChannels) {
 		return spy(new SingleInputGateBuilder()
@@ -303,15 +302,10 @@ public class NetworkEnvironmentTest {
 			int channelIndex,
 			ResultPartition resultPartition,
 			ConnectionManager connManager) {
-		RemoteInputChannel channel = new RemoteInputChannel(
-			inputGate,
-			channelIndex,
-			resultPartition.getPartitionId(),
-			mock(ConnectionID.class),
-			connManager,
-			0,
-			0,
-			InputChannelTestUtils.newUnregisteredInputChannelMetrics());
-		inputGate.setInputChannel(resultPartition.getPartitionId().getPartitionId(), channel);
+		InputChannelBuilder.newBuilder()
+			.setChannelIndex(channelIndex)
+			.setPartitionId(resultPartition.getPartitionId())
+			.setConnectionManager(connManager)
+			.buildRemoteAndSetToGate(inputGate);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -44,6 +44,10 @@ public abstract class AbstractCollectingResultPartitionWriter implements ResultP
 	}
 
 	@Override
+	public void setup() {
+	}
+
+	@Override
 	public BufferProvider getBufferProvider() {
 		return bufferProvider;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -474,6 +474,10 @@ public class RecordWriterTest {
 		}
 
 		@Override
+		public void setup() {
+		}
+
+		@Override
 		public BufferProvider getBufferProvider() {
 			return bufferProvider;
 		}
@@ -532,6 +536,10 @@ public class RecordWriterTest {
 
 		private RecyclingPartitionWriter(BufferProvider bufferProvider) {
 			this.bufferProvider = bufferProvider;
+		}
+
+		@Override
+		public void setup() {
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
@@ -54,7 +54,7 @@ public class BufferPoolFactoryTest {
 
 	@Before
 	public void setupNetworkBufferPool() {
-		networkBufferPool = new NetworkBufferPool(numBuffers, memorySegmentSize);
+		networkBufferPool = new NetworkBufferPool(numBuffers, memorySegmentSize, 1);
 	}
 
 	@After
@@ -244,7 +244,7 @@ public class BufferPoolFactoryTest {
 
 	@Test
 	public void testUniformDistributionBounded3() throws IOException {
-		NetworkBufferPool globalPool = new NetworkBufferPool(3, 128);
+		NetworkBufferPool globalPool = new NetworkBufferPool(3, 128, 1);
 		try {
 			BufferPool first = globalPool.createBufferPool(0, 10);
 			assertEquals(3, first.getNumBuffers());
@@ -277,12 +277,12 @@ public class BufferPoolFactoryTest {
 	 */
 	@Test
 	public void testUniformDistributionBounded4() throws IOException {
-		NetworkBufferPool globalPool = new NetworkBufferPool(10, 128);
+		NetworkBufferPool globalPool = new NetworkBufferPool(10, 128, 2);
 		try {
 			BufferPool first = globalPool.createBufferPool(0, 10);
 			assertEquals(10, first.getNumBuffers());
 
-			List<MemorySegment> segmentList1 = globalPool.requestMemorySegments(2);
+			List<MemorySegment> segmentList1 = globalPool.requestMemorySegments();
 			assertEquals(2, segmentList1.size());
 			assertEquals(8, first.getNumBuffers());
 
@@ -290,12 +290,12 @@ public class BufferPoolFactoryTest {
 			assertEquals(4, first.getNumBuffers());
 			assertEquals(4, second.getNumBuffers());
 
-			List<MemorySegment> segmentList2 = globalPool.requestMemorySegments(2);
+			List<MemorySegment> segmentList2 = globalPool.requestMemorySegments();
 			assertEquals(2, segmentList2.size());
 			assertEquals(3, first.getNumBuffers());
 			assertEquals(3, second.getNumBuffers());
 
-			List<MemorySegment> segmentList3 = globalPool.requestMemorySegments(2);
+			List<MemorySegment> segmentList3 = globalPool.requestMemorySegments();
 			assertEquals(2, segmentList3.size());
 			assertEquals(2, first.getNumBuffers());
 			assertEquals(2, second.getNumBuffers());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
@@ -48,7 +48,7 @@ public class LocalBufferPoolDestroyTest {
 		LocalBufferPool localBufferPool = null;
 
 		try {
-			networkBufferPool = new NetworkBufferPool(1, 4096);
+			networkBufferPool = new NetworkBufferPool(1, 4096, 1);
 			localBufferPool = new LocalBufferPool(networkBufferPool, 1);
 
 			// Drain buffer pool

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -67,7 +67,7 @@ public class LocalBufferPoolTest extends TestLogger {
 
 	@Before
 	public void setupLocalBufferPool() {
-		networkBufferPool = new NetworkBufferPool(numBuffers, memorySegmentSize);
+		networkBufferPool = new NetworkBufferPool(numBuffers, memorySegmentSize, 1);
 		localBufferPool = new LocalBufferPool(networkBufferPool, 1);
 
 		assertEquals(0, localBufferPool.getNumberOfAvailableMemorySegments());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -136,14 +136,13 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 	 */
 	@Test
 	public void testReceiveBuffer() throws Exception {
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(8, 8);
 			inputGate.setBufferPool(bufferPool);
-			final int numExclusiveBuffers = 2;
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 
 			final CreditBasedPartitionRequestClientHandler handler = new CreditBasedPartitionRequestClientHandler();
 			handler.addInputChannel(inputChannel);
@@ -245,15 +244,14 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 		final PartitionRequestClient client = new PartitionRequestClient(
 			channel, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
 
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel1 = createRemoteInputChannel(inputGate, client);
 		final RemoteInputChannel inputChannel2 = createRemoteInputChannel(inputGate, client);
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(6, 6);
 			inputGate.setBufferPool(bufferPool);
-			final int numExclusiveBuffers = 2;
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 
 			inputChannel1.requestSubpartition(0);
 			inputChannel2.requestSubpartition(0);
@@ -346,14 +344,13 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 		final PartitionRequestClient client = new PartitionRequestClient(
 			channel, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
 
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(6, 6);
 			inputGate.setBufferPool(bufferPool);
-			final int numExclusiveBuffers = 2;
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 
 			inputChannel.requestSubpartition(0);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -127,14 +127,13 @@ public class PartitionRequestClientHandlerTest {
 	 */
 	@Test
 	public void testReceiveBuffer() throws Exception {
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(8, 8);
 			inputGate.setBufferPool(bufferPool);
-			final int numExclusiveBuffers = 2;
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 
 			final PartitionRequestClientHandler handler = new PartitionRequestClientHandler();
 			handler.addInputChannel(inputChannel);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientTest.java
@@ -52,15 +52,15 @@ public class PartitionRequestClientTest {
 		final PartitionRequestClient client = new PartitionRequestClient(
 			channel, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
 
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+		final int numExclusiveBuffers = 2;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, numExclusiveBuffers);
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client, 1, 2);
 
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(6, 6);
 			inputGate.setBufferPool(bufferPool);
-			final int numExclusiveBuffers = 2;
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 
 			// first subpartition request
 			inputChannel.requestSubpartition(0);
@@ -106,15 +106,15 @@ public class PartitionRequestClientTest {
 		final PartitionRequestClient client = new PartitionRequestClient(
 			channel, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
 
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+		final int numExclusiveBuffers = 2;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, numExclusiveBuffers);
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
 
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(6, 6);
 			inputGate.setBufferPool(bufferPool);
-			final int numExclusiveBuffers = 2;
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			inputChannel.requestSubpartition(0);
 
 			// The input channel should only send one partition request

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -28,9 +26,8 @@ import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -75,24 +72,7 @@ public class InputChannelTestUtils {
 	}
 
 	public static SingleInputGate createSingleInputGate(int numberOfChannels) {
-		return createSingleInputGate(numberOfChannels, ResultPartitionType.PIPELINED, true);
-	}
-
-	public static SingleInputGate createSingleInputGate(
-		int numberOfChannels,
-		ResultPartitionType partitionType,
-		boolean isCreditBased) {
-
-		return new SingleInputGate(
-			"InputGate",
-			new JobID(),
-			new IntermediateDataSetID(),
-			partitionType,
-			0,
-			numberOfChannels,
-			new NoOpTaskActions(),
-			new SimpleCounter(),
-			isCreditBased);
+		return new SingleInputGateBuilder().setNumberOfChannels(numberOfChannels).build();
 	}
 
 	public static ConnectionManager createDummyConnectionManager() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -20,9 +20,9 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
-import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
@@ -31,8 +31,6 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import java.net.InetSocketAddress;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -43,9 +41,6 @@ import static org.mockito.Mockito.when;
  * Some utility methods used for testing InputChannels and InputGates.
  */
 public class InputChannelTestUtils {
-
-	private static final ConnectionID STUB_CONNECTION_ID = new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
-
 	/**
 	 * Creates a result partition manager that ignores all IDs, and simply returns the given
 	 * subpartitions in sequence.
@@ -96,15 +91,10 @@ public class InputChannelTestUtils {
 		int channelIndex,
 		ResultPartitionManager partitionManager) {
 
-		return new LocalInputChannel(
-			inputGate,
-			channelIndex,
-			new ResultPartitionID(),
-			partitionManager,
-			new TaskEventDispatcher(),
-			0,
-			0,
-			newUnregisteredInputChannelMetrics());
+		return InputChannelBuilder.newBuilder()
+			.setChannelIndex(channelIndex)
+			.setPartitionManager(partitionManager)
+			.buildLocalAndSetToGate(inputGate);
 	}
 
 	public static LocalInputChannel createLocalInputChannel(
@@ -113,15 +103,11 @@ public class InputChannelTestUtils {
 		int initialBackoff,
 		int maxBackoff) {
 
-		return new LocalInputChannel(
-			inputGate,
-			0,
-			new ResultPartitionID(),
-			partitionManager,
-			new TaskEventDispatcher(),
-			initialBackoff,
-			maxBackoff,
-			newUnregisteredInputChannelMetrics());
+		return InputChannelBuilder.newBuilder()
+			.setPartitionManager(partitionManager)
+			.setInitialBackoff(initialBackoff)
+			.setMaxBackoff(maxBackoff)
+			.buildLocalAndSetToGate(inputGate);
 	}
 
 	public static RemoteInputChannel createRemoteInputChannel(
@@ -129,15 +115,10 @@ public class InputChannelTestUtils {
 		int channelIndex,
 		ConnectionManager connectionManager) {
 
-		return new RemoteInputChannel(
-			inputGate,
-			channelIndex,
-			new ResultPartitionID(),
-			STUB_CONNECTION_ID,
-			connectionManager,
-			0,
-			0,
-			newUnregisteredInputChannelMetrics());
+		return InputChannelBuilder.newBuilder()
+			.setChannelIndex(channelIndex)
+			.setConnectionManager(connectionManager)
+			.buildRemoteAndSetToGate(inputGate);
 	}
 
 	public static InputChannelMetrics newUnregisteredInputChannelMetrics() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
-import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 
@@ -63,9 +62,7 @@ public class InputGateConcurrentTest {
 		final SingleInputGate gate = createSingleInputGate(numberOfChannels);
 
 		for (int i = 0; i < numberOfChannels; i++) {
-			LocalInputChannel channel = createLocalInputChannel(gate, i, resultPartitionManager);
-			gate.setInputChannel(channel.getPartitionId().getPartitionId(), channel);
-
+			createLocalInputChannel(gate, i, resultPartitionManager);
 			partitions[i] = new PipelinedSubpartition(0, resultPartition);
 			sources[i] = new PipelinedSubpartitionSource(partitions[i]);
 		}
@@ -92,8 +89,6 @@ public class InputGateConcurrentTest {
 
 		for (int i = 0; i < numberOfChannels; i++) {
 			RemoteInputChannel channel = createRemoteInputChannel(gate, i, connManager);
-			gate.setInputChannel(channel.getPartitionId().getPartitionId(), channel);
-
 			sources[i] = new RemoteChannelSource(channel);
 		}
 
@@ -137,14 +132,11 @@ public class InputGateConcurrentTest {
 				localPartitions[local++] = psp;
 				sources[i] = new PipelinedSubpartitionSource(psp);
 
-				LocalInputChannel channel = createLocalInputChannel(gate, i, resultPartitionManager);
-				gate.setInputChannel(channel.getPartitionId().getPartitionId(), channel);
+				createLocalInputChannel(gate, i, resultPartitionManager);
 			}
 			else {
 				//remote channel
 				RemoteInputChannel channel = createRemoteInputChannel(gate, i, connManager);
-				gate.setInputChannel(channel.getPartitionId().getPartitionId(), channel);
-
 				sources[i] = new RemoteChannelSource(channel);
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
-import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
@@ -92,8 +91,7 @@ public class InputGateFairnessTest {
 		final SingleInputGate gate = createFairnessVerifyingInputGate(numberOfChannels);
 
 		for (int i = 0; i < numberOfChannels; i++) {
-			LocalInputChannel channel = createLocalInputChannel(gate, i, resultPartitionManager);
-			gate.setInputChannel(channel.getPartitionId().getPartitionId(), channel);
+			createLocalInputChannel(gate, i, resultPartitionManager);
 		}
 
 		// read all the buffers and the EOF event
@@ -138,8 +136,7 @@ public class InputGateFairnessTest {
 			final SingleInputGate gate = createFairnessVerifyingInputGate(numberOfChannels);
 
 			for (int i = 0; i < numberOfChannels; i++) {
-				LocalInputChannel channel = createLocalInputChannel(gate, i, resultPartitionManager);
-				gate.setInputChannel(channel.getPartitionId().getPartitionId(), channel);
+				createLocalInputChannel(gate, i, resultPartitionManager);
 			}
 
 			// seed one initial buffer
@@ -192,8 +189,6 @@ public class InputGateFairnessTest {
 				channel.onBuffer(mockBuffer, p, -1);
 			}
 			channel.onBuffer(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), buffersPerChannel, -1);
-
-			gate.setInputChannel(channel.getPartitionId().getPartitionId(), channel);
 		}
 
 		// read all the buffers and the EOF event
@@ -234,7 +229,6 @@ public class InputGateFairnessTest {
 		for (int i = 0; i < numberOfChannels; i++) {
 			RemoteInputChannel channel = createRemoteInputChannel(gate, i, connManager);
 			channels[i] = channel;
-			gate.setInputChannel(channel.getPartitionId().getPartitionId(), channel);
 		}
 
 		channels[11].onBuffer(mockBuffer, 0, -1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
@@ -33,6 +34,7 @@ import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.runtime.taskmanager.TaskActions;
+import org.apache.flink.util.function.SupplierWithException;
 
 import org.junit.Test;
 
@@ -311,6 +313,9 @@ public class InputGateFairnessTest {
 	// ------------------------------------------------------------------------
 
 	private static class FairnessVerifyingInputGate extends SingleInputGate {
+		private static final SupplierWithException<BufferPool, IOException> STUB_BUFFER_POOL_FACTORY = () -> {
+			throw new UnsupportedOperationException();
+		};
 
 		private final ArrayDeque<InputChannel> channelsWithData;
 
@@ -327,7 +332,8 @@ public class InputGateFairnessTest {
 				boolean isCreditBased) {
 
 			super(owningTaskName, jobId, consumedResultId, ResultPartitionType.PIPELINED,
-				consumedSubpartitionIndex, numberOfInputChannels, taskActions, new SimpleCounter(), isCreditBased);
+				consumedSubpartitionIndex, numberOfInputChannels, taskActions, new SimpleCounter(),
+				isCreditBased, STUB_BUFFER_POOL_FACTORY);
 
 			try {
 				Field f = SingleInputGate.class.getDeclaredField("inputChannelsWithData");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.io.network.NetworkEnvironment;
+
 /**
  * This class should consolidate all mocking logic for ResultPartitions.
  * While using Mockito internally (for now), the use of Mockito should not
@@ -45,9 +47,11 @@ public class PartitionTestUtils {
 	}
 
 	public static ResultPartition createPartition(
+			NetworkEnvironment environment,
 			ResultPartitionType partitionType,
 			int numChannels) {
 		return new ResultPartitionBuilder()
+			.setupBufferPoolFactoryFromNetworkEnvironment(environment)
 			.setResultPartitionType(partitionType)
 			.setNumberOfSubpartitions(numChannels)
 			.build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -18,10 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.io.disk.iomanager.NoOpIOManager;
-import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
-
 /**
  * This class should consolidate all mocking logic for ResultPartitions.
  * While using Mockito internally (for now), the use of Mockito should not
@@ -34,41 +30,26 @@ public class PartitionTestUtils {
 	}
 
 	public static ResultPartition createPartition(ResultPartitionType type) {
-		return createPartition(
-				new NoOpResultPartitionConsumableNotifier(),
-				type,
-				false);
-	}
-
-	public static ResultPartition createPartition(ResultPartitionType type, int numChannels) {
-		return createPartition(new NoOpResultPartitionConsumableNotifier(), type, numChannels, false);
+		return new ResultPartitionBuilder().setResultPartitionType(type).build();
 	}
 
 	public static ResultPartition createPartition(
 			ResultPartitionConsumableNotifier notifier,
 			ResultPartitionType type,
 			boolean sendScheduleOrUpdateConsumersMessage) {
-
-		return createPartition(notifier, type, 1, sendScheduleOrUpdateConsumersMessage);
+		return new ResultPartitionBuilder()
+			.setResultPartitionConsumableNotifier(notifier)
+			.setResultPartitionType(type)
+			.setSendScheduleOrUpdateConsumersMessage(sendScheduleOrUpdateConsumersMessage)
+			.build();
 	}
 
 	public static ResultPartition createPartition(
-			ResultPartitionConsumableNotifier notifier,
-			ResultPartitionType type,
-			int numChannels,
-			boolean sendScheduleOrUpdateConsumersMessage) {
-
-		return new ResultPartition(
-				"TestTask",
-				new NoOpTaskActions(),
-				new JobID(),
-				new ResultPartitionID(),
-				type,
-				numChannels,
-				numChannels,
-				new ResultPartitionManager(),
-				notifier,
-				new NoOpIOManager(),
-				sendScheduleOrUpdateConsumersMessage);
+			ResultPartitionType partitionType,
+			int numChannels) {
+		return new ResultPartitionBuilder()
+			.setResultPartitionType(partitionType)
+			.setNumberOfSubpartitions(numChannels)
+			.build();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -28,9 +28,6 @@ import org.apache.flink.runtime.taskmanager.TaskActions;
  * Utility class to encapsulate the logic of building a {@link ResultPartition} instance.
  */
 public class ResultPartitionBuilder {
-
-	private static final String taskName = "Result Partition";
-
 	private JobID jobId = new JobID();
 
 	private final TaskActions taskActions = new NoOpTaskActions();
@@ -97,17 +94,15 @@ public class ResultPartitionBuilder {
 	}
 
 	public ResultPartition build() {
-		return new ResultPartition(
-			taskName,
+		return new ResultPartitionFactory(partitionManager, ioManager).create(
+			"Result Partition task",
 			taskActions,
 			jobId,
 			partitionId,
 			partitionType,
 			numberOfSubpartitions,
 			numTargetKeyGroups,
-			partitionManager,
 			partitionConsumableNotifier,
-			ioManager,
 			sendScheduleOrUpdateConsumersMessage);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -56,7 +56,7 @@ public class ResultPartitionBuilder {
 
 	private boolean sendScheduleOrUpdateConsumersMessage = false;
 
-	private NetworkBufferPool networkBufferPool = new NetworkBufferPool(1, 1,1);
+	private NetworkBufferPool networkBufferPool = new NetworkBufferPool(1, 1, 1);
 
 	private int networkBuffersPerChannel = 1;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
+import org.apache.flink.runtime.taskmanager.TaskActions;
+
+/**
+ * Utility class to encapsulate the logic of building a {@link ResultPartition} instance.
+ */
+public class ResultPartitionBuilder {
+
+	private static final String taskName = "Result Partition";
+
+	private JobID jobId = new JobID();
+
+	private final TaskActions taskActions = new NoOpTaskActions();
+
+	private ResultPartitionID partitionId = new ResultPartitionID();
+
+	private ResultPartitionType partitionType = ResultPartitionType.PIPELINED;
+
+	private int numberOfSubpartitions = 1;
+
+	private int numTargetKeyGroups = 1;
+
+	private ResultPartitionManager partitionManager = new ResultPartitionManager();
+
+	private ResultPartitionConsumableNotifier partitionConsumableNotifier = new NoOpResultPartitionConsumableNotifier();
+
+	private IOManager ioManager = new IOManagerAsync();
+
+	private boolean sendScheduleOrUpdateConsumersMessage = false;
+
+	public ResultPartitionBuilder setJobId(JobID jobId) {
+		this.jobId = jobId;
+		return this;
+	}
+
+	public ResultPartitionBuilder setResultPartitionId(ResultPartitionID partitionId) {
+		this.partitionId = partitionId;
+		return this;
+	}
+
+	public ResultPartitionBuilder setResultPartitionType(ResultPartitionType partitionType) {
+		this.partitionType = partitionType;
+		return this;
+	}
+
+	public ResultPartitionBuilder setNumberOfSubpartitions(int numberOfSubpartitions) {
+		this.numberOfSubpartitions = numberOfSubpartitions;
+		return this;
+	}
+
+	public ResultPartitionBuilder setNumTargetKeyGroups(int numTargetKeyGroups) {
+		this.numTargetKeyGroups = numTargetKeyGroups;
+		return this;
+	}
+
+	public ResultPartitionBuilder setResultPartitionManager(ResultPartitionManager partitionManager) {
+		this.partitionManager = partitionManager;
+		return this;
+	}
+
+	ResultPartitionBuilder setResultPartitionConsumableNotifier(ResultPartitionConsumableNotifier notifier) {
+		this.partitionConsumableNotifier = notifier;
+		return this;
+	}
+
+	public ResultPartitionBuilder setIOManager(IOManager ioManager) {
+		this.ioManager = ioManager;
+		return this;
+	}
+
+	public ResultPartitionBuilder setSendScheduleOrUpdateConsumersMessage(boolean sendScheduleOrUpdateConsumersMessage) {
+		this.sendScheduleOrUpdateConsumersMessage = sendScheduleOrUpdateConsumersMessage;
+		return this;
+	}
+
+	public ResultPartition build() {
+		return new ResultPartition(
+			taskName,
+			taskActions,
+			jobId,
+			partitionId,
+			partitionType,
+			numberOfSubpartitions,
+			numTargetKeyGroups,
+			partitionManager,
+			partitionConsumableNotifier,
+			ioManager,
+			sendScheduleOrUpdateConsumersMessage);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -215,10 +215,9 @@ public class ResultPartitionTest {
 		final int numAllBuffers = 10;
 		final NetworkEnvironment network = new NetworkEnvironmentBuilder()
 			.setNumNetworkBuffers(numAllBuffers).build();
-		final ResultPartitionConsumableNotifier notifier = new NoOpResultPartitionConsumableNotifier();
-		final ResultPartition resultPartition = createPartition(notifier, resultPartitionType, false);
+		final ResultPartition resultPartition = createPartition(network, resultPartitionType, 1);
 		try {
-			network.setupPartition(resultPartition);
+			resultPartition.setup();
 
 			// take all buffers (more than the minimum required)
 			for (int i = 0; i < numAllBuffers; ++i) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.LocalConnectionManager;
@@ -47,6 +48,7 @@ public class InputChannelBuilder {
 	private int initialBackoff = 0;
 	private int maxBackoff = 0;
 	private InputChannelMetrics metrics = InputChannelTestUtils.newUnregisteredInputChannelMetrics();
+	private MemorySegmentProvider memorySegmentProvider = InputChannelTestUtils.StubMemorySegmentProvider.getInstance();
 
 	public static InputChannelBuilder newBuilder() {
 		return new InputChannelBuilder();
@@ -92,11 +94,17 @@ public class InputChannelBuilder {
 		return this;
 	}
 
+	public InputChannelBuilder setMemorySegmentProvider(MemorySegmentProvider memorySegmentProvider) {
+		this.memorySegmentProvider = memorySegmentProvider;
+		return this;
+	}
+
 	InputChannelBuilder setupFromNetworkEnvironment(NetworkEnvironment network) {
 		this.partitionManager = network.getResultPartitionManager();
 		this.connectionManager = network.getConnectionManager();
 		this.initialBackoff = network.getConfiguration().partitionRequestInitialBackoff();
 		this.maxBackoff = network.getConfiguration().partitionRequestMaxBackoff();
+		this.memorySegmentProvider = network.getNetworkBufferPool();
 		return this;
 	}
 
@@ -110,7 +118,8 @@ public class InputChannelBuilder {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
-			metrics);
+			metrics,
+			memorySegmentProvider);
 		inputGate.setInputChannel(partitionId.getPartitionId(), channel);
 		return channel;
 	}
@@ -138,7 +147,8 @@ public class InputChannelBuilder {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
-			metrics);
+			metrics,
+			memorySegmentProvider);
 		inputGate.setInputChannel(partitionId.getPartitionId(), channel);
 		return channel;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.ConnectionManager;
+import org.apache.flink.runtime.io.network.LocalConnectionManager;
+import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.TaskEventPublisher;
+import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
+import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Builder for various {@link InputChannel} types.
+ */
+public class InputChannelBuilder {
+	static final ConnectionID STUB_CONNECTION_ID =
+		new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
+
+	private int channelIndex = 0;
+	private ResultPartitionID partitionId = new ResultPartitionID();
+	private ConnectionID connectionID = STUB_CONNECTION_ID;
+	private ResultPartitionManager partitionManager = new ResultPartitionManager();
+	private TaskEventPublisher taskEventPublisher = new TaskEventDispatcher();
+	private ConnectionManager connectionManager = new LocalConnectionManager();
+	private int initialBackoff = 0;
+	private int maxBackoff = 0;
+	private InputChannelMetrics metrics = InputChannelTestUtils.newUnregisteredInputChannelMetrics();
+
+	public static InputChannelBuilder newBuilder() {
+		return new InputChannelBuilder();
+	}
+
+	public InputChannelBuilder setChannelIndex(int channelIndex) {
+		this.channelIndex = channelIndex;
+		return this;
+	}
+
+	public InputChannelBuilder setPartitionId(ResultPartitionID partitionId) {
+		this.partitionId = partitionId;
+		return this;
+	}
+
+	public InputChannelBuilder setPartitionManager(ResultPartitionManager partitionManager) {
+		this.partitionManager = partitionManager;
+		return this;
+	}
+
+	InputChannelBuilder setTaskEventPublisher(TaskEventPublisher taskEventPublisher) {
+		this.taskEventPublisher = taskEventPublisher;
+		return this;
+	}
+
+	public InputChannelBuilder setConnectionManager(ConnectionManager connectionManager) {
+		this.connectionManager = connectionManager;
+		return this;
+	}
+
+	public InputChannelBuilder setInitialBackoff(int initialBackoff) {
+		this.initialBackoff = initialBackoff;
+		return this;
+	}
+
+	public InputChannelBuilder setMaxBackoff(int maxBackoff) {
+		this.maxBackoff = maxBackoff;
+		return this;
+	}
+
+	public InputChannelBuilder setMetrics(InputChannelMetrics metrics) {
+		this.metrics = metrics;
+		return this;
+	}
+
+	InputChannelBuilder setupFromNetworkEnvironment(NetworkEnvironment network) {
+		this.partitionManager = network.getResultPartitionManager();
+		this.connectionManager = network.getConnectionManager();
+		this.initialBackoff = network.getConfiguration().partitionRequestInitialBackoff();
+		this.maxBackoff = network.getConfiguration().partitionRequestMaxBackoff();
+		return this;
+	}
+
+	UnknownInputChannel buildUnknownAndSetToGate(SingleInputGate inputGate) {
+		UnknownInputChannel channel = new UnknownInputChannel(
+			inputGate,
+			channelIndex,
+			partitionId,
+			partitionManager,
+			taskEventPublisher,
+			connectionManager,
+			initialBackoff,
+			maxBackoff,
+			metrics);
+		inputGate.setInputChannel(partitionId.getPartitionId(), channel);
+		return channel;
+	}
+
+	public LocalInputChannel buildLocalAndSetToGate(SingleInputGate inputGate) {
+		LocalInputChannel channel = new LocalInputChannel(
+			inputGate,
+			channelIndex,
+			partitionId,
+			partitionManager,
+			taskEventPublisher,
+			initialBackoff,
+			maxBackoff,
+			metrics);
+		inputGate.setInputChannel(partitionId.getPartitionId(), channel);
+		return channel;
+	}
+
+	public RemoteInputChannel buildRemoteAndSetToGate(SingleInputGate inputGate) {
+		RemoteInputChannel channel = new RemoteInputChannel(
+			inputGate,
+			channelIndex,
+			partitionId,
+			connectionID,
+			connectionManager,
+			initialBackoff,
+			maxBackoff,
+			metrics);
+		inputGate.setInputChannel(partitionId.getPartitionId(), channel);
+		return channel;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 
 import org.junit.runner.RunWith;
@@ -74,17 +75,22 @@ public abstract class InputGateTestBase {
 	}
 
 	protected SingleInputGate createInputGate(int numberOfInputChannels) {
-		return createInputGate(numberOfInputChannels, ResultPartitionType.PIPELINED);
+		return createInputGate(null, numberOfInputChannels, ResultPartitionType.PIPELINED);
 	}
 
 	protected SingleInputGate createInputGate(
-			int numberOfInputChannels, ResultPartitionType partitionType) {
-		SingleInputGate inputGate = new SingleInputGateBuilder()
+		NetworkEnvironment environment, int numberOfInputChannels, ResultPartitionType partitionType) {
+
+		SingleInputGateBuilder builder = new SingleInputGateBuilder()
 			.setNumberOfChannels(numberOfInputChannels)
 			.setResultPartitionType(partitionType)
-			.setIsCreditBased(enableCreditBasedFlowControl)
-			.build();
+			.setIsCreditBased(enableCreditBasedFlowControl);
 
+		if (environment != null) {
+			builder = builder.setupBufferPoolFactory(environment);
+		}
+
+		SingleInputGate inputGate = builder.build();
 		assertEquals(partitionType, inputGate.getConsumedPartitionType());
 		return inputGate;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -80,10 +79,11 @@ public abstract class InputGateTestBase {
 
 	protected SingleInputGate createInputGate(
 			int numberOfInputChannels, ResultPartitionType partitionType) {
-		SingleInputGate inputGate = createSingleInputGate(
-			numberOfInputChannels,
-			partitionType,
-			enableCreditBasedFlowControl);
+		SingleInputGate inputGate = new SingleInputGateBuilder()
+			.setNumberOfChannels(numberOfInputChannels)
+			.setResultPartitionType(partitionType)
+			.setIsCreditBased(enableCreditBasedFlowControl)
+			.build();
 
 		assertEquals(partitionType, inputGate.getConsumedPartitionType());
 		return inputGate;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -115,11 +115,12 @@ public class LocalInputChannelTest {
 				.setNumTargetKeyGroups(parallelism)
 				.setResultPartitionManager(partitionManager)
 				.setSendScheduleOrUpdateConsumersMessage(true)
+				.setBufferPoolFactory(p ->
+					networkBuffers.createBufferPool(producerBufferPoolSize, producerBufferPoolSize))
 				.build();
 
 			// Create a buffer pool for this partition
-			partition.registerBufferPool(
-				networkBuffers.createBufferPool(producerBufferPoolSize, producerBufferPoolSize));
+			partition.setup();
 
 			// Create the producer
 			partitionProducers[i] = new TestPartitionProducer(
@@ -130,10 +131,6 @@ public class LocalInputChannelTest {
 					partition.getBufferProvider(),
 					numberOfBuffersPerChannel)
 			);
-
-			// Register with the partition manager in order to allow the local input channels to
-			// request their respective partitions.
-			partitionManager.registerResultPartition(partition);
 		}
 
 		// Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -98,7 +98,7 @@ public class LocalInputChannelTest {
 
 		final NetworkBufferPool networkBuffers = new NetworkBufferPool(
 			(parallelism * producerBufferPoolSize) + (parallelism * parallelism),
-			TestBufferFactory.BUFFER_SIZE);
+			TestBufferFactory.BUFFER_SIZE, 1);
 
 		final ResultPartitionManager partitionManager = new ResultPartitionManager();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -41,7 +40,6 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.io.network.util.TestPartitionProducer;
 import org.apache.flink.runtime.io.network.util.TestProducerSource;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.util.function.CheckedSupplier;
@@ -452,16 +450,10 @@ public class LocalInputChannelTest {
 			checkArgument(numberOfInputChannels >= 1);
 			checkArgument(numberOfExpectedBuffersPerChannel >= 1);
 
-			this.inputGate = new SingleInputGate(
-				"Test Name",
-				new JobID(),
-				new IntermediateDataSetID(),
-				ResultPartitionType.PIPELINED,
-				subpartitionIndex,
-				numberOfInputChannels,
-				new NoOpTaskActions(),
-				new SimpleCounter(),
-				true);
+			this.inputGate = new SingleInputGateBuilder()
+				.setConsumedSubpartitionIndex(subpartitionIndex)
+				.setNumberOfChannels(numberOfInputChannels)
+				.build();
 
 			// Set buffer pool
 			inputGate.setBufferPool(bufferPool);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
@@ -29,19 +27,16 @@ import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
-import org.apache.flink.runtime.io.network.partition.NoOpResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.io.network.util.TestPartitionProducer;
 import org.apache.flink.runtime.io.network.util.TestProducerSource;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.util.function.CheckedSupplier;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
@@ -107,12 +102,6 @@ public class LocalInputChannelTest {
 			(parallelism * producerBufferPoolSize) + (parallelism * parallelism),
 			TestBufferFactory.BUFFER_SIZE);
 
-		final ResultPartitionConsumableNotifier partitionConsumableNotifier = new NoOpResultPartitionConsumableNotifier();
-
-		final IOManager ioManager = mock(IOManager.class);
-
-		final JobID jobId = new JobID();
-
 		final ResultPartitionManager partitionManager = new ResultPartitionManager();
 
 		final ResultPartitionID[] partitionIds = new ResultPartitionID[parallelism];
@@ -122,18 +111,13 @@ public class LocalInputChannelTest {
 		for (int i = 0; i < parallelism; i++) {
 			partitionIds[i] = new ResultPartitionID();
 
-			final ResultPartition partition = new ResultPartition(
-				"Test Name",
-				new NoOpTaskActions(),
-				jobId,
-				partitionIds[i],
-				ResultPartitionType.PIPELINED,
-				parallelism,
-				parallelism,
-				partitionManager,
-				partitionConsumableNotifier,
-				ioManager,
-				true);
+			final ResultPartition partition = new ResultPartitionBuilder()
+				.setResultPartitionId(partitionIds[i])
+				.setNumberOfSubpartitions(parallelism)
+				.setNumTargetKeyGroups(parallelism)
+				.setResultPartitionManager(partitionManager)
+				.setSendScheduleOrUpdateConsumersMessage(true)
+				.build();
 
 			// Create a buffer pool for this partition
 			partition.registerBufferPool(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -325,8 +325,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testAvailableBuffersLessThanRequiredBuffers() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32);
-		final int numExclusiveBuffers = 2;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32, 2);
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
@@ -335,7 +334,7 @@ public class RemoteInputChannelTest {
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			inputChannel.requestSubpartition(0);
 
 			// Prepare the exclusive and floating buffers to verify recycle logic later
@@ -464,8 +463,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testAvailableBuffersEqualToRequiredBuffers() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32);
-		final int numExclusiveBuffers = 2;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32, 2);
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
@@ -474,7 +472,7 @@ public class RemoteInputChannelTest {
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			inputChannel.requestSubpartition(0);
 
 			// Prepare the exclusive and floating buffers to verify recycle logic later
@@ -539,8 +537,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testAvailableBuffersMoreThanRequiredBuffers() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32);
-		final int numExclusiveBuffers = 2;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32, 2);
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
@@ -549,7 +546,7 @@ public class RemoteInputChannelTest {
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			inputChannel.requestSubpartition(0);
 
 			// Prepare the exclusive and floating buffers to verify recycle logic later
@@ -628,8 +625,8 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testFairDistributionFloatingBuffers() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(12, 32);
 		final int numExclusiveBuffers = 2;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(12, 32, numExclusiveBuffers);
 		final int numFloatingBuffers = 3;
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
@@ -640,7 +637,7 @@ public class RemoteInputChannelTest {
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			channel1.requestSubpartition(0);
 			channel2.requestSubpartition(0);
 			channel3.requestSubpartition(0);
@@ -695,11 +692,11 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testFailureInNotifyBufferAvailable() throws Exception {
 		// Setup
-		final int numExclusiveBuffers = 0;
+		final int numExclusiveBuffers = 1;
 		final int numFloatingBuffers = 1;
 		final int numTotalBuffers = numExclusiveBuffers + numFloatingBuffers;
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(
-			numTotalBuffers, 32);
+			numTotalBuffers, 32, numExclusiveBuffers);
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel successfulRemoteIC = createRemoteInputChannel(inputGate);
@@ -757,8 +754,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testConcurrentOnSenderBacklogAndRelease() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(130, 32);
-		final int numExclusiveBuffers = 2;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(130, 32, 2);
 		final int numFloatingBuffers = 128;
 
 		final ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -769,7 +765,7 @@ public class RemoteInputChannelTest {
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			inputChannel.requestSubpartition(0);
 
 			final Callable<Void> requestBufferTask = new Callable<Void>() {
@@ -818,8 +814,8 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testConcurrentOnSenderBacklogAndRecycle() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(248, 32);
 		final int numExclusiveSegments = 120;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(248, 32, numExclusiveSegments);
 		final int numFloatingBuffers = 128;
 		final int backlog = 128;
 
@@ -831,7 +827,7 @@ public class RemoteInputChannelTest {
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveSegments);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			inputChannel.requestSubpartition(0);
 
 			final Callable<Void> requestBufferTask = new Callable<Void>() {
@@ -870,8 +866,8 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testConcurrentRecycleAndRelease() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(248, 32);
 		final int numExclusiveSegments = 120;
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(248, 32, numExclusiveSegments);
 		final int numFloatingBuffers = 128;
 
 		final ExecutorService executor = Executors.newFixedThreadPool(3);
@@ -882,7 +878,7 @@ public class RemoteInputChannelTest {
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveSegments);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			inputChannel.requestSubpartition(0);
 
 			final Callable<Void> releaseTask = new Callable<Void>() {
@@ -926,7 +922,7 @@ public class RemoteInputChannelTest {
 		final int numFloatingBuffers = 2;
 		final int numTotalBuffers = numExclusiveBuffers + numFloatingBuffers;
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(
-			numTotalBuffers, 32);
+			numTotalBuffers, 32, numExclusiveBuffers);
 
 		final ExecutorService executor = Executors.newFixedThreadPool(2);
 
@@ -936,7 +932,7 @@ public class RemoteInputChannelTest {
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool, numExclusiveBuffers);
+			inputGate.assignExclusiveSegments(networkBufferPool);
 			inputChannel.requestSubpartition(0);
 
 			final Callable<Void> bufferPoolInteractionsTask = () -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -329,12 +330,12 @@ public class RemoteInputChannelTest {
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, networkBufferPool);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool);
+			inputGate.assignExclusiveSegments();
 			inputChannel.requestSubpartition(0);
 
 			// Prepare the exclusive and floating buffers to verify recycle logic later
@@ -467,12 +468,12 @@ public class RemoteInputChannelTest {
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, networkBufferPool);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool);
+			inputGate.assignExclusiveSegments();
 			inputChannel.requestSubpartition(0);
 
 			// Prepare the exclusive and floating buffers to verify recycle logic later
@@ -541,12 +542,12 @@ public class RemoteInputChannelTest {
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, networkBufferPool);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool);
+			inputGate.assignExclusiveSegments();
 			inputChannel.requestSubpartition(0);
 
 			// Prepare the exclusive and floating buffers to verify recycle logic later
@@ -630,14 +631,14 @@ public class RemoteInputChannelTest {
 		final int numFloatingBuffers = 3;
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel channel1 = spy(createRemoteInputChannel(inputGate));
-		final RemoteInputChannel channel2 = spy(createRemoteInputChannel(inputGate));
-		final RemoteInputChannel channel3 = spy(createRemoteInputChannel(inputGate));
+		final RemoteInputChannel channel1 = spy(createRemoteInputChannel(inputGate, networkBufferPool));
+		final RemoteInputChannel channel2 = spy(createRemoteInputChannel(inputGate, networkBufferPool));
+		final RemoteInputChannel channel3 = spy(createRemoteInputChannel(inputGate, networkBufferPool));
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool);
+			inputGate.assignExclusiveSegments();
 			channel1.requestSubpartition(0);
 			channel2.requestSubpartition(0);
 			channel3.requestSubpartition(0);
@@ -760,12 +761,12 @@ public class RemoteInputChannelTest {
 		final ExecutorService executor = Executors.newFixedThreadPool(2);
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel  = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, networkBufferPool);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool);
+			inputGate.assignExclusiveSegments();
 			inputChannel.requestSubpartition(0);
 
 			final Callable<Void> requestBufferTask = new Callable<Void>() {
@@ -822,12 +823,12 @@ public class RemoteInputChannelTest {
 		final ExecutorService executor = Executors.newFixedThreadPool(3);
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel  = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, networkBufferPool);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool);
+			inputGate.assignExclusiveSegments();
 			inputChannel.requestSubpartition(0);
 
 			final Callable<Void> requestBufferTask = new Callable<Void>() {
@@ -873,12 +874,12 @@ public class RemoteInputChannelTest {
 		final ExecutorService executor = Executors.newFixedThreadPool(3);
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel  = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, networkBufferPool);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool);
+			inputGate.assignExclusiveSegments();
 			inputChannel.requestSubpartition(0);
 
 			final Callable<Void> releaseTask = new Callable<Void>() {
@@ -927,12 +928,12 @@ public class RemoteInputChannelTest {
 		final ExecutorService executor = Executors.newFixedThreadPool(2);
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel  = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, networkBufferPool);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
 			inputGate.setBufferPool(bufferPool);
-			inputGate.assignExclusiveSegments(networkBufferPool);
+			inputGate.assignExclusiveSegments();
 			inputChannel.requestSubpartition(0);
 
 			final Callable<Void> bufferPoolInteractionsTask = () -> {
@@ -993,9 +994,18 @@ public class RemoteInputChannelTest {
 	// ---------------------------------------------------------------------------------------------
 
 	private RemoteInputChannel createRemoteInputChannel(SingleInputGate inputGate)
-			throws IOException, InterruptedException {
+		throws IOException, InterruptedException {
 
-		return createRemoteInputChannel(inputGate, mock(PartitionRequestClient.class), 0, 0);
+		return createRemoteInputChannel(inputGate, InputChannelTestUtils.StubMemorySegmentProvider.getInstance());
+	}
+
+	private RemoteInputChannel createRemoteInputChannel(
+		SingleInputGate inputGate,
+		MemorySegmentProvider memorySegmentProvider)
+		throws IOException, InterruptedException {
+
+		return createRemoteInputChannel(
+				inputGate, mock(PartitionRequestClient.class), 0, 0, memorySegmentProvider);
 	}
 
 	private RemoteInputChannel createRemoteInputChannel(
@@ -1003,6 +1013,18 @@ public class RemoteInputChannelTest {
 			PartitionRequestClient partitionRequestClient,
 			int initialBackoff,
 			int maxBackoff)
+			throws IOException, InterruptedException {
+
+		return createRemoteInputChannel(inputGate, partitionRequestClient, initialBackoff, maxBackoff,
+			InputChannelTestUtils.StubMemorySegmentProvider.getInstance());
+	}
+
+	private RemoteInputChannel createRemoteInputChannel(
+			SingleInputGate inputGate,
+			PartitionRequestClient partitionRequestClient,
+			int initialBackoff,
+			int maxBackoff,
+			MemorySegmentProvider memorySegmentProvider)
 			throws IOException, InterruptedException {
 
 		final ConnectionManager connectionManager = mock(ConnectionManager.class);
@@ -1013,6 +1035,7 @@ public class RemoteInputChannelTest {
 			.setConnectionManager(connectionManager)
 			.setInitialBackoff(initialBackoff)
 			.setMaxBackoff(maxBackoff)
+			.setMemorySegmentProvider(memorySegmentProvider)
 			.buildRemoteAndSetToGate(inputGate);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -47,8 +47,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import scala.Tuple2;
-
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasProperty;
@@ -189,28 +187,24 @@ public class RemoteInputChannelTest {
 
 	@Test(expected = IllegalStateException.class)
 	public void testRetriggerWithoutPartitionRequest() throws Exception {
-		Tuple2<Integer, Integer> backoff = new Tuple2<Integer, Integer>(500, 3000);
 		PartitionRequestClient connClient = mock(PartitionRequestClient.class);
 		SingleInputGate inputGate = mock(SingleInputGate.class);
 
-		RemoteInputChannel ch = createRemoteInputChannel(inputGate, connClient, backoff);
+		RemoteInputChannel ch = createRemoteInputChannel(inputGate, connClient, 500, 3000);
 
 		ch.retriggerSubpartitionRequest(0);
 	}
 
 	@Test
 	public void testPartitionRequestExponentialBackoff() throws Exception {
-		// Config
-		Tuple2<Integer, Integer> backoff = new Tuple2<Integer, Integer>(500, 3000);
-
 		// Start with initial backoff, then keep doubling, and cap at max.
-		int[] expectedDelays = {backoff._1(), 1000, 2000, backoff._2()};
+		int[] expectedDelays = {500, 1000, 2000, 3000};
 
 		// Setup
 		PartitionRequestClient connClient = mock(PartitionRequestClient.class);
 		SingleInputGate inputGate = mock(SingleInputGate.class);
 
-		RemoteInputChannel ch = createRemoteInputChannel(inputGate, connClient, backoff);
+		RemoteInputChannel ch = createRemoteInputChannel(inputGate, connClient, 500, 3000);
 
 		// Initial request
 		ch.requestSubpartition(0);
@@ -235,14 +229,11 @@ public class RemoteInputChannelTest {
 
 	@Test
 	public void testPartitionRequestSingleBackoff() throws Exception {
-		// Config
-		Tuple2<Integer, Integer> backoff = new Tuple2<Integer, Integer>(500, 500);
-
 		// Setup
 		PartitionRequestClient connClient = mock(PartitionRequestClient.class);
 		SingleInputGate inputGate = mock(SingleInputGate.class);
 
-		RemoteInputChannel ch = createRemoteInputChannel(inputGate, connClient, backoff);
+		RemoteInputChannel ch = createRemoteInputChannel(inputGate, connClient, 500, 500);
 
 		// No delay for first request
 		ch.requestSubpartition(0);
@@ -250,7 +241,7 @@ public class RemoteInputChannelTest {
 
 		// Initial delay for second request
 		ch.retriggerSubpartitionRequest(0);
-		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(backoff._1()));
+		verify(connClient).requestSubpartition(eq(ch.partitionId), eq(0), eq(ch), eq(500));
 
 		// Exception after backoff is greater than the maximum backoff.
 		try {
@@ -264,14 +255,11 @@ public class RemoteInputChannelTest {
 
 	@Test
 	public void testPartitionRequestNoBackoff() throws Exception {
-		// Config
-		Tuple2<Integer, Integer> backoff = new Tuple2<Integer, Integer>(0, 0);
-
 		// Setup
 		PartitionRequestClient connClient = mock(PartitionRequestClient.class);
 		SingleInputGate inputGate = mock(SingleInputGate.class);
 
-		RemoteInputChannel ch = createRemoteInputChannel(inputGate, connClient, backoff);
+		RemoteInputChannel ch = createRemoteInputChannel(inputGate, connClient, 0, 0);
 
 		// No delay for first request
 		ch.requestSubpartition(0);
@@ -297,13 +285,10 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = mock(SingleInputGate.class);
 
-		final RemoteInputChannel ch = new RemoteInputChannel(
-				inputGate,
-				0,
-				partitionId,
-				mock(ConnectionID.class),
-				connectionManager,
-				InputChannelTestUtils.newUnregisteredInputChannelMetrics());
+		final RemoteInputChannel ch = InputChannelBuilder.newBuilder()
+			.setPartitionId(partitionId)
+			.setConnectionManager(connectionManager)
+			.buildRemoteAndSetToGate(inputGate);
 
 		ch.onFailedPartitionRequest();
 
@@ -346,7 +331,6 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(inputChannel.partitionId.getPartitionId(), inputChannel);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
@@ -486,7 +470,6 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(inputChannel.partitionId.getPartitionId(), inputChannel);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
@@ -562,7 +545,6 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(inputChannel.partitionId.getPartitionId(), inputChannel);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
@@ -654,9 +636,6 @@ public class RemoteInputChannelTest {
 		final RemoteInputChannel channel1 = spy(createRemoteInputChannel(inputGate));
 		final RemoteInputChannel channel2 = spy(createRemoteInputChannel(inputGate));
 		final RemoteInputChannel channel3 = spy(createRemoteInputChannel(inputGate));
-		inputGate.setInputChannel(channel1.partitionId.getPartitionId(), channel1);
-		inputGate.setInputChannel(channel2.partitionId.getPartitionId(), channel2);
-		inputGate.setInputChannel(channel3.partitionId.getPartitionId(), channel3);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
@@ -724,14 +703,11 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel successfulRemoteIC = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(successfulRemoteIC.partitionId.getPartitionId(), successfulRemoteIC);
-
 		successfulRemoteIC.requestSubpartition(0);
 
 		// late creation -> no exclusive buffers, also no requested subpartition in successfulRemoteIC
 		// (to trigger a failure in RemoteInputChannel#notifyBufferAvailable())
 		final RemoteInputChannel failingRemoteIC = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(failingRemoteIC.partitionId.getPartitionId(), failingRemoteIC);
 
 		Buffer buffer = null;
 		Throwable thrown = null;
@@ -789,7 +765,6 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel  = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(inputChannel.partitionId.getPartitionId(), inputChannel);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
@@ -852,7 +827,6 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel  = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(inputChannel.partitionId.getPartitionId(), inputChannel);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
@@ -904,7 +878,6 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel  = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(inputChannel.partitionId.getPartitionId(), inputChannel);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
@@ -959,7 +932,6 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel inputChannel  = createRemoteInputChannel(inputGate);
-		inputGate.setInputChannel(inputChannel.partitionId.getPartitionId(), inputChannel);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers);
@@ -1027,29 +999,25 @@ public class RemoteInputChannelTest {
 	private RemoteInputChannel createRemoteInputChannel(SingleInputGate inputGate)
 			throws IOException, InterruptedException {
 
-		return createRemoteInputChannel(
-				inputGate, mock(PartitionRequestClient.class), new Tuple2<Integer, Integer>(0, 0));
+		return createRemoteInputChannel(inputGate, mock(PartitionRequestClient.class), 0, 0);
 	}
 
 	private RemoteInputChannel createRemoteInputChannel(
 			SingleInputGate inputGate,
 			PartitionRequestClient partitionRequestClient,
-			Tuple2<Integer, Integer> initialAndMaxRequestBackoff)
+			int initialBackoff,
+			int maxBackoff)
 			throws IOException, InterruptedException {
 
 		final ConnectionManager connectionManager = mock(ConnectionManager.class);
 		when(connectionManager.createPartitionRequestClient(any(ConnectionID.class)))
 				.thenReturn(partitionRequestClient);
 
-		return new RemoteInputChannel(
-			inputGate,
-			0,
-			new ResultPartitionID(),
-			mock(ConnectionID.class),
-			connectionManager,
-			initialAndMaxRequestBackoff._1(),
-			initialAndMaxRequestBackoff._2(),
-			InputChannelTestUtils.newUnregisteredInputChannelMetrics());
+		return InputChannelBuilder.newBuilder()
+			.setConnectionManager(connectionManager)
+			.setInitialBackoff(initialBackoff)
+			.setMaxBackoff(maxBackoff)
+			.buildRemoteAndSetToGate(inputGate);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
+import org.apache.flink.runtime.taskmanager.TaskActions;
+
+/**
+ * Utility class to encapsulate the logic of building a {@link SingleInputGate} instance.
+ */
+public class SingleInputGateBuilder {
+
+	private final JobID jobId = new JobID();
+
+	private final IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+
+	private ResultPartitionType partitionType = ResultPartitionType.PIPELINED;
+
+	private int consumedSubpartitionIndex = 0;
+
+	private int numberOfChannels = 1;
+
+	private final TaskActions taskActions = new NoOpTaskActions();
+
+	private final Counter numBytesInCounter = new SimpleCounter();
+
+	private boolean isCreditBased = true;
+
+	public SingleInputGateBuilder setResultPartitionType(ResultPartitionType partitionType) {
+		this.partitionType = partitionType;
+		return this;
+	}
+
+	SingleInputGateBuilder setConsumedSubpartitionIndex(int consumedSubpartitionIndex) {
+		this.consumedSubpartitionIndex = consumedSubpartitionIndex;
+		return this;
+	}
+
+	public SingleInputGateBuilder setNumberOfChannels(int numberOfChannels) {
+		this.numberOfChannels = numberOfChannels;
+		return this;
+	}
+
+	public SingleInputGateBuilder setIsCreditBased(boolean isCreditBased) {
+		this.isCreditBased = isCreditBased;
+		return this;
+	}
+
+	public SingleInputGate build() {
+		return new SingleInputGate(
+			"Single Input Gate",
+			jobId,
+			intermediateDataSetID,
+			partitionType,
+			consumedSubpartitionIndex,
+			numberOfChannels,
+			taskActions,
+			numBytesInCounter,
+			isCreditBased);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -391,17 +391,17 @@ public class SingleInputGateTest extends InputGateTestBase {
 	 */
 	@Test
 	public void testRequestBuffersWithRemoteInputChannel() throws Exception {
-		final SingleInputGate inputGate = createInputGate(1, ResultPartitionType.PIPELINED_BOUNDED);
+		final NetworkEnvironment network = createNetworkEnvironment();
+		final SingleInputGate inputGate = createInputGate(network, 1, ResultPartitionType.PIPELINED_BOUNDED);
 		int buffersPerChannel = 2;
 		int extraNetworkBuffersPerGate = 8;
-		final NetworkEnvironment network = createNetworkEnvironment();
 
 		try {
 			RemoteInputChannel remote =
 				InputChannelBuilder.newBuilder()
 					.setupFromNetworkEnvironment(network)
 					.buildRemoteAndSetToGate(inputGate);
-			network.setupInputGate(inputGate);
+			inputGate.setup();
 
 			NetworkBufferPool bufferPool = network.getNetworkBufferPool();
 			if (enableCreditBasedFlowControl) {
@@ -427,16 +427,16 @@ public class SingleInputGateTest extends InputGateTestBase {
 	 */
 	@Test
 	public void testRequestBuffersWithUnknownInputChannel() throws Exception {
-		final SingleInputGate inputGate = createInputGate(1, ResultPartitionType.PIPELINED_BOUNDED);
+		final NetworkEnvironment network = createNetworkEnvironment();
+		final SingleInputGate inputGate = createInputGate(network, 1, ResultPartitionType.PIPELINED_BOUNDED);
 		int buffersPerChannel = 2;
 		int extraNetworkBuffersPerGate = 8;
-		final NetworkEnvironment network = createNetworkEnvironment();
 
 		try {
 			final ResultPartitionID resultPartitionId = new ResultPartitionID();
 			addUnknownInputChannel(network, inputGate, resultPartitionId, 0);
 
-			network.setupInputGate(inputGate);
+			inputGate.setup();
 			NetworkBufferPool bufferPool = network.getNetworkBufferPool();
 
 			if (enableCreditBasedFlowControl) {
@@ -478,8 +478,8 @@ public class SingleInputGateTest extends InputGateTestBase {
 	 */
 	@Test
 	public void testUpdateUnknownInputChannel() throws Exception {
-		final SingleInputGate inputGate = createInputGate(2);
 		final NetworkEnvironment network = createNetworkEnvironment();
+		final SingleInputGate inputGate = createInputGate(network, 2, ResultPartitionType.PIPELINED);
 
 		try {
 			final ResultPartitionID localResultPartitionId = new ResultPartitionID();
@@ -488,7 +488,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 			final ResultPartitionID remoteResultPartitionId = new ResultPartitionID();
 			addUnknownInputChannel(network, inputGate, remoteResultPartitionId, 1);
 
-			network.setupInputGate(inputGate);
+			inputGate.setup();
 
 			assertThat(inputGate.getInputChannels().get(remoteResultPartitionId.getPartitionId()),
 				is(instanceOf((UnknownInputChannel.class))));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -332,15 +332,18 @@ public class SingleInputGateTest extends InputGateTestBase {
 			.setIsCreditBased(enableCreditBasedFlowControl)
 			.build();
 
-		SingleInputGate gate = SingleInputGate.create(
-			"TestTask",
-			new JobID(),
-			gateDesc,
-			netEnv,
-			new TaskEventDispatcher(),
-			new NoOpTaskActions(),
-			InputChannelTestUtils.newUnregisteredInputChannelMetrics(),
-			new SimpleCounter());
+		SingleInputGate gate = new SingleInputGateFactory(
+			netEnv.getConfiguration(),
+			netEnv.getConnectionManager(),
+			netEnv.getResultPartitionManager(),
+			new TaskEventDispatcher())
+			.create(
+				"TestTask",
+				new JobID(),
+				gateDesc,
+				new NoOpTaskActions(),
+				InputChannelTestUtils.newUnregisteredInputChannelMetrics(),
+				new SimpleCounter());
 
 		try {
 			assertEquals(gateDesc.getConsumedPartitionType(), gate.getConsumedPartitionType());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -336,7 +336,8 @@ public class SingleInputGateTest extends InputGateTestBase {
 			netEnv.getConfiguration(),
 			netEnv.getConnectionManager(),
 			netEnv.getResultPartitionManager(),
-			new TaskEventDispatcher())
+			new TaskEventDispatcher(),
+			netEnv.getNetworkBufferPool())
 			.create(
 				"TestTask",
 				new JobID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -26,9 +26,6 @@ import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.io.network.ConnectionID;
-import org.apache.flink.runtime.io.network.ConnectionManager;
-import org.apache.flink.runtime.io.network.LocalConnectionManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.NetworkEnvironmentBuilder;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -36,7 +33,6 @@ import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -52,7 +48,6 @@ import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -179,21 +174,24 @@ public class SingleInputGateTest extends InputGateTestBase {
 
 		inputGate.setBufferPool(bufferPool);
 
-		final InputChannelMetrics metrics = InputChannelTestUtils.newUnregisteredInputChannelMetrics();
-
 		// Local
 		ResultPartitionID localPartitionId = new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID());
 
-		InputChannel local = new LocalInputChannel(inputGate, 0, localPartitionId, partitionManager, taskEventDispatcher, metrics);
+		InputChannelBuilder.newBuilder()
+			.setPartitionId(localPartitionId)
+			.setPartitionManager(partitionManager)
+			.setTaskEventPublisher(taskEventDispatcher)
+			.buildLocalAndSetToGate(inputGate);
 
 		// Unknown
 		ResultPartitionID unknownPartitionId = new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID());
 
-		InputChannel unknown = new UnknownInputChannel(inputGate, 1, unknownPartitionId, partitionManager, taskEventDispatcher, mock(ConnectionManager.class), 0, 0, metrics);
-
-		// Set channels
-		inputGate.setInputChannel(localPartitionId.getPartitionId(), local);
-		inputGate.setInputChannel(unknownPartitionId.getPartitionId(), unknown);
+		InputChannelBuilder.newBuilder()
+			.setChannelIndex(1)
+			.setPartitionId(unknownPartitionId)
+			.setPartitionManager(partitionManager)
+			.setTaskEventPublisher(taskEventDispatcher)
+			.buildUnknownAndSetToGate(inputGate);
 
 		// Request partitions
 		inputGate.requestPartitions();
@@ -227,18 +225,9 @@ public class SingleInputGateTest extends InputGateTestBase {
 
 		ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
 
-		InputChannel unknown = new UnknownInputChannel(
-			inputGate,
-			0,
-			new ResultPartitionID(),
-			partitionManager,
-			new TaskEventDispatcher(),
-			new LocalConnectionManager(),
-			0,
-			0,
-			InputChannelTestUtils.newUnregisteredInputChannelMetrics());
-
-		inputGate.setInputChannel(unknown.partitionId.getPartitionId(), unknown);
+		InputChannel unknown = InputChannelBuilder.newBuilder()
+			.setPartitionManager(partitionManager)
+			.buildUnknownAndSetToGate(inputGate);
 
 		// Update to a local channel and verify that no request is triggered
 		inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(
@@ -260,18 +249,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 		// Setup the input gate with a single channel that does nothing
 		final SingleInputGate inputGate = createInputGate(1);
 
-		InputChannel unknown = new UnknownInputChannel(
-			inputGate,
-			0,
-			new ResultPartitionID(),
-			new ResultPartitionManager(),
-			new TaskEventDispatcher(),
-			new LocalConnectionManager(),
-			0,
-			0,
-			InputChannelTestUtils.newUnregisteredInputChannelMetrics());
-
-		inputGate.setInputChannel(unknown.partitionId.getPartitionId(), unknown);
+		InputChannelBuilder.newBuilder().buildUnknownAndSetToGate(inputGate);
 
 		// Start the consumer in a separate Thread
 		Thread asyncConsumer = new Thread() {
@@ -335,7 +313,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 			// Remote
 			new InputChannelDeploymentDescriptor(
 				partitionIds[1],
-				ResultPartitionLocation.createRemote(new ConnectionID(new InetSocketAddress("localhost", 5000), 0))),
+				ResultPartitionLocation.createRemote(InputChannelBuilder.STUB_CONNECTION_ID)),
 			// Unknown
 			new InputChannelDeploymentDescriptor(
 				partitionIds[2],
@@ -415,16 +393,14 @@ public class SingleInputGateTest extends InputGateTestBase {
 		final NetworkEnvironment network = createNetworkEnvironment();
 
 		try {
-			final ResultPartitionID resultPartitionId = new ResultPartitionID();
-			final ConnectionID connectionId = new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
-			addRemoteInputChannel(network, inputGate, connectionId, resultPartitionId, 0);
-
+			RemoteInputChannel remote =
+				InputChannelBuilder.newBuilder()
+					.setupFromNetworkEnvironment(network)
+					.buildRemoteAndSetToGate(inputGate);
 			network.setupInputGate(inputGate);
 
 			NetworkBufferPool bufferPool = network.getNetworkBufferPool();
 			if (enableCreditBasedFlowControl) {
-				RemoteInputChannel remote = (RemoteInputChannel) inputGate.getInputChannels()
-					.get(resultPartitionId.getPartitionId());
 				// only the exclusive buffers should be assigned/available now
 				assertEquals(buffersPerChannel, remote.getNumberOfAvailableBuffers());
 
@@ -469,10 +445,9 @@ public class SingleInputGateTest extends InputGateTestBase {
 			}
 
 			// Trigger updates to remote input channel from unknown input channel
-			final ConnectionID connectionId = new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
 			inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(
 				resultPartitionId,
-				ResultPartitionLocation.createRemote(connectionId)));
+				ResultPartitionLocation.createRemote(InputChannelBuilder.STUB_CONNECTION_ID)));
 
 			if (enableCreditBasedFlowControl) {
 				RemoteInputChannel remote = (RemoteInputChannel) inputGate.getInputChannels()
@@ -517,10 +492,9 @@ public class SingleInputGateTest extends InputGateTestBase {
 				is(instanceOf((UnknownInputChannel.class))));
 
 			// Trigger updates to remote input channel from unknown input channel
-			final ConnectionID remoteConnectionId = new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
 			inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(
 				remoteResultPartitionId,
-				ResultPartitionLocation.createRemote(remoteConnectionId)));
+				ResultPartitionLocation.createRemote(InputChannelBuilder.STUB_CONNECTION_ID)));
 
 			assertThat(inputGate.getInputChannels().get(remoteResultPartitionId.getPartitionId()),
 				is(instanceOf((RemoteInputChannel.class))));
@@ -549,38 +523,11 @@ public class SingleInputGateTest extends InputGateTestBase {
 			SingleInputGate inputGate,
 			ResultPartitionID partitionId,
 			int channelIndex) {
-		UnknownInputChannel unknown =
-			createUnknownInputChannel(network, inputGate, partitionId, channelIndex);
-		inputGate.setInputChannel(partitionId.getPartitionId(), unknown);
-	}
-
-	private UnknownInputChannel createUnknownInputChannel(
-			NetworkEnvironment network,
-			SingleInputGate inputGate,
-			ResultPartitionID partitionId,
-			int channelIndex) {
-		return new UnknownInputChannel(
-			inputGate,
-			channelIndex,
-			partitionId,
-			network.getResultPartitionManager(),
-			new TaskEventDispatcher(),
-			network.getConnectionManager(),
-			network.getConfiguration().partitionRequestInitialBackoff(),
-			network.getConfiguration().partitionRequestMaxBackoff(),
-			InputChannelTestUtils.newUnregisteredInputChannelMetrics());
-	}
-
-	private void addRemoteInputChannel(
-			NetworkEnvironment network,
-			SingleInputGate inputGate,
-			ConnectionID connectionId,
-			ResultPartitionID partitionId,
-			int channelIndex) {
-		RemoteInputChannel remote =
-			createUnknownInputChannel(network, inputGate, partitionId, channelIndex)
-				.toRemoteInputChannel(connectionId);
-		inputGate.setInputChannel(partitionId.getPartitionId(), remote);
+		InputChannelBuilder.newBuilder()
+			.setChannelIndex(channelIndex)
+			.setPartitionId(partitionId)
+			.setupFromNetworkEnvironment(network)
+			.buildUnknownAndSetToGate(inputGate);
 	}
 
 	private NetworkEnvironment createNetworkEnvironment() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImplITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImplITCase.java
@@ -92,7 +92,7 @@ public class BackPressureStatsTrackerImplITCase extends TestLogger {
 
 	@Before
 	public void setUp() throws Exception {
-		networkBufferPool = new NetworkBufferPool(100, 8192);
+		networkBufferPool = new NetworkBufferPool(100, 8192, 1);
 		testBufferPool = networkBufferPool.createBufferPool(1, Integer.MAX_VALUE);
 
 		final Configuration configuration = new Configuration();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -204,6 +204,10 @@ public class BarrierBufferMassiveRandomTest {
 		}
 
 		@Override
+		public void setup() {
+		}
+
+		@Override
 		public void close() {
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -53,8 +53,8 @@ public class BarrierBufferMassiveRandomTest {
 		try {
 			ioMan = new IOManagerAsync();
 
-			networkBufferPool1 = new NetworkBufferPool(100, PAGE_SIZE);
-			networkBufferPool2 = new NetworkBufferPool(100, PAGE_SIZE);
+			networkBufferPool1 = new NetworkBufferPool(100, PAGE_SIZE, 1);
+			networkBufferPool2 = new NetworkBufferPool(100, PAGE_SIZE, 1);
 			BufferPool pool1 = networkBufferPool1.createBufferPool(100, 100);
 			BufferPool pool2 = networkBufferPool2.createBufferPool(100, 100);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -65,6 +65,10 @@ public class MockInputGate extends InputGate {
 	}
 
 	@Override
+	public void setup() {
+	}
+
+	@Override
 	public int getNumberOfInputChannels() {
 		return numberOfChannels;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -219,9 +219,10 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 			.setNumberOfSubpartitions(channels)
 			.setResultPartitionManager(environment.getResultPartitionManager())
 			.setIOManager(ioManager)
+			.setupBufferPoolFactoryFromNetworkEnvironment(environment)
 			.build();
 
-		environment.setupPartition(resultPartition);
+		resultPartition.setup();
 
 		return resultPartition;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory;
 import org.apache.flink.runtime.io.network.partition.consumer.UnionInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
@@ -248,15 +249,18 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 				channel,
 				channelDescriptors);
 
-			SingleInputGate gate = SingleInputGate.create(
-				"receiving task[" + channel + "]",
-				jobId,
-				gateDescriptor,
-				environment,
-				new TaskEventDispatcher(),
-				new NoOpTaskActions(),
-				InputChannelTestUtils.newUnregisteredInputChannelMetrics(),
-				new SimpleCounter());
+			SingleInputGate gate = new SingleInputGateFactory(
+				environment.getConfiguration(),
+				environment.getConnectionManager(),
+				environment.getResultPartitionManager(),
+				new TaskEventDispatcher())
+				.create(
+					"receiving task[" + channel + "]",
+					jobId,
+					gateDescriptor,
+					new NoOpTaskActions(),
+					InputChannelTestUtils.newUnregisteredInputChannelMetrics(),
+					new SimpleCounter());
 
 			environment.setupInputGate(gate);
 			gates[channel] = gate;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -253,7 +253,8 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 				environment.getConfiguration(),
 				environment.getConnectionManager(),
 				environment.getResultPartitionManager(),
-				new TaskEventDispatcher())
+				new TaskEventDispatcher(),
+				environment.getNetworkBufferPool())
 				.create(
 					"receiving task[" + channel + "]",
 					jobId,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -38,8 +38,8 @@ import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
-import org.apache.flink.runtime.io.network.partition.NoOpResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
@@ -211,18 +211,14 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 			NetworkEnvironment environment,
 			int channels) throws Exception {
 
-		ResultPartition resultPartition = new ResultPartition(
-			"sender task",
-			new NoOpTaskActions(),
-			jobId,
-			partitionId,
-			ResultPartitionType.PIPELINED_BOUNDED,
-			channels,
-			1,
-			environment.getResultPartitionManager(),
-			new NoOpResultPartitionConsumableNotifier(),
-			ioManager,
-			false);
+		ResultPartition resultPartition = new ResultPartitionBuilder()
+			.setJobId(jobId)
+			.setResultPartitionId(partitionId)
+			.setResultPartitionType(ResultPartitionType.PIPELINED_BOUNDED)
+			.setNumberOfSubpartitions(channels)
+			.setResultPartitionManager(environment.getResultPartitionManager())
+			.setIOManager(ioManager)
+			.build();
 
 		environment.setupPartition(resultPartition);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -264,7 +264,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 					InputChannelTestUtils.newUnregisteredInputChannelMetrics(),
 					new SimpleCounter());
 
-			environment.setupInputGate(gate);
+			gate.setup();
 			gates[channel] = gate;
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

Introduce partition/gate setup to decouple task registration with NetworkEnvironment.
The PR also does some preparation refactoring.

## Brief change log

  - Introduce factories for ResultPartion and SingleInputgates
  - Introduce buffer pool factories for ResultPartion and SingleInputgates
  - Introduce MemorySegmentProvider for RemoteInputChannel to assign exclusive segments
  - Refactor NetworkEnvironment#setupXXX() to ResultPartitionWriter#setup() and InputGate#setup()

## Verifying this change

existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
