### PR TITLE
[FLINK-12497][network] Refactor the start method of ConnectionManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/ConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/ConnectionManager.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 
 import java.io.IOException;
 
@@ -29,7 +28,7 @@ import java.io.IOException;
  */
 public interface ConnectionManager {
 
-	void start(ResultPartitionProvider partitionProvider, TaskEventPublisher taskEventDispatcher) throws IOException;
+	void start() throws IOException;
 
 	/**
 	 * Creates a {@link PartitionRequestClient} instance for the given {@link ConnectionID}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/LocalConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/LocalConnectionManager.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 
 /**
  * A connection manager implementation to bypass setup overhead for task managers running in local
@@ -28,7 +27,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 public class LocalConnectionManager implements ConnectionManager {
 
 	@Override
-	public void start(ResultPartitionProvider partitionProvider, TaskEventPublisher taskEventPublisher) {
+	public void start() {
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -120,8 +120,12 @@ public class NetworkEnvironment {
 		checkNotNull(config);
 
 		NettyConfig nettyConfig = config.nettyConfig();
+
+		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
+
 		ConnectionManager connectionManager = nettyConfig != null ?
-			new NettyConnectionManager(nettyConfig, config.isCreditBased()) : new LocalConnectionManager();
+			new NettyConnectionManager(resultPartitionManager, taskEventPublisher, nettyConfig, config.isCreditBased()) :
+			new LocalConnectionManager();
 
 		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
 			config.numNetworkBuffers(),
@@ -130,7 +134,6 @@ public class NetworkEnvironment {
 
 		registerNetworkMetrics(metricGroup, networkBufferPool);
 
-		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
 		ResultPartitionFactory resultPartitionFactory = new ResultPartitionFactory(
 			resultPartitionManager,
 			ioManager,
@@ -280,7 +283,7 @@ public class NetworkEnvironment {
 
 			try {
 				LOG.debug("Starting network connection manager");
-				connectionManager.start(resultPartitionManager, taskEventPublisher);
+				connectionManager.start();
 			} catch (IOException t) {
 				throw new IOException("Failed to instantiate network connection manager.", t);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 public class NettyConnectionManager implements ConnectionManager {
 
 	private final NettyServer server;
@@ -35,24 +37,27 @@ public class NettyConnectionManager implements ConnectionManager {
 
 	private final PartitionRequestClientFactory partitionRequestClientFactory;
 
-	private final boolean isCreditBased;
+	private final NettyProtocol nettyProtocol;
 
-	public NettyConnectionManager(NettyConfig nettyConfig, boolean isCreditBased) {
+	public NettyConnectionManager(
+		ResultPartitionProvider partitionProvider,
+		TaskEventPublisher taskEventPublisher,
+		NettyConfig nettyConfig,
+		boolean isCreditBased) {
+
 		this.server = new NettyServer(nettyConfig);
 		this.client = new NettyClient(nettyConfig);
 		this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas());
 
 		this.partitionRequestClientFactory = new PartitionRequestClientFactory(client);
 
-		this.isCreditBased = isCreditBased;
+		this.nettyProtocol = new NettyProtocol(checkNotNull(partitionProvider), checkNotNull(taskEventPublisher), isCreditBased);
 	}
 
 	@Override
-	public void start(ResultPartitionProvider partitionProvider, TaskEventPublisher taskEventPublisher) throws IOException {
-		NettyProtocol partitionRequestProtocol = new NettyProtocol(partitionProvider, taskEventPublisher, isCreditBased);
-
-		client.init(partitionRequestProtocol, bufferPool);
-		server.init(partitionRequestProtocol, bufferPool);
+	public void start() throws IOException {
+		client.init(nettyProtocol, bufferPool);
+		server.init(nettyProtocol, bufferPool);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.util.NetUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.bootstrap.Bootstrap;
@@ -33,7 +33,6 @@ import java.lang.reflect.Field;
 import java.net.InetAddress;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 /**
  * Simple netty connection manager test.
@@ -57,11 +56,8 @@ public class NettyConnectionManagerTest {
 				numberOfSlots,
 				new Configuration());
 
-		NettyConnectionManager connectionManager = new NettyConnectionManager(config, true);
-
-		connectionManager.start(
-				mock(ResultPartitionProvider.class),
-				mock(TaskEventDispatcher.class));
+		NettyConnectionManager connectionManager = createNettyConnectionManager(config);
+		connectionManager.start();
 
 		assertEquals(numberOfSlots, connectionManager.getBufferPool().getNumberOfArenas());
 
@@ -125,11 +121,8 @@ public class NettyConnectionManagerTest {
 				1337,
 				flinkConfig);
 
-		NettyConnectionManager connectionManager = new NettyConnectionManager(config, true);
-
-		connectionManager.start(
-				mock(ResultPartitionProvider.class),
-				mock(TaskEventDispatcher.class));
+		NettyConnectionManager connectionManager = createNettyConnectionManager(config);
+		connectionManager.start();
 
 		assertEquals(numberOfArenas, connectionManager.getBufferPool().getNumberOfArenas());
 
@@ -170,4 +163,7 @@ public class NettyConnectionManagerTest {
 		}
 	}
 
+	private NettyConnectionManager createNettyConnectionManager(NettyConfig config) {
+		return new NettyConnectionManager(new ResultPartitionManager(), new TaskEventDispatcher(), config, true);
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -22,7 +22,6 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
-import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
@@ -141,7 +140,7 @@ public class InputChannelTestUtils {
 	public static ConnectionManager mockConnectionManagerWithPartitionRequestClient(PartitionRequestClient client) {
 		return new ConnectionManager() {
 			@Override
-			public void start(ResultPartitionProvider partitionProvider, TaskEventPublisher taskEventDispatcher) {
+			public void start() {
 			}
 
 			@Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes `ConnectionManager#start` more cleaner for both `NettyConnectionManager` and `LocalConnectionManager` implementations. And it seems better to avoid following dependency by passing `TaskEventDispatcher` into `NettyConnectionManager` in the constructor of `NetworkEnvironment`*

## Brief change log

  - *Remove parameters from `ConnectionManager#start()`*
  - *Fix the `NettyConnectionManager` and `LocalConnectionManager` implementations*
  - *Fix the logic in `NetworkEnvironment`.

## Verifying this change

This change is a trivial rework / code.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
