### PR TITLE
[FLINK-12550] fix local input split assignment for hostnames containing a dot (".")

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
@@ -18,6 +18,15 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.Public;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.core.io.InputSplitAssigner;
+import org.apache.flink.core.io.LocatableInputSplit;
+import org.apache.flink.util.NetUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -25,14 +34,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.apache.flink.annotation.Public;
-import org.apache.flink.core.io.InputSplit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.apache.flink.core.io.InputSplitAssigner;
-import org.apache.flink.core.io.LocatableInputSplit;
-import org.apache.flink.util.NetUtils;
 
 /**
  * The locatable input split assigner assigns to each host splits that are local, before assigning
@@ -59,14 +60,14 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 	// --------------------------------------------------------------------------------------------
 
 	public LocatableInputSplitAssigner(Collection<LocatableInputSplit> splits) {
-		for(LocatableInputSplit split : splits) {
+		for (LocatableInputSplit split : splits) {
 			this.unassigned.add(new LocatableInputSplitWithCount(split));
 		}
 		this.remoteSplitChooser = new LocatableInputSplitChooser(unassigned);
 	}
 
 	public LocatableInputSplitAssigner(LocatableInputSplit[] splits) {
-		for(LocatableInputSplit split : splits) {
+		for (LocatableInputSplit split : splits) {
 			this.unassigned.add(new LocatableInputSplitWithCount(split));
 		}
 		this.remoteSplitChooser = new LocatableInputSplitChooser(unassigned);
@@ -149,7 +150,6 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 				}
 			}
 		}
-
 
 		// at this point, we have a list of local splits (possibly empty)
 		// we need to make sure no one else operates in the current list (that protects against
@@ -291,13 +291,13 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 
 		public LocatableInputSplitChooser(Collection<LocatableInputSplitWithCount> splits) {
 			this.splits = new LinkedList<LocatableInputSplitWithCount>();
-			for(LocatableInputSplitWithCount isw : splits) {
+			for (LocatableInputSplitWithCount isw : splits) {
 				this.addInputSplit(isw);
 			}
 		}
 
 		/**
-		 * Adds a single input split
+		 * Adds a single input split.
 		 *
 		 * @param split The input split to add
 		 */
@@ -316,7 +316,7 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 				// all other splits have more local host than this one
 				this.elementCycleCount = 1;
 				splits.offerFirst(split);
-			} else if (localCount == minLocalCount ) {
+			} else if (localCount == minLocalCount) {
 				this.elementCycleCount++;
 				this.splits.offerFirst(split);
 			} else {
@@ -337,7 +337,7 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 		 */
 		public LocatableInputSplitWithCount getNextUnassignedMinLocalCountSplit(Set<LocatableInputSplitWithCount> unassignedSplits) {
 
-			if(splits.size() == 0) {
+			if (splits.size() == 0) {
 				return null;
 			}
 
@@ -361,7 +361,7 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 					// split was already assigned
 					split = null;
 				}
-				if(elementCycleCount == 0) {
+				if (elementCycleCount == 0) {
 					// one full cycle, but no split with min local count found
 					// update minLocalCnt and element cycle count for next pass over the splits
 					minLocalCount = nextMinLocalCount;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
@@ -220,7 +220,9 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 			return false;
 		}
 		for (String h : hosts) {
-			if (h != null && NetUtils.getHostnameFromFQDN(h.toLowerCase()).equals(flinkHost)) {
+			if (h != null &&
+				NetUtils.getHostnameFromFQDN(h.toLowerCase()).equals(
+					NetUtils.getHostnameFromFQDN(flinkHost.toLowerCase()))) {
 				return true;
 			}
 		}

--- a/flink-core/src/test/java/org/apache/flink/core/io/LocatableSplitAssignerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/io/LocatableSplitAssignerTest.java
@@ -69,6 +69,31 @@ public class LocatableSplitAssignerTest {
 	}
 
 	@Test
+	public void testLocalSplitAssignmentForHostWithDomainName() {
+		try {
+			String hostNameWithDot = "host.domain";
+
+			// load one split
+			Set<LocatableInputSplit> splits =
+				new HashSet<LocatableInputSplit>();
+			splits.add(new LocatableInputSplit(0, hostNameWithDot));
+
+			// get next split for host with same name
+			LocatableInputSplitAssigner ia =
+				new LocatableInputSplitAssigner(splits);
+			InputSplit is = null;
+			ia.getNextInputSplit(hostNameWithDot, 0);
+
+			// the one split should be assigned locally
+			assertEquals(0, ia.getNumberOfRemoteAssignments());
+			assertEquals(1, ia.getNumberOfLocalAssignments());
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
 	public void testSerialSplitAssignmentAllForSameHost() {
 		try {
 			final int NUM_SPLITS = 50;


### PR DESCRIPTION
## What is the purpose of the change
LocatableInputSplitAssigner does not assign input splits locally if the hostname contains a dot ("."), like in hostname.domain. This PR should fix this issue.

## Brief change log
- The hostnames of the input split locations are now prepared in the same way as the hostname of the TaskManager that is getting the next input split, before they are compared to each other.
- LocatableInputSplitAssigner and LocatableSplitAssignerTest are reformatted to match code style requirements.

## Verifying this change
A unit test has been added (testLocalSplitAssignmentForHostWithDomainName in LocatableSplitAssignerTest). This test fails with all previous versions of LocatableInputSplitAssigner and passes with the change introcuced in this PR.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
