### PR TITLE
[FLINK-12491][docs][configuration] Fix incorrect javadoc for path sep…

### DIFF
--- a/docs/_includes/generated/common_miscellaneous_section.html
+++ b/docs/_includes/generated/common_miscellaneous_section.html
@@ -24,7 +24,7 @@
             <td><h5>io.tmp.dirs</h5></td>
             <td style="word-wrap: break-word;">'LOCAL_DIRS' on Yarn. '_FLINK_TMP_DIR' on Mesos. System.getProperty("java.io.tmpdir") in standalone.</td>
             <td>String</td>
-            <td>Directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
+            <td>Directories for temporary files, separated by",", or the system's java.io.File.pathSeparator.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -68,7 +68,7 @@ This check should only be disabled if such a leak prevents further jobs from run
             <td><h5>io.tmp.dirs</h5></td>
             <td style="word-wrap: break-word;">'LOCAL_DIRS' on Yarn. '_FLINK_TMP_DIR' on Mesos. System.getProperty("java.io.tmpdir") in standalone.</td>
             <td>String</td>
-            <td>Directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
+            <td>Directories for temporary files, separated by",", or the system's java.io.File.pathSeparator.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -208,8 +208,8 @@ public final class ConfigConstants {
     public static final String TASK_MANAGER_DATA_SSL_ENABLED = "taskmanager.data.ssl.enabled";
 
     /**
-     * The config parameter defining the directories for temporary files, separated by ",", "|", or
-     * the system's {@link java.io.File#pathSeparator}.
+     * The config parameter defining the directories for temporary files, separated by ",", or the
+     * system's {@link java.io.File#pathSeparator}.
      *
      * @deprecated Use {@link CoreOptions#TMP_DIRS} instead
      */

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -320,8 +320,8 @@ public class CoreOptions {
     // ------------------------------------------------------------------------
 
     /**
-     * The config parameter defining the directories for temporary files, separated by ",", "|", or
-     * the system's {@link java.io.File#pathSeparator}.
+     * The config parameter defining the directories for temporary files, separated by ",", or the
+     * system's {@link java.io.File#pathSeparator}.
      */
     @Documentation.OverrideDefault(
             "'LOCAL_DIRS' on Yarn. '_FLINK_TMP_DIR' on Mesos. System.getProperty(\"java.io.tmpdir\") in standalone.")
@@ -331,7 +331,7 @@ public class CoreOptions {
                     .defaultValue(System.getProperty("java.io.tmpdir"))
                     .withDeprecatedKeys("taskmanager.tmp.dirs")
                     .withDescription(
-                            "Directories for temporary files, separated by\",\", \"|\", or the system's java.io.File.pathSeparator.");
+                            "Directories for temporary files, separated by\",\", or the system's java.io.File.pathSeparator.");
 
     // ------------------------------------------------------------------------
     //  program

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
@@ -22,17 +22,29 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /** Tests for the {@link ConfigurationUtils}. */
 public class ConfigurationUtilsTest extends TestLogger {
+
+    private static final String[] TESTING_PATHS = {
+        "C:\\\\", "current\\\\leaf", "/root/dir/./../spaced dir/dotted.d/leaf",
+    };
 
     @Test
     public void testPropertiesToConfiguration() {
@@ -91,5 +103,81 @@ public class ConfigurationUtilsTest extends TestLogger {
                 ConfigurationUtils.getPrefixedKeyValuePairs(prefix, configuration);
 
         assertThat(resultKeyValuePairs, is(equalTo(expectedKeyValuePairs)));
+    }
+
+    @Test
+    public void testSplitPathsForEmptyPath() {
+        String[] paths = ConfigurationUtils.splitPaths("");
+        assertThat(paths, emptyArray());
+    }
+
+    @Test
+    public void testSplitPathsForSupportedSeparators() {
+        for (String separator : ConfigurationUtils.PATH_SEPARATORS) {
+            List<String> expectedPaths =
+                    Arrays.stream(TESTING_PATHS)
+                            .filter(p -> !p.contains(separator))
+                            .filter(p -> !p.contains(File.pathSeparator))
+                            .collect(Collectors.toList());
+            String separatedPaths = String.join(separator, expectedPaths);
+            String[] actualPaths = ConfigurationUtils.splitPaths(separatedPaths);
+            String message =
+                    String.format(
+                            "Separator %s pattern separators %s",
+                            separator, Arrays.toString(ConfigurationUtils.PATH_SEPARATORS));
+            assertEquals(message, expectedPaths, Arrays.asList(actualPaths));
+        }
+    }
+
+    @Test
+    public void testSplitPathsForNotSupportedSeparators() {
+        String[] notSupportedSeparators =
+                Stream.of("|", ":", ";")
+                        .filter(s -> !s.equals(File.pathSeparator))
+                        .toArray(String[]::new);
+        for (String separator : notSupportedSeparators) {
+            List<String> expectedPaths =
+                    Arrays.stream(TESTING_PATHS)
+                            .filter(p -> !p.contains(separator))
+                            .filter(p -> !p.contains(File.pathSeparator))
+                            .collect(Collectors.toList());
+            String separatedPaths = String.join(separator, expectedPaths);
+            String[] actualPaths = ConfigurationUtils.splitPaths(separatedPaths);
+            String message =
+                    String.format(
+                            "Pattern separators %s separatedPaths %s actualPaths: %s",
+                            Arrays.toString(ConfigurationUtils.PATH_SEPARATORS),
+                            separatedPaths,
+                            Arrays.toString(actualPaths));
+            assertThat(message, actualPaths, arrayWithSize(1));
+            assertEquals(message, separatedPaths, actualPaths[0]);
+        }
+    }
+
+    @Test
+    public void testSplitPathsForCustomSeparators() {
+        String[] customSeparators =
+                Stream.of(
+                                Stream.of("|", "$"),
+                                Stream.of(ConfigurationUtils.PATH_SEPARATORS),
+                                // This way we can test both unix and windows path separator without
+                                // ci test matrix.
+                                Stream.of(":", ";"))
+                        .flatMap(Function.identity())
+                        .distinct()
+                        .toArray(String[]::new);
+        for (String separator : customSeparators) {
+            List<String> expectedPaths =
+                    Arrays.stream(TESTING_PATHS)
+                            .filter(p -> Arrays.stream(customSeparators).noneMatch(p::contains))
+                            .collect(Collectors.toList());
+            String separatedPaths = String.join(separator, expectedPaths);
+            String[] actualPaths = ConfigurationUtils.splitPaths(separatedPaths, customSeparators);
+            String message =
+                    String.format(
+                            "Separator %s pattern separators %s",
+                            separator, Arrays.toString(customSeparators));
+            assertEquals(message, expectedPaths, Arrays.asList(actualPaths));
+        }
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.CloseableRegistry;
@@ -340,7 +341,7 @@ public class RocksDBStateBackend extends AbstractManagedMemoryStateBackend
         } else {
             final String rocksdbLocalPaths = config.get(RocksDBOptions.LOCAL_DIRECTORIES);
             if (rocksdbLocalPaths != null) {
-                String[] directories = rocksdbLocalPaths.split(",|" + File.pathSeparator);
+                String[] directories = ConfigurationUtils.splitPaths(rocksdbLocalPaths);
 
                 try {
                     setDbStoragePaths(directories);


### PR DESCRIPTION
…arators of CoreOptions.TMP_DIRS

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Fix incorrect javadoc for path separators part of  `CoreOptions.TMP_DIRS` and `ConfigConstants.TASK_MANAGER_TMP_DIR_KEY`

## Brief change log
* Fix incorrect javadoc for path separators part of  `CoreOptions.TMP_DIRS` and `ConfigConstants.TASK_MANAGER_TMP_DIR_KEY`.
* Refactor `ConfigurationUtils.splitPaths` so we can test both unix and windows path separators without demand on ci test matrix.


## Verifying this change
This change added tests and can be verified as follows:
* Added test for documented path separators.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
