### PR TITLE
[FLINK-12642][network][metrics] Fix In/OutputBufferPoolUsageGauge failure with NullPointerException if BufferPool has not been inited yet

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputBufferPoolUsageGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputBufferPoolUsageGauge.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.metrics;
 
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 
 /**
@@ -38,8 +39,11 @@ public class InputBufferPoolUsageGauge implements Gauge<Float> {
 		int bufferPoolSize = 0;
 
 		for (SingleInputGate inputGate : inputGates) {
-			usedBuffers += inputGate.getBufferPool().bestEffortGetNumOfUsedBuffers();
-			bufferPoolSize += inputGate.getBufferPool().getNumBuffers();
+			BufferPool bufferPool = inputGate.getBufferPool();
+			if (bufferPool != null) {
+				usedBuffers += bufferPool.bestEffortGetNumOfUsedBuffers();
+				bufferPoolSize += bufferPool.getNumBuffers();
+			}
 		}
 
 		if (bufferPoolSize != 0) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/OutputBufferPoolUsageGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/OutputBufferPoolUsageGauge.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.metrics;
 
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 
 /**
@@ -38,8 +39,12 @@ public class OutputBufferPoolUsageGauge implements Gauge<Float> {
 		int bufferPoolSize = 0;
 
 		for (ResultPartition resultPartition : resultPartitions) {
-			usedBuffers += resultPartition.getBufferPool().bestEffortGetNumOfUsedBuffers();
-			bufferPoolSize += resultPartition.getBufferPool().getNumBuffers();
+			BufferPool bufferPool = resultPartition.getBufferPool();
+
+			if (bufferPool != null) {
+				usedBuffers += bufferPool.bestEffortGetNumOfUsedBuffers();
+				bufferPoolSize += bufferPool.getNumBuffers();
+			}
 		}
 
 		if (bufferPoolSize != 0) {


### PR DESCRIPTION
## What is the purpose of the change

The result partition metrics are initialised before `ResultPartitiion#setup` was called. If a reporter tries to access a In/OutputBufferPoolUsageGauge in between it will fail with an `NullPointerException` since the `BufferPool` of the partition is still `null`. Currently, the quick fix is to return zero metrics until the `BufferPool` is initialised. When we have a single-threaded access from `Task#run`, we can merge partition/gate create and setup then it should not be the case anymore.

## Brief change log

Check the partition `BufferPool` is not `null` in `In/OutputBufferPoolUsageGauge#getValue` and return zero metrics if it is `null`.

## Verifying this change

Trivial fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
