### PR TITLE
[FLINK-12422] Remove IN_TESTS for make test code and production code consistent

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn.cli;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.client.cli.AbstractCustomCommandLine;
 import org.apache.flink.client.cli.CliArgsException;
 import org.apache.flink.client.cli.CliFrontend;
@@ -584,6 +585,11 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	}
 
 	public int run(String[] args) throws CliArgsException, FlinkException {
+		return runWithYarnClusterDescriptor(args, null);
+	}
+
+	@VisibleForTesting
+	public int runWithYarnClusterDescriptor(String[] args, List<File> shipFiles) throws CliArgsException, FlinkException {
 		//
 		//	Command Line Options
 		//
@@ -594,7 +600,10 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 			return 0;
 		}
 
-		final AbstractYarnClusterDescriptor yarnClusterDescriptor = createClusterDescriptor(cmd);
+		AbstractYarnClusterDescriptor yarnClusterDescriptor = createClusterDescriptor(cmd);
+		if (shipFiles != null && shipFiles.size() > 0) {
+			yarnClusterDescriptor.addShipFiles(shipFiles);
+		}
 
 		try {
 			// Query cluster for metrics


### PR DESCRIPTION
## What is the purpose of the change

*This pull request removes IN_TESTS for make test code and production code consistent*

## Brief change log

  - *Remove IN_TESTS for make test code and production code consistent*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
