### PR TITLE
[FLINK-12485][python] Add completeness test for Table and TableEnviro…

### DIFF
--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -1,4 +1,4 @@
-# ###############################################################################
+################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -1,0 +1,53 @@
+# ###############################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from pyflink.testing.test_case_utils import PythonAPICompletenessTestCase
+from pyflink.table import TableEnvironment
+
+
+class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase):
+    """
+    Test whether the Python :class:`TableEnvironment` is consistent with
+    Java `org.apache.flink.table.api.TableEnvironment`.
+    """
+    @classmethod
+    def python_class(cls):
+        return TableEnvironment
+
+    @classmethod
+    def java_class(cls):
+        return "org.apache.flink.table.api.TableEnvironment"
+
+    @classmethod
+    def exclude_methods(cls):
+        # registerFunction and listUserDefinedFunctions should be supported when UDFs supported.
+        # registerExternalCatalog, getRegisteredExternalCatalog and listTables
+        # should be supported when catalog supported in python.
+        return {'registerExternalCatalog', 'getRegisteredExternalCatalog',
+                'registerFunction', 'listUserDefinedFunctions', 'listTables'}
+
+
+if __name__ == '__main__':
+    import unittest
+
+    try:
+        import xmlrunner
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -22,7 +22,7 @@ from pyflink.table import TableEnvironment
 
 class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase):
     """
-    Test whether the Python :class:`TableEnvironment` is consistent with
+    Tests whether the Python :class:`TableEnvironment` is consistent with
     Java `org.apache.flink.table.api.TableEnvironment`.
     """
     @classmethod
@@ -34,7 +34,7 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase):
         return "org.apache.flink.table.api.TableEnvironment"
 
     @classmethod
-    def exclude_methods(cls):
+    def excluded_methods(cls):
         # registerFunction and listUserDefinedFunctions should be supported when UDFs supported.
         # registerExternalCatalog, getRegisteredExternalCatalog and listTables
         # should be supported when catalog supported in python.

--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -1,4 +1,4 @@
-# ###############################################################################
+################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information

--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -1,0 +1,62 @@
+# ###############################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from pyflink.testing.test_case_utils import PythonAPICompletenessTestCase
+from pyflink.table import Table
+
+
+class TableAPICompletenessTests(PythonAPICompletenessTestCase):
+    """
+    Test whether the Python :class:`Table` is consistent with
+    Java `org.apache.flink.table.api.Table`.
+    """
+
+    @classmethod
+    def python_class(cls):
+        return Table
+
+    @classmethod
+    def java_class(cls):
+        return "org.apache.flink.table.api.Table"
+
+    @classmethod
+    def exclude_methods(cls):
+        # row-based operators should be supported when UDFs supported in python.
+        return {'map', 'flatMap', 'flatAggregate',  'aggregate'}
+
+    @classmethod
+    def java_method_name(cls, python_method_name):
+        """
+        Due to 'as' is python keyword, so we use 'alias'
+        in Python API corresponding 'as' in Java API.
+
+        :param python_method_name:
+        :return:
+        """
+        return {'alias': 'as'}.get(python_method_name, python_method_name)
+
+
+if __name__ == '__main__':
+    import unittest
+
+    try:
+        import xmlrunner
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -22,7 +22,7 @@ from pyflink.table import Table
 
 class TableAPICompletenessTests(PythonAPICompletenessTestCase):
     """
-    Test whether the Python :class:`Table` is consistent with
+    Tests whether the Python :class:`Table` is consistent with
     Java `org.apache.flink.table.api.Table`.
     """
 
@@ -35,7 +35,7 @@ class TableAPICompletenessTests(PythonAPICompletenessTestCase):
         return "org.apache.flink.table.api.Table"
 
     @classmethod
