### PR TITLE
[FLINK-12529][runtime] Release record-deserializer buffers timely to improve the efficiency of heap usage on taskmanager

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -321,8 +321,13 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 			if (event.getClass() != EndOfPartitionEvent.class) {
 				throw new IOException("Unexpected event: " + event);
 			}
+			int channelIndex = bufferOrEvent.getChannelIndex();
 
-			handleEndOfPartitionEvent(bufferOrEvent.getChannelIndex());
+			handleEndOfPartitionEvent(channelIndex);
+
+			// release the record deserializer immediately,
+			// which is very valuable in case of bounded stream
+			releaseDeserializer(channelIndex);
 		}
 	}
 
@@ -350,17 +355,27 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 
 	@Override
 	public void close() throws IOException {
-		// clear the buffers first. this part should not ever fail
-		for (RecordDeserializer<?> deserializer : recordDeserializers) {
+		// release the deserializers first. this part should not ever fail
+		for (int channelIndex = 0; channelIndex < recordDeserializers.length; channelIndex++) {
+			releaseDeserializer(channelIndex);
+		}
+
+		// cleanup the barrier handler resources
+		barrierHandler.cleanup();
+	}
+
+	private void releaseDeserializer(int channelIndex) {
+		RecordDeserializer<?> deserializer = recordDeserializers[channelIndex];
+		if (deserializer != null) {
+			// recycle buffers and clear the deserializer.
 			Buffer buffer = deserializer.getCurrentBuffer();
 			if (buffer != null && !buffer.isRecycled()) {
 				buffer.recycleBuffer();
 			}
 			deserializer.clear();
-		}
 
-		// cleanup the barrier handler resources
-		barrierHandler.cleanup();
+			recordDeserializers[channelIndex] = null;
+		}
 	}
 
 	private class ForwardingValveOutputHandler1 implements StatusWatermarkValve.ValveOutputHandler {


### PR DESCRIPTION
## What is the purpose of the change

This pull request releases the buffer of  the corresponding record deserializer after receiving `EndOfPartitionEvent` from the input channel  to improve the efficiency of heap memory usage on taskmanager.


## Brief change log

  - Change `StreamInputProcessor` to release the buffer of the corresponding record deserializer immediately after receiving `EndOfPartitionEvent` from the input channel
  - Change `StreamTwoInputProcessor` to release the buffer of the corresponding record deserializer immediately after receiving `EndOfPartitionEvent` from the input channel


## Verifying this change

This change is already covered by existing tests, such as `OneInputStreamTaskTest`, `TwoInputStreamTaskTest`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
