### PR TITLE
[hotfix][runtime] Set log level to error when job transits to erroneous states

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1353,7 +1353,11 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 		// now do the actual state transition
 		if (STATE_UPDATER.compareAndSet(this, current, newState)) {
-			LOG.info("Job {} ({}) switched from state {} to {}.", getJobName(), getJobID(), current, newState, error);
+			if (error == null) {
+				LOG.info("Job {} ({}) switched from state {} to {}.", getJobName(), getJobID(), current, newState);
+			} else {
+				LOG.error("Job {} ({}) switched from state {} to {}.", getJobName(), getJobID(), current, newState, error);
+			}
 
 			stateTimestamps[newState.ordinal()] = System.currentTimeMillis();
 			notifyJobStatusChange(newState, error);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -961,7 +961,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 			if (cause == null) {
 				LOG.info("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState);
 			} else {
-				LOG.info("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState, cause);
+				LOG.error("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState, cause);
 			}
 
 			return true;


### PR DESCRIPTION
## What is the purpose of the change

When a job/task fails and transits to an erroneous state, we should log it on error level instead of info level.

## Brief change log

* Set log level to error when job or task transits states with an exception 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?
