### PR TITLE
[FLINK-12630][network] Refactor abstract InputGate to general interface

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/FutureBasedDataAvailability.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/FutureBasedDataAvailability.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A general tool which is used for tracing the data availability based on future state.
+ */
+public class FutureBasedDataAvailability {
+
+	public static final CompletableFuture<?> AVAILABLE = CompletableFuture.completedFuture(null);
+
+	protected CompletableFuture<?> isAvailable = new CompletableFuture<>();
+
+	/**
+	 * @return a future that is completed if there are more data available. If there more data
+	 * available immediately, {@link #AVAILABLE} should be returned.
+	 */
+	public CompletableFuture<?> isAvailable() {
+		return isAvailable;
+	}
+
+	protected void resetIsAvailable() {
+		// try to avoid volatile access in isDone()}
+		if (isAvailable == AVAILABLE || isAvailable.isDone()) {
+			isAvailable = new CompletableFuture<>();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * An input gate consumes one or more partitions of a single produced intermediate result.
  *
@@ -68,70 +66,43 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * will have an input gate attached to it. This will provide its input, which will consist of one
  * subpartition from each partition of the intermediate result.
  */
-public abstract class InputGate implements AutoCloseable {
+public interface InputGate extends AutoCloseable {
 
-	public static final CompletableFuture<?> AVAILABLE = CompletableFuture.completedFuture(null);
+	String getOwningTaskName();
 
-	protected CompletableFuture<?> isAvailable = new CompletableFuture<>();
+	int getNumberOfInputChannels();
 
-	public abstract int getNumberOfInputChannels();
+	int getPageSize();
 
-	public abstract String getOwningTaskName();
+	/**
+	 * Setup gate, potentially heavy-weight, blocking operation comparing to just creation.
+	 */
+	void setup() throws IOException;
 
-	public abstract boolean isFinished();
-
-	public abstract void requestPartitions() throws IOException, InterruptedException;
+	void requestPartitions() throws IOException, InterruptedException;
 
 	/**
 	 * Blocking call waiting for next {@link BufferOrEvent}.
 	 *
 	 * @return {@code Optional.empty()} if {@link #isFinished()} returns true.
 	 */
-	public abstract Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException;
+	Optional<BufferOrEvent> getNextBufferOrEvent() throws IOException, InterruptedException;
 
 	/**
 	 * Poll the {@link BufferOrEvent}.
 	 *
 	 * @return {@code Optional.empty()} if there is no data to return or if {@link #isFinished()} returns true.
 	 */
-	public abstract Optional<BufferOrEvent> pollNextBufferOrEvent() throws IOException, InterruptedException;
+	Optional<BufferOrEvent> pollNextBufferOrEvent() throws IOException, InterruptedException;
 
-	public abstract void sendTaskEvent(TaskEvent event) throws IOException;
-
-	public abstract int getPageSize();
+	void sendTaskEvent(TaskEvent event) throws IOException;
 
 	/**
-	 * @return a future that is completed if there are more records available. If there more records
-	 * available immediately, {@link #AVAILABLE} should be returned.
+	 * Checks whether the data in this gate is available or not based on future state.
+	 *
+	 * @return a future for tracing the data availability.
 	 */
-	public CompletableFuture<?> isAvailable() {
-		return isAvailable;
-	}
+	CompletableFuture<?> isAvailable();
 
-	protected void resetIsAvailable() {
-		// try to avoid volatile access in isDone()}
-		if (isAvailable == AVAILABLE || isAvailable.isDone()) {
-			isAvailable = new CompletableFuture<>();
-		}
-	}
-
-	/**
-	 * Simple pojo for INPUT, DATA and moreAvailable.
-	 */
-	protected static class InputWithData<INPUT, DATA> {
-		protected final INPUT input;
-		protected final DATA data;
-		protected final boolean moreAvailable;
-
-		InputWithData(INPUT input, DATA data, boolean moreAvailable) {
-			this.input = checkNotNull(input);
-			this.data = checkNotNull(data);
-			this.moreAvailable = moreAvailable;
-		}
-	}
-
-	/**
-	 * Setup gate, potentially heavy-weight, blocking operation comparing to just creation.
-	 */
-	public abstract void setup() throws IOException;
+	boolean isFinished();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputWithData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputWithData.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A combination of data, input and a flag indicating availability of further data.
+ *
+ * @param <INPUT> indicates a single channel or single gate.
+ * @param <DATA> indicates a buffer or event.
+ */
+public class InputWithData<INPUT, DATA> {
+
+	private final INPUT input;
+	private final DATA data;
+	private final boolean moreAvailable;
+
+	InputWithData(INPUT input, DATA data, boolean moreAvailable) {
+		this.input = checkNotNull(input);
+		this.data = checkNotNull(data);
+		this.moreAvailable = moreAvailable;
+	}
+
+	public INPUT input() {
+		return input;
+	}
+
+	public DATA data() {
+		return data;
+	}
+
+	public boolean moreAvailable() {
+		return moreAvailable;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -97,7 +97,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * in two partitions (Partition 1 and 2). Each of these partitions is further partitioned into two
  * subpartitions -- one for each parallel reduce subtask.
  */
-public class SingleInputGate extends InputGate {
+public class SingleInputGate extends FutureBasedDataAvailability implements InputGate {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SingleInputGate.class);
 
@@ -525,9 +525,9 @@ public class SingleInputGate extends InputGate {
 
 		InputWithData<InputChannel, BufferAndAvailability> inputWithData = next.get();
 		return Optional.of(transformToBufferOrEvent(
-			inputWithData.data.buffer(),
-			inputWithData.moreAvailable,
-			inputWithData.input));
+			inputWithData.data().buffer(),
+			inputWithData.moreAvailable(),
+			inputWithData.input()));
 	}
 
 	private Optional<InputWithData<InputChannel, BufferAndAvailability>> waitAndGetNextData(boolean blocking)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -64,7 +64,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *
  * <strong>It is NOT possible to recursively union union input gates.</strong>
  */
-public class UnionInputGate extends InputGate {
+public class UnionInputGate extends FutureBasedDataAvailability implements InputGate {
 
 	/** The input gates to union. */
 	private final InputGate[] inputGates;
@@ -189,11 +189,11 @@ public class UnionInputGate extends InputGate {
 
 		InputWithData<InputGate, BufferOrEvent> inputWithData = next.get();
 
-		handleEndOfPartitionEvent(inputWithData.data, inputWithData.input);
+		handleEndOfPartitionEvent(inputWithData.data(), inputWithData.input());
 		return Optional.of(adjustForUnionInputGate(
-			inputWithData.data,
-			inputWithData.input,
-			inputWithData.moreAvailable));
+			inputWithData.data(),
+			inputWithData.input(),
+			inputWithData.moreAvailable()));
 	}
 
 	private Optional<InputWithData<InputGate, BufferOrEvent>> waitAndGetNextData(boolean blocking)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.FutureBasedDataAvailability;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
 import org.junit.Test;
@@ -129,7 +130,7 @@ public class BarrierBufferMassiveRandomTest {
 		}
 	}
 
-	private static class RandomGeneratingInputGate extends InputGate {
+	private static class RandomGeneratingInputGate extends FutureBasedDataAvailability implements InputGate {
 
 		private final int numberOfChannels;
 		private final BufferPool[] bufferPools;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.FutureBasedDataAvailability;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
 import java.util.ArrayDeque;
@@ -31,7 +32,7 @@ import java.util.Queue;
 /**
  * Mock {@link InputGate}.
  */
-public class MockInputGate extends InputGate {
+public class MockInputGate extends FutureBasedDataAvailability implements InputGate {
 
 	private final int pageSize;
 


### PR DESCRIPTION
## What is the purpose of the change

*`InputGate` is currently defined as an abstract class which implements the logic of checking data availability for subclasses `SingleInputGate` and `UnionInputGate`, but it might bring limits for further extending `InputGate` implementations in shuffle service architecture. So we refactor the `InputGate` as a general interface and define a new isAvailable method for it. The existing implementation of data availability is extracted as a separate class which could still be used for both single and union gates as now. The future new `InputGate` instances from other shuffle services might have different implementations for data availability.*

## Brief change log

  - *Refactor `InputGate` as interface and define `isAvailable` for it.*
  - *Extract the data available implementation as separate class `FutureBasedDataAvailability`*
  - *Extract `InputWithData` as a separate class*

## Verifying this change

*covered by existing tests.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)