### PR TITLE
[FLINK-12241][hive] Support function related operations in GenericHiveMetastoreCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Function;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -91,6 +92,21 @@ public class HiveCatalog extends HiveCatalogBase {
 			catalogDatabase.getComment(),
 			hiveCatalogDatabase.getLocation(),
 			hiveCatalogDatabase.getProperties());
+	}
+
+	@Override
+	protected Function createHiveFunction(ObjectPath functionPath, CatalogFunction function) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected CatalogFunction createCatalogFunction(Function function) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected void validateCatalogFunction(CatalogFunction catalogFunction) throws CatalogException {
+		throw new UnsupportedOperationException();
 	}
 
 	// ------ tables and views------
@@ -255,10 +271,16 @@ public class HiveCatalog extends HiveCatalogBase {
 	}
 
 	@Override
-	public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists)
-			throws FunctionNotExistException, CatalogException {
+	public List<String> listFunctions(String dbName) throws DatabaseNotExistException, CatalogException {
 		throw new UnsupportedOperationException();
 	}
+
+	@Override
+	public CatalogFunction getFunction(ObjectPath functionPath) throws FunctionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	// ------ stats ------
 
 	@Override
 	public void alterTableStatistics(ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
@@ -278,21 +300,6 @@ public class HiveCatalog extends HiveCatalogBase {
 	@Override
 	public void alterPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
 
-	}
-
-	@Override
-	public List<String> listFunctions(String dbName) throws DatabaseNotExistException, CatalogException {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public CatalogFunction getFunction(ObjectPath functionPath) throws FunctionNotExistException, CatalogException {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public boolean functionExists(ObjectPath functionPath) throws CatalogException {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/GenericHiveMetastoreCatalogTest.java
@@ -24,10 +24,12 @@ import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTestBase;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.GenericCatalogDatabase;
+import org.apache.flink.table.catalog.GenericCatalogFunction;
 import org.apache.flink.table.catalog.GenericCatalogTable;
 import org.apache.flink.table.catalog.GenericCatalogView;
 
@@ -168,5 +170,15 @@ public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
 			createAnotherTableSchema(),
 			new HashMap<>(),
 			"This is another view");
+	}
+
+	@Override
+	protected CatalogFunction createFunction() {
+		return new GenericCatalogFunction(MyScalarFunction.class.getName());
+	}
+
+	@Override
+	protected CatalogFunction createAnotherFunction() {
+		return new GenericCatalogFunction(MyOtherScalarFunction.class.getName());
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.catalog.hive;
 
 import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTestBase;
 import org.apache.flink.table.catalog.CatalogView;
@@ -47,6 +48,50 @@ public class HiveCatalogTest extends CatalogTestBase {
 	// =====================
 
 	public void testCreateTable_Streaming() throws Exception {
+	}
+
+	// ------ functions ------
+
+	public void testCreateFunction() throws Exception {
+	}
+
+	public void testCreateFunction_DatabaseNotExistException() throws Exception {
+	}
+
+	public void testCreateFunction_FunctionAlreadyExistException() throws Exception {
+	}
+
+	public void testCreateFunction_FunctionAlreadyExist_ignored() throws Exception {
+	}
+
+	public void testAlterFunction() throws Exception {
+	}
+
+	public void testAlterFunction_FunctionNotExistException() throws Exception {
+	}
+
+	public void testAlterFunction_FunctionNotExist_ignored() throws Exception {
+	}
+
+	public void testListFunctions() throws Exception {
+	}
+
+	public void testListFunctions_DatabaseNotExistException() throws Exception{
+	}
+
+	public void testGetFunction_FunctionNotExistException() throws Exception {
+	}
+
+	public void testGetFunction_FunctionNotExistException_NoDb() throws Exception {
+	}
+
+	public void testDropFunction() throws Exception {
+	}
+
+	public void testDropFunction_FunctionNotExistException() throws Exception {
+	}
+
+	public void testDropFunction_FunctionNotExist_ignored() throws Exception {
 	}
 
 	// ------ utils ------
@@ -130,6 +175,16 @@ public class HiveCatalogTest extends CatalogTestBase {
 			createAnotherTableSchema(),
 			new HashMap<>(),
 			"This is another hive view");
+	}
+
+	@Override
+	protected CatalogFunction createFunction() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected CatalogFunction createAnotherFunction() {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -25,8 +25,11 @@ import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.functions.ScalarFunction;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -88,7 +91,9 @@ public abstract class CatalogTestBase {
 		if (catalog.tableExists(path4)) {
 			catalog.dropTable(path4, true);
 		}
-
+		if (catalog.functionExists(path1)) {
+			catalog.dropFunction(path1, true);
+		}
 		if (catalog.databaseExists(db1)) {
 			catalog.dropDatabase(db1, true);
 		}
@@ -595,6 +600,134 @@ public abstract class CatalogTestBase {
 		assertTrue(catalog.tableExists(path3));
 	}
 
+	// ------ functions ------
+
+	@Test
+	public void testCreateFunction() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		assertFalse(catalog.functionExists(path1));
+
+		catalog.createFunction(path1, createFunction(), false);
+
+		assertTrue(catalog.functionExists(path1));
+	}
+
+	@Test
+	public void testCreateFunction_DatabaseNotExistException() throws Exception {
+		assertFalse(catalog.databaseExists(db1));
+
+		exception.expect(DatabaseNotExistException.class);
+		exception.expectMessage("Database db1 does not exist in Catalog");
+		catalog.createFunction(path1, createFunction(), false);
+	}
+
+	@Test
+	public void testCreateFunction_FunctionAlreadyExistException() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.createFunction(path1, createFunction(), false);
+
+		assertTrue(catalog.functionExists(path1));
+
+		// test 'ignoreIfExist' flag
+		catalog.createFunction(path1, createAnotherFunction(), true);
+
+		exception.expect(FunctionAlreadyExistException.class);
+		exception.expectMessage("Function db1.t1 already exists in Catalog");
+		catalog.createFunction(path1, createFunction(), false);
+	}
+
+	@Test
+	public void testAlterFunction() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		CatalogFunction func = createFunction();
+		catalog.createFunction(path1, func, false);
+
+		checkEquals(func, catalog.getFunction(path1));
+
+		CatalogFunction newFunc = createAnotherFunction();
+		catalog.alterFunction(path1, newFunc, false);
+		CatalogFunction actual = catalog.getFunction(path1);
+
+		assertFalse(func.getClassName().equals(actual.getClassName()));
+		checkEquals(newFunc, actual);
+	}
+
+	@Test
+	public void testAlterFunction_FunctionNotExistException() throws Exception {
+		exception.expect(FunctionNotExistException.class);
+		exception.expectMessage("Function db1.nonexist does not exist in Catalog");
+		catalog.alterFunction(nonExistObjectPath, createFunction(), false);
+	}
+
+	@Test
+	public void testAlterFunction_FunctionNotExist_ignored() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.alterFunction(nonExistObjectPath, createFunction(), true);
+
+		assertFalse(catalog.functionExists(nonExistObjectPath));
+	}
+
+	@Test
+	public void testListFunctions() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		CatalogFunction func = createFunction();
+		catalog.createFunction(path1, func, false);
+
+		assertEquals(path1.getObjectName(), catalog.listFunctions(db1).get(0));
+	}
+
+	@Test
+	public void testListFunctions_DatabaseNotExistException() throws Exception{
+		exception.expect(DatabaseNotExistException.class);
+		exception.expectMessage("Database db1 does not exist in Catalog");
+		catalog.listFunctions(db1);
+	}
+
+	@Test
+	public void testGetFunction_FunctionNotExistException() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		exception.expect(FunctionNotExistException.class);
+		exception.expectMessage("Function db1.nonexist does not exist in Catalog");
+		catalog.getFunction(nonExistObjectPath);
+	}
+
+	@Test
+	public void testGetFunction_FunctionNotExistException_NoDb() throws Exception {
+		exception.expect(FunctionNotExistException.class);
+		exception.expectMessage("Function db1.nonexist does not exist in Catalog");
+		catalog.getFunction(nonExistObjectPath);
+	}
+
+	@Test
+	public void testDropFunction() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.createFunction(path1, createFunction(), false);
+
+		assertTrue(catalog.functionExists(path1));
+
+		catalog.dropFunction(path1, false);
+
+		assertFalse(catalog.functionExists(path1));
+	}
+
+	@Test
+	public void testDropFunction_FunctionNotExistException() throws Exception {
+		exception.expect(FunctionNotExistException.class);
+		exception.expectMessage("Function non.exist does not exist in Catalog");
+		catalog.dropFunction(nonExistDbPath, false);
+	}
+
+	@Test
+	public void testDropFunction_FunctionNotExist_ignored() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.dropFunction(nonExistObjectPath, true);
+		catalog.dropDatabase(db1, false);
+	}
+
 	// ------ utilities ------
 
 	/**
@@ -660,6 +793,20 @@ public abstract class CatalogTestBase {
 	 */
 	public abstract CatalogView createAnotherView();
 
