### PR TITLE
[FLINK-10707][web-dashboard] flink cluster overview dashboard improvements

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.module.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.module.ts
@@ -63,7 +63,8 @@ import {
   ReloadOutline,
   DownloadOutline,
   ShrinkOutline,
-  PicCenterOutline
+  PicCenterOutline,
+  DatabaseFill
 } from '@ant-design/icons-angular/icons';
 
 import { StatusService } from 'services';
@@ -130,7 +131,8 @@ export function AppInitServiceFactory(
         FullscreenOutline,
         ArrowsAltOutline,
         ShrinkOutline,
-        PicCenterOutline
+        PicCenterOutline,
+        DatabaseFill
       ]
     },
     {

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
@@ -36,7 +36,7 @@ export interface TaskmanagersItemInterface {
   path: string;
   dataPort: number;
   timeSinceLastHeartbeat: number;
-  secondsSinceLastHeartBeat: number;
+  milliSecondsSinceLastHeartBeat: number;
   slotsNumber: number;
   freeSlots: number;
   hardware: Hardware;

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
@@ -36,10 +36,13 @@ export interface TaskmanagersItemInterface {
   path: string;
   dataPort: number;
   timeSinceLastHeartbeat: number;
-  milliSecondsSinceLastHeartBeat: number;
   slotsNumber: number;
   freeSlots: number;
   hardware: Hardware;
+}
+
+export interface TaskmanagersItemCalInterface extends TaskmanagersItemInterface {
+  milliSecondsSinceLastHeartBeat?: number;
 }
 
 interface Hardware {

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
@@ -36,6 +36,7 @@ export interface TaskmanagersItemInterface {
   path: string;
   dataPort: number;
   timeSinceLastHeartbeat: number;
+  secondsSinceLastHeartBeat: number;
   slotsNumber: number;
   freeSlots: number;
   hardware: Hardware;

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/overview.module.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/overview.module.ts
@@ -22,10 +22,9 @@ import { ShareModule } from 'share/share.module';
 import { OverviewRoutingModule } from './overview-routing.module';
 import { OverviewComponent } from './overview.component';
 import { OverviewStatisticComponent } from './statistic/overview-statistic.component';
-import { TaskManagerItemComponent } from 'share/customize/task-manager-item/task-manager-item.component';
 
 @NgModule({
   imports: [CommonModule, ShareModule, OverviewRoutingModule],
-  declarations: [OverviewComponent, OverviewStatisticComponent, TaskManagerItemComponent]
+  declarations: [OverviewComponent, OverviewStatisticComponent]
 })
 export class OverviewModule {}

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -69,10 +69,15 @@
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
     <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
       <ng-container *ngFor="let manager of listOfTaskManager;">
-        <nz-avatar class="task-manager-avatar" [nzShape]="'square'" [nzSize]="64" [nzIcon]="'bars'" nz-tooltip [nzTitle]="managerTooltip"></nz-avatar>
+        <i class="task-manager-avatar" nz-icon nzType="database" nzTheme="fill" nz-tooltip [nzTitle]="managerTooltip"></i>
         <ng-template #managerTooltip>
-          <i nz-icon type="file " style="margin-right: 8px"></i> <span>{{manager.id}}</span><br />
-          <i nz-icon type="file" style="margin-right: 8px"></i> <span>{{manager.hardware.cpuCores}}</span>
+          <span>ID: {{manager.id}}</span><br />
+          <span>Free Slots:{{manager.freeSlots}}</span><br />
+          <span>Total Slots: {{manager.slotsNumber}}</span><br />
+          <span>CPU's:{{manager.hardware.cpuCores}}</span><br />
+          <span>Physical Mem: {{manager.hardware.physicalMemory | humanizeBytes}}</span><br />
+          <span>Free Mem: {{manager.hardware.freeMemory | humanizeBytes}}</span><br />
+          <span>Managed Mem: {{manager.hardware.managedMemory | humanizeBytes}}</span>
         </ng-template>
       </ng-container>
     </nz-card>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -69,7 +69,11 @@
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
     <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
       <ng-container *ngFor="let manager of listOfTaskManager;">
-        <nz-avatar class="task-manager-avatar" [nzShape]="'square'" [nzSize]="64" [nzIcon]="'bars'" nz-tooltip [nzTitle]="manager.id"></nz-avatar>
+        <nz-avatar class="task-manager-avatar" [nzShape]="'square'" [nzSize]="64" [nzIcon]="'bars'" nz-tooltip [nzTitle]="managerTooltip"></nz-avatar>
+        <ng-template #managerTooltip>
+          <i nz-icon type="file " style="margin-right: 8px"></i> <span>{{manager.id}}</span><br />
+          <i nz-icon type="file" style="margin-right: 8px"></i> <span>{{manager.hardware.cpuCores}}</span>
+        </ng-template>
       </ng-container>
     </nz-card>
   </div>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -20,7 +20,10 @@
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="12" [nzLg]="12" [nzXl]="12" class="col">
     <nz-card [nzBordered]="false" nzTitle="Available Task Slots" [nzLoading]="!statistic">
       <ng-container *ngIf="statistic">
-        <div class="total">{{ statistic['slots-available'] | number:'1.0-0' }}</div>
+        <div class="taskslots">
+          <div class="total">{{ statistic['slots-available'] | number:'1.0-0' }}</div>
+          <div class="task-slot-percentage-bar"><nz-progress [nzPercent]=taskSlotPercentage></nz-progress></div>
+        </div>
         <div class="footer">
           <div class="field">
             <span>Total Task Slots</span>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -68,7 +68,7 @@
   </div>
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
     <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
-      <ng-container *ngFor="let manager of listOfTaskManager;">
+      <ng-container *ngFor="let manager of listOfTaskManager;trackBy:trackByTaskManager">
         <div [ngClass]="{
             'task-manager-avatar': true,
             'task-manager-avatar-big' : listOfTaskManager.length < 20,

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -69,7 +69,7 @@
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
     <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
       <ng-container *ngFor="let manager of listOfTaskManager;">
-        <nz-avatar class="task-manager-avatar" [nzShape]="'square'" [nzSize]="64" [nzIcon]="'bars'"></nz-avatar>
+        <nz-avatar class="task-manager-avatar" [nzShape]="'square'" [nzSize]="64" [nzIcon]="'bars'" nz-tooltip [nzTitle]="manager.id"></nz-avatar>
       </ng-container>
     </nz-card>
   </div>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -22,7 +22,7 @@
       <ng-container *ngIf="statistic">
         <div class="taskslots">
           <div class="total">{{ statistic['slots-available'] | number:'1.0-0' }}</div>
-          <div class="task-slot-percentage-bar"><nz-progress [nzPercent]=taskSlotPercentage [nzStrokeColor]="'#1890ff'"></nz-progress></div>
+          <div class="task-slot-percentage-bar"><nz-progress [nzPercent]=taskSlotPercentage nzStatus="normal"></nz-progress></div>
         </div>
         <div class="footer">
           <div class="field">

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -69,38 +69,10 @@
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
     <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
       <ng-container *ngFor="let manager of listOfTaskManager;trackBy:trackByTaskManager">
-        <div [ngClass]="{
-            'task-manager-avatar': true,
-            'task-manager-avatar-big' : listOfTaskManager.length < 20,
-            'task-manager-avatar-small' : listOfTaskManager.length >= 20
-            }">
-          <i [ngClass]="{
-            'task-manager-avatar-big' : listOfTaskManager.length < 20,
-            'task-manager-avatar-small' : listOfTaskManager.length >= 20,
-            'task-manager-avatar-green' : manager.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds / 2,
-            'task-manager-avatar-yellow' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds / 2 && manager.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds,
-            'task-manager-avatar-red' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
-            }"
-             nz-icon nz-tooltip nzTheme="fill" nzType="database" [nzTitle]="managerTooltip"></i>
-          <nz-progress [ngClass]="{
-                      'task-manager-percentage-bar': true,
-                      'task-manager-percentage-bar-big' : listOfTaskManager.length < 20,
-                      'task-manager-percentage-bar-small' : listOfTaskManager.length >= 20
-                      }"
-                       [nzStrokeWidth]="listOfTaskManager.length < 20 ? 5 : 3"
-                       [nzPercent]="manager.freeSlots / manager.slotsNumber * 100" nzSize="small" [nzShowInfo]="false" nzStatus="normal"></nz-progress>
-        </div>
-        <ng-template #managerTooltip>
-          <span>ID: {{manager.id}}</span><br />
-          <span>Free Slots: {{manager.freeSlots}}</span><br />
-          <span>Total Slots: {{manager.slotsNumber}}</span><br />
-          <span>Slots free: {{manager.freeSlots / manager.slotsNumber * 100 | number}} %</span><br />
-          <span>CPU's :{{manager.hardware.cpuCores}}</span><br />
-          <span>Physical Mem: {{manager.hardware.physicalMemory | humanizeBytes}}</span><br />
-          <span>Free Mem: {{manager.hardware.freeMemory | humanizeBytes}}</span><br />
-          <span>Managed Mem: {{manager.hardware.managedMemory | humanizeBytes}}</span><br />
-          <span>Last Heartbeat: {{manager.milliSecondsSinceLastHeartBeat / 1000}} seconds ago</span>
-        </ng-template>
+        <flink-task-manager-item
+                [state]="manager"
+                [totalCount]="totalCount"
+                [timeoutThresholdSeconds]="timeoutThresholdSeconds"></flink-task-manager-item>
       </ng-container>
     </nz-card>
   </div>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -68,6 +68,13 @@
   </div>
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
     <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
+      <i [ngClass]="'task-manager-avatar-big'" nz-icon nz-tooltip nzTheme="fill" nzType="database"></i>
+      <nz-progress [ngClass]="{
+                    'task-manager-percentage-bar': true,
+                    'task-manager-percentage-bar-big' : listOfTaskManager.length < 20,
+                    'task-manager-percentage-bar-small' : listOfTaskManager.length >= 20
+                    }"
+                   [nzPercent]="30" [nzShowInfo]="false" nzSize="small" ></nz-progress>
       <ng-container *ngFor="let manager of listOfTaskManager;">
         <i [ngClass]="{
           'task-manager-avatar-big' : listOfTaskManager.length < 20,
