### PR TITLE
[FLINK-12480] Introduce mailbox to StreamTask main-loop

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -39,8 +39,6 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 
 	private StreamInputProcessor<IN> inputProcessor;
 
-	private volatile boolean running = true;
-
 	private final WatermarkGauge inputWatermarkGauge = new WatermarkGauge();
 
 	/**
@@ -98,13 +96,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 	}
 
 	@Override
-	protected void run() throws Exception {
-		// cache processor reference on the stack, to make the code more JIT friendly
-		final StreamInputProcessor<IN> inputProcessor = this.inputProcessor;
-
-		while (running && inputProcessor.processInput()) {
-			// all the work happens in the "processInput" method
-		}
+	protected boolean performDefaultAction() throws Exception {
+		return inputProcessor.processInput();
 	}
 
 	@Override
@@ -116,6 +109,5 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 
 	@Override
 	protected void cancelTask() {
-		running = false;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -96,8 +96,10 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 	}
 
 	@Override
-	protected boolean performDefaultAction() throws Exception {
-		return inputProcessor.processInput();
+	protected void performDefaultAction(ActionContext context) throws Exception {
+		if (!inputProcessor.processInput()) {
+			context.allActionsCompleted();
+		}
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -98,8 +98,11 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 	}
 
 	@Override
-	protected void run() throws Exception {
+	protected boolean performDefaultAction() throws Exception {
+		// Against the usual contract of this method, this implementation is not step-wise but blocking instead for
+		// compatibility reasons with the current source interface (source functions run as a loop, not in steps).
 		headOperator.run(getCheckpointLock(), getStreamStatusMaintainer());
+		return false;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -98,11 +98,11 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 	}
 
 	@Override
-	protected boolean performDefaultAction() throws Exception {
+	protected void performDefaultAction(ActionContext context) throws Exception {
 		// Against the usual contract of this method, this implementation is not step-wise but blocking instead for
 		// compatibility reasons with the current source interface (source functions run as a loop, not in steps).
 		headOperator.run(getCheckpointLock(), getStreamStatusMaintainer());
-		return false;
+		context.allActionsCompleted();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.BlockingQueueBroker;
 import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,88 +42,73 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamIterationHead.class);
 
-	private volatile boolean running = true;
+	private RecordWriterOutput<OUT>[] streamOutputs;
+
+	private final BlockingQueue<StreamRecord<OUT>> dataChannel;
+	private final String brokerID;
+	private final long iterationWaitTime;
+	private final boolean shouldWait;
 
 	public StreamIterationHead(Environment env) {
 		super(env);
+		final String iterationId = getConfiguration().getIterationId();
+		if (iterationId == null || iterationId.length() == 0) {
+			throw new FlinkRuntimeException("Missing iteration ID in the task configuration");
+		}
+
+		this.dataChannel = new ArrayBlockingQueue<>(1);
+		this.brokerID = createBrokerIdString(getEnvironment().getJobID(), iterationId,
+			getEnvironment().getTaskInfo().getIndexOfThisSubtask());
+		this.iterationWaitTime = getConfiguration().getIterationWaitTime();
+		this.shouldWait = iterationWaitTime > 0;
 	}
 
 	// ------------------------------------------------------------------------
 
 	@Override
-	protected void run() throws Exception {
+	protected boolean performDefaultAction() throws Exception {
+		StreamRecord<OUT> nextRecord = shouldWait ?
+			dataChannel.poll(iterationWaitTime, TimeUnit.MILLISECONDS) :
+			dataChannel.take();
 
-		final String iterationId = getConfiguration().getIterationId();
-		if (iterationId == null || iterationId.length() == 0) {
-			throw new Exception("Missing iteration ID in the task configuration");
+		if (nextRecord == null) {
+			return false;
 		}
 
-		final String brokerID = createBrokerIdString(getEnvironment().getJobID(), iterationId ,
-				getEnvironment().getTaskInfo().getIndexOfThisSubtask());
+		synchronized (getCheckpointLock()) {
+			for (RecordWriterOutput<OUT> output : streamOutputs) {
+				output.collect(nextRecord);
+			}
+		}
+		return true;
+	}
 
-		final long iterationWaitTime = getConfiguration().getIterationWaitTime();
-		final boolean shouldWait = iterationWaitTime > 0;
+	// ------------------------------------------------------------------------
 
-		final BlockingQueue<StreamRecord<OUT>> dataChannel = new ArrayBlockingQueue<StreamRecord<OUT>>(1);
-
+	@SuppressWarnings("unchecked")
+	@Override
+	public void init() {
 		// offer the queue for the tail
 		BlockingQueueBroker.INSTANCE.handIn(brokerID, dataChannel);
 		LOG.info("Iteration head {} added feedback queue under {}", getName(), brokerID);
 
-		// do the work
-		try {
-			@SuppressWarnings("unchecked")
-			RecordWriterOutput<OUT>[] outputs = (RecordWriterOutput<OUT>[]) getStreamOutputs();
+		this.streamOutputs = (RecordWriterOutput<OUT>[]) getStreamOutputs();
 
-			// If timestamps are enabled we make sure to remove cyclic watermark dependencies
-			if (isSerializingTimestamps()) {
-				synchronized (getCheckpointLock()) {
-					for (RecordWriterOutput<OUT> output : outputs) {
-						output.emitWatermark(new Watermark(Long.MAX_VALUE));
-					}
-				}
-			}
-
-			while (running) {
-				StreamRecord<OUT> nextRecord = shouldWait ?
-					dataChannel.poll(iterationWaitTime, TimeUnit.MILLISECONDS) :
-					dataChannel.take();
-
-				if (nextRecord != null) {
-					synchronized (getCheckpointLock()) {
-						for (RecordWriterOutput<OUT> output : outputs) {
-							output.collect(nextRecord);
-						}
-					}
-				}
-				else {
-					// done
-					break;
+		// If timestamps are enabled we make sure to remove cyclic watermark dependencies
+		if (isSerializingTimestamps()) {
+			synchronized (getCheckpointLock()) {
+				for (RecordWriterOutput<OUT> output : streamOutputs) {
+					output.emitWatermark(new Watermark(Long.MAX_VALUE));
 				}
 			}
 		}
-		finally {
-			// make sure that we remove the queue from the broker, to prevent a resource leak
-			BlockingQueueBroker.INSTANCE.remove(brokerID);
-			LOG.info("Iteration head {} removed feedback queue under {}", getName(), brokerID);
-		}
 	}
 
 	@Override
-	protected void cancelTask() {
-		running = false;
-	}
-
-	// ------------------------------------------------------------------------
-
-	@Override
-	public void init() {
-		// does not hold any resources, no initialization necessary
-	}
-
-	@Override
-	protected void cleanup() throws Exception {
-		// does not hold any resources, no cleanup necessary
+	protected void cleanup() {
+		// make sure that we remove the queue from the broker, to prevent a resource leak
+		BlockingQueueBroker.INSTANCE.remove(brokerID);
+		LOG.info("Iteration head {} removed feedback queue under {}", getName(), brokerID);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -66,21 +66,20 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 	// ------------------------------------------------------------------------
 
 	@Override
-	protected boolean performDefaultAction() throws Exception {
+	protected void performDefaultAction(ActionContext context) throws Exception {
 		StreamRecord<OUT> nextRecord = shouldWait ?
 			dataChannel.poll(iterationWaitTime, TimeUnit.MILLISECONDS) :
 			dataChannel.take();
 
-		if (nextRecord == null) {
-			return false;
-		}
-
-		synchronized (getCheckpointLock()) {
-			for (RecordWriterOutput<OUT> output : streamOutputs) {
-				output.collect(nextRecord);
+		if (nextRecord != null) {
+			synchronized (getCheckpointLock()) {
+				for (RecordWriterOutput<OUT> output : streamOutputs) {
+					output.collect(nextRecord);
+				}
 			}
+		} else {
+			context.allActionsCompleted();
 		}
-		return true;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -222,11 +222,23 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	protected abstract void init() throws Exception;
 
-	protected abstract void run() throws Exception;
-
 	protected abstract void cleanup() throws Exception;
 
 	protected abstract void cancelTask() throws Exception;
+
+	/**
+	 * This method implements the default action of the task (e.g. processing one event from the input). Implementations
+	 * should (in general) be non-blocking.
+	 *
+	 * @return <code>true</code> if there is more work to perform as default action for this task and <code>false</code>
+	 * if the task is ready to finish.
+	 * @throws Exception on any problems in the action.
+	 */
+	protected abstract boolean performDefaultAction() throws Exception;
+
+	protected void run() throws Exception {
+		while (isRunning && performDefaultAction()) {}
+	}
 
 	/**
 	 * Emits the {@link org.apache.flink.streaming.api.watermark.Watermark#MAX_WATERMARK MAX_WATERMARK}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -40,8 +40,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputS
 
 	private StreamTwoInputProcessor<IN1, IN2> inputProcessor;
 
-	private volatile boolean running = true;
-
 	private final WatermarkGauge input1WatermarkGauge;
 	private final WatermarkGauge input2WatermarkGauge;
 	private final MinWatermarkGauge minInputWatermarkGauge;
@@ -110,13 +108,8 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputS
 	}
 
 	@Override
-	protected void run() throws Exception {
-		// cache processor reference on the stack, to make the code more JIT friendly
-		final StreamTwoInputProcessor<IN1, IN2> inputProcessor = this.inputProcessor;
-
-		while (running && inputProcessor.processInput()) {
-			// all the work happens in the "processInput" method
-		}
+	protected boolean performDefaultAction() throws Exception {
+		return inputProcessor.processInput();
 	}
 
 	@Override
@@ -128,6 +121,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputS
 
 	@Override
 	protected void cancelTask() {
-		running = false;
+
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -108,8 +108,10 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputS
 	}
 
 	@Override
-	protected boolean performDefaultAction() throws Exception {
-		return inputProcessor.processInput();
+	protected void performDefaultAction(ActionContext context) throws Exception {
+		if (!inputProcessor.processInput()) {
+			context.allActionsCompleted();
+		}
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/Mailbox.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/Mailbox.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A mailbox is basically a blocking queue for inter-thread message exchange in form of {@link Runnable} objects between
+ * multiple producer threads and a single consumer.
+ */
+public interface Mailbox extends MailboxReceiver, MailboxSender {
+
+	/**
+	 * The effect of this is that all pending letters are dropped and the given priorityAction
+	 * is enqueued to the head of the mailbox.
+	 *
+	 * @param priorityAction action to enqueue atomically after the mailbox was cleared.
+	 */
+	void clearAndPut(@Nonnull Runnable priorityAction);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImpl.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Implementation of {@link Mailbox} inspired by {@link java.util.concurrent.ArrayBlockingQueue} and tailored towards
+ * our use case with multiple writers, single reader and volatile reads instead of lock & read on {@link #count}.
+ */
+public class MailboxImpl implements Mailbox {
+
+	/**
+	 * The enqueued letters.
+	 */
+	@GuardedBy("lock")
+	private final Runnable[] ringBuffer;
+
+	/**
+	 * Lock for all concurrent ops.
+	 */
+	private final ReentrantLock lock;
+
+	/**
+	 * Condition that is triggered when the buffer is no longer empty.
+	 */
+	@GuardedBy("lock")
+	private final Condition notEmpty;
+
+	/**
+	 * Condition that is triggered when the buffer is no longer full.
+	 */
+	@GuardedBy("lock")
+	private final Condition notFull;
+
+	/**
+	 * Index of the ring buffer head.
+	 */
+	@GuardedBy("lock")
+	private int headIndex;
+
+	/**
+	 * Index of the ring buffer tail.
+	 */
+	@GuardedBy("lock")
+	private int tailIndex;
+
+	/**
+	 * Number of letters in the mailbox.
+	 */
+	@GuardedBy("lock")
+	private volatile int count;
+
+	/**
+	 * A mask to wrap around the indexes of the ring buffer. We use this to avoid ifs or modulo ops.
+	 */
+	private final int moduloMask;
+
+	public MailboxImpl() {
+		this(6); // 2^6 = 64
+	}
+
+	public MailboxImpl(int capacityPow2) {
+		final int capacity = 1 << capacityPow2;
+		Preconditions.checkState(capacity > 0);
+		this.moduloMask = capacity - 1;
+		this.ringBuffer = new Runnable[capacity];
+		this.lock = new ReentrantLock();
+		this.notEmpty = lock.newCondition();
+		this.notFull = lock.newCondition();
+	}
+
+	@Override
+	public boolean hasMail() {
+		return count > 0;
+	}
+
+	@Override
+	public Runnable tryTakeMail() {
+		final ReentrantLock lock = this.lock;
+		lock.lock();
+		try {
+			return isEmpty() ? null : takeInternal();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Nonnull
+	@Override
+	public Runnable takeMail() throws InterruptedException {
+		final ReentrantLock lock = this.lock;
+		lock.lockInterruptibly();
+		try {
+			while (isEmpty()) {
+				notEmpty.await();
+			}
+			return takeInternal();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public void waitUntilHasMail() throws InterruptedException {
+		final ReentrantLock lock = this.lock;
+		lock.lockInterruptibly();
+		try {
+			while (isEmpty()) {
+				notEmpty.await();
+			}
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	//------------------------------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean tryPutMail(@Nonnull Runnable letter) {
+		final ReentrantLock lock = this.lock;
+		lock.lock();
+		try {
+			if (isFull()) {
+				return false;
+			} else {
+				putInternal(letter);
+				return true;
+			}
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public void putMail(@Nonnull Runnable letter) throws InterruptedException {
+		final ReentrantLock lock = this.lock;
+		lock.lockInterruptibly();
+		try {
+			while (isFull()) {
+				notFull.await();
+			}
+			putInternal(letter);
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public void waitUntilHasCapacity() throws InterruptedException {
+		final ReentrantLock lock = this.lock;
+		lock.lockInterruptibly();
+		try {
+			while (isFull()) {
+				notFull.await();
+			}
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	//------------------------------------------------------------------------------------------------------------------
+
+	private void putInternal(Runnable letter) {
+		assert lock.isHeldByCurrentThread();
+		this.ringBuffer[tailIndex] = letter;
+		tailIndex = increaseIndexWithWrapAround(tailIndex);
+		++count;
+		notEmpty.signal();
+	}
+
+	private Runnable takeInternal() {
+		assert lock.isHeldByCurrentThread();
+		final Runnable[] buffer = this.ringBuffer;
+		Runnable letter = buffer[headIndex];
+		buffer[headIndex] = null;
+		headIndex = increaseIndexWithWrapAround(headIndex);
+		--count;
+		notFull.signal();
+		return letter;
+	}
+
+	private int increaseIndexWithWrapAround(int old) {
+		return (old + 1) & moduloMask;
+	}
+
+	private boolean isFull() {
+		return count >= ringBuffer.length;
+	}
+
+	private boolean isEmpty() {
+		return count == 0;
+	}
+
+	@Override
+	public void clearAndPut(@Nonnull Runnable shutdownAction) {
+		lock.lock();
+		try {
+			int localCount = count;
+			while (localCount > 0) {
+				ringBuffer[headIndex] = null;
+				headIndex = increaseIndexWithWrapAround(headIndex);
+				--localCount;
+			}
+			count = 0;
+			putInternal(shutdownAction);
+		} finally {
+			lock.unlock();
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxReceiver.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxReceiver.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Consumer-facing side of the {@link Mailbox} interface. This is used to dequeue letters. The mailbox returns letters
+ * in the order by which they were enqueued. A mailbox should only be consumed by one thread at a time.
+ */
+public interface MailboxReceiver {
+
+	/**
+	 * Returns <code>true</code> if the mailbox contains mail.
+	 */
+	boolean hasMail();
+
+	/**
+	 * Returns the oldest letter from the mailbox (head of queue) if the mailbox is not empty or
+	 * <code>null</code> otherwise.
+	 *
+	 * @return the oldest letter from the mailbox (head of queue) if the mailbox is not empty or
+	 * <code>null</code> otherwise.
+	 */
+	@Nullable
+	Runnable tryTakeMail();
+
+	/**
+	 * This method returns the oldest letter from the mailbox (head of queue) or blocks until a letter is available.
+	 *
+	 * @return the oldest letter from the mailbox (head of queue).
+	 * @throws InterruptedException on interruption.
+	 */
+	@Nonnull
+	Runnable takeMail() throws InterruptedException;
+
+	/**
+	 * This method blocks if the mailbox is empty until mail becomes available.
+	 * @throws InterruptedException on interruption.
+	 */
+	void waitUntilHasMail() throws InterruptedException;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxSender.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxSender.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Producer-facing side of the {@link Mailbox} interface. This is used to enqueue letters. Multiple producers threads
+ * can put to the same mailbox.
+ */
+public interface MailboxSender {
+
+	/**
+	 * Enqueues the given letter to the mailbox, if capacity is available. On success, this returns <code>true</code>
+	 * and <code>false</code> if the mailbox was already full.
+	 *
+	 * @param letter the letter to enqueue.
+	 * @return <code>true</code> iff successful.
+	 */
+	boolean tryPutMail(@Nonnull Runnable letter);
+
+	/**
+	 * Enqueues the given letter to the mailbox and blocks until there is capacity for a successful put.
+	 *
+	 * @param letter the letter to enqueue.
+	 * @throws InterruptedException on interruption.
+	 */
+	void putMail(@Nonnull Runnable letter) throws InterruptedException;
+
+	/**
+	 * This method blocks until the mailbox has again capacity to enqueue new letters.
+	 *
+	 * @throws InterruptedException on interruption.
+	 */
+	void waitUntilHasCapacity() throws InterruptedException;
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
@@ -80,7 +80,9 @@ public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
 			protected void init() throws Exception {}
 
 			@Override
-			protected void run() throws Exception {}
+			protected boolean performDefaultAction() throws Exception {
+				return false;
+			}
 
 			@Override
 			protected void cleanup() throws Exception {}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
@@ -80,8 +80,8 @@ public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
 			protected void init() throws Exception {}
 
 			@Override
-			protected boolean performDefaultAction() throws Exception {
-				return false;
+			protected void performDefaultAction(ActionContext context) throws Exception {
+				context.allActionsCompleted();
 			}
 
 			@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
@@ -188,7 +188,9 @@ public class StreamTaskCancellationBarrierTest {
 		}
 
 		@Override
-		protected void run() throws Exception {}
+		protected boolean performDefaultAction() {
+			return false;
+		}
 
 		@Override
 		protected void cleanup() throws Exception {}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
@@ -188,8 +188,8 @@ public class StreamTaskCancellationBarrierTest {
 		}
 
 		@Override
-		protected boolean performDefaultAction() {
-			return false;
+		protected void performDefaultAction(ActionContext context) throws Exception {
+			context.allActionsCompleted();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -224,10 +224,11 @@ public class StreamTaskTerminationTest extends TestLogger {
 		}
 
 		@Override
-		protected void run() throws Exception {
+		protected boolean performDefaultAction() throws Exception {
 			RUN_LATCH.trigger();
 			// wait until we have started an asynchronous checkpoint
 			CHECKPOINTING_LATCH.await();
+			return false;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -224,11 +224,11 @@ public class StreamTaskTerminationTest extends TestLogger {
 		}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			RUN_LATCH.trigger();
 			// wait until we have started an asynchronous checkpoint
 			CHECKPOINTING_LATCH.await();
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -843,7 +843,9 @@ public class StreamTaskTest extends TestLogger {
 		protected void init() throws Exception {}
 
 		@Override
-		protected void run() throws Exception {}
+		protected boolean performDefaultAction() {
+			return false;
+		}
 
 		@Override
 		protected void cleanup() throws Exception {}
@@ -1031,7 +1033,9 @@ public class StreamTaskTest extends TestLogger {
 		protected void init() throws Exception {}
 
 		@Override
-		protected void run() throws Exception {}
+		protected boolean performDefaultAction() {
+			return false;
+		}
 
 		@Override
 		protected void cleanup() throws Exception {}
@@ -1059,10 +1063,11 @@ public class StreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		protected void run() throws Exception {
+		protected boolean performDefaultAction() {
 			if (fail) {
 				throw new RuntimeException();
 			}
+			return false;
 		}
 
 		@Override
@@ -1149,7 +1154,7 @@ public class StreamTaskTest extends TestLogger {
 		protected void init() {}
 
 		@Override
-		protected void run() throws Exception {
+		protected boolean performDefaultAction() throws Exception {
 			holder = new LockHolder(getCheckpointLock(), latch);
 			holder.start();
 			latch.await();
@@ -1164,6 +1169,7 @@ public class StreamTaskTest extends TestLogger {
 				// restore interruption state
 				Thread.currentThread().interrupt();
 			}
+			return false;
 		}
 
 		@Override
@@ -1193,7 +1199,7 @@ public class StreamTaskTest extends TestLogger {
 		protected void init() {}
 
 		@Override
-		protected void run() throws Exception {
+		protected boolean performDefaultAction() throws Exception {
 			final OneShotLatch latch = new OneShotLatch();
 			final Object lock = new Object();
 
@@ -1219,7 +1225,7 @@ public class StreamTaskTest extends TestLogger {
 			finally {
 				holder.close();
 			}
-
+			return false;
 		}
 
 		@Override
@@ -1259,8 +1265,9 @@ public class StreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		protected void run() throws Exception {
+		protected boolean performDefaultAction() throws Exception {
 			syncLatch.await();
+			return false;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -843,8 +843,8 @@ public class StreamTaskTest extends TestLogger {
 		protected void init() throws Exception {}
 
 		@Override
-		protected boolean performDefaultAction() {
-			return false;
+		protected void performDefaultAction(ActionContext context) throws Exception {
+			context.allActionsCompleted();
 		}
 
 		@Override
@@ -1033,8 +1033,8 @@ public class StreamTaskTest extends TestLogger {
 		protected void init() throws Exception {}
 
 		@Override
-		protected boolean performDefaultAction() {
-			return false;
+		protected void performDefaultAction(ActionContext context) throws Exception {
+			context.allActionsCompleted();
 		}
 
 		@Override
@@ -1063,11 +1063,11 @@ public class StreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		protected boolean performDefaultAction() {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			if (fail) {
 				throw new RuntimeException();
 			}
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override
@@ -1154,7 +1154,7 @@ public class StreamTaskTest extends TestLogger {
 		protected void init() {}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			holder = new LockHolder(getCheckpointLock(), latch);
 			holder.start();
 			latch.await();
@@ -1169,7 +1169,7 @@ public class StreamTaskTest extends TestLogger {
 				// restore interruption state
 				Thread.currentThread().interrupt();
 			}
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override
@@ -1199,7 +1199,7 @@ public class StreamTaskTest extends TestLogger {
 		protected void init() {}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			final OneShotLatch latch = new OneShotLatch();
 			final Object lock = new Object();
 
@@ -1225,7 +1225,7 @@ public class StreamTaskTest extends TestLogger {
 			finally {
 				holder.close();
 			}
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override
@@ -1265,9 +1265,9 @@ public class StreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			syncLatch.await();
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -156,9 +156,10 @@ public class SynchronousCheckpointITCase {
 		}
 
 		@Override
-		protected void run() throws Exception {
+		protected boolean performDefaultAction() throws Exception {
 			executionLatch.trigger();
 			cancellationLatch.await();
+			return false;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -156,10 +156,10 @@ public class SynchronousCheckpointITCase {
 		}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			executionLatch.trigger();
 			cancellationLatch.await();
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
@@ -174,9 +174,10 @@ public class SynchronousCheckpointTest {
 		protected void init() {}
 
 		@Override
-		protected void run() throws Exception {
+		protected boolean performDefaultAction() throws Exception {
 			runningLatch.trigger();
 			execLatch.await();
+			return false;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
@@ -174,10 +174,10 @@ public class SynchronousCheckpointTest {
 		protected void init() {}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			runningLatch.trigger();
 			execLatch.await();
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -505,8 +505,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 		public void init() {}
 
 		@Override
-		protected void run() throws Exception {
-
+		protected boolean performDefaultAction() throws Exception {
 			triggerCheckpointOnBarrier(
 				new CheckpointMetaData(
 					11L,
@@ -517,6 +516,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 			while (isRunning()) {
 				Thread.sleep(1L);
 			}
+			return false;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -505,7 +505,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 		public void init() {}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			triggerCheckpointOnBarrier(
 				new CheckpointMetaData(
 					11L,
@@ -516,7 +516,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 			while (isRunning()) {
 				Thread.sleep(1L);
 			}
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImplTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * Unit tests for {@link MailboxImpl}.
+ */
+public class MailboxImplTest {
+
+	private static final Runnable POISON_LETTER = () -> {};
+	private static final int CAPACITY_POW_2 = 1;
+	private static final int CAPACITY = 1 << CAPACITY_POW_2;
+
+	/**
+	 * Object under test.
+	 */
+	private Mailbox mailbox;
+
+	@Before
+	public void setUp() throws Exception {
+		mailbox = new MailboxImpl(CAPACITY_POW_2);
+	}
+
+	/**
+	 * Test for #clearAndPut should remove other pending events and enqueue directly to the head of the mailbox queue.
+	 */
+	@Test
+	public void testClearAndPut() {
+		for (int i = 0; i < CAPACITY; ++i) {
+			Assert.assertTrue(mailbox.tryPutMail(() -> {}));
+		}
+
+		mailbox.clearAndPut(POISON_LETTER);
+
+		Assert.assertTrue(mailbox.hasMail());
+		Assert.assertEquals(POISON_LETTER, mailbox.tryTakeMail());
+		Assert.assertFalse(mailbox.hasMail());
+	}
+
+	@Test
+	public void testContracts() throws Exception {
+		final Queue<Runnable> testObjects = new LinkedList<>();
+		Assert.assertFalse(mailbox.hasMail());
+
+		for (int i = 0; i < CAPACITY; ++i) {
+			Runnable letter = () -> {};
+			testObjects.add(letter);
+			Assert.assertTrue(mailbox.tryPutMail(letter));
+			Assert.assertTrue(mailbox.hasMail());
+		}
+
+		Assert.assertFalse(mailbox.tryPutMail(() -> {}));
+
+		while (!testObjects.isEmpty()) {
+			Assert.assertEquals(testObjects.remove(), mailbox.tryTakeMail());
+			Assert.assertEquals(!testObjects.isEmpty(), mailbox.hasMail());
+			mailbox.waitUntilHasCapacity(); // should not block here because the mailbox is not full
+		}
+
+		Thread waitingReader = new Thread(ThrowingRunnable.unchecked(() -> mailbox.waitUntilHasMail()));
+		waitingReader.start();
+		Thread.sleep(1);
+		Assert.assertTrue(waitingReader.isAlive());
+		mailbox.tryPutMail(() -> {});
+		waitingReader.join(); // should complete here
+
+		while (mailbox.tryPutMail(() -> {})) {}
+
+		Thread waitingWriter = new Thread(ThrowingRunnable.unchecked(() -> mailbox.waitUntilHasCapacity()));
+		waitingWriter.start();
+		Thread.sleep(1);
+		Assert.assertTrue(waitingWriter.isAlive());
+		mailbox.takeMail();
+		waitingWriter.join();
+	}
+
+	/**
+	 * Test the producer-consumer pattern using the blocking methods on the mailbox.
+	 */
+	@Test
+	public void testConcurrentPutTakeBlocking() throws Exception {
+		testPutTake(MailboxReceiver::takeMail, MailboxSender::putMail);
+	}
+
+	/**
+	 * Test the producer-consumer pattern using the non-blocking methods & waits on the mailbox.
+	 */
+	@Test
+	public void testConcurrentPutTakeNonBlockingAndWait() throws Exception {
+		testPutTake((mailbox -> {
+				mailbox.waitUntilHasMail();
+				return mailbox.tryTakeMail();
+			}),
+			((mailbox, runnable) -> {
+				while (!mailbox.tryPutMail(runnable)) {
+					mailbox.waitUntilHasCapacity();
+				}
+			}));
+	}
+
+	/**
+	 * Test producer-consumer pattern through the mailbox in a concurrent setting (n-writer / 1-reader).
+	 */
+	private void testPutTake(
+		FunctionWithException<Mailbox, Runnable, Exception> takeMethod,
+		BiConsumerWithException<Mailbox, Runnable, Exception> putMethod) throws Exception {
+		final int numThreads = 10;
+		final int numLettersPerThread = 1000;
+		final int[] results = new int[numThreads];
+		Thread[] writerThreads = new Thread[numThreads];
+		Thread readerThread = new Thread(ThrowingRunnable.unchecked(() -> {
+			Runnable letter;
+			while ((letter = takeMethod.apply(mailbox)) != POISON_LETTER) {
+				letter.run();
+			}
+		}));
+
+		readerThread.start();
+		for (int i = 0; i < writerThreads.length; ++i) {
+			final int threadId = i;
+			writerThreads[i] = new Thread(ThrowingRunnable.unchecked(() -> {
+				for (int k = 0; k < numLettersPerThread; ++k) {
+					putMethod.accept(mailbox, () -> ++results[threadId]);
+				}
+			}));
+		}
+
+		for (Thread writerThread : writerThreads) {
+			writerThread.start();
+		}
+
+		for (Thread writerThread : writerThreads) {
+			writerThread.join();
+		}
+
+		mailbox.putMail(POISON_LETTER);
+
+		readerThread.join();
+		for (int perThreadResult : results) {
+			Assert.assertEquals(numLettersPerThread, perThreadResult);
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -81,7 +81,9 @@ public class MockStreamTask extends StreamTask {
 	public void init() { }
 
 	@Override
-	protected void run() { }
+	protected boolean performDefaultAction() {
+		return false;
+	}
 
 	@Override
 	protected void cleanup() { }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -81,8 +81,8 @@ public class MockStreamTask extends StreamTask {
 	public void init() { }
 
 	@Override
-	protected boolean performDefaultAction() {
-		return false;
+	protected void performDefaultAction(ActionContext context) throws Exception {
+		context.allActionsCompleted();
 	}
 
 	@Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -283,13 +283,14 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		protected void run() throws InterruptedException {
+		protected boolean performDefaultAction() throws Exception {
 			final long taskIndex = getEnvironment().getTaskInfo().getIndexOfThisSubtask();
 			if (taskIndex == 0) {
 				numberOfRestarts.countDown();
 			}
 			invokeLatch.countDown();
 			finishLatch.await();
+			return false;
 		}
 
 		@Override
@@ -339,9 +340,10 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		protected void run() throws InterruptedException {
+		protected boolean performDefaultAction() throws Exception {
 			invokeLatch.countDown();
 			finishLatch.await();
+			return false;
 		}
 
 		@Override
@@ -367,8 +369,8 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		protected void run() throws Exception {
-
+		protected boolean performDefaultAction() throws Exception {
+			return false;
 		}
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -283,14 +283,14 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			final long taskIndex = getEnvironment().getTaskInfo().getIndexOfThisSubtask();
 			if (taskIndex == 0) {
 				numberOfRestarts.countDown();
 			}
 			invokeLatch.countDown();
 			finishLatch.await();
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override
@@ -340,10 +340,10 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
+		protected void performDefaultAction(ActionContext context) throws Exception {
 			invokeLatch.countDown();
 			finishLatch.await();
-			return false;
+			context.allActionsCompleted();
 		}
 
 		@Override
@@ -369,8 +369,8 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		protected boolean performDefaultAction() throws Exception {
-			return false;
+		protected void performDefaultAction(ActionContext context) throws Exception {
+			context.allActionsCompleted();
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change
This PR sits on top of #8409 and introduces the mailbox approach to the `StreamTask`. It is the next sub-task in our effort to change the threading model of `StreamTask`

## Brief change log

- New class `MailboxImpl` with interfaces.
- Rewritten `StreamTask#run` that spins around default action and mailbox.

## Verifying this change
Added unit tests for the mailbox, everything else is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
