### PR TITLE
[FLINK-12560][Docs] Documentation language build flags

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,13 @@ to files that are modified. Note that if you are making changes that affect
 the sidebar navigation, you'll have to build the entire site to see
 those changes reflected on every page.
 
+| Flag | Action | 
+| -----| -------| 
+| -p   | Run interactive preview | 
+| -i   | Incremental builds | 
+| -e   | Build only English docs |
+| -z   | Build only Chinese docs |
+
 ## Generate configuration tables
 
 Configuration descriptions are auto generated from code. To trigger the generation you need to run:

--- a/docs/_config_dev_en.yml
+++ b/docs/_config_dev_en.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+exclude:
+  - "*.zh.md"

--- a/docs/_config_dev_zh.yml
+++ b/docs/_config_dev_zh.yml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+exclude:
+  - "*.md"
+
+include:
+  - "*.zh.md"

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -51,9 +51,13 @@ DOCS_DST=${DOCS_SRC}/content
 # default jekyll command is to just build site
 JEKYLL_CMD="build"
 
+JEKYLL_CONFIG=""
+
 # if -p flag is provided, serve site on localhost
 # -i is like -p, but incremental (only rebuilds the modified file)
-while getopts "pi" opt; do
+# -e builds only english documentation
+# -z builds only chinese documentation 
+while getopts "piez" opt; do
 	case $opt in
 		p)
 		JEKYLL_CMD="serve --baseurl= --watch"
@@ -62,8 +66,14 @@ while getopts "pi" opt; do
 		[[ `${RUBY} -v` =~ 'ruby 1' ]] && echo "Error: building the docs with the incremental option requires at least ruby 2.0" && exit 1
 		JEKYLL_CMD="liveserve --baseurl= --watch --incremental"
 		;;
+		e)
+		JEKYLL_CONFIG="--config _config.yml,_config_dev_en.yml"
+		;;
+		z)
+		JEKYLL_CONFIG="--config _config.yml,_config_dev_zh.yml"
+		;;
 	esac
 done
 
 # use 'bundle exec' to insert the local Ruby dependencies
-bundle exec jekyll ${JEKYLL_CMD} --source "${DOCS_SRC}" --destination "${DOCS_DST}"
+bundle exec jekyll ${JEKYLL_CMD} ${JEKYLL_CONFIG} --source "${DOCS_SRC}" --destination "${DOCS_DST}"


### PR DESCRIPTION
## What is the purpose of the change

Most documentation writers are only ever focused on one language at a time. Adding language-specific build flags can dramatically reduce render time during local development. 

We add two new flags to the build script
-e: Only build English documentation
-z: Only build Chinese documentation

## Verifying this change

Benchmarking on a MacBook Pro

Full clean builds

./build.sh:  176 seconds
./build.sh -e:  96 seconds
./build.sh -z: 62 seconds

Incremental Builds after changing one file
./build.sh -pi : 6.2 seconds
./build.sh -pie : 3.1 seconds
