### PR TITLE
 [FLINK-12147] [metrics] Error for monitor kafka metrics when Use influxDB metr…

### DIFF
--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxPointBuilder.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxPointBuilder.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.metrics.influxdb;
 
 import org.influxdb.dto.Point;

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxPointBuilder.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxPointBuilder.java
@@ -1,0 +1,90 @@
+package org.apache.flink.metrics.influxdb;
+
+import org.influxdb.dto.Point;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wrapper around influxDB Point.builder which excludes non influx compatible values (i.e. +-infininty) from
+ * being sent. (Influx would throw an error and ignore them anyways).
+ */
+public class InfluxPointBuilder {
+
+	private Point.Builder builder;
+
+	/**
+	 * Create a new wrapper around the InfluxDB Point.Builder.
+	 */
+	public InfluxPointBuilder(MeasurementInfo info, Instant timestamp) {
+		builder = Point.measurement(info.getName())
+			.tag(info.getTags())
+			.time(timestamp.toEpochMilli(), TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * wrap {@link org.influxdb.dto.Point.Builder#addField(String,boolean)}.
+	 */
+	public InfluxPointBuilder addField(final String field, final boolean value) {
+		builder.addField(field, value);
+		return this;
+	}
+
+	/**
+	 * wrap {@link org.influxdb.dto.Point.Builder#addField(String,long)}.
+	 */
+	public InfluxPointBuilder addField(final String field, final long value) {
+		builder.addField(field, value);
+		return this;
+	}
+
+	/**
+	 * wrap {@link org.influxdb.dto.Point.Builder#addField(String,double)}.
+	 */
+	public InfluxPointBuilder addField(final String field, final double value) {
+		if (!Double.isInfinite(value)) {
+			builder.addField(field, value);
+		}
+		return this;
+	}
+
+	/**
+	 * wrap {@link org.influxdb.dto.Point.Builder#addField(String,Number)}.
+	 */
+	public InfluxPointBuilder addField(final String field, final Number value) {
+		if (value == null) {
+			return this;
+		}
+
+		if ((value instanceof Double) && Double.isInfinite(value.doubleValue())) {
+			return this;
+		}
+
+		if ((value instanceof Float) && Float.isInfinite(value.floatValue())) {
+			return this;
+		}
+
+		builder.addField(field, value);
+		return this;
+	}
+
+	/**
+	 * wrap {@link org.influxdb.dto.Point.Builder#addField(String,String)}.
+	 */
+	public InfluxPointBuilder addField(final String field, final String value) {
+		builder.addField(field, value);
+		return this;
+	}
+
+	/**
+	 * wrap {@link org.influxdb.dto.Point.Builder#build()} which can return null as well.
+	 */
+	public Point build() {
+		if (builder.hasFields()) {
+			return builder.build();
+		}
+
+		// If there are no fields, a measurement can't be inserted to influx and we thus won't send the metric.
+		return null;
+	}
+}

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -30,6 +30,7 @@ import org.apache.flink.metrics.reporter.Scheduled;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
 
 import javax.annotation.Nullable;
 
@@ -105,19 +106,31 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 		report.retentionPolicy("");
 		try {
 			for (Map.Entry<Gauge<?>, MeasurementInfo> entry : gauges.entrySet()) {
-				report.point(MetricMapper.map(entry.getValue(), timestamp, entry.getKey()));
+				Point point = MetricMapper.map(entry.getValue(), timestamp, entry.getKey());
+				if (point != null) {
+					report.point(point);
+				}
 			}
 
 			for (Map.Entry<Counter, MeasurementInfo> entry : counters.entrySet()) {
-				report.point(MetricMapper.map(entry.getValue(), timestamp, entry.getKey()));
+				Point point = MetricMapper.map(entry.getValue(), timestamp, entry.getKey());
+				if (point != null) {
+					report.point(point);
+				}
 			}
 
 			for (Map.Entry<Histogram, MeasurementInfo> entry : histograms.entrySet()) {
-				report.point(MetricMapper.map(entry.getValue(), timestamp, entry.getKey()));
+				Point point = MetricMapper.map(entry.getValue(), timestamp, entry.getKey());
+				if (point != null) {
+					report.point(point);
+				}
 			}
 
 			for (Map.Entry<Meter, MeasurementInfo> entry : meters.entrySet()) {
-				report.point(MetricMapper.map(entry.getValue(), timestamp, entry.getKey()));
+				Point point = MetricMapper.map(entry.getValue(), timestamp, entry.getKey());
+				if (point != null) {
+					report.point(point);
+				}
 			}
 		}
 		catch (ConcurrentModificationException | NoSuchElementException e) {

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/MetricMapper.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/MetricMapper.java
@@ -27,12 +27,11 @@ import org.apache.flink.metrics.Meter;
 import org.influxdb.dto.Point;
 
 import java.time.Instant;
-import java.util.concurrent.TimeUnit;
 
 class MetricMapper {
 
 	static Point map(MeasurementInfo info, Instant timestamp, Gauge<?> gauge) {
-		Point.Builder builder = builder(info, timestamp);
+		InfluxPointBuilder builder = new InfluxPointBuilder(info, timestamp);
 		Object value = gauge.getValue();
 		if (value instanceof Number) {
 			builder.addField("value", (Number) value);
@@ -43,14 +42,14 @@ class MetricMapper {
 	}
 
 	static Point map(MeasurementInfo info, Instant timestamp, Counter counter) {
-		return builder(info, timestamp)
+		return new InfluxPointBuilder(info, timestamp)
 			.addField("count", counter.getCount())
 			.build();
 	}
 
 	static Point map(MeasurementInfo info, Instant timestamp, Histogram histogram) {
 		HistogramStatistics statistics = histogram.getStatistics();
-		return builder(info, timestamp)
+		return new InfluxPointBuilder(info, timestamp)
 			.addField("count", statistics.size())
 			.addField("min", statistics.getMin())
 			.addField("max", statistics.getMax())
@@ -66,15 +65,9 @@ class MetricMapper {
 	}
 
 	static Point map(MeasurementInfo info, Instant timestamp, Meter meter) {
-		return builder(info, timestamp)
+		return new InfluxPointBuilder(info, timestamp)
 			.addField("count", meter.getCount())
 			.addField("rate", meter.getRate())
 			.build();
-	}
-
-	private static Point.Builder builder(MeasurementInfo info, Instant timestamp) {
-		return Point.measurement(info.getName())
-			.tag(info.getTags())
-			.time(timestamp.toEpochMilli(), TimeUnit.MILLISECONDS);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

As InfluxDB doesn't support infinity values in float/double, we just don't send them to influx . There is no behavioral change here as InfluxDB wouldn't store those values anyways, but we are not going to pollute our logs with influxdb partial write errors about each sent infinity value on each report.


## Brief change log

When submitting metrics, check the current metric values and ignore them if they are +-infinity, so that they are not sent. 

## Verifying this change

This change is already covered by existing tests, such as InfluxDBReporter.testMetricReporting . The test was extended in order to make sure that the invalid values are filtered out correctly. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
