### PR TITLE
[FLINK-12555] Introduce an encapsulated metric group layout for shuffle API

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1000,7 +1000,8 @@ Thus, in order to infer the metric identifier:
   </tbody>
 </table>
 
-### Network
+
+### Network (Deprecated: use [Default shuffle service metrics]({{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service))
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -1044,10 +1045,10 @@ Thus, in order to infer the metric identifier:
     <tr>
       <td>outPoolUsage</td>
       <td>An estimate of the output buffers usage.</td>
-      <td>Gauge</td>      
+      <td>Gauge</td>
     </tr>
     <tr>
-      <td rowspan="4">Network.&lt;Input|Output&gt;.&lt;gate&gt;<br />
+      <td rowspan="4">Network.&lt;Input|Output&gt;.&lt;gate|partition&gt;<br />
         <strong>(only available if <tt>taskmanager.net.detailed-metrics</tt> config option is set)</strong></td>
       <td>totalQueueLen</td>
       <td>Total number of queued buffers in all input/output channels.</td>
@@ -1067,6 +1068,123 @@ Thus, in order to infer the metric identifier:
       <td>avgQueueLen</td>
       <td>Average number of queued buffers in all input/output channels.</td>
       <td>Gauge</td>
+    </tr>
+  </tbody>
+</table>
+
+### Default shuffle service
+
+Metrics related to data exchange between task executors using netty network communication.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 22%">Infix</th>
+      <th class="text-left" style="width: 22%">Metrics</th>
+      <th class="text-left" style="width: 30%">Description</th>
+      <th class="text-left" style="width: 8%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="2"><strong>TaskManager</strong></th>
+      <td rowspan="2">Status.Shuffle.Netty</td>
+      <td>AvailableMemorySegments</td>
+      <td>The number of unused memory segments.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>TotalMemorySegments</td>
+      <td>The number of allocated memory segments.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="8">Task</th>
+      <td rowspan="2">Shuffle.Netty.Input.Buffers</td>
+      <td>inputQueueLength</td>
+      <td>The number of queued input buffers.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>inPoolUsage</td>
+      <td>An estimate of the input buffers usage.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Shuffle.Netty.Output.Buffers</td>
+      <td>outputQueueLength</td>
+      <td>The number of queued output buffers.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>outPoolUsage</td>
+      <td>An estimate of the output buffers usage.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td rowspan="4">Shuffle.Netty.&lt;Input|Output&gt;.&lt;gate|partition&gt;<br />
+        <strong>(only available if <tt>taskmanager.net.detailed-metrics</tt> config option is set)</strong></td>
+      <td>totalQueueLen</td>
+      <td>Total number of queued buffers in all input/output channels.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>minQueueLen</td>
+      <td>Minimum number of queued buffers in all input/output channels.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>maxQueueLen</td>
+      <td>Maximum number of queued buffers in all input/output channels.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>avgQueueLen</td>
+      <td>Average number of queued buffers in all input/output channels.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="8"><strong>Task</strong></th>
+      <td rowspan="8">Shuffle.Netty.Input</td>
+      <td>numBytesInLocal</td>
+      <td>The total number of bytes this task has read from a local source.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numBytesInLocalPerSecond</td>
+      <td>The number of bytes this task reads from a local source per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>numBytesInRemote</td>
+      <td>The total number of bytes this task has read from a remote source.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numBytesInRemotePerSecond</td>
+      <td>The number of bytes this task reads from a remote source per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>numBuffersInLocal</td>
+      <td>The total number of network buffers this task has read from a local source.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numBuffersInLocalPerSecond</td>
+      <td>The number of network buffers this task reads from a local source per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>numBuffersInRemote</td>
+      <td>The total number of network buffers this task has read from a remote source.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numBuffersInRemotePerSecond</td>
+      <td>The number of network buffers this task reads from a remote source per second.</td>
+      <td>Meter</td>
     </tr>
   </tbody>
 </table>
@@ -1236,42 +1354,42 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     <tr>
       <th rowspan="12"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
