### PR TITLE
[FLINK-12254][table-common] Preparation for using the new type system

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -152,22 +152,6 @@ public class TableSchema {
 	}
 
 	/**
-	 * @deprecated Use {@link TableSchema#getFieldTypes()} instead. Can be dropped after 1.7.
-	 */
-	@Deprecated
-	public TypeInformation<?>[] getTypes() {
-		return getFieldTypes();
-	}
-
-	/**
-	 * @deprecated Use {@link TableSchema#getFieldNames()} instead. Can be dropped after 1.7.
-	 */
-	@Deprecated
-	public String[] getColumnNames() {
-		return getFieldNames();
-	}
-
-	/**
 	 * Converts a table schema into a (nested) type information describing a {@link Row}.
 	 */
 	public TypeInformation<Row> toRowType() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/AtomicDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/AtomicDataType.java
@@ -61,4 +61,9 @@ public final class AtomicDataType extends DataType {
 			logicalType,
 			Preconditions.checkNotNull(newConversionClass, "New conversion class must not be null."));
 	}
+
+	@Override
+	public <R> R accept(DataTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
@@ -92,6 +92,11 @@ public final class CollectionDataType extends DataType {
 	}
 
 	@Override
+	public <R> R accept(DataTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
@@ -116,6 +116,8 @@ public abstract class DataType implements Serializable {
 	 */
 	public abstract DataType bridgedTo(Class<?> newConversionClass);
 
+	public abstract <R> R accept(DataTypeVisitor<R> visitor);
+
 	@Override
 	public String toString() {
 		return logicalType.toString();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataTypeVisitor.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * The visitor definition of {@link DataType}. The visitor transforms a data type into
+ * instances of {@code R}.
+ */
+@PublicEvolving
+public interface DataTypeVisitor<R> {
+
+	R visit(AtomicDataType atomicDataType);
+
+	R visit(CollectionDataType collectionDataType);
+
+	R visit(FieldsDataType fieldsDataType);
+
+	R visit(KeyValueDataType keyValueDataType);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/FieldsDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/FieldsDataType.java
@@ -85,6 +85,11 @@ public final class FieldsDataType extends DataType {
 	}
 
 	@Override
+	public <R> R accept(DataTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/KeyValueDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/KeyValueDataType.java
@@ -92,6 +92,11 @@ public final class KeyValueDataType extends DataType {
 	}
 
 	@Override
+	public <R> R accept(DataTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
@@ -131,6 +131,14 @@ public final class LocalZonedTimestampType extends LogicalType {
 	}
 
 	@Override
+	public String asSummaryString() {
+		if (kind != TimestampKind.REGULAR) {
+			return String.format("%s *%s*", asSerializableString(), kind);
+		}
+		return asSerializableString();
+	}
+
+	@Override
 	public boolean supportsInputConversion(Class<?> clazz) {
 		return NOT_NULL_INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
@@ -117,6 +117,14 @@ public final class TimestampType extends LogicalType {
 	}
 
 	@Override
+	public String asSummaryString() {
+		if (kind != TimestampKind.REGULAR) {
+			return String.format("%s *%s*", asSerializableString(), kind);
+		}
+		return asSerializableString();
+	}
+
+	@Override
 	public boolean supportsInputConversion(Class<?> clazz) {
 		return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarBinaryType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarBinaryType.java
@@ -31,7 +31,8 @@ import java.util.Set;
  *
  * <p>The serialized string representation is {@code VARBINARY(n)} where {@code n} is the maximum
  * number of bytes. {@code n} must have a value between 1 and {@link Integer#MAX_VALUE} (both
- * inclusive). If no length is specified, {@code n} is equal to 1.
+ * inclusive). If no length is specified, {@code n} is equal to 1. {@code BYTES} is a synonym for
+ * {@code VARBINARY(2147483647)}.
  */
 @PublicEvolving
 public final class VarBinaryType extends LogicalType {
@@ -43,6 +44,8 @@ public final class VarBinaryType extends LogicalType {
 	public static final int DEFAULT_LENGTH = 1;
 
 	private static final String FORMAT = "VARBINARY(%d)";
+
+	private static final String MAX_FORMAT = "BYTES";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		byte[].class.getName(),
@@ -83,6 +86,9 @@ public final class VarBinaryType extends LogicalType {
 
 	@Override
 	public String asSerializableString() {
+		if (length == MAX_LENGTH) {
+			return withNullability(MAX_FORMAT);
+		}
 		return withNullability(FORMAT, length);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
@@ -31,7 +31,8 @@ import java.util.Set;
  *
  * <p>The serialized string representation is {@code VARCHAR(n)} where {@code n} is the maximum
  * number of code points. {@code n} must have a value between 1 and {@link Integer#MAX_VALUE} (both
- * inclusive). If no length is specified, {@code n} is equal to 1.
+ * inclusive). If no length is specified, {@code n} is equal to 1. {@code STRING} is a synonym for
+ * {@code VARCHAR(2147483647)}.
  *
  * <p>A conversion from and to {@code byte[]} assumes UTF-8 encoding.
  */
@@ -45,6 +46,8 @@ public final class VarCharType extends LogicalType {
 	public static final int DEFAULT_LENGTH = 1;
 
 	private static final String FORMAT = "VARCHAR(%d)";
+
+	private static final String MAX_FORMAT = "STRING";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		String.class.getName(),
@@ -86,6 +89,9 @@ public final class VarCharType extends LogicalType {
 
 	@Override
 	public String asSerializableString() {
+		if (length == MAX_LENGTH) {
+			return withNullability(MAX_FORMAT);
+		}
 		return withNullability(FORMAT, length);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ZonedTimestampType.java
@@ -122,6 +122,14 @@ public final class ZonedTimestampType extends LogicalType {
 	}
 
 	@Override
+	public String asSummaryString() {
+		if (kind != TimestampKind.REGULAR) {
+			return String.format("%s *%s*", asSerializableString(), kind);
+		}
+		return asSerializableString();
+	}
+
+	@Override
 	public boolean supportsInputConversion(Class<?> clazz) {
 		return INPUT_CONVERSION.contains(clazz.getName());
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeDefaultVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeDefaultVisitor.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.logical.AnyType;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DayTimeIntervalType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeVisitor;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.NullType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.YearMonthIntervalType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
+
+/**
+ * Implementation of {@link LogicalTypeVisitor} that redirects all calls to
+ * {@link LogicalTypeDefaultVisitor#defaultMethod(LogicalType)}.
+ */
+@Internal
+public abstract class LogicalTypeDefaultVisitor<R> implements LogicalTypeVisitor<R> {
+
+	@Override
+	public R visit(CharType charType) {
+		return defaultMethod(charType);
+	}
+
+	@Override
+	public R visit(VarCharType varCharType) {
+		return defaultMethod(varCharType);
+	}
+
+	@Override
+	public R visit(BooleanType booleanType) {
+		return defaultMethod(booleanType);
+	}
+
+	@Override
+	public R visit(BinaryType binaryType) {
+		return defaultMethod(binaryType);
+	}
+
+	@Override
+	public R visit(VarBinaryType varBinaryType) {
+		return defaultMethod(varBinaryType);
+	}
+
+	@Override
+	public R visit(DecimalType decimalType) {
+		return defaultMethod(decimalType);
+	}
+
+	@Override
+	public R visit(TinyIntType tinyIntType) {
+		return defaultMethod(tinyIntType);
+	}
+
+	@Override
+	public R visit(SmallIntType smallIntType) {
+		return defaultMethod(smallIntType);
+	}
+
+	@Override
+	public R visit(IntType intType) {
+		return defaultMethod(intType);
+	}
+
+	@Override
+	public R visit(BigIntType bigIntType) {
+		return defaultMethod(bigIntType);
+	}
+
+	@Override
+	public R visit(FloatType floatType) {
+		return defaultMethod(floatType);
+	}
+
+	@Override
+	public R visit(DoubleType doubleType) {
+		return defaultMethod(doubleType);
+	}
+
+	@Override
+	public R visit(DateType dateType) {
+		return defaultMethod(dateType);
+	}
+
+	@Override
+	public R visit(TimeType timeType) {
+		return defaultMethod(timeType);
+	}
+
+	@Override
+	public R visit(TimestampType timestampType) {
+		return defaultMethod(timestampType);
+	}
+
+	@Override
+	public R visit(ZonedTimestampType zonedTimestampType) {
+		return defaultMethod(zonedTimestampType);
+	}
+
+	@Override
+	public R visit(LocalZonedTimestampType localZonedTimestampType) {
+		return defaultMethod(localZonedTimestampType);
+	}
+
+	@Override
+	public R visit(YearMonthIntervalType yearMonthIntervalType) {
+		return defaultMethod(yearMonthIntervalType);
+	}
+
+	@Override
+	public R visit(DayTimeIntervalType dayTimeIntervalType) {
+		return defaultMethod(dayTimeIntervalType);
+	}
+
+	@Override
+	public R visit(ArrayType arrayType) {
+		return defaultMethod(arrayType);
+	}
+
+	@Override
+	public R visit(MultisetType multisetType) {
+		return defaultMethod(multisetType);
+	}
+
+	@Override
+	public R visit(MapType mapType) {
+		return defaultMethod(mapType);
+	}
+
+	@Override
+	public R visit(RowType rowType) {
+		return defaultMethod(rowType);
+	}
+
+	@Override
+	public R visit(DistinctType distinctType) {
+		return defaultMethod(distinctType);
+	}
+
+	@Override
+	public R visit(StructuredType structuredType) {
+		return defaultMethod(structuredType);
+	}
+
+	@Override
+	public R visit(NullType nullType) {
+		return defaultMethod(nullType);
+	}
+
+	@Override
+	public R visit(AnyType anyType) {
+		return defaultMethod(anyType);
+	}
+
+	@Override
+	public R visit(LogicalType other) {
+		return defaultMethod(other);
+	}
+
+	protected abstract R defaultMethod(LogicalType logicalType);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Class-based data type extractor that supports extraction of clearly identifiable data types for
+ * input and output conversion.
+ */
+@Internal
+public final class ClassDataTypeConverter {
+
+	private static final Map<String, DataType> defaultDataTypes = new HashMap<>();
+	static {
+		// NOTE: this list explicitly excludes data types that need further parameters
+		// exclusions: DECIMAL, INTERVAL YEAR TO MONTH, MAP, MULTISET, ROW, NULL, ANY
+		addDefaultDataType(String.class, DataTypes.STRING());
+		addDefaultDataType(Boolean.class, DataTypes.BOOLEAN());
+		addDefaultDataType(boolean.class, DataTypes.BOOLEAN());
+		addDefaultDataType(Byte.class, DataTypes.TINYINT());
+		addDefaultDataType(byte.class, DataTypes.TINYINT());
+		addDefaultDataType(Short.class, DataTypes.SMALLINT());
+		addDefaultDataType(short.class, DataTypes.SMALLINT());
+		addDefaultDataType(Integer.class, DataTypes.INT());
+		addDefaultDataType(int.class, DataTypes.INT());
+		addDefaultDataType(Long.class, DataTypes.BIGINT());
+		addDefaultDataType(long.class, DataTypes.BIGINT());
+		addDefaultDataType(Float.class, DataTypes.FLOAT());
+		addDefaultDataType(float.class, DataTypes.FLOAT());
+		addDefaultDataType(Double.class, DataTypes.DOUBLE());
+		addDefaultDataType(double.class, DataTypes.DOUBLE());
+		addDefaultDataType(java.sql.Date.class, DataTypes.DATE());
+		addDefaultDataType(java.time.LocalDate.class, DataTypes.DATE());
+		addDefaultDataType(java.sql.Time.class, DataTypes.TIME(9));
+		addDefaultDataType(java.time.LocalTime.class, DataTypes.TIME(9));
+		addDefaultDataType(java.sql.Timestamp.class, DataTypes.TIMESTAMP(9));
+		addDefaultDataType(java.time.LocalDateTime.class, DataTypes.TIMESTAMP(9));
+		addDefaultDataType(java.time.OffsetDateTime.class, DataTypes.TIMESTAMP_WITH_TIME_ZONE(9));
+		addDefaultDataType(java.time.Instant.class, DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9));
+		addDefaultDataType(java.time.Duration.class, DataTypes.INTERVAL(DataTypes.SECOND(9)));
+	}
+
+	private static void addDefaultDataType(Class<?> clazz, DataType rootType) {
+		final DataType dataType;
+		if (clazz.isPrimitive()) {
+			dataType = rootType.notNull();
+		} else {
+			dataType = rootType.nullable();
+		}
+		defaultDataTypes.put(clazz.getName(), dataType.bridgedTo(clazz));
+	}
+
+	/**
+	 * Returns the clearly identifiable data type if possible. For example, {@link Long} can be
+	 * expressed as {@link DataTypes#BIGINT()}. However, for example, {@link Row} cannot be extracted
+	 * as information about the fields is missing. Or {@link BigDecimal} needs to be mapped from a
+	 * variable precision/scale to constant ones.
+	 */
+	public static Optional<DataType> extractDataType(Class<?> clazz) {
+		// byte arrays have higher priority that regular arrays
+		if (clazz.equals(byte[].class)) {
+			return Optional.of(DataTypes.BYTES().nullable().bridgedTo(byte[].class));
+		}
+		if (clazz.isArray()) {
+			return extractDataType(clazz.getComponentType())
+				.map(element -> DataTypes.ARRAY(element).nullable().bridgedTo(clazz));
+		}
+		return Optional.ofNullable(defaultDataTypes.get(clazz.getName()));
+	}
+
+	private ClassDataTypeConverter() {
+		// no instantiation
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeDefaultVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeDefaultVisitor.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.DataTypeVisitor;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.KeyValueDataType;
+
+/**
+ * Implementation of {@link DataTypeVisitor} that redirects all calls to
+ * {@link DataTypeDefaultVisitor#defaultMethod(DataType)}.
+ */
+@Internal
+public abstract class DataTypeDefaultVisitor<R> implements DataTypeVisitor<R>{
+
+	@Override
+	public R visit(AtomicDataType atomicDataType) {
+		return defaultMethod(atomicDataType);
+	}
+
+	@Override
+	public R visit(CollectionDataType collectionDataType) {
+		return defaultMethod(collectionDataType);
+	}
+
+	@Override
+	public R visit(FieldsDataType fieldsDataType) {
+		return defaultMethod(fieldsDataType);
+	}
+
+	@Override
+	public R visit(KeyValueDataType keyValueDataType) {
+		return defaultMethod(keyValueDataType);
+	}
+
+	protected abstract R defaultMethod(DataType dataType);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LogicalTypeDataTypeConverter.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.utils;
+
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.logical.AnyType;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DayTimeIntervalType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeVisitor;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.NullType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.YearMonthIntervalType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A converter between {@link LogicalType} and {@link DataType}.
+ */
+public final class LogicalTypeDataTypeConverter {
+
+	private static final DefaultDataTypeCreator dataTypeCreator = new DefaultDataTypeCreator();
+
+	/**
+	 * Returns the data type of a logical type without explicit conversions.
+	 */
+	public static DataType toDataType(LogicalType logicalType) {
+		return logicalType.accept(dataTypeCreator);
+	}
+
+	/**
+	 * Returns the logical type of a data type.
+	 */
+	public static LogicalType toLogicalType(DataType dataType) {
+		return dataType.getLogicalType();
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static class DefaultDataTypeCreator implements LogicalTypeVisitor<DataType> {
+
+		@Override
+		public DataType visit(CharType charType) {
+			return new AtomicDataType(charType);
+		}
+
+		@Override
+		public DataType visit(VarCharType varCharType) {
+			return new AtomicDataType(varCharType);
+		}
+
+		@Override
+		public DataType visit(BooleanType booleanType) {
+			return new AtomicDataType(booleanType);
+		}
+
+		@Override
+		public DataType visit(BinaryType binaryType) {
+			return new AtomicDataType(binaryType);
+		}
+
+		@Override
+		public DataType visit(VarBinaryType varBinaryType) {
+			return new AtomicDataType(varBinaryType);
+		}
+
+		@Override
+		public DataType visit(DecimalType decimalType) {
+			return new AtomicDataType(decimalType);
+		}
+
+		@Override
+		public DataType visit(TinyIntType tinyIntType) {
+			return new AtomicDataType(tinyIntType);
+		}
+
+		@Override
+		public DataType visit(SmallIntType smallIntType) {
+			return new AtomicDataType(smallIntType);
+		}
+
+		@Override
+		public DataType visit(IntType intType) {
+			return new AtomicDataType(intType);
+		}
+
+		@Override
+		public DataType visit(BigIntType bigIntType) {
+			return new AtomicDataType(bigIntType);
+		}
+
+		@Override
+		public DataType visit(FloatType floatType) {
+			return new AtomicDataType(floatType);
+		}
+
+		@Override
+		public DataType visit(DoubleType doubleType) {
+			return new AtomicDataType(doubleType);
+		}
+
+		@Override
+		public DataType visit(DateType dateType) {
+			return new AtomicDataType(dateType);
+		}
+
+		@Override
+		public DataType visit(TimeType timeType) {
+			return new AtomicDataType(timeType);
+		}
+
+		@Override
+		public DataType visit(TimestampType timestampType) {
+			return new AtomicDataType(timestampType);
+		}
+
+		@Override
+		public DataType visit(ZonedTimestampType zonedTimestampType) {
+			return new AtomicDataType(zonedTimestampType);
+		}
+
+		@Override
+		public DataType visit(LocalZonedTimestampType localZonedTimestampType) {
+			return new AtomicDataType(localZonedTimestampType);
+		}
+
+		@Override
+		public DataType visit(YearMonthIntervalType yearMonthIntervalType) {
+			return new AtomicDataType(yearMonthIntervalType);
+		}
+
+		@Override
+		public DataType visit(DayTimeIntervalType dayTimeIntervalType) {
+			return new AtomicDataType(dayTimeIntervalType);
+		}
+
+		@Override
+		public DataType visit(ArrayType arrayType) {
+			return new CollectionDataType(
+				arrayType,
+				arrayType.getElementType().accept(this));
+		}
+
+		@Override
+		public DataType visit(MultisetType multisetType) {
+			return new CollectionDataType(
+				multisetType,
+				multisetType.getElementType().accept(this));
+		}
+
+		@Override
+		public DataType visit(MapType mapType) {
+			return new KeyValueDataType(
+				mapType,
+				mapType.getKeyType().accept(this),
+				mapType.getValueType().accept(this));
+		}
+
+		@Override
+		public DataType visit(RowType rowType) {
+			final Map<String, DataType> fieldDataTypes = rowType.getFields()
+				.stream()
+				.collect(Collectors.toMap(RowType.RowField::getName, f -> f.getType().accept(this)));
+			return new FieldsDataType(
+				rowType,
+				fieldDataTypes);
+		}
+
+		@Override
+		public DataType visit(DistinctType distinctType) {
+			return distinctType.getSourceType().accept(this);
+		}
+
+		@Override
+		public DataType visit(StructuredType structuredType) {
+			final Map<String, DataType> attributeDataTypes = structuredType.getAttributes()
+				.stream()
+				.collect(Collectors.toMap(StructuredAttribute::getName, a -> a.getType().accept(this)));
+			return new FieldsDataType(
+				structuredType,
+				attributeDataTypes);
+		}
+
+		@Override
+		public DataType visit(NullType nullType) {
+			return new AtomicDataType(nullType);
+		}
+
+		@Override
+		public DataType visit(AnyType anyType) {
+			return new AtomicDataType(anyType);
+		}
+
+		@Override
+		public DataType visit(LogicalType other) {
+			return new AtomicDataType(other);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private LogicalTypeDataTypeConverter() {
+		// do not instantiate
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ClassDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ClassDataTypeConverterTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.utils.ClassDataTypeConverter;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ClassDataTypeConverter}.
+ */
+@RunWith(Parameterized.class)
+public class ClassDataTypeConverterTest {
+
+	@Parameterized.Parameters(name = "[{index}] class: {0} type: {1}")
+	public static List<Object[]> testData() {
+		return Arrays.asList(
+			new Object[][]{
+
+				{long.class, DataTypes.BIGINT().notNull().bridgedTo(long.class)},
+
+				{byte[].class, DataTypes.BYTES().nullable().bridgedTo(byte[].class)},
+
+				{Long.class, DataTypes.BIGINT().nullable().bridgedTo(Long.class)},
+
+				{BigDecimal.class, null},
+
+				{
+					byte[][].class,
+					DataTypes.ARRAY(DataTypes.BYTES().nullable().bridgedTo(byte[].class))
+						.nullable()
+						.bridgedTo(byte[][].class)
+				},
+
+				{
+					Byte[].class,
+					DataTypes.ARRAY(DataTypes.TINYINT().nullable().bridgedTo(Byte.class))
+						.nullable()
+						.bridgedTo(Byte[].class)
+				},
+
+				{
+					Byte[][].class,
+					DataTypes.ARRAY(
+						DataTypes.ARRAY(DataTypes.TINYINT().nullable().bridgedTo(Byte.class))
+							.nullable()
+							.bridgedTo(Byte[].class))
+						.nullable()
+						.bridgedTo(Byte[][].class)
+				},
+
+				{
+					Integer[].class,
+					DataTypes.ARRAY(DataTypes.INT().nullable().bridgedTo(Integer.class))
+						.nullable()
+						.bridgedTo(Integer[].class)
+				},
+
+				{Row.class, null}
+			}
+		);
+	}
+
+	@Parameterized.Parameter
+	public Class<?> clazz;
+
+	@Parameterized.Parameter(1)
+	public @Nullable DataType dataType;
+
+	@Test
+	public void testClassToDataTypeConversion() {
+		assertEquals(Optional.ofNullable(dataType), ClassDataTypeConverter.extractDataType(clazz));
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -49,6 +49,7 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResolution;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
+import org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter;
 import org.apache.flink.types.Row;
 
 import org.junit.Test;
@@ -96,10 +97,13 @@ import static org.apache.flink.table.types.TypeTestingUtils.hasConversionClass;
 import static org.apache.flink.table.types.TypeTestingUtils.hasLogicalType;
 import static org.apache.flink.table.types.logical.DayTimeIntervalType.DEFAULT_DAY_PRECISION;
 import static org.apache.flink.table.types.logical.DayTimeIntervalType.DayTimeResolution.MINUTE_TO_SECOND;
+import static org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter.toDataType;
+import static org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter.toLogicalType;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /**
- * Tests for {@link DataTypes}.
+ * Tests for {@link DataTypes} and {@link LogicalTypeDataTypeConverter}.
  */
 @RunWith(Parameterized.class)
 public class DataTypesTest {
@@ -207,5 +211,15 @@ public class DataTypesTest {
 	@Test
 	public void testConversionClass() {
 		assertThat(dataType, hasConversionClass(expectedConversionClass));
+	}
+
+	@Test
+	public void testLogicalTypeToDataTypeConversion() {
+		assertThat(toDataType(expectedLogicalType), equalTo(dataType));
+	}
+
+	@Test
+	public void testDataTypeToLogicalTypeConversion() {
+		assertThat(toLogicalType(dataType), equalTo(expectedLogicalType));
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.TypeInformationAnyType;
@@ -272,6 +273,19 @@ public class LogicalTypesTest {
 	}
 
 	@Test
+	public void testTimestampTypeWithTimeAttribute() {
+		testAll(
+			new TimestampType(true, TimestampKind.ROWTIME, 9),
+			"TIMESTAMP(9)",
+			"TIMESTAMP(9) *ROWTIME*",
+			new Class[]{java.sql.Timestamp.class, java.time.LocalDateTime.class},
+			new Class[]{java.time.LocalDateTime.class},
+			new LogicalType[]{},
+			new TimestampType(3)
+		);
+	}
+
+	@Test
 	public void testZonedTimestampType() {
 		testAll(
 			new ZonedTimestampType(9),
@@ -285,11 +299,37 @@ public class LogicalTypesTest {
 	}
 
 	@Test
+	public void testZonedTimestampTypeWithTimeAttribute() {
+		testAll(
+			new ZonedTimestampType(true, TimestampKind.PROCTIME, 9),
+			"TIMESTAMP(9) WITH TIME ZONE",
+			"TIMESTAMP(9) WITH TIME ZONE *PROCTIME*",
+			new Class[]{java.time.ZonedDateTime.class, java.time.OffsetDateTime.class},
+			new Class[]{java.time.OffsetDateTime.class},
+			new LogicalType[]{},
+			new ZonedTimestampType(3)
+		);
+	}
+
+	@Test
 	public void testLocalZonedTimestampType() {
 		testAll(
 			new LocalZonedTimestampType(9),
 			"TIMESTAMP(9) WITH LOCAL TIME ZONE",
 			"TIMESTAMP(9) WITH LOCAL TIME ZONE",
+			new Class[]{java.time.Instant.class, long.class, int.class},
+			new Class[]{java.time.Instant.class},
+			new LogicalType[]{},
+			new LocalZonedTimestampType(3)
+		);
+	}
+
+	@Test
+	public void testLocalZonedTimestampTypeWithTimeAttribute() {
+		testAll(
+			new LocalZonedTimestampType(true, TimestampKind.ROWTIME, 9),
+			"TIMESTAMP(9) WITH LOCAL TIME ZONE",
+			"TIMESTAMP(9) WITH LOCAL TIME ZONE *ROWTIME*",
 			new Class[]{java.time.Instant.class, long.class, int.class},
 			new Class[]{java.time.Instant.class},
 			new LogicalType[]{},

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -104,6 +104,19 @@ public class LogicalTypesTest {
 	}
 
 	@Test
+	public void testVarCharTypeWithMaximumLength() {
+		testAll(
+			new VarCharType(Integer.MAX_VALUE),
+			"STRING",
+			"STRING",
+			new Class[]{String.class, byte[].class},
+			new Class[]{String.class, byte[].class},
+			new LogicalType[]{},
+			new VarCharType(12)
+		);
+	}
+
+	@Test
 	public void testBooleanType() {
 		testAll(
 			new BooleanType(),

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -156,6 +156,19 @@ public class LogicalTypesTest {
 	}
 
 	@Test
+	public void testVarBinaryTypeWithMaximumLength() {
+		testAll(
+			new VarBinaryType(Integer.MAX_VALUE),
+			"BYTES",
+			"BYTES",
+			new Class[]{byte[].class},
+			new Class[]{byte[].class},
+			new LogicalType[]{},
+			new VarBinaryType(12)
+		);
+	}
+
+	@Test
 	public void testDecimalType() {
 		testAll(
 			new DecimalType(10, 2),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
@@ -75,7 +75,7 @@ class FlinkLogicalTableSourceScan(
 
   override def explainTerms(pw: RelWriter): RelWriter = {
     super.explainTerms(pw)
-      .item("fields", tableSource.getTableSchema.getColumnNames.mkString(", "))
+      .item("fields", tableSource.getTableSchema.getFieldNames.mkString(", "))
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/GroupWindowITCase.scala
@@ -400,7 +400,7 @@ class GroupWindowITCase extends BatchTestBase {
     //      "c" -> new ColumnStats(9000000L, 0L, 1024D, 32, 6.1D, 0D))
     val table = new BatchTableSource[Row] {
       override def getReturnType: TypeInformation[Row] =
-        new RowTypeInfo(tableSchema.getTypes, tableSchema.getColumnNames)
+        new RowTypeInfo(tableSchema.getFieldTypes, tableSchema.getFieldNames)
 
       //      override def getTableStats: TableStats = new TableStats(10000000L, colStats)
 


### PR DESCRIPTION
## Brief change log

This PR is a preparation for FLINK-12254. It fixes a couple of shortcomings when working with the new type system and adds the first utility classes that might useful for other contributions as well.


## Verifying this change

See commit messages.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
