### PR TITLE
[hotfix] fix typos.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
@@ -108,7 +108,7 @@ public abstract class TypeInformation<T> implements Serializable {
 
 	/**
 	 * Gets the number of logical fields in this type. This includes its nested and transitively nested
-	 * fields, in the case of composite types. In the example below, the OuterType type has three
+	 * fields, in the case of composite types. In the example above, the OuterType type has three
 	 * fields in total.
 	 *
 	 * <p>The total number of fields must be at least 1.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -76,7 +76,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 	}
 
 	/**
-	 * Executes the JobGraph of the on a mini cluster of CLusterUtil with a user
+	 * Executes the JobGraph of the on a mini cluster of ClusterUtil with a user
 	 * specified name.
 	 *
 	 * @param jobName


### PR DESCRIPTION
1. [flink-core] below -> above in TypeInformation methods
2. [flink-streaming-java] CLusterUtil -> ClusterUtil in LocalStreamEnvironment methods