### PR TITLE
[FLINK-12494][JDBC] JDBCAppendTableSink add timeInterval to flush data

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkBuilder.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkBuilder.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.api.java.io.jdbc.JDBCOutputFormat.DEFAULT_BATCH_INTERVAL;
+import static org.apache.flink.api.java.io.jdbc.JDBCOutputFormat.DEFAULT_TIME_INTERVAL;
 
 /**
  * A builder to configure and build the JDBCAppendTableSink.
@@ -33,6 +34,7 @@ public class JDBCAppendTableSinkBuilder {
 	private String dbURL;
 	private String query;
 	private int batchSize = DEFAULT_BATCH_INTERVAL;
+	private int timeInterval = DEFAULT_TIME_INTERVAL;
 	private int[] parameterTypes;
 
 	/**
@@ -94,6 +96,15 @@ public class JDBCAppendTableSinkBuilder {
 	}
 
 	/**
+	 * Specify the interval of flush time.
+	 * @param timeInterval the interval of time(ms) to flush
+	 */
+	public JDBCAppendTableSinkBuilder setTimeInterval(int timeInterval) {
+		this.timeInterval = timeInterval;
+		return this;
+	}
+
+	/**
 	 * Specify the type of the rows that the sink will be accepting.
 	 * @param types the type of each field
 	 */
@@ -132,6 +143,7 @@ public class JDBCAppendTableSinkBuilder {
 			.setQuery(query)
 			.setDrivername(driverName)
 			.setBatchInterval(batchSize)
+			.setTimeInterval(timeInterval)
 			.setSqlTypes(parameterTypes)
 			.finish();
 

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
@@ -228,6 +228,7 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 		try {
 			upload.executeBatch();
 			batchCount = 0;
+			lastInsertTime = System.currentTimeMillis();
 		} catch (SQLException e) {
 			throw new RuntimeException("Execution of JDBC statement failed.", e);
 		}


### PR DESCRIPTION

## What is the purpose of the change

JDBCAppendTableSink flush to database when data size is reach batchInterval, this pr add flush chance when timeInterval reached.

## Brief change log

## Verifying this change

This change is already covered by existing tests:JDBCOutputFormatTest.testFlush
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
