### PR TITLE
[FLINK-12236][hive] Support Hive function in HiveCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogFunction.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.table.catalog.AbstractCatalogFunction;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+/**
+ * A hive catalog function implementation.
+ */
+public class HiveCatalogFunction extends AbstractCatalogFunction {
+
+	public HiveCatalogFunction(String className) {
+		super(className, new HashMap<>());
+	}
+
+	@Override
+	public HiveCatalogFunction copy() {
+		return new HiveCatalogFunction(getClassName());
+	}
+
+	@Override
+	public Optional<String> getDescription() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<String> getDetailedDescription() {
+		return Optional.empty();
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -50,53 +50,6 @@ public class HiveCatalogHiveMetadataTest extends CatalogTestBase {
 	public void testCreateTable_Streaming() throws Exception {
 	}
 
-	// ------ functions ------
-
-	public void testCreateFunction() throws Exception {
-	}
-
-	public void testCreateFunction_DatabaseNotExistException() throws Exception {
-	}
-
-	public void testCreateFunction_FunctionAlreadyExistException() throws Exception {
-	}
-
-	public void testCreateFunction_FunctionAlreadyExist_ignored() throws Exception {
-	}
-
-	public void testAlterFunction() throws Exception {
-	}
-
-	public void testAlterFunction_differentTypedFunction() throws Exception {
-	}
-
-	public void testAlterFunction_FunctionNotExistException() throws Exception {
-	}
-
-	public void testAlterFunction_FunctionNotExist_ignored() throws Exception {
-	}
-
-	public void testListFunctions() throws Exception {
-	}
-
-	public void testListFunctions_DatabaseNotExistException() throws Exception{
-	}
-
-	public void testGetFunction_FunctionNotExistException() throws Exception {
-	}
-
-	public void testGetFunction_FunctionNotExistException_NoDb() throws Exception {
-	}
-
-	public void testDropFunction() throws Exception {
-	}
-
-	public void testDropFunction_FunctionNotExistException() throws Exception {
-	}
-
-	public void testDropFunction_FunctionNotExist_ignored() throws Exception {
-	}
-
 	// ------ utils ------
 
 	@Override
@@ -182,12 +135,12 @@ public class HiveCatalogHiveMetadataTest extends CatalogTestBase {
 
 	@Override
 	protected CatalogFunction createFunction() {
-		throw new UnsupportedOperationException();
+		return new HiveCatalogFunction("test.class.name");
 	}
 
 	@Override
 	protected CatalogFunction createAnotherFunction() {
-		throw new UnsupportedOperationException();
+		return new HiveCatalogFunction("test.another.class.name");
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR creates `HiveCatalogFunction` class and adds support for Hive function operations in `HiveCatalog`

## Brief change log

- created `HiveCatalogFunction`
- added support for Hive function operations in `HiveCatalog`

## Verifying this change

This change is already covered by existing tests, such as *CatalogTestBase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
