### PR TITLE
[FLINK-12513][e2e] Improve end-to-end (bash based) tests

### DIFF
--- a/flink-end-to-end-tests/README.md
+++ b/flink-end-to-end-tests/README.md
@@ -75,12 +75,12 @@ The test runner performs a cleanup after each test case, which includes:
 - Reverting `conf` and `lib` dirs to default
 - Cleaning up log and temp directories
 
-In some cases your test is required to do to some *additional* cleanup, for example shutting down external systems like Kafka or Elasticsearch. In this case it is a common pattern to trap a `test_cleanup` function to `EXIT` like this:
+In some cases your test is required to do some *additional* cleanup, for example shutting down external systems like Kafka or Elasticsearch. In this case you can register a function that will be called on test exit like this:
 
 ```sh
 function test_cleanup {
     # do your custom cleanup here
 }
 
-trap test_cleanup EXIT
+on_exit test_cleanup
 ```

--- a/flink-end-to-end-tests/README.md
+++ b/flink-end-to-end-tests/README.md
@@ -72,7 +72,7 @@ Please note that a previously supported pattern where you could assign a value t
 The test runner performs a cleanup after each test case, which includes:
 - Stopping the cluster
 - Killing all task and job managers
-- Reverting config to default (if changed before)
+- Reverting `conf` and `lib` dirs to default
 - Cleaning up log and temp directories
 
 In some cases your test is required to do to some *additional* cleanup, for example shutting down external systems like Kafka or Elasticsearch. In this case it is a common pattern to trap a `test_cleanup` function to `EXIT` like this:

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -47,6 +47,8 @@ cd $TEST_INFRA_DIR
 TEST_INFRA_DIR=`pwd -P`
 cd $TEST_ROOT
 
+source "${TEST_INFRA_DIR}/common_utils.sh"
+
 NODENAME=${NODENAME:-`hostname -f`}
 
 # REST_PROTOCOL and CURL_SSL_ARGS can be modified in common_ssl.sh if SSL is activated

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -103,22 +103,21 @@ function revert_flink_dir() {
     CURL_SSL_ARGS=""
 }
 
-function set_conf() {
-    CONF_NAME=$1
-    VAL=$2
-    echo "$CONF_NAME: $VAL" >> $FLINK_DIR/conf/flink-conf.yaml
-}
-
 function add_optional_lib() {
     local lib_name=$1
     cp "$FLINK_DIR/opt/flink-${lib_name}"*".jar" "$FLINK_DIR/lib"
 }
 
