### PR TITLE
[FLINK-12476] [State TTL] Consider setting a default background cleanup strategy in StateTtlConfig

### DIFF
--- a/docs/dev/stream/state/state.zh.md
+++ b/docs/dev/stream/state/state.zh.md
@@ -363,7 +363,7 @@ import org.apache.flink.api.common.state.StateTtlConfig;
  <div data-lang="scala" markdown="1">
 {% highlight scala %}
 import org.apache.flink.api.common.state.StateTtlConfig
-val ttlConfig = StateTtlCon fig
+val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .cleanupIncrementally(10, true)
     .build

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -29,6 +29,9 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.EnumMap;
 
+import static org.apache.flink.api.common.state.StateTtlConfig.CleanupStrategies.EMPTY_STRATEGY;
+import static org.apache.flink.api.common.state.StateTtlConfig.IncrementalCleanupStrategy.DEFAULT_INCREMENTAL_CLEANUP_STRATEGY;
+import static org.apache.flink.api.common.state.StateTtlConfig.RocksdbCompactFilterCleanupStrategy.DEFAULT_ROCKSDB_COMPACT_FILTER_CLEANUP_STRATEGY;
 import static org.apache.flink.api.common.state.StateTtlConfig.StateVisibility.NeverReturnExpired;
 import static org.apache.flink.api.common.state.StateTtlConfig.TtlTimeCharacteristic.ProcessingTime;
 import static org.apache.flink.api.common.state.StateTtlConfig.UpdateType.OnCreateAndWrite;
