### PR TITLE
[FLINK-12592][python] Add `--force` for python install.

### DIFF
--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -28,7 +28,7 @@ deps =
     pytest
 commands =
     python --version
-    python setup.py install
+    python setup.py install --force
     pytest
 
 [flake8]


### PR DESCRIPTION
## What is the purpose of the change
For ensuring overwrite the python file when install, in this PR only  Add `--force` for python install command.

## Brief change log

  - Add `--force` for python install command.


## Verifying this change

This change does not need any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