+	/**
+	 * Create a CatalogFunction instance by specific catalog implementation.
+	 *
+	 * @return a CatalogFunction instance
+	 */
+	protected abstract CatalogFunction createFunction();
+
+	/**
+	 * Create another CatalogFunction instance by specific catalog implementation.
+	 *
+	 * @return another CatalogFunction instance
+	 */
+	protected abstract CatalogFunction createAnotherFunction();
+
 	protected TableSchema createTableSchema() {
 		return new TableSchema(
 			new String[] {"first", "second", "third"},
@@ -698,6 +845,24 @@ public abstract class CatalogTestBase {
 		}};
 	}
 
+	/**
+	 * A Flink function for test.
+	 */
+	public static class MyScalarFunction extends ScalarFunction {
+		public Integer eval(Integer i) {
+			return i + 1;
+		}
+	}
+
+	/**
+	 * Another Flink function for test.
+	 */
+	public static class MyOtherScalarFunction extends ScalarFunction {
+		public String eval(Integer i) {
+			return String.valueOf(i);
+		}
+	}
+
 	// ------ equality check utils ------
 	// Can be overriden by sub test class
 
@@ -715,5 +880,10 @@ public abstract class CatalogTestBase {
 		assertEquals(v1.getComment(), v2.getComment());
 		assertEquals(v1.getOriginalQuery(), v2.getOriginalQuery());
 		assertEquals(v1.getExpandedQuery(), v2.getExpandedQuery());
+	}
+
+	protected void checkEquals(CatalogFunction f1, CatalogFunction f2) {
+		assertEquals(f1.getClassName(), f2.getClassName());
+		assertEquals(f1.getProperties(), f2.getProperties());
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -50,11 +50,6 @@ public class CatalogTestUtil {
 		assertEquals(d1.getProperties(), d2.getProperties());
 	}
 
-	public static void checkEquals(CatalogFunction f1, CatalogFunction f2) {
-		assertEquals(f1.getClassName(), f2.getClassName());
-		assertEquals(f1.getProperties(), f2.getProperties());
-	}
-
 	public static void checkEquals(CatalogPartition p1, CatalogPartition p2) {
 		assertEquals(p1.getProperties(), p2.getProperties());
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR implements function related in `GenericHiveMetastoreCatalog`. Code that can be shared with `HiveCatalog` is put into `HiveCatalogBase`.

## Brief change log

- implemented base of function related catalog APIs in `HiveCatalogBase`
- implemented function related catalog APIs for `GenericHiveMetastoreCatalog`
- moved common tests for function catalog APIs from `GenericInMemoryCatalogTest` to `CatalogTestBase` so they can be reused

## Verifying this change

This change is already covered by existing tests, such as *CatalogTestBase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
