### PR TITLE
[FLINK-12336][monitoring] Add HTTPS support to InfluxDB reporter

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -655,6 +655,7 @@ Parameters:
 
 - `host` - the InfluxDB server host
 - `port` - (optional) the InfluxDB server port, defaults to `8086`
+- `scheme` - the InfluxDB scheme to access to influxdb, defaults to `http` (possibles values are `http` and  `https`)
 - `db` - the InfluxDB database to store metrics
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
@@ -666,6 +667,7 @@ Example configuration:
 metrics.reporter.influxdb.class: org.apache.flink.metrics.influxdb.InfluxdbReporter
 metrics.reporter.influxdb.host: localhost
 metrics.reporter.influxdb.port: 8086
+metrics.reporter.influxdb.scheme: http
 metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -40,6 +40,7 @@ import java.util.NoSuchElementException;
 
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.DB;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.HOST;
+import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.SCHEME;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.PASSWORD;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.PORT;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.USERNAME;
@@ -61,6 +62,7 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 	@Override
 	public void open(MetricConfig config) {
 		String host = getString(config, HOST);
+		String scheme = getString(config, SCHEME);
 		int port = getInteger(config, PORT);
 		if (!isValidHost(host) || !isValidPort(port)) {
 			throw new IllegalArgumentException("Invalid host/port configuration. Host: " + host + " Port: " + port);
@@ -69,7 +71,7 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 		if (database == null) {
 			throw new IllegalArgumentException("'" + DB.key() + "' configuration option is not set");
 		}
-		String url = String.format("http://%s:%d", host, port);
+		String url = String.format("%s://%s:%d", scheme, host, port);
 		String username = getString(config, USERNAME);
 		String password = getString(config, PASSWORD);
 

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
@@ -32,6 +32,12 @@ public class InfluxdbReporterOptions {
 		.noDefaultValue()
 		.withDescription("the InfluxDB server host");
 
+	public static final ConfigOption<Integer> SCHEME = ConfigOptions
+		.key("scheme")
+		.defaultValue("http")
+		.withDescription("the InfluxDB schema (http/https)");
+
+
 	public static final ConfigOption<Integer> PORT = ConfigOptions
 		.key("port")
 		.defaultValue(8086)

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -120,6 +120,7 @@ public class InfluxdbReporterTest extends TestLogger {
 
 	private MetricRegistryImpl createMetricRegistry() {
 		MetricConfig metricConfig = new MetricConfig();
+		metricConfig.setProperty("scheme","http");
 		metricConfig.setProperty("host", "localhost");
 		metricConfig.setProperty("port", String.valueOf(wireMockRule.port()));
 		metricConfig.setProperty("db", TEST_INFLUXDB_DB);


### PR DESCRIPTION
## What is the purpose of the change

Add HTTPS support to InfluxDB reporter

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Use an InfluxDB database with HTTPS interface

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs 
