### PR TITLE
[FLINK-12171][Network] Do not limit the network buffer memory by heap size on the TM side

### DIFF
--- a/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
@@ -76,19 +76,23 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 	 */
 	@Test
 	public void compareNetworkBufShellScriptWithJava() throws Exception {
+		final int totalMemoryInMB = 1000; // 1000MB
+		final long networkBufMin = 64L << 20; // 64MB
+		final long networkBufMax = 1L << 30; // 1GB
+
 		int managedMemSize = Integer.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue());
 		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
 
 		// manual tests from org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB()
 
 		compareNetworkBufJavaVsScript(
-			getConfig(1000, false, 0.1f, 64L << 20, 1L << 30, managedMemSize, managedMemFrac), 0.0f);
+			getConfig(totalMemoryInMB, false, 0.1f, networkBufMin, networkBufMax, managedMemSize, managedMemFrac), 0.0f);
 
 		compareNetworkBufJavaVsScript(
-			getConfig(1000, true, 0.1f, 64L << 20, 1L << 30, 10 /*MB*/, managedMemFrac), 0.0f);
+			getConfig(totalMemoryInMB, true, 0.1f, networkBufMin, networkBufMax, 10 /*MB*/, managedMemFrac), 0.0f);
 
 		compareNetworkBufJavaVsScript(
-			getConfig(1000, true, 0.1f, 64L << 20, 1L << 30, managedMemSize, 0.1f), 0.0f);
+			getConfig(totalMemoryInMB, true, 0.1f, networkBufMin, networkBufMax, managedMemSize, 0.1f), 0.0f);
 
 		// some automated tests with random (but valid) values
 
@@ -105,19 +109,23 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 	 */
 	@Test
 	public void compareHeapSizeShellScriptWithJava() throws Exception {
+		final int totalMemoryInMB = 1000; // 1000MB
+		final long networkBufMin = 64L << 20; // 64MB
+		final long networkBufMax = 1L << 30; // 1GB
+
 		int managedMemSize = Integer.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue());
 		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
 
 		// manual tests from org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB()
 
 		compareHeapSizeJavaVsScript(
-			getConfig(1000, false, 0.1f, 64L << 20, 1L << 30, managedMemSize, managedMemFrac), 0.0f);
+			getConfig(totalMemoryInMB, false, 0.1f, networkBufMin, networkBufMax, managedMemSize, managedMemFrac), 0.0f);
 
 		compareHeapSizeJavaVsScript(
-			getConfig(1000, true, 0.1f, 64L << 20, 1L << 30, 10 /*MB*/, managedMemFrac), 0.0f);
+			getConfig(totalMemoryInMB, true, 0.1f, networkBufMin, networkBufMax, 10 /*MB*/, managedMemFrac), 0.0f);
 
 		compareHeapSizeJavaVsScript(
-			getConfig(1000, true, 0.1f, 64L << 20, 1L << 30, managedMemSize, 0.1f), 0.0f);
+			getConfig(totalMemoryInMB, true, 0.1f, networkBufMin, networkBufMax, managedMemSize, 0.1f), 0.0f);
 
 		// some automated tests with random (but valid) values
 

--- a/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
@@ -94,6 +94,12 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		compareNetworkBufJavaVsScript(
 			getConfig(totalMemoryInMB, true, 0.1f, networkBufMin, networkBufMax, managedMemSize, 0.1f), 0.0f);
 
+		compareNetworkBufJavaVsScript(
+			getConfig(totalMemoryInMB, false, 0.6f, networkBufMin, networkBufMax, managedMemSize, managedMemFrac), 0.0f);
+
+		compareNetworkBufJavaVsScript(
+			getConfig(totalMemoryInMB, true, 0.6f, networkBufMin, networkBufMax, 10 /*MB*/, managedMemFrac), 0.0f);
+
 		// some automated tests with random (but valid) values
 
 		Random ran = new Random();
@@ -126,6 +132,12 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 
 		compareHeapSizeJavaVsScript(
 			getConfig(totalMemoryInMB, true, 0.1f, networkBufMin, networkBufMax, managedMemSize, 0.1f), 0.0f);
+
+		compareHeapSizeJavaVsScript(
+			getConfig(totalMemoryInMB, false, 0.6f, networkBufMin, networkBufMax, managedMemSize, managedMemFrac), 0.0f);
+
+		compareHeapSizeJavaVsScript(
+			getConfig(totalMemoryInMB, true, 0.6f, networkBufMin, networkBufMax, 10 /*MB*/, managedMemFrac), 0.0f);
 
 		// some automated tests with random (but valid) values
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -260,7 +260,12 @@ public class NettyShuffleEnvironmentConfiguration {
 		//              = jvmTotal - Math.min(networkBufMax, Math.max(networkBufMin, jvmHeap * netFraction)
 		// jvmTotal = jvmHeapNoNet / (1.0 - networkBufFraction)
 		float networkBufFraction = config.getFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION);
