### PR TITLE
[hotfix][javadocs] Correct the example of select for Interface Table.

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -97,9 +97,22 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.select("key, value.avg + ' The average' as average")
+	 *   tab.select("key")
 	 * }
 	 * </pre>
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.select("value.avg + ' The average' as average")
+	 * }
+	 * </pre>
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.groupBy("key").select("key, value.avg + ' The average' as average")
+	 * }
+	 * </pre>
+	 *
 	 */
 	Table select(String fields);
 
@@ -111,7 +124,19 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.select('key, 'value.avg + " The average" as 'average)
+	 *   tab.select('key)
+	 * }
+	 * </pre>
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.select('value.avg + " The average" as 'average)
+	 * }
+	 * </pre>
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.groupBy('key).select('key, 'value.avg + " The average" as 'average)
 	 * }
 	 * </pre>
 	 */


### PR DESCRIPTION
The example of select in Table.java is "tab.select("key, value.avg + ' The average' as average")" which can causes ValidationException "Cannot resolve field [key], input field list:[TMP_0]". So correct the example.