### PR TITLE
[FLINK-12631]:Check if proper JAR file in JobWithJars

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/JobWithJars.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/JobWithJars.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.jar.JarFile;
 
 /**
  * A JobWithJars is a Flink dataflow plan, together with a bunch of JAR files that contain
@@ -114,15 +115,20 @@ public class JobWithJars {
 		try {
 			jarFile = new File(jar.toURI());
 		} catch (URISyntaxException e) {
-			throw new IOException("JAR file path is invalid '" + jar + "'");
+			throw new IOException("JAR file path is invalid '" + jar + '\'');
 		}
 		if (!jarFile.exists()) {
-			throw new IOException("JAR file does not exist '" + jarFile.getAbsolutePath() + "'");
+			throw new IOException("JAR file does not exist '" + jarFile.getAbsolutePath() + '\'');
 		}
 		if (!jarFile.canRead()) {
-			throw new IOException("JAR file can't be read '" + jarFile.getAbsolutePath() + "'");
+			throw new IOException("JAR file can't be read '" + jarFile.getAbsolutePath() + '\'');
 		}
-		// TODO: Check if proper JAR file
+
+		try (JarFile ignored = new JarFile(jarFile)) {
+			// verify that we can open the Jar file
+		} catch (IOException e) {
+			throw new IOException("Error while opening jar file '" + jarFile.getAbsolutePath() + '\'', e);
+		}
 	}
 
 	public static ClassLoader buildUserCodeClassLoader(List<URL> jars, List<URL> classpaths, ClassLoader parent) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -820,7 +820,7 @@ public class PackagedProgram {
 			JobWithJars.checkJarFile(jarfile);
 		}
 		catch (IOException e) {
-			throw new ProgramInvocationException(e.getMessage());
+			throw new ProgramInvocationException(e.getMessage(), e);
 		}
 		catch (Throwable t) {
 			throw new ProgramInvocationException("Cannot access jar file" + (t.getMessage() == null ? "." : ": " + t.getMessage()), t);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerTest.java
@@ -93,10 +93,10 @@ public class JarRunHandlerTest extends TestLogger {
 						// implies the job was actually submitted
 						assertTrue(expected.get().getMessage().contains("ProgramInvocationException"));
 						// original cause is preserved in stack trace
-						assertThat(expected.get().getMessage(), containsString("ZipException"));
+						assertThat(expected.get().getMessage(), containsString("ZipException: zip file is empty"));
 						// implies the jar was registered for the job graph (otherwise the jar name would not occur in the exception)
 						// implies the jar was uploaded (otherwise the file would not be found at all)
-						assertTrue(expected.get().getMessage().contains("empty.jar'. zip file is empty"));
+						assertTrue(expected.get().getMessage().contains("empty.jar"));
 					} else {
 						throw e;
 					}


### PR DESCRIPTION

## What is the purpose of the change

*Related to FLINK-12631. Check if proper JAR file in JobWithJars.*


## Brief change log
  - *Check if proper JAR file in JobWithJars*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