-      <td>The total number of bytes this task has read from a local source.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBytesInLocalPerSecond</td>
-      <td>The number of bytes this task reads from a local source per second.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBytesInRemote</td>
-      <td>The total number of bytes this task has read from a remote source.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBytesInRemotePerSecond</td>
-      <td>The number of bytes this task reads from a remote source per second.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBuffersInLocal</td>
-      <td>The total number of network buffers this task has read from a local source.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBuffersInLocalPerSecond</td>
-      <td>The number of network buffers this task reads from a local source per second.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBuffersInRemote</td>
-      <td>The total number of network buffers this task has read from a remote source.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBuffersInRemotePerSecond</td>
-      <td>The number of network buffers this task reads from a remote source per second.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -998,7 +998,7 @@ Thus, in order to infer the metric identifier:
   </tbody>
 </table>
 
-### Network
+### Network (Deprecated: use [Default shuffle service metrics]({{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service))
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -1045,7 +1045,7 @@ Thus, in order to infer the metric identifier:
       <td>Gauge</td>
     </tr>
     <tr>
-      <td rowspan="4">Network.&lt;Input|Output&gt;.&lt;gate&gt;<br />
+      <td rowspan="4">Network.&lt;Input|Output&gt;.&lt;gate|partition&gt;<br />
         <strong>(only available if <tt>taskmanager.net.detailed-metrics</tt> config option is set)</strong></td>
       <td>totalQueueLen</td>
       <td>Total number of queued buffers in all input/output channels.</td>
@@ -1065,6 +1065,123 @@ Thus, in order to infer the metric identifier:
       <td>avgQueueLen</td>
       <td>Average number of queued buffers in all input/output channels.</td>
       <td>Gauge</td>
+    </tr>
+  </tbody>
+</table>
+
+### Default shuffle service
+
+Metrics related to data exchange between task executors using netty network communication.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 22%">Infix</th>
+      <th class="text-left" style="width: 22%">Metrics</th>
+      <th class="text-left" style="width: 30%">Description</th>
+      <th class="text-left" style="width: 8%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="2"><strong>TaskManager</strong></th>
+      <td rowspan="2">Status.Shuffle.Netty</td>
+      <td>AvailableMemorySegments</td>
+      <td>The number of unused memory segments.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>TotalMemorySegments</td>
+      <td>The number of allocated memory segments.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="8">Task</th>
+      <td rowspan="2">Shuffle.Netty.Input.Buffers</td>
+      <td>inputQueueLength</td>
+      <td>The number of queued input buffers.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>inPoolUsage</td>
+      <td>An estimate of the input buffers usage.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Shuffle.Netty.Output.Buffers</td>
+      <td>outputQueueLength</td>
+      <td>The number of queued output buffers.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>outPoolUsage</td>
+      <td>An estimate of the output buffers usage.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td rowspan="4">Shuffle.Netty.&lt;Input|Output&gt;.&lt;gate|partition&gt;<br />
+        <strong>(only available if <tt>taskmanager.net.detailed-metrics</tt> config option is set)</strong></td>
+      <td>totalQueueLen</td>
+      <td>Total number of queued buffers in all input/output channels.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>minQueueLen</td>
+      <td>Minimum number of queued buffers in all input/output channels.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>maxQueueLen</td>
+      <td>Maximum number of queued buffers in all input/output channels.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>avgQueueLen</td>
+      <td>Average number of queued buffers in all input/output channels.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="8"><strong>Task</strong></th>
+      <td rowspan="8">Shuffle.Netty.Input</td>
+      <td>numBytesInLocal</td>
+      <td>The total number of bytes this task has read from a local source.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numBytesInLocalPerSecond</td>
+      <td>The number of bytes this task reads from a local source per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>numBytesInRemote</td>
+      <td>The total number of bytes this task has read from a remote source.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numBytesInRemotePerSecond</td>
+      <td>The number of bytes this task reads from a remote source per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>numBuffersInLocal</td>
+      <td>The total number of network buffers this task has read from a local source.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numBuffersInLocalPerSecond</td>
+      <td>The number of network buffers this task reads from a local source per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>numBuffersInRemote</td>
+      <td>The total number of network buffers this task has read from a remote source.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numBuffersInRemotePerSecond</td>
+      <td>The number of network buffers this task reads from a remote source per second.</td>
+      <td>Meter</td>
     </tr>
   </tbody>
 </table>
