### PR TITLE
[FLINK-10190] [Kinesis Connector] Allow AWS_REGION to be supplied along with custom Kinesis endpoint

### DIFF
--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -414,17 +414,14 @@ starting point. If the queue size limits throughput (below 1MB per second per
 shard), try increasing the queue limit slightly.
 
 
-## Using Non-AWS Kinesis Endpoints for Testing
+## Using Custom Kinesis Endpoints
 
-It is sometimes desirable to have Flink operate as a consumer or producer against a non-AWS Kinesis endpoint such as
-[Kinesalite](https://github.com/mhart/kinesalite); this is especially useful when performing functional testing of a Flink
-application. The AWS endpoint that would normally be inferred by the AWS region set in the Flink configuration must be overridden via a configuration property.
+It is sometimes desirable to have Flink operate as a consumer or producer against a Kinesis VPC endpoint or a non-AWS
+Kinesis endpoint such as [Kinesalite](https://github.com/mhart/kinesalite); this is especially useful when performing
+functional testing of a Flink application. The AWS endpoint that would normally be inferred by the AWS region set in the
+Flink configuration must be overridden via a configuration property.
 
-To override the AWS endpoint, taking the producer for example, set the `AWSConfigConstants.AWS_ENDPOINT` property in the
-Flink configuration, in addition to the `AWSConfigConstants.AWS_REGION` required by Flink. Although the region is
-required, it will not be used to determine the AWS endpoint URL.
-
-The following example shows how one might supply the `AWSConfigConstants.AWS_ENDPOINT` configuration property:
+To override the AWS endpoint, set the `AWSConfigConstants.AWS_ENDPOINT` and `AWSConfigConstants.AWS_REGION` properties. The region will be used to sign the endpoint URL.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/docs/dev/connectors/kinesis.zh.md
+++ b/docs/dev/connectors/kinesis.zh.md
@@ -414,17 +414,14 @@ starting point. If the queue size limits throughput (below 1MB per second per
 shard), try increasing the queue limit slightly.
 
 
-## Using Non-AWS Kinesis Endpoints for Testing
+## Using Custom Kinesis Endpoints
 
-It is sometimes desirable to have Flink operate as a consumer or producer against a non-AWS Kinesis endpoint such as
-[Kinesalite](https://github.com/mhart/kinesalite); this is especially useful when performing functional testing of a Flink
-application. The AWS endpoint that would normally be inferred by the AWS region set in the Flink configuration must be overridden via a configuration property.
+It is sometimes desirable to have Flink operate as a consumer or producer against a Kinesis VPC endpoint or a non-AWS
+Kinesis endpoint such as [Kinesalite](https://github.com/mhart/kinesalite); this is especially useful when performing
+functional testing of a Flink application. The AWS endpoint that would normally be inferred by the AWS region set in the
+Flink configuration must be overridden via a configuration property.
 
-To override the AWS endpoint, taking the producer for example, set the `AWSConfigConstants.AWS_ENDPOINT` property in the
-Flink configuration, in addition to the `AWSConfigConstants.AWS_REGION` required by Flink. Although the region is
-required, it will not be used to determine the AWS endpoint URL.
-
-The following example shows how one might supply the `AWSConfigConstants.AWS_ENDPOINT` configuration property:
+To override the AWS endpoint, set the `AWSConfigConstants.AWS_ENDPOINT` and `AWSConfigConstants.AWS_REGION` properties. The region will be used to sign the endpoint URL.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -84,13 +84,20 @@ public class AWSUtil {
 				.withCredentials(AWSUtil.getCredentialsProvider(configProps))
 				.withClientConfiguration(awsClientConfig);
 
-		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {
-			// Set signingRegion as null, to facilitate mocking Kinesis for local tests
+		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT) && configProps.containsKey(AWSConfigConstants.AWS_REGION)) {
+			// Set signingRegion to the value of AWS_REGION for region-specific signing on a custom endpoint
 			builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
-													configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT),
-													null));
+					configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT),
+					configProps.getProperty(AWSConfigConstants.AWS_REGION)));
 		} else {
-			builder.withRegion(Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION)));
+			if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {
+				// Set signingRegion as null, to facilitate mocking Kinesis for local tests
+				builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
+						configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT),
+						null));
+			} else {
+				builder.withRegion(Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION)));
+			}
 		}
 		return builder.build();
 	}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -84,20 +84,14 @@ public class AWSUtil {
 				.withCredentials(AWSUtil.getCredentialsProvider(configProps))
 				.withClientConfiguration(awsClientConfig);
 
-		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT) && configProps.containsKey(AWSConfigConstants.AWS_REGION)) {
-			// Set signingRegion to the value of AWS_REGION for region-specific signing on a custom endpoint
+		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {
+			// If an endpoint is specified, we give preference to using an endpoint and use the region property to
+			// sign the request.
 			builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
-					configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT),
-					configProps.getProperty(AWSConfigConstants.AWS_REGION)));
+				configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT),
+				configProps.getProperty(AWSConfigConstants.AWS_REGION)));
 		} else {
-			if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {
-				// Set signingRegion as null, to facilitate mocking Kinesis for local tests
-				builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
-						configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT),
-						null));
-			} else {
-				builder.withRegion(Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION)));
-			}
+			builder.withRegion(Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION)));
 		}
 		return builder.build();
 	}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -83,10 +83,9 @@ public class KinesisConfigUtil {
 
 		validateAwsConfiguration(config);
 
-		//noinspection SimplifiableBooleanExpression - the current logic expression is actually easier to understand
-		if (!(config.containsKey(AWSConfigConstants.AWS_REGION) ^ config.containsKey(ConsumerConfigConstants.AWS_ENDPOINT))) {
+		if (!(config.containsKey(AWSConfigConstants.AWS_REGION) || config.containsKey(ConsumerConfigConstants.AWS_ENDPOINT))) {
 			// per validation in AwsClientBuilder
-			throw new IllegalArgumentException(String.format("For FlinkKinesisConsumer either AWS region ('%s') or AWS endpoint ('%s') must be set in the config.",
+			throw new IllegalArgumentException(String.format("For FlinkKinesisConsumer AWS region ('%s') and/or AWS endpoint ('%s') must be set in the config.",
 					AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT));
 		}
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -185,14 +185,43 @@ public class KinesisConfigUtilTest {
 	// ----------------------------------------------------------------------
 
 	@Test
-	public void testAwsRegionOrEndpointInConsumerConfig() {
-		String expectedMessage = String.format("For FlinkKinesisConsumer either AWS region ('%s') or AWS endpoint ('%s') must be set in the config.",
+	public void testNoAwsRegionOrEndpointInConsumerConfig() {
+		String expectedMessage = String.format("For FlinkKinesisConsumer AWS region ('%s') and/or AWS endpoint ('%s') must be set in the config.",
 				AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT);
 		exception.expect(IllegalArgumentException.class);
 		exception.expectMessage(expectedMessage);
 
 		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+	}
+
+	@Test
+	public void testAwsRegionAndEndpointInConsumerConfig() {
+		Properties testConfig = new Properties();
 		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(AWSConfigConstants.AWS_ENDPOINT, "fake");
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+	}
+
+	@Test
+	public void testAwsRegionInConsumerConfig() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+	}
+
+	@Test
+	public void testEndpointInConsumerConfig() {
+		Properties testConfig = new Properties();
 		testConfig.setProperty(AWSConfigConstants.AWS_ENDPOINT, "fake");
 		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
 		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");


### PR DESCRIPTION
## What is the purpose of the change

Allow an AWS region (e.g. `us-east-1`) to be supplied along with a custom Kinesis endpoint in the Kinesis configuration.

Using a [Kinesis VPC endpoint](https://aws.amazon.com/blogs/aws/new-aws-privatelink-endpoints-kinesis-ec2-systems-manager-and-elb-apis-in-your-vpc/) can prevent traffic leaving the AWS network. This greatly reduces costs by eliminating NAT traversal and cross-AZ transfers. However, this requires that the Kinesis endpoint URL be signed for a specific region. This is accomplished by including the region name along with the endpoint URL when constructing the Kinesis client.

## Brief change log

  - Permit both region and endpoint to be set
  - Set the region on the endpoint configuration when both region and endpoint are set

## Verifying this change

This change added tests and can be verified by running connector unit tests.

## Does this pull request potentially affect one of the following parts:

No

## Documentation

Documentation for the Kinesis connector has been updated.