### PR TITLE
[FLINK-12588][python] Add TableSchema for Python Table API.

### DIFF
--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -115,6 +115,8 @@ def import_flink_view(gateway):
     java_import(gateway.jvm, "org.apache.flink.table.sources.*")
     java_import(gateway.jvm, "org.apache.flink.table.sinks.*")
     java_import(gateway.jvm, "org.apache.flink.table.python.*")
+    java_import(gateway.jvm, "org.apache.flink.table.types.*")
+    java_import(gateway.jvm, "org.apache.flink.table.types.logical.*")
     java_import(gateway.jvm, "org.apache.flink.python.bridge.*")
     java_import(gateway.jvm, "org.apache.flink.api.common.typeinfo.TypeInformation")
     java_import(gateway.jvm, "org.apache.flink.api.common.typeinfo.Types")

--- a/flink-python/pyflink/table/__init__.py
+++ b/flink-python/pyflink/table/__init__.py
@@ -41,6 +41,7 @@ from pyflink.table.table_source import TableSource, CsvTableSource
 from pyflink.table.types import DataTypes, UserDefinedType, Row
 from pyflink.table.window import Tumble, Session, Slide, Over
 from pyflink.table.table_descriptor import Rowtime, Schema, OldCsv, FileSystem, Kafka, Elasticsearch
+from pyflink.table.table_schema import TableSchema
 
 __all__ = [
     'TableEnvironment',
@@ -64,5 +65,6 @@ __all__ = [
     'UserDefinedType',
     'Row',
     'Kafka',
-    'Elasticsearch'
+    'Elasticsearch',
+    'TableSchema'
 ]

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -19,6 +19,7 @@ import sys
 
 from py4j.java_gateway import get_method
 from pyflink.java_gateway import get_gateway
+from pyflink.table.table_schema import TableSchema
 
 from pyflink.table.window import GroupWindow
 from pyflink.util.utils import to_jarray
@@ -531,6 +532,9 @@ class Table(object):
         gateway = get_gateway()
         j_table_path = to_jarray(gateway.jvm.String, table_path_continued)
         self._j_table.insertInto(table_path, j_table_path)
+
+    def get_schema(self):
+        return TableSchema(java_object=self._j_table.getSchema())
 
     def print_schema(self):
         """

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -534,7 +534,12 @@ class Table(object):
         self._j_table.insertInto(table_path, j_table_path)
 
     def get_schema(self):
-        return TableSchema(java_object=self._j_table.getSchema())
+        """
+        Returns the :class:`TableSchema` of this table.
+
+        :return: The schema of this table.
+        """
+        return TableSchema(j_table_schema=self._j_table.getSchema())
 
     def print_schema(self):
         """

--- a/flink-python/pyflink/table/table_descriptor.py
+++ b/flink-python/pyflink/table/table_descriptor.py
@@ -180,6 +180,15 @@ class Schema(Descriptor):
         super(Schema, self).__init__(self._j_schema)
 
     def schema(self, table_schema):
+        """
+        Sets the schema with field names and the types. Required.
+
+        This method overwrites existing fields added with
+        :func:`~pyflink.table.table_descriptor.Schema.field`.
+
+        :param schema: The :class:`TableSchema` object.
+        :return: This schema object.
+        """
         self._j_schema = self._j_schema.schema(table_schema._j_table_schema)
         return self
 
@@ -292,6 +301,15 @@ class OldCsv(FormatDescriptor):
         return self
 
     def schema(self, schema):
+        """
+        Sets the schema with field names and the types. Required.
+
+        This method overwrites existing fields added with
+        :func:`~pyflink.table.table_descriptor.OldCsv.field`.
+
+        :param schema: The :class:`TableSchema` object.
+        :return: This schema object.
+        """
         self._j_csv = self._j_csv.schema(schema._j_table_schema)
         return self
 

--- a/flink-python/pyflink/table/table_descriptor.py
+++ b/flink-python/pyflink/table/table_descriptor.py
@@ -179,6 +179,10 @@ class Schema(Descriptor):
         self._j_schema = gateway.jvm.Schema()
         super(Schema, self).__init__(self._j_schema)
 
+    def schema(self, table_schema):
+        self._j_schema = self._j_schema.schema(table_schema._j_table_schema)
+        return self
+
     def field(self, field_name, field_type):
         """
         Adds a field with the field name and the data type or type string. Required.
@@ -285,6 +289,10 @@ class OldCsv(FormatDescriptor):
         :return: This :class:`OldCsv` object.
         """
         self._j_csv = self._j_csv.lineDelimiter(delimiter)
+        return self
+
+    def schema(self, schema):
+        self._j_csv = self._j_csv.schema(schema._j_table_schema)
         return self
 
     def field(self, field_name, field_type):

--- a/flink-python/pyflink/table/table_descriptor.py
+++ b/flink-python/pyflink/table/table_descriptor.py
@@ -186,7 +186,7 @@ class Schema(Descriptor):
         This method overwrites existing fields added with
         :func:`~pyflink.table.table_descriptor.Schema.field`.
 
-        :param schema: The :class:`TableSchema` object.
+        :param table_schema: The :class:`TableSchema` object.
         :return: This schema object.
         """
         self._j_schema = self._j_schema.schema(table_schema._j_table_schema)
@@ -300,17 +300,17 @@ class OldCsv(FormatDescriptor):
         self._j_csv = self._j_csv.lineDelimiter(delimiter)
         return self
 
-    def schema(self, schema):
+    def schema(self, table_schema):
         """
         Sets the schema with field names and the types. Required.
 
         This method overwrites existing fields added with
         :func:`~pyflink.table.table_descriptor.OldCsv.field`.
 
-        :param schema: The :class:`TableSchema` object.
+        :param table_schema: The :class:`TableSchema` object.
         :return: This schema object.
         """
-        self._j_csv = self._j_csv.schema(schema._j_table_schema)
+        self._j_csv = self._j_csv.schema(table_schema._j_table_schema)
         return self
 
     def field(self, field_name, field_type):

--- a/flink-python/pyflink/table/table_schema.py
+++ b/flink-python/pyflink/table/table_schema.py
@@ -24,6 +24,8 @@ from pyflink.util.utils import to_jarray
 if sys.version >= '3':
     unicode = str
 
+__all__ = ['TableSchema']
+
 
 class TableSchema(object):
     """

--- a/flink-python/pyflink/table/table_schema.py
+++ b/flink-python/pyflink/table/table_schema.py
@@ -1,0 +1,236 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import sys
+
+from pyflink.java_gateway import get_gateway
+from pyflink.table.types import _to_java_type, _to_python_type
+from pyflink.util.utils import to_jarray
+
+if sys.version >= '3':
+    unicode = str
+
+
+class TableSchema(object):
+    """
+    A table schema that represents a table's structure with field names and data types.
+    """
+
+    def __init__(self, field_names=None, data_types=None, java_object=None):
+        if java_object is None:
+            gateway = get_gateway()
+            j_field_names = to_jarray(gateway.jvm.String, field_names)
+            j_data_types = to_jarray(gateway.jvm.TypeInformation,
+                                     [_to_java_type(item) for item in data_types])
+            self._j_table_schema = gateway.jvm.TableSchema(j_field_names, j_data_types)
+        else:
+            self._j_table_schema = java_object
+
+    def copy(self):
+        """
+        Returns a deep copy of the table schema.
+
+        :return: A deep copy of the table schema.
+        """
+        return TableSchema(java_object=self._j_table_schema.copy())
+
+    def get_field_types(self):
+        """
+        Returns all field data types as an array.
+
+        .. note::
+            Deprecated.
+            Use :func:`pyflink.table.table_schema.TableSchema.get_field_data_types` instead.
+
+
+        :return: A list of all field data types.
+        """
+        return [_to_python_type(item) for item in self._j_table_schema.getFieldTypes()]
+
+    def get_field_data_types(self):
+        """
+        Returns all field data types as an array.
+
+        :return: A list of all field data types.
+        """
+        return [_to_python_type(item) for item in self._j_table_schema.getFieldDataTypes()]
+
+    def get_field_data_type(self, field):
+        """
+        Returns the specified data type for the given field index or field name.
+
+        :param field: The index of the field or the name of the field.
+        :return: The specified data type.
+        """
+        if not isinstance(field, (int, str, unicode)):
+            raise TypeError("not supported data type: %s" % type(field))
+        optional_result = self._j_table_schema.getFieldDataType(field)
+        if optional_result.isPresent():
+            return _to_python_type(optional_result.get())
+        else:
+            return None
+
+    def get_field_type(self, field):
+        """
+        Returns the specified data type for the given field index or field name.
+
+        .. note::
+            Deprecated.
+            Use :func:`pyflink.table.table_schema.TableSchema.get_field_data_type` instead.
+
+        :param field: The index of the field or the name of the field.
+        :return: The specified data type.
+        """
+        if not isinstance(field, (int, str, unicode)):
+            raise TypeError("not supported data type: %s" % type(field))
+        optional_result = self._j_table_schema.getFieldType(field)
+        if optional_result.isPresent():
+            return _to_python_type(optional_result.get())
+        else:
+            return None
+
+    def get_field_count(self):
+        """
+        Returns the number of fields.
+
+        :return: The number of fields.
+        """
+        return self._j_table_schema.getFieldCount()
+
+    def get_field_names(self):
+        """
+        Returns all field names as a list.
+
+        :return: The list of all field names.
+        """
+        return list(self._j_table_schema.getFieldNames())
+
+    def get_field_name(self, field_index):
+        """
+        Returns the specified name for the given field index.
+
+        :param field_index: The index of the field.
+        :return: The field name.
+        """
+        optional_result = self._j_table_schema.getFieldName(field_index)
+        if optional_result.isPresent():
+            return optional_result.get()
+        else:
+            return None
+
+    def to_row_data_type(self):
+        """
+        Converts a table schema into a (nested) data type describing a
+        :func:`pyflink.table.types.DataTypes.ROW`.
+
+        :return: The row data type.
+        """
+        return _to_python_type(self._j_table_schema.toRowDataType())
+
+    def to_row_type(self):
+        """
+        Converts a table schema into a (nested) data type describing a
+        :func:`pyflink.table.types.DataTypes.ROW`.
+
+        .. note::
+            Deprecated.
+            Use :func:`pyflink.table.table_schema.TableSchema.to_row_data_type` instead.
+
+        :return: The row data type.
+        """
+        return _to_python_type(self._j_table_schema.toRowType())
+
+    def __repr__(self):
+        if self._j_table_schema is not None:
+            return self._j_table_schema.toString()
+        else:
+            return super(TableSchema, self).__repr__()
+
+    def __str__(self):
+        if self._j_table_schema is not None:
+            return self._j_table_schema.toString()
+        else:
+            return super(TableSchema, self).__str__()
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._j_table_schema == other._j_table_schema
+
+    def __hash__(self):
+        if self._j_table_schema is not None:
+            return self._j_table_schema.hashCode()
+        else:
+            return super(TableSchema, self).__hash__()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    @classmethod
+    def from_type_info(cls, data_type):
+        """
+        Creates a table schema from a :class:`DataType` instance. If the type information is
+        a composite type, the field names and types for the composite type are used to
+        construct the :class:`TableSchema` instance. Otherwise, a table schema with a single field
+        is created. The field name is "f0" and the field type the provided type.
+
+        ..note::
+            Deprecated.
+            This method will be removed soon. Use :class:`DataTypes` to declare types.
+
+        :param data_type: The data type from which the table schema is generated.
+        :return: The table schema that was generated from the given :class:`DataType`.
+        """
+        gateway = get_gateway()
+        return TableSchema(
+            java_object=gateway.jvm.TableSchema.fromTypeInfo(_to_java_type(data_type)))
+
+    @classmethod
+    def builder(cls):
+        return TableSchema.Builder()
+
+    class Builder(object):
+        """
+        Builder for creating a :class:`TableSchema`.
+
+        """
+
+        def __init__(self):
+            self._field_names = []
+            self._field_data_types = []
+
+        def field(self, name, data_type):
+            """
+            Add a field with name and data type.
+
+            The call order of this method determines the order of fields in the schema.
+
+            :param name: The field name.
+            :param data_type: The field data type.
+            :return: This object.
+            """
+            assert name is not None
+            assert data_type is not None
+            self._field_names.append(name)
+            self._field_data_types.append(data_type)
+            return self
+
+        def build(self):
+            """
+            Returns a :class:`TableSchema` instance.
+
+            :return: The :class:`TableSchema` instance.
+            """
+            return TableSchema(self._field_names, self._field_data_types)

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -103,7 +103,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         a.fromstring('ABCD')
         t = t_env.from_elements(
             [(1, 1.0, "hi", "hello", datetime.date(1970, 1, 2), datetime.time(1, 0, 0),
-             datetime.datetime(1970, 1, 2, 0, 0), [1.0, 2.0], array.array("d", [1.0, 2.0]),
+             datetime.datetime(1970, 1, 2, 0, 0), [1.0, None], array.array("d", [1.0, 2.0]),
              ["abc"], [datetime.date(1970, 1, 2)], Decimal(1), Row("a", "b")(1, 2.0),
              {"key": 1.0}, a, ExamplePoint(1.0, 2.0),
              PythonOnlyPoint(3.0, 4.0))])
@@ -131,7 +131,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         t_env.execute()
         actual = source_sink_utils.results()
 
-        expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,[1.0, 2.0],'
+        expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,[1.0, null],'
                     '[1.0, 2.0],[abc],[1970-01-02],1,1,2.0,{key=1.0},[65, 66, 67, 68],[1.0, 2.0],'
                     '[3.0, 4.0]']
         self.assert_equals(actual, expected)

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -113,7 +113,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
                        DataTypes.STRING(), DataTypes.DATE(),
                        DataTypes.TIME(),
                        DataTypes.TIMESTAMP(),
