### PR TITLE
[FLINK-12234][hive] Support view related operations in HiveCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
@@ -201,7 +201,7 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 			hiveTable.setViewExpandedText(view.getExpandedQuery());
 			hiveTable.setTableType(TableType.VIRTUAL_VIEW.name());
 		} else {
-			throw new IllegalArgumentException(
+			throw new CatalogException(
 				"GenericHiveMetastoreCatalog only supports CatalogTable and CatalogView");
 		}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -24,8 +24,6 @@ import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
-import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
@@ -167,7 +165,7 @@ public class HiveCatalog extends HiveCatalogBase {
 		List<FieldSchema> allColumns = HiveTableUtil.createHiveColumns(table.getSchema());
 
 		// Table columns and partition keys
-		if (table instanceof CatalogTable) {
+		if (table instanceof HiveCatalogTable) {
 			HiveCatalogTable catalogTable = (HiveCatalogTable) table;
 
 			if (catalogTable.isPartitioned()) {
@@ -181,7 +179,7 @@ public class HiveCatalog extends HiveCatalogBase {
 				sd.setCols(allColumns);
 				hiveTable.setPartitionKeys(new ArrayList<>());
 			}
-		} else if (table instanceof CatalogView) {
+		} else if (table instanceof HiveCatalogView) {
 			HiveCatalogView view = (HiveCatalogView) table;
 
 			// TODO: [FLINK-12398] Support partitioned view in catalog API
@@ -192,7 +190,8 @@ public class HiveCatalog extends HiveCatalogBase {
 			hiveTable.setViewExpandedText(view.getExpandedQuery());
 			hiveTable.setTableType(TableType.VIRTUAL_VIEW.name());
 		} else {
-			throw new CatalogException("HiveCatalog only supports CatalogTable and CatalogView");
+			throw new CatalogException(
+				"HiveCatalog only supports HiveCatalogTable and HiveCatalogView");
 		}
 
 		hiveTable.setSd(sd);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -49,46 +49,6 @@ public class HiveCatalogTest extends CatalogTestBase {
 	public void testCreateTable_Streaming() throws Exception {
 	}
 
-	// =====================
-	// HiveCatalog doesn't support view operation yet
-	// Thus, overriding the following tests which involve table operation in CatalogTestBase so they won't run against HiveCatalog
-	// =====================
-
-	// TODO: re-enable these tests once HiveCatalog support view operations
-
-	public void testListTables() throws Exception {
-	}
-
-	public void testCreateView() throws Exception {
-	}
-
-	public void testCreateView_DatabaseNotExistException() throws Exception {
-	}
-
-	public void testCreateView_TableAlreadyExistException() throws Exception {
-	}
-
-	public void testCreateView_TableAlreadyExist_ignored() throws Exception {
-	}
-
-	public void testDropView() throws Exception {
-	}
-
-	public void testAlterView() throws Exception {
-	}
-
-	public void testAlterView_TableNotExistException() throws Exception {
-	}
-
-	public void testAlterView_TableNotExist_ignored() throws Exception {
-	}
-
-	public void testListView() throws Exception {
-	}
-
-	public void testRenameView() throws Exception {
-	}
-
 	// ------ utils ------
 
 	@Override
@@ -154,14 +114,22 @@ public class HiveCatalogTest extends CatalogTestBase {
 
 	@Override
 	public CatalogView createView() {
-		// TODO: implement this once HiveCatalog support view operations
-		return null;
+		return new HiveCatalogView(
+			String.format("select * from %s", t1),
+			String.format("select * from %s.%s", TEST_CATALOG_NAME, path1.getFullName()),
+			createTableSchema(),
+			new HashMap<>(),
+			"This is a hive view");
 	}
 
 	@Override
 	public CatalogView createAnotherView() {
-		// TODO: implement this once HiveCatalog support view operations
-		return null;
+		return new HiveCatalogView(
+			String.format("select * from %s", t2),
+			String.format("select * from %s.%s", TEST_CATALOG_NAME, path2.getFullName()),
+			createAnotherTableSchema(),
+			new HashMap<>(),
+			"This is another hive view");
 	}
 
 	@Override
@@ -174,5 +142,16 @@ public class HiveCatalogTest extends CatalogTestBase {
 		// Hive tables may have properties created by itself
 		// thus properties of Hive table is a super set of those in its corresponding Flink table
 		assertTrue(t2.getProperties().entrySet().containsAll(t1.getProperties().entrySet()));
+	}
+
+	protected void checkEquals(CatalogView v1, CatalogView v2) {
+		assertEquals(v1.getSchema(), v1.getSchema());
+		assertEquals(v1.getComment(), v2.getComment());
+		assertEquals(v1.getOriginalQuery(), v2.getOriginalQuery());
+		assertEquals(v1.getExpandedQuery(), v2.getExpandedQuery());
+
+		// Hive views may have properties created by itself
+		// thus properties of Hive view is a super set of those in its corresponding Flink view
+		assertTrue(v2.getProperties().entrySet().containsAll(v1.getProperties().entrySet()));
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -451,7 +451,7 @@ public abstract class CatalogTestBase {
 		catalog.createTable(path1, view, false);
 
 		assertTrue(catalog.getTable(path1) instanceof CatalogView);
-		CatalogTestUtil.checkEquals(view, (CatalogView) catalog.getTable(path1));
+		checkEquals(view, (CatalogView) catalog.getTable(path1));
 	}
 
 	@Test
@@ -481,12 +481,12 @@ public abstract class CatalogTestBase {
 		catalog.createTable(path1, view, false);
 
 		assertTrue(catalog.getTable(path1) instanceof CatalogView);
-		CatalogTestUtil.checkEquals(view, (CatalogView) catalog.getTable(path1));
+		checkEquals(view, (CatalogView) catalog.getTable(path1));
 
 		catalog.createTable(path1, createAnotherView(), true);
 
 		assertTrue(catalog.getTable(path1) instanceof CatalogView);
-		CatalogTestUtil.checkEquals(view, (CatalogView) catalog.getTable(path1));
+		checkEquals(view, (CatalogView) catalog.getTable(path1));
 	}
 
 	@Test
@@ -508,13 +508,13 @@ public abstract class CatalogTestBase {
 		CatalogView view = createView();
 		catalog.createTable(path1, view, false);
 
-		CatalogTestUtil.checkEquals(view, (CatalogView) catalog.getTable(path1));
+		checkEquals(view, (CatalogView) catalog.getTable(path1));
 
 		CatalogView newView = createAnotherView();
 		catalog.alterTable(path1, newView, false);
 
 		assertTrue(catalog.getTable(path1) instanceof CatalogView);
-		CatalogTestUtil.checkEquals(newView, (CatalogView) catalog.getTable(path1));
+		checkEquals(newView, (CatalogView) catalog.getTable(path1));
 	}
 
 	@Test
@@ -672,5 +672,13 @@ public abstract class CatalogTestBase {
 		assertEquals(t1.getComment(), t2.getComment());
 		assertEquals(t1.getPartitionKeys(), t2.getPartitionKeys());
 		assertEquals(t1.isPartitioned(), t2.isPartitioned());
+	}
+
+	protected void checkEquals(CatalogView v1, CatalogView v2) {
+		assertEquals(v1.getSchema(), v1.getSchema());
+		assertEquals(v1.getProperties(), v2.getProperties());
+		assertEquals(v1.getComment(), v2.getComment());
+		assertEquals(v1.getOriginalQuery(), v2.getOriginalQuery());
+		assertEquals(v1.getExpandedQuery(), v2.getExpandedQuery());
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -45,14 +45,6 @@ public class CatalogTestUtil {
 		assertEquals(ts1.getColumnStats().size(), ts2.getColumnStats().size());
 	}
 
-	public static void checkEquals(CatalogView v1, CatalogView v2) {
-		assertEquals(v1.getSchema(), v1.getSchema());
-		assertEquals(v1.getProperties(), v2.getProperties());
-		assertEquals(v1.getComment(), v2.getComment());
-		assertEquals(v1.getOriginalQuery(), v2.getOriginalQuery());
-		assertEquals(v1.getExpandedQuery(), v2.getExpandedQuery());
-	}
-
 	public static void checkEquals(CatalogDatabase d1, CatalogDatabase d2) {
 		assertEquals(d1.getProperties(), d2.getProperties());
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR supports view related operations in `HiveCatalog` and creates `HiveCatalogView`.

## Brief change log

- added view related operations in `HiveCatalog`
- created `HiveCatalogView`
- enabled view related unit tests in `HiveCatalogView`

## Verifying this change

This change is already covered by existing tests in `HiveCatalogTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs) Documentation will be added later along with doc of `HiveCatalog`
