### PR TITLE
[FLINK-12413] [runtime] Implement ExecutionFailureHandler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.throwable.ThrowableClassifier;
+import org.apache.flink.runtime.throwable.ThrowableType;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This handler deals with task failures to return a {@link FailureHandlingResult} which contains tasks
+ * to be restarted to recover from failures.
+ */
+public class ExecutionFailureHandler {
+
+	/** Strategy to judge which tasks should be restarted. */
+	private FailoverStrategy failoverStrategy;
+
+	/** Strategy to judge whether and when a restarting should be done. */
+	private RestartBackoffTimeStrategy restartBackoffTimeStrategy;
+
+	/**
+	 * Creates the handler to deal with task failures.
+	 *
+	 * @param topology of tasks of current job
+	 * @param failoverStrategyFactory is the factory to create the failover strategy
+	 * @param restartStrategyFactory is the factory to create the restart strategy
+	 */
+	public ExecutionFailureHandler(
+		FailoverTopology topology,
+		FailoverStrategy.Factory failoverStrategyFactory,
+		RestartBackoffTimeStrategy.Factory restartStrategyFactory) {
+
+		this.failoverStrategy = checkNotNull(failoverStrategyFactory.create(topology));
+		this.restartBackoffTimeStrategy = checkNotNull(restartStrategyFactory.create());
+	}
+
+	/**
+	 * Return result of failure handling. Can be a set of task vertices to be restarted
+	 * and a delay of the restarting. Or that the failure is not recoverable and the reason for it.
+	 *
+	 * @param failedTask is the ID of the failed task vertex
+	 * @param cause of the task failure
+	 * @return result of the failure handling
+	 */
+	public FailureHandlingResult getFailureHandlingResult(ExecutionVertexID failedTask, Throwable cause) {
+		if (ThrowableClassifier.getThrowableType(cause) == ThrowableType.NonRecoverableError) {
+			return new FailureHandlingResult(new JobException("The failure is not recoverable", cause));
+		}
+
+		restartBackoffTimeStrategy.notifyFailure(cause);
+		if (restartBackoffTimeStrategy.canRestart()) {
+			return new FailureHandlingResult(
+				failoverStrategy.getTasksNeedingRestart(failedTask, cause),
+				restartBackoffTimeStrategy.getBackoffTime());
+		} else {
+			return new FailureHandlingResult(
+				new JobException("Failed task restarting is suppressed by " + restartBackoffTimeStrategy, cause));
+		}
+	}
+
+	@VisibleForTesting
+	FailoverStrategy getFailoverStrategy() {
+		return failoverStrategy;
+	}
+
+	@VisibleForTesting
+	RestartBackoffTimeStrategy getRestartBackoffTimeStrategy() {
+		return restartBackoffTimeStrategy;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
@@ -27,7 +27,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * This handler deals with task failures to return a {@link FailureHandlingResult} which contains tasks
- * to be restarted to recover from failures.
+ * to restart to recover from failures.
  */
 public class ExecutionFailureHandler {
 
@@ -54,7 +54,7 @@ public class ExecutionFailureHandler {
 	}
 
 	/**
-	 * Return result of failure handling. Can be a set of task vertices to be restarted
+	 * Return result of failure handling. Can be a set of task vertices to restart
 	 * and a delay of the restarting. Or that the failure is not recoverable and the reason for it.
 	 *
 	 * @param failedTask is the ID of the failed task vertex

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategy.java
@@ -40,7 +40,7 @@ public interface FailoverStrategy {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * The factory to Instantiate {@link FailoverStrategy}.
+	 * The factory to instantiate {@link FailoverStrategy}.
 	 */
 	interface Factory {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
@@ -93,21 +93,25 @@ public class FailureHandlingResult {
 	}
 
 	/**
+	 * Returns reason why the restarting cannot be conducted.
+	 *
+	 * @return reason why the restarting cannot be conducted
+	 */
+	public Throwable getError() {
+		if (canRestart()) {
+			throw new IllegalStateException("Cannot get error when the restarting is accepted.");
+		} else {
+			return error;
+		}
+	}
+
+	/**
 	 * Returns whether the restarting can be conducted.
 	 *
 	 * @return whether the restarting can be conducted
 	 */
 	public boolean canRestart() {
 		return error == null;
-	}
-
-	/**
-	 * Returns reason why the restarting cannot be conducted.
-	 *
-	 * @return reason why the restarting cannot be conducted
-	 */
-	public Throwable getError() {
-		return error;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Result containing the tasks to be restarted upon a task failure.
+ * Also contains the reason if the failure is not recoverable(non-recoverable
+ * failure type or restarting suppressed by restart strategy).
+ */
+public class FailureHandlingResult {
+
+	/** Task vertices to be restarted to recover from the failure. */
+	private Set<ExecutionVertexID> verticesToBeRestarted;
+
+	/** Delay before the restarting can be conducted. Negative values means no restart should be conducted. */
+	private long restartDelayMS = -1;
+
+	/** Reason why the failure is not recoverable. */
+	private Throwable error;
+
+	/**
+	 * Creates a result of a set of tasks to be restarted to recover from the failure.
+	 *
+	 * @param verticesToBeRestarted containing task vertices to be restarted to recover from the failure
+	 * @param restartDelayMS indicate a delay before conducting the restart
+	 */
+	public FailureHandlingResult(Set<ExecutionVertexID> verticesToBeRestarted, long restartDelayMS) {
+		checkState(restartDelayMS >= 0);
+
+		this.verticesToBeRestarted = checkNotNull(verticesToBeRestarted);
+		this.restartDelayMS = restartDelayMS;
+	}
+
+	/**
+	 * Creates a result that the failure is not recoverable and no restarting should be conducted.
+	 *
+	 * @param error reason why the failure is not recoverable
+	 */
+	public FailureHandlingResult(Throwable error) {
+		this.error = checkNotNull(error);
+	}
+
+	/**
+	 * Returns the tasks to be restarted.
+	 *
+	 * @return the tasks to be restarted
+	 */
+	public Set<ExecutionVertexID> getVerticesToBeRestarted() {
+		return verticesToBeRestarted;
+	}
+
+	/**
+	 * Returns the delay before the restarting.
+	 *
+	 * @return the delay before the restarting
+	 */
+	public long getRestartDelayMS() {
+		return restartDelayMS;
+	}
+
+	/**
+	 * Returns whether the restarting can be conducted.
+	 *
+	 * @return whether the restarting can be conducted
+	 */
+	public boolean canRestart() {
+		return error == null && restartDelayMS >= 0;
+	}
+
+	/**
+	 * Returns reason why the restarting cannot be conducted.
+	 *
+	 * @return reason why the restarting cannot be conducted
+	 */
+	public Throwable getError() {
+		return error;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
@@ -50,7 +50,7 @@ public class FailureHandlingResult {
 	private FailureHandlingResult(Set<ExecutionVertexID> verticesToRestart, long restartDelayMS) {
 		checkState(restartDelayMS >= 0);
 
-		this.verticesToRestart = checkNotNull(verticesToRestart);
+		this.verticesToRestart = Collections.unmodifiableSet(checkNotNull(verticesToRestart));
 		this.restartDelayMS = restartDelayMS;
 		this.error = null;
 	}
@@ -73,7 +73,7 @@ public class FailureHandlingResult {
 	 */
 	public Set<ExecutionVertexID> getVerticesToRestart() {
 		if (canRestart()) {
-			return Collections.unmodifiableSet(verticesToRestart);
+			return verticesToRestart;
 		} else {
 			throw new IllegalStateException("Cannot get vertices to restart when the restarting is suppressed.");
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategy.java
@@ -48,7 +48,7 @@ public interface RestartBackoffTimeStrategy {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * The factory to Instantiate {@link RestartBackoffTimeStrategy}.
+	 * The factory to instantiate {@link RestartBackoffTimeStrategy}.
 	 */
 	interface Factory {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategy.java
@@ -17,39 +17,46 @@
 
 package org.apache.flink.runtime.executiongraph.failover.flip1;
 
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
-
-import java.util.Set;
-
 /**
- * New interface for failover strategies.
+ * Strategy to decide whether to restart failed tasks and the delay to do the restarting.
  */
-public interface FailoverStrategy {
+public interface RestartBackoffTimeStrategy {
 
 	/**
-	 * Returns a set of IDs corresponding to the set of vertices that should be restarted.
+	 * Returns whether a restart should be conducted.
 	 *
-	 * @param executionVertexId ID of the failed task
-	 * @param cause cause of the failure
-	 * @return set of IDs of vertices to restart
+	 * @return whether a restart should be conducted
 	 */
-	Set<ExecutionVertexID> getTasksNeedingRestart(ExecutionVertexID executionVertexId, Throwable cause);
+	boolean canRestart();
+
+	/**
+	 * Returns the delay to do the restarting.
+	 *
+	 * @return the delay to do the restarting
+	 */
+	long getBackoffTime();
+
+	/**
+	 * Notify the strategy about the task failure cause.
+	 *
+	 * @param cause of the task failure
+	 */
+	void notifyFailure(Throwable cause);
 
 	// ------------------------------------------------------------------------
 	//  factory
 	// ------------------------------------------------------------------------
 
 	/**
-	 * The factory to Instantiate {@link FailoverStrategy}.
+	 * The factory to Instantiate {@link RestartBackoffTimeStrategy}.
 	 */
 	interface Factory {
 
 		/**
-		 * Instantiates the {@link FailoverStrategy}.
+		 * Instantiates the {@link RestartBackoffTimeStrategy}.
 		 *
-		 * @param topology of the graph to failover
-		 * @return The instantiated failover strategy.
+		 * @return The instantiated restart strategy.
 		 */
-		FailoverStrategy create(FailoverTopology topology);
+		RestartBackoffTimeStrategy create();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throwable/ThrowableClassifier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throwable/ThrowableClassifier.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.throwable;
 
+import java.util.Optional;
+
 /**
  * Helper class, given a exception do the classification.
  */
@@ -32,5 +34,30 @@ public class ThrowableClassifier {
 	public static ThrowableType getThrowableType(Throwable cause) {
 		final ThrowableAnnotation annotation = cause.getClass().getAnnotation(ThrowableAnnotation.class);
 		return annotation == null ? ThrowableType.RecoverableError : annotation.value();
+	}
+
+	/**
+	 * Checks whether a throwable chain contains a specific throwable type and returns the corresponding throwable.
+	 *
+	 * @param throwable the throwable chain to check.
+	 * @param throwableType the throwable type to search for in the chain.
+	 * @return Optional throwable of the throwable type if available, otherwise empty
+	 */
+	public static Optional<Throwable> findThrowableOfThrowableType(Throwable throwable, ThrowableType throwableType) {
+		if (throwable == null || throwableType == null) {
+			return Optional.empty();
+		}
+
+		Throwable t = throwable;
+		while (t != null) {
+			final ThrowableAnnotation annotation = t.getClass().getAnnotation(ThrowableAnnotation.class);
+			if (annotation != null && annotation.value() == throwableType) {
+				return Optional.of(t);
+			} else {
+				t = t.getCause();
+			}
+		}
+
+		return Optional.empty();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ThrowableClassifierTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ThrowableClassifierTest.java
@@ -27,6 +27,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test throwable classifier
@@ -68,6 +70,34 @@ public class ThrowableClassifierTest extends TestLogger {
 			ThrowableClassifier.getThrowableType(new Sub_ThrowableType_PartitionDataMissingError_Exception()));
 	}
 
+	@Test
+	public void testFindThrowableOfThrowableType() {
+		// no throwable type
+		assertFalse(ThrowableClassifier.findThrowableOfThrowableType(
+			new Exception(),
+			ThrowableType.RecoverableError).isPresent());
+
+		// no recoverable throwable type
+		assertFalse(ThrowableClassifier.findThrowableOfThrowableType(
+			new ThrowableType_PartitionDataMissingError_Exception(),
+			ThrowableType.RecoverableError).isPresent());
+
+		// direct recoverable throwable
+		assertTrue(ThrowableClassifier.findThrowableOfThrowableType(
+			new ThrowableType_RecoverableFailure_Exception(),
+			ThrowableType.RecoverableError).isPresent());
+
+		// nested recoverable throwable
+		assertTrue(ThrowableClassifier.findThrowableOfThrowableType(
+			new Exception(new ThrowableType_RecoverableFailure_Exception()),
+			ThrowableType.RecoverableError).isPresent());
+
+		// inherit recoverable throwable
+		assertTrue(ThrowableClassifier.findThrowableOfThrowableType(
+			new Sub_ThrowableType_RecoverableFailure_Exception(),
+			ThrowableType.RecoverableError).isPresent());
+	}
+
 	@ThrowableAnnotation(ThrowableType.PartitionDataMissingError)
 	private class ThrowableType_PartitionDataMissingError_Exception extends Exception {
 	}
@@ -81,5 +111,8 @@ public class ThrowableClassifierTest extends TestLogger {
 	}
 
 	private class Sub_ThrowableType_PartitionDataMissingError_Exception extends ThrowableType_PartitionDataMissingError_Exception {
+	}
+
+	private class Sub_ThrowableType_RecoverableFailure_Exception extends ThrowableType_RecoverableFailure_Exception {
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandlerTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -67,7 +68,7 @@ public class ExecutionFailureHandlerTest extends TestLogger {
 		// verify results
 		assertTrue(result.canRestart());
 		assertEquals(restartDelayMs, result.getRestartDelayMS());
-		assertEquals(tasksToBeRestarted, result.getVerticesToBeRestarted());
+		assertEquals(tasksToBeRestarted, result.getVerticesToRestart());
 		assertNull(result.getError());
 	}
 
@@ -96,9 +97,19 @@ public class ExecutionFailureHandlerTest extends TestLogger {
 
 		// verify results
 		assertFalse(result.canRestart());
-		assertTrue(result.getRestartDelayMS() < 0);
-		assertNull(result.getVerticesToBeRestarted());
 		assertNotNull(result.getError());
+		try {
+			result.getVerticesToRestart();
+			fail("get tasks to restart is not allowed when restarting is suppressed");
+		} catch (IllegalStateException ex) {
+			// expected
+		}
+		try {
+			result.getRestartDelayMS();
+			fail("get restart delay is not allowed when restarting is suppressed");
+		} catch (IllegalStateException ex) {
+			// expected
+		}
 	}
 
 	/**
@@ -126,9 +137,19 @@ public class ExecutionFailureHandlerTest extends TestLogger {
 
 		// verify results
 		assertFalse(result.canRestart());
-		assertTrue(result.getRestartDelayMS() < 0);
-		assertNull(result.getVerticesToBeRestarted());
 		assertNotNull(result.getError());
+		try {
+			result.getVerticesToRestart();
+			fail("get tasks to restart is not allowed when restarting is suppressed");
+		} catch (IllegalStateException ex) {
+			// expected
+		}
+		try {
+			result.getRestartDelayMS();
+			fail("get restart delay is not allowed when restarting is suppressed");
+		} catch (IllegalStateException ex) {
+			// expected
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandlerTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.execution.SuppressRestartsException;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link ExecutionFailureHandler}.
+ */
+public class ExecutionFailureHandlerTest extends TestLogger {
+
+	/**
+	 * Tests the case that task restarting is accepted.
+	 */
+	@Test
+	public void testNormalFailureHandling() throws Exception {
+		ExecutionFailureHandler executionFailureHandler = createExecutionFailureHandler();
+		FailoverStrategy failoverStrategy = executionFailureHandler.getFailoverStrategy();
+		RestartBackoffTimeStrategy restartStrategy = executionFailureHandler.getRestartBackoffTimeStrategy();
+
+		Set<ExecutionVertexID> tasksToBeRestarted = new HashSet<>();
+		when(failoverStrategy.getTasksNeedingRestart(any(ExecutionVertexID.class), any(Throwable.class))).thenReturn(
+			tasksToBeRestarted);
+
+		long restartDelayMs = 1234;
+		when(restartStrategy.getBackoffTime()).thenReturn(restartDelayMs);
+
+		// accept restarts
+		when(restartStrategy.canRestart()).thenReturn(true);
+
+		FailureHandlingResult result = executionFailureHandler.getFailureHandlingResult(
+			new ExecutionVertexID(new JobVertexID(), 0),
+			new Exception("test failure"));
+
+		// verify results
+		assertTrue(result.canRestart());
+		assertEquals(restartDelayMs, result.getRestartDelayMS());
+		assertEquals(tasksToBeRestarted, result.getVerticesToBeRestarted());
+		assertNull(result.getError());
+	}
+
+	/**
+	 * Tests the case that task restarting is suppressed.
+	 */
+	@Test
+	public void testRestartingSuppressedFailureHandlingResult() throws Exception {
+		ExecutionFailureHandler executionFailureHandler = createExecutionFailureHandler();
+		FailoverStrategy failoverStrategy = executionFailureHandler.getFailoverStrategy();
+		RestartBackoffTimeStrategy restartStrategy = executionFailureHandler.getRestartBackoffTimeStrategy();
+
+		Set<ExecutionVertexID> tasksToBeRestarted = new HashSet<>();
+		when(failoverStrategy.getTasksNeedingRestart(any(ExecutionVertexID.class), any(Throwable.class))).thenReturn(
+			tasksToBeRestarted);
+
+		long restartDelayMs = 1234;
+		when(restartStrategy.getBackoffTime()).thenReturn(restartDelayMs);
+
+		// suppress restarts
+		when(restartStrategy.canRestart()).thenReturn(false);
+
+		FailureHandlingResult result = executionFailureHandler.getFailureHandlingResult(
+			new ExecutionVertexID(new JobVertexID(), 0),
+			new Exception("test failure"));
+
+		// verify results
+		assertFalse(result.canRestart());
+		assertTrue(result.getRestartDelayMS() < 0);
+		assertNull(result.getVerticesToBeRestarted());
+		assertNotNull(result.getError());
+	}
+
+	/**
+	 * Tests the case that the failure is non-recoverable type.
+	 */
+	@Test
+	public void testNonRecoverableFailureHandlingResult() throws Exception {
+		ExecutionFailureHandler executionFailureHandler = createExecutionFailureHandler();
+		FailoverStrategy failoverStrategy = executionFailureHandler.getFailoverStrategy();
+		RestartBackoffTimeStrategy restartStrategy = executionFailureHandler.getRestartBackoffTimeStrategy();
+
+		Set<ExecutionVertexID> tasksToBeRestarted = new HashSet<>();
+		when(failoverStrategy.getTasksNeedingRestart(any(ExecutionVertexID.class), any(Throwable.class))).thenReturn(
+			tasksToBeRestarted);
+
+		long restartDelayMs = 1234;
+		when(restartStrategy.getBackoffTime()).thenReturn(restartDelayMs);
+
+		// accept restarts
+		when(restartStrategy.canRestart()).thenReturn(true);
+
+		FailureHandlingResult result = executionFailureHandler.getFailureHandlingResult(
+			new ExecutionVertexID(new JobVertexID(), 0),
+			new SuppressRestartsException(new Exception("test failure")));
+
+		// verify results
+		assertFalse(result.canRestart());
+		assertTrue(result.getRestartDelayMS() < 0);
+		assertNull(result.getVerticesToBeRestarted());
+		assertNotNull(result.getError());
+	}
+
+	// ------------------------------------------------------------------------
+	//  utilities
+	// ------------------------------------------------------------------------
+
+	private ExecutionFailureHandler createExecutionFailureHandler() {
+		FailoverTopology topology = new TestFailoverTopology.Builder().build();
+
+		FailoverStrategy.Factory failoverStrategyFactory = mock(FailoverStrategy.Factory.class);
+		when(failoverStrategyFactory.create(any(FailoverTopology.class))).thenReturn(mock(FailoverStrategy.class));
+
+		RestartBackoffTimeStrategy.Factory restartStrategyFactory = mock(RestartBackoffTimeStrategy.Factory.class);
+		when(restartStrategyFactory.create()).thenReturn(mock(RestartBackoffTimeStrategy.class));
+
+		return new ExecutionFailureHandler(topology, failoverStrategyFactory, restartStrategyFactory);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResultTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph.failover.flip1;
 
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
@@ -27,7 +28,6 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -43,13 +43,19 @@ public class FailureHandlingResultTest extends TestLogger {
 	public void testNormalFailureHandlingResult() {
 		// create a normal FailureHandlingResult
 		Set<ExecutionVertexID> tasks = new HashSet<>();
+		tasks.add(new ExecutionVertexID(new JobVertexID(), 0));
 		long delay = 1234;
 		FailureHandlingResult result = FailureHandlingResult.restartable(tasks, delay);
 
 		assertTrue(result.canRestart());
 		assertEquals(delay, result.getRestartDelayMS());
 		assertEquals(tasks, result.getVerticesToRestart());
-		assertNull(result.getError());
+		try {
+			result.getError();
+			fail("Cannot get error when the restarting is accepted");
+		} catch (IllegalStateException ex) {
+			// expected
+		}
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResultTest.java
@@ -40,11 +40,11 @@ public class FailureHandlingResultTest extends TestLogger {
 	 * Tests normal FailureHandlingResult.
 	 */
 	@Test
-	public void testNormalFailureHandlingResult() throws Exception {
+	public void testNormalFailureHandlingResult() {
 		// create a normal FailureHandlingResult
 		Set<ExecutionVertexID> tasks = new HashSet<>();
 		long delay = 1234;
-		FailureHandlingResult result = new FailureHandlingResult(tasks, delay);
+		FailureHandlingResult result = FailureHandlingResult.restartable(tasks, delay);
 
 		assertTrue(result.canRestart());
 		assertEquals(delay, result.getRestartDelayMS());
@@ -56,10 +56,10 @@ public class FailureHandlingResultTest extends TestLogger {
 	 * Tests FailureHandlingResult which suppresses restarts.
 	 */
 	@Test
-	public void testRestartingSuppressedFailureHandlingResult() throws Exception {
+	public void testRestartingSuppressedFailureHandlingResult() {
 		// create a FailureHandlingResult with error
 		Throwable error = new Exception("test error");
-		FailureHandlingResult result = new FailureHandlingResult(error);
+		FailureHandlingResult result = FailureHandlingResult.unrecoverable(error);
 
 		assertFalse(result.canRestart());
 		assertEquals(error, result.getError());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResultTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link FailureHandlingResult}.
@@ -47,7 +48,7 @@ public class FailureHandlingResultTest extends TestLogger {
 
 		assertTrue(result.canRestart());
 		assertEquals(delay, result.getRestartDelayMS());
-		assertEquals(tasks, result.getVerticesToBeRestarted());
+		assertEquals(tasks, result.getVerticesToRestart());
 		assertNull(result.getError());
 	}
 
@@ -61,7 +62,18 @@ public class FailureHandlingResultTest extends TestLogger {
 		FailureHandlingResult result = new FailureHandlingResult(error);
 
 		assertFalse(result.canRestart());
-		assertTrue(result.getRestartDelayMS() < 0);
 		assertEquals(error, result.getError());
+		try {
+			result.getVerticesToRestart();
+			fail("get tasks to restart is not allowed when restarting is suppressed");
+		} catch (IllegalStateException ex) {
+			// expected
+		}
+		try {
+			result.getRestartDelayMS();
+			fail("get restart delay is not allowed when restarting is suppressed");
+		} catch (IllegalStateException ex) {
+			// expected
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResultTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link FailureHandlingResult}.
+ */
+public class FailureHandlingResultTest extends TestLogger {
+
+	/**
+	 * Tests normal FailureHandlingResult.
+	 */
+	@Test
+	public void testNormalFailureHandlingResult() throws Exception {
+		// create a normal FailureHandlingResult
+		Set<ExecutionVertexID> tasks = new HashSet<>();
+		long delay = 1234;
+		FailureHandlingResult result = new FailureHandlingResult(tasks, delay);
+
+		assertTrue(result.canRestart());
+		assertEquals(delay, result.getRestartDelayMS());
+		assertEquals(tasks, result.getVerticesToBeRestarted());
+		assertNull(result.getError());
+	}
+
+	/**
+	 * Tests FailureHandlingResult which suppresses restarts.
+	 */
+	@Test
+	public void testRestartingSuppressedFailureHandlingResult() throws Exception {
+		// create a FailureHandlingResult with error
+		Throwable error = new Exception("test error");
+		FailureHandlingResult result = new FailureHandlingResult(error);
+
+		assertFalse(result.canRestart());
+		assertTrue(result.getRestartDelayMS() < 0);
+		assertEquals(error, result.getError());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*ExecutionFailureHandler is a component of new generation scheduling. See [FLINK-10429](https://issues.apache.org/jira/browse/FLINK-10429). It serves task failover handling by returning tasks to restart upon task failures. This PR is to implement ExecutionFailureHandler and related classes.*


## Brief change log

Detailed design doc can be found at [design](https://docs.google.com/document/d/1D4EP9i5rx9CTQ4-iRu6DVqVEG8KzIMu07Lk4zjxLy08/edit#)
  - *Implement ExecutionFailureHandler*
  - *Implement FailureHandlingResult*
  - *Add interface RestartBackoffTimeStrategy and RestartBackoffTimeStrategy.Factory*
  - *Add interface FailoverStrategy.Factory*


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *UT for ExecutionFailureHandler*
  - *UT for FailureHandlingResult*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
