### PR TITLE
[FLINK-12372] [runtime] implement ExecutionSlotAllocator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -84,7 +84,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 
 	private static final Logger LOG = ExecutionGraph.LOG;
 
-	private static final int MAX_DISTINCT_LOCATIONS_TO_CONSIDER = 8;
+	public static final int MAX_DISTINCT_LOCATIONS_TO_CONSIDER = 8;
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -86,7 +86,6 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 
 	public static final int MAX_DISTINCT_LOCATIONS_TO_CONSIDER = 8;
 
-	public static final int ABC = 1;
 	// --------------------------------------------------------------------------------------------
 
 	private final ExecutionJobVertex jobVertex;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -86,6 +86,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 
 	public static final int MAX_DISTINCT_LOCATIONS_TO_CONSIDER = 8;
 
+	public static final int ABC = 1;
 	// --------------------------------------------------------------------------------------------
 
 	private final ExecutionJobVertex jobVertex;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionEdge;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.Scheduler;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionVertex.MAX_DISTINCT_LOCATIONS_TO_CONSIDER;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default {@link ExecutionSlotAllocator} which will use {@link SlotProvider} to allocate slots and
+ * keep the unfulfilled requests for further cancellation.
+ */
+public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
+
+	static final Logger LOG = LoggerFactory.getLogger(DefaultExecutionSlotAllocator.class);
+
+	/**
+	 * Store the uncompleted slot assignments.
+	 */
+	private final Map<ExecutionVertexID, SlotExecutionVertexAssignment> pendingSlotAssignments;
+
+	private final SlotProvider slotProvider;
+
+	private final ExecutionGraph executionGraph;
+
+	public DefaultExecutionSlotAllocator(SlotProvider slotProvider, ExecutionGraph executionGraph) {
+		this.slotProvider = checkNotNull(slotProvider);
+		this.executionGraph = checkNotNull(executionGraph);
+
+		pendingSlotAssignments = new HashMap<>();
+	}
+
+	@Override
+	public Collection<SlotExecutionVertexAssignment> allocateSlotsFor(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+
+		List<SlotExecutionVertexAssignment> slotExecutionVertexAssignments =
+				new ArrayList<>(executionVertexSchedulingRequirements.size());
+
+		Set<AllocationID> allPreviousAllocationIds =
+				computeAllPriorAllocationIdsIfRequiredByScheduling(executionVertexSchedulingRequirements);
+
+		Set<ExecutionVertexID> verticesScheduledTogether = getAllExecutionVerticesId(executionVertexSchedulingRequirements);
+
+		for (ExecutionVertexSchedulingRequirements schedulingRequirements : executionVertexSchedulingRequirements) {
+			final ExecutionVertexID executionVertexId = schedulingRequirements.getExecutionVertexId();
+			final SlotRequestId slotRequestId = new SlotRequestId();
+			final SlotSharingGroupId slotSharingGroupId = schedulingRequirements.getSlotSharingGroupId();
+
+			Execution execution = null;
+			ExecutionJobVertex ejv = executionGraph.getJobVertex(executionVertexId.getJobVertexId());
+			if (ejv != null && ejv.getParallelism() > executionVertexId.getSubtaskIndex()) {
+				execution = ejv.getTaskVertices()[executionVertexId.getSubtaskIndex()].getCurrentExecutionAttempt();
+
+			}
+			if (execution == null) {
+				throw new IllegalArgumentException("Fail to get execution for vertex id " + executionVertexId);
+			}
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Allocate slot with id {} for execution {}", slotRequestId, executionVertexId);
+			}
+
+			// TODO: the calculation of preferred location should be refined so we can use the preferredLocations
+			// in ExecutionVertexSchedulingRequirements instead of calculating it here
+			CompletableFuture<LogicalSlot> slotFuture =
+					calculatePreferredLocations(execution, verticesScheduledTogether).thenCompose(
+							(Collection<TaskManagerLocation> preferredLocations) ->
+								slotProvider.allocateSlot(
+									slotRequestId,
+									new ScheduledUnit(
+											null,
+											executionVertexId.getJobVertexId(),
+											slotSharingGroupId,
+											schedulingRequirements.getCoLocationConstraint()),
+									new SlotProfile(
+											schedulingRequirements.getResourceProfile(),
+											preferredLocations,
+											Arrays.asList(schedulingRequirements.getPreviousAllocationId()),
+											allPreviousAllocationIds),
+									executionGraph.isQueuedSchedulingAllowed(),
+									executionGraph.getAllocationTimeout()));
+
+			SlotExecutionVertexAssignment slotExecutionVertexAssignment =
+					new SlotExecutionVertexAssignment(executionVertexId, slotFuture);
+			// add to map first to avoid the future completed before added.
+			pendingSlotAssignments.put(executionVertexId, slotExecutionVertexAssignment);
+
+			slotFuture.whenComplete(
+					(ignored, throwable) -> {
+						pendingSlotAssignments.remove(executionVertexId);
+						if (throwable != null) {
+							slotProvider.cancelSlotRequest(slotRequestId, slotSharingGroupId, throwable);
+						}
+					});
+
+			slotExecutionVertexAssignments.add(slotExecutionVertexAssignment);
+		}
+
+		return slotExecutionVertexAssignments;
+	}
+
+	@Override
+	public void cancel(ExecutionVertexID executionVertexId) {
+		SlotExecutionVertexAssignment slotExecutionVertexAssignment = pendingSlotAssignments.get(executionVertexId);
+		if (slotExecutionVertexAssignment != null) {
+			slotExecutionVertexAssignment.getLogicalSlotFuture().cancel(false);
+		}
+	}
+
+	@Override
+	public CompletableFuture<Void> stop() {
+		List<ExecutionVertexID> executionVertexIds = new ArrayList<>(pendingSlotAssignments.keySet());
+		executionVertexIds.stream().forEach(executionVertexID -> cancel(executionVertexID));
+
+		return CompletableFuture.completedFuture(null);
+	}
+
+	private static Set<ExecutionVertexID> getAllExecutionVerticesId(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+		Set<ExecutionVertexID> executionVertexIds = new HashSet<>(executionVertexSchedulingRequirements.size());
+		for (ExecutionVertexSchedulingRequirements schedulingRequirements : executionVertexSchedulingRequirements) {
+			executionVertexIds.add(schedulingRequirements.getExecutionVertexId());
+		}
+		return executionVertexIds;
+	}
+
+	/**
+	 * Calculates the preferred locations for an execution.
+	 * It will first try to use preferred locations based on state,
+	 * if null, will use the preferred locations based on inputs.
+	 */
+	private static CompletableFuture<Collection<TaskManagerLocation>> calculatePreferredLocations(
+			Execution execution,
+			Collection<ExecutionVertexID> verticesScheduledTogether) {
+
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations =
+				execution.getVertex().getPreferredLocationsBasedOnState();
+
+		if (preferredLocations == null) {
+			preferredLocations = getPreferredLocationsBasedOnInputs(execution, verticesScheduledTogether);
+		}
+		return FutureUtils.combineAll(preferredLocations);
+	}
+
+	/**
+	 * Gets the location preferences of the execution, as determined by the locations
+	 * of the predecessors from which it receives input data.
+	 * If there are more than {@link MAX_DISTINCT_LOCATIONS_TO_CONSIDER} different locations of source data,
+	 * or neither the sources have not been started nor will be started with the execution together,
+	 * this method returns an empty collection to indicate no location preference.
+	 *
+	 * @return The preferred locations based in input streams, or an empty iterable,
+	 *         if there is no input-based preference.
+	 */
+	@VisibleForTesting
+	static Collection<CompletableFuture<TaskManagerLocation>> getPreferredLocationsBasedOnInputs(
+			Execution execution,
+			Collection<ExecutionVertexID> verticesScheduledTogether) {
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations = new HashSet<>();
+
+		Set<CompletableFuture<TaskManagerLocation>> inputLocations = new HashSet<>();
+		for (int i = 0; i < execution.getVertex().getNumberOfInputs(); i++) {
+			ExecutionEdge[] inputEdges = execution.getVertex().getInputEdges(i);
+			if (inputEdges.length <= MAX_DISTINCT_LOCATIONS_TO_CONSIDER) {
+				for (ExecutionEdge inputEdge : inputEdges) {
+					ExecutionVertex producer = inputEdge.getSource().getProducer();
+					if (verticesScheduledTogether.contains(
+							new ExecutionVertexID(producer.getJobvertexId(), producer.getParallelSubtaskIndex()))
+							|| producer.getExecutionState() != ExecutionState.CREATED) {
+						inputLocations.add(producer.getCurrentTaskManagerLocationFuture());
+					} else {
+						inputLocations.clear();
+						break;
+					}
+				}
+				if (preferredLocations.isEmpty() ||
+						(!inputLocations.isEmpty() && inputLocations.size() < preferredLocations.size())) {
+					preferredLocations.clear();
+					preferredLocations.addAll(inputLocations);
+				}
+				inputLocations.clear();
+			}
+		}
+		return preferredLocations;
+	}
+
+	/**
+	 * Returns the result of {@link #computeAllPriorAllocationIds}, but only if the scheduling really requires it.
+	 * Otherwise this method simply returns an empty set.
+	 */
+	private Set<AllocationID> computeAllPriorAllocationIdsIfRequiredByScheduling(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+		// This is a temporary optimization to avoid computing all previous allocations if not required
+		// This can go away when we progress with the implementation of the Scheduler.
+		if (slotProvider instanceof Scheduler && ((Scheduler) slotProvider).requiresPreviousExecutionGraphAllocations()) {
+			return computeAllPriorAllocationIds(executionVertexSchedulingRequirements);
+		} else {
+			return Collections.emptySet();
+		}
+	}
+
+	/**
+	 * Computes and returns a set with the prior allocation ids from all execution vertices scheduled together.
+	 *
+	 * @param executionVertexSchedulingRequirements contains the execution vertices which are scheduled together
+	 */
+	@VisibleForTesting
+	static Set<AllocationID> computeAllPriorAllocationIds(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+		HashSet<AllocationID> allPreviousAllocationIds = new HashSet<>(executionVertexSchedulingRequirements.size());
+		for (ExecutionVertexSchedulingRequirements schedulingRequirements : executionVertexSchedulingRequirements) {
+			AllocationID priorAllocation = schedulingRequirements.getPreviousAllocationId();
+			if (priorAllocation != null) {
+				allPreviousAllocationIds.add(priorAllocation);
+			}
+		}
+		return allPreviousAllocationIds;
+	}
+
+	@VisibleForTesting
+	Map<ExecutionVertexID, SlotExecutionVertexAssignment> getPendingSlotAssignments() {
+		return Collections.unmodifiableMap(pendingSlotAssignments);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -104,7 +104,6 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 			}
 
 			// TODO: the calculation of preferred location should be refined.
