### PR TITLE
[FLINK-12562][table] Improve code in ExpandColumnFunctionsRule

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ExpandColumnFunctionsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ExpandColumnFunctionsRule.java
@@ -26,7 +26,6 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionUtils;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
-import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -164,10 +163,11 @@ final class ExpandColumnFunctionsRule implements ResolverRule {
 					.orElseThrow(() -> new ValidationException("Constant integer value expected."));
 				int end = ExpressionUtils.extractValue(call.getChildren().get(1), Integer.class)
 					.orElseThrow(() -> new ValidationException("Constant integer value expected."));
-				Preconditions.checkArgument(
-					start <= end,
-					String.format("The start:%s of %s() or %s() should not bigger than end:%s.",
-						start, WITH_COLUMNS.getName(), WITHOUT_COLUMNS.getName(), end));
+				if (start > end) {
+					throw new ValidationException(
+						String.format("The start:%s of %s() or %s() should not bigger than end:%s.",
+							start, WITH_COLUMNS.getName(), WITHOUT_COLUMNS.getName(), end));
+				}
 
 				return inputFieldReferences.subList(start - 1, end);
 
@@ -177,10 +177,11 @@ final class ExpandColumnFunctionsRule implements ResolverRule {
 
 				int start = indexOfName(inputFieldReferences, startName);
 				int end = indexOfName(inputFieldReferences, endName);
-				Preconditions.checkArgument(
-					start <= end,
-					String.format("The start name:%s of %s() or %s() should not behind the end:%s.",
-						startName, WITH_COLUMNS.getName(), WITHOUT_COLUMNS.getName(), endName));
+				if (start > end) {
+					throw new ValidationException(
+						String.format("The start name:%s of %s() or %s() should not behind the end:%s.",
+							startName, WITH_COLUMNS.getName(), WITHOUT_COLUMNS.getName(), endName));
+				}
 
 				return inputFieldReferences.subList(start, end + 1);
 			} else {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/ColumnFunctionsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/ColumnFunctionsValidationTest.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.api.validation
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.{Slide, TableException, ValidationException}
+import org.apache.flink.table.api.{Slide, ValidationException}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.BuiltInFunctionDefinitions
 import org.apache.flink.table.utils.{StreamTableTestUtil, TableTestBase}
@@ -58,7 +58,7 @@ class ColumnFunctionsValidationTest extends TableTestBase {
 
   @Test
   def testInvalidParameters(): Unit = {
-    expectedException.expect(classOf[TableException])
+    expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage(
       s"The parameters of $withCol() or $withoutCol() only accept column name or " +
         "column index, but receive CallExpression.")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/ColumnFunctionsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/ColumnFunctionsValidationTest.scala
@@ -36,7 +36,7 @@ class ColumnFunctionsValidationTest extends TableTestBase {
 
   @Test
   def testIndexRangeInvalid(): Unit = {
-    expectedException.expect(classOf[IllegalArgumentException])
+    expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage(
       s"The start:2 of $withCol() or $withoutCol() should not bigger than end:1")
 
@@ -47,7 +47,7 @@ class ColumnFunctionsValidationTest extends TableTestBase {
 
   @Test
   def testNameRangeInvalid(): Unit = {
-    expectedException.expect(classOf[IllegalArgumentException])
+    expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage(
       s"The start name:b of $withCol() or $withoutCol() should not behind the end:a.")
 


### PR DESCRIPTION

## What is the purpose of the change

This pull requests resolve IntelliJ warnings in `ExpandColumnFunctionsRule`. Also, change TableException to ValidationException for the validation as `ValidationException` is used to indicate something wrong from users while `TableException` means unsupported stuff or some weird state for Flink. 


## Brief change log

  - Change TableException to ValidationException for validation.
  - Fix code warnings.
  - Adjust tests.


## Verifying this change


This change is already covered by existing tests, such as `ColumnFunctionsValidationTest`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)