-    def exclude_methods(cls):
+    def excluded_methods(cls):
         # row-based operators should be supported when UDFs supported in python.
         return {'map', 'flatMap', 'flatAggregate',  'aggregate'}
 

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -161,8 +161,8 @@ class PythonAPICompletenessTestCase(unittest.TestCase):
     @classmethod
     def excluded_methods(cls):
         """
-        Exclude method names that do not need to be checked. When adding excluded methods to the lists
-        you should give a good reason in a comment.
+        Exclude method names that do not need to be checked. When adding excluded methods
+        to the lists you should give a good reason in a comment.
         :return:
         """
         return {}

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -96,8 +96,8 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
 
 class PythonAPICompletenessTestCase(unittest.TestCase):
     """
-    Base class for python api completeness tests, i.e.,
-    python api should be aligned with the Java API as much as possible.
+    Base class for Python API completeness tests, i.e.,
+    Python API should be aligned with the Java API as much as possible.
     """
 
     @classmethod
@@ -111,7 +111,7 @@ class PythonAPICompletenessTestCase(unittest.TestCase):
         return output[0].lower() + output[1:]
 
     @staticmethod
-    def get_java_class_method(java_class):
+    def get_java_class_methods(java_class):
         gateway = get_gateway()
         s = set()
         method_arr = gateway.jvm.Class.forName(java_class).getDeclaredMethods()
@@ -121,21 +121,20 @@ class PythonAPICompletenessTestCase(unittest.TestCase):
 
     @classmethod
     def check_methods(cls):
-        java_methods = PythonAPICompletenessTestCase.get_java_class_method(cls.java_class())
+        java_methods = PythonAPICompletenessTestCase.get_java_class_methods(cls.java_class())
         python_methods = cls.get_python_class_methods(cls.python_class())
-        missing_methods = java_methods - python_methods - cls.exclude_methods()
+        missing_methods = java_methods - python_methods - cls.excluded_methods()
         if len(missing_methods) > 0:
             print(missing_methods)
             print('The Exception should be raised after FLINK-12407 is merged.')
             # raise Exception('Methods: %s in Java class %s have not been added in Python class %s.'
-            #                % (missing_methods, java_class, python_class))
+            #                % (missing_methods, cls.java_class(), cls.python_class()))
 
     @classmethod
     def java_method_name(cls, python_method_name):
         """
-        This method should be overWrite when the method name of the Python API cannot be
-        consistent with the Java API method name. we need to get the corresponding
-        Java API method name based on the Python method name. e.g.: 'as' is python
+        This method should be overwritten when the method name of the Python API cannot be
+        consistent with the Java API method name. e.g.: 'as' is python
         keyword, so we use 'alias' in Python API corresponding 'as' in Java API.
 
         :param python_method_name: Method name of Python API.
@@ -160,7 +159,7 @@ class PythonAPICompletenessTestCase(unittest.TestCase):
         pass
 
     @classmethod
-    def exclude_methods(cls):
+    def excluded_methods(cls):
         """
         Exclude method names that do not need to be checked. When adding excluded methods to the lists
         you should give a good reason in a comment.
@@ -169,5 +168,5 @@ class PythonAPICompletenessTestCase(unittest.TestCase):
         return {}
 
     def test_completeness(self):
-        if self.python_class() is not None:
+        if self.python_class() is not None and self.java_class() is not None:
             self.check_methods()

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -138,7 +138,7 @@ class PythonAPICompletenessTestCase(unittest.TestCase):
         keyword, so we use 'alias' in Python API corresponding 'as' in Java API.
 
         :param python_method_name: Method name of Python API.
