### PR TITLE
[FLINK-12101] Race condition when concurrently running uploaded jars via REST

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/Utils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/Utils.java
@@ -31,9 +31,12 @@ import org.apache.flink.configuration.Configuration;
 
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Optional;
 import java.util.Random;
 
 /**
@@ -294,6 +297,24 @@ public final class Utils {
 			}
 		}
 		return ret;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Resolves the given factories. The thread local factory has preference over the static factory.
+	 * If none is set, the method returns {@link Optional#empty()}.
+	 *
+	 * @param threadLocalFactory containing the thread local factory
+	 * @param staticFactory containing the global factory
+	 * @param <T> type of factory
+	 * @return Optional containing the resolved factory if it exists, otherwise it's empty
+	 */
+	public static <T> Optional<T> resolveFactory(ThreadLocal<T> threadLocalFactory, @Nullable T staticFactory) {
+		final T localFactory = threadLocalFactory.get();
+		final T factory = localFactory == null ? staticFactory : localFactory;
+
+		return Optional.ofNullable(factory);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -117,6 +117,9 @@ public abstract class StreamExecutionEnvironment {
 	 */
 	private static StreamExecutionEnvironmentFactory contextEnvironmentFactory;
 
+	/** The ThreadLocal used to store {@link StreamExecutionEnvironmentFactory}. */
+	private static ThreadLocal<StreamExecutionEnvironmentFactory> contextEnvironmentFactoryThreadLocal = new ThreadLocal<>();
+
 	/** The default parallelism used when creating a local environment. */
 	private static int defaultLocalParallelism = Runtime.getRuntime().availableProcessors();
 
@@ -1568,6 +1571,9 @@ public abstract class StreamExecutionEnvironment {
 	 * executed.
 	 */
 	public static StreamExecutionEnvironment getExecutionEnvironment() {
+		if (contextEnvironmentFactoryThreadLocal.get() != null) {
+			return contextEnvironmentFactoryThreadLocal.get().createExecutionEnvironment();
+		}
 		if (contextEnvironmentFactory != null) {
 			return contextEnvironmentFactory.createExecutionEnvironment();
 		}
@@ -1766,10 +1772,12 @@ public abstract class StreamExecutionEnvironment {
 
 	protected static void initializeContextEnvironment(StreamExecutionEnvironmentFactory ctx) {
 		contextEnvironmentFactory = ctx;
+		contextEnvironmentFactoryThreadLocal.set(contextEnvironmentFactory);
 	}
 
 	protected static void resetContextEnvironment() {
 		contextEnvironmentFactory = null;
+		contextEnvironmentFactoryThreadLocal.remove();
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -34,6 +34,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.io.TextInputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -115,10 +116,10 @@ public abstract class StreamExecutionEnvironment {
 	/**
 	 * The environment of the context (local by default, cluster if invoked through command line).
 	 */
-	private static StreamExecutionEnvironmentFactory contextEnvironmentFactory;
+	private static StreamExecutionEnvironmentFactory contextEnvironmentFactory = null;
 
 	/** The ThreadLocal used to store {@link StreamExecutionEnvironmentFactory}. */
-	private static ThreadLocal<StreamExecutionEnvironmentFactory> contextEnvironmentFactoryThreadLocal = new ThreadLocal<>();
+	private static final ThreadLocal<StreamExecutionEnvironmentFactory> threadLocalContextEnvironmentFactory = new ThreadLocal<>();
 
 	/** The default parallelism used when creating a local environment. */
 	private static int defaultLocalParallelism = Runtime.getRuntime().availableProcessors();
@@ -1571,13 +1572,12 @@ public abstract class StreamExecutionEnvironment {
 	 * executed.
 	 */
 	public static StreamExecutionEnvironment getExecutionEnvironment() {
-		if (contextEnvironmentFactoryThreadLocal.get() != null) {
-			return contextEnvironmentFactoryThreadLocal.get().createExecutionEnvironment();
-		}
-		if (contextEnvironmentFactory != null) {
-			return contextEnvironmentFactory.createExecutionEnvironment();
-		}
+		return Utils.resolveFactory(threadLocalContextEnvironmentFactory, contextEnvironmentFactory)
+			.map(StreamExecutionEnvironmentFactory::createExecutionEnvironment)
+			.orElseGet(StreamExecutionEnvironment::createStreamExecutionEnvironment);
+	}
 
+	private static StreamExecutionEnvironment createStreamExecutionEnvironment() {
 		// because the streaming project depends on "flink-clients" (and not the other way around)
 		// we currently need to intercept the data set environment and create a dependent stream env.
 		// this should be fixed once we rework the project dependencies
@@ -1772,12 +1772,12 @@ public abstract class StreamExecutionEnvironment {
 
 	protected static void initializeContextEnvironment(StreamExecutionEnvironmentFactory ctx) {
 		contextEnvironmentFactory = ctx;
-		contextEnvironmentFactoryThreadLocal.set(contextEnvironmentFactory);
+		threadLocalContextEnvironmentFactory.set(contextEnvironmentFactory);
 	}
 
 	protected static void resetContextEnvironment() {
 		contextEnvironmentFactory = null;
-		contextEnvironmentFactoryThreadLocal.remove();
+		threadLocalContextEnvironmentFactory.remove();
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Fix race condition when concurrently running uploaded jars via REST.


## Brief change log

* Introduce a _ThreadLocal_ field to store _ExecutionEnvironmentFactory_ 
* When _contextEnvironmentFactory_ is null, use _ThreadLocal_ to get Factory.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

cc @tillrohrmann 