@@ -77,10 +84,17 @@
           'task-manager-avatar-red' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
           }"
            nz-icon nz-tooltip nzTheme="fill" nzType="database" [nzTitle]="managerTooltip"></i>
+        <nz-progress [ngClass]="{
+                    'task-manager-percentage-bar': true,
+                    'task-manager-percentage-bar-big' : listOfTaskManager.length < 20,
+                    'task-manager-percentage-bar-small' : listOfTaskManager.length >= 20
+                    }"
+                     [nzPercent]="(manager.slotsNumber - manager.freeSlots) / manager.slotsNumber * 100" nzSize="small" [nzShowInfo]="false"></nz-progress>
         <ng-template #managerTooltip>
           <span>ID: {{manager.id}}</span><br />
           <span>Free Slots: {{manager.freeSlots}}</span><br />
           <span>Total Slots: {{manager.slotsNumber}}</span><br />
+          <span>Slots free: {{(manager.slotsNumber - manager.freeSlots) / manager.slotsNumber * 100 | number}} %</span><br />
           <span>CPU's :{{manager.hardware.cpuCores}}</span><br />
           <span>Physical Mem: {{manager.hardware.physicalMemory | humanizeBytes}}</span><br />
           <span>Free Mem: {{manager.hardware.freeMemory | humanizeBytes}}</span><br />

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -22,7 +22,7 @@
       <ng-container *ngIf="statistic">
         <div class="taskslots">
           <div class="total">{{ statistic['slots-available'] | number:'1.0-0' }}</div>
