### PR TITLE
[FLINK-12254][table-common] More preparation for using the new type system

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -240,10 +240,27 @@ public final class DataTypes {
 	 * <p>Compared to the SQL standard, leap seconds (23:59:60 and 23:59:61) are not supported as the
 	 * semantics are closer to {@link java.time.LocalTime}. A time WITH time zone is not provided.
 	 *
+	 * @see #TIME()
 	 * @see TimeType
 	 */
 	public static DataType TIME(int precision) {
 		return new AtomicDataType(new TimeType(precision));
+	}
+
+	/**
+	 * Data type of a time WITHOUT time zone {@code TIME} with no fractional seconds by default.
+	 *
+	 * <p>An instance consists of {@code hour:minute:second} with up to second precision
+	 * and values ranging from {@code 00:00:00} to {@code 23:59:59}.
+	 *
+	 * <p>Compared to the SQL standard, leap seconds (23:59:60 and 23:59:61) are not supported as the
+	 * semantics are closer to {@link java.time.LocalTime}. A time WITH time zone is not provided.
+	 *
+	 * @see #TIME(int)
+	 * @see TimeType
+	 */
+	public static DataType TIME() {
+		return new AtomicDataType(new TimeType());
 	}
 
 	/**
@@ -267,6 +284,26 @@ public final class DataTypes {
 	}
 
 	/**
+	 * Data type of a timestamp WITHOUT time zone {@code TIMESTAMP} with 6 digits of fractional seconds
+	 * by default.
+	 *
+	 * <p>An instance consists of {@code year-month-day hour:minute:second[.fractional]} with up to
+	 * microsecond precision and values ranging from {@code 0000-01-01 00:00:00.000000} to
+	 * {@code 9999-12-31 23:59:59.999999}.
+	 *
+	 * <p>Compared to the SQL standard, leap seconds (23:59:60 and 23:59:61) are not supported as the
+	 * semantics are closer to {@link java.time.LocalDateTime}.
+	 *
+	 * @see #TIMESTAMP(int)
+	 * @see #TIMESTAMP_WITH_TIME_ZONE(int)
+	 * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)
+	 * @see TimestampType
+	 */
+	public static DataType TIMESTAMP() {
+		return new AtomicDataType(new TimestampType());
+	}
+
+	/**
 	 * Data type of a timestamp WITH time zone {@code TIMESTAMP(p) WITH TIME ZONE} where {@code p} is
 	 * the number of digits of fractional seconds (=precision). {@code p} must have a value between 0
 	 * and 9 (both inclusive).
@@ -284,6 +321,26 @@ public final class DataTypes {
 	 */
 	public static DataType TIMESTAMP_WITH_TIME_ZONE(int precision) {
 		return new AtomicDataType(new ZonedTimestampType(precision));
+	}
+
+	/**
+	 * Data type of a timestamp WITH time zone {@code TIMESTAMP WITH TIME ZONE} with 6 digits of fractional
+	 * seconds by default.
+	 *
+	 * <p>An instance consists of {@code year-month-day hour:minute:second[.fractional] zone} with up
+	 * to microsecond precision and values ranging from {@code 0000-01-01 00:00:00.000000 +14:59} to
+	 * {@code 9999-12-31 23:59:59.999999 -14:59}.
+	 *
+	 * <p>Compared to the SQL standard, leap seconds (23:59:60 and 23:59:61) are not supported as the
+	 * semantics are closer to {@link java.time.OffsetDateTime}.
+	 *
+	 * @see #TIMESTAMP_WITH_TIME_ZONE(int)
+	 * @see #TIMESTAMP(int)
+	 * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)
+	 * @see ZonedTimestampType
+	 */
+	public static DataType TIMESTAMP_WITH_TIME_ZONE() {
+		return new AtomicDataType(new ZonedTimestampType());
 	}
 
 	/**
@@ -310,6 +367,32 @@ public final class DataTypes {
 	 */
 	public static DataType TIMESTAMP_WITH_LOCAL_TIME_ZONE(int precision) {
 		return new AtomicDataType(new LocalZonedTimestampType(precision));
+	}
+
+	/**
+	 * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP WITH LOCAL TIME ZONE} with 6 digits
+	 * of fractional seconds by default.
+	 *
+	 * <p>An instance consists of {@code year-month-day hour:minute:second[.fractional] zone} with up
+	 * to microsecond precision and values ranging from {@code 0000-01-01 00:00:00.000000 +14:59} to
+	 * {@code 9999-12-31 23:59:59.999999 -14:59}. Leap seconds (23:59:60 and 23:59:61) are not supported
+	 * as the semantics are closer to {@link java.time.OffsetDateTime}.
+	 *
+	 * <p>Compared to {@link ZonedTimestampType}, the time zone offset information is not stored physically
+	 * in every datum. Instead, the type assumes {@link java.time.Instant} semantics in UTC time zone
+	 * at the edges of the table ecosystem. Every datum is interpreted in the local time zone configured
+	 * in the current session for computation and visualization.
+	 *
+	 * <p>This type fills the gap between time zone free and time zone mandatory timestamp types by
+	 * allowing the interpretation of UTC timestamps according to the configured session timezone.
+	 *
+	 * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)
+	 * @see #TIMESTAMP(int)
+	 * @see #TIMESTAMP_WITH_TIME_ZONE(int)
+	 * @see LocalZonedTimestampType
+	 */
+	public static DataType TIMESTAMP_WITH_LOCAL_TIME_ZONE() {
+		return new AtomicDataType(new LocalZonedTimestampType());
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/Expression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/Expression.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.expressions;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.types.DataType;
 
 import java.util.List;
 
@@ -26,8 +27,11 @@ import java.util.List;
  * The interface for all expressions.
  *
  * <p>Expressions represent a logical tree for producing a computation result. Every expression
- * consists of zero or more sub-expressions. Expressions might be literal values, function calls,
+ * consists of zero, one, or more sub-expressions. Expressions might be literal values, function calls,
  * or field references.
+ *
+ * <p>Expressions are part of the API. Thus, values and return types are expressed as instances of
+ * {@link DataType}.
  */
 @PublicEvolving
 public interface Expression {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
@@ -43,7 +43,7 @@ public final class CollectionDataType extends DataType {
 			LogicalType logicalType,
 			@Nullable Class<?> conversionClass,
 			DataType elementDataType) {
-		super(logicalType, conversionClass);
+		super(logicalType, ensureArrayConversionClass(logicalType, elementDataType, conversionClass));
 		this.elementDataType = Preconditions.checkNotNull(elementDataType, "Element data type must not be null.");
 	}
 
@@ -82,16 +82,6 @@ public final class CollectionDataType extends DataType {
 	}
 
 	@Override
-	public Class<?> getConversionClass() {
-		// arrays are a special case because their default conversion class depends on the
-		// conversion class of the element type
-		if (logicalType.getTypeRoot() == LogicalTypeRoot.ARRAY && conversionClass == null) {
-			return Array.newInstance(elementDataType.getConversionClass(), 0).getClass();
-		}
-		return super.getConversionClass();
-	}
-
-	@Override
 	public <R> R accept(DataTypeVisitor<R> visitor) {
 		return visitor.visit(this);
 	}
@@ -114,5 +104,19 @@ public final class CollectionDataType extends DataType {
 	@Override
 	public int hashCode() {
 		return Objects.hash(super.hashCode(), elementDataType);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static Class<?> ensureArrayConversionClass(
+			LogicalType logicalType,
+			DataType elementDataType,
+			@Nullable Class<?> clazz) {
+		// arrays are a special case because their default conversion class depends on the
+		// conversion class of the element type
+		if (logicalType.getTypeRoot() == LogicalTypeRoot.ARRAY && clazz == null) {
+			return Array.newInstance(elementDataType.getConversionClass(), 0).getClass();
+		}
+		return clazz;
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
@@ -52,13 +52,15 @@ import java.util.Objects;
 @PublicEvolving
 public abstract class DataType implements Serializable {
 
-	protected LogicalType logicalType;
+	protected final LogicalType logicalType;
 
-	protected @Nullable Class<?> conversionClass;
+	protected final Class<?> conversionClass;
 
 	DataType(LogicalType logicalType, @Nullable Class<?> conversionClass) {
 		this.logicalType = Preconditions.checkNotNull(logicalType, "Logical type must not be null.");
-		this.conversionClass = performEarlyClassValidation(logicalType, conversionClass);
+		this.conversionClass = performEarlyClassValidation(
+			logicalType,
+			ensureConversionClass(logicalType, conversionClass));
 	}
 
 	/**
@@ -79,9 +81,6 @@ public abstract class DataType implements Serializable {
 	 * @return the expected conversion class
 	 */
 	public Class<?> getConversionClass() {
-		if (conversionClass == null) {
-			return logicalType.getDefaultConversion();
-		}
 		return conversionClass;
 	}
 
@@ -133,7 +132,7 @@ public abstract class DataType implements Serializable {
 		}
 		DataType dataType = (DataType) o;
 		return logicalType.equals(dataType.logicalType) &&
-			Objects.equals(conversionClass, dataType.conversionClass);
+			conversionClass.equals(dataType.conversionClass);
 	}
 
 	@Override
@@ -161,5 +160,12 @@ public abstract class DataType implements Serializable {
 					candidate.getName()));
 		}
 		return candidate;
+	}
+
+	private static Class<?> ensureConversionClass(LogicalType logicalType, @Nullable Class<?> clazz) {
+		if (clazz == null) {
+			return logicalType.getDefaultConversion();
+		}
+		return clazz;
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LegacyTypeInformationType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LegacyTypeInformationType.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This type is a temporary solution to fully support the old type system stack through the new
+ * stack. Many types can be mapped directly to the new type system, however, some types such as
+ * {@code DECIMAL}, POJOs, or case classes need special handling.
+ *
+ * <p>This type differs from {@link TypeInformationAnyType}. This type is allowed to travel through
+ * the stack whereas {@link TypeInformationAnyType} should be resolved eagerly to {@link AnyType} by
+ * the planner.
+ *
+ * <p>This class can be removed once we have removed all deprecated methods that take or return
+ * {@link TypeInformation}.
+ *
+ * @see LegacyTypeInfoDataTypeConverter
+ */
+@Internal
+public final class LegacyTypeInformationType<T> extends LogicalType {
+
+	private static final String FORMAT = "LEGACY(%s)";
+
+	private final TypeInformation<T> typeInfo;
+
+	public LegacyTypeInformationType(LogicalTypeRoot logicalTypeRoot, TypeInformation<T> typeInfo) {
+		super(true, logicalTypeRoot);
+		this.typeInfo = Preconditions.checkNotNull(typeInfo, "Type information must not be null.");
+	}
+
+	public TypeInformation<T> getTypeInformation() {
+		return typeInfo;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new LegacyTypeInformationType<>(getTypeRoot(), typeInfo);
+	}
+
+	@Override
+	public String asSerializableString() {
+		throw new TableException("Legacy type information has no serializable string representation.");
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(FORMAT, typeInfo);
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return typeInfo.getTypeClass().isAssignableFrom(clazz);
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return clazz.isAssignableFrom(typeInfo.getTypeClass());
+	}
+
+	@Override
+	public Class<?> getDefaultConversion() {
+		return typeInfo.getTypeClass();
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		LegacyTypeInformationType<?> that = (LegacyTypeInformationType<?>) o;
+		return typeInfo.equals(that.typeInfo);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), typeInfo);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
@@ -80,6 +80,7 @@ public final class LogicalTypeChecks {
 
 		@Override
 		protected TimestampKind defaultMethod(LogicalType logicalType) {
+			// we don't verify that type is actually a timestamp
 			return TimestampKind.REGULAR;
 		}
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
+
+/**
+ * Utilities for checking {@link LogicalType}.
+ */
+@Internal
+public final class LogicalTypeChecks {
+
+	private static final TimeAttributeChecker TIME_ATTRIBUTE_CHECKER = new TimeAttributeChecker();
+
+	public static boolean hasRoot(LogicalType logicalType, LogicalTypeRoot typeRoot) {
+		return logicalType.getTypeRoot() == typeRoot;
+	}
+
+	public static boolean hasFamily(LogicalType logicalType, LogicalTypeFamily family) {
+		return logicalType.getTypeRoot().getFamilies().contains(family);
+	}
+
+	public static boolean isTimeAttribute(LogicalType logicalType) {
+		return logicalType.accept(TIME_ATTRIBUTE_CHECKER) != TimestampKind.REGULAR;
+	}
+
+	public static boolean isRowtimeAttribute(LogicalType logicalType) {
+		return logicalType.accept(TIME_ATTRIBUTE_CHECKER) == TimestampKind.ROWTIME;
+	}
+
+	public static boolean isProctimeAttribute(LogicalType logicalType) {
+		return logicalType.accept(TIME_ATTRIBUTE_CHECKER) == TimestampKind.PROCTIME;
+	}
+
+	private LogicalTypeChecks() {
+		// no instantiation
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static class TimeAttributeChecker extends LogicalTypeDefaultVisitor<TimestampKind> {
+
+		@Override
+		public TimestampKind visit(TimestampType timestampType) {
+			return timestampType.getKind();
+		}
+
+		@Override
+		public TimestampKind visit(ZonedTimestampType zonedTimestampType) {
+			return zonedTimestampType.getKind();
+		}
+
+		@Override
+		public TimestampKind visit(LocalZonedTimestampType localZonedTimestampType) {
+			return localZonedTimestampType.getKind();
+		}
+
+		@Override
+		protected TimestampKind defaultMethod(LogicalType logicalType) {
+			return TimestampKind.REGULAR;
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
@@ -56,7 +56,7 @@ public final class ClassDataTypeConverter {
 		addDefaultDataType(double.class, DataTypes.DOUBLE());
 		addDefaultDataType(java.sql.Date.class, DataTypes.DATE());
 		addDefaultDataType(java.time.LocalDate.class, DataTypes.DATE());
-		addDefaultDataType(java.sql.Time.class, DataTypes.TIME(9));
+		addDefaultDataType(java.sql.Time.class, DataTypes.TIME(3));
 		addDefaultDataType(java.time.LocalTime.class, DataTypes.TIME(9));
 		addDefaultDataType(java.sql.Timestamp.class, DataTypes.TIMESTAMP(9));
 		addDefaultDataType(java.time.LocalDateTime.class, DataTypes.TIMESTAMP(9));

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.CompositeType;
+import org.apache.flink.api.java.typeutils.MapTypeInfo;
+import org.apache.flink.api.java.typeutils.MultisetTypeInfo;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TypeInformationAnyType;
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo;
+import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Converter between {@link TypeInformation} and {@link DataType} that reflects the behavior before
+ * Flink 1.9. The conversion is a 1:1 mapping that allows back-and-forth conversion.
+ *
+ * <p>This converter only exists to still support deprecated methods that take or return {@link TypeInformation}.
+ * Some methods will still support type information in the future, however, the future type information
+ * support will integrate nicer with the new type stack. This converter reflects the old behavior that includes:
+ *
+ * <p>Use old {@code java.sql.*} time classes for time data types.
+ *
+ * <p>Only support millisecond precision for timestamps or day-time intervals.
+ *
+ * <p>Do not support fractional seconds for the time type.
+ *
+ * <p>Let variable precision and scale for decimal types pass through the planner.
+ *
+ * <p>Let POJOs, case classes, and tuples pass through the planner.
+ *
+ * <p>Inconsistent nullability. Most types are nullable even though type information does not support it.
+ */
+@Internal
+public final class LegacyTypeInfoDataTypeConverter {
+
+	private static final Map<TypeInformation<?>, DataType> typeInfoDataTypeMap = new HashMap<>();
+	private static final Map<DataType, TypeInformation<?>> dataTypeTypeInfoMap = new HashMap<>();
+	static {
+		addMapping(Types.STRING, DataTypes.STRING().bridgedTo(String.class));
+		addMapping(Types.BOOLEAN, DataTypes.BOOLEAN().bridgedTo(Boolean.class));
+		addMapping(Types.BYTE, DataTypes.TINYINT().bridgedTo(Byte.class));
+		addMapping(Types.SHORT, DataTypes.SMALLINT().bridgedTo(Short.class));
+		addMapping(Types.INT, DataTypes.INT().bridgedTo(Integer.class));
+		addMapping(Types.LONG, DataTypes.BIGINT().bridgedTo(Long.class));
+		addMapping(Types.FLOAT, DataTypes.FLOAT().bridgedTo(Float.class));
+		addMapping(Types.DOUBLE, DataTypes.DOUBLE().bridgedTo(Double.class));
+		addMapping(Types.BIG_DEC, createLegacyType(LogicalTypeRoot.DECIMAL, Types.BIG_DEC));
+		addMapping(Types.SQL_DATE, DataTypes.DATE().bridgedTo(java.sql.Date.class));
+		addMapping(Types.SQL_TIME, DataTypes.TIME(0).bridgedTo(java.sql.Time.class));
+		addMapping(Types.SQL_TIMESTAMP, DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class));
+		addMapping(
+			TimeIntervalTypeInfo.INTERVAL_MONTHS,
+			DataTypes.INTERVAL(DataTypes.MONTH()).bridgedTo(Integer.class));
+		addMapping(
+			TimeIntervalTypeInfo.INTERVAL_MILLIS,
+			DataTypes.INTERVAL(DataTypes.SECOND(3)).bridgedTo(Long.class));
+		addMapping(
+			PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO,
+			DataTypes.ARRAY(DataTypes.BOOLEAN().notNull().bridgedTo(boolean.class)).bridgedTo(boolean[].class));
+		addMapping(
+			PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
+			DataTypes.BYTES().bridgedTo(byte[].class));
+		addMapping(
+			PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO,
+			DataTypes.ARRAY(DataTypes.SMALLINT().notNull().bridgedTo(short.class)).bridgedTo(short[].class));
+		addMapping(
+			PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO,
+			DataTypes.ARRAY(DataTypes.INT().notNull().bridgedTo(int.class)).bridgedTo(int[].class));
+		addMapping(
+			PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO,
+			DataTypes.ARRAY(DataTypes.BIGINT().notNull().bridgedTo(long.class)).bridgedTo(long[].class));
+		addMapping(
+			PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO,
+			DataTypes.ARRAY(DataTypes.FLOAT().notNull().bridgedTo(float.class)).bridgedTo(float[].class));
+		addMapping(
+			PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO,
+			DataTypes.ARRAY(DataTypes.DOUBLE().notNull().bridgedTo(double.class)).bridgedTo(double[].class));
+	}
+
+	private static void addMapping(TypeInformation<?> typeInfo, DataType dataType) {
+		Preconditions.checkArgument(!typeInfoDataTypeMap.containsKey(typeInfo));
+		typeInfoDataTypeMap.put(typeInfo, dataType);
+		dataTypeTypeInfoMap.put(dataType, typeInfo);
+	}
+
+	public static DataType toDataType(TypeInformation<?> typeInfo) {
+		// time indicators first as their hashCode/equals is shared with those of regular timestamps
+		if (typeInfo instanceof TimeIndicatorTypeInfo) {
+			return convertToTimeAttributeType((TimeIndicatorTypeInfo) typeInfo);
+		}
+
+		final DataType foundDataType = typeInfoDataTypeMap.get(typeInfo);
+		if (foundDataType != null) {
+			return foundDataType;
+		}
+
+		if (typeInfo instanceof RowTypeInfo) {
+			return convertToRowType((RowTypeInfo) typeInfo);
+		}
+
+		else if (typeInfo instanceof ObjectArrayTypeInfo) {
+			return convertToArrayType(
+				typeInfo.getTypeClass(),
+				((ObjectArrayTypeInfo) typeInfo).getComponentInfo());
+		}
+
+		else if (typeInfo instanceof BasicArrayTypeInfo) {
+			return convertToArrayType(
+				typeInfo.getTypeClass(),
+				((BasicArrayTypeInfo) typeInfo).getComponentInfo());
+		}
+
+		else if (typeInfo instanceof MultisetTypeInfo) {
+			return convertToMultisetType(((MultisetTypeInfo) typeInfo).getElementTypeInfo());
+		}
+
+		else if (typeInfo instanceof MapTypeInfo) {
+			return convertToMapType((MapTypeInfo) typeInfo);
+		}
+
+		else if (typeInfo instanceof CompositeType) {
+			return createLegacyType(LogicalTypeRoot.STRUCTURED_TYPE, typeInfo);
+		}
+
+		return DataTypes.ANY(typeInfo);
+	}
+
+	public static TypeInformation<?> toLegacyTypeInfo(DataType dataType) {
+		// time indicators first as their hashCode/equals is shared with those of regular timestamps
+		if (canConvertToTimeAttributeTypeInfo(dataType)) {
+			return convertToTimeAttributeTypeInfo((TimestampType) dataType.getLogicalType());
+		}
+
+		final TypeInformation<?> foundTypeInfo = dataTypeTypeInfoMap.get(dataType);
+		if (foundTypeInfo != null) {
+			return foundTypeInfo;
+		}
+
+		if (canConvertToRowTypeInfo(dataType)) {
+			return convertToRowTypeInfo((FieldsDataType) dataType);
+		}
+
+		else if (canConvertToObjectArrayTypeInfo(dataType)) {
+			return convertToObjectArrayTypeInfo((CollectionDataType) dataType);
+		}
+
+		else if (canConvertToMultisetTypeInfo(dataType)) {
+			return convertToMultisetTypeInfo((CollectionDataType) dataType);
+		}
+
+		else if (canConvertToMapTypeInfo(dataType)) {
+			return convertToMapTypeInfo((KeyValueDataType) dataType);
+		}
+
+		else  if (canConvertToLegacyTypeInfo(dataType)) {
+			return convertToLegacyTypeInfo(dataType);
+		}
+
+		else if (canConvertToAnyTypeInfo(dataType)) {
+			return convertToAnyTypeInfo(dataType);
+		}
+
+		throw new TableException(
+			String.format(
+				"Unsupported conversion from data type '%s' to type information. Only data types " +
+					"that originated from type information fully support a reverse conversion.",
+				dataType));
+	}
+
+	private static DataType createLegacyType(LogicalTypeRoot typeRoot, TypeInformation<?> typeInfo) {
+		return new AtomicDataType(new LegacyTypeInformationType<>(typeRoot, typeInfo))
+			.bridgedTo(typeInfo.getTypeClass());
+	}
+
+	private static DataType convertToTimeAttributeType(TimeIndicatorTypeInfo timeIndicatorTypeInfo) {
+		final TimestampKind kind;
+		if (timeIndicatorTypeInfo.isEventTime()) {
+			kind = TimestampKind.ROWTIME;
+		} else {
+			kind = TimestampKind.PROCTIME;
+		}
+		return new AtomicDataType(new TimestampType(true, kind, 3))
+			.bridgedTo(java.sql.Timestamp.class);
+	}
+
+	private static boolean canConvertToTimeAttributeTypeInfo(DataType dataType) {
+		return dataType.getLogicalType().getTypeRoot() == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE &&
+			dataTypeTypeInfoMap.containsKey(dataType) && // checks precision and conversion
+			((TimestampType) dataType.getLogicalType()).getKind() != TimestampKind.REGULAR;
+	}
+
+	private static TypeInformation<?> convertToTimeAttributeTypeInfo(TimestampType timestampType) {
+		if (timestampType.getKind() == TimestampKind.ROWTIME) {
+			return TimeIndicatorTypeInfo.ROWTIME_INDICATOR;
+		} else {
+			return TimeIndicatorTypeInfo.PROCTIME_INDICATOR;
+		}
+	}
+
+	private static DataType convertToRowType(RowTypeInfo rowTypeInfo) {
+		final String[] fieldNames = rowTypeInfo.getFieldNames();
+		final DataTypes.Field[] fields = IntStream.range(0, rowTypeInfo.getArity())
+			.mapToObj(i -> {
+				final String fieldName = fieldNames[i];
+				DataType fieldType = toDataType(rowTypeInfo.getTypeAt(i));
+
+				return DataTypes.FIELD(
+					fieldNames[i],
+					fieldType);
+			})
+			.toArray(DataTypes.Field[]::new);
+
+		return DataTypes.ROW(fields).bridgedTo(Row.class);
+	}
+
+	private static boolean canConvertToRowTypeInfo(DataType dataType) {
+		return dataType.getLogicalType().getTypeRoot() == LogicalTypeRoot.ROW &&
+			dataType.getConversionClass().equals(Row.class) &&
+			((RowType) dataType.getLogicalType()).getFields().stream()
+				.noneMatch(f -> f.getDescription().isPresent());
+	}
+
+	private static TypeInformation<?> convertToRowTypeInfo(FieldsDataType fieldsDataType) {
+		final RowType rowType = (RowType) fieldsDataType.getLogicalType();
+
+		final String[] fieldNames = rowType.getFields()
+			.stream()
+			.map(RowType.RowField::getName)
+			.toArray(String[]::new);
+
+		final TypeInformation<?>[] fieldTypes = Stream.of(fieldNames)
+			.map(name -> fieldsDataType.getFieldDataTypes().get(name))
+			.map(LegacyTypeInfoDataTypeConverter::toLegacyTypeInfo)
+			.toArray(TypeInformation[]::new);
+
+		return Types.ROW_NAMED(fieldNames, fieldTypes);
+	}
+
+	private static DataType convertToArrayType(Class<?> arrayClass, TypeInformation<?> elementTypeInfo) {
+		return DataTypes.ARRAY(toDataType(elementTypeInfo)).bridgedTo(arrayClass);
+	}
+
+	private static boolean canConvertToObjectArrayTypeInfo(DataType dataType) {
+		return dataType.getLogicalType().getTypeRoot() == LogicalTypeRoot.ARRAY &&
+			dataType.getConversionClass().isArray();
+	}
+
+	private static TypeInformation<?> convertToObjectArrayTypeInfo(CollectionDataType collectionDataType) {
+		return Types.OBJECT_ARRAY(
+			toLegacyTypeInfo(collectionDataType.getElementDataType()));
+	}
+
+	private static DataType convertToMultisetType(TypeInformation elementTypeInfo) {
+		return DataTypes.MULTISET(toDataType(elementTypeInfo)).bridgedTo(Map.class);
+	}
+
+	private static boolean canConvertToMultisetTypeInfo(DataType dataType) {
+		return dataType.getLogicalType().getTypeRoot() == LogicalTypeRoot.MULTISET &&
+			dataType.getConversionClass() == Map.class;
+	}
+
+	private static TypeInformation<?> convertToMultisetTypeInfo(CollectionDataType collectionDataType) {
+		return new MultisetTypeInfo<>(
+			toLegacyTypeInfo(collectionDataType.getElementDataType()));
+	}
+
+	private static DataType convertToMapType(MapTypeInfo typeInfo) {
+		return DataTypes.MAP(
+				toDataType(typeInfo.getKeyTypeInfo()),
+				toDataType(typeInfo.getValueTypeInfo()))
+			.bridgedTo(Map.class);
+	}
+
+	private static boolean canConvertToMapTypeInfo(DataType dataType) {
+		return dataType.getLogicalType().getTypeRoot() == LogicalTypeRoot.MAP &&
+			dataType.getConversionClass() == Map.class;
+	}
+
+	private static TypeInformation<?> convertToMapTypeInfo(KeyValueDataType dataType) {
+		return Types.MAP(
+			toLegacyTypeInfo(dataType.getKeyDataType()),
+			toLegacyTypeInfo(dataType.getValueDataType()));
+	}
+
+	private static boolean canConvertToLegacyTypeInfo(DataType dataType) {
+		return dataType.getLogicalType() instanceof LegacyTypeInformationType;
+	}
+
+	private static TypeInformation<?> convertToLegacyTypeInfo(DataType dataType) {
+		return ((LegacyTypeInformationType) dataType.getLogicalType()).getTypeInformation();
+	}
+
+	private static boolean canConvertToAnyTypeInfo(DataType dataType) {
+		return dataType.getLogicalType() instanceof TypeInformationAnyType &&
+			dataType.getConversionClass().equals(
+				((TypeInformationAnyType) dataType.getLogicalType()).getTypeInformation().getTypeClass());
+	}
+
+	private static TypeInformation<?> convertToAnyTypeInfo(DataType dataType) {
+		return ((TypeInformationAnyType) dataType.getLogicalType()).getTypeInformation();
+	}
+
+	private LegacyTypeInfoDataTypeConverter() {
+		// no instantiation
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/TypeConversions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/TypeConversions.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Conversion hub for interoperability of {@link Class}, {@link TypeInformation}, {@link DataType},
+ * and {@link LogicalType}.
+ *
+ * <p>See the corresponding converter classes for more information about how the conversion is performed.
+ */
+@Internal
+public final class TypeConversions {
+
+	public static DataType fromLegacyInfoToDataType(TypeInformation<?> typeInfo) {
+		return LegacyTypeInfoDataTypeConverter.toDataType(typeInfo);
+	}
+
+	public static DataType[] fromLegacyInfoToDataType(TypeInformation<?>[] typeInfo) {
+		return Stream.of(typeInfo)
+			.map(TypeConversions::fromLegacyInfoToDataType)
+			.toArray(DataType[]::new);
+	}
+
+	public static TypeInformation<?> fromDataTypeToLegacyInfo(DataType dataType) {
+		return LegacyTypeInfoDataTypeConverter.toLegacyTypeInfo(dataType);
+	}
+
+	public static TypeInformation<?>[] fromDataTypeToLegacyInfo(DataType[] dataType) {
+		return Stream.of(dataType)
+			.map(TypeConversions::fromDataTypeToLegacyInfo)
+			.toArray(TypeInformation[]::new);
+	}
+
+	public static Optional<DataType> fromClassToDataType(Class<?> clazz) {
+		return ClassDataTypeConverter.extractDataType(clazz);
+	}
+
+	public static DataType fromLogicalToDataType(LogicalType logicalType) {
+		return LogicalTypeDataTypeConverter.toDataType(logicalType);
+	}
+
+	public static DataType[] fromLogicalToDataType(LogicalType[] logicalTypes) {
+		return Stream.of(logicalTypes)
+			.map(LogicalTypeDataTypeConverter::toDataType)
+			.toArray(DataType[]::new);
+	}
+
+	public static LogicalType fromDataToLogicalType(DataType dataType) {
+		return dataType.getLogicalType();
+	}
+
+	public static LogicalType[] fromDataToLogicalType(DataType[] dataTypes) {
+		return Stream.of(dataTypes)
+			.map(TypeConversions::fromDataToLogicalType)
+			.toArray(LogicalType[]::new);
+	}
+
+	private TypeConversions() {
+		// no instance
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypeTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.types;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 
 import org.junit.Test;
@@ -127,5 +128,10 @@ public class DataTypeTest {
 	@Test(expected = ValidationException.class)
 	public void testInvalidOrderInterval() {
 		INTERVAL(MONTH(), YEAR(2));
+	}
+
+	@Test
+	public void testConversionEquality() {
+		assertEquals(DataTypes.VARCHAR(2).bridgedTo(String.class), DataTypes.VARCHAR(2));
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -144,14 +144,26 @@ public class DataTypesTest {
 
 				{TIME(3), new TimeType(3), java.time.LocalTime.class},
 
+				{TIME(), new TimeType(0), java.time.LocalTime.class},
+
 				{TIMESTAMP(3), new TimestampType(3), java.time.LocalDateTime.class},
+
+				{TIMESTAMP(), new TimestampType(6), java.time.LocalDateTime.class},
 
 				{TIMESTAMP_WITH_TIME_ZONE(3),
 					new ZonedTimestampType(3),
 					java.time.OffsetDateTime.class},
 
+				{TIMESTAMP_WITH_TIME_ZONE(),
+					new ZonedTimestampType(6),
+					java.time.OffsetDateTime.class},
+
 				{TIMESTAMP_WITH_LOCAL_TIME_ZONE(3),
 					new LocalZonedTimestampType(3),
+					java.time.Instant.class},
+
+				{TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
+					new LocalZonedTimestampType(6),
 					java.time.Instant.class},
 
 				{INTERVAL(MINUTE(), SECOND(3)),

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LegacyTypeInfoDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LegacyTypeInfoDataTypeConverterTest.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.table.types;
 
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
@@ -59,7 +61,10 @@ public class LegacyTypeInfoDataTypeConverterTest {
 
 				{
 					Types.GENERIC(LegacyTypeInfoDataTypeConverterTest.class),
-					DataTypes.ANY(Types.GENERIC(LegacyTypeInfoDataTypeConverterTest.class))
+					new AtomicDataType(
+						new LegacyTypeInformationType<>(
+							LogicalTypeRoot.ANY,
+							Types.GENERIC(LegacyTypeInfoDataTypeConverterTest.class)))
 				},
 
 				{
@@ -91,6 +96,20 @@ public class LegacyTypeInfoDataTypeConverterTest {
 						DataTypes.ARRAY(DataTypes.FLOAT().notNull().bridgedTo(float.class))
 							.bridgedTo(float[].class))
 						.bridgedTo(float[][].class)
+				},
+
+				{
+					BasicArrayTypeInfo.getInfoFor(String[].class),
+					new AtomicDataType(
+						new LegacyTypeInformationType<>(
+							LogicalTypeRoot.ARRAY,
+							Types.OBJECT_ARRAY(Types.STRING)))
+				},
+
+				{
+					ObjectArrayTypeInfo.getInfoFor(Types.STRING),
+					DataTypes.ARRAY(DataTypes.STRING())
+						.bridgedTo(String[].class)
 				},
 
 				{

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LegacyTypeInfoDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LegacyTypeInfoDataTypeConverterTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link LegacyTypeInfoDataTypeConverter}.
+ */
+@RunWith(Parameterized.class)
+public class LegacyTypeInfoDataTypeConverterTest {
+
+	@Parameters(name = "[{index}] type info: {0} data type: {1}")
+	public static List<Object[]> typeInfo() {
+		return Arrays.asList(
+			new Object[][]{
+				{Types.STRING, DataTypes.STRING()},
+
+				{Types.BOOLEAN, DataTypes.BOOLEAN()},
+
+				{Types.SQL_TIMESTAMP, DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class)},
+
+				{
+					Types.GENERIC(LegacyTypeInfoDataTypeConverterTest.class),
+					DataTypes.ANY(Types.GENERIC(LegacyTypeInfoDataTypeConverterTest.class))
+				},
+
+				{
+					Types.ROW_NAMED(new String[] {"field1", "field2"}, Types.INT, Types.LONG),
+					DataTypes.ROW(
+							FIELD("field1", DataTypes.INT()),
+							FIELD("field2", DataTypes.BIGINT()))
+				},
+
+				{
+					Types.MAP(Types.FLOAT, Types.ROW(Types.BYTE)),
+					DataTypes.MAP(DataTypes.FLOAT(), DataTypes.ROW(FIELD("f0", DataTypes.TINYINT())))
+				},
+
+				{
+					Types.PRIMITIVE_ARRAY(Types.FLOAT),
+					DataTypes.ARRAY(DataTypes.FLOAT().notNull().bridgedTo(float.class))
+						.bridgedTo(float[].class)
+				},
+
+				{
+					Types.PRIMITIVE_ARRAY(Types.BYTE),
+					DataTypes.BYTES()
+				},
+
+				{
+					Types.OBJECT_ARRAY(Types.PRIMITIVE_ARRAY(Types.FLOAT)),
+					DataTypes.ARRAY(
+						DataTypes.ARRAY(DataTypes.FLOAT().notNull().bridgedTo(float.class))
+							.bridgedTo(float[].class))
+						.bridgedTo(float[][].class)
+				},
+
+				{
+					Types.TUPLE(Types.SHORT, Types.DOUBLE, Types.FLOAT),
+					new AtomicDataType(
+						new LegacyTypeInformationType<>(
+							LogicalTypeRoot.STRUCTURED_TYPE,
+							Types.TUPLE(Types.SHORT, Types.DOUBLE, Types.FLOAT)))
+				},
+
+				{
+					TimeIndicatorTypeInfo.ROWTIME_INDICATOR,
+					new AtomicDataType(new TimestampType(true, TimestampKind.ROWTIME, 3))
+						.bridgedTo(java.sql.Timestamp.class)
+				}
+			}
+		);
+	}
+
+	@Parameter
+	public TypeInformation<?> inputTypeInfo;
+
+	@Parameter(1)
+	public DataType dataType;
+
+	@Test
+	public void testTypeInfoToDataTypeConversion() {
+		assertThat(LegacyTypeInfoDataTypeConverter.toDataType(inputTypeInfo), equalTo(dataType));
+	}
+
+	@Test
+	public void testDataTypeToTypeInfoConversion() {
+		assertThat(LegacyTypeInfoDataTypeConverter.toLegacyTypeInfo(dataType), equalTo(inputTypeInfo));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR contains another set of utility classes for enabling the new type system. The most important part is the `LegacyTypeInfoDataTypeConverter`. It basically allows converting all the type information that we supported in the Table & SQL API before to DataType.

## Brief change log

See commit messages.

## Verifying this change

Tested via `LegacyTypeInfoDataTypeConverterTest` and existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
