### PR TITLE
[FLINK-12617] [container] StandaloneJobClusterEntrypoint defaults to random JobID for non-HA setups

### DIFF
--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfiguration.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfiguration.java
@@ -37,7 +37,7 @@ final class StandaloneJobClusterConfiguration extends EntrypointClusterConfigura
 	@Nonnull
 	private final SavepointRestoreSettings savepointRestoreSettings;
 
-	@Nonnull
+	@Nullable
 	private final JobID jobId;
 
 	@Nullable
@@ -50,11 +50,11 @@ final class StandaloneJobClusterConfiguration extends EntrypointClusterConfigura
 			@Nullable String hostname,
 			int restPort,
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
-			@Nonnull JobID jobId,
+			@Nullable JobID jobId,
 			@Nullable String jobClassName) {
 		super(configDir, dynamicProperties, args, hostname, restPort);
 		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
-		this.jobId = requireNonNull(jobId, "jobId");
+		this.jobId = jobId;
 		this.jobClassName = jobClassName;
 	}
 
@@ -63,7 +63,7 @@ final class StandaloneJobClusterConfiguration extends EntrypointClusterConfigura
 		return savepointRestoreSettings;
 	}
 
-	@Nonnull
+	@Nullable
 	JobID getJobId() {
 		return jobId;
 	}

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
@@ -29,6 +29,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Properties;
 
@@ -42,8 +43,6 @@ import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.REST
  * list of command line arguments.
  */
 public class StandaloneJobClusterConfigurationParserFactory implements ParserResultFactory<StandaloneJobClusterConfiguration> {
-
-	static final JobID DEFAULT_JOB_ID = new JobID(0, 0);
 
 	private static final Option JOB_CLASS_NAME_OPTION = Option.builder("j")
 		.longOpt("job-classname")
@@ -105,10 +104,11 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 		}
 	}
 
+	@Nullable
 	private static JobID getJobId(CommandLine commandLine) throws FlinkParseException {
 		String jobId = commandLine.getOptionValue(JOB_ID_OPTION.getOpt());
 		if (jobId == null) {
-			return DEFAULT_JOB_ID;
+			return null;
 		}
 		try {
 			return JobID.fromHexString(jobId);

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerCo
 import org.apache.flink.runtime.entrypoint.component.JobDispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
@@ -35,6 +36,8 @@ import org.apache.flink.runtime.util.SignalHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -42,6 +45,8 @@ import static java.util.Objects.requireNonNull;
  * location.
  */
 public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
+
+	public static final JobID ZERO_JOB_ID = new JobID(0, 0);
 
 	@Nonnull
 	private final JobID jobId;
@@ -97,12 +102,27 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 
 		StandaloneJobClusterEntryPoint entrypoint = new StandaloneJobClusterEntryPoint(
 			configuration,
-			clusterConfiguration.getJobId(),
+			resolveJobIdForCluster(Optional.ofNullable(clusterConfiguration.getJobId()), configuration),
 			clusterConfiguration.getSavepointRestoreSettings(),
 			clusterConfiguration.getArgs(),
 			clusterConfiguration.getJobClassName());
 
 		ClusterEntrypoint.runClusterEntrypoint(entrypoint);
+	}
+
+	@VisibleForTesting
+	@Nonnull
+	static JobID resolveJobIdForCluster(Optional<JobID> optionalJobID, Configuration configuration) {
+		return optionalJobID.orElseGet(() -> createJobIdForCluster(configuration));
+	}
+
+	@Nonnull
+	private static JobID createJobIdForCluster(Configuration globalConfiguration) {
+		if (HighAvailabilityMode.isHighAvailabilityModeActivated(globalConfiguration)) {
+			return ZERO_JOB_ID;
+		} else {
+			return JobID.generate();
+		}
 	}
 
 	@VisibleForTesting

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
@@ -19,14 +19,20 @@
 package org.apache.flink.container.entrypoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -47,9 +53,21 @@ import static org.junit.Assert.fail;
  */
 public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogger {
 
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+	private File confFile;
+	private String confDirPath;
+
+	@Before
+	public void createEmptyFlinkConfiguration() throws IOException {
+		File confDir = tempFolder.getRoot();
+		confDirPath = confDir.getAbsolutePath();
+		confFile = new File(confDir, GlobalConfiguration.FLINK_CONF_FILENAME);
+		confFile.createNewFile();
+	}
+
 	private static final CommandLineParser<StandaloneJobClusterConfiguration> commandLineParser = new CommandLineParser<>(new StandaloneJobClusterConfigurationParserFactory());
 	private static final String JOB_CLASS_NAME = "foobar";
-	private static final String CONFIG_DIR = "/foo/bar";
 
 	@Test
 	public void testEntrypointClusterConfigurationParsing() throws FlinkParseException {
@@ -58,11 +76,11 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 		final int restPort = 1234;
 		final String arg1 = "arg1";
 		final String arg2 = "arg2";
-		final String[] args = {"--configDir", CONFIG_DIR, "--webui-port", String.valueOf(restPort), "--job-classname", JOB_CLASS_NAME, String.format("-D%s=%s", key, value), arg1, arg2};
+		final String[] args = {"--configDir", confDirPath, "--webui-port", String.valueOf(restPort), "--job-classname", JOB_CLASS_NAME, String.format("-D%s=%s", key, value), arg1, arg2};
 
 		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
-		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(CONFIG_DIR)));
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(confDirPath)));
 		assertThat(clusterConfiguration.getJobClassName(), is(equalTo(JOB_CLASS_NAME)));
 		assertThat(clusterConfiguration.getRestPort(), is(equalTo(restPort)));
 		final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