-			// in ExecutionVertexSchedulingRequirements instead of calculating it here
 			CompletableFuture<LogicalSlot> slotFuture = calculatePreferredLocations(
 					executionVertexId,
 					schedulingRequirements.getPreferredLocations(),
@@ -217,20 +216,17 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 				);
 				// If the parallelism is large, wait for all futures coming back may cost a long time,
 				// so using the unfulfilled future number here to speed up it.
-				System.out.println(inputLocations.size() + " while " + inputLocationsFutures.size());
 				if (inputLocations.size() > MAX_DISTINCT_LOCATIONS_TO_CONSIDER ||
 						inputLocationsFutures.size() > MAX_DISTINCT_LOCATIONS_TO_CONSIDER) {
 					locationsFutures.clear();
 					break;
 				}
 			}
-			System.out.println(executionVertexId + " should wait for " + locationsFutures);
 
 			if (!locationsFutures.isEmpty()) {
 				CompletableFuture<Collection<TaskManagerLocation>> uniqueLocationsFuture =
 						FutureUtils.combineAll(locationsFutures).thenApply(
 								(locations) -> {
-									System.out.println("I am completed with size " + locations.size());
 									Set<TaskManagerLocation> uniqueLocations = new HashSet<>(locations);
 									if (uniqueLocations.size() <= MAX_DISTINCT_LOCATIONS_TO_CONSIDER) {
 										return uniqueLocations;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -171,7 +172,7 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 	/**
 	 * Gets the location preferences of the execution, as determined by the locations
 	 * of the predecessors from which it receives input data.
-	 * If there are more than {@link MAX_DISTINCT_LOCATIONS_TO_CONSIDER} different locations of source data,
+	 * If there are more than {@link ExecutionVertex#MAX_DISTINCT_LOCATIONS_TO_CONSIDER} different locations of source data,
 	 * or neither the sources have not been started nor will be started with the execution together,
 	 * this method returns an empty collection to indicate no location preference.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -48,7 +48,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionVertex.MAX_DISTINCT_LOCATIONS_TO_CONSIDER;
-
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -105,7 +105,6 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 									slotProvider.allocateSlot(
 											slotRequestId,
 											new ScheduledUnit(
-													null,
 													executionVertexId.getJobVertexId(),
 													slotSharingGroupId,
 													schedulingRequirements.getCoLocationConstraint()),
@@ -162,7 +161,7 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 			Collection<TaskManagerLocation> preferredLocationsBasedOnState,
 			InputsLocationsRetriever inputsLocationsRetriever) {
 
-		if (preferredLocationsBasedOnState != null && !preferredLocationsBasedOnState.isEmpty()) {
+		if (!preferredLocationsBasedOnState.isEmpty()) {
 			return CompletableFuture.completedFuture(preferredLocationsBasedOnState);
 		}
 
@@ -244,7 +243,7 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 	}
 
 	@VisibleForTesting
-	Map<ExecutionVertexID, SlotExecutionVertexAssignment> getPendingSlotAssignments() {
-		return Collections.unmodifiableMap(pendingSlotAssignments);
+	int getNumberOfPendingSlotAssignments() {
+		return pendingSlotAssignments.size();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Component responsible for assigning slots to a collection of {@link Execution}.
+ */
+public interface ExecutionSlotAllocator {
+
+	/**
+	 * Allocates slots for the given executions.
+	 *
+	 * @param executionVertexSchedulingRequirements The requirements for scheduling the executions.
+	 */
+	Collection<SlotExecutionVertexAssignment> allocateSlotsFor(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements);
+
+	/**
+	 * Cancel an ongoing slot request.
+	 *
+	 * @param executionVertexId identifying which slot request should be canceled.
+	 */
+	void cancel(ExecutionVertexID executionVertexId);
+
+	/**
+	 * Stop the allocator.
+	 */
+	CompletableFuture<Void> stop();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocator.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 public interface ExecutionSlotAllocator {
 
 	/**
-	 * Allocates slots for the given executions.
+	 * Allocates slots for executions.
 	 *
 	 * @param executionVertexSchedulingRequirements The requirements for scheduling the executions.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.Collections;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.AbstractID;
+
+import java.util.Collection;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The requirements for scheduling a {@link ExecutionVertex}.
+ */
+public class ExecutionVertexSchedulingRequirements {
+
+	private final ExecutionVertexID executionVertexId;
+
+	private final AllocationID previousAllocationId;
+
+	private final ResourceProfile resourceProfile;
+
+	private final SlotSharingGroupId slotSharingGroupId;
+
+	private final CoLocationConstraint coLocationConstraint;
+
+	private final AbstractID groupId;
+
+	private final Collection<TaskManagerLocation> preferredLocations;
+
+	public ExecutionVertexSchedulingRequirements(
+			ExecutionVertexID executionVertexId,
+			AllocationID previousAllocationId,
+			ResourceProfile resourceProfile,
+			SlotSharingGroupId slotSharingGroupId,
+			CoLocationConstraint coLocationConstraint,
+			AbstractID groupId,
+			Collection<TaskManagerLocation> preferredLocations) {
+		this.executionVertexId = checkNotNull(executionVertexId);
+		this.previousAllocationId = previousAllocationId;
+		this.resourceProfile = checkNotNull(resourceProfile);
+		this.slotSharingGroupId = slotSharingGroupId;
+		this.coLocationConstraint = coLocationConstraint;
+		this.groupId = groupId;
+		this.preferredLocations = preferredLocations;
+	}
+
+	public ExecutionVertexID getExecutionVertexId() {
+		return executionVertexId;
+	}
+
+	public AllocationID getPreviousAllocationId() {
+		return previousAllocationId;
+	}
+
+	public ResourceProfile getResourceProfile() {
+		return resourceProfile;
+	}
+
+	public SlotSharingGroupId getSlotSharingGroupId() {
+		return slotSharingGroupId;
+	}
+
+	public CoLocationConstraint getCoLocationConstraint() {
+		return coLocationConstraint;
+	}
+
+	public AbstractID getGroupId() {
+		return groupId;
+	}
+
+	public Collection<TaskManagerLocation> getPreferredLocations() {
+		return preferredLocations;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -26,7 +26,9 @@ import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -59,13 +61,19 @@ public class ExecutionVertexSchedulingRequirements {
 		this.resourceProfile = checkNotNull(resourceProfile);
 		this.slotSharingGroupId = slotSharingGroupId;
 		this.coLocationConstraint = coLocationConstraint;
-		this.preferredLocations = preferredLocations;
+		this.preferredLocations = checkNotNull(preferredLocations);
 	}
 
+	/**
+	 * a {@link ExecutionVertex#MAX_DISTINCT_LOCATIONS_TO_CONSIDER} test.
+	 *
+	 * @return
+	 */
 	public ExecutionVertexID getExecutionVertexId() {
 		return executionVertexId;
 	}
 
+	@Nullable
 	public AllocationID getPreviousAllocationId() {
 		return previousAllocationId;
 	}
@@ -74,15 +82,75 @@ public class ExecutionVertexSchedulingRequirements {
 		return resourceProfile;
 	}
 
+	@Nullable
 	public SlotSharingGroupId getSlotSharingGroupId() {
 		return slotSharingGroupId;
 	}
 
+	@Nullable
 	public CoLocationConstraint getCoLocationConstraint() {
 		return coLocationConstraint;
 	}
 
 	public Collection<TaskManagerLocation> getPreferredLocations() {
 		return preferredLocations;
+	}
+
+	/**
+	 * Builder for {@link ExecutionVertexSchedulingRequirements}.
+	 */
+	public static class Builder {
+
+		private ExecutionVertexID executionVertexId;
+
+		private AllocationID previousAllocationId;
+
+		private ResourceProfile resourceProfile = ResourceProfile.UNKNOWN;
+
+		private SlotSharingGroupId slotSharingGroupId;
+
+		private CoLocationConstraint coLocationConstraint;
+
+		private Collection<TaskManagerLocation> preferredLocations = Collections.emptyList();
+
+		public Builder withExecutionVertexId(final ExecutionVertexID executionVertexId) {
+			this.executionVertexId = executionVertexId;
+			return this;
+		}
+
+		public Builder withPreviousAllocationId(final AllocationID previousAllocationId) {
+			this.previousAllocationId = previousAllocationId;
+			return this;
+		}
+
+		public Builder withResourceProfile(final ResourceProfile resourceProfile) {
+			this.resourceProfile = resourceProfile;
+			return this;
+		}
+
+		public Builder withSlotSharingGroupId(final SlotSharingGroupId slotSharingGroupId) {
+			this.slotSharingGroupId = slotSharingGroupId;
+			return this;
+		}
+
+		public Builder withCoLocationConstraint(final CoLocationConstraint coLocationConstraint) {
+			this.coLocationConstraint = coLocationConstraint;
+			return this;
+		}
+
+		public Builder withPreferredLocations(final Collection<TaskManagerLocation> preferredLocations) {
+			this.preferredLocations = preferredLocations;
+			return this;
+		}
+
+		public ExecutionVertexSchedulingRequirements build() {
+			return new ExecutionVertexSchedulingRequirements(
+					executionVertexId,
+					previousAllocationId,
+					resourceProfile,
+					slotSharingGroupId,
+					coLocationConstraint,
+					preferredLocations);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.AbstractID;
 
 import java.util.Collection;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -46,8 +46,6 @@ public class ExecutionVertexSchedulingRequirements {
 
 	private final CoLocationConstraint coLocationConstraint;
 
-	private final AbstractID groupId;
-
 	private final Collection<TaskManagerLocation> preferredLocations;
 
 	public ExecutionVertexSchedulingRequirements(
@@ -56,14 +54,12 @@ public class ExecutionVertexSchedulingRequirements {
 			ResourceProfile resourceProfile,
 			SlotSharingGroupId slotSharingGroupId,
 			CoLocationConstraint coLocationConstraint,
-			AbstractID groupId,
 			Collection<TaskManagerLocation> preferredLocations) {
 		this.executionVertexId = checkNotNull(executionVertexId);
 		this.previousAllocationId = previousAllocationId;
 		this.resourceProfile = checkNotNull(resourceProfile);
 		this.slotSharingGroupId = slotSharingGroupId;
 		this.coLocationConstraint = coLocationConstraint;
-		this.groupId = groupId;
 		this.preferredLocations = preferredLocations;
 	}
 
@@ -85,10 +81,6 @@ public class ExecutionVertexSchedulingRequirements {
 
 	public CoLocationConstraint getCoLocationConstraint() {
 		return coLocationConstraint;
-	}
-
-	public AbstractID getGroupId() {
-		return groupId;
 	}
 
 	public Collection<TaskManagerLocation> getPreferredLocations() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -40,22 +40,25 @@ public class ExecutionVertexSchedulingRequirements {
 
 	private final ExecutionVertexID executionVertexId;
 
+	@Nullable
 	private final AllocationID previousAllocationId;
 
 	private final ResourceProfile resourceProfile;
 
+	@Nullable
 	private final SlotSharingGroupId slotSharingGroupId;
 
+	@Nullable
 	private final CoLocationConstraint coLocationConstraint;
 
 	private final Collection<TaskManagerLocation> preferredLocations;
 
 	private ExecutionVertexSchedulingRequirements(
 			ExecutionVertexID executionVertexId,
-			AllocationID previousAllocationId,
+			@Nullable AllocationID previousAllocationId,
 			ResourceProfile resourceProfile,
-			SlotSharingGroupId slotSharingGroupId,
-			CoLocationConstraint coLocationConstraint,
+			@Nullable SlotSharingGroupId slotSharingGroupId,
+			@Nullable CoLocationConstraint coLocationConstraint,
 			Collection<TaskManagerLocation> preferredLocations) {
 		this.executionVertexId = checkNotNull(executionVertexId);
 		this.previousAllocationId = previousAllocationId;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -50,7 +50,7 @@ public class ExecutionVertexSchedulingRequirements {
 
 	private final Collection<TaskManagerLocation> preferredLocations;
 
-	public ExecutionVertexSchedulingRequirements(
+	private ExecutionVertexSchedulingRequirements(
 			ExecutionVertexID executionVertexId,
 			AllocationID previousAllocationId,
 			ResourceProfile resourceProfile,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InputsLocationsRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InputsLocationsRetriever.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Component to retrieve the inputs locations of a {@link Execution}.
+ */
+public interface InputsLocationsRetriever {
+
+	/**
+	 * Get the producers of the result partitions consumed by an execution.
+	 *
+	 * @param executionVertexId identifies the execution
+	 * @return the producers of the result partitions group by job vertex id
+	 */
+	Collection<Collection<ExecutionVertexID>> getConsumedResultPartitionsProducers(ExecutionVertexID executionVertexId);
+
+	/**
+	 * Get the task manager location future for an execution.
+	 *
+	 * @param executionVertexId identifying the execution
+	 * @return the task manager location future
+	 */
+	Optional<CompletableFuture<TaskManagerLocation>> getTaskManagerLocation(ExecutionVertexID executionVertexId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotExecutionVertexAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotExecutionVertexAssignment.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The slot assignment for a {@link ExecutionVertex}.
+ */
+public class SlotExecutionVertexAssignment {
+
+	private final ExecutionVertexID executionVertexId;
+
+	private final CompletableFuture<LogicalSlot> logicalSlotFuture;
+
+	public SlotExecutionVertexAssignment(
+			ExecutionVertexID executionVertexId,
+			CompletableFuture<LogicalSlot> logicalSlotFuture) {
+		this.executionVertexId = checkNotNull(executionVertexId);
+		this.logicalSlotFuture = checkNotNull(logicalSlotFuture);
+	}
+
+	public ExecutionVertexID getExecutionVertexId() {
+		return executionVertexId;
+	}
+
+	public CompletableFuture<LogicalSlot> getLogicalSlotFuture() {
+		return logicalSlotFuture;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
@@ -109,7 +109,6 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 					ResourceProfile.UNKNOWN,
 					new SlotSharingGroupId(),
 					null,
-					null,
 					null
 			));
 			executionVertexIds.add(executionVertexId);
@@ -193,13 +192,11 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 						ResourceProfile.UNKNOWN,
 						null,
 						null,
-						null,
 						null),
 				new ExecutionVertexSchedulingRequirements(
 						executionVertexIds.get(1),
 						expectAllocationIds.get(0),
 						ResourceProfile.UNKNOWN,
-						null,
 						null,
 						null,
 						null),
@@ -209,13 +206,11 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 						ResourceProfile.UNKNOWN,
 						null,
 						null,
-						null,
 						null),
 				new ExecutionVertexSchedulingRequirements(
 						executionVertexIds.get(3),
 						null,
 						ResourceProfile.UNKNOWN,
-						null,
 						null,
 						null,
 						null)
@@ -270,7 +265,7 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 
 		// The first upstream has more than 10 different locations
 		List<TaskManagerLocation> locationsOfProducer1 = new ArrayList<>(producer1.getParallelism());
-		for (int i = 0 ; i < producer1.getParallelism(); i++) {
+		for (int i = 0; i < producer1.getParallelism(); i++) {
 			TaskManagerLocation location = new LocalTaskManagerLocation();
 			locationsRetriever.getTaskManagerLocation(new ExecutionVertexID(producer1.getID(), i))
 					.ifPresent((locationFuture -> locationFuture.complete(location)));
@@ -279,7 +274,7 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 
 		// The second upstream has 1 different locations with 7 uncompleted
 		TaskManagerLocation location = new LocalTaskManagerLocation();
-		for (int i = 0 ; i < 3; i++) {
+		for (int i = 0; i < 3; i++) {
 			locationsRetriever.getTaskManagerLocation(new ExecutionVertexID(producer2.getID(), i))
 					.ifPresent((locationFuture -> locationFuture.complete(location)));
 		}
@@ -289,7 +284,7 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 					.ifPresent((locationFuture -> locationFuture.complete(new LocalTaskManagerLocation())));
 
 		// The fourth upstream has 3 different locations
-		for (int i = 0 ; i < producer4.getParallelism(); i++) {
+		for (int i = 0; i < producer4.getParallelism(); i++) {
 			locationsRetriever.getTaskManagerLocation(new ExecutionVertexID(producer4.getID(), i))
 					.ifPresent((locationFuture -> locationFuture.complete(new LocalTaskManagerLocation())));
 		}
@@ -307,7 +302,7 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 		}
 		assertFalse(preferredLocationsOfConsumer1.isDone());
 
-		for (int i = 0 ; i < producer5.getParallelism(); i++) {
+		for (int i = 0; i < producer5.getParallelism(); i++) {
 			locationsRetriever.getTaskManagerLocation(new ExecutionVertexID(producer5.getID(), i))
 					.ifPresent((locationFuture -> locationFuture.complete(new LocalTaskManagerLocation())));
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TestingSlotProvider;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link DefaultExecutionSlotAllocator}.
+ */
+public class DefaultExecutionSlotAllocatorTest extends TestLogger {
+
+	private DefaultExecutionSlotAllocator executionSlotAllocator;
+
+	private TestingSlotProvider slotProvider;
+
+	private ExecutionGraph executionGraph;
+
+	private List<ExecutionVertexSchedulingRequirements> schedulingRequirements;
+
+	private Queue<CompletableFuture<LogicalSlot>> slotFutures;
+
+	private List<SlotRequestId> receivedSlotRequestIds;
+
+	private List<SlotRequestId> cancelledSlotRequestIds;
+
+	private List<ExecutionVertexID> executionVertexIds;
+
+	private int executionVerticesNum;
+
+	@Before
+	public void setUp() throws Exception {
+		executionGraph = createSimpleProducerConsumerGraph();
+
+		executionVerticesNum = executionGraph.getTotalNumberOfVertices();
+		receivedSlotRequestIds = new ArrayList<>(executionVerticesNum);
+		cancelledSlotRequestIds = new ArrayList<>(executionVerticesNum);
+		slotFutures = new ArrayDeque<>(executionVerticesNum);
+
+		slotProvider = new TestingSlotProvider(slotRequestId -> {
+			receivedSlotRequestIds.add(slotRequestId);
+			return slotFutures.poll();
+		});
+		slotProvider.setSlotCanceller(slotRequestId -> cancelledSlotRequestIds.add(slotRequestId));
+
+		executionSlotAllocator = new DefaultExecutionSlotAllocator(slotProvider, executionGraph);
+
+		schedulingRequirements = new ArrayList<>(executionVerticesNum);
+		executionVertexIds = new ArrayList<>(executionVerticesNum);
+
+		for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
+			ExecutionVertexID executionVertexId =
+					new ExecutionVertexID(executionVertex.getJobvertexId(), executionVertex.getParallelSubtaskIndex());
+			schedulingRequirements.add(new ExecutionVertexSchedulingRequirements(
+					executionVertexId,
+					null,
+					ResourceProfile.UNKNOWN,
+					new SlotSharingGroupId(),
+					null,
+					null,
+					null
+			));
+			executionVertexIds.add(executionVertexId);
+			slotFutures.add(new CompletableFuture<>());
+		}
+	}
+
+	/**
+	 * Tests that it will allocate slots from slot provider and remove the slot assignments when request are fulfilled.
+	 */
+	@Test
+	public void testAllocateSlotsFor() {
+		List<CompletableFuture<LogicalSlot>> backupSlotFutures = new ArrayList<>(slotFutures);
+
+		executionSlotAllocator.allocateSlotsFor(schedulingRequirements);
+
+		assertThat(receivedSlotRequestIds, hasSize(executionVerticesNum / 2));
+		assertThat(executionSlotAllocator.getPendingSlotAssignments().keySet(), containsInAnyOrder(executionVertexIds.toArray()));
+
+		completeProducerSlotRequest(backupSlotFutures);
+
+		assertThat(receivedSlotRequestIds, hasSize(executionVerticesNum));
+	}
+
+	/**
+	 * Tests that when cancelling a slot request, the request to slot provider should also be cancelled.
+	 */
+	@Test
+	public void testCancel() {
+		List<CompletableFuture<LogicalSlot>> backupSlotFutures = new ArrayList<>(slotFutures);
+
+		executionSlotAllocator.allocateSlotsFor(schedulingRequirements);
+
+		// cancel a non-existing execution vertex
+		ExecutionVertexID inValidExecutionVertexId = new ExecutionVertexID(new JobVertexID(), 0);
+		executionSlotAllocator.cancel(inValidExecutionVertexId);
+		assertThat(cancelledSlotRequestIds, hasSize(0));
+
+		assertThat(receivedSlotRequestIds, hasSize(executionVerticesNum / 2));
+
+		completeProducerSlotRequest(backupSlotFutures);
+
+		for (ExecutionVertexID executionVertexId : executionVertexIds) {
+			executionSlotAllocator.cancel(executionVertexId);
+		}
+
+		// only the consumers slot request will be cancelled
+		List<SlotRequestId> expectCancelledSlotRequestIds =
+				receivedSlotRequestIds.subList(executionVerticesNum / 2, executionVerticesNum);
+		assertThat(cancelledSlotRequestIds, containsInAnyOrder(expectCancelledSlotRequestIds.toArray()));
+	}
+
+	/**
+	 * Tests that all unfulfilled slot requests will be cancelled when stopped.
+	 */
+	@Test
+	public void testStop() {
+		executionSlotAllocator.allocateSlotsFor(schedulingRequirements);
+
+		// only the producers will ask for slots as the preferred location futures of consumers are not fulfilled.
+		assertThat(executionSlotAllocator.getPendingSlotAssignments().keySet(), hasSize(executionVerticesNum));
+		assertThat(receivedSlotRequestIds, hasSize(executionVerticesNum / 2));
+
+		executionSlotAllocator.stop().getNow(null);
+
+		assertThat(cancelledSlotRequestIds, hasSize(executionVerticesNum / 2));
+		assertThat(cancelledSlotRequestIds, containsInAnyOrder(receivedSlotRequestIds.toArray()));
+		assertThat(executionSlotAllocator.getPendingSlotAssignments().keySet(), hasSize(0));
+	}
+
+	/**
+	 * Tests that all prior allocation ids are computed by union all previous allocation ids in scheduling requirements.
+	 */
+	@Test
+	public void testComputeAllPriorAllocationIds() {
+		List<AllocationID> expectAllocationIds = Arrays.asList(new AllocationID(), new AllocationID());
+		List<ExecutionVertexSchedulingRequirements> testSchedulingRequirements = Arrays.asList(
+				new ExecutionVertexSchedulingRequirements(
+						executionVertexIds.get(0),
+						expectAllocationIds.get(0),
+						ResourceProfile.UNKNOWN,
+						null,
+						null,
+						null,
+						null),
+				new ExecutionVertexSchedulingRequirements(
+						executionVertexIds.get(1),
+						expectAllocationIds.get(0),
+						ResourceProfile.UNKNOWN,
+						null,
+						null,
+						null,
+						null),
+				new ExecutionVertexSchedulingRequirements(
+						executionVertexIds.get(2),
+						expectAllocationIds.get(1),
+						ResourceProfile.UNKNOWN,
+						null,
+						null,
+						null,
+						null),
+				new ExecutionVertexSchedulingRequirements(
+						executionVertexIds.get(3),
+						null,
+						ResourceProfile.UNKNOWN,
+						null,
+						null,
+						null,
+						null)
+		);
+
+		Set<AllocationID> allPriorAllocationIds = executionSlotAllocator.computeAllPriorAllocationIds(testSchedulingRequirements);
+		assertThat(allPriorAllocationIds, containsInAnyOrder(expectAllocationIds.toArray()));
+	}
+
+	/**
+	 * Tests the calculation of preferred locations based on inputs for an execution.
+	 */
+	@Test
+	public void testGetPreferredLocationsBasedOnInputs() throws Exception {
+		TestingSlotProvider testingSlotProvider = new TestingSlotProvider((slotRequestId) -> new CompletableFuture<>());
+
+		JobVertex producer1 = new JobVertex("producer1");
+		producer1.setInvokableClass(NoOpInvokable.class);
+		producer1.setParallelism(10);
+
+		JobVertex producer2 = new JobVertex("producer2");
+		producer2.setInvokableClass(NoOpInvokable.class);
+		producer2.setParallelism(5);
+
+		JobVertex producer3 = new JobVertex("producer3");
+		producer3.setInvokableClass(NoOpInvokable.class);
+		producer3.setParallelism(3);
+
+		JobVertex consumer = new JobVertex("consumer");
+		consumer.setInvokableClass(NoOpInvokable.class);
+		consumer.setParallelism(1);
+
+		consumer.connectNewDataSetAsInput(producer1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		consumer.connectNewDataSetAsInput(producer2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		consumer.connectNewDataSetAsInput(producer3, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(new JobID(), producer1, producer2, producer3, consumer);
+
+		Set<ExecutionVertexID> executionVertexIds = new HashSet<>(eg.getTotalNumberOfVertices());
+		for (ExecutionVertex ev : eg.getAllExecutionVertices()) {
+			executionVertexIds.add(new ExecutionVertexID(ev.getJobvertexId(), ev.getParallelSubtaskIndex()));
+		}
+		Execution execution = eg.getJobVertex(consumer.getID()).getTaskVertices()[0].getCurrentExecutionAttempt();
+
+		// all producers have not been started.
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations1 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, Collections.emptySet());
+		assertThat(preferredLocations1, hasSize(0));
+
+		// all producers scheduled together, will use the locations of the inputs whose parallelism is smallest.
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations2 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, executionVertexIds);
+		assertThat(preferredLocations2, hasSize(3));
+
+		for (ExecutionVertex ev : eg.getJobVertex(producer1.getID()).getTaskVertices()) {
+			ev.scheduleForExecution(testingSlotProvider, true, LocationPreferenceConstraint.ALL, Collections.EMPTY_SET);
+		}
+
+		// if source have too many different locations, it will be ignored
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations3 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, Collections.EMPTY_SET);
+		assertThat(preferredLocations3, hasSize(0));
+
+		List<TaskManagerLocation> locationsForProducer2 = new ArrayList<>(producer2.getParallelism());
+		for (ExecutionVertex ev : eg.getJobVertex(producer2.getID()).getTaskVertices()) {
+			ev.scheduleForExecution(testingSlotProvider, true, LocationPreferenceConstraint.ALL, Collections.EMPTY_SET);
+			TaskManagerLocation location = new LocalTaskManagerLocation();
+			ev.getCurrentTaskManagerLocationFuture().complete(location);
+			locationsForProducer2.add(location);
+		}
+
+		// use the locations of input that have been stated
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations4 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, Collections.EMPTY_SET);
+		assertThat(FutureUtils.combineAll(preferredLocations4).getNow(null), containsInAnyOrder(locationsForProducer2.toArray()));
+
+		List<TaskManagerLocation> locationsForProducer3 = new ArrayList<>(producer3.getParallelism());
+		for (ExecutionVertex ev : eg.getJobVertex(producer3.getID()).getTaskVertices()) {
+			ev.scheduleForExecution(testingSlotProvider, true, LocationPreferenceConstraint.ALL, Collections.EMPTY_SET);
+			TaskManagerLocation location = new LocalTaskManagerLocation();
+			ev.getCurrentTaskManagerLocationFuture().complete(location);
+			locationsForProducer3.add(location);
+		}
+
+		// use the locations of input whose parallelism is smaller
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations5 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, Collections.EMPTY_SET);
+		assertThat(FutureUtils.combineAll(preferredLocations5).getNow(null), containsInAnyOrder(locationsForProducer3.toArray()));
+	}
+
+	private void completeProducerSlotRequest(List<CompletableFuture<LogicalSlot>> totalSlotFutures) {
+		// fulfill the producers and the location preferences of consumers, so the consumers will allocate slots
+		for (int i = 0; i < executionVerticesNum / 2; i++) {
+			LogicalSlot slot = new TestingLogicalSlot();
+			totalSlotFutures.get(i).complete(slot);
+			ExecutionJobVertex ejv = executionGraph.getJobVertex(executionVertexIds.get(i).getJobVertexId());
+			Execution execution = ejv.getTaskVertices()[executionVertexIds.get(i).getSubtaskIndex()].getCurrentExecutionAttempt();
+			execution.getTaskManagerLocationFuture().complete(slot.getTaskManagerLocation());
+		}
+	}
+
+	static ExecutionGraph createSimpleProducerConsumerGraph() throws Exception {
+		int parallelism = 3;
+
+		JobVertex producer = new JobVertex("producer");
+		producer.setInvokableClass(NoOpInvokable.class);
+		producer.setParallelism(parallelism);
+
+		JobVertex consumer = new JobVertex("consumer");
+		consumer.setInvokableClass(NoOpInvokable.class);
+		consumer.setParallelism(parallelism);
+
+		consumer.connectNewDataSetAsInput(producer, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+
+		return ExecutionGraphTestUtils.createSimpleTestGraph(new JobID(), producer, consumer);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
@@ -112,7 +112,7 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 	 * Tests that validate the parameters when calling allocateSlot in SlotProvider.
 	 */
 	@Test
-	public void testAllocateSlotsParameters() throws Exception {
+	public void testAllocateSlotsParameters() {
 		final ExecutionVertexID executionVertexId = new ExecutionVertexID(new JobVertexID(), 0);
 		final AllocationID allocationId = new AllocationID();
 		final SlotSharingGroupId sharingGroupId = new SlotSharingGroupId();
@@ -200,7 +200,7 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 		try {
 			assignments.iterator().next().getLogicalSlotFuture().get();
 			fail("Expect a CancellationException but got nothing.");
-		} catch (CancellationException e) {
+		} catch (CancellationException ignored) {
 			// Expected exception
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
@@ -41,6 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/PreferredLocationsCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/PreferredLocationsCalculationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the calculation of preferred locations based on inputs in {@link DefaultExecutionSlotAllocator}.
+ */
+public class PreferredLocationsCalculationTest extends TestLogger {
+
+	/**
+	 * Tests that the input edge will be ignored if it has too many different locations.
+	 */
+	@Test
+	public void testIgnoreEdgeOfTooManyLocations() {
+		final ExecutionVertexID consumerId = new ExecutionVertexID(new JobVertexID(), 0);
+
+		TestingInputsLocationsRetriever.Builder locationRetrieverBuilder = new TestingInputsLocationsRetriever.Builder();
+		JobVertexID jobVertexID = new JobVertexID();
+		for (int i = 0; i < 9; i++) {
+			final ExecutionVertexID producerId = new ExecutionVertexID(jobVertexID, i);
+			locationRetrieverBuilder.connectConsumerToProducer(consumerId, producerId);
+		}
+
+		final TestingInputsLocationsRetriever inputsLocationsRetriever = locationRetrieverBuilder.build();
+
+		CompletableFuture<Collection<TaskManagerLocation>> preferredLocations =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(consumerId, inputsLocationsRetriever);
+
+		assertThat(preferredLocations.getNow(null), hasSize(0));
+	}
+
+	/**
+	 * Tests that will choose the locations on the edge which has less different number.
+	 */
+	@Test
+	public void testChooseLocationsOnEdgeWithLessDifferentNumber() {
+		final ExecutionVertexID consumerId = new ExecutionVertexID(new JobVertexID(), 0);
+
+		TestingInputsLocationsRetriever.Builder locationRetrieverBuilder = new TestingInputsLocationsRetriever.Builder();
+		final JobVertexID jobVertexID1 = new JobVertexID();
+		final JobVertexID jobVertexID2 = new JobVertexID();
+		int parallelism1 = 3;
+		int parallelism2 = 5;
+		List<ExecutionVertexID> producers1 = new ArrayList<>(parallelism1);
+		List<ExecutionVertexID> producers2 = new ArrayList<>(parallelism2);
+
+		for (int i = 0; i < parallelism1; i++) {
+			final ExecutionVertexID producerId = new ExecutionVertexID(jobVertexID1, i);
+			producers1.add(producerId);
+			locationRetrieverBuilder.connectConsumerToProducer(consumerId, producerId);
+		}
+
+		for (int i = 0; i < parallelism2; i++) {
+			final ExecutionVertexID producerId = new ExecutionVertexID(jobVertexID2, i);
+			producers2.add(producerId);
+			locationRetrieverBuilder.connectConsumerToProducer(consumerId, producerId);
+		}
+
+		final TestingInputsLocationsRetriever inputsLocationsRetriever = locationRetrieverBuilder.build();
+
+		List<TaskManagerLocation> expectedLocations = new ArrayList<>(parallelism1);
+		for (int i = 0; i < parallelism1; i++) {
+			inputsLocationsRetriever.assignTaskManagerLocation(producers1.get(i));
+			expectedLocations.add(inputsLocationsRetriever.getTaskManagerLocation(producers1.get(i)).get().getNow(null));
+		}
+
+		for (int i = 0; i < parallelism2; i++) {
+			inputsLocationsRetriever.assignTaskManagerLocation(producers2.get(i));
+		}
+
+		CompletableFuture<Collection<TaskManagerLocation>> preferredLocations =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(consumerId, inputsLocationsRetriever);
+
+		assertThat(preferredLocations.getNow(null), containsInAnyOrder(expectedLocations.toArray()));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingInputsLocationsRetriever.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingInputsLocationsRetriever.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A simple inputs locations retriever for testing purposes.
+ */
+public class TestingInputsLocationsRetriever implements InputsLocationsRetriever {
+
+	private final Map<ExecutionVertexID, Collection<Collection<ExecutionVertexID>>> vertexToUpstreams;
+
+	private final Map<ExecutionVertexID, CompletableFuture<TaskManagerLocation>> vertexToTaskManagerLocations;
+
+	public TestingInputsLocationsRetriever(JobVertex... jobVertices) {
+		this.vertexToUpstreams = new HashMap<>();
+		this.vertexToTaskManagerLocations = new HashMap<>();
+
+		initVertexToUpstreamsRelation(jobVertices);
+		initVertexTaskManagerLocationFutures(jobVertices);
+	}
+
+	@Override
+	public Collection<Collection<ExecutionVertexID>> getConsumedResultPartitionsProducers(ExecutionVertexID executionVertexId) {
+		return vertexToUpstreams.getOrDefault(executionVertexId, Collections.emptyList());
+	}
+
+	@Override
+	public Optional<CompletableFuture<TaskManagerLocation>> getTaskManagerLocation(ExecutionVertexID executionVertexId) {
+		return Optional.ofNullable(vertexToTaskManagerLocations.get(executionVertexId));
+	}
+
+	public int getTotalNumberOfVertices() {
+		return vertexToTaskManagerLocations.size();
+	}
+
+	public Collection<ExecutionVertexID> getAllExecutionVertices() {
+		return  vertexToTaskManagerLocations.keySet();
+	}
+
+	private void initVertexToUpstreamsRelation(JobVertex... jobVertices) {
+
+		for (JobVertex jobVertex : jobVertices) {
+			for (JobEdge jobEdge : jobVertex.getInputs()) {
+				JobVertex upstream = jobEdge.getSource().getProducer();
+
+				Collection<ExecutionVertexID> upstreams = new ArrayList<>();
+				if (jobEdge.getDistributionPattern() == DistributionPattern.ALL_TO_ALL) {
+					for (int i = 0; i < upstream.getParallelism(); i++) {
+						upstreams.add(new ExecutionVertexID(upstream.getID(), i));
+					}
+				}
+
+				for (int i = 0; i < jobVertex.getParallelism(); i++) {
+					if (jobEdge.getDistributionPattern() == DistributionPattern.POINTWISE) {
+						upstreams = new ArrayList<>();
+						if (jobVertex.getParallelism() > upstream.getParallelism()) {
+							int times = (int) Math.ceil(jobVertex.getParallelism() / upstream.getParallelism());
+							upstreams.add(new ExecutionVertexID(upstream.getID(), i / times));
+						} else {
+							int times = (int) Math.ceil(upstream.getParallelism() / jobVertex.getParallelism());
+							for (int j = i * times; j < (i + 1) * times && j < upstream.getParallelism(); j++) {
+								upstreams.add(new ExecutionVertexID(upstream.getID(), j));
+							}
+						}
+					}
+					ExecutionVertexID executionVertexId = new ExecutionVertexID(jobVertex.getID(), i);
+					Collection<Collection<ExecutionVertexID>> existingUpstreams =
+							vertexToUpstreams.computeIfAbsent(executionVertexId, k -> new ArrayList<>());
+					existingUpstreams.add(upstreams);
+				}
+			}
+		}
+	}
+
+	private void initVertexTaskManagerLocationFutures(JobVertex... jobVertices) {
+
+		for (JobVertex jobVertex : jobVertices) {
+			for (int i = 0; i < jobVertex.getParallelism(); i++) {
+				ExecutionVertexID executionVertexId = new ExecutionVertexID(jobVertex.getID(), i);
+				vertexToTaskManagerLocations.put(executionVertexId, new CompletableFuture<>());
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingInputsLocationsRetriever.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingInputsLocationsRetriever.java
@@ -38,18 +38,18 @@ import java.util.stream.Collectors;
  */
 class TestingInputsLocationsRetriever implements InputsLocationsRetriever {
 
-	private final Map<ExecutionVertexID, List<ExecutionVertexID>> producersByVertex;
+	private final Map<ExecutionVertexID, List<ExecutionVertexID>> producersByConsumer;
 
 	private final Map<ExecutionVertexID, CompletableFuture<TaskManagerLocation>> taskManagerLocationsByVertex = new HashMap<>();
 
-	TestingInputsLocationsRetriever(final Map<ExecutionVertexID, List<ExecutionVertexID>> producersByVertex) {
-		this.producersByVertex = new HashMap<>(producersByVertex);
+	TestingInputsLocationsRetriever(final Map<ExecutionVertexID, List<ExecutionVertexID>> producersByConsumer) {
+		this.producersByConsumer = new HashMap<>(producersByConsumer);
 	}
 
 	@Override
 	public Collection<Collection<ExecutionVertexID>> getConsumedResultPartitionsProducers(final ExecutionVertexID executionVertexId) {
 		final Map<JobVertexID, List<ExecutionVertexID>> executionVerticesByJobVertex =
-				producersByVertex.getOrDefault(executionVertexId, Collections.emptyList())
+				producersByConsumer.getOrDefault(executionVertexId, Collections.emptyList())
 						.stream()
 						.collect(Collectors.groupingBy(ExecutionVertexID::getJobVertexId));
 
@@ -77,10 +77,10 @@ class TestingInputsLocationsRetriever implements InputsLocationsRetriever {
 
 	static class Builder {
 
-		private final Map<ExecutionVertexID, List<ExecutionVertexID>> consumerToProducers = new HashMap<>();
+		private final Map<ExecutionVertexID, List<ExecutionVertexID>> producersByConsumer = new HashMap<>();
 
 		public Builder connectConsumerToProducer(final ExecutionVertexID consumer, final ExecutionVertexID producer) {
-			consumerToProducers.compute(consumer, (key, producers) -> {
+			producersByConsumer.compute(consumer, (key, producers) -> {
 				if (producers == null) {
 					producers = new ArrayList<>();
 				}
@@ -91,7 +91,7 @@ class TestingInputsLocationsRetriever implements InputsLocationsRetriever {
 		}
 
 		public TestingInputsLocationsRetriever build() {
-			return new TestingInputsLocationsRetriever(consumerToProducers);
+			return new TestingInputsLocationsRetriever(producersByConsumer);
 		}
 
 	}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request introduces the ExecutionSlotAllocator interface related classes and a default implementation. The implementation of ExecutionSlotAllocator will first calculate the preferred locations for the executions and then allocate slots for them. In the future, the calculation of preferred locations will be removed from here to make the ExecutionSlotAllocator more clean.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests in DefaultExecutionSlotAllocatorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
