### PR TITLE
[FLINK-12310][hive] shade user facing common libraries in flink-connector-hive

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -404,6 +404,33 @@ under the License.
 									</excludes>
 								</filter>
 							</filters>
+							<relocations combine.children="override">
+								<!-- DO NOT RELOCATE GUAVA IN THIS PACKAGE -->
+								<relocation>
+									<pattern>org.apache.commons</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.org.apache.commons</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.com.fasterxml.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.jolbox</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.com.jolbox</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.thrift</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.org.apache.thrift</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.datanucleus</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.org.datanucleus</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.antlr</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.org.antlr</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
## What is the purpose of the change

As discussed with Stephan, Timo, and Chesnay previously that we will need to shade user facing common libraries in flink-connector-hive.

This PR shades common libraries that user may use to avoid conflicts.

## Brief change log

- shaded apache commons, jackson, jolbox, org.apache thrift, datanucleus, and antlr in flink-connector-hive

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
