### PR TITLE
[FLINK-12520] Support to provide fully-qualified domain host name in TaskManagerMetricGroup

### DIFF
--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -102,5 +102,10 @@
             <td style="word-wrap: break-word;">5000</td>
             <td>Interval between probing of system resource metrics specified in milliseconds. Has an effect only when 'metrics.system-resource' is enabled.</td>
         </tr>
+        <tr>
+            <td><h5>metrics.tm.full-hostname</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Flag indicating whether Flink should use fully qualified host name in task manager metrics.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -185,6 +185,14 @@ public class MetricOptions {
 				"faster updating metrics. Increase this value if the metric fetcher causes too much load. Setting this value to 0 " +
 				"disables the metric fetching completely.");
 
+	/**
+	 * Whether the host name in task manager metrics should be fully qualified domain name.
+	 */
+	public static final ConfigOption<Boolean> METRIC_FULL_HOST_NAME =
+		key("metrics.tm.full-hostname")
+			.defaultValue(false)
+			.withDescription("Flag indicating whether Flink should use fully qualified host name in task manager metrics.");
+
 	private MetricOptions() {
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginUtils;
@@ -360,9 +361,12 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 				remoteAddress,
 				localCommunicationOnly);
 
+		boolean useFullHostName = configuration.getBoolean(
+			MetricOptions.METRIC_FULL_HOST_NAME,
+			MetricOptions.METRIC_FULL_HOST_NAME.defaultValue());
 		Tuple2<TaskManagerMetricGroup, MetricGroup> taskManagerMetricGroup = MetricUtils.instantiateTaskManagerMetricGroup(
 			metricRegistry,
-			TaskManagerLocation.getHostName(remoteAddress),
+			TaskManagerLocation.getHostName(remoteAddress, useFullHostName),
 			resourceID,
 			taskManagerServicesConfiguration.getSystemResourceMetricsProbingInterval());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
@@ -191,6 +191,18 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	 * @return hostname of the TaskManager
 	 */
 	public static String getHostName(InetAddress inetAddress) {
+		return getHostName(inetAddress, false);
+	}
+
+	/**
+	 * Gets the hostname of the TaskManager based on the network address. If {@code useFullHostName} is set as true,
+	 * it would return the fully qualified domain name if possible otherwise not.
+	 *
+	 * @param inetAddress the network address that the TaskManager binds its sockets to
+	 * @param useFullHostName whether to return the fully qualified domain name or take the first part.
+	 * @return hostname of the TaskManager
+	 */
+	public static String getHostName(InetAddress inetAddress, boolean useFullHostName) {
 		String hostName;
 		String fqdnHostName = getFqdnHostName(inetAddress);
 
@@ -202,7 +214,11 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 			LOG.warn("No hostname could be resolved for the IP address {}, using IP address as host name. "
 				+ "Local input split assignment (such as for HDFS files) may be impacted.", inetAddress.getHostAddress());
 		} else {
-			hostName = NetUtils.getHostnameFromFQDN(fqdnHostName);
+			if (useFullHostName) {
+				hostName = fqdnHostName;
+			} else {
+				hostName = NetUtils.getHostnameFromFQDN(fqdnHostName);
+			}
 		}
 
 		return hostName;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerLocationTest.java
@@ -198,4 +198,25 @@ public class TaskManagerLocationTest {
 			fail(e.getMessage());
 		}
 	}
+
+	@Test
+	public void testGetMetricHostName() {
+		try {
+			InetAddress address = mock(InetAddress.class);
+			String fqdn = "worker2.cluster.mycompany.com";
+			when(address.getCanonicalHostName()).thenReturn(fqdn);
+			when(address.getHostName()).thenReturn(fqdn);
+			when(address.getHostAddress()).thenReturn("127.0.0.1");
+
+			String hostName = TaskManagerLocation.getHostName(address, false);
+			assertEquals("worker2", hostName);
+
+			hostName = TaskManagerLocation.getHostName(address, true);
+			assertEquals(fqdn, hostName);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Inspired from [Chinese user-mail](https://lists.apache.org/thread.html/e1774a42430815b689ea792103d002b1da734d6086682d34c044ef35@%3Cuser-zh.flink.apache.org%3E) which complains that host name in metrics name could only show the first part. However, their full host name is like "ambari.host12.yy" which means the first part "ambari" cannot identify anything.

With this PR, we could support to let user record their full host name in the `TaskManagerMetricGroup` so that to identify metrics from different hosts.

## Brief change log

  - Add new option `metrics.tm.full-hostname` in `MetricOptions` to indicate whether Flink should use fully qualified host name in task manager metrics.
  - Use above metric option when `instantiateTaskManagerMetricGroup` in `TaskManagerRunner`

## Verifying this change
This change added tests and can be verified as follows:

  - Added test that `TaskManagerLocation#getHostName(InetAddress, boolean)` could return the host name as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **docs**
