### PR TITLE
[hotfix][doc] fix type of fromCollection in index.md

### DIFF
--- a/docs/dev/batch/index.md
+++ b/docs/dev/batch/index.md
@@ -829,7 +829,7 @@ File-based:
 
 Collection-based:
 
-- `fromCollection(Collection)` - Creates a data set from the Java Java.util.Collection. All elements
+- `fromCollection(Collection)` - Creates a data set from a Java.util.Collection. All elements
   in the collection must be of the same type.
 
 - `fromCollection(Iterator, Class)` - Creates a data set from an iterator. The class specifies the
@@ -970,8 +970,8 @@ File-based:
 
 Collection-based:
 
-- `fromCollection(Seq)` - Creates a data set from a Seq. All elements
-  in the collection must be of the same type.
+- `fromCollection(Iterable)` - Creates a data set from an Iterable. All elements
+  returned by the Iterable must be of the same type.
 
 - `fromCollection(Iterator)` - Creates a data set from an Iterator. The class specifies the
   data type of the elements returned by the iterator.


### PR DESCRIPTION
## What is the purpose of the change
doc fix

## Brief change log
method signatures were wrong for `fromCollection` for the scala API

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

  - Does this pull request introduce a new feature? (yes / no) => no
