### PR TITLE
[FLINK-12284][Network,Metrics]Fix the incorrect inputBufferUsage metric in credit-based network mode

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1043,6 +1043,16 @@ Thus, in order to infer the metric identifier:
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>inputFloatingBuffersUsage</td>
+      <td>An estimate of the floating input buffers usage, dediciated for credit-based mode.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>inputExclusiveBuffersUsage</td>
+      <td>An estimate of the exclusive input buffers usage, dediciated for credit-based mode.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>outPoolUsage</td>
       <td>An estimate of the output buffers usage.</td>
       <td>Gauge</td>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -1042,6 +1042,16 @@ Thus, in order to infer the metric identifier:
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>inputFloatingBuffersUsage</td>
+      <td>An estimate of the floating input buffers usage, dediciated for credit-based mode.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>inputExclusiveBuffersUsage</td>
+      <td>An estimate of the exclusive input buffers usage, dediciated for credit-based mode.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>outPoolUsage</td>
       <td>An estimate of the output buffers usage.</td>
       <td>Gauge</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -224,7 +224,7 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 				inputGates[counter++] = inputGate;
 			}
 
-			registerInputMetrics(config.isNetworkDetailedMetrics(), networkInputGroup, inputGates);
+			registerInputMetrics(config.isNetworkDetailedMetrics(), config.isCreditBased(), networkInputGroup, inputGates);
 			return Arrays.asList(inputGates);
 		}
 	}
@@ -244,6 +244,7 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 			InputGate[] inputGates) {
 		NettyShuffleMetricFactory.registerLegacyNetworkMetrics(
 			config.isNetworkDetailedMetrics(),
+			config.isCreditBased(),
 			metricGroup,
 			producedPartitions,
 			inputGates);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -434,6 +434,14 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		return Math.max(0, receivedBuffers.size());
 	}
 
