### PR TITLE
[FLINK-12673][network] Introduce NetworkEnvironment.getUnreleasedPartitions instead of using getResultPartitionManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -174,6 +174,7 @@ public class NetworkEnvironment {
 	//  Properties
 	// --------------------------------------------------------------------------------------------
 
+	@VisibleForTesting
 	public ResultPartitionManager getResultPartitionManager() {
 		return resultPartitionManager;
 	}
@@ -207,6 +208,16 @@ public class NetworkEnvironment {
 		for (ResultPartitionID partitionId : partitionIds) {
 			resultPartitionManager.releasePartition(partitionId, null);
 		}
+	}
+
+	/**
+	 * Report unreleased partitions.
+	 *
+	 * @return collection of partitions which still occupy some resources locally on this task executor
+	 * and have been not released yet.
+	 */
+	public Collection<ResultPartitionID> getUnreleasedPartitions() {
+		return resultPartitionManager.getUnreleasedPartitions();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -120,14 +121,9 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 		}
 	}
 
-	public boolean areAllPartitionsReleased() {
+	public Collection<ResultPartitionID> getUnreleasedPartitions() {
 		synchronized (registeredPartitions) {
-			for (ResultPartition partition : registeredPartitions.values()) {
-				if (!partition.isReleased()) {
-					return false;
-				}
-			}
-			return true;
+			return registeredPartitions.keySet();
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -106,19 +106,17 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 	// ------------------------------------------------------------------------
 
 	void onConsumedPartition(ResultPartition partition) {
-		final ResultPartition previous;
-
 		LOG.debug("Received consume notification from {}.", partition);
 
 		synchronized (registeredPartitions) {
-			previous = registeredPartitions.remove(partition.getPartitionId());
-		}
-
-		// Release the partition if it was successfully removed
-		if (partition == previous) {
-			partition.release();
-
-			LOG.debug("Released {}.", partition);
+			final ResultPartition previous = registeredPartitions.remove(partition.getPartitionId());
+			// Release the partition if it was successfully removed
+			if (partition == previous) {
+				partition.release();
+				ResultPartitionID partitionId = partition.getPartitionId();
+				LOG.debug("Released partition {} produced by {}.",
+					partitionId.getPartitionId(), partitionId.getProducerId());
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -271,7 +271,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	@Override
 	public CompletableFuture<Boolean> canBeReleased() {
 		return CompletableFuture.completedFuture(
-			taskExecutorServices.getNetworkEnvironment().getResultPartitionManager().areAllPartitionsReleased());
+			taskExecutorServices.getNetworkEnvironment().getUnreleasedPartitions().isEmpty());
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

At the moment NetworkEnvironment.getResultPartitionManager is used to query TaskExecutor whether all partitions are released. We should hide this direct access to ResultPartitionManager behind a Shuffle API method call: NetworkEnvironment.getUnreleasedPartitions.

## Brief change log

 - Refactor `ResultPartitionManager.areAllPartitionsReleased` to `getUnreleasedPartitions`
 - Add `NetworkEnvironment.getUnreleasedPartitions`

## Verifying this change

Trivial refactor covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
