### PR TITLE
[FLINK-12648][filesystem] Load Hadoop file system via org.apache.hado…

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFsInitTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFsInitTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.connectors.fs.bucketing;
 
 import org.apache.flink.core.fs.FileSystemSafetyNet;
-import org.apache.flink.core.fs.UnsupportedFileSystemSchemeException;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -28,6 +27,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -75,7 +76,7 @@ public class BucketingSinkFsInitTest {
 		assertEquals("hdfs", fs.getUri().getScheme());
 	}
 
-	@Test(expected = UnsupportedFileSystemSchemeException.class)
+	@Test(expected = IOException.class)
 	public void testInitForUnsupportedFileSystem() throws Exception {
 		final Path path = new Path("nofs://localhost:51234/some/path/");
 		BucketingSink.createHadoopFileSystem(path, null);

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
@@ -117,12 +117,6 @@ public class HadoopFsFactory implements FileSystemFactory {
 		}
 	}
 
-	private static String getMissingAuthorityErrorPrefix(URI fsURI) {
-		return "The given file system URI (" + fsURI.toString() + ") did not describe the authority " +
-				"(like for example HDFS NameNode address/port or S3 host). " +
-				"The attempt to use a configured default authority failed: ";
-	}
-
 	private static FileSystem limitIfConfigured(HadoopFileSystem fs, String scheme, Configuration config) {
 		final ConnectionLimitingSettings limitSettings = ConnectionLimitingSettings.fromConfig(config, scheme);
 

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactoryTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactoryTest.java
@@ -58,7 +58,7 @@ public class HadoopFsFactoryTest extends TestLogger {
 			fail("should have failed with an exception");
 		}
 		catch (IOException e) {
-			assertTrue(e.getMessage().contains("authority"));
+			assertTrue(e.getMessage().contains("Incomplete HDFS URI"));
 		}
 	}
 }


### PR DESCRIPTION
…op.fs.FileSystem.get()

## What is the purpose of the change

I think there are some duplicated codes in org.apache.flink.runtime.fs.hdfs.HadoopFsFactory#create with codes in apache hadoop-common dependency.

We can use org.apache.hadoop.fs.FileSystem#get(java.net.URI, org.apache.hadoop.conf.Configuration) to remove the duplicated codes.


## Brief change log

Replace some codes with org.apache.hadoop.fs.FileSystem#get(java.net.URI, org.apache.hadoop.conf.Configuration)

## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.runtime.fs.hdfs.HadoopFsFactoryTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
