### PR TITLE
[FLINK-12533][table] Introduce TABLE_AGGREGATE_FUNCTION FunctionDefinition.Type

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/AggregateFunctionDefinition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/AggregateFunctionDefinition.java
@@ -23,10 +23,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.functions.UserDefinedAggregateFunction;
 import org.apache.flink.util.Preconditions;
 
-import static org.apache.flink.table.expressions.FunctionDefinition.Type.AGGREGATE_FUNCTION;
-
 /**
- * The function definition of an user-defined aggregate function.
+ * The function definition of an user-defined aggregate or a table aggregate function.
  */
 @PublicEvolving
 public final class AggregateFunctionDefinition extends FunctionDefinition {
@@ -40,7 +38,7 @@ public final class AggregateFunctionDefinition extends FunctionDefinition {
 			UserDefinedAggregateFunction<?, ?> aggregateFunction,
 			TypeInformation<?> resultTypeInfo,
 			TypeInformation<?> accTypeInfo) {
-		super(name, AGGREGATE_FUNCTION);
+		super(name, FunctionDefinition.getFunctionType(aggregateFunction));
 		this.aggregateFunction = Preconditions.checkNotNull(aggregateFunction);
 		this.resultTypeInfo = Preconditions.checkNotNull(resultTypeInfo);
 		this.accumulatorTypeInfo = Preconditions.checkNotNull(accTypeInfo);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/FunctionDefinition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/FunctionDefinition.java
@@ -19,6 +19,11 @@
 package org.apache.flink.table.expressions;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.TableAggregateFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Objects;
@@ -34,6 +39,7 @@ public class FunctionDefinition {
 	 */
 	public enum Type {
 		AGGREGATE_FUNCTION,
+		TABLE_AGGREGATE_FUNCTION,
 		SCALAR_FUNCTION,
 		TABLE_FUNCTION,
 		OTHER_FUNCTION
@@ -75,5 +81,23 @@ public class FunctionDefinition {
 	@Override
 	public String toString() {
 		return name;
+	}
+
+	/**
+	 * Util method to get {@link FunctionDefinition.Type} according to a {@link UserDefinedFunction}.
+	 */
+	public static FunctionDefinition.Type getFunctionType(UserDefinedFunction userDefinedFunction) {
+		Preconditions.checkNotNull(userDefinedFunction);
+		if (userDefinedFunction instanceof TableFunction) {
+			return Type.TABLE_FUNCTION;
+		} else if (userDefinedFunction instanceof ScalarFunction) {
+			return Type.SCALAR_FUNCTION;
+		} else if (userDefinedFunction instanceof AggregateFunction) {
+			return Type.AGGREGATE_FUNCTION;
+		} else if (userDefinedFunction instanceof TableAggregateFunction) {
+			return Type.TABLE_AGGREGATE_FUNCTION;
+		} else {
+			return Type.OTHER_FUNCTION;
+		}
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/FunctionDefinitionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/FunctionDefinitionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions;
+
+import org.apache.flink.table.expressions.FunctionDefinition.Type;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.TableAggregateFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.UserDefinedFunction;
+
+import org.junit.Test;
+
+import static org.apache.flink.table.expressions.FunctionDefinition.getFunctionType;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FunctionDefinition}.
+ */
+public class FunctionDefinitionTest {
+
+	private static final UserDefinedFunction DUMMY_USER_DEFINED_FUNCTION = new UserDefinedFunction() {
+		// dummy
+	};
+
+	private static final ScalarFunction DUMMY_SCALAR_FUNCTION = new ScalarFunction() {
+		// dummy
+	};
+
+	private static final TableFunction DUMMY_TABLE_FUNCTION = new TableFunction() {
+		// dummy
+	};
+
+	private static final AggregateFunction DUMMY_AGGREGATE_FUNCTION = new AggregateFunction() {
+		@Override
+		public Object getValue(Object accumulator) {
+			return null;
+		}
+
+		@Override
+		public Object createAccumulator() {
+			return null;
+		}
+	};
+
+	private static final TableAggregateFunction DUMMY_TABLE_AGGREGATE_FUNCTION = new TableAggregateFunction() {
+		@Override
+		public Object createAccumulator() {
+			return null;
+		}
+	};
+
+	@Test
+	public void testGetFunctionType() {
+		assertEquals(Type.SCALAR_FUNCTION, getFunctionType(DUMMY_SCALAR_FUNCTION));
+		assertEquals(Type.TABLE_FUNCTION, getFunctionType(DUMMY_TABLE_FUNCTION));
+		assertEquals(Type.AGGREGATE_FUNCTION, getFunctionType(DUMMY_AGGREGATE_FUNCTION));
+		assertEquals(Type.TABLE_AGGREGATE_FUNCTION, getFunctionType(DUMMY_TABLE_AGGREGATE_FUNCTION));
+		assertEquals(Type.OTHER_FUNCTION, getFunctionType(DUMMY_USER_DEFINED_FUNCTION));
+	}
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/TableOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/TableOperationConverter.java
@@ -81,6 +81,7 @@ import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.AS;
 import static org.apache.flink.table.expressions.ExpressionUtils.extractValue;
 import static org.apache.flink.table.expressions.ExpressionUtils.isFunctionOfType;
 import static org.apache.flink.table.expressions.FunctionDefinition.Type.AGGREGATE_FUNCTION;
+import static org.apache.flink.table.expressions.FunctionDefinition.Type.TABLE_AGGREGATE_FUNCTION;
 
 /**
  * Converter from Flink's specific relational representation: {@link TableOperation} to Calcite's specific relational
@@ -379,7 +380,7 @@ public class TableOperationConverter extends TableOperationDefaultVisitor<RelNod
 	private class TableAggregateVisitor extends AggregateVisitor {
 		@Override
 		public AggCall visitCall(CallExpression call) {
-			if (isFunctionOfType(call, AGGREGATE_FUNCTION)) {
+			if (isFunctionOfType(call, TABLE_AGGREGATE_FUNCTION)) {
 				AggFunctionCall aggFunctionCall = (AggFunctionCall) expressionBridge.bridge(call);
 				return aggFunctionCall.toAggCall(aggFunctionCall.toString(), false, relBuilder);
 			}


### PR DESCRIPTION

## What is the purpose of the change

This pull request adds TABLE_AGGREGATE_FUNCTION FunctionDefinition.Type.

Currently, there are four kinds of FunctionDefinition.Type,
```
public enum Type {
		AGGREGATE_FUNCTION,
		SCALAR_FUNCTION,
		TABLE_FUNCTION,
		OTHER_FUNCTION
}
```
The Type AGGREGATE_FUNCTION is used to express both AggregateFunction and TableAggregateFunction. However, due to the two kinds of the function contains different semantics. It would be nice if we can separate these two kinds of functions more clearly by introducing another type TABLE_AGGREGATE_FUNCTION.

## Brief change log

  - Add `TABLE_AGGREGATE_FUNCTION` and use `TABLE_AGGREGATE_FUNCTION` for user defined table aggregate function in `AggregateFunctionDefinition`. 
  - Use `TABLE_AGGREGATE_FUNCTION` to judge whether it is table aggregate in `AggregateOperationFactory` and `TableOperationConverter`.
  - Add tests for FunctionDefinition.


## Verifying this change


This change is already covered by existing tests, such as `TableAggregateTest`, `TableAggregateValidationTest` and `TableAggregateITCase`.

Also `FunctionDefinitionTest` has been added to test the new `getFunctionType` function in `FunctionDefinition`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
