### PR TITLE
[FLINK-12578] Use secure URLs for Maven repositories

### DIFF
--- a/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<repositories>
 		<repository>
 			<id>confluent</id>
-			<url>http://packages.confluent.io/maven/</url>
+			<url>https://packages.confluent.io/maven/</url>
 		</repository>
 	</repositories>
 

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<repositories>
 		<repository>
 			<id>confluent</id>
-			<url>http://packages.confluent.io/maven/</url>
+			<url>https://packages.confluent.io/maven/</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1017,14 +1017,14 @@ under the License.
 				<repository>
 					<id>HDPReleases</id>
 					<name>HDP Releases</name>
-					<url>http://repo.hortonworks.com/content/repositories/releases/</url>
+					<url>https://repo.hortonworks.com/content/repositories/releases/</url>
 					<snapshots><enabled>false</enabled></snapshots>
 					<releases><enabled>true</enabled></releases>
 				</repository>
 				<repository>
 					<id>HortonworksJettyHadoop</id>
 					<name>HDP Jetty</name>
-					<url>http://repo.hortonworks.com/content/repositories/jetty-hadoop</url>
+					<url>https://repo.hortonworks.com/content/repositories/jetty-hadoop</url>
 					<snapshots><enabled>false</enabled></snapshots>
 					<releases><enabled>true</enabled></releases>
 				</repository>


### PR DESCRIPTION
## What is the purpose of the change

This pull requests changes the scheme of maven repositories URL from http to https to leverage secured transformation when interacting with repository.

This pull requests changes Confluent and HWX repository URLs: it doesn't change MapR URL as of now since it seems to incur build failure (might be certification issue on MapR side). 

## Brief change log

- Replace http scheme to https for repository URLs which are available without build failure

## Verifying this change

This change is verified by rebuilding flink with `mvn clean install -DskipTests`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
