### PR TITLE
[FLINK-12534][travis][python] Reduce the test cost for Python API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,10 +120,6 @@ jobs:
       env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
       name: core - hadoop 2.4.1
     - if: type = cron
-      script: ./tools/travis_controller.sh python
-      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
-      name: python - hadoop 2.4.1
-    - if: type = cron
       script: ./tools/travis_controller.sh libraries
       env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
       name: libraries - hadoop 2.4.1
@@ -155,10 +151,6 @@ jobs:
       script: ./tools/travis_controller.sh core
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
       name: core - scala 2.12
-    - if: type = cron
-      script: ./tools/travis_controller.sh python
-      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
-      name: python - scala 2.12
     - if: type = cron
       script: ./tools/travis_controller.sh libraries
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
@@ -197,7 +189,7 @@ jobs:
       jdk: "openjdk9"
       script: ./tools/travis_controller.sh python
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
-      name: python
+      name: python - jdk 9
     - if: type = cron
       jdk: "openjdk9"
       script: ./tools/travis_controller.sh libraries

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -158,7 +158,10 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
             # by removing files not required for subsequent stages
     
             # jars are re-built in subsequent stages, so no need to cache them (cannot be avoided)
-            find "$CACHE_FLINK_DIR" -maxdepth 8 -type f -name '*.jar' ! -path "$CACHE_FLINK_DIR/flink-dist/*" ! -path "*tests.jar" | xargs rm -rf
+            find "$CACHE_FLINK_DIR" -maxdepth 8 -type f -name '*.jar' \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-dist*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-table*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner/target/flink-table-planner*tests.jar" | xargs rm -rf
     
             # .git directory
             # not deleting this can cause build stability issues


### PR DESCRIPTION
## What is the purpose of the change

*This pull request removes all jars except flink-dist.jar,  flink-table.jar and flink-table-planner-test.jar from travis compile result and remove python tests in scala 2.12 and hadoop 2.4.1 travis cron test jobs. That means only these 3 jars would be cached in travis, which can make the cache file shrink by 350MB per profile. *


## Brief change log

  - *Delete more jars after compile, only flink-dist.jar,  flink-table.jar and flink-table-planner-test.jar will be cached now.*
  - *Remove python tests in scala 2.12 and hadoop 2.4.1 cron test jobs.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

  - Does this pull request introduce a new feature? (no)