-function change_conf() {
-    CONF_NAME=$1
-    OLD_VAL=$2
-    NEW_VAL=$3
-    sed -i -e "s/${CONF_NAME}: ${OLD_VAL}/${CONF_NAME}: ${NEW_VAL}/" ${FLINK_DIR}/conf/flink-conf.yaml
+function delete_config_key() {
+    local config_key=$1
+    sed -i -e "/^${config_key}: /d" ${FLINK_DIR}/conf/flink-conf.yaml
+}
+
+function set_config_key() {
+    local config_key=$1
+    local value=$2
+    delete_config_key ${config_key}
+    echo "$config_key: $value" >> $FLINK_DIR/conf/flink-conf.yaml
 }
 
 function create_ha_config() {
@@ -535,8 +534,8 @@ function kill_random_taskmanager {
 function setup_flink_slf4j_metric_reporter() {
   INTERVAL="${1:-1 SECONDS}"
   add_optional_lib "metrics-slf4j"
-  set_conf "metrics.reporter.slf4j.class" "org.apache.flink.metrics.slf4j.Slf4jReporter"
-  set_conf "metrics.reporter.slf4j.interval" "${INTERVAL}"
+  set_config_key "metrics.reporter.slf4j.class" "org.apache.flink.metrics.slf4j.Slf4jReporter"
+  set_config_key "metrics.reporter.slf4j.interval" "${INTERVAL}"
 }
 
 function get_job_metric {

--- a/flink-end-to-end-tests/test-scripts/common_s3.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3.sh
@@ -64,8 +64,8 @@ s3util="java -jar ${END_TO_END_DIR}/flink-e2e-test-utils/target/S3UtilProgram.ja
 ###################################
 function s3_setup {
   add_optional_lib "s3-fs-$1"
-  echo "s3.access-key: $IT_CASE_S3_ACCESS_KEY" >> "$FLINK_DIR/conf/flink-conf.yaml"
-  echo "s3.secret-key: $IT_CASE_S3_SECRET_KEY" >> "$FLINK_DIR/conf/flink-conf.yaml"
+  set_config_key "s3.access-key" "$IT_CASE_S3_ACCESS_KEY"
+  set_config_key "s3.secret-key" "$IT_CASE_S3_SECRET_KEY"
 }
 
 ###################################

--- a/flink-end-to-end-tests/test-scripts/common_s3.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3.sh
@@ -63,17 +63,7 @@ s3util="java -jar ${END_TO_END_DIR}/flink-e2e-test-utils/target/S3UtilProgram.ja
 #   None
 ###################################
 function s3_setup {
-  # make sure we delete the file at the end
-  function s3_cleanup {
-    rm $FLINK_DIR/lib/flink-s3-fs*.jar
-
-    # remove any leftover settings
-    sed -i -e 's/s3.access-key: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
-    sed -i -e 's/s3.secret-key: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
-  }
-  trap s3_cleanup EXIT
-
-  cp $FLINK_DIR/opt/flink-s3-fs-$1-*.jar $FLINK_DIR/lib/
+  add_optional_lib "s3-fs-$1"
   echo "s3.access-key: $IT_CASE_S3_ACCESS_KEY" >> "$FLINK_DIR/conf/flink-conf.yaml"
   echo "s3.secret-key: $IT_CASE_S3_SECRET_KEY" >> "$FLINK_DIR/conf/flink-conf.yaml"
 }

--- a/flink-end-to-end-tests/test-scripts/common_ssl.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ssl.sh
@@ -61,12 +61,12 @@ function _set_conf_ssl_helper {
     # adapt config
     # (here we rely on security.ssl.enabled enabling SSL for all components and internal as well as
     # external communication channels)
-    set_conf security.ssl.${type}.enabled true
-    set_conf security.ssl.${type}.keystore ${ssl_dir}/node.keystore
-    set_conf security.ssl.${type}.keystore-password ${password}
-    set_conf security.ssl.${type}.key-password ${password}
-    set_conf security.ssl.${type}.truststore ${ssl_dir}/ca.truststore
-    set_conf security.ssl.${type}.truststore-password ${password}
+    set_config_key security.ssl.${type}.enabled true
+    set_config_key security.ssl.${type}.keystore ${ssl_dir}/node.keystore
+    set_config_key security.ssl.${type}.keystore-password ${password}
+    set_config_key security.ssl.${type}.key-password ${password}
+    set_config_key security.ssl.${type}.truststore ${ssl_dir}/ca.truststore
+    set_config_key security.ssl.${type}.truststore-password ${password}
 }
 
 function _set_conf_mutual_rest_ssl {
@@ -78,7 +78,7 @@ function _set_conf_mutual_rest_ssl {
         mutual="true";
     fi
     echo "Mutual ssl auth: ${mutual}"
-    set_conf security.ssl.rest.authentication-enabled ${mutual}
+    set_config_key security.ssl.rest.authentication-enabled ${mutual}
 }
 
 function set_conf_rest_ssl {

--- a/flink-end-to-end-tests/test-scripts/common_utils.sh
+++ b/flink-end-to-end-tests/test-scripts/common_utils.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+### Some general purpose helper functions that can be used in test scripts.
+
+_on_exit_commands=()
+
+function _on_exit_callback {
+  # Un-register the callback, to avoid multiple invocations: some shells may treat some signals as subset of others.
+  trap "" INT EXIT
+  # Fast exit, if there is another keyboard interrupt.
+  trap "exit -1" INT
+
+  for command in "${_on_exit_commands[@]-}"; do
+    eval "${command}"
+  done
+}
+
+# Register for multiple signals: some shells interpret them as mutually exclusive.
+trap _on_exit_callback INT EXIT
+
+# Helper method to register a command that should be called on current script exit.
+# It allows to have multiple "on exit" commands to be called, compared to the built-in `trap "$command" EXIT`.
+# Note: tests should not use `trap $command INT|EXIT` directly, to avoid having "Highlander" situation.
+function on_exit {
+  local command="$1"
+
+  # Keep commands in reverse order, so commands would be executed in LIFO order.
+  _on_exit_commands=("${command}" "${_on_exit_commands[@]-}")
+}

--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -36,7 +36,7 @@ function setup_kafka_dist {
   mkdir -p $TEST_DATA_DIR
   KAFKA_URL="https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
   echo "Downloading Kafka from $KAFKA_URL"
-  curl "$KAFKA_URL" > $TEST_DATA_DIR/kafka.tgz
+  curl "$KAFKA_URL" --retry 5 --retry-max-time 60 > $TEST_DATA_DIR/kafka.tgz
 
   tar xzf $TEST_DATA_DIR/kafka.tgz -C $TEST_DATA_DIR/
 

--- a/flink-end-to-end-tests/test-scripts/queryable_state_base.sh
+++ b/flink-end-to-end-tests/test-scripts/queryable_state_base.sh
@@ -18,22 +18,9 @@
 ################################################################################
 
 function link_queryable_state_lib {
-    echo "Moving flink-queryable-state-runtime from opt/ to lib/"
-    mv ${FLINK_DIR}/opt/flink-queryable-state-runtime* ${FLINK_DIR}/lib/
-    if [ $? != 0 ]; then
-        echo "Failed to move flink-queryable-state-runtime from opt/ to lib/. Exiting"
-        exit 1
-    fi
+    echo "Adding flink-queryable-state-runtime to lib/"
+    add_optional_lib "queryable-state-runtime"
     set_conf "queryable-state.enable" "true"
-}
-
-function unlink_queryable_state_lib {
-    echo "Moving flink-queryable-state-runtime from lib/ to opt/"
-    mv ${FLINK_DIR}/lib/flink-queryable-state-runtime* ${FLINK_DIR}/opt/
-    if [ $? != 0 ]; then
-        echo "Failed to move flink-queryable-state-runtime from lib/ to opt/. Exiting"
-        exit 1
-    fi
 }
 
 # Returns the ip address of the queryable state server

--- a/flink-end-to-end-tests/test-scripts/queryable_state_base.sh
+++ b/flink-end-to-end-tests/test-scripts/queryable_state_base.sh
@@ -20,7 +20,7 @@
 function link_queryable_state_lib {
     echo "Adding flink-queryable-state-runtime to lib/"
     add_optional_lib "queryable-state-runtime"
-    set_conf "queryable-state.enable" "true"
+    set_config_key "queryable-state.enable" "true"
 }
 
 # Returns the ip address of the queryable state server

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -39,7 +39,7 @@ function run_test {
     export TEST_DATA_DIR=$TEST_INFRA_DIR/temp-test-directory-$(date +%S%N)
     echo "TEST_DATA_DIR: $TEST_DATA_DIR"
 
-    backup_config
+    backup_flink_dir
     start_timer
 
     function test_error() {
@@ -96,7 +96,7 @@ function post_test_validation {
 # Shuts down cluster and reverts changes to cluster configs
 function cleanup_proc {
     shutdown_all
-    revert_default_config
+    revert_flink_dir
 }
 
 # Cleans up all temporary folders and files

--- a/flink-end-to-end-tests/test-scripts/test_azure_fs.sh
+++ b/flink-end-to-end-tests/test-scripts/test_azure_fs.sh
@@ -59,17 +59,9 @@ AZURE_TEST_DATA_WORDS_URI="wasbs://$IT_CASE_AZURE_CONTAINER@$IT_CASE_AZURE_ACCOU
 #   None
 ###################################
 function azure_setup {
-  # make sure we delete the file at the end
-  function azure_cleanup {
-    rm $FLINK_DIR/lib/flink-azure-fs*.jar
-
-    # remove any leftover settings
-    sed -i -e 's/fs.azure.account.key.*//' "$FLINK_DIR/conf/flink-conf.yaml"
-  }
-  trap azure_cleanup EXIT
 
   echo "Copying flink azure jars and writing out configs"
-  cp $FLINK_DIR/opt/flink-azure-fs-hadoop-*.jar $FLINK_DIR/lib/
+  add_optional_lib "azure-fs-hadoop"
   echo "fs.azure.account.key.$IT_CASE_AZURE_ACCOUNT.blob.core.windows.net: $IT_CASE_AZURE_ACCESS_KEY" >> "$FLINK_DIR/conf/flink-conf.yaml"
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_azure_fs.sh
+++ b/flink-end-to-end-tests/test-scripts/test_azure_fs.sh
@@ -62,7 +62,7 @@ function azure_setup {
 
   echo "Copying flink azure jars and writing out configs"
   add_optional_lib "azure-fs-hadoop"
-  echo "fs.azure.account.key.$IT_CASE_AZURE_ACCOUNT.blob.core.windows.net: $IT_CASE_AZURE_ACCESS_KEY" >> "$FLINK_DIR/conf/flink-conf.yaml"
+  set_config_key "fs.azure.account.key.$IT_CASE_AZURE_ACCOUNT.blob.core.windows.net" "$IT_CASE_AZURE_ACCESS_KEY"
 }
 
 azure_setup

--- a/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
@@ -26,8 +26,8 @@ TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-dataset-allround-test/target/DataSetAll
 echo "Run DataSet-Allround-Test Program"
 
 # modify configuration to include spilling to disk
-echo "taskmanager.network.memory.min: 10485760" >> $FLINK_DIR/conf/flink-conf.yaml
-echo "taskmanager.network.memory.max: 10485760" >> $FLINK_DIR/conf/flink-conf.yaml
+set_config_key "taskmanager.network.memory.min" "10485760"
+set_config_key "taskmanager.network.memory.max" "10485760"
 
 set_conf_ssl "server"
 start_cluster

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -35,17 +35,11 @@ function verify_output {
 }
 
 function test_cleanup {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   stop_confluent_schema_registry
   stop_kafka_cluster
 }
 
-trap test_cleanup INT
-trap test_cleanup EXIT
+on_exit test_cleanup
 
 setup_kafka_dist
 setup_confluent_dist

--- a/flink-end-to-end-tests/test-scripts/test_ha_dataset.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_dataset.sh
@@ -23,17 +23,11 @@ source "$(dirname "$0")"/common_ha.sh
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-dataset-allround-test/target/DataSetAllroundTestProgram.jar
 
 function ha_cleanup() {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   # kill the cluster and zookeeper
   stop_watchdogs
 }
 
-trap ha_cleanup INT
-trap ha_cleanup EXIT
+on_exit ha_cleanup
 
 function run_ha_test() {
     local PARALLELISM=$1

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -44,8 +44,8 @@ function run_ha_test() {
     create_ha_config
     # change the pid dir to start log files always from 0, this is important for checks in the
     # jm killing loop
-    set_conf "env.pid.dir" "${TEST_DATA_DIR}"
-    set_conf "env.java.opts" "-ea"
+    set_config_key "env.pid.dir" "${TEST_DATA_DIR}"
+    set_config_key "env.java.opts" "-ea"
     start_local_zk
     start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -23,17 +23,11 @@ source "$(dirname "$0")"/common_ha.sh
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/DataStreamAllroundTestProgram.jar
 
 function ha_cleanup() {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   # kill the cluster and zookeeper
   stop_watchdogs
 }
 
-trap ha_cleanup INT
-trap ha_cleanup EXIT
+on_exit ha_cleanup
 
 function run_ha_test() {
     local PARALLELISM=$1

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -26,17 +26,11 @@ FLINK_LIB_DIR=${FLINK_DIR}/lib
 JOB_ID="00000000000000000000000000000000"
 
 function ha_cleanup() {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   stop_watchdogs
   kill_all 'StandaloneJobClusterEntryPoint'
 }
 
-trap ha_cleanup INT
-trap ha_cleanup EXIT
+on_exit ha_cleanup
 
 function run_job() {
     local PARALLELISM=$1

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -33,7 +33,6 @@ function ha_cleanup() {
 
   stop_watchdogs
   kill_all 'StandaloneJobClusterEntryPoint'
-  rm ${FLINK_LIB_DIR}/${TEST_PROGRAM_JAR_NAME}
 }
 
 trap ha_cleanup INT

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -107,7 +107,7 @@ function run_ha_test() {
 
     # change the pid dir to start log files always from 0, this is important for checks in the
     # jm killing loop
-    set_conf "env.pid.dir" "${TEST_DATA_DIR}"
+    set_config_key "env.pid.dir" "${TEST_DATA_DIR}"
 
     start_local_zk
 

--- a/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
+++ b/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
@@ -25,15 +25,15 @@ TEST=flink-heavy-deployment-stress-test
 TEST_PROGRAM_NAME=HeavyDeploymentStressTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-set_conf "taskmanager.heap.mb" "512" # 512Mb x 10TMs = 5Gb total heap
+set_config_key "taskmanager.heap.mb" "512" # 512Mb x 10TMs = 5Gb total heap
 
-set_conf "taskmanager.memory.size" "8" # 8Mb
-set_conf "taskmanager.network.memory.min" "8mb"
-set_conf "taskmanager.network.memory.max" "8mb"
-set_conf "taskmanager.network.request-backoff.max" "60000"
-set_conf "taskmanager.memory.segment-size" "8kb"
+set_config_key "taskmanager.memory.size" "8" # 8Mb
+set_config_key "taskmanager.network.memory.min" "8mb"
+set_config_key "taskmanager.network.memory.max" "8mb"
+set_config_key "taskmanager.network.request-backoff.max" "60000"
+set_config_key "taskmanager.memory.segment-size" "8kb"
 
-set_conf "taskmanager.numberOfTaskSlots" "10" # 10 slots per TM
+set_config_key "taskmanager.numberOfTaskSlots" "10" # 10 slots per TM
 
 start_cluster # this also starts 1TM
 start_taskmanagers 9 # 1TM + 9TM = 10TM a 10 slots = 100 slots

--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -25,18 +25,18 @@ TEST=flink-high-parallelism-iterations-test
 TEST_PROGRAM_NAME=HighParallelismIterationsTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-set_conf "taskmanager.heap.mb" "52" # 52Mb x 100 TMs = 5Gb total heap
+set_config_key "taskmanager.heap.mb" "52" # 52Mb x 100 TMs = 5Gb total heap
 
-set_conf "taskmanager.memory.size" "8" # 8Mb
-set_conf "taskmanager.network.memory.min" "8mb"
-set_conf "taskmanager.network.memory.max" "8mb"
-set_conf "taskmanager.memory.segment-size" "8kb"
+set_config_key "taskmanager.memory.size" "8" # 8Mb
+set_config_key "taskmanager.network.memory.min" "8mb"
+set_config_key "taskmanager.network.memory.max" "8mb"
+set_config_key "taskmanager.memory.segment-size" "8kb"
 
-set_conf "taskmanager.network.netty.server.numThreads" "1"
-set_conf "taskmanager.network.netty.client.numThreads" "1"
-set_conf "taskmanager.network.request-backoff.max" "60000"
+set_config_key "taskmanager.network.netty.server.numThreads" "1"
+set_config_key "taskmanager.network.netty.client.numThreads" "1"
+set_config_key "taskmanager.network.request-backoff.max" "60000"
 
-set_conf "taskmanager.numberOfTaskSlots" "1"
+set_config_key "taskmanager.numberOfTaskSlots" "1"
 
 print_mem_use
 start_cluster

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -53,7 +53,7 @@ function start_kubernetes_if_not_running {
     return $?
 }
 
-trap cleanup EXIT
+on_exit cleanup
 
 mkdir -p $OUTPUT_VOLUME
 

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -45,12 +45,9 @@ function check_logs {
     fi
 }
 
-# This function does a cleanup after the test. The configuration is restored, the watchdog is terminated and temporary
+# This function does a cleanup after the test. The watchdog is terminated and temporary
 # files and folders are deleted.
 function cleanup_after_test {
-    # Reset the configurations
-    sed -i -e 's/log4j.rootLogger=.*/log4j.rootLogger=INFO, file/' "$FLINK_DIR/conf/log4j.properties"
-    #
     kill ${watchdog_pid} 2> /dev/null
     wait ${watchdog_pid} 2> /dev/null
 }

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -81,9 +81,9 @@ function run_local_recovery_test {
     sed -i -e 's/log4j.rootLogger=.*/log4j.rootLogger=DEBUG, file/' "$FLINK_DIR/conf/log4j.properties"
 
     # Enable local recovery
-    set_conf "state.backend.local-recovery" "true"
+    set_config_key "state.backend.local-recovery" "true"
     # Ensure that each TM only has one operator(chain)
-    set_conf "taskmanager.numberOfTaskSlots" "1"
+    set_config_key "taskmanager.numberOfTaskSlots" "1"
 
     rm $FLINK_DIR/log/* 2> /dev/null
 

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state.sh
@@ -50,7 +50,6 @@ function run_test {
 }
 
 function test_cleanup {
-    unlink_queryable_state_lib
     clean_stdout_files
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state.sh
@@ -53,5 +53,5 @@ function test_cleanup {
     clean_stdout_files
 }
 
-trap test_cleanup EXIT
+on_exit test_cleanup
 run_test $1

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -52,8 +52,8 @@ function run_test() {
     local PORT="9069" # port of queryable state server
 
     # speeds up TM loss detection
-    set_conf "heartbeat.interval" "2000"
-    set_conf "heartbeat.timeout" "10000"
+    set_config_key "heartbeat.interval" "2000"
+    set_config_key "heartbeat.timeout" "10000"
 
     link_queryable_state_lib
     start_cluster

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -164,9 +164,4 @@ function get_completed_number_of_checkpoints {
         sed 's/,.*//'     # 24
 }
 
-function test_cleanup {
-    unlink_queryable_state_lib
-}
-
-trap test_cleanup EXIT
 run_test

--- a/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
+++ b/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
@@ -98,15 +98,9 @@ setup_elasticsearch "https://artifacts.elastic.co/downloads/elasticsearch/elasti
 wait_elasticsearch_working
 
 function shutdownAndCleanup {
-    # don't call ourselves again for another signal interruption
-    trap "exit -1" INT
-    # don't call ourselves again for normal exit
-    trap "" EXIT
-
     shutdown_elasticsearch_cluster "$ES_INDEX"
 }
-trap shutdownAndCleanup INT
-trap shutdownAndCleanup EXIT
+on_exit shutdownAndCleanup
 
 TEST_PROGRAM_JAR=${TEST_DATA_DIR}/${ARTIFACT_ID}/target/${ARTIFACT_ID}-${ARTIFACT_VERSION}.jar
 

--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -37,8 +37,8 @@ else
  NUM_SLOTS=$NEW_DOP
 fi
 
-change_conf "taskmanager.numberOfTaskSlots" "1" "${NUM_SLOTS}"
-set_conf "metrics.fetcher.update-interval" "2000"
+set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
+set_config_key "metrics.fetcher.update-interval" "2000"
 setup_flink_slf4j_metric_reporter
 start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -42,17 +42,6 @@ set_conf "metrics.fetcher.update-interval" "2000"
 setup_flink_slf4j_metric_reporter
 start_cluster
 
-function test_cleanup {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
-  rollback_flink_slf4j_metric_reporter
-}
-trap test_cleanup INT
-trap test_cleanup EXIT
-
 CHECKPOINT_DIR="$TEST_DATA_DIR/externalized-chckpt-e2e-backend-dir"
 CHECKPOINT_DIR_URI="file://$CHECKPOINT_DIR"
 

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -66,19 +66,6 @@ setup_flink_slf4j_metric_reporter
 
 start_cluster
 
-# make sure to stop Kafka and ZooKeeper at the end, as well as cleaning up the Flink cluster and our moodifications
-function test_cleanup {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
-  # revert our modifications to the Flink distribution
-  rm ${FLINK_DIR}/lib/flink-metrics-slf4j-*.jar
-}
-trap test_cleanup INT
-trap test_cleanup EXIT
-
 CHECKPOINT_DIR="file://$TEST_DATA_DIR/savepoint-e2e-test-chckpt-dir"
 
 # run the DataStream allroundjob

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -55,12 +55,12 @@ else
   NUM_SLOTS=$NEW_DOP
 fi
 
-change_conf "taskmanager.numberOfTaskSlots" "1" "${NUM_SLOTS}"
+set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
 
 if [ $STATE_BACKEND_ROCKS_TIMER_SERVICE_TYPE == 'rocks' ]; then
-  set_conf "state.backend.rocksdb.timer-service.factory" "rocksdb"
+  set_config_key "state.backend.rocksdb.timer-service.factory" "rocksdb"
 fi
-set_conf "metrics.fetcher.update-interval" "2000"
+set_config_key "metrics.fetcher.update-interval" "2000"
 
 setup_flink_slf4j_metric_reporter
 

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -78,16 +78,10 @@ rm -r $EXTRACTED_JAR
 ELASTICSEARCH_INDEX='my_users'
 
 function sql_cleanup() {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   stop_kafka_cluster
   shutdown_elasticsearch_cluster "$ELASTICSEARCH_INDEX"
 }
-trap sql_cleanup INT
-trap sql_cleanup EXIT
+on_exit sql_cleanup
 
 # prepare Kafka
 echo "Preparing Kafka..."

--- a/flink-end-to-end-tests/test-scripts/test_sql_client_kafka_common.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client_kafka_common.sh
@@ -35,15 +35,9 @@ source "$(dirname "$0")"/kafka_sql_common.sh \
 ################################################################################
 
 function sql_cleanup() {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   stop_kafka_cluster
 }
-trap sql_cleanup INT
-trap sql_cleanup EXIT
+on_exit sql_cleanup
 
 # prepare Kafka
 echo "Preparing Kafka $KAFKA_VERSION..."

--- a/flink-end-to-end-tests/test-scripts/test_state_evolution.sh
+++ b/flink-end-to-end-tests/test-scripts/test_state_evolution.sh
@@ -61,7 +61,7 @@ function run_test {
 
     SAVEPOINT_DIR="file:///${END_TO_END_DIR}/flink-state-evolution-test/savepoints/1.7/"
 
-    set_conf "state.backend.fs.memory-threshold" 1048576
+    set_config_key "state.backend.fs.memory-threshold" 1048576
     start_cluster
 
     # restart the job from the savepoint from Flink 1.7 with the old Avro Schema

--- a/flink-end-to-end-tests/test-scripts/test_state_migration.sh
+++ b/flink-end-to-end-tests/test-scripts/test_state_migration.sh
@@ -28,7 +28,7 @@ function run_test {
 
     SAVEPOINT_DIR="file:///${END_TO_END_DIR}/flink-state-evolution-test/savepoints/1.6/"
 
-    set_conf "state.backend.fs.memory-threshold" 1048576
+    set_config_key "state.backend.fs.memory-threshold" 1048576
     start_cluster
 
     # restart the job from the savepoint from Flink 1.6

--- a/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
@@ -28,9 +28,9 @@ else
   NUM_SLOTS=${NEW_DOP}
 fi
 
-change_conf "taskmanager.numberOfTaskSlots" "1" "${NUM_SLOTS}"
+set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
 setup_flink_slf4j_metric_reporter
-set_conf "metrics.fetcher.update-interval" "2000"
+set_config_key "metrics.fetcher.update-interval" "2000"
 
 start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
@@ -34,19 +34,6 @@ set_conf "metrics.fetcher.update-interval" "2000"
 
 start_cluster
 
-# make sure to stop Kafka and ZooKeeper at the end, as well as cleaning up the Flink cluster and our moodifications
-function test_cleanup {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
-  # revert our modifications to the Flink distribution
-  rm ${FLINK_DIR}/lib/flink-metrics-slf4j-*.jar
-}
-trap test_cleanup INT
-trap test_cleanup EXIT
-
 CHECKPOINT_DIR="file://${TEST_DATA_DIR}/savepoint-e2e-test-chckpt-dir"
 
 TEST_PROGRAM_JAR="${END_TO_END_DIR}/flink-stream-stateful-job-upgrade-test/target/StatefulStreamJobUpgradeTestProgram.jar"

--- a/flink-end-to-end-tests/test-scripts/test_stream_state_ttl.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stream_state_ttl.sh
@@ -32,17 +32,6 @@ TEST_PROGRAM_NAME=DataStreamStateTTLTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
 setup_flink_slf4j_metric_reporter
-function test_cleanup {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
-  # revert our modifications to the Flink distribution
-  rm ${FLINK_DIR}/lib/flink-metrics-slf4j-*.jar
-}
-trap test_cleanup INT
-trap test_cleanup EXIT
 
 set_conf "metrics.fetcher.update-interval" "2000"
 

--- a/flink-end-to-end-tests/test-scripts/test_stream_state_ttl.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stream_state_ttl.sh
@@ -33,7 +33,7 @@ TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
 setup_flink_slf4j_metric_reporter
 
-set_conf "metrics.fetcher.update-interval" "2000"
+set_config_key "metrics.fetcher.update-interval" "2000"
 
 start_cluster
 if [ "${PARALLELISM}" -gt "1" ]; then

--- a/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
@@ -35,8 +35,7 @@ function bucketing_cleanup() {
   stop_cluster
   $FLINK_DIR/bin/taskmanager.sh stop-all
 }
-trap bucketing_cleanup INT
-trap bucketing_cleanup EXIT
+on_exit bucketing_cleanup
 
 JOB_ID=$($FLINK_DIR/bin/flink run -d -p 4 $TEST_PROGRAM_JAR -outputPath $TEST_DATA_DIR/out/result \
   | grep "Job has been submitted with JobID" | sed 's/.* //g')

--- a/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
@@ -34,9 +34,6 @@ function bucketing_cleanup() {
 
   stop_cluster
   $FLINK_DIR/bin/taskmanager.sh stop-all
-
-  # restore default logging level
-  sed -i -e 's/log4j.logger.org.apache.flink=DEBUG/#log4j.logger.org.apache.flink=INFO/g' $FLINK_DIR/conf/log4j.properties
 }
 trap bucketing_cleanup INT
 trap bucketing_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
@@ -21,13 +21,6 @@ source "$(dirname "$0")"/common.sh
 
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-parent-child-classloading-test-program/target/ClassLoaderTestProgram.jar
 
-echo "Testing parent-first class loading"
-
-# remove any leftover classloader settings
-sed -i -e 's/classloader.resolve-order: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
-sed -i -e 's/classloader.parent-first-patterns: .*//' $FLINK_DIR/conf/flink-conf.yaml
-echo "classloader.resolve-order: parent-first" >> "$FLINK_DIR/conf/flink-conf.yaml"
-
 echo "Moving fake LibPackage.jar from end-to-end tests to lib/"
 cp ${END_TO_END_DIR}/flink-parent-child-classloading-test-lib-package/target/LibPackage.jar ${FLINK_DIR}/lib/
 
@@ -37,14 +30,16 @@ function classloader_cleanup() {
 }
 on_exit classloader_cleanup
 
+echo "Testing parent-first class loading"
+
+delete_config_key "classloader.parent-first-patterns"
+set_config_key "classloader.resolve-order" "parent-first"
+
 start_cluster
 
 $FLINK_DIR/bin/flink run -p 1 $TEST_PROGRAM_JAR --resolve-order parent-first --output $TEST_DATA_DIR/out/cl_out_pf
 
 stop_cluster
-
-# remove classloader settings again
-sed -i -e 's/classloader.resolve-order: .*//' $FLINK_DIR/conf/flink-conf.yaml
 
 OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_pf`
 # first field: whether we found the method on TaskManager
@@ -62,19 +57,14 @@ fi
 # "parent-first-pattern" is "org.apache.flink"
 echo "Testing child-first class loading with Flink classes loaded via parent"
 
-# remove any leftover classloader settings
-sed -i -e 's/classloader.resolve-order: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
-sed -i -e 's/classloader.parent-first-patterns: .*//' $FLINK_DIR/conf/flink-conf.yaml
-echo "classloader.resolve-order: child-first" >> "$FLINK_DIR/conf/flink-conf.yaml"
+delete_config_key "classloader.parent-first-patterns"
+set_config_key "classloader.resolve-order" "child-first"
 
 start_cluster
 
 $FLINK_DIR/bin/flink run -p 1 $TEST_PROGRAM_JAR --resolve-order parent-first --output $TEST_DATA_DIR/out/cl_out_cf_pf
 
 stop_cluster
-
-# remove classloader settings again
-sed -i -e 's/classloader.resolve-order: .*//' $FLINK_DIR/conf/flink-conf.yaml
 
 OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_cf_pf`
 # first field: whether we found the method on TaskManager
@@ -90,20 +80,14 @@ fi
 
 echo "Testing child-first class loading"
 
-# remove any leftover classloader settings
-sed -i -e 's/classloader.resolve-order: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
-echo "classloader.resolve-order: child-first" >> "$FLINK_DIR/conf/flink-conf.yaml"
-echo "classloader.parent-first-patterns: foo.bar" >> "$FLINK_DIR/conf/flink-conf.yaml"
+set_config_key "classloader.parent-first-patterns" "foo.bar"
+set_config_key "classloader.resolve-order" "child-first"
 
 start_cluster
 
 $FLINK_DIR/bin/flink run -p 1 $TEST_PROGRAM_JAR --resolve-order child-first --output $TEST_DATA_DIR/out/cl_out_cf
 
 stop_cluster
-
-# remove classloader settings again
-sed -i -e 's/classloader.resolve-order: .*//' $FLINK_DIR/conf/flink-conf.yaml
-sed -i -e 's/classloader.parent-first-patterns: .*//' $FLINK_DIR/conf/flink-conf.yaml
 
 OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_cf`
 # first field: whether we found the method on TaskManager

--- a/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
@@ -39,9 +39,6 @@ function classloader_cleanup() {
 
   stop_cluster
   $FLINK_DIR/bin/taskmanager.sh stop-all
-
-  # remove LibPackage.jar again
-  rm ${FLINK_DIR}/lib/LibPackage.jar
 }
 trap classloader_cleanup INT
 trap classloader_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
@@ -32,16 +32,10 @@ echo "Moving fake LibPackage.jar from end-to-end tests to lib/"
 cp ${END_TO_END_DIR}/flink-parent-child-classloading-test-lib-package/target/LibPackage.jar ${FLINK_DIR}/lib/
 
 function classloader_cleanup() {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   stop_cluster
   $FLINK_DIR/bin/taskmanager.sh stop-all
 }
-trap classloader_cleanup INT
-trap classloader_cleanup EXIT
+on_exit classloader_cleanup
 
 start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_elasticsearch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_elasticsearch.sh
@@ -34,8 +34,7 @@ function test_cleanup {
   shutdown_elasticsearch_cluster index
 }
 
-trap test_cleanup INT
-trap test_cleanup EXIT
+on_exit test_cleanup
 
 TEST_ES_JAR=${END_TO_END_DIR}/flink-elasticsearch${ELASTICSEARCH_VERSION}-test/target/Elasticsearch${ELASTICSEARCH_VERSION}SinkExample.jar
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -48,7 +48,7 @@ function out_cleanup {
   s3_delete_by_full_path_prefix $OUT
 }
 if [ "${OUT_TYPE}" == "s3" ]; then
-  trap out_cleanup EXIT
+  on_exit out_cleanup
 fi
 
 TEST_PROGRAM_JAR="${END_TO_END_DIR}/flink-streaming-file-sink-test/target/StreamingFileSinkProgram.jar"

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -24,7 +24,7 @@ source "$(dirname "$0")"/common_s3.sh
 
 s3_setup hadoop
 set_conf_ssl "mutual"
-set_conf "metrics.fetcher.update-interval" "2000"
+set_config_key "metrics.fetcher.update-interval" "2000"
 
 OUT=temp/test_streaming_file_sink-$(uuidgen)
 OUTPUT_PATH="$TEST_DATA_DIR/$OUT"

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka_common.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka_common.sh
@@ -23,7 +23,6 @@ setup_kafka_dist
 start_kafka_cluster
 
 # modify configuration to have enough slots
-cp $FLINK_DIR/conf/flink-conf.yaml $FLINK_DIR/conf/flink-conf.yaml.bak
 sed -i -e "s/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 3/" $FLINK_DIR/conf/flink-conf.yaml
 
 start_cluster
@@ -35,9 +34,6 @@ function test_cleanup {
   trap "" EXIT
 
   stop_kafka_cluster
-
-  # revert our modifications to the Flink distribution
-  mv -f $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
 }
 trap test_cleanup INT
 trap test_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka_common.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka_common.sh
@@ -28,15 +28,9 @@ sed -i -e "s/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 3/"
 start_cluster
 
 function test_cleanup {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   stop_kafka_cluster
 }
-trap test_cleanup INT
-trap test_cleanup EXIT
+on_exit test_cleanup
 
 # create the required topics
 create_kafka_topic 1 1 test-input

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka_common.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka_common.sh
@@ -23,7 +23,7 @@ setup_kafka_dist
 start_kafka_cluster
 
 # modify configuration to have enough slots
-sed -i -e "s/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 3/" $FLINK_DIR/conf/flink-conf.yaml
+set_config_key "taskmanager.numberOfTaskSlots" "3"
 
 start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kinesis.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kinesis.sh
@@ -36,17 +36,12 @@ docker run -d --rm --entrypoint "/tini" --name flink-test-kinesis -p ${KINESALIT
 docker logs flink-test-kinesis
 
 function test_cleanup {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
   # job needs to stop before kinesalite
   stop_cluster
   echo "terminating kinesalite"
   docker kill flink-test-kinesis
 }
-trap test_cleanup INT
-trap test_cleanup EXIT
+on_exit test_cleanup
 
 # prefix com.amazonaws.sdk.disableCertChecking to account for shading
 DISABLE_CERT_CHECKING_JAVA_OPTS="-Dorg.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking"

--- a/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
@@ -32,16 +32,10 @@ $FLINK_DIR/bin/taskmanager.sh start
 $FLINK_DIR/bin/flink run -p 4 $TEST_PROGRAM_JAR -outputPath file://${TEST_DATA_DIR}/out/result
 
 function sql_cleanup() {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   stop_cluster
   $FLINK_DIR/bin/taskmanager.sh stop-all
 }
-trap sql_cleanup INT
-trap sql_cleanup EXIT
+on_exit sql_cleanup
 
 # collect results from files
 cat $TEST_DATA_DIR/out/result/20/.part-* $TEST_DATA_DIR/out/result/20/part-* | sort > $TEST_DATA_DIR/out/result-complete

--- a/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
@@ -22,7 +22,7 @@ source "$(dirname "$0")"/common.sh
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-stream-sql-test/target/StreamSQLTestProgram.jar
 
 # copy flink-table jar into lib folder
-cp $FLINK_DIR/opt/flink-table*jar $FLINK_DIR/lib
+add_optional_lib "table"
 
 start_cluster
 $FLINK_DIR/bin/taskmanager.sh start
@@ -39,10 +39,6 @@ function sql_cleanup() {
 
   stop_cluster
   $FLINK_DIR/bin/taskmanager.sh stop-all
-
-  # remove flink-table from lib folder
-  rm $FLINK_DIR/lib/flink-table*jar
-
 }
 trap sql_cleanup INT
 trap sql_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
@@ -55,16 +55,10 @@ esac
 
 # make sure we stop our cluster at the end
 function cluster_shutdown {
-  # don't call ourselves again for another signal interruption
-  trap "exit -1" INT
-  # don't call ourselves again for normal exit
-  trap "" EXIT
-
   docker-compose -f $END_TO_END_DIR/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml down
   rm $FLINK_TARBALL_DIR/$FLINK_TARBALL
 }
-trap cluster_shutdown INT
-trap cluster_shutdown EXIT
+on_exit cluster_shutdown
 
 function start_hadoop_cluster() {
     echo "Starting Hadoop cluster"


### PR DESCRIPTION
## What is the purpose of the change

Make bash based end-to-end tests more "isolated" from each other (by more thorough clean up).

## Brief change log

  - whole Flink `lib` and `conf` sub directories are backuped and restored on each test run by `test-runner-common.sh`. Tests themselves don't need to revert their changes for this dirs anymore.
  - introduced an `on_exit` hook as alternative to built-in `trap` hook. The letter is discouraged to be used directly in tests.
  - refactored Flink config key delete and setter methods.


## Verifying this change

 - Would be nice to run this changes in CI environment and see if there are any test failures.
  - Some new methods and their behavior was tested manually by running a sample test:
```bash
#!/usr/bin/env bash

source "$(dirname "$0")"/common.sh

# Check on_exit hook
function foo {
    echo "Debug 1"
    ls -la "$FLINK_DIR/lib/"
}

function foo_2 {
    echo "Debug 2"
    ls -la "$FLINK_DIR/lib/"
}

on_exit foo
on_exit foo_2

# Check add_optional_lib

add_optional_lib "table"
add_optional_lib "s3-fs-presto"

ls -lh "$FLINK_DIR/lib"

# Check config_key methods

set_config_key "jobmanager.archive.fs.dir" "hdfs:///sdsds-jobs/"
set_config_key parallelism.default 42
delete_config_key high-availability
delete_config_key jobmanager.rpc.address
cp ${FLINK_DIR}/conf/flink-conf.yaml ${FLINK_DIR}/conf/flink-conf.test.yaml
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