-                       DataTypes.ARRAY(DataTypes.DOUBLE()),
+                       DataTypes.ARRAY(DataTypes.DOUBLE().not_null()),
                        DataTypes.ARRAY(DataTypes.STRING()),
                        DataTypes.ARRAY(DataTypes.DATE()),
                        DataTypes.DECIMAL(),

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -103,17 +103,18 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         a.fromstring('ABCD')
         t = t_env.from_elements(
             [(1, 1.0, "hi", "hello", datetime.date(1970, 1, 2), datetime.time(1, 0, 0),
-             datetime.datetime(1970, 1, 2, 0, 0), array.array("d", [1]), ["abc"],
-             [datetime.date(1970, 1, 2)], Decimal(1), Row("a", "b")(1, 2.0),
+             datetime.datetime(1970, 1, 2, 0, 0), [1.0, 2.0], array.array("d", [1.0, 2.0]),
+             ["abc"], [datetime.date(1970, 1, 2)], Decimal(1), Row("a", "b")(1, 2.0),
              {"key": 1.0}, a, ExamplePoint(1.0, 2.0),
              PythonOnlyPoint(3.0, 4.0))])
         field_names = ["a", "b", "c", "d", "e", "f", "g", "h",
-                       "i", "j", "k", "l", "m", "n", "o", "p"]
+                       "i", "j", "k", "l", "m", "n", "o", "p", "q"]
         field_types = [DataTypes.BIGINT(), DataTypes.DOUBLE(), DataTypes.STRING(),
                        DataTypes.STRING(), DataTypes.DATE(),
                        DataTypes.TIME(),
                        DataTypes.TIMESTAMP(),
-                       DataTypes.ARRAY(DataTypes.DOUBLE().not_null()),
+                       DataTypes.ARRAY(DataTypes.DOUBLE()),
+                       DataTypes.ARRAY(DataTypes.DOUBLE(False)),
                        DataTypes.ARRAY(DataTypes.STRING()),
                        DataTypes.ARRAY(DataTypes.DATE()),
                        DataTypes.DECIMAL(),
@@ -130,8 +131,9 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         t_env.execute()
         actual = source_sink_utils.results()
 
-        expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,[1.0],[abc],'
-                    '[1970-01-02],1,1,2.0,{key=1.0},[65, 66, 67, 68],[1.0, 2.0],[3.0, 4.0]']
+        expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,[1.0, 2.0],'
+                    '[1.0, 2.0],[abc],[1970-01-02],1,1,2.0,{key=1.0},[65, 66, 67, 68],[1.0, 2.0],'
+                    '[3.0, 4.0]']
         self.assert_equals(actual, expected)
 
 

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -19,6 +19,7 @@ import os
 
 from pyflink.table.table_descriptor import (FileSystem, OldCsv, Rowtime, Schema, Kafka,
                                             Elasticsearch)