@@ -166,7 +169,9 @@ public class StateTtlConfig implements Serializable {
 		private StateVisibility stateVisibility = NeverReturnExpired;
 		private TtlTimeCharacteristic ttlTimeCharacteristic = ProcessingTime;
 		private Time ttl;
-		private CleanupStrategies cleanupStrategies = new CleanupStrategies();
+		private boolean isCleanupInBackground = false;
+		private final EnumMap<CleanupStrategies.Strategies, CleanupStrategies.CleanupStrategy> strategies =
+			new EnumMap<>(CleanupStrategies.Strategies.class);
 
 		public Builder(@Nonnull Time ttl) {
 			this.ttl = ttl;
@@ -249,7 +254,7 @@ public class StateTtlConfig implements Serializable {
 		/** Cleanup expired state in full snapshot on checkpoint. */
 		@Nonnull
 		public Builder cleanupFullSnapshot() {
-			cleanupStrategies.activate(CleanupStrategies.Strategies.FULL_STATE_SCAN_SNAPSHOT);
+			strategies.put(CleanupStrategies.Strategies.FULL_STATE_SCAN_SNAPSHOT, EMPTY_STRATEGY);
 			return this;
 		}
 
@@ -284,7 +289,7 @@ public class StateTtlConfig implements Serializable {
 		public Builder cleanupIncrementally(
 			@Nonnegative int cleanupSize,
 			boolean runCleanupForEveryRecord) {
-			cleanupStrategies.activate(
+			strategies.put(
 				CleanupStrategies.Strategies.INCREMENTAL_CLEANUP,
 				new IncrementalCleanupStrategy(cleanupSize, runCleanupForEveryRecord));
 			return this;
@@ -304,8 +309,10 @@ public class StateTtlConfig implements Serializable {
 		 * https://github.com/facebook/rocksdb/blob/master/include/rocksdb/compaction_filter.h#L69
 		 * It means that the TTL filter should be tested for List state taking into account this caveat.
 		 *
+		 * @deprecated Use more general configuration method {@link #cleanupInBackground()} instead
 		 */
 		@Nonnull
+		@Deprecated
 		public Builder cleanupInRocksdbCompactFilter() {
 			return cleanupInRocksdbCompactFilter(1000L);
 		}
@@ -322,8 +329,20 @@ public class StateTtlConfig implements Serializable {
 		 */
 		@Nonnull
 		public Builder cleanupInRocksdbCompactFilter(long queryTimeAfterNumEntries) {
-			cleanupStrategies.activate(CleanupStrategies.Strategies.ROCKSDB_COMPACTION_FILTER,
+			strategies.put(
+				CleanupStrategies.Strategies.ROCKSDB_COMPACTION_FILTER,
 				new RocksdbCompactFilterCleanupStrategy(queryTimeAfterNumEntries));
+			return this;
+		}
+
+		/**
+		 * Enable cleanup of expired state in background.
+		 *
+		 * <p>Depending on actually used backend, the corresponding cleanup will kick in if supported.
+		 */
+		@Nonnull
+		public Builder cleanupInBackground() {
+			isCleanupInBackground = true;
 			return this;
 		}
 
@@ -344,7 +363,7 @@ public class StateTtlConfig implements Serializable {
 				stateVisibility,
 				ttlTimeCharacteristic,
 				ttl,
-				cleanupStrategies);
+				new CleanupStrategies(strategies, isCleanupInBackground));
 		}
 	}
 
@@ -358,7 +377,11 @@ public class StateTtlConfig implements Serializable {
 	public static class CleanupStrategies implements Serializable {
 		private static final long serialVersionUID = -1617740467277313524L;
 
-		private static final CleanupStrategy EMPTY_STRATEGY = new EmptyCleanupStrategy();
+		static final CleanupStrategy EMPTY_STRATEGY = new EmptyCleanupStrategy();
+
+		private final boolean isCleanupInBackground;
+
+		private final EnumMap<Strategies, CleanupStrategy> strategies;
 
 		/** Fixed strategies ordinals in {@code strategies} config field. */
 		enum Strategies {
@@ -376,38 +399,41 @@ public class StateTtlConfig implements Serializable {
 			private static final long serialVersionUID = 1373998465131443873L;
 		}
 
-		final EnumMap<Strategies, CleanupStrategy> strategies = new EnumMap<>(Strategies.class);
-
-		public void activate(Strategies strategy) {
-			activate(strategy, EMPTY_STRATEGY);
-		}
-
-		public void activate(Strategies strategy, CleanupStrategy config) {
-			strategies.put(strategy, config);
+		private CleanupStrategies(EnumMap<Strategies, CleanupStrategy> strategies, boolean isCleanupInBackground) {
+			this.strategies = strategies;
+			this.isCleanupInBackground = isCleanupInBackground;
 		}
 
 		public boolean inFullSnapshot() {
 			return strategies.containsKey(Strategies.FULL_STATE_SCAN_SNAPSHOT);
 		}
 
+		public boolean isCleanupInBackground() {
+			return isCleanupInBackground;
+		}
+
 		@Nullable
 		public IncrementalCleanupStrategy getIncrementalCleanupStrategy() {
-			return (IncrementalCleanupStrategy) strategies.get(Strategies.INCREMENTAL_CLEANUP);
+			IncrementalCleanupStrategy defaultStrategy = isCleanupInBackground ? DEFAULT_INCREMENTAL_CLEANUP_STRATEGY : null;
+			return (IncrementalCleanupStrategy) strategies.getOrDefault(Strategies.INCREMENTAL_CLEANUP, defaultStrategy);
 		}
 
 		public boolean inRocksdbCompactFilter() {
-			return strategies.containsKey(Strategies.ROCKSDB_COMPACTION_FILTER);
+			return getRocksdbCompactFilterCleanupStrategy() != null;
 		}
 
 		@Nullable
 		public RocksdbCompactFilterCleanupStrategy getRocksdbCompactFilterCleanupStrategy() {
-			return (RocksdbCompactFilterCleanupStrategy) strategies.get(Strategies.ROCKSDB_COMPACTION_FILTER);
+			RocksdbCompactFilterCleanupStrategy defaultStrategy = isCleanupInBackground ? DEFAULT_ROCKSDB_COMPACT_FILTER_CLEANUP_STRATEGY : null;
+			return (RocksdbCompactFilterCleanupStrategy) strategies.getOrDefault(Strategies.ROCKSDB_COMPACTION_FILTER, defaultStrategy);
 		}
 	}
 
 	/** Configuration of cleanup strategy while taking the full snapshot.  */
 	public static class IncrementalCleanupStrategy implements CleanupStrategies.CleanupStrategy {
 		private static final long serialVersionUID = 3109278696501988780L;
+
+		static final IncrementalCleanupStrategy DEFAULT_INCREMENTAL_CLEANUP_STRATEGY = new IncrementalCleanupStrategy(5, false);
 
 		/** Max number of keys pulled from queue for clean up upon state touch for any key. */
 		private final int cleanupSize;
@@ -436,6 +462,9 @@ public class StateTtlConfig implements Serializable {
 	/** Configuration of cleanup strategy using custom compaction filter in RocksDB.  */
 	public static class RocksdbCompactFilterCleanupStrategy implements CleanupStrategies.CleanupStrategy {
 		private static final long serialVersionUID = 3109278796506988980L;
+
+		static final RocksdbCompactFilterCleanupStrategy DEFAULT_ROCKSDB_COMPACT_FILTER_CLEANUP_STRATEGY =
+			new RocksdbCompactFilterCleanupStrategy(1000L);
 
 		/** Number of state entries to process by compaction filter before updating current timestamp. */
 		private final long queryTimeAfterNumEntries;

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/StateTtlConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/StateTtlConfigTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.api.common.time.Time;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link StateTtlConfig}.
+ */
+public class StateTtlConfigTest {
+
+	@Test
+	public void testStateTtlConfigBuildWithCleanupInBackground() {
+		StateTtlConfig ttlConfig = StateTtlConfig
+			.newBuilder(Time.seconds(1))
+			.cleanupInBackground()
+			.build();
+
+		assertNotNull(ttlConfig.getCleanupStrategies());
+
+		StateTtlConfig.CleanupStrategies cleanupStrategies = ttlConfig.getCleanupStrategies();
+		StateTtlConfig.IncrementalCleanupStrategy incrementalCleanupStrategy =
+			cleanupStrategies.getIncrementalCleanupStrategy();
+		StateTtlConfig.RocksdbCompactFilterCleanupStrategy rocksdbCleanupStrategy =
+			cleanupStrategies.getRocksdbCompactFilterCleanupStrategy();
+
+		assertTrue(cleanupStrategies.isCleanupInBackground());
+		assertNotNull(incrementalCleanupStrategy);
+		assertNotNull(rocksdbCleanupStrategy);
+		assertTrue(cleanupStrategies.inRocksdbCompactFilter());
+		assertEquals(5, incrementalCleanupStrategy.getCleanupSize());
+		assertFalse(incrementalCleanupStrategy.runCleanupForEveryRecord());
+		assertEquals(1000, rocksdbCleanupStrategy.getQueryTimeAfterNumEntries());
+	}
+
+}

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/DataStreamStateTTLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/DataStreamStateTTLTestProgram.java
@@ -58,8 +58,7 @@ public class DataStreamStateTTLTestProgram {
 		TtlTestConfig config = TtlTestConfig.fromArgs(pt);
 		StateTtlConfig ttlConfig = StateTtlConfig.newBuilder(config.ttl)
 			.cleanupFullSnapshot()
-			.cleanupIncrementally(5, true)
-			.cleanupInRocksdbCompactFilter()
+			.cleanupInBackground()
 			.build();
 
 		env

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
@@ -99,7 +99,7 @@ public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
 		}
 
 		StateDescriptor<?, ?> stateDesc = initTest(getConfBuilder(TTL)
-			.cleanupInRocksdbCompactFilter()
+			.cleanupInBackground()
 			.setStateVisibility(StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp)
 			.build());
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request sets a default background cleanup strategy in StateTtlConfig*

## Brief change log

  - *Added a general config method `cleanupInBackground`*
  - *Changed document*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