-          <div class="task-slot-percentage-bar"><nz-progress [nzPercent]=taskSlotPercentage></nz-progress></div>
+          <div class="task-slot-percentage-bar"><nz-progress [nzPercent]=taskSlotPercentage [nzStrokeColor]="'#1890ff'"></nz-progress></div>
         </div>
         <div class="footer">
           <div class="field">
@@ -68,33 +68,33 @@
   </div>
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
     <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
-      <i [ngClass]="'task-manager-avatar-big'" nz-icon nz-tooltip nzTheme="fill" nzType="database"></i>
-      <nz-progress [ngClass]="{
-                    'task-manager-percentage-bar': true,
-                    'task-manager-percentage-bar-big' : listOfTaskManager.length < 20,
-                    'task-manager-percentage-bar-small' : listOfTaskManager.length >= 20
-                    }"
-                   [nzPercent]="30" [nzShowInfo]="false" nzSize="small" ></nz-progress>
       <ng-container *ngFor="let manager of listOfTaskManager;">
-        <i [ngClass]="{
-          'task-manager-avatar-big' : listOfTaskManager.length < 20,
-          'task-manager-avatar-small' : listOfTaskManager.length >= 20,
-          'task-manager-avatar-green' : manager.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds / 2,
-          'task-manager-avatar-yellow' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds / 2 && manager.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds,
-          'task-manager-avatar-red' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
-          }"
-           nz-icon nz-tooltip nzTheme="fill" nzType="database" [nzTitle]="managerTooltip"></i>
-        <nz-progress [ngClass]="{
-                    'task-manager-percentage-bar': true,
-                    'task-manager-percentage-bar-big' : listOfTaskManager.length < 20,
-                    'task-manager-percentage-bar-small' : listOfTaskManager.length >= 20
-                    }"
-                     [nzPercent]="(manager.slotsNumber - manager.freeSlots) / manager.slotsNumber * 100" nzSize="small" [nzShowInfo]="false"></nz-progress>
+        <div [ngClass]="{
+            'task-manager-avatar': true,
+            'task-manager-avatar-big' : listOfTaskManager.length < 20,
+            'task-manager-avatar-small' : listOfTaskManager.length >= 20
+            }">
+          <i [ngClass]="{
+            'task-manager-avatar-big' : listOfTaskManager.length < 20,
+            'task-manager-avatar-small' : listOfTaskManager.length >= 20,
+            'task-manager-avatar-green' : manager.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds / 2,
+            'task-manager-avatar-yellow' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds / 2 && manager.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds,
+            'task-manager-avatar-red' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
+            }"
+             nz-icon nz-tooltip nzTheme="fill" nzType="database" [nzTitle]="managerTooltip"></i>
+          <nz-progress [ngClass]="{
+                      'task-manager-percentage-bar': true,
+                      'task-manager-percentage-bar-big' : listOfTaskManager.length < 20,
+                      'task-manager-percentage-bar-small' : listOfTaskManager.length >= 20
+                      }"
+                       [nzStrokeWidth]="listOfTaskManager.length < 20 ? 5 : 3"
+                       [nzPercent]="manager.freeSlots / manager.slotsNumber * 100" nzSize="small" [nzShowInfo]="false" [nzStrokeColor]="'#1890ff'"></nz-progress>
+        </div>
         <ng-template #managerTooltip>
           <span>ID: {{manager.id}}</span><br />
           <span>Free Slots: {{manager.freeSlots}}</span><br />
           <span>Total Slots: {{manager.slotsNumber}}</span><br />
-          <span>Slots free: {{(manager.slotsNumber - manager.freeSlots) / manager.slotsNumber * 100 | number}} %</span><br />
+          <span>Slots free: {{manager.freeSlots / manager.slotsNumber * 100 | number}} %</span><br />
           <span>CPU's :{{manager.hardware.cpuCores}}</span><br />
           <span>Physical Mem: {{manager.hardware.physicalMemory | humanizeBytes}}</span><br />
           <span>Free Mem: {{manager.hardware.freeMemory | humanizeBytes}}</span><br />

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -69,15 +69,23 @@
   <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
     <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
       <ng-container *ngFor="let manager of listOfTaskManager;">
-        <i class="task-manager-avatar" nz-icon nzType="database" nzTheme="fill" nz-tooltip [nzTitle]="managerTooltip"></i>
+        <i [ngClass]="{
+          'task-manager-avatar-big' : listOfTaskManager.length < 20,
+          'task-manager-avatar-small' : listOfTaskManager.length >= 20,
+          'task-manager-avatar-green' : manager.secondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds / 2,
+          'task-manager-avatar-yellow' : manager.secondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds / 2 && manager.secondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds,
+          'task-manager-avatar-red' : manager.secondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
+          }"
+           nz-icon nz-tooltip nzTheme="fill" nzType="database" [nzTitle]="managerTooltip"></i>
         <ng-template #managerTooltip>
           <span>ID: {{manager.id}}</span><br />