+from pyflink.table.table_schema import TableSchema
 from pyflink.table.table_sink import CsvTableSink
 from pyflink.table.types import DataTypes
 from pyflink.testing.test_case_utils import (PyFlinkTestCase, PyFlinkStreamTableTestCase,
@@ -506,6 +507,22 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         assert properties == expected
 
+    def test_schema(self):
+        csv = OldCsv()
+        schema = TableSchema(["a", "b"], [DataTypes.INT(), DataTypes.STRING()])
+
+        csv = csv.schema(schema)
+
+        properties = csv.to_properties()
+        expected = {'format.fields.0.name': 'a',
+                    'format.fields.0.type': 'INT',
+                    'format.fields.1.name': 'b',
+                    'format.fields.1.type': 'VARCHAR',
+                    'format.type': 'csv',
+                    'format.property-version': '1'}
+
+        assert properties == expected
+
 
 class RowTimeDescriptorTests(PyFlinkTestCase):
 
@@ -736,6 +753,19 @@ class SchemaDescriptorTests(PyFlinkTestCase):
                     'schema.2.rowtime.watermarks.delay': '5000',
                     'schema.3.name': 'string_field',
                     'schema.3.type': 'VARCHAR'}
+        assert properties == expected
+
+    def test_schema(self):
+        schema = Schema()
+        table_schema = TableSchema(["a", "b"], [DataTypes.INT(), DataTypes.STRING()])
+
+        schema = schema.schema(table_schema)
+
+        properties = schema.to_properties()
+        expected = {'schema.0.name': 'a',
+                    'schema.0.type': 'INT',
+                    'schema.1.name': 'b',
+                    'schema.1.type': 'VARCHAR'}
         assert properties == expected
 
 

--- a/flink-python/pyflink/table/tests/test_schema_operation.py
+++ b/flink-python/pyflink/table/tests/test_schema_operation.py
@@ -15,9 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
-import os
-
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import DataTypes
 from pyflink.testing import source_sink_utils
@@ -52,7 +49,7 @@ class StreamTableSchemaTests(PyFlinkStreamTableTestCase):
         result = t.group_by("c").select("a.sum as a, c as b")
         schema = result.get_schema()
 
-        assert schema == TableSchema(["a", "b"], [DataTypes.INT(), DataTypes.STRING()])
+        assert schema == TableSchema(["a", "b"], [DataTypes.BIGINT(), DataTypes.STRING()])
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_schema_operation.py
+++ b/flink-python/pyflink/table/tests/test_schema_operation.py
@@ -16,6 +16,9 @@
 # limitations under the License.
 ################################################################################
 
+import os
+
+from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import DataTypes
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
@@ -35,6 +38,21 @@ class StreamTableSchemaTests(PyFlinkStreamTableTestCase):
 
         result = t.group_by("c").select("a.sum, c as b")
         result.print_schema()
