### PR TITLE
[FLINK-12582][table] Alterations in GenericInMemoryCatalog should check existing object and new object are of the same class

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -149,7 +149,17 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));
 		checkNotNull(newDatabase);
 
-		if (databaseExists(databaseName)) {
+		CatalogDatabase existingDatabase = databases.get(databaseName);
+
+		if (existingDatabase != null) {
+
+			if (existingDatabase.getClass() != newDatabase.getClass()) {
+				throw new CatalogException(
+					String.format("Database types don't match. Existing database is '%s' and new database is '%s'",
+						existingDatabase.getClass().getName(), newDatabase.getClass().getName())
+				);
+			}
+
 			databases.put(databaseName, newDatabase.copy());
 		} else if (!ignoreIfNotExists) {
 			throw new DatabaseNotExistException(catalogName, databaseName);
@@ -212,13 +222,13 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkNotNull(tablePath);
 		checkNotNull(newTable);
 
-		if (tableExists(tablePath)) {
-			CatalogBaseTable oldTable = tables.get(tablePath);
+		CatalogBaseTable existingTable = tables.get(tablePath);
 
-			if (oldTable.getClass() != newTable.getClass()) {
+		if (existingTable != null) {
+			if (existingTable.getClass() != newTable.getClass()) {
 				throw new CatalogException(
 					String.format("Table classes don't match. Existing table is '%s' and new table is '%s'. They should be of the same class.",
-						oldTable.getClass().getName(), newTable.getClass().getName()));
+						existingTable.getClass().getName(), newTable.getClass().getName()));
 			}
 
 			tables.put(tablePath, newTable.copy());
@@ -362,7 +372,17 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkNotNull(functionPath);
 		checkNotNull(newFunction);
 
-		if (functionExists(functionPath)) {
+		CatalogFunction existingFunction = functions.get(functionPath);
+
+		if (existingFunction != null) {
+
+			if (existingFunction.getClass() != newFunction.getClass()) {
+				throw new CatalogException(
+					String.format("Function types don't match. Existing function is '%s' and new function is '%s'",
+						existingFunction.getClass().getName(), newFunction.getClass().getName())
+				);
+			}
+
 			functions.put(functionPath, newFunction.copy());
 		} else if (!ignoreIfNotExists) {
 			throw new FunctionNotExistException(catalogName, functionPath);
@@ -464,6 +484,15 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkNotNull(newPartition);
 
 		if (partitionExists(tablePath, partitionSpec)) {
+			CatalogPartition existingPartition = partitions.get(tablePath).get(partitionSpec);
+
+			if (existingPartition.getClass() != newPartition.getClass()) {
+				throw new CatalogException(
+					String.format("Partition types don't match. Existing partition is '%s' and new partition is '%s'",
+						existingPartition.getClass().getName(), newPartition.getClass().getName())
+				);
+			}
+
 			partitions.get(tablePath).put(partitionSpec, newPartition.copy());
 		} else if (!ignoreIfNotExists) {
 			throw new PartitionNotExistException(catalogName, tablePath, partitionSpec);


### PR DESCRIPTION
## What is the purpose of the change

This PR made alterations in GenericInMemoryCatalog check existing object and new object are of the same class.

It currently doesn't, and you can alter an existing generic table with a new hive table.

## Brief change log

- check existing object and new object are of the same class in `alterDatabase()`,`alterPartition()`, `alterFunction()` in `GenericInMemoryCatalog`
- improved check logic in `alterTable()` 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