@@ -1234,42 +1351,42 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     <tr>
       <th rowspan="12"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
-      <td>The total number of bytes this task has read from a local source.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBytesInLocalPerSecond</td>
-      <td>The number of bytes this task reads from a local source per second.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBytesInRemote</td>
-      <td>The total number of bytes this task has read from a remote source.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBytesInRemotePerSecond</td>
-      <td>The number of bytes this task reads from a remote source per second.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBuffersInLocal</td>
-      <td>The total number of network buffers this task has read from a local source.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBuffersInLocalPerSecond</td>
-      <td>The number of network buffers this task reads from a local source per second.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBuffersInRemote</td>
-      <td>The total number of network buffers this task has read from a remote source.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBuffersInRemotePerSecond</td>
-      <td>The number of network buffers this task reads from a remote source per second.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/zh/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -38,19 +37,13 @@ import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
 import org.apache.flink.runtime.shuffle.ShuffleServiceFactory;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 
-import static org.apache.flink.runtime.io.network.NettyShuffleEnvironment.METRIC_GROUP_NETTY;
-import static org.apache.flink.runtime.io.network.NettyShuffleEnvironment.METRIC_GROUP_SHUFFLE;
+import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.registerShuffleMetrics;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Netty based shuffle service implementation.
  */
 public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettyShuffleDescriptor, ResultPartition, SingleInputGate> {
-
-	// shuffle environment level metrics: Shuffle.Netty.*
-
-	private static final String METRIC_TOTAL_MEMORY_SEGMENT = "TotalMemorySegments";
-	private static final String METRIC_AVAILABLE_MEMORY_SEGMENT = "AvailableMemorySegments";
 
 	@Override
 	public NettyShuffleMaster createShuffleMaster(Configuration configuration) {
@@ -99,9 +92,7 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 			config.networkBufferSize(),
 			config.networkBuffersPerChannel());
 
-		//noinspection deprecation
-		registerNetworkMetrics(NettyShuffleEnvironment.METRIC_GROUP_NETWORK_DEPRECATED, metricGroup, networkBufferPool);
-		registerNetworkMetrics(METRIC_GROUP_NETTY, metricGroup.addGroup(METRIC_GROUP_SHUFFLE), networkBufferPool);
+		registerShuffleMetrics(metricGroup, networkBufferPool);
 
 		ResultPartitionFactory resultPartitionFactory = new ResultPartitionFactory(
 			resultPartitionManager,
@@ -127,16 +118,5 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 			resultPartitionManager,
 			resultPartitionFactory,
 			singleInputGateFactory);
-	}
-
-	private static void registerNetworkMetrics(
-			String groupName,
-			MetricGroup metricGroup,
-			NetworkBufferPool networkBufferPool) {
-		MetricGroup networkGroup = metricGroup.addGroup(groupName);
-		networkGroup.<Integer, Gauge<Integer>>gauge(METRIC_TOTAL_MEMORY_SEGMENT,
-			networkBufferPool::getTotalNumberOfMemorySegments);
-		networkGroup.<Integer, Gauge<Integer>>gauge(METRIC_AVAILABLE_MEMORY_SEGMENT,
-			networkBufferPool::getNumberOfAvailableMemorySegments);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputChannelMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputChannelMetrics.java
@@ -24,6 +24,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.util.Preconditions;
 
 /**
  * Collects metrics for {@link RemoteInputChannel} and {@link LocalInputChannel}.
@@ -32,29 +33,28 @@ public class InputChannelMetrics {
 
 	private static final String IO_NUM_BYTES_IN_LOCAL = MetricNames.IO_NUM_BYTES_IN + "Local";
 	private static final String IO_NUM_BYTES_IN_REMOTE = MetricNames.IO_NUM_BYTES_IN + "Remote";
-	private static final String IO_NUM_BYTES_IN_LOCAL_RATE = IO_NUM_BYTES_IN_LOCAL + MetricNames.SUFFIX_RATE;
-	private static final String IO_NUM_BYTES_IN_REMOTE_RATE = IO_NUM_BYTES_IN_REMOTE + MetricNames.SUFFIX_RATE;
-
 	private static final String IO_NUM_BUFFERS_IN_LOCAL = MetricNames.IO_NUM_BUFFERS_IN + "Local";
 	private static final String IO_NUM_BUFFERS_IN_REMOTE = MetricNames.IO_NUM_BUFFERS_IN + "Remote";
-	private static final String IO_NUM_BUFFERS_IN_LOCAL_RATE = IO_NUM_BUFFERS_IN_LOCAL + MetricNames.SUFFIX_RATE;
-	private static final String IO_NUM_BUFFERS_IN_REMOTE_RATE = IO_NUM_BUFFERS_IN_REMOTE + MetricNames.SUFFIX_RATE;
 
 	private final Counter numBytesInLocal;
 	private final Counter numBytesInRemote;
 	private final Counter numBuffersInLocal;
 	private final Counter numBuffersInRemote;
 
-	public InputChannelMetrics(MetricGroup parent) {
-		this.numBytesInLocal = parent.counter(IO_NUM_BYTES_IN_LOCAL);
-		this.numBytesInRemote = parent.counter(IO_NUM_BYTES_IN_REMOTE);
-		parent.meter(IO_NUM_BYTES_IN_LOCAL_RATE, new MeterView(numBytesInLocal, 60));
-		parent.meter(IO_NUM_BYTES_IN_REMOTE_RATE, new MeterView(numBytesInRemote, 60));
+	public InputChannelMetrics(MetricGroup ... parents) {
+		this.numBytesInLocal = createCounter(IO_NUM_BYTES_IN_LOCAL, parents);
+		this.numBytesInRemote = createCounter(IO_NUM_BYTES_IN_REMOTE, parents);
+		this.numBuffersInLocal = createCounter(IO_NUM_BUFFERS_IN_LOCAL, parents);
+		this.numBuffersInRemote = createCounter(IO_NUM_BUFFERS_IN_REMOTE, parents);
+	}
 
-		this.numBuffersInLocal = parent.counter(IO_NUM_BUFFERS_IN_LOCAL);
-		this.numBuffersInRemote = parent.counter(IO_NUM_BUFFERS_IN_REMOTE);
-		parent.meter(IO_NUM_BUFFERS_IN_LOCAL_RATE, new MeterView(numBuffersInLocal, 60));
-		parent.meter(IO_NUM_BUFFERS_IN_REMOTE_RATE, new MeterView(numBuffersInRemote, 60));
+	private static Counter createCounter(String name, MetricGroup ... parents) {
+		Counter[] counters = new Counter[parents.length];
+		for (int i = 0; i < parents.length; i++) {
+			counters[i] = parents[i].counter(name);
+			parents[i].meter(name + MetricNames.SUFFIX_RATE, new MeterView(counters[i], 60));
+		}
+		return new MultiCounterWrapper(counters);
 	}
 
 	public Counter getNumBytesInLocalCounter() {
@@ -71,5 +71,48 @@ public class InputChannelMetrics {
 
 	public Counter getNumBuffersInRemoteCounter() {
 		return numBuffersInRemote;
+	}
+
+	private static class MultiCounterWrapper implements Counter {
+		private final Counter[] counters;
+
+		private MultiCounterWrapper(Counter ... counters) {
+			Preconditions.checkArgument(counters.length > 0);
+			this.counters = counters;
+		}
+
+		@Override
+		public void inc() {
+			for (Counter c : counters) {
+				c.inc();
+			}
+		}
+
+		@Override
+		public void inc(long n) {
+			for (Counter c : counters) {
+				c.inc(n);
+			}
+		}
+
+		@Override
+		public void dec() {
+			for (Counter c : counters) {
+				c.dec();
+			}
+		}
+
+		@Override
+		public void dec(long n) {
+			for (Counter c : counters) {
+				c.dec(n);
+			}
+		}
+
+		@Override
+		public long getCount() {
+			// assume that the counters are not accessed directly elsewhere
+			return counters[0].getCount();
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Factory for netty shuffle service metrics.
+ */
+public class NettyShuffleMetricFactory {
+
+	// deprecated metric groups
+
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
+	private static final String METRIC_GROUP_NETWORK_DEPRECATED = "Network";
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
+	private static final String METRIC_GROUP_BUFFERS_DEPRECATED = "buffers";
+
+	// shuffle environment level metrics: Shuffle.Netty.*
+
+	private static final String METRIC_TOTAL_MEMORY_SEGMENT = "TotalMemorySegments";
+	private static final String METRIC_AVAILABLE_MEMORY_SEGMENT = "AvailableMemorySegments";
+
+	// task level metric group structure: Shuffle.Netty.<Input|Output>.Buffers
+
+	private static final String METRIC_GROUP_SHUFFLE = "Shuffle";
+	private static final String METRIC_GROUP_NETTY = "Netty";
+	public static final String METRIC_GROUP_OUTPUT = "Output";
+	public static final String METRIC_GROUP_INPUT = "Input";
+	private static final String METRIC_GROUP_BUFFERS = "Buffers";
+
+	// task level output metrics: Shuffle.Netty.Output.*
+
+	private static final String METRIC_OUTPUT_QUEUE_LENGTH = "outputQueueLength";
+	private static final String METRIC_OUTPUT_POOL_USAGE = "outPoolUsage";
+
+	// task level input metrics: Shuffle.Netty.Input.*
+
+	private static final String METRIC_INPUT_QUEUE_LENGTH = "inputQueueLength";
+	private static final String METRIC_INPUT_POOL_USAGE = "inPoolUsage";
+
+	private NettyShuffleMetricFactory() {
+	}
+
+	public static void registerShuffleMetrics(
+			MetricGroup metricGroup,
+			NetworkBufferPool networkBufferPool) {
+		checkNotNull(metricGroup);
+		checkNotNull(networkBufferPool);
+
+		//noinspection deprecation
+		registerShuffleMetrics(METRIC_GROUP_NETWORK_DEPRECATED, metricGroup, networkBufferPool);
+		registerShuffleMetrics(METRIC_GROUP_NETTY, metricGroup.addGroup(METRIC_GROUP_SHUFFLE), networkBufferPool);
+	}
+
+	private static void registerShuffleMetrics(
+			String groupName,
+			MetricGroup metricGroup,
+			NetworkBufferPool networkBufferPool) {
+		MetricGroup networkGroup = metricGroup.addGroup(groupName);
+		networkGroup.<Integer, Gauge<Integer>>gauge(METRIC_TOTAL_MEMORY_SEGMENT,
+			networkBufferPool::getTotalNumberOfMemorySegments);
+		networkGroup.<Integer, Gauge<Integer>>gauge(METRIC_AVAILABLE_MEMORY_SEGMENT,
+			networkBufferPool::getNumberOfAvailableMemorySegments);
+	}
+
+	public static MetricGroup createShuffleIOOwnerMetricGroup(MetricGroup parentGroup) {
+		return parentGroup.addGroup(METRIC_GROUP_SHUFFLE).addGroup(METRIC_GROUP_NETTY);
+	}
+
+	/**
+	 * Registers legacy network metric groups before shuffle service refactoring.
+	 *
+	 * <p>Registers legacy metric groups if shuffle service implementation is original default one.
+	 *
+	 * @deprecated should be removed in future
+	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
+	public static void registerLegacyNetworkMetrics(
+			boolean isDetailedMetrics,
+			MetricGroup metricGroup,
+			ResultPartitionWriter[] producedPartitions,
+			InputGate[] inputGates) {
+		checkNotNull(metricGroup);
+		checkNotNull(producedPartitions);
+		checkNotNull(inputGates);
+
+		// add metrics for buffers
+		final MetricGroup buffersGroup = metricGroup.addGroup(METRIC_GROUP_BUFFERS_DEPRECATED);
+
+		// similar to MetricUtils.instantiateNetworkMetrics() but inside this IOMetricGroup (metricGroup)
+		final MetricGroup networkGroup = metricGroup.addGroup(METRIC_GROUP_NETWORK_DEPRECATED);
+		final MetricGroup outputGroup = networkGroup.addGroup(METRIC_GROUP_OUTPUT);
+		final MetricGroup inputGroup = networkGroup.addGroup(METRIC_GROUP_INPUT);
+
+		ResultPartition[] resultPartitions = Arrays.copyOf(producedPartitions, producedPartitions.length, ResultPartition[].class);
+		registerOutputMetrics(isDetailedMetrics, outputGroup, buffersGroup, resultPartitions);
+
+		SingleInputGate[] singleInputGates = Arrays.copyOf(inputGates, inputGates.length, SingleInputGate[].class);
+		registerInputMetrics(isDetailedMetrics, inputGroup, buffersGroup, singleInputGates);
+	}
+
+	public static void registerOutputMetrics(
+			boolean isDetailedMetrics,
+			MetricGroup outputGroup,
+			ResultPartition[] resultPartitions) {
+		registerOutputMetrics(
+			isDetailedMetrics,
+			outputGroup,
+			outputGroup.addGroup(METRIC_GROUP_BUFFERS),
+			resultPartitions);
+	}
+
+	private static void registerOutputMetrics(
+			boolean isDetailedMetrics,
+			MetricGroup outputGroup,
+			MetricGroup buffersGroup,
+			ResultPartition[] resultPartitions) {
+		if (isDetailedMetrics) {
+			ResultPartitionMetrics.registerQueueLengthMetrics(outputGroup, resultPartitions);
+		}
+		buffersGroup.gauge(METRIC_OUTPUT_QUEUE_LENGTH, new OutputBuffersGauge(resultPartitions));
+		buffersGroup.gauge(METRIC_OUTPUT_POOL_USAGE, new OutputBufferPoolUsageGauge(resultPartitions));
+	}
+
+	public static void registerInputMetrics(
+			boolean isDetailedMetrics,
+			MetricGroup inputGroup,
+			SingleInputGate[] inputGates) {
+		registerInputMetrics(
+			isDetailedMetrics,
+			inputGroup,
+			inputGroup.addGroup(METRIC_GROUP_BUFFERS),
+			inputGates);
+	}
+
+	private static void registerInputMetrics(
+			boolean isDetailedMetrics,
+			MetricGroup inputGroup,
+			MetricGroup buffersGroup,
+			SingleInputGate[] inputGates) {
+		if (isDetailedMetrics) {
+			InputGateMetrics.registerQueueLengthMetrics(inputGroup, inputGates);
+		}
+		buffersGroup.gauge(METRIC_INPUT_QUEUE_LENGTH, new InputBuffersGauge(inputGates));
+		buffersGroup.gauge(METRIC_INPUT_POOL_USAGE, new InputBufferPoolUsageGauge(inputGates));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironment.java
@@ -93,24 +93,33 @@ public interface ShuffleEnvironment<P extends ResultPartitionWriter, G extends I
 	int start() throws IOException;
 
 	/**
+	 * Create a context of the shuffle input/output owner used to create partitions or gates belonging to the owner.
+	 *
+	 * <p>This method has to be called only once to avoid duplicated internal metric group registration.
+	 *
+	 * @param ownerName the owner name, used for logs
+	 * @param executionAttemptID execution attempt id of the producer or consumer
+	 * @param parentGroup parent of shuffle specific metric group
+	 * @return context of the shuffle input/output owner used to create partitions or gates belonging to the owner
+	 */
+	ShuffleIOOwnerContext createShuffleIOOwnerContext(
+		String ownerName,
+		ExecutionAttemptID executionAttemptID,
+		MetricGroup parentGroup);
+
+	/**
 	 * Factory method for the {@link ResultPartitionWriter ResultPartitionWriters} to produce result partitions.
 	 *
 	 * <p>The order of the {@link ResultPartitionWriter ResultPartitionWriters} in the returned collection
 	 * should be the same as the iteration order of the passed {@code resultPartitionDeploymentDescriptors}.
 	 *
-	 * @param ownerName the owner name, used for logs
-	 * @param executionAttemptID execution attempt id of the producer
+	 * @param ownerContext the owner context relevant for partition creation
 	 * @param resultPartitionDeploymentDescriptors descriptors of the partition, produced by the owner
-	 * @param outputGroup shuffle specific group for output metrics
-	 * @param buffersGroup shuffle specific group for buffer metrics
 	 * @return collection of the {@link ResultPartitionWriter ResultPartitionWriters}
 	 */
 	Collection<P> createResultPartitionWriters(
-		String ownerName,
-		ExecutionAttemptID executionAttemptID,
-		Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
-		MetricGroup outputGroup,
-		MetricGroup buffersGroup);
+		ShuffleIOOwnerContext ownerContext,
+		Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors);
 
 	/**
 	 * Release local resources occupied by the given partitions.
@@ -133,23 +142,15 @@ public interface ShuffleEnvironment<P extends ResultPartitionWriter, G extends I
 	 * <p>The order of the {@link InputGate InputGates} in the returned collection should be the same as the iteration order
 	 * of the passed {@code inputGateDeploymentDescriptors}.
 	 *
-	 * @param ownerName the owner name, used for logs
-	 * @param executionAttemptID execution attempt id of the consumer
+	 * @param ownerContext the owner context relevant for gate creation
 	 * @param partitionProducerStateProvider producer state provider to query whether the producer is ready for consumption
 	 * @param inputGateDeploymentDescriptors descriptors of the input gates to consume
-	 * @param parentGroup parent of shuffle specific metric group
-	 * @param inputGroup shuffle specific group for input metrics
-	 * @param buffersGroup shuffle specific group for buffer metrics
 	 * @return collection of the {@link InputGate InputGates}
 	 */
 	Collection<G> createInputGates(
-		String ownerName,
-		ExecutionAttemptID executionAttemptID,
+		ShuffleIOOwnerContext ownerContext,
 		PartitionProducerStateProvider partitionProducerStateProvider,
-		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
-		MetricGroup parentGroup,
-		MetricGroup inputGroup,
-		MetricGroup buffersGroup);
+		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors);
 
 	/**
 	 * Update a gate with the newly available partition information, previously unknown.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleIOOwnerContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleIOOwnerContext.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Context of shuffle input/output owner used to create partitions or gates belonging to the owner.
+ */
+public class ShuffleIOOwnerContext {
+	private final String ownerName;
+	private final ExecutionAttemptID executionAttemptID;
+	private final MetricGroup parentGroup;
+	private final MetricGroup outputGroup;
+	private final MetricGroup inputGroup;
+
+	public ShuffleIOOwnerContext(
+			String ownerName,
+			ExecutionAttemptID executionAttemptID,
+			MetricGroup parentGroup,
+			MetricGroup outputGroup,
+			MetricGroup inputGroup) {
+		this.ownerName = checkNotNull(ownerName);
+		this.executionAttemptID = checkNotNull(executionAttemptID);
+		this.parentGroup = checkNotNull(parentGroup);
+		this.outputGroup = checkNotNull(outputGroup);
+		this.inputGroup = checkNotNull(inputGroup);
+	}
+
+	public String getOwnerName() {
+		return ownerName;
+	}
+
+	public ExecutionAttemptID getExecutionAttemptID() {
+		return executionAttemptID;
+	}
+
+	public MetricGroup getParentGroup() {
+		return parentGroup;
+	}
+
+	public MetricGroup getOutputGroup() {
+		return outputGroup;
+	}
+
+	public MetricGroup getInputGroup() {
+		return inputGroup;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -361,7 +361,7 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 
 		final String taskNameWithSubtaskAndId = taskNameWithSubtask + " (" + executionId + ')';
 
-		ShuffleIOOwnerContext taskShuffleContext = shuffleEnvironment
+		final ShuffleIOOwnerContext taskShuffleContext = shuffleEnvironment
 			.createShuffleIOOwnerContext(taskNameWithSubtaskAndId, executionId, metrics.getIOMetricGroup());
 
 		// produced intermediate result partitions

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -28,7 +28,6 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystemSafetyNet;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.SafetyNetCloseableRegistry;
-import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
@@ -50,6 +49,7 @@ import org.apache.flink.runtime.executiongraph.JobInformation;
 import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.shuffle.ShuffleIOOwnerContext;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
@@ -360,21 +361,13 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 
 		final String taskNameWithSubtaskAndId = taskNameWithSubtask + " (" + executionId + ')';
 
-		// add metrics for buffers
-		final MetricGroup buffersGroup = metrics.getIOMetricGroup().addGroup("buffers");
-
-		// similar to MetricUtils.instantiateNetworkMetrics() but inside this IOMetricGroup
-		final MetricGroup networkGroup = metrics.getIOMetricGroup().addGroup("Network");
-		final MetricGroup outputGroup = networkGroup.addGroup("Output");
-		final MetricGroup inputGroup = networkGroup.addGroup("Input");
+		ShuffleIOOwnerContext taskShuffleContext = shuffleEnvironment
+			.createShuffleIOOwnerContext(taskNameWithSubtaskAndId, executionId, metrics.getIOMetricGroup());
 
 		// produced intermediate result partitions
 		final ResultPartitionWriter[] resultPartitionWriters = shuffleEnvironment.createResultPartitionWriters(
-			taskNameWithSubtaskAndId,
-			executionId,
-			resultPartitionDeploymentDescriptors,
-			outputGroup,
-			buffersGroup).toArray(new ResultPartitionWriter[] {});
+			taskShuffleContext,
+			resultPartitionDeploymentDescriptors).toArray(new ResultPartitionWriter[] {});
 
 		this.consumableNotifyingPartitionWriters = ConsumableNotifyingResultPartitionWriterDecorator.decorate(
 			resultPartitionDeploymentDescriptors,
@@ -385,18 +378,20 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 
 		// consumed intermediate result partitions
 		final InputGate[] gates = shuffleEnvironment.createInputGates(
-			taskNameWithSubtaskAndId,
-			executionId,
+			taskShuffleContext,
 			this,
-			inputGateDeploymentDescriptors,
-			metrics.getIOMetricGroup(),
-			inputGroup,
-			buffersGroup).toArray(new InputGate[] {});
+			inputGateDeploymentDescriptors).toArray(new InputGate[] {});
 
 		this.inputGates = new InputGate[gates.length];
 		int counter = 0;
 		for (InputGate gate : gates) {
 			inputGates[counter++] = new InputGateWithMetrics(gate, metrics.getIOMetricGroup().getNumBytesInCounter());
+		}
+
+		if (shuffleEnvironment instanceof NettyShuffleEnvironment) {
+			//noinspection deprecation
+			((NettyShuffleEnvironment) shuffleEnvironment)
+				.registerLegacyNetworkMetrics(metrics.getIOMetricGroup(), resultPartitionWriters, gates);
 		}
 
 		invokableHasBeenCanceled = new AtomicBoolean(false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -608,13 +608,9 @@ public class SingleInputGateTest extends InputGateTestBase {
 
 		ExecutionAttemptID consumerID = new ExecutionAttemptID();
 		SingleInputGate[] gates = network.createInputGates(
-			"",
-			consumerID,
+			network.createShuffleIOOwnerContext("", consumerID, new UnregisteredMetricsGroup()),
 			SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
-			Arrays.asList(gateDescs),
-			new UnregisteredMetricsGroup(),
-			new UnregisteredMetricsGroup(),
-			new UnregisteredMetricsGroup()).toArray(new SingleInputGate[] {});
+			Arrays.asList(gateDescs)).toArray(new SingleInputGate[] {});
 		Map<InputGateID, SingleInputGate> inputGatesById = new HashMap<>();
 		for (int i = 0; i < numberOfGates; i++) {
 			inputGatesById.put(new InputGateID(ids[i], consumerID), gates[i]);


### PR DESCRIPTION
## What is the purpose of the change

At the moment, partition/gate create methods in NetworkEnvironment have a lot of metrics arguments to maintain original layout for metric groups. This approach is not quite encapsulated and clean for shuffle API. We can have just one parent group for shuffle metrics. The old layout can be still maintained in parallel and deprecated. At the moment we can do it with a couple of casts (if shuffle implementation is NetworkEnvironment) and adding an additional legacy metric registration which can be removed later.

## Brief change log

  - Change `NetworkEnvironment.createResultPartitionWriters/createInputGates` to have only one parent metric group argument.
  - Add InputChannelMetricsWithLegacy to increment input metrics from the legacy group as well
  - Move legacy metric group creation to deprecated `NetworkEnvironment.registerLegacyNetworkMetrics`
  - clean `Task` of legacy code but add call to `NetworkEnvironment.registerLegacyNetworkMetrics` after creation of partitions and gates (later needs instanceOf check for actual ShuffleService)

## Verifying this change

simple refactoring, existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