+	public int unsynchronizedGetExclusiveBuffersUsed() {
+		return Math.max(0, initialCredit - bufferQueue.exclusiveBuffers.size());
+	}
+
+	public int unsynchronizedGetFloatingBuffersAvailable() {
+		return Math.max(0, bufferQueue.floatingBuffers.size());
+	}
+
 	public InputChannelID getInputChannelId() {
 		return id;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputBuffersMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputBuffersMetricsTest.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.io.network.TestingConnectionManager;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.metrics.CreditBasedInputBuffersUsageGauge;
+import org.apache.flink.runtime.io.network.metrics.ExclusiveBuffersUsageGauge;
+import org.apache.flink.runtime.io.network.metrics.FloatingBuffersUsageGauge;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the metrics for input buffers usage.
+ */
+public class InputBuffersMetricsTest extends TestLogger {
+
+	@Test
+	public void testCalculateTotalBuffersSize() throws IOException {
+		int numberOfRemoteChannels = 2;
+		int numberOfLocalChannels = 0;
+
+		int numberOfBufferPerChannel = 2;
+		int numberOfBuffersPerGate = 8;
+
+		NettyShuffleEnvironment network = new NettyShuffleEnvironmentBuilder()
+			.setNetworkBuffersPerChannel(numberOfBufferPerChannel)
+			.setFloatingNetworkBuffersPerGate(numberOfBuffersPerGate)
+			.build();
+
+		SingleInputGate inputGate1 = buildInputGate(
+			network,
+			numberOfRemoteChannels,
+			numberOfLocalChannels).f0;
+
+		SingleInputGate[] inputGates = new SingleInputGate[]{inputGate1};
+		FloatingBuffersUsageGauge floatingBuffersUsageGauge = new FloatingBuffersUsageGauge(inputGates);
+		ExclusiveBuffersUsageGauge exclusiveBuffersUsageGauge = new ExclusiveBuffersUsageGauge(inputGates);
+		CreditBasedInputBuffersUsageGauge inputBufferPoolUsageGauge = new CreditBasedInputBuffersUsageGauge(
+			floatingBuffersUsageGauge,
+			exclusiveBuffersUsageGauge,
+			inputGates);
+
+		try (CloseableRegistry closeableRegistry = new CloseableRegistry()) {
+
+			closeableRegistry.registerCloseable(network::close);
+			closeableRegistry.registerCloseable(inputGate1::close);
+
+			assertEquals(numberOfBuffersPerGate, floatingBuffersUsageGauge.calculateTotalBuffers(inputGate1));
+			assertEquals(numberOfRemoteChannels * numberOfBufferPerChannel, exclusiveBuffersUsageGauge.calculateTotalBuffers(inputGate1));
+			assertEquals(numberOfRemoteChannels * numberOfBufferPerChannel + numberOfBuffersPerGate, inputBufferPoolUsageGauge.calculateTotalBuffers(inputGate1));
+		}
+	}
+
+	@Test
+	public void testExclusiveBuffersUsage() throws IOException {
+		int numberOfRemoteChannelsGate1 = 2;
+		int numberOfLocalChannelsGate1 = 0;
+		int numberOfRemoteChannelsGate2 = 1;
+		int numberOfLocalChannelsGate2 = 1;
+
+		int totalNumberOfRemoteChannels = numberOfRemoteChannelsGate1 + numberOfRemoteChannelsGate2;
+
+		int buffersPerChannel = 2;
+		int extraNetworkBuffersPerGate = 8;
+
+		NettyShuffleEnvironment network = new NettyShuffleEnvironmentBuilder()
+			.setNetworkBuffersPerChannel(buffersPerChannel)
+			.setFloatingNetworkBuffersPerGate(extraNetworkBuffersPerGate)
+			.build();
+
+		Tuple2<SingleInputGate, List<RemoteInputChannel>> tuple1 = buildInputGate(
+			network,
+			numberOfRemoteChannelsGate1,
+			numberOfLocalChannelsGate1);
+		Tuple2<SingleInputGate, List<RemoteInputChannel>> tuple2 = buildInputGate(
+			network,
+			numberOfRemoteChannelsGate2,
+			numberOfLocalChannelsGate2);
+
+		SingleInputGate inputGate1 = tuple1.f0;
+		SingleInputGate inputGate2 = tuple2.f0;
+
+		List<RemoteInputChannel> remoteInputChannels = tuple1.f1;
+
+		SingleInputGate[] inputGates = new SingleInputGate[]{tuple1.f0, tuple2.f0};
+		FloatingBuffersUsageGauge floatingBuffersUsageGauge = new FloatingBuffersUsageGauge(inputGates);
+		ExclusiveBuffersUsageGauge exclusiveBuffersUsageGauge = new ExclusiveBuffersUsageGauge(inputGates);
+		CreditBasedInputBuffersUsageGauge inputBuffersUsageGauge = new CreditBasedInputBuffersUsageGauge(
+			floatingBuffersUsageGauge,
+			exclusiveBuffersUsageGauge,
+			inputGates);
+
+		try (CloseableRegistry closeableRegistry = new CloseableRegistry()) {
+			assertEquals(0.0, exclusiveBuffersUsageGauge.getValue(), 0.0);
+			assertEquals(0.0, inputBuffersUsageGauge.getValue(), 0.0);
+
+			int totalBuffers = extraNetworkBuffersPerGate * inputGates.length + buffersPerChannel * totalNumberOfRemoteChannels;
+
+			int channelIndex = 1;
+			for (RemoteInputChannel channel : remoteInputChannels) {
+				drainAndValidate(
+					buffersPerChannel,
+					buffersPerChannel * channelIndex++,
+					channel,
+					closeableRegistry,
+					totalBuffers,
+					buffersPerChannel * totalNumberOfRemoteChannels,
+					exclusiveBuffersUsageGauge,
+					inputBuffersUsageGauge,
+					inputGate1);
+			}
+		} finally {
+			inputGate1.close();
+			inputGate2.close();
+			network.close();
+		}
+	}
+
+	@Test
+	public void testFloatingBuffersUsage() throws IOException, InterruptedException {
+
+		int numberOfRemoteChannelsGate1 = 2;
+		int numberOfLocalChannelsGate1 = 0;
+		int numberOfRemoteChannelsGate2 = 1;
+		int numberOfLocalChannelsGate2 = 1;
+
+		int totalNumberOfRemoteChannels = numberOfRemoteChannelsGate1 + numberOfRemoteChannelsGate2;
+
+		int buffersPerChannel = 2;
+		int extraNetworkBuffersPerGate = 8;
+
+		NettyShuffleEnvironment network = new NettyShuffleEnvironmentBuilder()
+			.setNetworkBuffersPerChannel(buffersPerChannel)
+			.setFloatingNetworkBuffersPerGate(extraNetworkBuffersPerGate)
+			.build();
+
+		Tuple2<SingleInputGate, List<RemoteInputChannel>> tuple1 = buildInputGate(
+			network,
+			numberOfRemoteChannelsGate1,
+			numberOfLocalChannelsGate1);
+		SingleInputGate inputGate2 = buildInputGate(
+			network,
+			numberOfRemoteChannelsGate2,
+			numberOfLocalChannelsGate2).f0;
+
+		SingleInputGate inputGate1 = tuple1.f0;
+
+		RemoteInputChannel remoteInputChannel1 = tuple1.f1.get(0);
+
+		SingleInputGate[] inputGates = new SingleInputGate[]{tuple1.f0, inputGate2};
+		FloatingBuffersUsageGauge floatingBuffersUsageGauge = new FloatingBuffersUsageGauge(inputGates);
+		ExclusiveBuffersUsageGauge exclusiveBuffersUsageGauge = new ExclusiveBuffersUsageGauge(inputGates);
+		CreditBasedInputBuffersUsageGauge inputBuffersUsageGauge = new CreditBasedInputBuffersUsageGauge(
+			floatingBuffersUsageGauge,
+			exclusiveBuffersUsageGauge,
+			inputGates);
+
+		try (CloseableRegistry closeableRegistry = new CloseableRegistry()) {
+			assertEquals(0.0, floatingBuffersUsageGauge.getValue(), 0.0);
+			assertEquals(0.0, inputBuffersUsageGauge.getValue(), 0.0);
+
+			// drain gate1's exclusive buffers
+			drainBuffer(buffersPerChannel, remoteInputChannel1, closeableRegistry);
+
+			int totalBuffers = extraNetworkBuffersPerGate * inputGates.length + buffersPerChannel * totalNumberOfRemoteChannels;
+
+			remoteInputChannel1.requestSubpartition(0);
+
+			int backlog = 3;
+			int totalRequestedBuffers = buffersPerChannel + backlog;
+
+			remoteInputChannel1.onSenderBacklog(backlog);
+
+			assertEquals(totalRequestedBuffers, remoteInputChannel1.unsynchronizedGetFloatingBuffersAvailable());
+
+			drainBuffer(totalRequestedBuffers, remoteInputChannel1, closeableRegistry);
+
+			assertEquals(0, remoteInputChannel1.unsynchronizedGetFloatingBuffersAvailable());
+			assertEquals((double) (buffersPerChannel + totalRequestedBuffers) / totalBuffers,
+				inputBuffersUsageGauge.getValue(), 0.0001);
+		} finally {
+			inputGate1.close();
+			inputGate2.close();
+			network.close();
+		}
+	}
+
+	private void drainAndValidate(
+		int numBuffersToRequest,
+		int totalRequestedBuffers,
+		RemoteInputChannel channel,
+		CloseableRegistry closeableRegistry,
+		int totalBuffers,
+		int totalExclusiveBuffers,
+		ExclusiveBuffersUsageGauge exclusiveBuffersUsageGauge,
+		CreditBasedInputBuffersUsageGauge inputBuffersUsageGauge,
+		SingleInputGate inputGate) throws IOException {
+
+		drainBuffer(numBuffersToRequest, channel, closeableRegistry);
+		assertEquals(totalRequestedBuffers, exclusiveBuffersUsageGauge.calculateUsedBuffers(inputGate));
+		assertEquals((double) totalRequestedBuffers / totalExclusiveBuffers, exclusiveBuffersUsageGauge.getValue(), 0.0001);
+		assertEquals((double) totalRequestedBuffers / totalBuffers, inputBuffersUsageGauge.getValue(), 0.0001);
+	}
+
+	private void drainBuffer(int boundary, RemoteInputChannel channel, CloseableRegistry closeableRegistry) throws IOException {
+		for (int i = 0; i < boundary; i++) {
+			Buffer buffer = channel.requestBuffer();
+			if (buffer != null) {
+				closeableRegistry.registerCloseable(buffer::recycleBuffer);
+			} else {
+				break;
+			}
+		}
+	}
+
+	private Tuple2<SingleInputGate, List<RemoteInputChannel>> buildInputGate(
+		NettyShuffleEnvironment network,
+		int numberOfRemoteChannels,
+		int numberOfLocalChannels) throws IOException {
+
+		SingleInputGate inputGate = new SingleInputGateBuilder()
+			.setNumberOfChannels(numberOfRemoteChannels + numberOfLocalChannels)
+			.setResultPartitionType(ResultPartitionType.PIPELINED_BOUNDED)
+			.setupBufferPoolFactory(network)
+			.build();
+
+		Tuple2<SingleInputGate, List<RemoteInputChannel>> res = Tuple2.of(inputGate, new ArrayList<>());
+
+		int channelIdx = 0;
+		for (int i = 0; i < numberOfRemoteChannels; i++) {
+			res.f1.add(buildRemoteChannel(channelIdx, inputGate, network));
+			channelIdx++;
+		}
+
+		for (int i = 0; i < numberOfLocalChannels; i++) {
+			buildLocalChannel(channelIdx, inputGate, network);
+		}
+		inputGate.setup();
+		return res;
+	}
+
+	private RemoteInputChannel buildRemoteChannel(
+		int channelIndex,
+		SingleInputGate inputGate,
+		NettyShuffleEnvironment network) {
+		return new InputChannelBuilder()
+			.setChannelIndex(channelIndex)
+			.setupFromNettyShuffleEnvironment(network)
+			.setConnectionManager(new TestingConnectionManager())
+			.buildRemoteAndSetToGate(inputGate);
+	}
+
+	private void buildLocalChannel(
+		int channelIndex,
+		SingleInputGate inputGate,
+		NettyShuffleEnvironment network) {
+		new InputChannelBuilder()
+			.setChannelIndex(channelIndex)
+			.setupFromNettyShuffleEnvironment(network)
+			.setConnectionManager(new TestingConnectionManager())
+			.buildLocalAndSetToGate(inputGate);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR is to fix the bug in the calculation of  inputBufferUsage. It does't now take the exclusive buffer which is assigned from global buffer pool into account. 


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