-          <span>Free Slots:{{manager.freeSlots}}</span><br />
+          <span>Free Slots: {{manager.freeSlots}}</span><br />
           <span>Total Slots: {{manager.slotsNumber}}</span><br />
-          <span>CPU's:{{manager.hardware.cpuCores}}</span><br />
+          <span>CPU's :{{manager.hardware.cpuCores}}</span><br />
           <span>Physical Mem: {{manager.hardware.physicalMemory | humanizeBytes}}</span><br />
           <span>Free Mem: {{manager.hardware.freeMemory | humanizeBytes}}</span><br />
-          <span>Managed Mem: {{manager.hardware.managedMemory | humanizeBytes}}</span>
+          <span>Managed Mem: {{manager.hardware.managedMemory | humanizeBytes}}</span><br />
+          <span>Last Heartbeat: {{manager.secondsSinceLastHeartBeat / 1000}} seconds ago</span>
         </ng-template>
       </ng-container>
     </nz-card>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -22,7 +22,7 @@
       <ng-container *ngIf="statistic">
         <div class="taskslots">
           <div class="total">{{ statistic['slots-available'] | number:'1.0-0' }}</div>
-          <div class="task-slot-percentage-bar"><nz-progress [nzPercent]=taskSlotPercentage nzStatus="normal"></nz-progress></div>
+          <div class="task-slot-percentage-bar"><h6>Task Slots Usage</h6><nz-progress [nzPercent]=taskSlotPercentage nzStatus="normal"></nz-progress></div>
         </div>
         <div class="footer">
           <div class="field">

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -34,6 +34,11 @@
             <span>Task Managers</span>
             <span>{{ statistic['taskmanagers'] | number:'1.0-0' }}</span>
           </div>
+          <nz-divider nzType="vertical"></nz-divider>
+          <div class="field">
+            <span>CPU Cores</span>
+            <span>{{ taskManagerCPUs | number:'1.0-0' }}</span>
+          </div>
         </div>
       </ng-container>
     </nz-card>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -22,7 +22,7 @@
       <ng-container *ngIf="statistic">
         <div class="taskslots">
           <div class="total">{{ statistic['slots-available'] | number:'1.0-0' }}</div>
-          <div class="task-slot-percentage-bar"><h6>Task Slots Usage</h6><nz-progress [nzPercent]=taskSlotPercentage nzStatus="normal"></nz-progress></div>
+          <div class="task-slot-percentage-bar"><h6>Task Slots Usage</h6><nz-progress [nzPercent]="taskSlotPercentage" nzStatus="normal"></nz-progress></div>
         </div>
         <div class="footer">
           <div class="field">

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -88,7 +88,7 @@
                       'task-manager-percentage-bar-small' : listOfTaskManager.length >= 20
                       }"
                        [nzStrokeWidth]="listOfTaskManager.length < 20 ? 5 : 3"
-                       [nzPercent]="manager.freeSlots / manager.slotsNumber * 100" nzSize="small" [nzShowInfo]="false" [nzStrokeColor]="'#1890ff'"></nz-progress>
+                       [nzPercent]="manager.freeSlots / manager.slotsNumber * 100" nzSize="small" [nzShowInfo]="false" nzStatus="normal"></nz-progress>
         </div>
         <ng-template #managerTooltip>
           <span>ID: {{manager.id}}</span><br />

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -72,9 +72,9 @@
         <i [ngClass]="{
           'task-manager-avatar-big' : listOfTaskManager.length < 20,
           'task-manager-avatar-small' : listOfTaskManager.length >= 20,
-          'task-manager-avatar-green' : manager.secondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds / 2,
-          'task-manager-avatar-yellow' : manager.secondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds / 2 && manager.secondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds,
-          'task-manager-avatar-red' : manager.secondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
+          'task-manager-avatar-green' : manager.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds / 2,
+          'task-manager-avatar-yellow' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds / 2 && manager.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds,
+          'task-manager-avatar-red' : manager.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
           }"
            nz-icon nz-tooltip nzTheme="fill" nzType="database" [nzTitle]="managerTooltip"></i>
         <ng-template #managerTooltip>
@@ -85,7 +85,7 @@
           <span>Physical Mem: {{manager.hardware.physicalMemory | humanizeBytes}}</span><br />
           <span>Free Mem: {{manager.hardware.freeMemory | humanizeBytes}}</span><br />
           <span>Managed Mem: {{manager.hardware.managedMemory | humanizeBytes}}</span><br />
-          <span>Last Heartbeat: {{manager.secondsSinceLastHeartBeat / 1000}} seconds ago</span>
+          <span>Last Heartbeat: {{manager.milliSecondsSinceLastHeartBeat / 1000}} seconds ago</span>
         </ng-template>
       </ng-container>
     </nz-card>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.html
@@ -66,4 +66,11 @@
       </ng-container>
     </nz-card>
   </div>
+  <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" class="col">
+    <nz-card [nzBordered]="false" nzTitle="Task Manager Overview" [nzLoading]="!listOfTaskManager">
+      <ng-container *ngFor="let manager of listOfTaskManager;">
+        <nz-avatar class="task-manager-avatar" [nzShape]="'square'" [nzSize]="64" [nzIcon]="'bars'"></nz-avatar>
+      </ng-container>
+    </nz-card>
+  </div>
 </div>

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -45,14 +45,6 @@ nz-card {
   display: inline-block;
 }
 
