### PR TITLE
[FLINK-12580][hive] Rename GenericHiveMetastoreCatalogTest to HiveCatalogGenericMetadataTest, and HiveCatalogTest to HiveCatalogHiveMetadataTest

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.util.HashMap;
 
 /**
- * Test for HiveCatalog on Flink generic metadata.
+ * Test for HiveCatalog on generic metadata.
  */
 public class HiveCatalogGenericMetadataTest extends CatalogTestBase {
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -38,9 +38,9 @@ import java.io.IOException;
 import java.util.HashMap;
 
 /**
- * Test for GenericHiveMetastoreCatalog.
+ * Test for HiveCatalog on Flink generic metadata.
  */
-public class GenericHiveMetastoreCatalogTest extends CatalogTestBase {
+public class HiveCatalogGenericMetadataTest extends CatalogTestBase {
 
 	@BeforeClass
 	public static void init() throws IOException {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -32,9 +32,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test for HiveCatalog.
+ * Test for HiveCatalog on Hive metadata.
  */
-public class HiveCatalogTest extends CatalogTestBase {
+public class HiveCatalogHiveMetadataTest extends CatalogTestBase {
 
 	@BeforeClass
 	public static void init() throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

This PR simply renames `GenericHiveMetastoreCatalogTest` to `HiveCatalogGenericMetadataTest`, and `HiveCatalogTest` to `HiveCatalogHiveMetadataTest`, since we unified `GenericHiveMetastoreCatalog` and `HiveCatalog` into a new `HiveCatalog`.

## Brief change log

- renames `GenericHiveMetastoreCatalogTest` to `HiveCatalogGenericMetadataTest`
- renames `HiveCatalogTest` to `HiveCatalogHiveMetadataTest`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
