### PR TITLE
[FLINK-12571][network] Make NetworkEnvironment#start() return the binded data port

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/ConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/ConnectionManager.java
@@ -26,7 +26,12 @@ import java.io.IOException;
  */
 public interface ConnectionManager {
 
-	void start() throws IOException;
+	/**
+	 * Starts the internal related components for network connection and communication.
+	 *
+	 * @return a port to connect to the task executor for shuffle data exchange, -1 if only local connection is possible.
+	 */
+	int start() throws IOException;
 
 	/**
 	 * Creates a {@link PartitionRequestClient} instance for the given {@link ConnectionID}.
@@ -39,8 +44,6 @@ public interface ConnectionManager {
 	void closeOpenChannelConnections(ConnectionID connectionId);
 
 	int getNumberOfActiveConnections();
-
-	int getDataPort();
 
 	void shutdown() throws IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/LocalConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/LocalConnectionManager.java
@@ -25,7 +25,8 @@ package org.apache.flink.runtime.io.network;
 public class LocalConnectionManager implements ConnectionManager {
 
 	@Override
-	public void start() {
+	public int start() {
+		return -1;
 	}
 
 	@Override
@@ -39,11 +40,6 @@ public class LocalConnectionManager implements ConnectionManager {
 	@Override
 	public int getNumberOfActiveConnections() {
 		return 0;
-	}
-
-	@Override
-	public int getDataPort() {
-		return -1;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -94,8 +94,6 @@ public class NetworkEnvironment {
 
 	private final Map<InputGateID, SingleInputGate> inputGatesById;
 
-	private final TaskEventPublisher taskEventPublisher;
-
 	private final ResultPartitionFactory resultPartitionFactory;
 
 	private final SingleInputGateFactory singleInputGateFactory;
@@ -107,7 +105,6 @@ public class NetworkEnvironment {
 			NetworkBufferPool networkBufferPool,
 			ConnectionManager connectionManager,
 			ResultPartitionManager resultPartitionManager,
-			TaskEventPublisher taskEventPublisher,
 			ResultPartitionFactory resultPartitionFactory,
 			SingleInputGateFactory singleInputGateFactory) {
 		this.config = config;
@@ -115,7 +112,6 @@ public class NetworkEnvironment {
 		this.connectionManager = connectionManager;
 		this.resultPartitionManager = resultPartitionManager;
 		this.inputGatesById = new ConcurrentHashMap<>();
-		this.taskEventPublisher = taskEventPublisher;
 		this.resultPartitionFactory = resultPartitionFactory;
 		this.singleInputGateFactory = singleInputGateFactory;
 		this.isShutdown = false;
@@ -164,7 +160,6 @@ public class NetworkEnvironment {
 			networkBufferPool,
 			connectionManager,
 			resultPartitionManager,
-			taskEventPublisher,
 			resultPartitionFactory,
 			singleInputGateFactory);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -187,6 +187,7 @@ public class NetworkEnvironment {
 		return resultPartitionManager;
 	}
 
+	@VisibleForTesting
 	public ConnectionManager getConnectionManager() {
 		return connectionManager;
 	}
@@ -317,7 +318,12 @@ public class NetworkEnvironment {
 		return true;
 	}
 
-	public void start() throws IOException {
+	/*
+	 * Starts the internal related components for network connection and communication.
+	 *
+	 * @return a port to connect to the task executor for shuffle data exchange, -1 if only local connection is possible.
+	 */
+	public int start() throws IOException {
 		synchronized (lock) {
 			Preconditions.checkState(!isShutdown, "The NetworkEnvironment has already been shut down.");
 
@@ -325,7 +331,7 @@ public class NetworkEnvironment {
 
 			try {
 				LOG.debug("Starting network connection manager");
-				connectionManager.start();
+				return connectionManager.start();
 			} catch (IOException t) {
 				throw new IOException("Failed to instantiate network connection manager.", t);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -56,9 +56,10 @@ public class NettyConnectionManager implements ConnectionManager {
 	}
 
 	@Override
-	public void start() throws IOException {
+	public int start() throws IOException {
 		client.init(nettyProtocol, bufferPool);
-		server.init(nettyProtocol, bufferPool);
+
+		return server.init(nettyProtocol, bufferPool);
 	}
 
 	@Override
@@ -75,15 +76,6 @@ public class NettyConnectionManager implements ConnectionManager {
 	@Override
 	public int getNumberOfActiveConnections() {
 		return partitionRequestClientFactory.getNumberOfActiveClients();
-	}
-
-	@Override
-	public int getDataPort() {
-		if (server != null && server.getLocalAddress() != null) {
-			return server.getLocalAddress().getPort();
-		} else {
-			return -1;
-		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -64,7 +64,7 @@ class NettyServer {
 		localAddress = null;
 	}
 
-	void init(final NettyProtocol protocol, NettyBufferPool nettyBufferPool) throws IOException {
+	int init(final NettyProtocol protocol, NettyBufferPool nettyBufferPool) throws IOException {
 		checkState(bootstrap == null, "Netty server has already been initialized.");
 
 		final long start = System.nanoTime();
@@ -164,6 +164,8 @@ class NettyServer {
 
 		final long duration = (System.nanoTime() - start) / 1_000_000;
 		LOG.info("Successful initialization (took {} ms). Listening on SocketAddress {}.", duration, localAddress);
+
+		return localAddress.getPort();
 	}
 
 	NettyConfig getConfig() {
@@ -172,10 +174,6 @@ class NettyServer {
 
 	ServerBootstrap getBootstrap() {
 		return bootstrap;
-	}
-
-	public InetSocketAddress getLocalAddress() {
-		return localAddress;
 	}
 
 	void shutdown() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -248,7 +248,7 @@ public class TaskManagerServices {
 
 		final NetworkEnvironment network = NetworkEnvironment.create(
 			taskManagerServicesConfiguration.getNetworkConfig(), taskEventDispatcher, taskManagerMetricGroup, ioManager);
-		network.start();
+		int dataPort = network.start();
 
 		final KvStateService kvStateService = KvStateService.fromConfiguration(taskManagerServicesConfiguration);
 		kvStateService.start();
@@ -256,7 +256,7 @@ public class TaskManagerServices {
 		final TaskManagerLocation taskManagerLocation = new TaskManagerLocation(
 			resourceID,
 			taskManagerServicesConfiguration.getTaskManagerAddress(),
-			network.getConnectionManager().getDataPort());
+			dataPort);
 
 		// this call has to happen strictly after the network stack has been initialized
 		final MemoryManager memoryManager = createMemoryManager(taskManagerServicesConfiguration, freeHeapMemoryWithDefrag, maxJvmHeapMemory);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TestingConnectionManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TestingConnectionManager.java
@@ -27,7 +27,9 @@ import java.io.IOException;
 public class TestingConnectionManager implements ConnectionManager {
 
 	@Override
-	public void start() {}
+	public int start() {
+		return -1;
+	}
 
 	@Override
 	public PartitionRequestClient createPartitionRequestClient(ConnectionID connectionId) throws IOException {
@@ -40,11 +42,6 @@ public class TestingConnectionManager implements ConnectionManager {
 	@Override
 	public int getNumberOfActiveConnections() {
 		return 0;
-	}
-
-	@Override
-	public int getDataPort() {
-		return -1;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -140,7 +140,8 @@ public class InputChannelTestUtils {
 	public static ConnectionManager mockConnectionManagerWithPartitionRequestClient(PartitionRequestClient client) {
 		return new ConnectionManager() {
 			@Override
-			public void start() {
+			public int start() {
+				return -1;
 			}
 
 			@Override
@@ -154,11 +155,6 @@ public class InputChannelTestUtils {
 
 			@Override
 			public int getNumberOfActiveConnections() {
-				return 0;
-			}
-
-			@Override
-			public int getDataPort() {
 				return 0;
 			}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -89,6 +89,8 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 
 	protected ResultPartitionID[] partitionIds;
 
+	private int dataPort;
+
 	public void setUp(
 			int writers,
 			int channels,
@@ -141,7 +143,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 		ioManager = new IOManagerAsync();
 
 		senderEnv = createNettyNetworkEnvironment(senderBufferPoolSize, config);
-		senderEnv.start();
+		this.dataPort = senderEnv.start();
 		if (localMode && senderBufferPoolSize == receiverBufferPoolSize) {
 			receiverEnv = senderEnv;
 		}
@@ -163,7 +165,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 		TaskManagerLocation senderLocation = new TaskManagerLocation(
 			ResourceID.generate(),
 			LOCAL_ADDRESS,
-			senderEnv.getConnectionManager().getDataPort());
+			dataPort);
 
 		InputGate receiverGate = createInputGate(
 			dataSetID,


### PR DESCRIPTION
## What is the purpose of the change

*`NetworkEnvironment#getConnectionManager` is currently used for getting binded data port from `ConnectionManager`. Considering the general shuffle service architecture, the internal `ConnectionManager` in `NetworkEnvironment` should not be exposed to outsides. We could make `ShuffleService#start` return the binded data port directly if exists, then for other cases it could return a default int value which seems no harm.*

## Brief change log

  - *Make `ConnectionManager#start` return binded data port.*
  - *Make `NetworkEnvironment#start` return binded data port*
  - *Return legacy getter method in `NettyServer`*
  - *Refactor the process in `TaskManagerServices`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)