### PR TITLE
[FLINK-12490][network] Introduce Input and NetworkInput interfaces

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -570,6 +570,7 @@ public class SingleInputGate extends InputGate {
 					checkState(!moreAvailable || !pollNext().isPresent());
 					moreAvailable = false;
 					hasReceivedAllEndOfPartitionEvents = true;
+					markAvailable();
 				}
 
 				currentChannel.notifySubpartitionConsumed();
@@ -578,6 +579,15 @@ public class SingleInputGate extends InputGate {
 
 			return new BufferOrEvent(event, currentChannel.getChannelIndex(), moreAvailable, buffer.getSize());
 		}
+	}
+
+	private void markAvailable() {
+		CompletableFuture<?> toNotfiy;
+		synchronized (inputChannelsWithData) {
+			toNotfiy = isAvailable;
+			isAvailable = AVAILABLE;
+		}
+		toNotfiy.complete(null);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -138,13 +138,7 @@ public class UnionInputGate extends InputGate {
 
 	@Override
 	public boolean isFinished() {
-		for (InputGate inputGate : inputGates) {
-			if (!inputGate.isFinished()) {
-				return false;
-			}
-		}
-
-		return true;
+		return inputGatesWithRemainingData.isEmpty();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
@@ -72,6 +72,23 @@ public abstract class InputGateTestBase {
 		assertEquals(AsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
 	}
 
+	protected void testIsAvailableAfterFinished(
+		InputGate inputGateToTest,
+		Runnable endOfPartitionEvent) throws Exception {
+
+		CompletableFuture<?> available = inputGateToTest.isAvailable();
+		assertFalse(available.isDone());
+		assertFalse(inputGateToTest.pollNext().isPresent());
+
+		endOfPartitionEvent.run();
+
+		assertTrue(inputGateToTest.pollNext().isPresent()); // EndOfPartitionEvent
+
+		assertTrue(available.isDone());
+		assertTrue(inputGateToTest.isAvailable().isDone());
+		assertEquals(AsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
+	}
+
 	protected SingleInputGate createInputGate() {
 		return createInputGate(2);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -129,6 +129,20 @@ public class SingleInputGateTest extends InputGateTestBase {
 	}
 
 	@Test
+	public void testIsAvailableAfterFinished() throws Exception {
+		final SingleInputGate inputGate = createInputGate(1);
+		TestInputChannel inputChannel = new TestInputChannel(inputGate, 0);
+		inputGate.setInputChannel(new IntermediateResultPartitionID(), inputChannel);
+
+		testIsAvailableAfterFinished(
+			inputGate,
+			() -> {
+				inputChannel.readEndOfPartitionEvent();
+				inputGate.notifyChannelNonEmpty(inputChannel);
+			});
+	}
+
+	@Test
 	public void testIsMoreAvailableReadingFromSingleInputChannel() throws Exception {
 		// Setup
 		final SingleInputGate inputGate = createInputGate();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -77,7 +77,7 @@ public class TestInputChannel extends InputChannel {
 		return read(buffer, moreAvailable);
 	}
 
-	TestInputChannel readEndOfPartitionEvent() throws InterruptedException {
+	TestInputChannel readEndOfPartitionEvent() {
 		addBufferAndAvailability(
 			() -> {
 				setReleased();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -115,4 +115,24 @@ public class UnionInputGateTest extends InputGateTestBase {
 
 		testIsAvailable(new UnionInputGate(inputGate1, inputGate2), inputGate1, inputChannel1);
 	}
+
+	@Test
+	public void testIsAvailableAfterFinished() throws Exception {
+		final SingleInputGate inputGate1 = createInputGate(1);
+		TestInputChannel inputChannel1 = new TestInputChannel(inputGate1, 0);
+		inputGate1.setInputChannel(new IntermediateResultPartitionID(), inputChannel1);
+
+		final SingleInputGate inputGate2 = createInputGate(1);
+		TestInputChannel inputChannel2 = new TestInputChannel(inputGate2, 0);
+		inputGate2.setInputChannel(new IntermediateResultPartitionID(), inputChannel2);
+
+		testIsAvailableAfterFinished(
+			new UnionInputGate(inputGate1, inputGate2),
+			() -> {
+				inputChannel1.readEndOfPartitionEvent();
+				inputChannel2.readEndOfPartitionEvent();
+				inputGate1.notifyChannelNonEmpty(inputChannel1);
+				inputGate2.notifyChannelNonEmpty(inputChannel2);
+			});
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -588,6 +588,11 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		}
 	}
 
+	@Override
+	public int getNumberOfInputChannels() {
+		return totalNumberOfInputChannels;
+	}
+
 	// ------------------------------------------------------------------------
 	// Utilities
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
@@ -151,6 +151,11 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 		return 0L;
 	}
 
+	@Override
+	public int getNumberOfInputChannels() {
+		return totalNumberOfInputChannels;
+	}
+
 	private void processBarrier(CheckpointBarrier receivedBarrier, int channelIndex) throws Exception {
 		final long barrierId = receivedBarrier.getId();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -61,4 +61,9 @@ public interface CheckpointBarrierHandler extends AsyncDataInput<BufferOrEvent> 
 	 * @return The duration in nanoseconds
 	 */
 	long getAlignmentDurationNanos();
+
+	/**
+	 * @return number of underlying input channels.
+	 */
+	int getNumberOfInputChannels();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -74,9 +74,6 @@ public class StreamInputProcessor<IN> {
 	/** Valve that controls how watermarks and stream statuses are forwarded. */
 	private StatusWatermarkValve statusWatermarkValve;
 
-	/** Number of input channels the valve needs to handle. */
-	private final int numInputChannels;
-
 	private final StreamStatusMaintainer streamStatusMaintainer;
 
 	private final OneInputStreamOperator<IN, ?> streamOperator;
@@ -114,14 +111,12 @@ public class StreamInputProcessor<IN> {
 
 		this.lock = checkNotNull(lock);
 
-		this.numInputChannels = inputGate.getNumberOfInputChannels();
-
 		this.streamStatusMaintainer = checkNotNull(streamStatusMaintainer);
 		this.streamOperator = checkNotNull(streamOperator);
 
 		this.statusWatermarkValve = new StatusWatermarkValve(
-				numInputChannels,
-				new ForwardingValveOutputHandler(streamOperator, lock));
+			inputGate.getNumberOfInputChannels(),
+			new ForwardingValveOutputHandler(streamOperator, lock));
 
 		this.watermarkGauge = watermarkGauge;
 		metrics.gauge("checkpointAlignmentTime", barrierHandler::getAlignmentDurationNanos);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskInput.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.NullableAsyncDataInput;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+
+import java.io.Closeable;
+
+/**
+ * Basic interface for inputs of stream operators.
+ */
+@Internal
+public interface StreamTaskInput extends NullableAsyncDataInput<StreamElement>, Closeable {
+	int UNSPECIFIED = -1;
+
+	/**
+	 * @return channel index of last returned {@link StreamElement}, or {@link #UNSPECIFIED} if
+	 * it is unspecified.
+	 */
+	int getLastChannel();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
+import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer.DeserializationResult;
+import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.plugable.DeserializationDelegate;
+import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Implementation of {@link StreamTaskInput} that wraps an input from network taken from {@link CheckpointBarrierHandler}.
+ */
+@Internal
+public final class StreamTaskNetworkInput implements StreamTaskInput {
+
+	private final CheckpointBarrierHandler barrierHandler;
+
+	private final DeserializationDelegate<StreamElement> deserializationDelegate;
+
+	private final RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers;
+
+	private int lastChannel = UNSPECIFIED;
+
+	private RecordDeserializer<DeserializationDelegate<StreamElement>> currentRecordDeserializer = null;
+
+	private boolean isFinished = false;
+
+	@SuppressWarnings("unchecked")
+	public StreamTaskNetworkInput(
+			CheckpointBarrierHandler barrierHandler,
+			TypeSerializer<?> inputSerializer,
+			IOManager ioManager) {
+		this.barrierHandler = barrierHandler;
+		this.deserializationDelegate = new NonReusingDeserializationDelegate<>(
+			new StreamElementSerializer<>(inputSerializer));
+
+		// Initialize one deserializer per input channel
+		this.recordDeserializers = new SpillingAdaptiveSpanningRecordDeserializer[barrierHandler.getNumberOfInputChannels()];
+		for (int i = 0; i < recordDeserializers.length; i++) {
+			recordDeserializers[i] = new SpillingAdaptiveSpanningRecordDeserializer<>(
+				ioManager.getSpillingDirectoriesPaths());
+		}
+	}
+
+	@Override
+	@Nullable
+	public StreamElement pollNextNullable() throws Exception {
+
+		while (true) {
+			// get the stream element from the deserializer
+			if (currentRecordDeserializer != null) {
+				DeserializationResult result = currentRecordDeserializer.getNextRecord(deserializationDelegate);
+				if (result.isBufferConsumed()) {
+					currentRecordDeserializer.getCurrentBuffer().recycleBuffer();
+					currentRecordDeserializer = null;
+				}
+
+				if (result.isFullRecord()) {
+					return deserializationDelegate.getInstance();
+				}
+			}
+
+			Optional<BufferOrEvent> bufferOrEvent = barrierHandler.pollNext();
+			if (bufferOrEvent.isPresent()) {
+				processBufferOrEvent(bufferOrEvent.get());
+			} else {
+				if (barrierHandler.isFinished()) {
+					isFinished = true;
+					checkState(barrierHandler.isAvailable().isDone(), "Finished BarrierHandler should be available");
+					if (!barrierHandler.isEmpty()) {
+						throw new IllegalStateException("Trailing data in checkpoint barrier handler.");
+					}
+				}
+				return null;
+			}
+		}
+	}
+
+	private void processBufferOrEvent(BufferOrEvent bufferOrEvent) throws IOException {
+		if (bufferOrEvent.isBuffer()) {
+			lastChannel = bufferOrEvent.getChannelIndex();
+			currentRecordDeserializer = recordDeserializers[lastChannel];
+			currentRecordDeserializer.setNextBuffer(bufferOrEvent.getBuffer());
+		}
+		else {
+			// Event received
+			final AbstractEvent event = bufferOrEvent.getEvent();
+			// TODO: with barrierHandler.isFinished() we might not need to support any events on this level.
+			if (event.getClass() != EndOfPartitionEvent.class) {
+				throw new IOException("Unexpected event: " + event);
+			}
+		}
+	}
+
+	@Override
+	public int getLastChannel() {
+		return lastChannel;
+	}
+
+	@Override
+	public boolean isFinished() {
+		return isFinished;
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return barrierHandler.isAvailable();
+	}
+
+	@Override
+	public void close() throws IOException {
+		// clear the buffers. this part should not ever fail
+		for (RecordDeserializer<?> deserializer : recordDeserializers) {
+			Buffer buffer = deserializer.getCurrentBuffer();
+			if (buffer != null && !buffer.isRecycled()) {
+				buffer.recycleBuffer();
+			}
+			deserializer.clear();
+		}
+
+		barrierHandler.cleanup();
+	}
+}


### PR DESCRIPTION
This PR depends on https://github.com/apache/flink/pull/8467 

It introduces `Input` interface, it's implementation `NetworkInput` (extracted from `StreamInputProcessor`) and use them in `StreamInputProcessor`.

Local benchmark run shows increase in records throughput of `SumLongsBenchmark` from 8600 records/ms to 9200-9400 records/ms.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