+
+    def test_get_schema(self):
+        t_env = self.t_env
+        t = t_env.from_elements([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hello'), (2, 'Hello', 'Hello')],
+                                ['a', 'b', 'c'])
+        field_names = ["a", "b"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING()]
+        t_env.register_table_sink(
+            "Results",
+            field_names, field_types, source_sink_utils.TestRetractSink())
+
+        result = t.group_by("c").select("a.sum as a, c as b")
+        schema = result.get_schema()
+
+        assert schema == TableSchema(["a", "b"], [DataTypes.INT(), DataTypes.STRING()])
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_table_schema.py
+++ b/flink-python/pyflink/table/tests/test_table_schema.py
@@ -1,0 +1,199 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.table.types import DataTypes
+from pyflink.table.table_schema import TableSchema
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class TableSchemaTests(PyFlinkTestCase):
+
+    def test_init(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        assert schema.get_field_count() == 3
+        assert schema.get_field_names() == ["a", "b", "c"]
+        assert schema.get_field_types() == [DataTypes.INT(),
+                                            DataTypes.BIGINT(),
+                                            DataTypes.STRING()]
+
+    def test_copy(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        copied_schema = schema.copy()
+
+        assert schema == copied_schema
+        copied_schema._j_table_schema = None
+        assert schema != copied_schema
+
+    def test_get_field_types(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        types = schema.get_field_types()
+
+        assert types == [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()]
+
+    def test_get_field_data_types(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        types = schema.get_field_data_types()
+
+        assert types == [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()]
+
+    def test_get_field_type(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        type_by_name = schema.get_field_type("b")
+        type_by_index = schema.get_field_type(2)
+        type_by_name_not_exist = schema.get_field_type("d")
+        type_by_index_not_exist = schema.get_field_type(6)
+        with self.assertRaises(TypeError):
+            schema.get_field_type(None)
+
+        assert type_by_name == DataTypes.BIGINT()
+        assert type_by_index == DataTypes.STRING()
+        assert type_by_name_not_exist is None
+        assert type_by_index_not_exist is None
+
+    def test_get_field_data_type(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        type_by_name = schema.get_field_data_type("b")
+        type_by_index = schema.get_field_data_type(2)
+        type_by_name_not_exist = schema.get_field_data_type("d")
+        type_by_index_not_exist = schema.get_field_data_type(6)
+        with self.assertRaises(TypeError):
+            schema.get_field_data_type(None)
+
+        assert type_by_name == DataTypes.BIGINT()
+        assert type_by_index == DataTypes.STRING()
+        assert type_by_name_not_exist is None
+        assert type_by_index_not_exist is None
+
+    def test_get_field_count(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        count = schema.get_field_count()
+
+        assert count == 3
+
+    def test_get_field_names(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        names = schema.get_field_names()
+
+        assert names == ["a", "b", "c"]
+
+    def test_get_field_name(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        field_name = schema.get_field_name(2)
+        field_name_not_exist = schema.get_field_name(3)
+
+        assert field_name == "c"
+        assert field_name_not_exist is None
+
+    def test_to_row_data_type(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        row_type = schema.to_row_data_type()
+
+        expected = DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
+                                  DataTypes.FIELD("b", DataTypes.BIGINT()),
+                                  DataTypes.FIELD("c", DataTypes.STRING())])
+        assert row_type == expected
+
+    def test_to_row_type(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        row_type = schema.to_row_type()
+
+        expected = DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
+                                  DataTypes.FIELD("b", DataTypes.BIGINT()),
+                                  DataTypes.FIELD("c", DataTypes.STRING())])
+        assert row_type == expected
+
+    def test_from_type_info(self):
+        schema = TableSchema.from_type_info(DataTypes.ROW(
+            [DataTypes.FIELD("a", DataTypes.INT()),
+             DataTypes.FIELD("b", DataTypes.BIGINT()),
+             DataTypes.FIELD("c", DataTypes.STRING())]))
+
+        assert schema.get_field_count() == 3
+        assert schema.get_field_names() == ["a", "b", "c"]
+        assert schema.get_field_types() == [DataTypes.INT(),
+                                            DataTypes.BIGINT(),
+                                            DataTypes.STRING()]
+
+    def test_hash(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema2 = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        assert hash(schema) == hash(schema2)
+
+    def test_str(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        assert str(schema) == "root\n |-- a: INT\n |-- b: BIGINT\n |-- c: STRING\n"
+
+    def test_repr(self):
+        schema = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+
+        assert repr(schema) == "root\n |-- a: INT\n |-- b: BIGINT\n |-- c: STRING\n"
+
+    def test_builder(self):
+        schema_builder = TableSchema.builder()
+
+        schema = schema_builder \
+            .field("a", DataTypes.INT())\
+            .field("b", DataTypes.BIGINT())\
+            .field("c", DataTypes.STRING()).build()
+
+        expected = \
+            TableSchema(["a", "b", "c"],
+                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        assert schema == expected

--- a/flink-python/pyflink/table/tests/test_table_schema.py
+++ b/flink-python/pyflink/table/tests/test_table_schema.py
@@ -29,9 +29,9 @@ class TableSchemaTests(PyFlinkTestCase):
 
         assert schema.get_field_count() == 3
         assert schema.get_field_names() == ["a", "b", "c"]
-        assert schema.get_field_types() == [DataTypes.INT(),
-                                            DataTypes.BIGINT(),
-                                            DataTypes.STRING()]
+        assert schema.get_field_data_types() == [DataTypes.INT(),
+                                                 DataTypes.BIGINT(),
+                                                 DataTypes.STRING()]
 
     def test_copy(self):
         schema = \
@@ -44,15 +44,6 @@ class TableSchemaTests(PyFlinkTestCase):
         copied_schema._j_table_schema = None
         assert schema != copied_schema
 
-    def test_get_field_types(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
-
-        types = schema.get_field_types()
-
-        assert types == [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()]
-
     def test_get_field_data_types(self):
         schema = \
             TableSchema(["a", "b", "c"],
@@ -61,23 +52,6 @@ class TableSchemaTests(PyFlinkTestCase):
         types = schema.get_field_data_types()
 
         assert types == [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()]
-
-    def test_get_field_type(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
-
-        type_by_name = schema.get_field_type("b")
-        type_by_index = schema.get_field_type(2)
-        type_by_name_not_exist = schema.get_field_type("d")
-        type_by_index_not_exist = schema.get_field_type(6)
-        with self.assertRaises(TypeError):
-            schema.get_field_type(None)
-
-        assert type_by_name == DataTypes.BIGINT()
-        assert type_by_index == DataTypes.STRING()
-        assert type_by_name_not_exist is None
-        assert type_by_index_not_exist is None
 
     def test_get_field_data_type(self):
         schema = \
@@ -136,30 +110,6 @@ class TableSchemaTests(PyFlinkTestCase):
                                   DataTypes.FIELD("b", DataTypes.BIGINT()),
                                   DataTypes.FIELD("c", DataTypes.STRING())])
         assert row_type == expected
-
-    def test_to_row_type(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
-
-        row_type = schema.to_row_type()
-
-        expected = DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
-                                  DataTypes.FIELD("b", DataTypes.BIGINT()),
-                                  DataTypes.FIELD("c", DataTypes.STRING())])
-        assert row_type == expected
-
-    def test_from_type_info(self):
-        schema = TableSchema.from_type_info(DataTypes.ROW(
-            [DataTypes.FIELD("a", DataTypes.INT()),
-             DataTypes.FIELD("b", DataTypes.BIGINT()),
-             DataTypes.FIELD("c", DataTypes.STRING())]))
-
-        assert schema.get_field_count() == 3
-        assert schema.get_field_names() == ["a", "b", "c"]
-        assert schema.get_field_types() == [DataTypes.INT(),
-                                            DataTypes.BIGINT(),
-                                            DataTypes.STRING()]
 
     def test_hash(self):
         schema = \

--- a/flink-python/pyflink/table/tests/test_table_schema.py
+++ b/flink-python/pyflink/table/tests/test_table_schema.py
@@ -23,9 +23,8 @@ from pyflink.testing.test_case_utils import PyFlinkTestCase
 class TableSchemaTests(PyFlinkTestCase):
 
     def test_init(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         assert schema.get_field_count() == 3
         assert schema.get_field_names() == ["a", "b", "c"]
@@ -34,9 +33,8 @@ class TableSchemaTests(PyFlinkTestCase):
                                                  DataTypes.STRING()]
 
     def test_copy(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         copied_schema = schema.copy()
 
@@ -45,18 +43,16 @@ class TableSchemaTests(PyFlinkTestCase):
         assert schema != copied_schema
 
     def test_get_field_data_types(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         types = schema.get_field_data_types()
 
         assert types == [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()]
 
     def test_get_field_data_type(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         type_by_name = schema.get_field_data_type("b")
         type_by_index = schema.get_field_data_type(2)
@@ -71,27 +67,24 @@ class TableSchemaTests(PyFlinkTestCase):
         assert type_by_index_not_exist is None
 
     def test_get_field_count(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         count = schema.get_field_count()
 
         assert count == 3
 
     def test_get_field_names(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         names = schema.get_field_names()
 
         assert names == ["a", "b", "c"]
 
     def test_get_field_name(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         field_name = schema.get_field_name(2)
         field_name_not_exist = schema.get_field_name(3)
@@ -100,9 +93,8 @@ class TableSchemaTests(PyFlinkTestCase):
         assert field_name_not_exist is None
 
     def test_to_row_data_type(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         row_type = schema.to_row_data_type()
 
@@ -112,26 +104,22 @@ class TableSchemaTests(PyFlinkTestCase):
         assert row_type == expected
 
     def test_hash(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
-        schema2 = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema2 = TableSchema(["a", "b", "c"],
+                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         assert hash(schema) == hash(schema2)
 
     def test_str(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         assert str(schema) == "root\n |-- a: INT\n |-- b: BIGINT\n |-- c: STRING\n"
 
     def test_repr(self):
-        schema = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        schema = TableSchema(["a", "b", "c"],
+                             [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         assert repr(schema) == "root\n |-- a: INT\n |-- b: BIGINT\n |-- c: STRING\n"
 
@@ -143,7 +131,6 @@ class TableSchemaTests(PyFlinkTestCase):
             .field("b", DataTypes.BIGINT())\
             .field("c", DataTypes.STRING()).build()
 
-        expected = \
-            TableSchema(["a", "b", "c"],
-                        [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
+        expected = TableSchema(["a", "b", "c"],
+                               [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
         assert schema == expected

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -30,7 +30,7 @@ from pyflink.table.types import (_infer_schema_from_data, _infer_type,
                                  _array_type_mappings, _merge_type,
                                  _create_type_verifier, UserDefinedType, DataTypes, Row, RowField,
                                  RowType, ArrayType, BigIntType, VarCharType, MapType, DataType,
-                                 _to_java_type, _to_python_type, TimestampKind)
+                                 _to_java_type, _from_java_type, TimestampKind)
 
 
 class ExamplePointUDT(UserDefinedType):
@@ -761,7 +761,7 @@ class DataTypeConvertTests(unittest.TestCase):
 
         java_types = [_to_java_type(item) for item in test_types]
 
-        converted_python_types = [_to_python_type(item) for item in java_types]
+        converted_python_types = [_from_java_type(item) for item in java_types]
 
         self.assertEqual(test_types, converted_python_types)
 
@@ -776,7 +776,7 @@ class DataTypeConvertTests(unittest.TestCase):
                       JDataTypes.CHAR(50).notNull(),
                       JDataTypes.DECIMAL(20, 10).notNull()]
 
-        converted_python_types = [_to_python_type(item) for item in java_types]
+        converted_python_types = [_from_java_type(item) for item in java_types]
 
         expected = [DataTypes.TIME(3, False).bridged_to("java.time.LocalTime"),
                     DataTypes.TIMESTAMP(TimestampKind.REGULAR, 5, False)
@@ -798,7 +798,7 @@ class DataTypeConvertTests(unittest.TestCase):
 
         java_types = [_to_java_type(item) for item in test_types]
 
-        converted_python_types = [_to_python_type(item) for item in java_types]
+        converted_python_types = [_from_java_type(item) for item in java_types]
 
         self.assertEqual(test_types, converted_python_types)
 
@@ -810,7 +810,7 @@ class DataTypeConvertTests(unittest.TestCase):
 
         java_types = [_to_java_type(item) for item in test_types]
 
-        converted_python_types = [_to_python_type(item) for item in java_types]
+        converted_python_types = [_from_java_type(item) for item in java_types]
 
         self.assertEqual(test_types, converted_python_types)
 
@@ -824,7 +824,7 @@ class DataTypeConvertTests(unittest.TestCase):
 
         java_types = [_to_java_type(item) for item in test_types]
 
-        converted_python_types = [_to_python_type(item) for item in java_types]
+        converted_python_types = [_from_java_type(item) for item in java_types]
 
         self.assertEqual(test_types, converted_python_types)
 
@@ -837,7 +837,7 @@ class DataTypeConvertTests(unittest.TestCase):
 
         java_types = [_to_java_type(item) for item in test_types]
 
-        converted_python_types = [_to_python_type(item) for item in java_types]
+        converted_python_types = [_from_java_type(item) for item in java_types]
 
         self.assertEqual(test_types, converted_python_types)
 

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -23,12 +23,14 @@ import pickle
 import sys
 import unittest
 
+from pyflink.java_gateway import get_gateway
 from pyflink.table.types import (_infer_schema_from_data, _infer_type,
                                  _array_signed_int_typecode_ctype_mappings,
                                  _array_unsigned_int_typecode_ctype_mappings,
                                  _array_type_mappings, _merge_type,
                                  _create_type_verifier, UserDefinedType, DataTypes, Row, RowField,
-                                 RowType, ArrayType, BigIntType, VarCharType, MapType)
+                                 RowType, ArrayType, BigIntType, VarCharType, MapType, DataType,
+                                 _to_java_type, _to_python_type, TimestampKind)
 
 
 class ExamplePointUDT(UserDefinedType):
@@ -531,6 +533,20 @@ class TypesTests(unittest.TestCase):
         row_class = Row("c1", "c2")
         self.assertRaises(ValueError, lambda: row_class(1, 2, 3))
 
+    def test_nullable(self):
+        t = DataType(nullable=False)
+
+        self.assertEqual(t._nullable, False)
+        t_nullable = t.nullable()
+        self.assertEqual(t_nullable._nullable, True)
+
+    def test_not_null(self):
+        t = DataType(nullable=True)
+
+        self.assertEqual(t._nullable, True)
+        t_notnull = t.not_null()
+        self.assertEqual(t_notnull._nullable, False)
+
 
 class DataTypeVerificationTests(unittest.TestCase):
 
@@ -725,6 +741,105 @@ class DataTypeVerificationTests(unittest.TestCase):
             msg = "verify_type(%s, %s, nullable=False) == %s" % (obj, data_type, exp)
             with self.assertRaises(exp, msg=msg):
                 _create_type_verifier(data_type.not_null())(obj)
+
+
+class DataTypeConvertTests(unittest.TestCase):
+
+    def test_basic_type(self):
+        test_types = [DataTypes.STRING(),
+                      DataTypes.BOOLEAN(),
+                      DataTypes.BYTES(),
+                      DataTypes.TINYINT(),
+                      DataTypes.SMALLINT(),
+                      DataTypes.INT(),
+                      DataTypes.BIGINT(),
+                      DataTypes.FLOAT(),
+                      DataTypes.DOUBLE(),
+                      DataTypes.DATE(),
+                      DataTypes.TIME(),
+                      DataTypes.TIMESTAMP()]
+
+        java_types = [_to_java_type(item) for item in test_types]
+
+        converted_python_types = [_to_python_type(item) for item in java_types]
+
+        self.assertEqual(test_types, converted_python_types)
+
+    def test_atomic_type_with_data_type_with_parameters(self):
+        gateway = get_gateway()
+        JDataTypes = gateway.jvm.DataTypes
+        java_types = [JDataTypes.TIME(3).notNull(),
+                      JDataTypes.TIMESTAMP(5).notNull(),
+                      JDataTypes.VARBINARY(100).notNull(),
+                      JDataTypes.BINARY(2).notNull(),
+                      JDataTypes.VARCHAR(30).notNull(),
+                      JDataTypes.CHAR(50).notNull(),
+                      JDataTypes.DECIMAL(20, 10).notNull()]
+
+        converted_python_types = [_to_python_type(item) for item in java_types]
+
+        expected = [DataTypes.TIME(3, False).bridged_to("java.time.LocalTime"),
+                    DataTypes.TIMESTAMP(TimestampKind.REGULAR, 5, False)
+                             .bridged_to("java.time.LocalDateTime"),
+                    DataTypes.VARBINARY(100, False),
+                    DataTypes.BINARY(2, False),
+                    DataTypes.VARCHAR(30, False),
+                    DataTypes.CHAR(50, False),
+                    DataTypes.DECIMAL(20, 10, False)]
+        self.assertEqual(converted_python_types, expected)
+
+    def test_array_type(self):
+        test_types = [DataTypes.ARRAY(DataTypes.BIGINT()),
+                      # array type with not null basic data type means primitive array
+                      DataTypes.ARRAY(DataTypes.BIGINT().not_null()),
+                      DataTypes.ARRAY(DataTypes.STRING()),
+                      DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT())),
+                      DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING()))]
+
+        java_types = [_to_java_type(item) for item in test_types]
+
+        converted_python_types = [_to_python_type(item) for item in java_types]
+
+        self.assertEqual(test_types, converted_python_types)
+
+    def test_multiset_type(self):
+        test_types = [DataTypes.MULTISET(DataTypes.BIGINT()),
+                      DataTypes.MULTISET(DataTypes.STRING()),
+                      DataTypes.MULTISET(DataTypes.MULTISET(DataTypes.BIGINT())),
+                      DataTypes.MULTISET(DataTypes.MULTISET(DataTypes.STRING()))]
+
+        java_types = [_to_java_type(item) for item in test_types]
+
+        converted_python_types = [_to_python_type(item) for item in java_types]
+
+        self.assertEqual(test_types, converted_python_types)
+
+    def test_map_type(self):
+        test_types = [DataTypes.MAP(DataTypes.BIGINT(), DataTypes.BIGINT()),
+                      DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()),
+                      DataTypes.MAP(DataTypes.STRING(),
+                                    DataTypes.MAP(DataTypes.STRING(), DataTypes.BIGINT())),
+                      DataTypes.MAP(DataTypes.STRING(),
+                                    DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()))]
+
+        java_types = [_to_java_type(item) for item in test_types]
+
+        converted_python_types = [_to_python_type(item) for item in java_types]
+
+        self.assertEqual(test_types, converted_python_types)
+
+    def test_row_type(self):
+        test_types = [DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
+                                     DataTypes.FIELD("b",
+                                                     DataTypes.ROW(
+                                                         [DataTypes.FIELD("c",
+                                                                          DataTypes.STRING())]))])]
+
+        java_types = [_to_java_type(item) for item in test_types]
+
+        converted_python_types = [_to_python_type(item) for item in java_types]
+
+        self.assertEqual(test_types, converted_python_types)
 
 
 if __name__ == "__main__":

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -769,7 +769,7 @@ class DataTypeConvertTests(unittest.TestCase):
         gateway = get_gateway()
         JDataTypes = gateway.jvm.DataTypes
         java_types = [JDataTypes.TIME(3).notNull(),
-                      JDataTypes.TIMESTAMP(5).notNull(),
+                      JDataTypes.TIMESTAMP().notNull(),
                       JDataTypes.VARBINARY(100).notNull(),
                       JDataTypes.BINARY(2).notNull(),
                       JDataTypes.VARCHAR(30).notNull(),
@@ -778,9 +778,8 @@ class DataTypeConvertTests(unittest.TestCase):
 
         converted_python_types = [_from_java_type(item) for item in java_types]
 
-        expected = [DataTypes.TIME(3, False).bridged_to("java.time.LocalTime"),
-                    DataTypes.TIMESTAMP(TimestampKind.REGULAR, 5, False)
-                             .bridged_to("java.time.LocalDateTime"),
+        expected = [DataTypes.TIME(3, False),
+                    DataTypes.TIMESTAMP(TimestampKind.REGULAR).not_null(),
                     DataTypes.VARBINARY(100, False),
                     DataTypes.BINARY(2, False),
                     DataTypes.VARCHAR(30, False),

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1373,8 +1373,8 @@ def _from_java_type(j_data_type):
             data_type = DataTypes.VARBINARY(logical_type.getLength(), logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.DecimalType):
             data_type = DataTypes.DECIMAL(logical_type.getPrecision(),
-                                            logical_type.getScale(),
-                                            logical_type.isNullable())
+                                          logical_type.getScale(),
+                                          logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.TimeType):
             data_type = DataTypes.TIME(logical_type.getPrecision(), logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.TimestampType):
@@ -1389,8 +1389,8 @@ def _from_java_type(j_data_type):
             if kind is None:
                 raise Exception("Unsupported java timestamp kind %s" % j_kind)
             data_type = DataTypes.TIMESTAMP(kind,
-                                              logical_type.getPrecision(),
-                                              logical_type.isNullable())
+                                            logical_type.getPrecision(),
+                                            logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.BooleanType):
             data_type = DataTypes.BOOLEAN(logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.TinyIntType):
@@ -1454,7 +1454,7 @@ def _from_java_type(j_data_type):
             data_type = DataTypes.ARRAY(_from_java_type(element_type), logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.MultisetType):
             data_type = DataTypes.MULTISET(_from_java_type(element_type),
-                                             logical_type.isNullable())
+                                           logical_type.isNullable())
         else:
             raise TypeError("Unsupported collection data type: %s" % j_data_type)
 

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1343,7 +1343,7 @@ def _is_instance_of(java_data_type, java_class):
         raise TypeError(
             "java_class must be a string, a JavaClass, or a JavaObject")
 
-    return gateway.jvm.org.apache.flink.api.python.py4j.reflection.TypeUtil.isInstanceOf(
+    return gateway.jvm.org.apache.flink.python.shaded.py4j.reflection.TypeUtil.isInstanceOf(
         param, java_data_type)
 
 

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1328,14 +1328,14 @@ _primitive_to_boxed_map = {'int': 'java.lang.Integer',
                            'double': 'java.lang.Double'}
 
 
-def is_instance_of(java_data_type, java_class):
+def _is_instance_of(java_data_type, java_class):
     gateway = get_gateway()
     if isinstance(java_class, basestring):
         param = java_class
     elif isinstance(java_class, JavaClass):
         param = get_java_class(java_class)
     elif isinstance(java_class, JavaObject):
-        if not is_instance_of(java_class, gateway.jvm.Class):
+        if not _is_instance_of(java_class, gateway.jvm.Class):
             param = java_class.getClass()
         else:
             param = java_class
@@ -1347,37 +1347,37 @@ def is_instance_of(java_data_type, java_class):
         param, java_data_type)
 
 
-def _to_python_type(java_data_type_input):
+def _from_java_type(j_data_type):
     gateway = get_gateway()
 
-    if is_instance_of(java_data_type_input, gateway.jvm.TypeInformation):
+    if _is_instance_of(j_data_type, gateway.jvm.TypeInformation):
         # input is TypeInformation
         LegacyTypeInfoDataTypeConverter = \
             gateway.jvm.org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter
-        java_data_type = LegacyTypeInfoDataTypeConverter.toDataType(java_data_type_input)
+        java_data_type = LegacyTypeInfoDataTypeConverter.toDataType(j_data_type)
     else:
         # input is DataType
-        java_data_type = java_data_type_input
+        java_data_type = j_data_type
 
     # Atomic Type with parameters.
-    if is_instance_of(java_data_type, gateway.jvm.AtomicDataType):
+    if _is_instance_of(java_data_type, gateway.jvm.AtomicDataType):
         logical_type = java_data_type.getLogicalType()
         conversion_clz = java_data_type.getConversionClass()
-        if is_instance_of(logical_type, gateway.jvm.CharType):
-            python_type = DataTypes.CHAR(logical_type.getLength(), logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.VarCharType):
-            python_type = DataTypes.VARCHAR(logical_type.getLength(), logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.BinaryType):
-            python_type = DataTypes.BINARY(logical_type.getLength(), logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.VarBinaryType):
-            python_type = DataTypes.VARBINARY(logical_type.getLength(), logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.DecimalType):
-            python_type = DataTypes.DECIMAL(logical_type.getPrecision(),
+        if _is_instance_of(logical_type, gateway.jvm.CharType):
+            data_type = DataTypes.CHAR(logical_type.getLength(), logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.VarCharType):
+            data_type = DataTypes.VARCHAR(logical_type.getLength(), logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.BinaryType):
+            data_type = DataTypes.BINARY(logical_type.getLength(), logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.VarBinaryType):
+            data_type = DataTypes.VARBINARY(logical_type.getLength(), logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.DecimalType):
+            data_type = DataTypes.DECIMAL(logical_type.getPrecision(),
                                             logical_type.getScale(),
                                             logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.TimeType):
-            python_type = DataTypes.TIME(logical_type.getPrecision(), logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.TimestampType):
+        elif _is_instance_of(logical_type, gateway.jvm.TimeType):
+            data_type = DataTypes.TIME(logical_type.getPrecision(), logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.TimestampType):
             j_kind = logical_type.getKind()
             kind = None
             if j_kind == gateway.jvm.TimestampKind.REGULAR:
@@ -1387,119 +1387,119 @@ def _to_python_type(java_data_type_input):
             elif j_kind == gateway.jvm.TimestampKind.PROCTIME:
                 kind = TimestampKind.PROCTIME
             if kind is None:
-                raise Exception("not supported java timestamp kind %s" % j_kind)
-            python_type = DataTypes.TIMESTAMP(kind,
+                raise Exception("Unsupported java timestamp kind %s" % j_kind)
+            data_type = DataTypes.TIMESTAMP(kind,
                                               logical_type.getPrecision(),
                                               logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.BooleanType):
-            python_type = DataTypes.BOOLEAN(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.TinyIntType):
-            python_type = DataTypes.TINYINT(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.SmallIntType):
-            python_type = DataTypes.SMALLINT(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.IntType):
-            python_type = DataTypes.INT(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.BigIntType):
-            python_type = DataTypes.BIGINT(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.FloatType):
-            python_type = DataTypes.FLOAT(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.DoubleType):
-            python_type = DataTypes.DOUBLE(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.DateType):
-            python_type = DataTypes.DATE(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.TimeType):
-            python_type = DataTypes.TIME(logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.ZonedTimestampType):
+        elif _is_instance_of(logical_type, gateway.jvm.BooleanType):
+            data_type = DataTypes.BOOLEAN(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.TinyIntType):
+            data_type = DataTypes.TINYINT(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.SmallIntType):
+            data_type = DataTypes.SMALLINT(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.IntType):
+            data_type = DataTypes.INT(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.BigIntType):
+            data_type = DataTypes.BIGINT(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.FloatType):
+            data_type = DataTypes.FLOAT(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.DoubleType):
+            data_type = DataTypes.DOUBLE(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.DateType):
+            data_type = DataTypes.DATE(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.TimeType):
+            data_type = DataTypes.TIME(logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.ZonedTimestampType):
             raise \
-                TypeError("Not supported type: %s, ZonedTimestampType is not supported currently."
-                          % java_data_type_input)
-        elif is_instance_of(logical_type, gateway.jvm.LocalZonedTimestampType):
+                TypeError("Unsupported type: %s, ZonedTimestampType is not supported yet."
+                          % j_data_type)
+        elif _is_instance_of(logical_type, gateway.jvm.LocalZonedTimestampType):
             raise \
-                TypeError("Not supported type: %s, LocalZonedTimestampType is not supported "
-                          "currently." % java_data_type_input)
-        elif is_instance_of(logical_type, gateway.jvm.DayTimeIntervalType):
+                TypeError("Unsupported type: %s, LocalZonedTimestampType is not supported "
+                          "currently." % j_data_type)
+        elif _is_instance_of(logical_type, gateway.jvm.DayTimeIntervalType):
             raise \
-                TypeError("Not supported type: %s, DayTimeIntervalType is not supported currently."
-                          % java_data_type_input)
-        elif is_instance_of(logical_type, gateway.jvm.YearMonthIntervalType):
+                TypeError("Unsupported type: %s, DayTimeIntervalType is not supported yet."
+                          % j_data_type)
+        elif _is_instance_of(logical_type, gateway.jvm.YearMonthIntervalType):
             raise \
-                TypeError("Not supported type: %s, YearMonthIntervalType is not supported "
-                          "currently." % java_data_type_input)
-        elif is_instance_of(logical_type, gateway.jvm.LegacyTypeInformationType):
+                TypeError("Unsupported type: %s, YearMonthIntervalType is not supported "
+                          "currently." % j_data_type)
+        elif _is_instance_of(logical_type, gateway.jvm.LegacyTypeInformationType):
             type_info = logical_type.getTypeInformation()
             BasicArrayTypeInfo = gateway.jvm.org.apache.flink.api.common.typeinfo.\
                 BasicArrayTypeInfo
             if type_info == BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO:
-                python_type = DataTypes.ARRAY(DataTypes.STRING())
+                data_type = DataTypes.ARRAY(DataTypes.STRING())
             else:
-                raise TypeError("Not supported type: %s, it is recognized as a legacy type."
+                raise TypeError("Unsupported type: %s, it is recognized as a legacy type."
                                 % type_info)
         else:
-            raise TypeError("Not supported type: %s, it is not supported in python type system"
-                            " currently" % java_data_type_input)
+            raise TypeError("Unsupported type: %s, it is not supported yet in current python type"
+                            " system" % j_data_type)
 
         if conversion_clz is not None:
             type_class_name = conversion_clz.getName()
             if type_class_name in _primitive_to_boxed_map:
                 type_class_name = _primitive_to_boxed_map[type_class_name]
-            python_type.bridged_to(type_class_name)
-        return python_type
+            data_type.bridged_to(type_class_name)
+        return data_type
 
     # Array Type, MultiSet Type.
-    elif is_instance_of(java_data_type, gateway.jvm.CollectionDataType):
+    elif _is_instance_of(java_data_type, gateway.jvm.CollectionDataType):
         logical_type = java_data_type.getLogicalType()
         element_type = java_data_type.getElementDataType()
         conversion_clz = java_data_type.getConversionClass()
-        if is_instance_of(logical_type, gateway.jvm.ArrayType):
-            python_type = DataTypes.ARRAY(_to_python_type(element_type), logical_type.isNullable())
-        elif is_instance_of(logical_type, gateway.jvm.MultisetType):
-            python_type = DataTypes.MULTISET(_to_python_type(element_type),
+        if _is_instance_of(logical_type, gateway.jvm.ArrayType):
+            data_type = DataTypes.ARRAY(_from_java_type(element_type), logical_type.isNullable())
+        elif _is_instance_of(logical_type, gateway.jvm.MultisetType):
+            data_type = DataTypes.MULTISET(_from_java_type(element_type),
                                              logical_type.isNullable())
         else:
-            raise TypeError("Not supported colletion data type: %s" % java_data_type_input)
+            raise TypeError("Unsupported collection data type: %s" % j_data_type)
 
         if conversion_clz is not None:
-            python_type.bridged_to(conversion_clz.getName())
-        return python_type
+            data_type.bridged_to(conversion_clz.getName())
+        return data_type
 
     # Map Type.
-    elif is_instance_of(java_data_type, gateway.jvm.KeyValueDataType):
+    elif _is_instance_of(java_data_type, gateway.jvm.KeyValueDataType):
         logical_type = java_data_type.getLogicalType()
         key_type = java_data_type.getKeyDataType()
         value_type = java_data_type.getValueDataType()
         conversion_clz = java_data_type.getConversionClass()
-        if is_instance_of(logical_type, gateway.jvm.MapType):
-            python_type = DataTypes.MAP(
-                _to_python_type(key_type),
-                _to_python_type(value_type),
+        if _is_instance_of(logical_type, gateway.jvm.MapType):
+            data_type = DataTypes.MAP(
+                _from_java_type(key_type),
+                _from_java_type(value_type),
                 logical_type.isNullable())
         else:
-            raise TypeError("Not supported map data type: %s" % java_data_type_input)
+            raise TypeError("Unsupported map data type: %s" % j_data_type)
 
         if conversion_clz is not None:
-            python_type.bridged_to(conversion_clz.getName())
-        return python_type
+            data_type.bridged_to(conversion_clz.getName())
+        return data_type
 
     # Row Type.
-    elif is_instance_of(java_data_type, gateway.jvm.FieldsDataType):
+    elif _is_instance_of(java_data_type, gateway.jvm.FieldsDataType):
         logical_type = java_data_type.getLogicalType()
         field_data_types = java_data_type.getFieldDataTypes()
         conversion_clz = java_data_type.getConversionClass()
-        if is_instance_of(logical_type, gateway.jvm.RowType):
+        if _is_instance_of(logical_type, gateway.jvm.RowType):
             fields = [DataTypes.FIELD(item,
-                                      _to_python_type(
+                                      _from_java_type(
                                           field_data_types[item])) for item in field_data_types]
-            python_type = DataTypes.ROW(fields, logical_type.isNullable())
+            data_type = DataTypes.ROW(fields, logical_type.isNullable())
         else:
-            raise TypeError("Not supported row data type: %s" % java_data_type_input)
+            raise TypeError("Unsupported row data type: %s" % j_data_type)
 
         if conversion_clz is not None:
-            python_type.bridged_to(conversion_clz.getName())
-        return python_type
+            data_type.bridged_to(conversion_clz.getName())
+        return data_type
 
     # Unrecognized type.
     else:
-        TypeError("Unsupported data type: %s" % java_data_type_input)
+        TypeError("Unsupported data type: %s" % j_data_type)
 
 
 def _create_row(fields, values):

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
@@ -150,4 +150,8 @@ public final class TimeType extends LogicalType {
 	public int hashCode() {
 		return Objects.hash(super.hashCode(), precision);
 	}
+
+	public int getPrecision() {
+		return this.precision;
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
@@ -150,8 +150,4 @@ public final class TimeType extends LogicalType {
 	public int hashCode() {
 		return Objects.hash(super.hashCode(), precision);
 	}
-
-	public int getPrecision() {
-		return this.precision;
-	}
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/python/PythonTableUtils.scala
@@ -158,12 +158,15 @@ object PythonTableUtils {
     case _: PrimitiveArrayTypeInfo[_] |
          _: BasicArrayTypeInfo[_, _] |
          _: ObjectArrayTypeInfo[_, _] =>
+      var boxed = false
       val elementType = dataType match {
         case p: PrimitiveArrayTypeInfo[_] =>
           p.getComponentType
         case b: BasicArrayTypeInfo[_, _] =>
+          boxed = true
           b.getComponentInfo
         case o: ObjectArrayTypeInfo[_, _] =>
+          boxed = true
           o.getComponentInfo
       }
       val elementFromJava = convertTo(elementType)
@@ -172,11 +175,13 @@ object PythonTableUtils {
         case c: java.util.List[_] =>
           createArray(elementType,
                       c.size(),
-                      i => elementFromJava(c.get(i)))
+                      i => elementFromJava(c.get(i)),
+                      boxed)
         case c if c.getClass.isArray =>
           createArray(elementType,
                       c.asInstanceOf[Array[_]].length,
-                      i => elementFromJava(c.asInstanceOf[Array[_]](i)))
+                      i => elementFromJava(c.asInstanceOf[Array[_]](i)),
+                      boxed)
       }
 
     case m: MapTypeInfo[_, _] =>
@@ -233,56 +238,113 @@ object PythonTableUtils {
   private def createArray(
       elementType: TypeInformation[_],
       length: Int,
-      getElement: Int => Any): Array[_] = {
+      getElement: Int => Any,
+      boxed: Boolean = false): Array[_] = {
     elementType match {
       case BasicTypeInfo.BOOLEAN_TYPE_INFO =>
-        val array = new Array[Boolean](length)
-        for (i <- 0 until length) {
-          array(i) = getElement(i).asInstanceOf[Boolean]
+        if (!boxed) {
+          val array = new Array[Boolean](length)
+          for (i <- 0 until length) {
+            array(i) = getElement(i).asInstanceOf[Boolean]
+          }
+          array
+        } else {
+          val array = new Array[java.lang.Boolean](length)
+          for (i <- 0 until length) {
+            array(i) = java.lang.Boolean.valueOf(getElement(i).asInstanceOf[Boolean])
+          }
+          array
         }
-        array
 
       case BasicTypeInfo.BYTE_TYPE_INFO =>
-        val array = new Array[Byte](length)
-        for (i <- 0 until length) {
-          array(i) = getElement(i).asInstanceOf[Byte]
+        if (!boxed) {
+          val array = new Array[Byte](length)
+          for (i <- 0 until length) {
+            array(i) = getElement(i).asInstanceOf[Byte]
+          }
+          array
+        } else {
+          val array = new Array[java.lang.Byte](length)
+          for (i <- 0 until length) {
+            array(i) = java.lang.Byte.valueOf(getElement(i).asInstanceOf[Byte])
+          }
+          array
         }
-        array
 
       case BasicTypeInfo.SHORT_TYPE_INFO =>
-        val array = new Array[Short](length)
-        for (i <- 0 until length) {
-          array(i) = getElement(i).asInstanceOf[Short]
+        if (!boxed) {
+          val array = new Array[Short](length)
+          for (i <- 0 until length) {
+            array(i) = getElement(i).asInstanceOf[Short]
+          }
+          array
+        } else {
+          val array = new Array[java.lang.Short](length)
+          for (i <- 0 until length) {
+            array(i) = java.lang.Short.valueOf(getElement(i).asInstanceOf[Short])
+          }
+          array
         }
-        array
 
       case BasicTypeInfo.INT_TYPE_INFO =>
-        val array = new Array[Int](length)
-        for (i <- 0 until length) {
-          array(i) = getElement(i).asInstanceOf[Int]
+        if (!boxed) {
+          val array = new Array[Int](length)
+          for (i <- 0 until length) {
+            array(i) = getElement(i).asInstanceOf[Int]
+          }
+          array
+        } else {
+          val array = new Array[java.lang.Integer](length)
+          for (i <- 0 until length) {
+            array(i) = java.lang.Integer.valueOf(getElement(i).asInstanceOf[Int])
+          }
+          array
         }
-        array
 
       case BasicTypeInfo.LONG_TYPE_INFO =>
-        val array = new Array[Long](length)
-        for (i <- 0 until length) {
-          array(i) = getElement(i).asInstanceOf[Long]
+        if (!boxed) {
+          val array = new Array[Long](length)
+          for (i <- 0 until length) {
+            array(i) = getElement(i).asInstanceOf[Long]
+          }
+          array
+        } else {
+          val array = new Array[java.lang.Long](length)
+          for (i <- 0 until length) {
+            array(i) = java.lang.Long.valueOf(getElement(i).asInstanceOf[Long])
+          }
+          array
         }
-        array
 
       case BasicTypeInfo.FLOAT_TYPE_INFO =>
-        val array = new Array[Float](length)
-        for (i <- 0 until length) {
-          array(i) = getElement(i).asInstanceOf[Float]
+        if (!boxed) {
+          val array = new Array[Float](length)
+          for (i <- 0 until length) {
+            array(i) = getElement(i).asInstanceOf[Float]
+          }
+          array
+        } else {
+          val array = new Array[java.lang.Float](length)
+          for (i <- 0 until length) {
+            array(i) = java.lang.Float.valueOf(getElement(i).asInstanceOf[Float])
+          }
+          array
         }
-        array
 
       case BasicTypeInfo.DOUBLE_TYPE_INFO =>
-        val array = new Array[Double](length)
-        for (i <- 0 until length) {
-          array(i) = getElement(i).asInstanceOf[Double]
+        if (!boxed) {
+          val array = new Array[Double](length)
+          for (i <- 0 until length) {
+            array(i) = getElement(i).asInstanceOf[Double]
+          }
+          array
+        } else {
+          val array = new Array[java.lang.Double](length)
+          for (i <- 0 until length) {
+            array(i) = java.lang.Double.valueOf(getElement(i).asInstanceOf[Double])
+          }
+          array
         }
-        array
 
       case BasicTypeInfo.STRING_TYPE_INFO =>
         val array = new Array[java.lang.String](length)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/python/PythonTableUtils.scala
@@ -251,7 +251,11 @@ object PythonTableUtils {
         } else {
           val array = new Array[java.lang.Boolean](length)
           for (i <- 0 until length) {
-            array(i) = java.lang.Boolean.valueOf(getElement(i).asInstanceOf[Boolean])
+            if (getElement(i) != null) {
+              array(i) = java.lang.Boolean.valueOf(getElement(i).asInstanceOf[Boolean])
+            } else {
+              array(i) = null
+            }
           }
           array
         }
@@ -266,7 +270,11 @@ object PythonTableUtils {
         } else {
           val array = new Array[java.lang.Byte](length)
           for (i <- 0 until length) {
-            array(i) = java.lang.Byte.valueOf(getElement(i).asInstanceOf[Byte])
+            if (getElement(i) != null) {
+              array(i) = java.lang.Byte.valueOf(getElement(i).asInstanceOf[Byte])
+            } else {
+              array(i) = null
+            }
           }
           array
         }
@@ -281,7 +289,11 @@ object PythonTableUtils {
         } else {
           val array = new Array[java.lang.Short](length)
           for (i <- 0 until length) {
-            array(i) = java.lang.Short.valueOf(getElement(i).asInstanceOf[Short])
+            if (getElement(i) != null) {
+              array(i) = java.lang.Short.valueOf(getElement(i).asInstanceOf[Short])
+            } else {
+              array(i) = null
+            }
           }
           array
         }
@@ -296,7 +308,11 @@ object PythonTableUtils {
         } else {
           val array = new Array[java.lang.Integer](length)
           for (i <- 0 until length) {
-            array(i) = java.lang.Integer.valueOf(getElement(i).asInstanceOf[Int])
+            if (getElement(i) != null) {
+              array(i) = java.lang.Integer.valueOf(getElement(i).asInstanceOf[Int])
+            } else {
+              array(i) = null
+            }
           }
           array
         }
@@ -311,7 +327,11 @@ object PythonTableUtils {
         } else {
           val array = new Array[java.lang.Long](length)
           for (i <- 0 until length) {
-            array(i) = java.lang.Long.valueOf(getElement(i).asInstanceOf[Long])
+            if (getElement(i) != null) {
+              array(i) = java.lang.Long.valueOf(getElement(i).asInstanceOf[Long])
+            } else {
+              array(i) = null
+            }
           }
           array
         }
@@ -326,7 +346,11 @@ object PythonTableUtils {
         } else {
           val array = new Array[java.lang.Float](length)
           for (i <- 0 until length) {
-            array(i) = java.lang.Float.valueOf(getElement(i).asInstanceOf[Float])
+            if (getElement(i) != null) {
+              array(i) = java.lang.Float.valueOf(getElement(i).asInstanceOf[Float])
+            } else {
+              array(i) = null
+            }
           }
           array
         }
@@ -341,7 +365,11 @@ object PythonTableUtils {
         } else {
           val array = new Array[java.lang.Double](length)
           for (i <- 0 until length) {
-            array(i) = java.lang.Double.valueOf(getElement(i).asInstanceOf[Double])
+            if (getElement(i) != null) {
+              array(i) = java.lang.Double.valueOf(getElement(i).asInstanceOf[Double])
+            } else {
+              array(i) = null
+            }
           }
           array
         }


### PR DESCRIPTION
## What is the purpose of the change

This pull request is intended to add TableSchema for Python Table API. For this goal, a `_to_python_type` function is introduced in this pull request. This function is for converting Java's DataType and TypeInformation objects into Python's DataType objects. For ensuring that `_to_python_type` and the existing `_to_java_type` are mutually inverse functions, this PR makes some changes on the flink python type system.


## Brief change log

  - *Add the `TableSchema` class.*
  - *Add `get_schema` method in `Table` class.*
  - *Add `schema` method in `OldCsv` and `Schema` class.*
  - *Add `_to_python_type` function.*
  - *Changed many default value and default behavior of current data types.*


## Verifying this change

Added integration tests in `test_table_schema.py`, `test_schema_operation.py` and `test_types.py`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (python docs)
