### PR TITLE
[FLINK-12440][python] Add all connector support align Java Table API.

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
@@ -63,7 +63,7 @@ if [[ -n "$FLINK_TESTING" ]]; then
     else
       FLINK_TEST_CLASSPATH="$FLINK_TEST_CLASSPATH":"$testJarFile"
     fi
-  done < <(find "$FLINK_SOURCE_ROOT_DIR" ! -type d \( -name 'flink-*-tests.jar' -o -path '*flink-connector-*-base/target/flink*.jar' \) -print0 | sort -z)
+  done < <(find "$FLINK_SOURCE_ROOT_DIR" ! -type d \( -name 'flink-*-tests.jar' -o -path "${FLINK_SOURCE_ROOT_DIR}/flink-connectors/flink-connector-elasticsearch-base/target/flink*.jar" -o -path "${FLINK_SOURCE_ROOT_DIR}/flink-connectors/flink-connector-kafka-base/target/flink*.jar" \) -print0 | sort -z)
 fi
 
 exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -cp ${FLINK_CLASSPATH}:${TABLE_JAR_PATH}:${FLINK_TEST_CLASSPATH} ${DRIVER} ${ARGS[@]}

--- a/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
@@ -63,7 +63,7 @@ if [[ -n "$FLINK_TESTING" ]]; then
     else
       FLINK_TEST_CLASSPATH="$FLINK_TEST_CLASSPATH":"$testJarFile"
     fi
-  done < <(find "$FLINK_SOURCE_ROOT_DIR" ! -type d -name 'flink-*-tests.jar' -print0 | sort -z)
+  done < <(find "$FLINK_SOURCE_ROOT_DIR" ! -type d \( -name 'flink-*-tests.jar' -o -path '*flink-connector-*-base/target/flink*.jar' \) -print0 | sort -z)
 fi
 
 exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -cp ${FLINK_CLASSPATH}:${TABLE_JAR_PATH}:${FLINK_TEST_CLASSPATH} ${DRIVER} ${ARGS[@]}

--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -98,6 +98,7 @@ def launch_gateway():
         gateway_parameters=GatewayParameters(port=gateway_port, auto_convert=True))
 
     # Import the classes used by PyFlink
+    java_import(gateway.jvm, "java.util.Properties")
     java_import(gateway.jvm, "org.apache.flink.table.api.*")
     java_import(gateway.jvm, "org.apache.flink.table.api.java.*")
     java_import(gateway.jvm, "org.apache.flink.table.api.dataview.*")

--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -98,7 +98,6 @@ def launch_gateway():
         gateway_parameters=GatewayParameters(port=gateway_port, auto_convert=True))
 
     # Import the classes used by PyFlink
-    java_import(gateway.jvm, "java.util.Properties")
     java_import(gateway.jvm, "org.apache.flink.table.api.*")
     java_import(gateway.jvm, "org.apache.flink.table.api.java.*")
     java_import(gateway.jvm, "org.apache.flink.table.api.dataview.*")

--- a/flink-python/pyflink/table/__init__.py
+++ b/flink-python/pyflink/table/__init__.py
@@ -40,7 +40,7 @@ from pyflink.table.table_sink import TableSink, CsvTableSink
 from pyflink.table.table_source import TableSource, CsvTableSource
 from pyflink.table.types import DataTypes, UserDefinedType, Row
 from pyflink.table.window import Tumble, Session, Slide, Over
-from pyflink.table.table_descriptor import Rowtime, Schema, OldCsv, FileSystem
+from pyflink.table.table_descriptor import Rowtime, Schema, OldCsv, FileSystem, Kafka, Elasticsearch
 
 __all__ = [
     'TableEnvironment',
@@ -63,4 +63,6 @@ __all__ = [
     'FileSystem',
     'UserDefinedType',
     'Row',
+    'Kafka',
+    'Elasticsearch'
 ]

--- a/flink-python/pyflink/table/table_descriptor.py
+++ b/flink-python/pyflink/table/table_descriptor.py
@@ -383,7 +383,7 @@ class Kafka(ConnectorDescriptor):
     def __init__(self):
         gateway = get_gateway()
         self._j_kafka = gateway.jvm.Kafka()
-        super(ConnectorDescriptor, self).__init__(self._j_kafka)
+        super(Kafka, self).__init__(self._j_kafka)
 
     def version(self, version):
         """
@@ -416,7 +416,7 @@ class Kafka(ConnectorDescriptor):
         :return: This object.
         """
         gateway = get_gateway()
-        properties = gateway.jvm.Properties()
+        properties = gateway.jvm.java.util.Properties()
         for key in property_dict:
             properties.setProperty(key, property_dict[key])
         self._j_kafka = self._j_kafka.properties(properties)

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -161,7 +161,8 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
             find "$CACHE_FLINK_DIR" -maxdepth 8 -type f -name '*.jar' \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-dist*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-table*.jar" \
-            ! -path "$CACHE_FLINK_DIR/flink-connectors/*-base/target/flink-*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-elasticsearch-base/target/flink-*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-kafka-base/target/flink-*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner/target/flink-table-planner*tests.jar" | xargs rm -rf
     
             # .git directory

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -161,6 +161,7 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
             find "$CACHE_FLINK_DIR" -maxdepth 8 -type f -name '*.jar' \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-dist*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-table*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-connectors/*-base/target/flink-*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner/target/flink-table-planner*tests.jar" | xargs rm -rf
     
             # .git directory


### PR DESCRIPTION
## What is the purpose of the change

This pull request add 2 `ConnectorDescriptor` classes for flink python API: `Kafka` and `Elasticsearch`. Because no appropriate format descriptor is available, we can't add end to end tests currently. So only the tests for descriptor APIs are added.

## Brief change log

  - *Add 2 `ConnectorDescriptor`: `Kafka` and `Elasticsearch`.*
  - *Adjust `travis_controller.sh` and `pyflink-gateway-server.sh` to include necessary jars.*
  - *Add tests for the new descriptors.*

## Verifying this change

This change added tests and can be verified as follows:

Added integration tests in `test_descriptorr.py`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (python docs)