-		long networkBufSize = (long) (jvmHeapNoNet / (1.0 - networkBufFraction) * networkBufFraction);
+
+		// Converts to double for higher precision. Converting via string achieve higher precision for those
+		// numbers can not be represented preciously by float, like 0.4f.
+		double heapNoNetFraction = 1.0 - Double.valueOf(Float.toString(networkBufFraction));
+		long totalJavaMemorySize = (long) (jvmHeapNoNet / heapNoNetFraction);
+		long networkBufSize = (long) (totalJavaMemorySize * networkBufFraction);
 
 		// Do not need to check the maximum allowed memory since the computed total memory should always
 		// be larger than the computed network buffer memory as long as the fraction is less than 1.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -236,40 +236,40 @@ public class NettyShuffleEnvironmentConfiguration {
 	public static long calculateNewNetworkBufferMemory(Configuration config, long maxJvmHeapMemory) {
 		// The maximum heap memory has been adjusted as in TaskManagerServices#calculateHeapSizeMB
 		// and we need to invert these calculations.
-		final long jvmHeapNoNet;
+		final long heapAndManagedMemory;
 		final MemoryType memoryType = ConfigurationParserUtils.getMemoryType(config);
 		if (memoryType == MemoryType.HEAP) {
-			jvmHeapNoNet = maxJvmHeapMemory;
+			heapAndManagedMemory = maxJvmHeapMemory;
 		} else if (memoryType == MemoryType.OFF_HEAP) {
 			long configuredMemory = ConfigurationParserUtils.getManagedMemorySize(config) << 20; // megabytes to bytes
 			if (configuredMemory > 0) {
 				// The maximum heap memory has been adjusted according to configuredMemory, i.e.
 				// maxJvmHeap = jvmHeapNoNet - configuredMemory
-				jvmHeapNoNet = maxJvmHeapMemory + configuredMemory;
+				heapAndManagedMemory = maxJvmHeapMemory + configuredMemory;
 			} else {
 				// The maximum heap memory has been adjusted according to the fraction, i.e.
 				// maxJvmHeap = jvmHeapNoNet - jvmHeapNoNet * managedFraction = jvmHeapNoNet * (1 - managedFraction)
-				jvmHeapNoNet = (long) (maxJvmHeapMemory / (1.0 - ConfigurationParserUtils.getManagedMemoryFraction(config)));
+				heapAndManagedMemory = (long) (maxJvmHeapMemory / (1.0 - ConfigurationParserUtils.getManagedMemoryFraction(config)));
 			}
 		} else {
 			throw new RuntimeException("No supported memory type detected.");
 		}
 
 		// finally extract the network buffer memory size again from:
-		// jvmHeapNoNet = jvmTotal - networkBufBytes
-		//              = jvmTotal - Math.min(networkBufMax, Math.max(networkBufMin, jvmHeap * netFraction)
-		// jvmTotal = jvmHeapNoNet / (1.0 - networkBufFraction)
+		// heapAndManagedMemory = totalProcessMemory - networkReservedMemory
+		//                      = totalProcessMemory - Math.min(networkBufMax, Math.max(networkBufMin, totalProcessMemory * networkBufFraction)
+		// totalProcessMemory = heapAndManagedMemory / (1.0 - networkBufFraction)
 		float networkBufFraction = config.getFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION);
 
 		// Converts to double for higher precision. Converting via string achieve higher precision for those
 		// numbers can not be represented preciously by float, like 0.4f.
-		double heapNoNetFraction = 1.0 - Double.valueOf(Float.toString(networkBufFraction));
-		long totalJavaMemorySize = (long) (jvmHeapNoNet / heapNoNetFraction);
-		long networkBufSize = (long) (totalJavaMemorySize * networkBufFraction);
+		double heapAndManagedFraction = 1.0 - Double.valueOf(Float.toString(networkBufFraction));
+		long totalProcessMemory = (long) (heapAndManagedMemory / heapAndManagedFraction);
+		long networkMemoryByFraction = (long) (totalProcessMemory * networkBufFraction);
 
 		// Do not need to check the maximum allowed memory since the computed total memory should always
 		// be larger than the computed network buffer memory as long as the fraction is less than 1.
-		return calculateNewNetworkBufferMemory(config, networkBufSize, Long.MAX_VALUE);
+		return calculateNewNetworkBufferMemory(config, networkMemoryByFraction, Long.MAX_VALUE);
 	}
 
 	/**
@@ -284,34 +284,34 @@ public class NettyShuffleEnvironmentConfiguration {
 	 *  <li>{@link NettyShuffleEnvironmentOptions#NETWORK_NUM_BUFFERS} (fallback if the ones above do not exist)</li>
 	 * </ul>.
 	 *
-	 * @param totalJavaMemorySize overall available memory to use (in bytes)
+	 * @param totalProcessMemory overall available memory to use (in bytes)
 	 * @param config configuration object
 	 *
 	 * @return memory to use for network buffers (in bytes)
 	 */
 	@SuppressWarnings("deprecation")
