### PR TITLE
[FLINK-12436][hive] Differentiate Flink database properties from Hive database properties

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalog.java
@@ -90,7 +90,7 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 	@Override
 	protected CatalogDatabase createCatalogDatabase(Database hiveDatabase) {
 		return new GenericCatalogDatabase(
-			hiveDatabase.getParameters(),
+			retrieveFlinkProperties(hiveDatabase.getParameters()),
 			hiveDatabase.getDescription()
 		);
 	}
@@ -102,7 +102,7 @@ public class GenericHiveMetastoreCatalog extends HiveCatalogBase {
 			catalogDatabase.getComment(),
 			// HDFS location URI which GenericCatalogDatabase shouldn't care
 			null,
-			catalogDatabase.getProperties());
+			maskFlinkProperties(catalogDatabase.getProperties()));
 	}
 
 	// ------ tables and views------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -105,9 +105,13 @@ public abstract class CatalogTestBase {
 
 	@Test
 	public void testCreateDb() throws Exception {
-		catalog.createDatabase(db2, createDb(), false);
+		assertFalse(catalog.databaseExists(db1));
 
-		assertEquals(2, catalog.listDatabases().size());
+		CatalogDatabase cd = createDb();
+		catalog.createDatabase(db1, cd, false);
+
+		assertTrue(catalog.databaseExists(db1));
+		CatalogTestUtil.checkEquals(cd, catalog.getDatabase(db1));
 	}
 
 	@Test
@@ -125,13 +129,13 @@ public abstract class CatalogTestBase {
 		catalog.createDatabase(db1, cd1, false);
 		List<String> dbs = catalog.listDatabases();
 
-		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(cd1.getProperties().entrySet()));
+		CatalogTestUtil.checkEquals(cd1, catalog.getDatabase(db1));
 		assertEquals(2, dbs.size());
 		assertEquals(new HashSet<>(Arrays.asList(db1, catalog.getDefaultDatabase())), new HashSet<>(dbs));
 
 		catalog.createDatabase(db1, createAnotherDb(), true);
 
-		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(cd1.getProperties().entrySet()));
+		CatalogTestUtil.checkEquals(cd1, catalog.getDatabase(db1));
 		assertEquals(2, dbs.size());
 		assertEquals(new HashSet<>(Arrays.asList(db1, catalog.getDefaultDatabase())), new HashSet<>(dbs));
 	}
@@ -147,11 +151,11 @@ public abstract class CatalogTestBase {
 	public void testDropDb() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
 
-		assertTrue(catalog.listDatabases().contains(db1));
+		assertTrue(catalog.databaseExists(db1));
 
 		catalog.dropDatabase(db1, false);
 
-		assertFalse(catalog.listDatabases().contains(db1));
+		assertFalse(catalog.databaseExists(db1));
 	}
 
 	@Test
@@ -181,13 +185,11 @@ public abstract class CatalogTestBase {
 		CatalogDatabase db = createDb();
 		catalog.createDatabase(db1, db, false);
 
-		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(db.getProperties().entrySet()));
-
 		CatalogDatabase newDb = createAnotherDb();
 		catalog.alterDatabase(db1, newDb, false);
 
 		assertFalse(catalog.getDatabase(db1).getProperties().entrySet().containsAll(db.getProperties().entrySet()));
-		assertTrue(catalog.getDatabase(db1).getProperties().entrySet().containsAll(newDb.getProperties().entrySet()));
+		CatalogTestUtil.checkEquals(newDb, catalog.getDatabase(db1));
 	}
 
 	@Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -46,6 +46,7 @@ public class CatalogTestUtil {
 	}
 
 	public static void checkEquals(CatalogDatabase d1, CatalogDatabase d2) {
+		assertEquals(d1.getComment(), d2.getComment());
 		assertEquals(d1.getProperties(), d2.getProperties());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support to differentiate Flink database properties from Hive database properties by using a Flink specific prefix for each property key, similar to how we differentiate Flink table properties from Hive table properties.

## Brief change log

  - Using a 'flink.' prefix for each Flink database config key stored in Hive metastore, and process flink properties upon reading and writing
  - Updated test util and a few unit tests

## Verifying this change

This change is already covered by existing tests, such as GenericHiveMetastoreCatalogTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