-        :return: Method name corresponding to Java API.
+        :return: The corresponding method name of Java API.
         """
         return python_method_name
 

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -22,9 +22,11 @@ import shutil
 import sys
 import tempfile
 import unittest
+from abc import abstractmethod
 
 from pyflink.find_flink_home import _find_flink_home
 from pyflink.table import TableEnvironment, TableConfig
+from pyflink.java_gateway import get_gateway
 
 if sys.version_info[0] >= 3:
     xrange = range
@@ -90,3 +92,82 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
         super(PyFlinkBatchTableTestCase, self).setUp()
         self.t_config = TableConfig.Builder().as_batch_execution().set_parallelism(4).build()
         self.t_env = TableEnvironment.get_table_environment(self.t_config)
+
+
+class PythonAPICompletenessTestCase(unittest.TestCase):
+    """
+    Base class for python api completeness tests, i.e.,
+    python api should be aligned with the Java API as much as possible.
+    """
+
+    @classmethod
+    def get_python_class_methods(cls, python_class):
+        return {cls.snake_to_camel(cls.java_method_name(method_name))
+                for method_name in dir(python_class) if not method_name.startswith('_')}
+
+    @staticmethod
+    def snake_to_camel(method_name):
+        output = ''.join(x.capitalize() or '_' for x in method_name.split('_'))
+        return output[0].lower() + output[1:]
+
+    @staticmethod
+    def get_java_class_method(java_class):
+        gateway = get_gateway()
+        s = set()
+        method_arr = gateway.jvm.Class.forName(java_class).getDeclaredMethods()
+        for i in range(0, len(method_arr)):
+            s.add(method_arr[i].getName())
+        return s
+
+    @classmethod
+    def check_methods(cls):
+        java_methods = PythonAPICompletenessTestCase.get_java_class_method(cls.java_class())
+        python_methods = cls.get_python_class_methods(cls.python_class())
+        missing_methods = java_methods - python_methods - cls.exclude_methods()
+        if len(missing_methods) > 0:
+            print(missing_methods)
+            print('The Exception should be raised after FLINK-12407 is merged.')
+            # raise Exception('Methods: %s in Java class %s have not been added in Python class %s.'
+            #                % (missing_methods, java_class, python_class))
+
+    @classmethod
+    def java_method_name(cls, python_method_name):
+        """
+        This method should be overWrite when the method name of the Python API cannot be
+        consistent with the Java API method name. we need to get the corresponding
+        Java API method name based on the Python method name. e.g.: 'as' is python
+        keyword, so we use 'alias' in Python API corresponding 'as' in Java API.
+
+        :param python_method_name: Method name of Python API.
+        :return: Method name corresponding to Java API.
+        """
+        return python_method_name
+
+    @classmethod
+    @abstractmethod
+    def python_class(cls):
+        """
+        Return the Python class that needs to be compared. such as :class:`Table`.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def java_class(cls):
+        """
+        Return the Java class that needs to be compared. such as `org.apache.flink.table.api.Table`.
+        """
+        pass
+
+    @classmethod
+    def exclude_methods(cls):
+        """
+        Exclude method names that do not need to be checked. When adding excluded methods to the lists
+        you should give a good reason in a comment.
+        :return:
+        """
+        return {}
+
+    def test_completeness(self):
+        if self.python_class() is not None:
+            self.check_methods()


### PR DESCRIPTION
## What is the purpose of the change

After FLINK-12407 Python Table API will align with current Java Table API. So, In the following Table API development, it's better to add a new user interface to the Java Table API will also need to be added to the Python Table API. So In this Jira, we want to add the test_completeness to check the user interface of Python Table API aligns with Java Table API. 

I'm not sure if we want to force contributors to contribute to the Python Table API while developing the Java Table API. But at least we should have the ability to automatically check if Python is aligned with Java functionality.

## Brief change log
  -  Add `PythonAPICompletenessTestCase` which is base class for Python API completeness tests.
  - Add `TableAPICompletenessTests` which test whether the Python `Table` is consistent with Java `org.apache.flink.table.api.Table`.
  - Add `EnvironmentAPICompletenessTests` which test whether the Python `TableEnvironment` is consistent with Java `org.apache.flink.table.api.TableEnvironment`.

## Verifying this change
This change is only adding the test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature?  (no)
  - If yes, how is the feature documented? (not documented)