-	public static long calculateNetworkBufferMemory(long totalJavaMemorySize, Configuration config) {
+	public static long calculateNetworkBufferMemory(long totalProcessMemory, Configuration config) {
 		final int segmentSize = ConfigurationParserUtils.getPageSize(config);
 
-		final long networkBufBytes;
+		final long networkReservedMemory;
 		if (hasNewNetworkConfig(config)) {
 			float networkBufFraction = config.getFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION);
-			long networkBufSize = (long) (totalJavaMemorySize * networkBufFraction);
-			networkBufBytes = calculateNewNetworkBufferMemory(config, networkBufSize, totalJavaMemorySize);
+			long networkMemoryByFraction = (long) (totalProcessMemory * networkBufFraction);
+			networkReservedMemory = calculateNewNetworkBufferMemory(config, networkMemoryByFraction, totalProcessMemory);
 		} else {
 			// use old (deprecated) network buffers parameter
 			int numNetworkBuffers = config.getInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS);
-			networkBufBytes = (long) numNetworkBuffers * (long) segmentSize;
+			networkReservedMemory = (long) numNetworkBuffers * (long) segmentSize;
 
 			checkOldNetworkConfig(numNetworkBuffers);
 
-			ConfigurationParserUtils.checkConfigParameter(networkBufBytes < totalJavaMemorySize,
-				networkBufBytes, NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS.key(),
-				"Network buffer memory size too large: " + networkBufBytes + " >= " +
-					totalJavaMemorySize + " (total JVM memory size)");
+			ConfigurationParserUtils.checkConfigParameter(networkReservedMemory < totalProcessMemory,
+				networkReservedMemory, NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS.key(),
+				"Network buffer memory size too large: " + networkReservedMemory + " >= " +
+					totalProcessMemory + " (total JVM memory size)");
 		}
 
-		return networkBufBytes;
+		return networkReservedMemory;
 	}
 
 	/**
@@ -326,12 +326,12 @@ public class NettyShuffleEnvironmentConfiguration {
 	 * </ul>.
 	 *
 	 * @param config configuration object
-	 * @param networkBufSize memory of network buffers based on JVM memory size and network fraction
+	 * @param networkMemoryByFraction memory of network buffers based on JVM memory size and network fraction
 	 * @param maxAllowedMemory maximum memory used for checking the results of network memory
 	 *
 	 * @return memory to use for network buffers (in bytes)
 	 */
-	private static long calculateNewNetworkBufferMemory(Configuration config, long networkBufSize, long maxAllowedMemory) {
+	private static long calculateNewNetworkBufferMemory(Configuration config, long networkMemoryByFraction, long maxAllowedMemory) {
 		float networkBufFraction = config.getFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION);
 		long networkBufMin = MemorySize.parse(config.getString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN)).getBytes();
 		long networkBufMax = MemorySize.parse(config.getString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX)).getBytes();
@@ -340,7 +340,7 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		checkNewNetworkConfig(pageSize, networkBufFraction, networkBufMin, networkBufMax);
 
-		long networkBufBytes = Math.min(networkBufMax, Math.max(networkBufMin, networkBufSize));
+		long networkBufBytes = Math.min(networkBufMax, Math.max(networkBufMin, networkMemoryByFraction));
 
 		ConfigurationParserUtils.checkConfigParameter(networkBufBytes < maxAllowedMemory,
 			"(" + networkBufFraction + ", " + networkBufMin + ", " + networkBufMax + ")",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
@@ -242,12 +242,19 @@ public class NettyShuffleEnvironmentConfigurationTest extends TestLogger {
 		config.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.2f);
 		assertEquals(800, TaskManagerServices.calculateHeapSizeMB(1000, config));
 
+		config.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.6f);
+		assertEquals(400, TaskManagerServices.calculateHeapSizeMB(1000, config));
+
 		config.setBoolean(TaskManagerOptions.MEMORY_OFF_HEAP, true);
 		config.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
 		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "10m"); // 10MB
 		assertEquals(890, TaskManagerServices.calculateHeapSizeMB(1000, config));
 
+		config.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.6f);
+		assertEquals(390, TaskManagerServices.calculateHeapSizeMB(1000, config));
+
 		config.removeConfig(TaskManagerOptions.MANAGED_MEMORY_SIZE); // use fraction of given memory