@@ -78,12 +96,11 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 
 	@Test
 	public void testOnlyRequiredArguments() throws FlinkParseException {
-		final String configDir = "/foo/bar";
-		final String[] args = {"--configDir", configDir};
+		final String[] args = {"--configDir", confDirPath};
 
 		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
-		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(confDirPath)));
 		assertThat(clusterConfiguration.getDynamicProperties(), is(equalTo(new Properties())));
 		assertThat(clusterConfiguration.getArgs(), is(new String[0]));
 		assertThat(clusterConfiguration.getRestPort(), is(equalTo(-1)));
@@ -103,7 +120,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 	@Test
 	public void testSavepointRestoreSettingsParsing() throws FlinkParseException {
 		final String restorePath = "foobar";
-		final String[] args = {"-c", CONFIG_DIR, "-j", JOB_CLASS_NAME, "-s", restorePath, "-n"};
+		final String[] args = {"-c", confDirPath, "-j", JOB_CLASS_NAME, "-s", restorePath, "-n"};
 		final StandaloneJobClusterConfiguration standaloneJobClusterConfiguration = commandLineParser.parse(args);
 
 		final SavepointRestoreSettings savepointRestoreSettings = standaloneJobClusterConfiguration.getSavepointRestoreSettings();
@@ -116,7 +133,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 	@Test
 	public void testSetJobIdManually() throws FlinkParseException {
 		final JobID jobId = new JobID();
-		final String[] args = {"--configDir", "/foo/bar", "--job-classname", "foobar", "--job-id", jobId.toString()};
+		final String[] args = {"--configDir", confDirPath, "--job-classname", "foobar", "--job-id", jobId.toString()};
 
 		final StandaloneJobClusterConfiguration standaloneJobClusterConfiguration = commandLineParser.parse(args);
 
@@ -126,7 +143,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 	@Test
 	public void testInvalidJobIdThrows() {
 		final String invalidJobId = "0xINVALID";
-		final String[] args = {"--configDir", "/foo/bar", "--job-classname", "foobar", "--job-id", invalidJobId};
+		final String[] args = {"--configDir", confDirPath, "--job-classname", "foobar", "--job-id", invalidJobId};
 
 		try {
 			commandLineParser.parse(args);
@@ -140,13 +157,12 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 
 	@Test
 	public void testShortOptions() throws FlinkParseException {
-		final String configDir = "/foo/bar";
 		final String jobClassName = "foobar";
 		final JobID jobId = new JobID();
 		final String savepointRestorePath = "s3://foo/bar";
 
 		final String[] args = {
-			"-c", configDir,
+			"-c", confDirPath,
 			"-j", jobClassName,
 			"-jid", jobId.toString(),
 			"-s", savepointRestorePath,
@@ -154,7 +170,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 
 		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
-		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(confDirPath)));
 		assertThat(clusterConfiguration.getJobClassName(), is(equalTo(jobClassName)));
 		assertThat(clusterConfiguration.getJobId(), is(equalTo(jobId)));
 

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
@@ -36,13 +36,11 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
 
-import static org.apache.flink.container.entrypoint.StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -91,7 +89,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 
 		assertThat(clusterConfiguration.getSavepointRestoreSettings(), is(equalTo(SavepointRestoreSettings.none())));
 
-		assertThat(clusterConfiguration.getJobId(), is(equalTo(DEFAULT_JOB_ID)));
+		assertThat(clusterConfiguration.getJobId(), is(nullValue()));
 	}
 
 	@Test
@@ -106,7 +104,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 		assertThat(clusterConfiguration.getRestPort(), is(equalTo(-1)));
 		assertThat(clusterConfiguration.getHostname(), is(nullValue()));
 		assertThat(clusterConfiguration.getSavepointRestoreSettings(), is(equalTo(SavepointRestoreSettings.none())));
-		assertThat(clusterConfiguration.getJobId(), is(not(nullValue())));
+		assertThat(clusterConfiguration.getJobId(), is(nullValue()));
 		assertThat(clusterConfiguration.getJobClassName(),  is(nullValue()));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

## Brief change log

* StandaloneJobClusterEntrypoint defaults to random JobID for non-HA setups
* refactor StandaloneJobClusterConfigurationParserFactoryTest to use temporary folder for global Flink configuration

## Verifying this change
  - run unit tests in flink-container to check the correct defaults are 
  - build Flink locally, build job-cluster image
  -  run a job without HA and check that JobID is random
```
./build.sh --job-jar ../../flink-examples/flink-examples-streaming/target/flink-examples-streaming_2.11-1.9-SNAPSHOT-TopSpeedWindowing.jar --from-local-dist
FLINK_JOB=org.apache.flink.streaming.examples.windowing.TopSpeedWindowing docker-compose up
```
  - run a job without HA and explicit JobID and check that parameter takes precedence
```
FLINK_JOB_ARGUMENTS="--job-id 00000000000000000000000000000000" FLINK_JOB=org.apache.flink.streaming.examples.windowing.TopSpeedWindowing docker-compose up
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
