### PR TITLE
[FLINK-12452][table][hive] alterTable() should ensure existing base table and the new one are of the same type

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -319,6 +319,7 @@ public abstract class HiveCatalogBase implements Catalog {
 				if (!ignoreIfNotExists) {
 					throw new TableNotExistException(catalogName, tablePath);
 				}
+<<<<<<< HEAD
 				return;
 			}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -325,12 +325,7 @@ public abstract class HiveCatalogBase implements Catalog {
 			Table oldTable = getHiveTable(tablePath);
 			TableType oldTableType = TableType.valueOf(oldTable.getTableType());
 
-			if (oldTableType == TableType.EXTERNAL_TABLE
-					|| oldTableType == TableType.INDEX_TABLE
-					|| oldTableType == TableType.MATERIALIZED_VIEW) {
-				throw new CatalogException(
-					String.format("The existing Hive table is of type '%s', and HiveCatalogBase cannot handle it", oldTableType.name()));
-			} else if (oldTableType == TableType.VIRTUAL_VIEW) {
+			if (oldTableType == TableType.VIRTUAL_VIEW) {
 				if (!(newCatalogTable instanceof CatalogView)) {
 					throw new CatalogException(
 						String.format("Table types don't match. The existing table is a view, but the new catalog base table is not."));
@@ -344,7 +339,8 @@ public abstract class HiveCatalogBase implements Catalog {
 				// Else, do nothing
 			} else {
 				throw new CatalogException(
-					String.format("The existing table is a table, but the new catalog base table is not."));
+					String.format("Hive table type '%s' is not supported yet.",
+						oldTableType.name()));
 			}
 
 			Table newTable = createHiveTable(tablePath, newCatalogTable);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -319,7 +319,6 @@ public abstract class HiveCatalogBase implements Catalog {
 				if (!ignoreIfNotExists) {
 					throw new TableNotExistException(catalogName, tablePath);
 				}
-<<<<<<< HEAD
 				return;
 			}
 
@@ -334,18 +333,23 @@ public abstract class HiveCatalogBase implements Catalog {
 			} else if (oldTableType == TableType.VIRTUAL_VIEW) {
 				if (!(newCatalogTable instanceof CatalogView)) {
 					throw new CatalogException(
-						String.format("The existing table is a view, but the new catalog base table is not."));
+						String.format("HiveCatalogBase does not support type '%s' of existing Hive table yet.", oldTableType.name()));
+				}
+			} else if (oldTableType == TableType.VIRTUAL_VIEW) {
+				if (!(newCatalogTable instanceof CatalogView)) {
+					throw new CatalogException(
+						String.format("Table types don't match. The existing table is a view, but the new catalog base table is not."));
 				}
 				// Else, do nothing
 			} else if ((oldTableType == TableType.MANAGED_TABLE)) {
 				if (!(newCatalogTable instanceof CatalogTable)) {
 					throw new CatalogException(
-						String.format("The existing table is a table, but the new catalog base table is not."));
+						String.format("Table types don't match. The existing table is a table, but the new catalog base table is not."));
 				}
 				// Else, do nothing
 			} else {
 				throw new CatalogException(
-					String.format("HiveCatalogBase does not recognize Hive table type '%s'", oldTableType.name()));
+					String.format("The existing table is a table, but the new catalog base table is not."));
 			}
 
 			Table newTable = createHiveTable(tablePath, newCatalogTable);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.catalog.hive;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
@@ -320,13 +322,36 @@ public abstract class HiveCatalogBase implements Catalog {
 				return;
 			}
 
-			// TODO: [FLINK-12452] alterTable() in all catalogs should ensure existing base table and the new one are of the same type
+			Table oldTable = getHiveTable(tablePath);
+			TableType oldTableType = TableType.valueOf(oldTable.getTableType());
+
+			if (oldTableType == TableType.EXTERNAL_TABLE
+					|| oldTableType == TableType.INDEX_TABLE
+					|| oldTableType == TableType.MATERIALIZED_VIEW) {
+				throw new CatalogException(
+					String.format("The existing Hive table is of type '%s', and HiveCatalogBase cannot handle it", oldTableType.name()));
+			} else if (oldTableType == TableType.VIRTUAL_VIEW) {
+				if (!(newCatalogTable instanceof CatalogView)) {
+					throw new CatalogException(
+						String.format("The existing table is a view, but the new catalog base table is not."));
+				}
+				// Else, do nothing
+			} else if ((oldTableType == TableType.MANAGED_TABLE)) {
+				if (!(newCatalogTable instanceof CatalogTable)) {
+					throw new CatalogException(
+						String.format("The existing table is a table, but the new catalog base table is not."));
+				}
+				// Else, do nothing
+			} else {
+				throw new CatalogException(
+					String.format("HiveCatalogBase does not recognize Hive table type '%s'", oldTableType.name()));
+			}
+
 			Table newTable = createHiveTable(tablePath, newCatalogTable);
 
 			// client.alter_table() requires a valid location
 			// thus, if new table doesn't have that, it reuses location of the old table
 			if (!newTable.getSd().isSetLocation()) {
-				Table oldTable = getHiveTable(tablePath);
 				newTable.getSd().setLocation(oldTable.getSd().getLocation());
 			}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogBase.java