+		config.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
 		config.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.1f); // 10%
 		assertEquals(810, TaskManagerServices.calculateHeapSizeMB(1000, config));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
@@ -49,35 +49,35 @@ public class NetworkBufferCalculationTest extends TestLogger {
 			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.1f, networkBufMin, networkBufMax, MemoryType.HEAP);
-		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
+		assertEquals(100L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 900L << 20)); // 900MB
 
 		config = getConfig(
 			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.2f, networkBufMin, networkBufMax, MemoryType.HEAP);
-		assertEquals((200L << 20) + 3 /* slightly too many due to floating point imprecision */,
+		assertEquals(200L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 800L << 20)); // 800MB
 
 		config = getConfig(
 			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.6f, networkBufMin, networkBufMax, MemoryType.HEAP);
-		assertEquals((600L << 20),
+		assertEquals(600L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 400L << 20)); // 400MB
 
 		config = getConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.1f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
-		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
+		assertEquals(100L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 890L << 20)); // 890MB
 
 		config = getConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 				0.6f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
-		assertEquals((590L << 20),
+		assertEquals(615L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 400L << 20)); // 400MB
 
 		config = getConfig(0, 0.1f, 0.1f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
-		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
+		assertEquals(100L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 810L << 20)); // 810MB
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
@@ -42,26 +42,29 @@ public class NetworkBufferCalculationTest extends TestLogger {
 	public void calculateNetworkBufFromHeapSize() {
 		Configuration config;
 
+		final long networkBufMin = 64L << 20; // 64MB
+		final long networkBufMax = 1L << 30; // 1GB
+
 		config = getConfig(
 			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
-			0.1f, 60L << 20, 1L << 30, MemoryType.HEAP);
+			0.1f, networkBufMin, networkBufMax, MemoryType.HEAP);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 900L << 20)); // 900MB
 
 		config = getConfig(
 			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
-			0.2f, 60L << 20, 1L << 30, MemoryType.HEAP);
+			0.2f, networkBufMin, networkBufMax, MemoryType.HEAP);
 		assertEquals((200L << 20) + 3 /* slightly too many due to floating point imprecision */,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 800L << 20)); // 800MB
 
 		config = getConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
-			0.1f, 60L << 20, 1L << 30, MemoryType.OFF_HEAP);
+			0.1f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 890L << 20)); // 890MB
 
-		config = getConfig(0, 0.1f, 0.1f, 60L << 20, 1L << 30, MemoryType.OFF_HEAP);
+		config = getConfig(0, 0.1f, 0.1f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 810L << 20)); // 810MB
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
@@ -59,10 +59,22 @@ public class NetworkBufferCalculationTest extends TestLogger {
 		assertEquals((200L << 20) + 3 /* slightly too many due to floating point imprecision */,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 800L << 20)); // 800MB
 
+		config = getConfig(
+			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
+			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+			0.6f, networkBufMin, networkBufMax, MemoryType.HEAP);
+		assertEquals((600L << 20),
+			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 400L << 20)); // 400MB
+
 		config = getConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.1f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 890L << 20)); // 890MB
+
+		config = getConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+				0.6f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
+		assertEquals((590L << 20),
+			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 400L << 20)); // 400MB
 
 		config = getConfig(0, 0.1f, 0.1f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the bug that limits the network buffer size with the heap size on the TM side. In fact, network buffer occupies a part of direct memory and is independent with the heap.

To fix this problem, The limitation on the TM side is removed. Although we may want to compare the network memory size with the total memory size on the TM side, currently we can only compute the total memory with heap + computed network memory and the computed total memory should be always larger than the computed network memory.

To remove the limitation, the max allowed memory used to check the network memory size on TM side is changed to Long.MAX_VALUE. Another option is to move the checking to the caller function on the RM side. however, it is not easy to achieve since the checking relies on the configured values of MIN and MAX, and it is not accessible outside of the current function.

## Brief change log
  - f32dde51c1183d22e8a192e19d037a4f0c48c9ae extracts common variables to simplify the tests.
  - 17f93e19b39433dc5d93c24c5b8a85feb1c37b1f fixes the exception when network buffer fraction is larger than 0.5 on TM side, and adds new tests to cover the cases that the network buffer fraction is larger than 0.5
 - 2762ce8f219b8b988d9824a8beab5c6117119403 optimizes the computation of the network memory on TM side to fix the numerical precision problem.
 - aa5c15913e411babe2bf5cc3067cdbb112d57fd0 unifies the terminology in `NettyShuffleEnvironmentConfiguration`

## Verifying this change
This change added tests and can be verified as follows:
  - *Add tests for network buffer computation with `fraction > 0.5`*
  - *Manually verified the change by running a cluster with two task managers for both standalone and YARN mode, and test the configuration with heap = 3G/network = 2G and heap = 5G/network = 2G*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
