### PR TITLE
[FLINK-12511][table][hive] make variable 'comment' in all catalog metadata classes final

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogDatabase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogDatabase.java
@@ -19,13 +19,11 @@
 package org.apache.flink.table.catalog.hive;
 
 import org.apache.flink.table.catalog.CatalogDatabase;
-import org.apache.flink.util.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -35,28 +33,18 @@ public class HiveCatalogDatabase implements CatalogDatabase {
 	// Property of the database
 	private final Map<String, String> properties;
 	// HDFS path of the database
-	private String location;
+	private final String location;
 	// Comment of the database
-	private String comment = "This is a hive catalog database.";
-
-	public HiveCatalogDatabase() {
-		properties = new HashMap<>();
-	}
-
-	public HiveCatalogDatabase(Map<String, String> properties) {
-		this.properties = checkNotNull(properties, "properties cannot be null");
-	}
+	private final String comment;
 
 	public HiveCatalogDatabase(Map<String, String> properties, String comment) {
-		this(properties);
-		this.comment = checkNotNull(comment, "comment cannot be null");
+		this(properties, null, comment);
 	}
 
 	public HiveCatalogDatabase(Map<String, String> properties, String location, String comment) {
-		this(properties, comment);
-
-		checkArgument(!StringUtils.isNullOrWhitespaceOnly(location), "location cannot be null or empty");
+		this.properties = checkNotNull(properties, "properties cannot be null");
 		this.location = location;
+		this.comment = checkNotNull(comment, "comment cannot be null");
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogTable.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogTable.java
@@ -41,7 +41,7 @@ public class HiveCatalogTable implements CatalogTable {
 	// Properties of the table
 	private final Map<String, String> properties;
 	// Comment of the table
-	private String comment = "This is a hive catalog table.";
+	private final String comment;
 
 	public HiveCatalogTable(
 			TableSchema tableSchema,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogView.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogView.java
@@ -48,7 +48,7 @@ public class HiveCatalogView implements CatalogView {
 	// Properties of the view
 	private final Map<String, String> properties;
 	// Comment of the view
-	private String comment = "This is a hive catalog view.";
+	private final String comment;
 
 	public HiveCatalogView(
 			String originalQuery,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogDatabase.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogDatabase.java
@@ -29,19 +29,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class GenericCatalogDatabase implements CatalogDatabase {
 	private final Map<String, String> properties;
-	private String comment = "This is a generic catalog database.";
-
-	public GenericCatalogDatabase() {
-		this.properties = new HashMap<>();
-	}
+	private final String comment;
 
 	public GenericCatalogDatabase(Map<String, String> properties) {
-		this.properties = checkNotNull(properties, "properties cannot be null");
+		this(properties, null);
 	}
 
 	public GenericCatalogDatabase(Map<String, String> properties, String comment) {
-		this(properties);
-		this.comment = checkNotNull(comment, "comment cannot be null");
+		this.properties = checkNotNull(properties, "properties cannot be null");
+		this.comment = comment;
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogTable.java
@@ -39,7 +39,7 @@ public class GenericCatalogTable implements CatalogTable {
 	// Properties of the table
 	private final Map<String, String> properties;
 	// Comment of the table
-	private String comment = "This is a generic catalog table.";
+	private final String comment;
 
 	public GenericCatalogTable(
 			TableSchema tableSchema,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogView.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogView.java
@@ -19,10 +19,14 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.util.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A generic catalog view implementation.
@@ -37,22 +41,27 @@ public class GenericCatalogView implements CatalogView {
 	// Expanded query text takes care of the this, as an example.
 	private final String expandedQuery;
 
-	private final TableSchema schema;
+	// Schema of the view (column names and types)
+	private final TableSchema tableSchema;
+	// Properties of the view
 	private final Map<String, String> properties;
-	private String comment = "This is a generic catalog view";
+	// Comment of the view
+	private final String comment;
 
-	public GenericCatalogView(String originalQuery, String expandedQuery, TableSchema schema,
-		Map<String, String> properties, String comment) {
-		this(originalQuery, expandedQuery, schema, properties);
-		this.comment = comment;
-	}
+	public GenericCatalogView(
+			String originalQuery,
+			String expandedQuery,
+			TableSchema tableSchema,
+			Map<String, String> properties,
+			String comment) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(originalQuery), "original query cannot be null or empty");
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(expandedQuery), "expanded query cannot be null or empty");
 
-	public GenericCatalogView(String originalQuery, String expandedQuery, TableSchema schema,
-		Map<String, String> properties) {
 		this.originalQuery = originalQuery;
 		this.expandedQuery = expandedQuery;
-		this.schema = schema;
-		this.properties = properties;
+		this.tableSchema = checkNotNull(tableSchema, "tableSchema cannot be null");
+		this.properties = checkNotNull(properties, "properties cannot be null");
+		this.comment = comment;
 	}
 
 	@Override
@@ -72,7 +81,7 @@ public class GenericCatalogView implements CatalogView {
 
 	@Override
 	public TableSchema getSchema() {
-		return schema;
+		return tableSchema;
 	}
 
 	@Override
@@ -82,7 +91,7 @@ public class GenericCatalogView implements CatalogView {
 
 	@Override
 	public GenericCatalogView copy() {
-		return new GenericCatalogView(this.originalQuery, this.expandedQuery, schema.copy(),
+		return new GenericCatalogView(this.originalQuery, this.expandedQuery, tableSchema.copy(),
 			new HashMap<>(this.properties), comment);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Because of historical reasons, currently the variable "comment" in all catalog metadata classes are not final yet, it has a default value and can be overwritten in constructor. It creates problems like overloaded constructors are built in a weird, if not wrong, way. (See code below).

This PR removes the default value of "comment" and make it final that can only be assigned value upon construction, and ends the not-so-well-designed overloaded constructors for catalog metadata classes.

## Brief change log

- made 'comment' in catalog metadata classes and removed its default value
- rebuilt constructors for catalog metadata classes

## Verifying this change

This change is already covered by existing tests, such as *CatalogTestBase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
