### PR TITLE
[hotfix][examples] Fix the streaming example of TopSpeedWindowing 's increased distance in 100ms

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowing.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowing.java
@@ -132,7 +132,7 @@ public class TopSpeedWindowing {
 					} else {
 						speeds[carId] = Math.max(0, speeds[carId] - 5);
 					}
-					distances[carId] += speeds[carId] / 3.6d;
+					distances[carId] += speeds[carId] / 36d;
 					Tuple4<Integer, Integer, Double, Long> record = new Tuple4<>(carId,
 							speeds[carId], distances[carId], System.currentTimeMillis());
 					ctx.collect(record);


### PR DESCRIPTION
In the official streaming example of `org.apache.flink.streaming.examples.windowing.TopSpeedWindowing` , increased distance in 100ms is not rigorous enough with the value of speed/3.6d, it should be the value of speed/36d.
Checking process like this:
>incremental distance = ( km.h * 1000  / 3600) * 0.1 (s)  

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request makes more reasonable in  the process of the derivation of incremental distance in 100ms of the streaming example -- `org.apache.flink.streaming.examples.windowing.TopSpeedWindowing`

## Brief change log

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowing.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowing.java
@@ -132,7 +132,7 @@ public class TopSpeedWindowing {
                                        } else {
                                                speeds[carId] = Math.max(0, speeds[carId] - 5);
                                        }
-                                       distances[carId] += speeds[carId] / 3.6d;
+                                       distances[carId] += speeds[carId] / 36d;
                                        Tuple4<Integer, Integer, Double, Long> record = new Tuple4<>(carId,


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
 