### PR TITLE
[FLINK-12516][travis] use Ubuntu 16.04 LTS (Xenial) and change to openJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# send to fully-virtualized infrastructure: https://docs.travis-ci.com/user/trusty-ci-environment/
+# send to fully-virtualized infrastructure: https://docs.travis-ci.com/user/reference/xenial/
 sudo: required
-dist: trusty
+dist: xenial
 
 cache:
   # default timeout is too low
@@ -51,7 +51,7 @@ before_script:
    - "export -f travis_time_start"
    - "export -f travis_time_finish"
 
-# Install maven 3.2.5 since trusty uses 3.3.9 for which shading is broken
+# Install maven 3.2.5 since xenial uses 3.3.9 for which shading is broken
 before_install:
    - source ./tools/travis/setup_maven.sh
 
@@ -69,7 +69,7 @@ stages:
     if: type = cron
   - name: cleanup
 
-jdk: "oraclejdk8"
+jdk: "openjdk8"
 jobs:
   include:
     # main profile


### PR DESCRIPTION
## What is the purpose of the change

This changes the test environment from trusty to xenial which is still
supported until 2021-04 and provides more up-to-date system libraries.

Since oraclejdk8 is not available in Travis' xenial image and we can't switch
to oraclejdk9 yet, this also changes the JDK to openJDK8.

## Brief change log

- change Travis' distribution to `xenial`
- change Travis' JDK to `openjdk8`

## Verifying this change

Run Travis tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