@@ -333,11 +333,6 @@ public abstract class HiveCatalogBase implements Catalog {
 			} else if (oldTableType == TableType.VIRTUAL_VIEW) {
 				if (!(newCatalogTable instanceof CatalogView)) {
 					throw new CatalogException(
-						String.format("HiveCatalogBase does not support type '%s' of existing Hive table yet.", oldTableType.name()));
-				}
-			} else if (oldTableType == TableType.VIRTUAL_VIEW) {
-				if (!(newCatalogTable instanceof CatalogView)) {
-					throw new CatalogException(
 						String.format("Table types don't match. The existing table is a view, but the new catalog base table is not."));
 				}
 				// Else, do nothing

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -212,9 +212,7 @@ public class GenericInMemoryCatalog implements Catalog {
 		if (tableExists(tablePath)) {
 			CatalogBaseTable oldTable = tables.get(tablePath);
 
-			// Theoretically, in-memory catalog can store any table and view implementations
-			// thus, instead of only check whether the input table is a table or view,
-			// we need to make sure old and new tables are of exactly the same class
+			// make sure old and new tables are of exactly the same class
 			if (oldTable.getClass() != newTable.getClass()) {
 				throw new CatalogException(
 					String.format("Table classes don't match. Existing table is '%s' and new table is '%s'. They should be of the same class.",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -212,7 +212,6 @@ public class GenericInMemoryCatalog implements Catalog {
 		if (tableExists(tablePath)) {
 			CatalogBaseTable oldTable = tables.get(tablePath);
 
-			// make sure old and new tables are of exactly the same class
 			if (oldTable.getClass() != newTable.getClass()) {
 				throw new CatalogException(
 					String.format("Table classes don't match. Existing table is '%s' and new table is '%s'. They should be of the same class.",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -212,11 +212,12 @@ public class GenericInMemoryCatalog implements Catalog {
 		if (tableExists(tablePath)) {
 			CatalogBaseTable oldTable = tables.get(tablePath);
 
-			// Theoretically, in-memory catalog can store any tables and views implementations
-			// thus, we need to check they are of the same class
+			// Theoretically, in-memory catalog can store any table and view implementations
+			// thus, instead of only check whether the input table is a table or view,
+			// we need to make sure old and new tables are of exactly the same class
 			if (oldTable.getClass() != newTable.getClass()) {
 				throw new CatalogException(
-					String.format("Existing table is '%s' and new table is '%s'. They should be of the same class.",
+					String.format("Table classes don't match. Existing table is '%s' and new table is '%s'. They should be of the same class.",
 						oldTable.getClass().getName(), newTable.getClass().getName()));
 			}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -209,11 +209,17 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkNotNull(tablePath);
 		checkNotNull(newTable);
 
-		// TODO: validate the new and old CatalogBaseTable must be of the same type. For example, this doesn't
-		//		allow alter a regular table to partitioned table, or alter a view to a table, and vice versa.
-		//		And also add unit tests.
-
 		if (tableExists(tablePath)) {
+			CatalogBaseTable oldTable = tables.get(tablePath);
+
+			// Theoretically, in-memory catalog can store any tables and views implementations
+			// thus, we need to check they are of the same class
+			if (oldTable.getClass() != newTable.getClass()) {
+				throw new CatalogException(
+					String.format("Existing table is '%s' and new table is '%s'. They should be of the same class.",
+						oldTable.getClass().getName(), newTable.getClass().getName()));
+			}
+
 			tables.put(tablePath, newTable.copy());
 		} else if (!ignoreIfNotExists) {
 			throw new TableNotExistException(catalogName, tablePath);

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.catalog;
 
+import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
@@ -106,6 +107,28 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 		assertTrue(catalog.partitionExists(path3, catalogPartitionSpec));
 		assertFalse(catalog.tableExists(path1));
 		assertFalse(catalog.partitionExists(path1, catalogPartitionSpec));
+	}
+
+	@Test
+	public void testAlterTable_alterTableWithView() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.createTable(path1, createTable(), false);
+
+		exception.expect(CatalogException.class);
+		exception.expectMessage("Existing table is 'org.apache.flink.table.catalog.GenericCatalogTable' " +
+			"and new table is 'org.apache.flink.table.catalog.GenericCatalogView'. They should be of the same class.");
+		catalog.alterTable(path1, createView(), false);
+	}
+
+	@Test
+	public void testAlterTable_alterViewWithTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.createTable(path1, createView(), false);
+
+		exception.expect(CatalogException.class);
+		exception.expectMessage("Existing table is 'org.apache.flink.table.catalog.GenericCatalogView' " +
+			"and new table is 'org.apache.flink.table.catalog.GenericCatalogTable'. They should be of the same class.");
+		catalog.alterTable(path1, createTable(), false);
 	}
 
 	// ------ partitions ------


### PR DESCRIPTION
## What is the purpose of the change

Currently all catalogs doesn't check if existing base table and the new one are of the same type in alterTable(), e.g. existing table is a view but user tries to replace it with a table. This PR adds such checks to all catalogs

## Brief change log

- added check in in-memory catalog to make sure existing and new table are of the same classes since in-memory catalog theoretically can store any table and view implementations 
- added checks in `HiveCatalogBase` to make sure 1) existing and new table are of the same type 2) not alter existing Hive tables in types that Flink cannot create for now, including EXTERNAL_TABLE, INDEX_TABLE and MATERIALZED_VIEW. Flink of course cannot alter existing ones if it cannot create them.

Note that though Flink cannot create them, it's able to read most parts of their metadata, like schema and properties, thru existing mechanism, but not their unique metadata. 

Also note that add capability of creating EXTERNAL_TABLE should be fairly easy to do, e.g. with a table property "table_type=external", we just haven't done it yet.  INDEX_TABLE and MATERIALZED_VIEW need more research.

## Verifying this change

Added new unit tests in `GenericInMemoryCatalogTest` and `CatalogTestBase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