-.task-manager-avatar-small {
-  min-width: 30px;
-}
-
-.task-manager-avatar-big {
-  min-width: 60px;
-}
-
 .task-slot-percentage-bar {
   float: right;
   flex: 4;
@@ -73,10 +65,6 @@ nz-card {
   margin-left: -27px;
   top: -19px;
   width: 60px;
-}
-
-.task-manager-avatar {
-  margin-right: 10px;
 }
 
 .task-manager-avatar-green {

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -48,7 +48,10 @@ nz-card {
 .task-slot-percentage-bar {
   float: right;
   flex: 4;
-  margin-top: 16px;
+}
+
+.task-slot-percentage-bar h6 {
+  margin-bottom: 0;
 }
 
 .footer {

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -46,6 +46,18 @@ nz-card {
   margin-top: 16px;
 }
 
+.task-manager-percentage-bar .ant-progress {
+  transform: rotate(270deg);
+}
+
+.task-manager-percentage-bar-small .ant-progress {
+  width: 30px;
+}
+
+.task-manager-percentage-bar-big .ant-progress {
+  width: 60px;
+}
+
 .task-manager-avatar {
   margin-right: 10px;
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -40,21 +40,38 @@ nz-card {
   flex: 1
 }
 
+.task-manager-avatar {
+  overflow: hidden;
+  display: inline-block;
+}
+
+.task-manager-avatar-small {
+  min-width: 30px;
+}
+
+.task-manager-avatar-big {
+  min-width: 60px;
+}
+
 .task-slot-percentage-bar {
   float: right;
   flex: 4;
   margin-top: 16px;
 }
 
-.task-manager-percentage-bar .ant-progress {
+.task-manager-percentage-bar ::ng-deep .ant-progress {
   transform: rotate(270deg);
 }
 
-.task-manager-percentage-bar-small .ant-progress {
+.task-manager-percentage-bar-small ::ng-deep .ant-progress {
+  margin-left: -12px;
+  top: -8px;
   width: 30px;
 }
 
-.task-manager-percentage-bar-big .ant-progress {
+.task-manager-percentage-bar-big ::ng-deep .ant-progress {
+  margin-left: -27px;
+  top: -19px;
   width: 60px;
 }
 

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -47,6 +47,7 @@ nz-card {
 }
 
 .task-manager-avatar {
+  font-size: 30px;
   margin-right: 10px;
 }
 

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -46,6 +46,10 @@ nz-card {
   margin-top: 16px;
 }
 
+.task-manager-avatar {
+  margin-right: 10px;
+}
+
 .footer {
   padding-top: 9px;
   margin-top: 16px;

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -29,10 +29,21 @@ nz-card {
   }
 }
 
+.taskslots {
+  display: flex;
+}
+
 .total {
   color: @success-color;
   font-size: 36px;
   line-height: 38px;
+  flex: 1
+}
+
+.task-slot-percentage-bar {
+  float: right;
+  flex: 4;
+  margin-top: 16px;
 }
 
 .footer {

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -51,19 +51,22 @@ nz-card {
   margin-top: 16px;
 }
 
-.task-manager-percentage-bar ::ng-deep .ant-progress {
+.task-manager-percentage-bar-small {
   transform: rotate(270deg);
-}
-
-.task-manager-percentage-bar-small ::ng-deep .ant-progress {
+  display: inline-block;
+  position: relative;
+  top: -2px;
   margin-left: -12px;
-  top: -8px;
+  margin-top: -20px;
   width: 30px;
 }
-
-.task-manager-percentage-bar-big ::ng-deep .ant-progress {
-  margin-left: -27px;
-  top: -19px;
+.task-manager-percentage-bar-big {
+  transform: rotate(270deg);
+  display: inline-block;
+  position: relative;
+  top: -2px;
+  margin-left: -45px;
+  margin-top: -20px;
   width: 60px;
 }
 

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.less
@@ -47,8 +47,27 @@ nz-card {
 }
 
 .task-manager-avatar {
-  font-size: 30px;
   margin-right: 10px;
+}
+
+.task-manager-avatar-green {
+  color: @success-color;
+}
+
+.task-manager-avatar-yellow {
+  color: @warning-color;
+}
+
+.task-manager-avatar-red {
+  color: @error-color;
+}
+
+.task-manager-avatar-small {
+  font-size: 30px;
+}
+
+.task-manager-avatar-big {
+  font-size: 60px;
 }
 
 .footer {

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -106,4 +106,8 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
     this.destroy$.next();
     this.destroy$.complete();
   }
+
+  trackByTaskManager(_: number, item: TaskmanagersItemCalInterface) {
+    return item.id;
+  }
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -17,10 +17,10 @@
  */
 
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
-import { OverviewInterface } from 'interfaces';
+import { OverviewInterface, TaskmanagersItemInterface } from 'interfaces';
 import { Subject } from 'rxjs';
 import { flatMap, takeUntil } from 'rxjs/operators';
-import { OverviewService, StatusService } from 'services';
+import { OverviewService, StatusService, TaskManagerService } from 'services';
 
 @Component({
   selector: 'flink-overview-statistic',
@@ -30,12 +30,15 @@ import { OverviewService, StatusService } from 'services';
 })
 export class OverviewStatisticComponent implements OnInit, OnDestroy {
   statistic: OverviewInterface | null;
+  listOfTaskManager: TaskmanagersItemInterface[] = [];
   taskSlotPercentage: number;
+  taskManagerCPUs: number;
   destroy$ = new Subject();
 
   constructor(
     private statusService: StatusService,
     private overviewService: OverviewService,
+    private taskManagerService: TaskManagerService,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -52,6 +55,23 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
         );
         this.cdr.markForCheck();
       });
+    this.statusService.refresh$
+      .pipe(
+        takeUntil(this.destroy$),
+        flatMap(() => this.taskManagerService.loadManagers())
+      )
+      .subscribe(
+        data => {
+          this.listOfTaskManager = data;
+          this.taskManagerCPUs = 0;
+          this.listOfTaskManager.map(tm => (this.taskManagerCPUs += tm.hardware.cpuCores));
+          console.log(this.listOfTaskManager);
+          this.cdr.markForCheck();
+        },
+        () => {
+          this.cdr.markForCheck();
+        }
+      );
   }
 
   ngOnDestroy() {

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -75,7 +75,6 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
           this.cdr.markForCheck();
         },
         () => {
-          this.cdr.markForCheck();
         }
       );
     this.jobManagerService.loadConfig().subscribe(data => {

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -65,7 +65,6 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
           this.listOfTaskManager = data;
           this.taskManagerCPUs = 0;
           this.listOfTaskManager.map(tm => (this.taskManagerCPUs += tm.hardware.cpuCores));
-          console.log(this.listOfTaskManager);
           this.cdr.markForCheck();
         },
         () => {

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -76,7 +76,6 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
 
           this.cdr.markForCheck();
         },
-        () => {}
       );
     this.jobManagerService.loadConfig().subscribe(data => {
       this.listOfConfig = data;

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -17,7 +17,7 @@
  */
 
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
-import { OverviewInterface, TaskmanagersItemInterface } from 'interfaces';
+import { OverviewInterface, TaskmanagersItemCalInterface } from 'interfaces';
 import { Subject } from 'rxjs';
 import { flatMap, takeUntil } from 'rxjs/operators';
 import { JobManagerService, OverviewService, StatusService, TaskManagerService } from 'services';
@@ -30,7 +30,7 @@ import { JobManagerService, OverviewService, StatusService, TaskManagerService }
 })
 export class OverviewStatisticComponent implements OnInit, OnDestroy {
   statistic: OverviewInterface | null;
-  listOfTaskManager: TaskmanagersItemInterface[] = [];
+  listOfTaskManager: TaskmanagersItemCalInterface[] = [];
   taskSlotPercentage: number;
   taskManagerCPUs: number;
   milliSecondsSinceLastHeartBeat: number;
@@ -74,8 +74,7 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
           });
           this.cdr.markForCheck();
         },
-        () => {
-        }
+        () => {}
       );
     this.jobManagerService.loadConfig().subscribe(data => {
       this.listOfConfig = data;

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -33,7 +33,7 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
   listOfTaskManager: TaskmanagersItemCalInterface[] = [];
   taskSlotPercentage: number;
   taskManagerCPUs: number;
-  milliSecondsSinceLastHeartBeat: number;
+  totalCount: number;
   destroy$ = new Subject();
   listOfConfig: Array<{ key: string; value: string }> = [];
   timeoutThresholdSeconds: number;
@@ -76,6 +76,7 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
         },
         () => {}
       );
+    this.totalCount = this.listOfTaskManager.length;
     this.jobManagerService.loadConfig().subscribe(data => {
       this.listOfConfig = data;
       this.cdr.markForCheck();

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -33,7 +33,7 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
   listOfTaskManager: TaskmanagersItemInterface[] = [];
   taskSlotPercentage: number;
   taskManagerCPUs: number;
-  secondsSinceLastHeartBeat: number;
+  milliSecondsSinceLastHeartBeat: number;
   destroy$ = new Subject();
   listOfConfig: Array<{ key: string; value: string }> = [];
   timeoutThresholdSeconds: number;
@@ -70,7 +70,7 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
           this.taskManagerCPUs = 0;
           this.listOfTaskManager.map(tm => {
             this.taskManagerCPUs += tm.hardware.cpuCores;
-            tm.secondsSinceLastHeartBeat = new Date().getTime() - tm.timeSinceLastHeartbeat;
+            tm.milliSecondsSinceLastHeartBeat = new Date().getTime() - tm.timeSinceLastHeartbeat;
           });
           this.cdr.markForCheck();
         },

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -35,7 +35,6 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
   taskManagerCPUs: number;
   totalCount: number;
   destroy$ = new Subject();
-  listOfConfig: Array<{ key: string; value: string }> = [];
   timeoutThresholdSeconds: number;
 
   constructor(
@@ -64,24 +63,22 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$),
         flatMap(() => this.taskManagerService.loadManagers())
       )
-      .subscribe(
-        data => {
-          this.listOfTaskManager = data;
-          this.totalCount = data.length;
-          this.taskManagerCPUs = 0;
-          this.listOfTaskManager.map(tm => {
-            this.taskManagerCPUs += tm.hardware.cpuCores;
-            tm.milliSecondsSinceLastHeartBeat = new Date().getTime() - tm.timeSinceLastHeartbeat;
-          });
+      .subscribe(data => {
+        this.listOfTaskManager = data;
+        this.totalCount = data.length;
+        this.taskManagerCPUs = 0;
+        this.listOfTaskManager.map(tm => {
+          this.taskManagerCPUs += tm.hardware.cpuCores;
+          tm.milliSecondsSinceLastHeartBeat = new Date().getTime() - tm.timeSinceLastHeartbeat;
+        });
 
-          this.cdr.markForCheck();
-        },
-      );
+        this.cdr.markForCheck();
+      });
     this.jobManagerService.loadConfig().subscribe(data => {
-      this.listOfConfig = data;
+      const listOfConfig = data;
 
       let timeoutThreshold = '';
-      this.listOfConfig.map(config => {
+      listOfConfig.map(config => {
         if (config.key === 'akka.lookup.timeout') {
           timeoutThreshold = config.value;
         }

--- a/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/overview/statistic/overview-statistic.component.ts
@@ -30,6 +30,7 @@ import { OverviewService, StatusService } from 'services';
 })
 export class OverviewStatisticComponent implements OnInit, OnDestroy {
   statistic: OverviewInterface | null;
+  taskSlotPercentage: number;
   destroy$ = new Subject();
 
   constructor(
@@ -46,6 +47,9 @@ export class OverviewStatisticComponent implements OnInit, OnDestroy {
       )
       .subscribe(data => {
         this.statistic = data;
+        this.taskSlotPercentage = Math.round(
+          ((data['slots-total'] - data['slots-available']) / data['slots-total']) * 100
+        );
         this.cdr.markForCheck();
       });
   }

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.html
@@ -18,24 +18,24 @@
 
 <div [ngClass]="{
             'task-manager-avatar': true,
-            'task-manager-avatar-big' : totalCount < 20,
-            'task-manager-avatar-small' : totalCount >= 20
-            }">
+            'task-manager-avatar-big' : totalCount < totalCountStyleThreshold,
+            'task-manager-avatar-small' : totalCount >= totalCountStyleThreshold
+            }" nz-tooltip [nzTitle]="managerTooltip">
   <i [ngClass]="{
-            'task-manager-avatar-big' : totalCount < 20,
-            'task-manager-avatar-small' : totalCount >= 20,
+            'task-manager-avatar-big' : totalCount < totalCountStyleThreshold,
+            'task-manager-avatar-small' : totalCount >= totalCountStyleThreshold,
             'task-manager-avatar-green' : state.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds / 2,
             'task-manager-avatar-yellow' : state.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds / 2 && state.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds,
             'task-manager-avatar-red' : state.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
             }"
-     nz-icon nz-tooltip nzTheme="fill" nzType="database" [nzTitle]="managerTooltip"></i>
+     nz-icon nz-tooltip nzTheme="fill" nzType="database"></i>
   <nz-progress [ngClass]="{
                       'task-manager-percentage-bar': true,
-                      'task-manager-percentage-bar-big' : totalCount < 20,
-                      'task-manager-percentage-bar-small' : totalCount >= 20
+                      'task-manager-percentage-bar-big' : totalCount < totalCountStyleThreshold,
+                      'task-manager-percentage-bar-small' : totalCount >= totalCountStyleThreshold
                       }"
-               [nzStrokeWidth]="totalCount < 20 ? 5 : 3"
-               [nzPercent]="state.freeSlots / state.slotsNumber * 100" nzSize="small" [nzShowInfo]="false" nzStatus="normal"></nz-progress>
+               [nzStrokeWidth]="totalCount < totalCountStyleThreshold ? 5 : 3"
+               [nzPercent]="((state.slotsNumber -state.freeSlots) / state.slotsNumber) * 100 | number" nzSize="small" [nzShowInfo]="false" nzStatus="normal"></nz-progress>
   <ng-template #managerTooltip>
     <span>ID: {{state.id}}</span><br />
     <span>Free Slots: {{state.freeSlots}}</span><br />

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.html
@@ -1,0 +1,50 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div [ngClass]="{
+            'task-manager-avatar': true,
+            'task-manager-avatar-big' : totalCount < 20,
+            'task-manager-avatar-small' : totalCount >= 20
+            }">
+  <i [ngClass]="{
+            'task-manager-avatar-big' : totalCount < 20,
+            'task-manager-avatar-small' : totalCount >= 20,
+            'task-manager-avatar-green' : state.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds / 2,
+            'task-manager-avatar-yellow' : state.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds / 2 && state.milliSecondsSinceLastHeartBeat / 1000 < timeoutThresholdSeconds,
+            'task-manager-avatar-red' : state.milliSecondsSinceLastHeartBeat / 1000 >= timeoutThresholdSeconds
+            }"
+     nz-icon nz-tooltip nzTheme="fill" nzType="database" [nzTitle]="managerTooltip"></i>
+  <nz-progress [ngClass]="{
+                      'task-manager-percentage-bar': true,
+                      'task-manager-percentage-bar-big' : totalCount < 20,
+                      'task-manager-percentage-bar-small' : totalCount >= 20
+                      }"
+               [nzStrokeWidth]="totalCount < 20 ? 5 : 3"
+               [nzPercent]="state.freeSlots / state.slotsNumber * 100" nzSize="small" [nzShowInfo]="false" nzStatus="normal"></nz-progress>
+  <ng-template #managerTooltip>
+    <span>ID: {{state.id}}</span><br />
+    <span>Free Slots: {{state.freeSlots}}</span><br />
+    <span>Total Slots: {{state.slotsNumber}}</span><br />
+    <span>Slots free: {{state.freeSlots / state.slotsNumber * 100 | number}} %</span><br />
+    <span>CPU's :{{state.hardware.cpuCores}}</span><br />
+    <span>Physical Mem: {{state.hardware.physicalMemory | humanizeBytes}}</span><br />
+    <span>Free Mem: {{state.hardware.freeMemory | humanizeBytes}}</span><br />
+    <span>Managed Mem: {{state.hardware.managedMemory | humanizeBytes}}</span><br />
+    <span>Last Heartbeat: {{state.milliSecondsSinceLastHeartBeat / 1000}} seconds ago</span>
+  </ng-template>
+</div>

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.less
@@ -15,68 +15,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 @import "theme";
 
-nz-card {
-  ::ng-deep {
-    .ant-card-head {
-      border-bottom: 0;
-    }
-
-    .ant-card-body {
-      padding: 0 24px 8px;
-    }
-  }
-}
-
-.taskslots {
-  display: flex;
-}
-
-.total {
-  color: @success-color;
-  font-size: 36px;
-  line-height: 38px;
-  flex: 1
-}
-
 .task-manager-avatar {
-  overflow: hidden;
   display: inline-block;
 }
 
-.task-slot-percentage-bar {
-  float: right;
-  flex: 4;
-  margin-top: 16px;
+.task-manager-percentage-bar {
+  transform: rotate(270deg);
+  display: inline-block;
+  position: relative;
+  top: -2px;
 }
 
-.footer {
-  padding-top: 9px;
-  margin-top: 16px;
-  border-top: 1px solid @border-color-split;
-
-  .field {
-    display: inline-block;
-    font-size: 14px;
-    line-height: 22px;
-
-    span {
-      line-height: 22px;
-
-      &:last-child {
-        margin-left: 8px;
-        font-weight: 600;
-        color: @heading-color;
-      }
-    }
-  }
+.task-manager-percentage-bar-small {
+  margin-left: -12px;
+  margin-top: -20px;
+  width: 30px;
 }
 
-.col {
-  margin-bottom: 24px;
+.task-manager-percentage-bar-big {
+  margin-left: -45px;
+  margin-top: -20px;
+  width: 60px;
 }
 
-nz-divider {
-  margin: 0 12px;
+.task-manager-avatar-green {
+  color: @success-color;
+}
+
+.task-manager-avatar-yellow {
+  color: @warning-color;
+}
+
+.task-manager-avatar-red {
+  color: @error-color;
+}
+
+.task-manager-avatar-small {
+  font-size: 30px;
+}
+
+.task-manager-avatar-big {
+  font-size: 60px;
 }

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.less
@@ -26,19 +26,18 @@
   transform: rotate(270deg);
   display: inline-block;
   position: relative;
-  top: -2px;
 }
 
 .task-manager-percentage-bar-small {
-  margin-left: -12px;
-  margin-top: -20px;
+  margin-left: -20px;
+  top: -0.8px;
   width: 30px;
 }
 
 .task-manager-percentage-bar-big {
   margin-left: -45px;
-  margin-top: -20px;
   width: 60px;
+  top: -2px;
 }
 
 .task-manager-avatar-green {

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.ts
@@ -29,4 +29,9 @@ export class TaskManagerItemComponent {
   @Input() state: TaskmanagersItemCalInterface;
   @Input() totalCount: number;
   @Input() timeoutThresholdSeconds: number;
+  totalCountStyleThreshold: number;
+
+  constructor() {
+    this.totalCountStyleThreshold = 21;
+  }
 }

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/task-manager-item/task-manager-item.component.ts
@@ -16,16 +16,17 @@
  * limitations under the License.
  */
 
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ShareModule } from 'share/share.module';
-import { OverviewRoutingModule } from './overview-routing.module';
-import { OverviewComponent } from './overview.component';
-import { OverviewStatisticComponent } from './statistic/overview-statistic.component';
-import { TaskManagerItemComponent } from 'share/customize/task-manager-item/task-manager-item.component';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TaskmanagersItemCalInterface } from 'interfaces';
 
-@NgModule({
-  imports: [CommonModule, ShareModule, OverviewRoutingModule],
-  declarations: [OverviewComponent, OverviewStatisticComponent, TaskManagerItemComponent]
+@Component({
+  selector: 'flink-task-manager-item',
+  templateUrl: './task-manager-item.component.html',
+  styleUrls: ['./task-manager-item.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class OverviewModule {}
+export class TaskManagerItemComponent {
+  @Input() state: TaskmanagersItemCalInterface;
+  @Input() totalCount: number;
+  @Input() timeoutThresholdSeconds: number;
+}

--- a/flink-runtime-web/web-dashboard/src/app/share/share.module.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/share.module.ts
@@ -32,6 +32,7 @@ import { JobListComponent } from 'share/customize/job-list/job-list.component';
 import { TaskBadgeComponent } from 'share/customize/task-badge/task-badge.component';
 import { RefreshDownloadComponent } from 'share/customize/refresh-download/refresh-download.component';
 import { BackpressureBadgeComponent } from './customize/backpressure-badge/backpressure-badge.component';
+import { TaskManagerItemComponent } from 'share/customize/task-manager-item/task-manager-item.component';
 
 @NgModule({
   imports: [CommonModule, NgZorroAntdModule, PipeModule, DagreModule],
@@ -46,7 +47,8 @@ import { BackpressureBadgeComponent } from './customize/backpressure-badge/backp
     ResizeComponent,
     JobChartComponent,
     CheckpointBadgeComponent,
-    BackpressureBadgeComponent
+    BackpressureBadgeComponent,
+    TaskManagerItemComponent
   ],
   exports: [
     JobListComponent,
@@ -62,7 +64,8 @@ import { BackpressureBadgeComponent } from './customize/backpressure-badge/backp
     ResizeComponent,
     JobChartComponent,
     CheckpointBadgeComponent,
-    BackpressureBadgeComponent
+    BackpressureBadgeComponent,
+    TaskManagerItemComponent
   ]
 })
 export class ShareModule {}


### PR DESCRIPTION
## What is the purpose of the change

* Improve Flink Dashboard to provide more information

## Brief change log

  - *Task slot usage in cluster shown in percent*
  - *show total task manager CPU cores*
  - *show each task manager in overview*
    - *colorize task manager according to how far away heartbeat is away from akka.lookup.timeout*
    - *tooltip with metrics for task manager*
    - *percentage bar indicating task slot usage per task manager*
    - *resize if there are more than 20 task managers*

## Preview

![image](https://user-images.githubusercontent.com/3867569/60806155-8a529880-a182-11e9-9ce5-d379afd2f263.png)

## Verifying this change

This change is already covered by existing tests, such as the Flink Web Dashboard tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
