### PR TITLE
[FLINK-12535][network] Make CheckpointBarrierHandler non-blocking

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/AsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/AsyncDataInput.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface defining couple of essential methods for asynchronous and non blocking data polling.
+ *
+ * <p>For the most efficient usage, user of this class is supposed to call {@link #pollNext()}
+ * until it returns that no more elements are available. If that happens, he should check if
+ * input {@link #isFinished()}. If not, he should wait for {@link #isAvailable()}
+ * {@link CompletableFuture} to be completed. For example:
+ *
+ * <pre>
+ * {@code
+ *	AsyncDataInput<T> input = ...;
+ *	while (!input.isFinished()) {
+ *		Optional<T> next;
+ *
+ *		while (true) {
+ *			next = input.pollNext();
+ *			if (!next.isPresent()) {
+ *				break;
+ *			}
+ *			// do something with next
+ *		}
+ *
+ *		input.isAvailable().get();
+ *	}
+ * }
+ * </pre>
+ */
+@Internal
+public interface AsyncDataInput<T> extends AvailabilityListener {
+	/**
+	 * Poll the next element. This method should be non blocking.
+	 *
+	 * @return {@code Optional.empty()} will be returned if there is no data to return or
+	 * if {@link #isFinished()} returns true. Otherwise {@code Optional.of(element)}.
+	 */
+	Optional<T> pollNext() throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityListener.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface defining couple of essential methods for listening on data availability using
+ * {@link CompletableFuture}. For usage check out for example {@link AsyncDataInput}.
+ */
+@Internal
+public interface AvailabilityListener {
+	/**
+	 * Constant that allows to avoid volatile checks {@link CompletableFuture#isDone()}. Check
+	 * {@link #isAvailable()} for more explanation.
+	 */
+	CompletableFuture<?> AVAILABLE = CompletableFuture.completedFuture(null);
+
+	/**
+	 * @return true if is finished and for example end of input was reached, false otherwise.
+	 */
+	boolean isFinished();
+
+	/**
+	 * Check if this instance is available for further processing.
+	 *
+	 * <p>When hot looping to avoid volatile access in {@link CompletableFuture#isDone()} user of
+	 * this method should do the following check:
+	 * <pre>
+	 * {@code
+	 *	AvailabilityListener input = ...;
+	 *	if (input.isAvailable() == AvailabilityListener.AVAILABLE || input.isAvailable().isDone()) {
+	 *		// do something;
+	 *	}
+	 * }
+	 * </pre>
+	 *
+	 * @return a future that is completed if there are more records available. If there are more
+	 * records available immediately, {@link #AVAILABLE} should be returned. Previously returned
+	 * not completed futures should become completed once there is more input available or if
+	 * the input {@link #isFinished()}.
+	 */
+	CompletableFuture<?> isAvailable();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/NullableAsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/NullableAsyncDataInput.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.Nullable;
+
+/**
+ * The variant of {@link AsyncDataInput} that for performance reasons returns {@code null} from
+ * {@link #pollNextNullable()} instead returning {@code Optional.empty()} from
+ * {@link AsyncDataInput#pollNext()}.
+ */
+@Internal
+public interface NullableAsyncDataInput<T> extends AvailabilityListener {
+	/**
+	 * Poll the next element. This method should be non blocking.
+	 *
+	 * @return {@code null} will be returned if there is no data to return or
+	 * if {@link #isFinished()} returns true. Otherwise return {@code element}.
+	 */
+	@Nullable
+	T pollNextNullable() throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
@@ -83,7 +83,7 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
 				}
 			}
 
-			final BufferOrEvent bufferOrEvent = inputGate.getNextBufferOrEvent().orElseThrow(IllegalStateException::new);
+			final BufferOrEvent bufferOrEvent = inputGate.getNext().orElseThrow(IllegalStateException::new);
 
 			if (bufferOrEvent.isBuffer()) {
 				currentRecordDeserializer = recordDeserializers[bufferOrEvent.getChannelIndex()];

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.io.AsyncDataInput;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -68,9 +69,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * will have an input gate attached to it. This will provide its input, which will consist of one
  * subpartition from each partition of the intermediate result.
  */
-public abstract class InputGate implements AutoCloseable {
-
-	public static final CompletableFuture<?> AVAILABLE = CompletableFuture.completedFuture(null);
+public abstract class InputGate implements AsyncDataInput<BufferOrEvent>, AutoCloseable {
 
 	protected CompletableFuture<?> isAvailable = new CompletableFuture<>();
 
@@ -85,14 +84,14 @@ public abstract class InputGate implements AutoCloseable {
 	 *
 	 * @return {@code Optional.empty()} if {@link #isFinished()} returns true.
 	 */
-	public abstract Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException;
+	public abstract Optional<BufferOrEvent> getNext() throws IOException, InterruptedException;
 
 	/**
 	 * Poll the {@link BufferOrEvent}.
 	 *
 	 * @return {@code Optional.empty()} if there is no data to return or if {@link #isFinished()} returns true.
 	 */
-	public abstract Optional<BufferOrEvent> pollNextBufferOrEvent() throws IOException, InterruptedException;
+	public abstract Optional<BufferOrEvent> pollNext() throws IOException, InterruptedException;
 
 	public abstract void sendTaskEvent(TaskEvent event) throws IOException;
 
@@ -103,6 +102,7 @@ public abstract class InputGate implements AutoCloseable {
 	 * records available immediately, {@link #AVAILABLE} should be returned. Previously returned
 	 * not completed futures should become completed once there are more records available.
 	 */
+	@Override
 	public CompletableFuture<?> isAvailable() {
 		return isAvailable;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -99,8 +99,9 @@ public abstract class InputGate implements AutoCloseable {
 	public abstract int getPageSize();
 
 	/**
-	 * @return a future that is completed if there are more records available. If there more records
-	 * available immediately, {@link #AVAILABLE} should be returned.
+	 * @return a future that is completed if there are more records available. If there are more
+	 * records available immediately, {@link #AVAILABLE} should be returned. Previously returned
+	 * not completed futures should become completed once there are more records available.
 	 */
 	public CompletableFuture<?> isAvailable() {
 		return isAvailable;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -479,12 +479,12 @@ public class SingleInputGate extends InputGate {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException {
+	public Optional<BufferOrEvent> getNext() throws IOException, InterruptedException {
 		return getNextBufferOrEvent(true);
 	}
 
 	@Override
-	public Optional<BufferOrEvent> pollNextBufferOrEvent() throws IOException, InterruptedException {
+	public Optional<BufferOrEvent> pollNext() throws IOException, InterruptedException {
 		return getNextBufferOrEvent(false);
 	}
 
@@ -567,7 +567,7 @@ public class SingleInputGate extends InputGate {
 					// 1. releasing inputChannelsWithData lock in this method and reaching this place
 					// 2. empty data notification that re-enqueues a channel
 					// we can end up with moreAvailable flag set to true, while we expect no more data.
-					checkState(!moreAvailable || !pollNextBufferOrEvent().isPresent());
+					checkState(!moreAvailable || !pollNext().isPresent());
 					moreAvailable = false;
 					hasReceivedAllEndOfPartitionEvents = true;
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -447,15 +447,7 @@ public class SingleInputGate extends InputGate {
 
 	@Override
 	public boolean isFinished() {
-		synchronized (requestLock) {
-			for (InputChannel inputChannel : inputChannels.values()) {
-				if (!inputChannel.isReleased()) {
-					return false;
-				}
-			}
-		}
-
-		return true;
+		return hasReceivedAllEndOfPartitionEvents;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -101,7 +101,7 @@ public class UnionInputGate extends InputGate {
 		synchronized (inputGatesWithData) {
 			for (InputGate inputGate : inputGates) {
 				if (inputGate instanceof UnionInputGate) {
-					// if we want to add support for this, we need to implement pollNextBufferOrEvent()
+					// if we want to add support for this, we need to implement pollNext()
 					throw new UnsupportedOperationException("Cannot union a union of input gates.");
 				}
 
@@ -159,12 +159,12 @@ public class UnionInputGate extends InputGate {
 	}
 
 	@Override
-	public Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException {
+	public Optional<BufferOrEvent> getNext() throws IOException, InterruptedException {
 		return getNextBufferOrEvent(true);
 	}
 
 	@Override
-	public Optional<BufferOrEvent> pollNextBufferOrEvent() throws IOException, InterruptedException {
+	public Optional<BufferOrEvent> pollNext() throws IOException, InterruptedException {
 		return getNextBufferOrEvent(false);
 	}
 
@@ -201,7 +201,7 @@ public class UnionInputGate extends InputGate {
 			// In case of inputGatesWithData being inaccurate do not block on an empty inputGate, but just poll the data.
 			// Do not poll the gate under inputGatesWithData lock, since this can trigger notifications
 			// that could deadlock because of wrong locks taking order.
-			Optional<BufferOrEvent> bufferOrEvent = inputGate.get().pollNextBufferOrEvent();
+			Optional<BufferOrEvent> bufferOrEvent = inputGate.get().pollNext();
 
 			synchronized (inputGatesWithData) {
 				if (bufferOrEvent.isPresent() && bufferOrEvent.get().moreAvailable()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -71,13 +71,13 @@ public class InputGateWithMetrics extends InputGate {
 	}
 
 	@Override
-	public Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException {
-		return updateMetrics(inputGate.getNextBufferOrEvent());
+	public Optional<BufferOrEvent> getNext() throws IOException, InterruptedException {
+		return updateMetrics(inputGate.getNext());
 	}
 
 	@Override
-	public Optional<BufferOrEvent> pollNextBufferOrEvent() throws IOException, InterruptedException {
-		return updateMetrics(inputGate.pollNextBufferOrEvent());
+	public Optional<BufferOrEvent> pollNext() throws IOException, InterruptedException {
+		return updateMetrics(inputGate.pollNext());
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
@@ -271,7 +271,7 @@ public class InputGateConcurrentTest {
 		@Override
 		public void go() throws Exception {
 			for (int i = numBuffers; i > 0; --i) {
-				assertNotNull(gate.getNextBufferOrEvent());
+				assertNotNull(gate.getNext());
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -95,7 +95,7 @@ public class InputGateFairnessTest {
 
 		// read all the buffers and the EOF event
 		for (int i = numberOfChannels * (buffersPerChannel + 1); i > 0; --i) {
-			assertNotNull(gate.getNextBufferOrEvent());
+			assertNotNull(gate.getNext());
 
 			int min = Integer.MAX_VALUE;
 			int max = 0;
@@ -109,7 +109,7 @@ public class InputGateFairnessTest {
 			assertTrue(max == min || max == (min + 1));
 		}
 
-		assertFalse(gate.getNextBufferOrEvent().isPresent());
+		assertFalse(gate.getNext().isPresent());
 	}
 
 	@Test
@@ -143,7 +143,7 @@ public class InputGateFairnessTest {
 
 			// read all the buffers and the EOF event
 			for (int i = 0; i < numberOfChannels * buffersPerChannel; i++) {
-				assertNotNull(gate.getNextBufferOrEvent());
+				assertNotNull(gate.getNext());
 
 				int min = Integer.MAX_VALUE;
 				int max = 0;
@@ -192,7 +192,7 @@ public class InputGateFairnessTest {
 
 		// read all the buffers and the EOF event
 		for (int i = numberOfChannels * (buffersPerChannel + 1); i > 0; --i) {
-			assertNotNull(gate.getNextBufferOrEvent());
+			assertNotNull(gate.getNext());
 
 			int min = Integer.MAX_VALUE;
 			int max = 0;
@@ -206,7 +206,7 @@ public class InputGateFairnessTest {
 			assertTrue(max == min || max == (min + 1));
 		}
 
-		assertFalse(gate.getNextBufferOrEvent().isPresent());
+		assertFalse(gate.getNext().isPresent());
 	}
 
 	@Test
@@ -235,7 +235,7 @@ public class InputGateFairnessTest {
 
 		// read all the buffers and the EOF event
 		for (int i = 0; i < numberOfChannels * buffersPerChannel; i++) {
-			assertNotNull(gate.getNextBufferOrEvent());
+			assertNotNull(gate.getNext());
 
 			int min = Integer.MAX_VALUE;
 			int max = 0;
@@ -346,13 +346,13 @@ public class InputGateFairnessTest {
 		}
 
 		@Override
-		public Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException {
+		public Optional<BufferOrEvent> getNext() throws IOException, InterruptedException {
 			synchronized (channelsWithData) {
 				assertTrue("too many input channels", channelsWithData.size() <= getNumberOfInputChannels());
 				ensureUnique(channelsWithData);
 			}
 
-			return super.getNextBufferOrEvent();
+			return super.getNext();
 		}
 
 		private void ensureUnique(Collection<InputChannel> channels) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -139,7 +139,7 @@ public class PartialConsumePipelinedResultTest extends TestLogger {
 		@Override
 		public void invoke() throws Exception {
 			InputGate gate = getEnvironment().getInputGate(0);
-			Buffer buffer = gate.getNextBufferOrEvent().orElseThrow(IllegalStateException::new).getBuffer();
+			Buffer buffer = gate.getNext().orElseThrow(IllegalStateException::new).getBuffer();
 			if (buffer != null) {
 				buffer.recycleBuffer();
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.io.AsyncDataInput;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 
@@ -54,12 +55,12 @@ public abstract class InputGateTestBase {
 			TestInputChannel inputChannelWithNewData) throws Exception {
 
 		assertFalse(inputGateToTest.isAvailable().isDone());
-		assertFalse(inputGateToTest.pollNextBufferOrEvent().isPresent());
+		assertFalse(inputGateToTest.pollNext().isPresent());
 
 		CompletableFuture<?> isAvailable = inputGateToTest.isAvailable();
 
 		assertFalse(inputGateToTest.isAvailable().isDone());
-		assertFalse(inputGateToTest.pollNextBufferOrEvent().isPresent());
+		assertFalse(inputGateToTest.pollNext().isPresent());
 
 		assertEquals(isAvailable, inputGateToTest.isAvailable());
 
@@ -68,6 +69,7 @@ public abstract class InputGateTestBase {
 
 		assertTrue(isAvailable.isDone());
 		assertTrue(inputGateToTest.isAvailable().isDone());
+		assertEquals(AsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
 	}
 
 	protected SingleInputGate createInputGate() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -527,7 +527,7 @@ public class LocalInputChannelTest {
 
 			try {
 				Optional<BufferOrEvent> boe;
-				while ((boe = inputGate.getNextBufferOrEvent()).isPresent()) {
+				while ((boe = inputGate.getNext()).isPresent()) {
 					if (boe.get().isBuffer()) {
 						boe.get().getBuffer().recycleBuffer();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -260,7 +260,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 			@Override
 			public void run() {
 				try {
-					inputGate.getNextBufferOrEvent();
+					inputGate.getNext();
 				} catch (Exception e) {
 					asyncException.set(e);
 				}
@@ -536,7 +536,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 		inputGate.setInputChannel(partitionId.getPartitionId(), localChannel);
 		localChannel.setError(new PartitionNotFoundException(partitionId));
 		try {
-			inputGate.getNextBufferOrEvent();
+			inputGate.getNext();
 
 			fail("Should throw a PartitionNotFoundException.");
 		} catch (PartitionNotFoundException notFound) {
@@ -630,13 +630,13 @@ public class SingleInputGateTest extends InputGateTestBase {
 			int expectedChannelIndex,
 			boolean expectedMoreAvailable) throws IOException, InterruptedException {
 
-		final Optional<BufferOrEvent> bufferOrEvent = inputGate.getNextBufferOrEvent();
+		final Optional<BufferOrEvent> bufferOrEvent = inputGate.getNext();
 		assertTrue(bufferOrEvent.isPresent());
 		assertEquals(expectedIsBuffer, bufferOrEvent.get().isBuffer());
 		assertEquals(expectedChannelIndex, bufferOrEvent.get().getChannelIndex());
 		assertEquals(expectedMoreAvailable, bufferOrEvent.get().moreAvailable());
 		if (!expectedMoreAvailable) {
-			assertFalse(inputGate.pollNextBufferOrEvent().isPresent());
+			assertFalse(inputGate.pollNext().isPresent());
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -100,7 +100,7 @@ public class UnionInputGateTest extends InputGateTestBase {
 
 		// Return null when the input gate has received all end-of-partition events
 		assertTrue(union.isFinished());
-		assertFalse(union.getNextBufferOrEvent().isPresent());
+		assertFalse(union.getNext().isPresent());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
@@ -279,7 +279,7 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 			public void run() {
 				try {
 					while (true) {
-						inputGate.getNextBufferOrEvent();
+						inputGate.getNext();
 					}
 				} catch (Exception e) {
 					ASYNC_CONSUMER_EXCEPTION = e;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -164,7 +164,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			// process buffered BufferOrEvents before grabbing new ones
 			Optional<BufferOrEvent> next;
 			if (currentBuffered == null) {
-				next = inputGate.getNextBufferOrEvent();
+				next = inputGate.getNext();
 			}
 			else {
 				next = Optional.ofNullable(currentBuffered.getNext());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
@@ -91,7 +91,7 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 	@Override
 	public BufferOrEvent getNextNonBlocked() throws Exception {
 		while (true) {
-			Optional<BufferOrEvent> next = inputGate.getNextBufferOrEvent();
+			Optional<BufferOrEvent> next = inputGate.getNext();
 			if (!next.isPresent()) {
 				// buffer or input exhausted
 				return null;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The BarrierTracker keeps track of what checkpoint barriers have been received from
@@ -89,17 +90,27 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 	}
 
 	@Override
-	public BufferOrEvent getNextNonBlocked() throws Exception {
+	public CompletableFuture<?> isAvailable() {
+		return inputGate.isAvailable();
+	}
+
+	@Override
+	public boolean isFinished() {
+		return inputGate.isFinished();
+	}
+
+	@Override
+	public Optional<BufferOrEvent> pollNext() throws Exception {
 		while (true) {
-			Optional<BufferOrEvent> next = inputGate.getNext();
+			Optional<BufferOrEvent> next = inputGate.pollNext();
 			if (!next.isPresent()) {
 				// buffer or input exhausted
-				return null;
+				return next;
 			}
 
 			BufferOrEvent bufferOrEvent = next.get();
 			if (bufferOrEvent.isBuffer()) {
-				return bufferOrEvent;
+				return next;
 			}
 			else if (bufferOrEvent.getEvent().getClass() == CheckpointBarrier.class) {
 				processBarrier((CheckpointBarrier) bufferOrEvent.getEvent(), bufferOrEvent.getChannelIndex());
@@ -109,7 +120,7 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 			}
 			else {
 				// some other event
-				return bufferOrEvent;
+				return next;
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -25,8 +25,6 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 
 import java.io.IOException;
 
-import static org.apache.flink.util.Preconditions.checkState;
-
 /**
  * The CheckpointBarrierHandler reacts to checkpoint barrier arriving from the input channels.
  * Different implementations may either simply track barriers, or block certain inputs on
@@ -34,15 +32,6 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Internal
 public interface CheckpointBarrierHandler extends AsyncDataInput<BufferOrEvent> {
-	/**
-	 * Blocking version of {@link #pollNext()}.
-	 */
-	@Deprecated
-	default BufferOrEvent getNextNonBlocked() throws Exception {
-		Optional<BufferOrEvent> bufferOrEvent = pollNext();
-		checkState(bufferOrEvent.isPresent());
-		return bufferOrEvent.get();
-	}
 
 	/**
 	 * Registers the task be notified once all checkpoint barriers have been received for a checkpoint.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -276,28 +277,35 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 				}
 			}
 
-			final BufferOrEvent bufferOrEvent = barrierHandler.getNextNonBlocked();
-			if (bufferOrEvent != null) {
-
-				if (bufferOrEvent.isBuffer()) {
-					currentChannel = bufferOrEvent.getChannelIndex();
-					currentRecordDeserializer = recordDeserializers[currentChannel];
-					currentRecordDeserializer.setNextBuffer(bufferOrEvent.getBuffer());
-
+			final Optional<BufferOrEvent> bufferOrEvent = barrierHandler.pollNext();
+			if (bufferOrEvent.isPresent()) {
+				processBufferOrEvent(bufferOrEvent.get());
+			} else {
+				if (!barrierHandler.isFinished()) {
+					barrierHandler.isAvailable().get();
 				} else {
-					// Event received
-					final AbstractEvent event = bufferOrEvent.getEvent();
-					if (event.getClass() != EndOfPartitionEvent.class) {
-						throw new IOException("Unexpected event: " + event);
+					isFinished = true;
+					if (!barrierHandler.isEmpty()) {
+						throw new IllegalStateException("Trailing data in checkpoint barrier handler.");
 					}
+					return false;
 				}
 			}
-			else {
-				isFinished = true;
-				if (!barrierHandler.isEmpty()) {
-					throw new IllegalStateException("Trailing data in checkpoint barrier handler.");
-				}
-				return false;
+		}
+	}
+
+	private void processBufferOrEvent(BufferOrEvent bufferOrEvent) throws IOException {
+		if (bufferOrEvent.isBuffer()) {
+			currentChannel = bufferOrEvent.getChannelIndex();
+			currentRecordDeserializer = recordDeserializers[currentChannel];
+			currentRecordDeserializer.setNextBuffer(bufferOrEvent.getBuffer());
+		}
+		else {
+			// Event received
+			final AbstractEvent event = bufferOrEvent.getEvent();
+			// TODO: with barrierHandler.isFinished() we might not need to support any events on this level.
+			if (event.getClass() != EndOfPartitionEvent.class) {
+				throw new IOException("Unexpected event: " + event);
 			}
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
@@ -44,8 +44,8 @@ import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
@@ -160,8 +160,8 @@ public class BarrierBufferAlignmentLimitTest {
 			any(CheckpointOptions.class),
 			any(CheckpointMetrics.class));
 
-		assertNull(buffer.getNextNonBlocked());
-		assertNull(buffer.getNextNonBlocked());
+		assertFalse(buffer.pollNext().isPresent());
+		assertTrue(buffer.isFinished());
 
 		buffer.cleanup();
 		checkNoTempFilesRemain();
@@ -260,8 +260,8 @@ public class BarrierBufferAlignmentLimitTest {
 		verify(toNotify, times(0)).triggerCheckpointOnBarrier(
 			argThat(new CheckpointMatcher(3L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 
-		assertNull(buffer.getNextNonBlocked());
-		assertNull(buffer.getNextNonBlocked());
+		assertFalse(buffer.pollNext().isPresent());
+		assertTrue(buffer.isFinished());
 
 		buffer.cleanup();
 		checkNoTempFilesRemain();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
@@ -122,37 +122,37 @@ public class BarrierBufferAlignmentLimitTest {
 
 		// validating the sequence of buffers
 
-		check(sequence[0], buffer.getNextNonBlocked());
-		check(sequence[1], buffer.getNextNonBlocked());
-		check(sequence[2], buffer.getNextNonBlocked());
-		check(sequence[3], buffer.getNextNonBlocked());
+		check(sequence[0], buffer.pollNext().get());
+		check(sequence[1], buffer.pollNext().get());
+		check(sequence[2], buffer.pollNext().get());
+		check(sequence[3], buffer.pollNext().get());
 
 		// start of checkpoint
 		long startTs = System.nanoTime();
-		check(sequence[6], buffer.getNextNonBlocked());
-		check(sequence[8], buffer.getNextNonBlocked());
-		check(sequence[10], buffer.getNextNonBlocked());
+		check(sequence[6], buffer.pollNext().get());
+		check(sequence[8], buffer.pollNext().get());
+		check(sequence[10], buffer.pollNext().get());
 
 		// trying to pull the next makes the alignment overflow - so buffered buffers are replayed
-		check(sequence[5], buffer.getNextNonBlocked());
+		check(sequence[5], buffer.pollNext().get());
 		validateAlignmentTime(startTs, buffer);
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(7L), any(AlignmentLimitExceededException.class));
 
 		// playing back buffered events
-		check(sequence[7], buffer.getNextNonBlocked());
-		check(sequence[11], buffer.getNextNonBlocked());
-		check(sequence[12], buffer.getNextNonBlocked());
-		check(sequence[13], buffer.getNextNonBlocked());
-		check(sequence[14], buffer.getNextNonBlocked());
+		check(sequence[7], buffer.pollNext().get());
+		check(sequence[11], buffer.pollNext().get());
+		check(sequence[12], buffer.pollNext().get());
+		check(sequence[13], buffer.pollNext().get());
+		check(sequence[14], buffer.pollNext().get());
 
 		// the additional data
-		check(sequence[15], buffer.getNextNonBlocked());
-		check(sequence[16], buffer.getNextNonBlocked());
-		check(sequence[17], buffer.getNextNonBlocked());
+		check(sequence[15], buffer.pollNext().get());
+		check(sequence[16], buffer.pollNext().get());
+		check(sequence[17], buffer.pollNext().get());
 
-		check(sequence[19], buffer.getNextNonBlocked());
-		check(sequence[20], buffer.getNextNonBlocked());
-		check(sequence[21], buffer.getNextNonBlocked());
+		check(sequence[19], buffer.pollNext().get());
+		check(sequence[20], buffer.pollNext().get());
+		check(sequence[21], buffer.pollNext().get());
 
 		// no call for a completed checkpoint must have happened
 		verify(toNotify, times(0)).triggerCheckpointOnBarrier(
@@ -217,44 +217,44 @@ public class BarrierBufferAlignmentLimitTest {
 		// validating the sequence of buffers
 		long startTs;
 
-		check(sequence[0], buffer.getNextNonBlocked());
-		check(sequence[1], buffer.getNextNonBlocked());
+		check(sequence[0], buffer.pollNext().get());
+		check(sequence[1], buffer.pollNext().get());
 
 		// start of checkpoint
 		startTs = System.nanoTime();
-		check(sequence[3], buffer.getNextNonBlocked());
-		check(sequence[7], buffer.getNextNonBlocked());
+		check(sequence[3], buffer.pollNext().get());
+		check(sequence[7], buffer.pollNext().get());
 
 		// next checkpoint also in progress
-		check(sequence[11], buffer.getNextNonBlocked());
+		check(sequence[11], buffer.pollNext().get());
 
 		// checkpoint alignment aborted due to too much data
-		check(sequence[4], buffer.getNextNonBlocked());
+		check(sequence[4], buffer.pollNext().get());
 		validateAlignmentTime(startTs, buffer);
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(3L), any(AlignmentLimitExceededException.class));
 
 		// replay buffered data - in the middle, the alignment for checkpoint 4 starts
-		check(sequence[6], buffer.getNextNonBlocked());
+		check(sequence[6], buffer.pollNext().get());
 		startTs = System.nanoTime();
-		check(sequence[12], buffer.getNextNonBlocked());
+		check(sequence[12], buffer.pollNext().get());
 
 		// only checkpoint 4 is pending now - the last checkpoint 3 barrier will not trigger success
-		check(sequence[17], buffer.getNextNonBlocked());
+		check(sequence[17], buffer.pollNext().get());
 
 		// checkpoint 4 completed - check and validate buffered replay
-		check(sequence[9], buffer.getNextNonBlocked());
+		check(sequence[9], buffer.pollNext().get());
 		validateAlignmentTime(startTs, buffer);
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(
 			argThat(new CheckpointMatcher(4L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 
-		check(sequence[10], buffer.getNextNonBlocked());
-		check(sequence[15], buffer.getNextNonBlocked());
-		check(sequence[16], buffer.getNextNonBlocked());
+		check(sequence[10], buffer.pollNext().get());
+		check(sequence[15], buffer.pollNext().get());
+		check(sequence[16], buffer.pollNext().get());
 
 		// trailing data
-		check(sequence[19], buffer.getNextNonBlocked());
-		check(sequence[20], buffer.getNextNonBlocked());
-		check(sequence[21], buffer.getNextNonBlocked());
+		check(sequence[19], buffer.pollNext().get());
+		check(sequence[20], buffer.pollNext().get());
+		check(sequence[21], buffer.pollNext().get());
 
 		// only checkpoint 4 was successfully completed, not checkpoint 3
 		verify(toNotify, times(0)).triggerCheckpointOnBarrier(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -160,7 +160,7 @@ public class BarrierBufferMassiveRandomTest {
 		public void requestPartitions() {}
 
 		@Override
-		public Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException {
+		public Optional<BufferOrEvent> getNext() throws IOException, InterruptedException {
 			currentChannel = (currentChannel + 1) % numberOfChannels;
 
 			if (barrierGens[currentChannel].isNextBarrier()) {
@@ -179,8 +179,8 @@ public class BarrierBufferMassiveRandomTest {
 		}
 
 		@Override
-		public Optional<BufferOrEvent> pollNextBufferOrEvent() throws IOException, InterruptedException {
-			return getNextBufferOrEvent();
+		public Optional<BufferOrEvent> pollNext() throws IOException, InterruptedException {
+			return getNext();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -65,7 +65,7 @@ public class BarrierBufferMassiveRandomTest {
 			BarrierBuffer barrierBuffer = new BarrierBuffer(myIG, new BufferSpiller(ioMan, myIG.getPageSize()));
 
 			for (int i = 0; i < 2000000; i++) {
-				BufferOrEvent boe = barrierBuffer.getNextNonBlocked();
+				BufferOrEvent boe = barrierBuffer.pollNext().get();
 				if (boe.isBuffer()) {
 					boe.getBuffer().recycleBuffer();
 				}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTestBase.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -83,8 +84,8 @@ public abstract class BarrierBufferTestBase {
 
 	@After
 	public void ensureEmpty() throws Exception {
-		assertNull(buffer.getNextNonBlocked());
-		assertNull(buffer.getNextNonBlocked());
+		assertFalse(buffer.pollNext().isPresent());
+		assertTrue(buffer.isFinished());
 		assertTrue(buffer.isEmpty());
 
 		buffer.cleanup();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTestBase.java
@@ -49,7 +49,6 @@ import java.util.Random;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Matchers.any;
@@ -108,7 +107,7 @@ public abstract class BarrierBufferTestBase {
 		buffer = createBarrierBuffer(1, sequence);
 
 		for (BufferOrEvent boe : sequence) {
-			assertEquals(boe, buffer.getNextNonBlocked());
+			assertEquals(boe, buffer.pollNext().get());
 		}
 
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
@@ -129,7 +128,7 @@ public abstract class BarrierBufferTestBase {
 		buffer = createBarrierBuffer(4, sequence);
 
 		for (BufferOrEvent boe : sequence) {
-			assertEquals(boe, buffer.getNextNonBlocked());
+			assertEquals(boe, buffer.pollNext().get());
 		}
 
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
@@ -158,7 +157,7 @@ public abstract class BarrierBufferTestBase {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-				assertEquals(boe, buffer.getNextNonBlocked());
+				assertEquals(boe, buffer.pollNext().get());
 			}
 		}
 	}
@@ -208,76 +207,76 @@ public abstract class BarrierBufferTestBase {
 		handler.setNextExpectedCheckpointId(1L);
 
 		// pre checkpoint 1
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(1L, handler.getNextExpectedCheckpointId());
 
 		long startTs = System.nanoTime();
 
 		// blocking while aligning for checkpoint 1
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(1L, handler.getNextExpectedCheckpointId());
 
 		// checkpoint 1 done, returning buffered data
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, handler.getNextExpectedCheckpointId());
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 		validateAlignmentBuffered(handler.getLastReportedBytesBufferedInAlignment(), sequence[5], sequence[6]);
 
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
 
 		// pre checkpoint 2
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[11], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[11], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, handler.getNextExpectedCheckpointId());
 
 		// checkpoint 2 barriers come together
 		startTs = System.nanoTime();
-		check(sequence[17], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[17], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(3L, handler.getNextExpectedCheckpointId());
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 		validateAlignmentBuffered(handler.getLastReportedBytesBufferedInAlignment());
 
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 3 starts, data buffered
-		check(sequence[20], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[20], buffer.pollNext().get(), PAGE_SIZE);
 		validateAlignmentBuffered(handler.getLastReportedBytesBufferedInAlignment(), sequence[20], sequence[21]);
 		assertEquals(4L, handler.getNextExpectedCheckpointId());
-		check(sequence[21], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[21], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 4 happens without extra data
 
 		// pre checkpoint 5
-		check(sequence[27], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[27], buffer.pollNext().get(), PAGE_SIZE);
 
 		validateAlignmentBuffered(handler.getLastReportedBytesBufferedInAlignment());
 		assertEquals(5L, handler.getNextExpectedCheckpointId());
 
-		check(sequence[28], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[29], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[28], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[29], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 5 aligning
-		check(sequence[31], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[32], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[33], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[37], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[31], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[32], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[33], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[37], buffer.pollNext().get(), PAGE_SIZE);
 
 		// buffered data from checkpoint 5 alignment
-		check(sequence[34], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[36], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[38], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[39], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[34], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[36], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[38], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[39], buffer.pollNext().get(), PAGE_SIZE);
 
 		// remaining data
-		check(sequence[41], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[42], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[43], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[44], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[41], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[42], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[43], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[44], buffer.pollNext().get(), PAGE_SIZE);
 
 		validateAlignmentBuffered(handler.getLastReportedBytesBufferedInAlignment(),
 			sequence[34], sequence[36], sequence[38], sequence[39]);
@@ -302,31 +301,31 @@ public abstract class BarrierBufferTestBase {
 		handler.setNextExpectedCheckpointId(1L);
 
 		// pre-checkpoint 1
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(1L, handler.getNextExpectedCheckpointId());
 
 		// pre-checkpoint 2
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, handler.getNextExpectedCheckpointId());
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[8], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[8], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 2 alignment
 		long startTs = System.nanoTime();
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[14], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[19], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[14], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[19], buffer.pollNext().get(), PAGE_SIZE);
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 
 		// end of stream: remaining buffered contents
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[11], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[17], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[11], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[17], buffer.pollNext().get(), PAGE_SIZE);
 	}
 
 	/**
@@ -378,64 +377,64 @@ public abstract class BarrierBufferTestBase {
 		handler.setNextExpectedCheckpointId(1L);
 
 		// around checkpoint 1
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
 
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, handler.getNextExpectedCheckpointId());
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
 
 		// alignment of checkpoint 2 - buffering also some barriers for
 		// checkpoints 3 and 4
 		long startTs = System.nanoTime();
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[20], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[23], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[20], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[23], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 2 completed
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
-		check(sequence[25], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[27], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[30], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[32], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[25], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[27], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[30], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[32], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 3 completed (emit buffered)
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[19], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[28], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[19], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[28], buffer.pollNext().get(), PAGE_SIZE);
 
 		// past checkpoint 3
-		check(sequence[36], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[38], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[36], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[38], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 4 completed (emit buffered)
-		check(sequence[22], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[26], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[31], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[33], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[39], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[22], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[26], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[31], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[33], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[39], buffer.pollNext().get(), PAGE_SIZE);
 
 		// past checkpoint 4, alignment for checkpoint 5
-		check(sequence[42], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[45], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[46], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[42], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[45], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[46], buffer.pollNext().get(), PAGE_SIZE);
 
 		// abort checkpoint 5 (end of partition)
-		check(sequence[37], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[37], buffer.pollNext().get(), PAGE_SIZE);
 
 		// start checkpoint 6 alignment
-		check(sequence[47], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[48], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[47], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[48], buffer.pollNext().get(), PAGE_SIZE);
 
 		// end of input, emit remainder
-		check(sequence[43], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[44], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[43], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[44], buffer.pollNext().get(), PAGE_SIZE);
 	}
 
 	/**
@@ -472,51 +471,51 @@ public abstract class BarrierBufferTestBase {
 		long startTs;
 
 		// initial data
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
 
 		// align checkpoint 1
 		startTs = System.nanoTime();
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(1L, buffer.getCurrentCheckpointId());
 
 		// checkpoint done - replay buffered
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 		verify(toNotify).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(1L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
 
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
 
 		// alignment of checkpoint 2
 		startTs = System.nanoTime();
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[15], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[15], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 2 aborted, checkpoint 3 started
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(3L, buffer.getCurrentCheckpointId());
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 		verify(toNotify).abortCheckpointOnBarrier(eq(2L), isA(CheckpointDeclineSubsumedException.class));
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 3 alignment in progress
-		check(sequence[19], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[19], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 3 aborted (end of partition)
-		check(sequence[20], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[20], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify).abortCheckpointOnBarrier(eq(3L), isA(InputEndOfStreamException.class));
 
 		// replay buffered data from checkpoint 3
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
 
 		// all the remaining messages
-		check(sequence[21], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[22], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[23], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[24], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[21], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[22], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[23], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[24], buffer.pollNext().get(), PAGE_SIZE);
 	}
 
 	/**
@@ -556,45 +555,45 @@ public abstract class BarrierBufferTestBase {
 		handler.setNextExpectedCheckpointId(1L);
 
 		// checkpoint 1
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(1L, buffer.getCurrentCheckpointId());
 
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
 
 		// alignment of checkpoint 2
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, buffer.getCurrentCheckpointId());
-		check(sequence[15], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[19], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[21], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[15], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[19], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[21], buffer.pollNext().get(), PAGE_SIZE);
 
 		long startTs = System.nanoTime();
 
 		// checkpoint 2 aborted, checkpoint 4 started. replay buffered
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(4L, buffer.getCurrentCheckpointId());
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[22], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[22], buffer.pollNext().get(), PAGE_SIZE);
 
 		// align checkpoint 4 remainder
-		check(sequence[25], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[26], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[25], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[26], buffer.pollNext().get(), PAGE_SIZE);
 
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 
 		// checkpoint 4 aborted (due to end of partition)
-		check(sequence[24], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[27], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[28], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[29], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[30], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[24], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[27], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[28], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[29], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[30], buffer.pollNext().get(), PAGE_SIZE);
 	}
 
 	/**
@@ -642,45 +641,45 @@ public abstract class BarrierBufferTestBase {
 		buffer = createBarrierBuffer(3, sequence);
 
 		// checkpoint 1
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(1L, buffer.getCurrentCheckpointId());
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
 
 		// alignment of checkpoint 2
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[22], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[22], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, buffer.getCurrentCheckpointId());
 
 		// checkpoint 2 completed
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[15], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[15], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 3 skipped, alignment for 4 started
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(4L, buffer.getCurrentCheckpointId());
-		check(sequence[21], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[24], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[26], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[30], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[21], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[24], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[26], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[30], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 4 completed
-		check(sequence[20], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[28], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[29], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[20], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[28], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[29], buffer.pollNext().get(), PAGE_SIZE);
 
-		check(sequence[32], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[33], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[34], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[35], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[36], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[37], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[32], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[33], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[34], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[35], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[36], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[37], buffer.pollNext().get(), PAGE_SIZE);
 	}
 
 	@Test
@@ -702,29 +701,29 @@ public abstract class BarrierBufferTestBase {
 		handler.setNextExpectedCheckpointId(1L);
 
 		// pre-checkpoint 1
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(1L, handler.getNextExpectedCheckpointId());
 
 		// pre-checkpoint 2
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, handler.getNextExpectedCheckpointId());
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[8], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[8], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 2 alignment
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[14], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[19], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[14], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[19], buffer.pollNext().get(), PAGE_SIZE);
 
 		// drain buffer
-		buffer.getNextNonBlocked();
-		buffer.getNextNonBlocked();
-		buffer.getNextNonBlocked();
-		buffer.getNextNonBlocked();
-		buffer.getNextNonBlocked();
+		buffer.pollNext().get();
+		buffer.pollNext().get();
+		buffer.pollNext().get();
+		buffer.pollNext().get();
+		buffer.pollNext().get();
 	}
 
 	@Test
@@ -759,33 +758,33 @@ public abstract class BarrierBufferTestBase {
 		buffer = createBarrierBuffer(4, sequence);
 
 		// pre checkpoint 2
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[3], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[4], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[3], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[4], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 3 alignment
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, buffer.getCurrentCheckpointId());
-		check(sequence[8], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[11], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[8], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[11], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint 3 buffered
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(3L, buffer.getCurrentCheckpointId());
 
 		// after checkpoint 4
-		check(sequence[15], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[15], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(4L, buffer.getCurrentCheckpointId());
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[17], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[17], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
 
-		check(sequence[19], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[21], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[19], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[21], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(5L, buffer.getCurrentCheckpointId());
-		check(sequence[22], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[22], buffer.pollNext().get(), PAGE_SIZE);
 	}
 
 	@Test
@@ -811,22 +810,22 @@ public abstract class BarrierBufferTestBase {
 		buffer = createBarrierBuffer(3, sequence);
 
 		// data after first checkpoint
-		check(sequence[3], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[4], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[3], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[4], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(1L, buffer.getCurrentCheckpointId());
 
 		// alignment of second checkpoint
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(2L, buffer.getCurrentCheckpointId());
 
 		// first end-of-partition encountered: checkpoint will not be completed
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[8], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[11], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[14], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[8], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[11], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[14], buffer.pollNext().get(), PAGE_SIZE);
 	}
 
 	@Test
@@ -847,19 +846,19 @@ public abstract class BarrierBufferTestBase {
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);
 
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(1L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(5L, buffer.getCurrentCheckpointId());
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(2L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(4L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(5L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 
-		check(sequence[8], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[8], buffer.pollNext().get(), PAGE_SIZE);
 		assertEquals(6L, buffer.getCurrentCheckpointId());
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(6L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
@@ -909,52 +908,52 @@ public abstract class BarrierBufferTestBase {
 		long startTs;
 
 		// successful first checkpoint, with some aligned buffers
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[1], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[1], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
 		startTs = System.nanoTime();
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(1L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[8], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[8], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
 
 		// canceled checkpoint on last barrier
 		startTs = System.nanoTime();
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(2L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
 
 		// one more successful checkpoint
-		check(sequence[15], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[15], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
 		startTs = System.nanoTime();
-		check(sequence[20], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[20], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(3L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
-		check(sequence[21], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[21], buffer.pollNext().get(), PAGE_SIZE);
 
 		// this checkpoint gets immediately canceled
-		check(sequence[24], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[24], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(4L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 
 		// some buffers
-		check(sequence[26], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[27], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[28], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[26], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[27], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[28], buffer.pollNext().get(), PAGE_SIZE);
 
 		// a simple successful checkpoint
 		startTs = System.nanoTime();
-		check(sequence[32], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[32], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(5L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
-		check(sequence[33], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[33], buffer.pollNext().get(), PAGE_SIZE);
 
-		check(sequence[37], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[37], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(6L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 	}
@@ -993,33 +992,33 @@ public abstract class BarrierBufferTestBase {
 
 		long startTs;
 
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
 
 		// starting first checkpoint
 		startTs = System.nanoTime();
-		check(sequence[4], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[8], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[4], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[8], buffer.pollNext().get(), PAGE_SIZE);
 
 		// finished first checkpoint
-		check(sequence[3], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[3], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(1L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
 
 		// re-read the queued cancellation barriers
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(2L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[14], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[14], buffer.pollNext().get(), PAGE_SIZE);
 
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[17], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[17], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
 
 		// no further alignment should have happened
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
@@ -1075,39 +1074,39 @@ public abstract class BarrierBufferTestBase {
 
 		long startTs;
 
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
 
 		// starting first checkpoint
 		startTs = System.nanoTime();
-		check(sequence[2], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[3], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[6], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[2], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[3], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[6], buffer.pollNext().get(), PAGE_SIZE);
 
 		// cancelled by cancellation barrier
-		check(sequence[4], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[4], buffer.pollNext().get(), PAGE_SIZE);
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 		verify(toNotify).abortCheckpointOnBarrier(eq(1L), any(CheckpointDeclineOnCancellationBarrierException.class));
 
 		// the next checkpoint alignment starts now
 		startTs = System.nanoTime();
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[11], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[15], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[11], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[15], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint done
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 		verify(toNotify).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(2L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
 
 		// queued data
-		check(sequence[10], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[14], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[10], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[14], buffer.pollNext().get(), PAGE_SIZE);
 
 		// trailing data
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[19], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[20], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[19], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[20], buffer.pollNext().get(), PAGE_SIZE);
 
 		// check overall notifications
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class), any(CheckpointOptions.class), any(CheckpointMetrics.class));
@@ -1153,33 +1152,33 @@ public abstract class BarrierBufferTestBase {
 
 		// validate the sequence
 
-		check(sequence[0], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[0], buffer.pollNext().get(), PAGE_SIZE);
 
 		// beginning of first checkpoint
-		check(sequence[5], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[5], buffer.pollNext().get(), PAGE_SIZE);
 
 		// future barrier aborts checkpoint
 		startTs = System.nanoTime();
-		check(sequence[3], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[3], buffer.pollNext().get(), PAGE_SIZE);
 		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(3L), any(CheckpointDeclineSubsumedException.class));
-		check(sequence[4], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[4], buffer.pollNext().get(), PAGE_SIZE);
 
 		// alignment of next checkpoint
-		check(sequence[8], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[9], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[12], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[13], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[8], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[9], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[12], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[13], buffer.pollNext().get(), PAGE_SIZE);
 
 		// checkpoint finished
-		check(sequence[7], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[7], buffer.pollNext().get(), PAGE_SIZE);
 		validateAlignmentTime(startTs, buffer.getAlignmentDurationNanos());
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(5L)), any(CheckpointOptions.class), any(CheckpointMetrics.class));
-		check(sequence[11], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[11], buffer.pollNext().get(), PAGE_SIZE);
 
 		// remaining data
-		check(sequence[16], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[17], buffer.getNextNonBlocked(), PAGE_SIZE);
-		check(sequence[18], buffer.getNextNonBlocked(), PAGE_SIZE);
+		check(sequence[16], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[17], buffer.pollNext().get(), PAGE_SIZE);
+		check(sequence[18], buffer.pollNext().get(), PAGE_SIZE);
 
 		// check overall notifications
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class), any(CheckpointOptions.class), any(CheckpointMetrics.class));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -56,8 +56,8 @@ public class BarrierTrackerTest {
 
 	@After
 	public void ensureEmpty() throws Exception {
-		assertNull(tracker.getNextNonBlocked());
-		assertNull(tracker.getNextNonBlocked());
+		assertFalse(tracker.pollNext().isPresent());
+		assertTrue(tracker.isFinished());
 		assertTrue(tracker.isEmpty());
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -67,7 +67,7 @@ public class BarrierTrackerTest {
 		tracker = createBarrierTracker(1, sequence);
 
 		for (BufferOrEvent boe : sequence) {
-			assertEquals(boe, tracker.getNextNonBlocked());
+			assertEquals(boe, tracker.pollNext().get());
 		}
 	}
 
@@ -80,7 +80,7 @@ public class BarrierTrackerTest {
 		tracker = createBarrierTracker(4, sequence);
 
 		for (BufferOrEvent boe : sequence) {
-			assertEquals(boe, tracker.getNextNonBlocked());
+			assertEquals(boe, tracker.pollNext().get());
 		}
 	}
 
@@ -103,7 +103,7 @@ public class BarrierTrackerTest {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-				assertEquals(boe, tracker.getNextNonBlocked());
+				assertEquals(boe, tracker.pollNext().get());
 			}
 		}
 	}
@@ -127,7 +127,7 @@ public class BarrierTrackerTest {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-				assertEquals(boe, tracker.getNextNonBlocked());
+				assertEquals(boe, tracker.pollNext().get());
 			}
 		}
 	}
@@ -160,7 +160,7 @@ public class BarrierTrackerTest {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-				assertEquals(boe, tracker.getNextNonBlocked());
+				assertEquals(boe, tracker.pollNext().get());
 			}
 		}
 	}
@@ -197,7 +197,7 @@ public class BarrierTrackerTest {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-				assertEquals(boe, tracker.getNextNonBlocked());
+				assertEquals(boe, tracker.pollNext().get());
 			}
 		}
 	}
@@ -273,7 +273,7 @@ public class BarrierTrackerTest {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-				assertEquals(boe, tracker.getNextNonBlocked());
+				assertEquals(boe, tracker.pollNext().get());
 			}
 		}
 	}
@@ -300,7 +300,7 @@ public class BarrierTrackerTest {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer()) {
-				assertEquals(boe, tracker.getNextNonBlocked());
+				assertEquals(boe, tracker.pollNext().get());
 			}
 			assertTrue(tracker.isEmpty());
 		}
@@ -351,7 +351,7 @@ public class BarrierTrackerTest {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer()) {
-				assertEquals(boe, tracker.getNextNonBlocked());
+				assertEquals(boe, tracker.pollNext().get());
 			}
 		}
 	}
@@ -379,7 +379,7 @@ public class BarrierTrackerTest {
 
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer() || (boe.getEvent().getClass() != CheckpointBarrier.class && boe.getEvent().getClass() != CancelCheckpointMarker.class)) {
-				assertEquals(boe, tracker.getNextNonBlocked());
+				assertEquals(boe, tracker.pollNext().get());
 			}
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -52,210 +52,174 @@ public class BarrierTrackerTest {
 	private static final int PAGE_SIZE = 512;
 
 	@Test
-	public void testSingleChannelNoBarriers() {
-		try {
-			BufferOrEvent[] sequence = { createBuffer(0), createBuffer(0), createBuffer(0) };
+	public void testSingleChannelNoBarriers() throws Exception {
+		BufferOrEvent[] sequence = { createBuffer(0), createBuffer(0), createBuffer(0) };
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
-			BarrierTracker tracker = new BarrierTracker(gate);
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
 
-			for (BufferOrEvent boe : sequence) {
+		for (BufferOrEvent boe : sequence) {
+			assertEquals(boe, tracker.getNextNonBlocked());
+		}
+
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
+	}
+
+	@Test
+	public void testMultiChannelNoBarriers() throws Exception {
+		BufferOrEvent[] sequence = { createBuffer(2), createBuffer(2), createBuffer(0),
+				createBuffer(1), createBuffer(0), createBuffer(3),
+				createBuffer(1), createBuffer(1), createBuffer(2)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 4, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
+
+		for (BufferOrEvent boe : sequence) {
+			assertEquals(boe, tracker.getNextNonBlocked());
+		}
+
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
+	}
+
+	@Test
+	public void testSingleChannelWithBarriers() throws Exception {
+		BufferOrEvent[] sequence = {
+				createBuffer(0), createBuffer(0), createBuffer(0),
+				createBarrier(1, 0),
+				createBuffer(0), createBuffer(0), createBuffer(0), createBuffer(0),
+				createBarrier(2, 0), createBarrier(3, 0),
+				createBuffer(0), createBuffer(0),
+				createBarrier(4, 0), createBarrier(5, 0), createBarrier(6, 0),
+				createBuffer(0)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
+
+		CheckpointSequenceValidator validator =
+				new CheckpointSequenceValidator(1, 2, 3, 4, 5, 6);
+		tracker.registerCheckpointEventHandler(validator);
+
+		for (BufferOrEvent boe : sequence) {
+			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
 				assertEquals(boe, tracker.getNextNonBlocked());
 			}
+		}
 
-			assertNull(tracker.getNextNonBlocked());
-			assertNull(tracker.getNextNonBlocked());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
 	}
 
 	@Test
-	public void testMultiChannelNoBarriers() {
-		try {
-			BufferOrEvent[] sequence = { createBuffer(2), createBuffer(2), createBuffer(0),
-					createBuffer(1), createBuffer(0), createBuffer(3),
-					createBuffer(1), createBuffer(1), createBuffer(2)
-			};
+	public void testSingleChannelWithSkippedBarriers() throws Exception {
+		BufferOrEvent[] sequence = {
+				createBuffer(0),
+				createBarrier(1, 0),
+				createBuffer(0), createBuffer(0),
+				createBarrier(3, 0), createBuffer(0),
+				createBarrier(4, 0), createBarrier(6, 0), createBuffer(0),
+				createBarrier(7, 0), createBuffer(0), createBarrier(10, 0),
+				createBuffer(0)
+		};
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 4, Arrays.asList(sequence));
-			BarrierTracker tracker = new BarrierTracker(gate);
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
 
-			for (BufferOrEvent boe : sequence) {
+		CheckpointSequenceValidator validator =
+				new CheckpointSequenceValidator(1, 3, 4, 6, 7, 10);
+		tracker.registerCheckpointEventHandler(validator);
+
+		for (BufferOrEvent boe : sequence) {
+			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
 				assertEquals(boe, tracker.getNextNonBlocked());
 			}
+		}
 
-			assertNull(tracker.getNextNonBlocked());
-			assertNull(tracker.getNextNonBlocked());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
 	}
 
 	@Test
-	public void testSingleChannelWithBarriers() {
-		try {
-			BufferOrEvent[] sequence = {
-					createBuffer(0), createBuffer(0), createBuffer(0),
-					createBarrier(1, 0),
-					createBuffer(0), createBuffer(0), createBuffer(0), createBuffer(0),
-					createBarrier(2, 0), createBarrier(3, 0),
-					createBuffer(0), createBuffer(0),
-					createBarrier(4, 0), createBarrier(5, 0), createBarrier(6, 0),
-					createBuffer(0)
-			};
+	public void testMultiChannelWithBarriers() throws Exception {
+		BufferOrEvent[] sequence = {
+				createBuffer(0), createBuffer(2), createBuffer(0),
+				createBarrier(1, 1), createBarrier(1, 2),
+				createBuffer(2), createBuffer(1),
+				createBarrier(1, 0),
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
-			BarrierTracker tracker = new BarrierTracker(gate);
+				createBuffer(0), createBuffer(0), createBuffer(1), createBuffer(1), createBuffer(2),
+				createBarrier(2, 0), createBarrier(2, 1), createBarrier(2, 2),
 
-			CheckpointSequenceValidator validator =
-					new CheckpointSequenceValidator(1, 2, 3, 4, 5, 6);
-			tracker.registerCheckpointEventHandler(validator);
+				createBuffer(2), createBuffer(2),
+				createBarrier(3, 2),
+				createBuffer(2), createBuffer(2),
+				createBarrier(3, 0), createBarrier(3, 1),
 
-			for (BufferOrEvent boe : sequence) {
-				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-					assertEquals(boe, tracker.getNextNonBlocked());
-				}
+				createBarrier(4, 1), createBarrier(4, 2), createBarrier(4, 0),
+
+				createBuffer(0)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
+
+		CheckpointSequenceValidator validator =
+				new CheckpointSequenceValidator(1, 2, 3, 4);
+		tracker.registerCheckpointEventHandler(validator);
+
+		for (BufferOrEvent boe : sequence) {
+			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
+				assertEquals(boe, tracker.getNextNonBlocked());
 			}
+		}
 
-			assertNull(tracker.getNextNonBlocked());
-			assertNull(tracker.getNextNonBlocked());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
 	}
 
 	@Test
-	public void testSingleChannelWithSkippedBarriers() {
-		try {
-			BufferOrEvent[] sequence = {
-					createBuffer(0),
-					createBarrier(1, 0),
-					createBuffer(0), createBuffer(0),
-					createBarrier(3, 0), createBuffer(0),
-					createBarrier(4, 0), createBarrier(6, 0), createBuffer(0),
-					createBarrier(7, 0), createBuffer(0), createBarrier(10, 0),
-					createBuffer(0)
-			};
+	public void testMultiChannelSkippingCheckpoints() throws Exception {
+		BufferOrEvent[] sequence = {
+				createBuffer(0), createBuffer(2), createBuffer(0),
+				createBarrier(1, 1), createBarrier(1, 2),
+				createBuffer(2), createBuffer(1),
+				createBarrier(1, 0),
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
-			BarrierTracker tracker = new BarrierTracker(gate);
+				createBuffer(0), createBuffer(0), createBuffer(1), createBuffer(1), createBuffer(2),
+				createBarrier(2, 0), createBarrier(2, 1), createBarrier(2, 2),
 
-			CheckpointSequenceValidator validator =
-					new CheckpointSequenceValidator(1, 3, 4, 6, 7, 10);
-			tracker.registerCheckpointEventHandler(validator);
+				createBuffer(2), createBuffer(2),
+				createBarrier(3, 2),
+				createBuffer(2), createBuffer(2),
 
-			for (BufferOrEvent boe : sequence) {
-				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-					assertEquals(boe, tracker.getNextNonBlocked());
-				}
+				// jump to checkpoint 4
+				createBarrier(4, 0),
+				createBuffer(0), createBuffer(1), createBuffer(2),
+				createBarrier(4, 1),
+				createBuffer(1),
+				createBarrier(4, 2),
+
+				createBuffer(0)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
+
+		CheckpointSequenceValidator validator =
+				new CheckpointSequenceValidator(1, 2, 4);
+		tracker.registerCheckpointEventHandler(validator);
+
+		for (BufferOrEvent boe : sequence) {
+			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
+				assertEquals(boe, tracker.getNextNonBlocked());
 			}
-
-			assertNull(tracker.getNextNonBlocked());
-			assertNull(tracker.getNextNonBlocked());
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
 
-	@Test
-	public void testMultiChannelWithBarriers() {
-		try {
-			BufferOrEvent[] sequence = {
-					createBuffer(0), createBuffer(2), createBuffer(0),
-					createBarrier(1, 1), createBarrier(1, 2),
-					createBuffer(2), createBuffer(1),
-					createBarrier(1, 0),
-
-					createBuffer(0), createBuffer(0), createBuffer(1), createBuffer(1), createBuffer(2),
-					createBarrier(2, 0), createBarrier(2, 1), createBarrier(2, 2),
-
-					createBuffer(2), createBuffer(2),
-					createBarrier(3, 2),
-					createBuffer(2), createBuffer(2),
-					createBarrier(3, 0), createBarrier(3, 1),
-
-					createBarrier(4, 1), createBarrier(4, 2), createBarrier(4, 0),
-
-					createBuffer(0)
-			};
-
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-			BarrierTracker tracker = new BarrierTracker(gate);
-
-			CheckpointSequenceValidator validator =
-					new CheckpointSequenceValidator(1, 2, 3, 4);
-			tracker.registerCheckpointEventHandler(validator);
-
-			for (BufferOrEvent boe : sequence) {
-				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-					assertEquals(boe, tracker.getNextNonBlocked());
-				}
-			}
-
-			assertNull(tracker.getNextNonBlocked());
-			assertNull(tracker.getNextNonBlocked());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-
-	@Test
-	public void testMultiChannelSkippingCheckpoints() {
-		try {
-			BufferOrEvent[] sequence = {
-					createBuffer(0), createBuffer(2), createBuffer(0),
-					createBarrier(1, 1), createBarrier(1, 2),
-					createBuffer(2), createBuffer(1),
-					createBarrier(1, 0),
-
-					createBuffer(0), createBuffer(0), createBuffer(1), createBuffer(1), createBuffer(2),
-					createBarrier(2, 0), createBarrier(2, 1), createBarrier(2, 2),
-
-					createBuffer(2), createBuffer(2),
-					createBarrier(3, 2),
-					createBuffer(2), createBuffer(2),
-
-					// jump to checkpoint 4
-					createBarrier(4, 0),
-					createBuffer(0), createBuffer(1), createBuffer(2),
-					createBarrier(4, 1),
-					createBuffer(1),
-					createBarrier(4, 2),
-
-					createBuffer(0)
-			};
-
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-			BarrierTracker tracker = new BarrierTracker(gate);
-
-			CheckpointSequenceValidator validator =
-					new CheckpointSequenceValidator(1, 2, 4);
-			tracker.registerCheckpointEventHandler(validator);
-
-			for (BufferOrEvent boe : sequence) {
-				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-					assertEquals(boe, tracker.getNextNonBlocked());
-				}
-			}
-
-			assertNull(tracker.getNextNonBlocked());
-			assertNull(tracker.getNextNonBlocked());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
 	}
 
 	/**
@@ -269,77 +233,71 @@ public class BarrierTrackerTest {
 	 * checkpoint all together.
 	 */
 	@Test
-	public void testCompleteCheckpointsOnLateBarriers() {
-		try {
-			BufferOrEvent[] sequence = {
-					// checkpoint 2
-					createBuffer(1), createBuffer(1), createBuffer(0), createBuffer(2),
-					createBarrier(2, 1), createBarrier(2, 0), createBarrier(2, 2),
+	public void testCompleteCheckpointsOnLateBarriers() throws Exception {
+		BufferOrEvent[] sequence = {
+				// checkpoint 2
+				createBuffer(1), createBuffer(1), createBuffer(0), createBuffer(2),
+				createBarrier(2, 1), createBarrier(2, 0), createBarrier(2, 2),
 
-					// incomplete checkpoint 3
-					createBuffer(1), createBuffer(0),
-					createBarrier(3, 1), createBarrier(3, 2),
+				// incomplete checkpoint 3
+				createBuffer(1), createBuffer(0),
+				createBarrier(3, 1), createBarrier(3, 2),
 
-					// some barriers from checkpoint 4
-					createBuffer(1), createBuffer(0),
-					createBarrier(4, 2), createBarrier(4, 1),
-					createBuffer(1), createBuffer(2),
+				// some barriers from checkpoint 4
+				createBuffer(1), createBuffer(0),
+				createBarrier(4, 2), createBarrier(4, 1),
+				createBuffer(1), createBuffer(2),
 
-					// last barrier from checkpoint 3
-					createBarrier(3, 0),
+				// last barrier from checkpoint 3
+				createBarrier(3, 0),
 
-					// complete checkpoint 4
-					createBuffer(0), createBarrier(4, 0),
+				// complete checkpoint 4
+				createBuffer(0), createBarrier(4, 0),
 
-					// regular checkpoint 5
-					createBuffer(1), createBuffer(2), createBarrier(5, 1),
-					createBuffer(0), createBarrier(5, 0),
-					createBuffer(1), createBarrier(5, 2),
+				// regular checkpoint 5
+				createBuffer(1), createBuffer(2), createBarrier(5, 1),
+				createBuffer(0), createBarrier(5, 0),
+				createBuffer(1), createBarrier(5, 2),
 
-					// checkpoint 6 (incomplete),
-					createBuffer(1), createBarrier(6, 1),
-					createBuffer(0), createBarrier(6, 0),
+				// checkpoint 6 (incomplete),
+				createBuffer(1), createBarrier(6, 1),
+				createBuffer(0), createBarrier(6, 0),
 
-					// checkpoint 7, with early barriers for checkpoints 8 and 9
-					createBuffer(1), createBarrier(7, 1),
-					createBuffer(0), createBarrier(7, 2),
-					createBuffer(2), createBarrier(8, 2),
-					createBuffer(0), createBarrier(8, 1),
-					createBuffer(1), createBarrier(9, 1),
+				// checkpoint 7, with early barriers for checkpoints 8 and 9
+				createBuffer(1), createBarrier(7, 1),
+				createBuffer(0), createBarrier(7, 2),
+				createBuffer(2), createBarrier(8, 2),
+				createBuffer(0), createBarrier(8, 1),
+				createBuffer(1), createBarrier(9, 1),
 
-					// complete checkpoint 7, first barriers from checkpoint 10
-					createBarrier(7, 0),
-					createBuffer(0), createBarrier(9, 2),
-					createBuffer(2), createBarrier(10, 2),
+				// complete checkpoint 7, first barriers from checkpoint 10
+				createBarrier(7, 0),
+				createBuffer(0), createBarrier(9, 2),
+				createBuffer(2), createBarrier(10, 2),
 
-					// complete checkpoint 8 and 9
-					createBarrier(8, 0),
-					createBuffer(1), createBuffer(2), createBarrier(9, 0),
+				// complete checkpoint 8 and 9
+				createBarrier(8, 0),
+				createBuffer(1), createBuffer(2), createBarrier(9, 0),
 
-					// trailing data
-					createBuffer(1), createBuffer(0), createBuffer(2)
-			};
+				// trailing data
+				createBuffer(1), createBuffer(0), createBuffer(2)
+		};
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-			BarrierTracker tracker = new BarrierTracker(gate);
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
 
-			CheckpointSequenceValidator validator =
-					new CheckpointSequenceValidator(2, 3, 4, 5, 7, 8, 9);
-			tracker.registerCheckpointEventHandler(validator);
+		CheckpointSequenceValidator validator =
+				new CheckpointSequenceValidator(2, 3, 4, 5, 7, 8, 9);
+		tracker.registerCheckpointEventHandler(validator);
 
-			for (BufferOrEvent boe : sequence) {
-				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
-					assertEquals(boe, tracker.getNextNonBlocked());
-				}
+		for (BufferOrEvent boe : sequence) {
+			if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
+				assertEquals(boe, tracker.getNextNonBlocked());
 			}
+		}
 
-			assertNull(tracker.getNextNonBlocked());
-			assertNull(tracker.getNextNonBlocked());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedBarrierBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedBarrierBufferTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 public class CreditBasedBarrierBufferTest extends BarrierBufferTestBase {
 
 	@Override
-	public BarrierBuffer createBarrierHandler(InputGate gate) throws IOException {
+	public BarrierBuffer createBarrierBuffer(InputGate gate) throws IOException {
 		return new BarrierBuffer(gate, new CachedBufferBlocker(PAGE_SIZE));
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -72,7 +72,7 @@ public class MockInputGate extends InputGate {
 	}
 
 	@Override
-	public Optional<BufferOrEvent> getNextBufferOrEvent() {
+	public Optional<BufferOrEvent> getNext() {
 		BufferOrEvent next = bufferOrEvents.poll();
 		if (next == null) {
 			return Optional.empty();
@@ -91,8 +91,8 @@ public class MockInputGate extends InputGate {
 	}
 
 	@Override
-	public Optional<BufferOrEvent> pollNextBufferOrEvent() {
-		return getNextBufferOrEvent();
+	public Optional<BufferOrEvent> pollNext() {
+		return getNext();
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/SpillingBarrierBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/SpillingBarrierBufferTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -50,8 +49,10 @@ public class SpillingBarrierBufferTest extends BarrierBufferTestBase {
 		ioManager.shutdown();
 	}
 
-	@After
-	public void checkNoTempFilesRemain() {
+	@Override
+	public void ensureEmpty() throws Exception {
+		super.ensureEmpty();
+
 		// validate that all temp files have been removed
 		for (File dir : ioManager.getSpillingDirectories()) {
 			for (String file : dir.list()) {
@@ -63,7 +64,7 @@ public class SpillingBarrierBufferTest extends BarrierBufferTestBase {
 	}
 
 	@Override
-	public BarrierBuffer createBarrierHandler(InputGate gate) throws IOException{
+	public BarrierBuffer createBarrierBuffer(InputGate gate) throws IOException{
 		return new BarrierBuffer(gate, new BufferSpiller(ioManager, PAGE_SIZE));
 	}
 


### PR DESCRIPTION
This change makes `CheckpointBarrierHandler` a non blocking class with similar interface as `InputGate`. This is one step towards a mailbox model.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
