### PR TITLE
[FLINK-12495][python, client]Move PythonGatewayServer into flink-clie…

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -68,6 +68,13 @@ under the License.
 			<artifactId>commons-cli</artifactId>
 		</dependency>
 
+		<!-- Python API dependencies -->
+		<dependency>
+			<groupId>net.sf.py4j</groupId>
+			<artifactId>py4j</artifactId>
+			<version>${pyj4.version}</version>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -72,7 +72,7 @@ under the License.
 		<dependency>
 			<groupId>net.sf.py4j</groupId>
 			<artifactId>py4j</artifactId>
-			<version>${pyj4.version}</version>
+			<version>${py4j.version}</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-clients/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.python;
+package org.apache.flink.client.python;
 
 import py4j.GatewayServer;
 

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -86,13 +86,6 @@ under the License.
 			<artifactId>flink-shaded-guava</artifactId>
 		</dependency>
 
-		<!-- Python API dependencies -->
-		<dependency>
-			<groupId>net.sf.py4j</groupId>
-			<artifactId>py4j</artifactId>
-			<version>0.10.8.1</version>
-		</dependency>
-
 		<!-- ================== test dependencies ================== -->
 
 		<dependency>

--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -62,7 +62,7 @@ def launch_gateway():
         raise Exception("Windows system is not supported currently.")
     script = "./bin/pyflink-gateway-server.sh"
     command = [os.path.join(FLINK_HOME, script)]
-    command += ['-c', 'org.apache.flink.api.python.PythonGatewayServer']
+    command += ['-c', 'org.apache.flink.client.python.PythonGatewayServer']
 
     # Create a temporary directory where the gateway server should write the connection information.
     conn_info_dir = tempfile.mkdtemp()

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@ under the License.
 		<mockito.version>2.21.0</mockito.version>
 		<powermock.version>2.0.0-RC.4</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
+		<pyj4.version>0.10.8.1</pyj4.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>
 		<!--

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ under the License.
 		<mockito.version>2.21.0</mockito.version>
 		<powermock.version>2.0.0-RC.4</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<pyj4.version>0.10.8.1</pyj4.version>
+		<py4j.version>0.10.8.1</py4j.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>
 		<!--


### PR DESCRIPTION
## What is the purpose of the change

Due to we add py4j dependency for `PythonGatewayServer` when we put the `PythonGatewayServer` in `flink-core` module, and every module has a transitive dependency on `flink-core`, So It's better to move the `PythonGatewayServer` into `flink-clients`.(Great thanks to @aljoscha for the offline suggestion)

## Brief change log

  -  Move the `PythonGatewayServer` from `flink-core` to `flink-clients`.
  -  Move py4j dependency from `flink-core` to `flink-clients`.
  -  Modify the `java_gateway.py` script for package path of `PythonGatewayServer`.

## Verifying this change
This change is a core moving without any test coverage.
But we can run ` dev/lint-python.sh` to check the changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? ( not documented)
