### PR TITLE
[FLINK-12576][Network, Metrics]Take localInputChannel into account when compute inputQueueLength

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1031,7 +1031,7 @@ Thus, in order to infer the metric identifier:
       <th rowspan="8">Task</th>
       <td rowspan="4">buffers</td>
       <td>inputQueueLength</td>
-      <td>The number of queued input buffers.</td>
+      <td>The number of queued input buffers. (ignores LocalInputChannels which are using blocking subpartitions)</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -1030,7 +1030,7 @@ Thus, in order to infer the metric identifier:
       <th rowspan="8">Task</th>
       <td rowspan="4">buffers</td>
       <td>inputQueueLength</td>
-      <td>The number of queued input buffers.</td>
+      <td>The number of queued input buffers. (ignores LocalInputChannels which are using blocking subpartitions)</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -167,7 +167,7 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
 	}
 
 	@Override
-	public int unsafeGetSizeOfQueuedBuffer() {
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
 		return parent.unsynchronizedGetNumberOfQueuedBuffers();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -167,6 +167,11 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
 	}
 
 	@Override
+	public int unsafeGetSizeOfQueuedBuffer() {
+		return parent.unsynchronizedGetNumberOfQueuedBuffers();
+	}
+
+	@Override
 	public String toString() {
 		return String.format("Blocking Subpartition Reader: ID=%s, index=%d",
 				parent.parent.getPartitionId(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -61,4 +61,9 @@ public class NoOpResultSubpartitionView implements ResultSubpartitionView {
 	public boolean isAvailable() {
 		return false;
 	}
+
+	@Override
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
+		return 0;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -91,6 +91,11 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	}
 
 	@Override
+	public int unsafeGetSizeOfQueuedBuffer() {
+		return parent.unsynchronizedGetNumberOfQueuedBuffers();
+	}
+
+	@Override
 	public String toString() {
 		return String.format("PipelinedSubpartitionView(index: %d) of ResultPartition %s",
 				parent.index,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -91,7 +91,7 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	}
 
 	@Override
-	public int unsafeGetSizeOfQueuedBuffer() {
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
 		return parent.unsynchronizedGetNumberOfQueuedBuffers();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -61,5 +61,5 @@ public interface ResultSubpartitionView {
 
 	boolean isAvailable();
 
-	int unsafeGetSizeOfQueuedBuffer();
+	int unsynchronizedGetNumberOfQueuedBuffers();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -60,4 +60,8 @@ public interface ResultSubpartitionView {
 	boolean nextBufferIsEvent();
 
 	boolean isAvailable();
+
+	default int unsafeGetSizeOfQueuedBuffer() {
+		return 0;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -61,7 +61,5 @@ public interface ResultSubpartitionView {
 
 	boolean isAvailable();
 
-	default int unsafeGetSizeOfQueuedBuffer() {
-		return 0;
-	}
+	int unsafeGetSizeOfQueuedBuffer();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -249,6 +249,14 @@ public abstract class InputChannel {
 	}
 
 	// ------------------------------------------------------------------------
+	// Metric related method
+	// ------------------------------------------------------------------------
+
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
+		return 0;
+	}
+
+	// ------------------------------------------------------------------------
 
 	/**
 	 * A combination of a {@link Buffer} and a flag indicating availability of further buffers,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -260,13 +260,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		}
 	}
 
-	int unSafeGetSizeOfQueuedBuffer() {
-		if (subpartitionView != null) {
-			try {
-				return subpartitionView.unsafeGetSizeOfQueuedBuffer();
-			} catch (Exception ignore) {
+	@Override
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
+		ResultSubpartitionView view = subpartitionView;
 
-			}
+		if (view != null) {
+			return subpartitionView.unsynchronizedGetNumberOfQueuedBuffers();
 		}
 
 		return 0;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -260,6 +260,18 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		}
 	}
 
+	int unSafeGetSizeOfQueuedBuffer() {
+		if (subpartitionView != null) {
+			try {
+				return subpartitionView.unsafeGetSizeOfQueuedBuffer();
+			} catch (Exception ignore) {
+
+			}
+		}
+
+		return 0;
+	}
+
 	@Override
 	public String toString() {
 		return "LocalInputChannel [" + partitionId + "]";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -265,7 +265,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		ResultSubpartitionView view = subpartitionView;
 
 		if (view != null) {
-			return subpartitionView.unsynchronizedGetNumberOfQueuedBuffers();
+			return view.unsynchronizedGetNumberOfQueuedBuffers();
 		}
 
 		return 0;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -430,6 +430,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		}
 	}
 
+	@Override
 	public int unsynchronizedGetNumberOfQueuedBuffers() {
 		return Math.max(0, receivedBuffers.size());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -278,11 +278,7 @@ public class SingleInputGate extends InputGate {
 				int totalBuffers = 0;
 
 				for (InputChannel channel : inputChannels.values()) {
-					if (channel instanceof RemoteInputChannel) {
-						totalBuffers += ((RemoteInputChannel) channel).getNumberOfQueuedBuffers();
-					} else if (channel instanceof LocalInputChannel) {
-						totalBuffers += ((LocalInputChannel) channel).unSafeGetSizeOfQueuedBuffer();
-					}
+					totalBuffers += channel.unsynchronizedGetNumberOfQueuedBuffers();
 				}
 
 				return  totalBuffers;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -280,6 +280,8 @@ public class SingleInputGate extends InputGate {
 				for (InputChannel channel : inputChannels.values()) {
 					if (channel instanceof RemoteInputChannel) {
 						totalBuffers += ((RemoteInputChannel) channel).getNumberOfQueuedBuffers();
+					} else if (channel instanceof LocalInputChannel) {
+						totalBuffers += ((LocalInputChannel) channel).unSafeGetSizeOfQueuedBuffer();
 					}
 				}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -225,6 +225,11 @@ public class CancelPartitionRequestTest {
 		}
 
 		@Override
+		public int unsafeGetSizeOfQueuedBuffer() {
+			return 0;
+		}
+
+		@Override
 		public Throwable getFailureCause() {
 			return null;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -225,7 +225,7 @@ public class CancelPartitionRequestTest {
 		}
 
 		@Override
-		public int unsafeGetSizeOfQueuedBuffer() {
+		public int unsynchronizedGetNumberOfQueuedBuffers() {
 			return 0;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -559,8 +559,5 @@ public class LocalInputChannelTest {
 			return null;
 		}
 
-		public SingleInputGate getInputGate() {
-			return inputGate;
-		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -53,16 +53,13 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createLocalInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -430,97 +427,6 @@ public class LocalInputChannelTest {
 
 		channel.releaseAllResources();
 		assertFalse(channel.getNextBuffer().isPresent());
-	}
-
-	@Test
-	public void testQueuedNumberBuffers() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-		// Config
-		final int parallelism = 1;
-		final int producerBufferPoolSize = parallelism + 1;
-		final int numberOfBuffersPerChannel = 2;
-
-		checkArgument(parallelism >= 1);
-		checkArgument(producerBufferPoolSize >= parallelism);
-		checkArgument(numberOfBuffersPerChannel >= 1);
-
-		// Setup
-		// One thread per produced partition and one per consumer
-		final ExecutorService executor = Executors.newFixedThreadPool(2 * parallelism);
-
-		final NetworkBufferPool networkBuffers = new NetworkBufferPool(
-			(parallelism * producerBufferPoolSize) + (parallelism * parallelism),
-			TestBufferFactory.BUFFER_SIZE, 1);
-
-		final ResultPartitionManager partitionManager = new ResultPartitionManager();
-
-		final ResultPartitionID[] partitionIds = new ResultPartitionID[parallelism];
-		final TestPartitionProducer[] partitionProducers = new TestPartitionProducer[parallelism];
-
-		// Create all partitions
-		for (int i = 0; i < parallelism; i++) {
-			partitionIds[i] = new ResultPartitionID();
-
-			final ResultPartition partition = new ResultPartitionBuilder()
-				.setResultPartitionId(partitionIds[i])
-				.setNumberOfSubpartitions(parallelism)
-				.setNumTargetKeyGroups(parallelism)
-				.setResultPartitionManager(partitionManager)
-				.setSendScheduleOrUpdateConsumersMessage(true)
-				.setBufferPoolFactory(p ->
-					networkBuffers.createBufferPool(producerBufferPoolSize, producerBufferPoolSize))
-				.build();
-
-			// Create a buffer pool for this partition
-			partition.setup();
-
-			// Create the producer
-			partitionProducers[i] = new TestPartitionProducer(
-				partition,
-				false,
-				new TestPartitionProducerBufferSource(
-					parallelism,
-					partition.getBufferProvider(),
-					numberOfBuffersPerChannel)
-			);
-		}
-
-		// Test
-		try {
-			// Submit producer tasks
-			List<CompletableFuture<?>> results = Lists.newArrayListWithCapacity(
-				parallelism + 1);
-
-			for (int i = 0; i < parallelism; i++) {
-				results.add(CompletableFuture.supplyAsync(
-					CheckedSupplier.unchecked(partitionProducers[i]::call), executor));
-			}
-
-			// wait for produce complete
-			FutureUtils.waitForAll(results)
-				.get(60_000L, TimeUnit.MILLISECONDS);
-
-			// Create consumer & requestPartition
-			for (int i = 0; i < parallelism; i++) {
-				final TestLocalInputChannelConsumer consumer = new TestLocalInputChannelConsumer(
-					i,
-					parallelism,
-					numberOfBuffersPerChannel,
-					networkBuffers.createBufferPool(parallelism, parallelism),
-					partitionManager,
-					new TaskEventDispatcher(),
-					partitionIds);
-
-				consumer.getInputGate().requestPartitions();
-
-				// one is for EndOfPartitionEvent buffer
-				assertEquals(consumer.getInputGate().getNumberOfQueuedBuffers(), numberOfBuffersPerChannel + 1);
-			}
-		}
-		finally {
-			networkBuffers.destroyAllBufferPools();
-			networkBuffers.destroy();
-			executor.shutdown();
-		}
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -565,14 +565,14 @@ public class SingleInputGateTest extends InputGateTestBase {
 	public void testQueuedBuffers() throws Exception {
 		final NettyShuffleEnvironment network = createNettyShuffleEnvironment();
 
-		final ResultPartition localResultPartition = new ResultPartitionBuilder()
+		final ResultPartition resultPartition = new ResultPartitionBuilder()
 			.setResultPartitionManager(network.getResultPartitionManager())
 			.setupBufferPoolFactoryFromNettyShuffleEnvironment(network)
 			.build();
 
 		final SingleInputGate inputGate = createInputGate(network, 2, ResultPartitionType.PIPELINED);
 
-		final ResultPartitionID localResultPartitionId = localResultPartition.getPartitionId();
+		final ResultPartitionID localResultPartitionId = resultPartition.getPartitionId();
 
 		final RemoteInputChannel remoteInputChannel = InputChannelBuilder.newBuilder()
 			.setChannelIndex(1)
@@ -588,20 +588,19 @@ public class SingleInputGateTest extends InputGateTestBase {
 			.buildLocalAndSetToGate(inputGate);
 
 		try {
-			localResultPartition.setup();
+			resultPartition.setup();
 			inputGate.setup();
 
 			remoteInputChannel.onBuffer(TestBufferFactory.createBuffer(1), 0, 0);
 			assertEquals(1, inputGate.getNumberOfQueuedBuffers());
 
-			localResultPartition.addBufferConsumer(BufferBuilderTestUtils.createFilledBufferConsumer(1), 0);
+			resultPartition.addBufferConsumer(BufferBuilderTestUtils.createFilledBufferConsumer(1), 0);
 			assertEquals(2, inputGate.getNumberOfQueuedBuffers());
 		} finally {
-			localResultPartition.release();
+			resultPartition.release();
 			inputGate.close();
 			network.close();
 		}
-
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.TestingConnectionManager;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
@@ -41,6 +42,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.io.network.util.TestTaskEvent;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -557,6 +559,57 @@ public class SingleInputGateTest extends InputGateTestBase {
 			inputGate.close();
 			network.close();
 		}
+	}
+
+	@Test
+	public void testQueuedBuffers() throws Exception {
+		final NettyShuffleEnvironment network = createNettyShuffleEnvironment();
+
+		final ResultPartition localResultPartition = new ResultPartitionBuilder()
+			.setResultPartitionManager(network.getResultPartitionManager())
+			.setupBufferPoolFactoryFromNettyShuffleEnvironment(network)
+			.build();
+
+		final ResultPartition remoteResultPartition = new ResultPartitionBuilder()
+			.setResultPartitionManager(network.getResultPartitionManager())
+			.setupBufferPoolFactoryFromNettyShuffleEnvironment(network)
+			.build();
+
+		localResultPartition.setup();
+		remoteResultPartition.setup();
+
+		final SingleInputGate inputGate = createInputGate(network, 2, ResultPartitionType.PIPELINED);
+
+		try {
+			final ResultPartitionID localResultPartitionId = localResultPartition.getPartitionId();
+			addUnknownInputChannel(network, inputGate, localResultPartitionId, 0);
+			LocalInputChannel localInputChannel = InputChannelBuilder.newBuilder()
+				.setChannelIndex(0)
+				.setPartitionId(localResultPartitionId)
+				.setupFromNettyShuffleEnvironment(network)
+				.setConnectionManager(new TestingConnectionManager())
+				.buildLocalAndSetToGate(inputGate);
+
+			final ResultPartitionID remoteResultPartitionId = remoteResultPartition.getPartitionId();
+			RemoteInputChannel remoteInputChannel = InputChannelBuilder.newBuilder()
+				.setChannelIndex(1)
+				.setPartitionId(remoteResultPartitionId)
+				.setupFromNettyShuffleEnvironment(network)
+				.setConnectionManager(new TestingConnectionManager())
+				.buildRemoteAndSetToGate(inputGate);
+
+			inputGate.setup();
+
+			remoteInputChannel.onBuffer(TestBufferFactory.createBuffer(1), 0, 0);
+			assertEquals(1, inputGate.getNumberOfQueuedBuffers());
+
+			localResultPartition.addBufferConsumer(BufferBuilderTestUtils.createBufferBuilder(1).createBufferConsumer(), 0);
+			assertEquals(2, inputGate.getNumberOfQueuedBuffers());
+		} finally {
+			inputGate.close();
+			network.close();
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Take localInputChannel into account when complute inputQueueLength.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
