### PR TITLE
[FLINK-12703] [table-planner-blink] Introduce metadata handlers on SEMI/ANTI join and lookup join

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnInterval.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnInterval.scala
@@ -101,6 +101,16 @@ class FlinkRelMdColumnInterval private extends MetadataHandler[ColumnInterval] {
   }
 
   /**
+    * Gets interval of the given column on Snapshot.
+    *
+    * @param snapshot    Snapshot RelNode
+    * @param mq    RelMetadataQuery instance
+    * @param index the index of the given column
+    * @return interval of the given column on Snapshot.
+    */
+  def getColumnInterval(snapshot: Snapshot, mq: RelMetadataQuery, index: Int): ValueInterval = null
+
+  /**
     * Gets interval of the given column on Project.
     *
     * Note: Only support the simple RexNode, e.g RexInputRef.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnNullCount.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnNullCount.scala
@@ -68,6 +68,16 @@ class FlinkRelMdColumnNullCount private extends MetadataHandler[ColumnNullCount]
   }
 
   /**
+    * Gets the null count of the given column on Snapshot.
+    *
+    * @param snapshot    Snapshot RelNode
+    * @param mq    RelMetadataQuery instance
+    * @param index the index of the given column
+    * @return the null count of the given column on Snapshot.
+    */
+  def getColumnNullCount(snapshot: Snapshot, mq: RelMetadataQuery, index: Int): JDouble = null
+
+  /**
     * Gets the null count of the given column in Project.
     *
     * @param project Project RelNode

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnOriginNullCount.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnOriginNullCount.scala
@@ -58,6 +58,8 @@ class FlinkRelMdColumnOriginNullCount private extends MetadataHandler[ColumnOrig
     }
   }
 
+  def getColumnOriginNullCount(snapshot: Snapshot, mq: RelMetadataQuery, index: Int): JDouble = null
+
   def getColumnOriginNullCount(rel: Project, mq: RelMetadataQuery, index: Int): JDouble = {
     getColumnOriginNullOnProjects(rel.getInput, rel.getProjects, mq, index)
   }
@@ -118,8 +120,6 @@ class FlinkRelMdColumnOriginNullCount private extends MetadataHandler[ColumnOrig
       null
     }
   }
-
-  // TODO supports FlinkLogicalSnapshot
 
   def getColumnOriginNullCount(rel: RelNode, mq: RelMetadataQuery, index: Int): JDouble = null
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdSize.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdSize.scala
@@ -245,10 +245,9 @@ class FlinkRelMdSize private extends MetadataHandler[BuiltInMetadata.Size] {
 
   def averageColumnSizes(rel: Join, mq: RelMetadataQuery): JList[JDouble] = {
     val acsOfLeft = mq.getAverageColumnSizes(rel.getLeft)
-    val acsOfRight = if (rel.getJoinType.projectsRight) {
-      mq.getAverageColumnSizes(rel.getRight)
-    } else {
-      null
+    val acsOfRight = rel.getJoinType match {
+      case JoinRelType.SEMI | JoinRelType.ANTI => null
+      case _ => mq.getAverageColumnSizes(rel.getRight)
     }
     if (acsOfLeft == null && acsOfRight == null) {
       null

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueGroups.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueGroups.scala
@@ -341,11 +341,17 @@ class FlinkRelMdUniqueGroups private extends MetadataHandler[UniqueGroups] {
       mq: RelMetadataQuery,
       columns: ImmutableBitSet): ImmutableBitSet = {
     require(join.getSystemFieldList.isEmpty)
+    val fmq = FlinkRelMetadataQuery.reuseOrCreate(mq)
+    join.getJoinType match {
+      case JoinRelType.SEMI | JoinRelType.ANTI =>
+        return fmq.getUniqueGroups(join.getLeft, columns)
+      case _ => // do nothing
+    }
+
     val leftFieldCount = join.getLeft.getRowType.getFieldCount
     val (leftColumns, rightColumns) =
       FlinkRelMdUtil.splitColumnsIntoLeftAndRight(leftFieldCount, columns)
 
-    val fmq = FlinkRelMetadataQuery.reuseOrCreate(mq)
     val leftUniqueGroups = fmq.getUniqueGroups(join.getLeft, leftColumns)
     val rightUniqueGroups = fmq.getUniqueGroups(join.getRight, rightColumns)
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/join/LookupJoinTest.scala
@@ -84,7 +84,6 @@ class LookupJoinTest extends TableTestBase {
     )
   }
 
-
   @Test
   def testLogicalPlan(): Unit = {
     val sql1 =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnIntervalTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnIntervalTest.scala
@@ -86,6 +86,13 @@ class FlinkRelMdColumnIntervalTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetColumnIntervalOnSnapshot(): Unit = {
+    (0 until flinkLogicalSnapshot.getRowType.getFieldCount).foreach { idx =>
+      assertNull(mq.getColumnInterval(flinkLogicalSnapshot, idx))
+    }
+  }
+
+  @Test
   def testGetColumnIntervalOnProject(): Unit = {
     assertEquals(ValueInterval(0, null), mq.getColumnInterval(logicalProject, 0))
     assertNull(mq.getColumnInterval(logicalProject, 1))
@@ -525,6 +532,22 @@ class FlinkRelMdColumnIntervalTest extends FlinkRelMdHandlerTestBase {
     assertEquals(ValueInterval(8L, 1000L), mq.getColumnInterval(join, 6))
     assertNull(mq.getColumnInterval(join, 7))
     assertNull(mq.getColumnInterval(join, 8))
+
+    assertEquals(ValueInterval(0, null, includeLower = true),
+      mq.getColumnInterval(logicalSemiJoinNotOnUniqueKeys, 0))
+    assertEquals(ValueInterval(1L, 800000000L),
+      mq.getColumnInterval(logicalSemiJoinNotOnUniqueKeys, 1))
+    assertNull(mq.getColumnInterval(logicalSemiJoinNotOnUniqueKeys, 2))
+    assertNull(mq.getColumnInterval(logicalSemiJoinNotOnUniqueKeys, 3))
+    assertEquals(ValueInterval(1L, 100L), mq.getColumnInterval(logicalSemiJoinNotOnUniqueKeys, 4))
+
+    assertEquals(ValueInterval(0, null, includeLower = true),
+      mq.getColumnInterval(logicalAntiJoinWithoutEquiCond, 0))
+    assertEquals(ValueInterval(1L, 800000000L),
+      mq.getColumnInterval(logicalAntiJoinWithoutEquiCond, 1))
+    assertNull(mq.getColumnInterval(logicalAntiJoinWithoutEquiCond, 2))
+    assertNull(mq.getColumnInterval(logicalAntiJoinWithoutEquiCond, 3))
+    assertEquals(ValueInterval(1L, 100L), mq.getColumnInterval(logicalAntiJoinWithoutEquiCond, 4))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnNullCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnNullCountTest.scala
@@ -52,6 +52,13 @@ class FlinkRelMdColumnNullCountTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetColumnIntervalOnSnapshot(): Unit = {
+    (0 until flinkLogicalSnapshot.getRowType.getFieldCount).foreach { idx =>
+      assertNull(mq.getColumnNullCount(flinkLogicalSnapshot, idx))
+    }
+  }
+
+  @Test
   def testGetColumnNullCountOnProject(): Unit = {
     assertEquals(0.0, mq.getColumnNullCount(logicalProject, 0))
     assertEquals(0.0, mq.getColumnNullCount(logicalProject, 1))
@@ -261,6 +268,13 @@ class FlinkRelMdColumnNullCountTest extends FlinkRelMdHandlerTestBase {
       relBuilder.call(EQUALS, relBuilder.field(2, 0, 0), relBuilder.field(2, 1, 0))).build
     (0 until fullJoin.getRowType.getFieldCount).foreach { idx =>
       assertNull(mq.getColumnNullCount(fullJoin, idx))
+    }
+
+    // semi/anti join
+    Array(logicalSemiJoinWithEquiAndNonEquiCond, logicalAntiJoinWithoutEquiCond).foreach { join =>
+      (0 until join.getRowType.getFieldCount).foreach { idx =>
+        assertNull(mq.getColumnNullCount(fullJoin, idx))
+      }
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnOriginNullCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnOriginNullCountTest.scala
@@ -46,6 +46,13 @@ class FlinkRelMdColumnOriginNullCountTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetColumnOriginNullCountOnSnapshot(): Unit = {
+    (0 until flinkLogicalSnapshot.getRowType.getFieldCount).foreach { idx =>
+      assertNull(mq.getColumnOriginNullCount(flinkLogicalSnapshot, idx))
+    }
+  }
+
+  @Test
   def testGetColumnOriginNullCountOnProject(): Unit = {
     assertEquals(0.0, mq.getColumnOriginNullCount(logicalProject, 0))
     assertEquals(0.0, mq.getColumnOriginNullCount(logicalProject, 1))
@@ -127,7 +134,8 @@ class FlinkRelMdColumnOriginNullCountTest extends FlinkRelMdHandlerTestBase {
     assertEquals(0.0, mq.getColumnOriginNullCount(innerJoin2, 3))
 
     Array(logicalLeftJoinOnUniqueKeys, logicalRightJoinNotOnUniqueKeys,
-      logicalFullJoinWithEquiAndNonEquiCond).foreach { join =>
+      logicalFullJoinWithEquiAndNonEquiCond, logicalSemiJoinNotOnUniqueKeys,
+      logicalSemiJoinWithEquiAndNonEquiCond).foreach { join =>
       (0 until join.getRowType.getFieldCount).foreach { idx =>
         assertNull(mq.getColumnOriginNullCount(join, idx))
       }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -496,6 +496,43 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
     assertFalse(mq.areColumnsUnique(logicalFullJoinOnUniqueKeys, ImmutableBitSet.of(1, 6)))
     assertFalse(mq.areColumnsUnique(logicalFullJoinOnUniqueKeys, ImmutableBitSet.of(5, 6)))
     assertTrue(mq.areColumnsUnique(logicalFullJoinOnUniqueKeys, ImmutableBitSet.of(0, 1, 5, 6)))
+
+    // semi/anti join
+    Array(logicalSemiJoinOnUniqueKeys, logicalSemiJoinNotOnUniqueKeys,
+      logicalSemiJoinOnDisjointKeys, logicalAntiJoinOnUniqueKeys, logicalAntiJoinNotOnUniqueKeys,
+      logicalAntiJoinOnDisjointKeys).foreach { join =>
+      assertFalse(mq.areColumnsUnique(join, ImmutableBitSet.of(0)))
+      assertTrue(mq.areColumnsUnique(join, ImmutableBitSet.of(1)))
+      assertFalse(mq.areColumnsUnique(join, ImmutableBitSet.of(2)))
+      assertFalse(mq.areColumnsUnique(join, ImmutableBitSet.of(3)))
+      assertFalse(mq.areColumnsUnique(join, ImmutableBitSet.of(4)))
+      assertTrue(mq.areColumnsUnique(join, ImmutableBitSet.of(0, 1)))
+      assertFalse(mq.areColumnsUnique(join, ImmutableBitSet.of(0, 2)))
+    }
+  }
+
+  @Test
+  def testAreColumnsUniqueOnLookupJoin(): Unit = {
+    Array(batchLookupJoin, streamLookupJoin).foreach { join =>
+      assertFalse(mq.areColumnsUnique(join, ImmutableBitSet.of()))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(0)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(1)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(2)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(3)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(4)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(5)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(6)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(7)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(8)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(9)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(0, 1)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(1, 2)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(0, 7)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(1, 7)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(0, 8)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(7, 8)))
+      assertNull(mq.areColumnsUnique(join, ImmutableBitSet.of(8, 9)))
+    }
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
@@ -587,6 +587,24 @@ class FlinkRelMdDistinctRowCountTest extends FlinkRelMdHandlerTestBase {
       mq.getDistinctRowCount(logicalFullJoinNotOnUniqueKeys, ImmutableBitSet.of(0), null))
     assertEquals(505696447.06,
       mq.getDistinctRowCount(logicalFullJoinNotOnUniqueKeys, ImmutableBitSet.of(1), null), 1e-2)
+
+    assertEquals(50,
+      mq.getDistinctRowCount(logicalSemiJoinOnUniqueKeys, ImmutableBitSet.of(0), null), 1e-2)
+    assertEquals(50,
+      mq.getDistinctRowCount(logicalSemiJoinOnUniqueKeys, ImmutableBitSet.of(1), null), 1e-2)
+    assertEquals(2.0E7,
+      mq.getDistinctRowCount(logicalSemiJoinNotOnUniqueKeys, ImmutableBitSet.of(0), null))
+    assertEquals(8.0E8,
+      mq.getDistinctRowCount(logicalSemiJoinNotOnUniqueKeys, ImmutableBitSet.of(1), null))
+
+    assertEquals(2.0E7,
+      mq.getDistinctRowCount(logicalAntiJoinOnUniqueKeys, ImmutableBitSet.of(0), null))
+    assertEquals(7.9999995E8,
+      mq.getDistinctRowCount(logicalAntiJoinOnUniqueKeys, ImmutableBitSet.of(1), null))
+    assertEquals(1.970438234E7,
+      mq.getDistinctRowCount(logicalAntiJoinNotOnUniqueKeys, ImmutableBitSet.of(0), null), 1e-2)
+    assertEquals(8.0E7,
+      mq.getDistinctRowCount(logicalAntiJoinNotOnUniqueKeys, ImmutableBitSet.of(1), null))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
@@ -281,6 +281,9 @@ class FlinkRelMdModifiedMonotonicityTest extends FlinkRelMdHandlerTestBase {
     val join3 = relBuilder.push(left).push(right).join(JoinRelType.INNER,
       relBuilder.call(EQUALS, relBuilder.field(2, 0, 0), relBuilder.field(2, 1, 1))).build()
     assertEquals(null, mq.getRelModifiedMonotonicity(join3))
+
+    assertNull(mq.getRelModifiedMonotonicity(logicalAntiJoinNotOnUniqueKeys))
+    assertNull(mq.getRelModifiedMonotonicity(logicalAntiJoinOnUniqueKeys))
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdPercentageOriginalRowsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdPercentageOriginalRowsTest.scala
@@ -69,6 +69,10 @@ class FlinkRelMdPercentageOriginalRowsTest extends FlinkRelMdHandlerTestBase {
     assertEquals(1.0, mq.getPercentageOriginalRows(logicalRightJoinOnDisjointKeys))
     assertEquals(1.0, mq.getPercentageOriginalRows(logicalFullJoinOnUniqueKeys))
     assertEquals(1.0, mq.getPercentageOriginalRows(logicalFullJoinNotOnUniqueKeys))
+    assertEquals(1.0, mq.getPercentageOriginalRows(logicalSemiJoinOnUniqueKeys))
+    assertEquals(1.0, mq.getPercentageOriginalRows(logicalSemiJoinNotOnUniqueKeys))
+    assertEquals(1.0, mq.getPercentageOriginalRows(logicalAntiJoinOnUniqueKeys))
+    assertEquals(1.0, mq.getPercentageOriginalRows(logicalAntiJoinNotOnUniqueKeys))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdPopulationSizeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdPopulationSizeTest.scala
@@ -319,6 +319,20 @@ class FlinkRelMdPopulationSizeTest extends FlinkRelMdHandlerTestBase {
       mq.getPopulationSize(logicalFullJoinWithoutEquiCond, ImmutableBitSet.of(1, 5)))
     assertEquals(5.112E10,
       mq.getPopulationSize(logicalFullJoinWithoutEquiCond, ImmutableBitSet.of(0, 6)))
+
+    assertEquals(1.0, mq.getPopulationSize(logicalSemiJoinOnUniqueKeys, ImmutableBitSet.of()))
+    assertEquals(2.0E7, mq.getPopulationSize(logicalSemiJoinOnLHSUniqueKeys, ImmutableBitSet.of(0)))
+    assertEquals(8.0E8, mq.getPopulationSize(logicalSemiJoinNotOnUniqueKeys, ImmutableBitSet.of(1)))
+    assertEquals(8.0E8, mq.getPopulationSize(logicalSemiJoinOnUniqueKeys, ImmutableBitSet.of(0, 1)))
+    assertEquals(8.0E8,
+      mq.getPopulationSize(logicalSemiJoinNotOnUniqueKeys, ImmutableBitSet.of(0, 2)))
+
+    assertEquals(1.0, mq.getPopulationSize(logicalAntiJoinNotOnUniqueKeys, ImmutableBitSet.of()))
+    assertEquals(2.0E7, mq.getPopulationSize(logicalAntiJoinOnUniqueKeys, ImmutableBitSet.of(0)))
+    assertEquals(8.0E8, mq.getPopulationSize(logicalAntiJoinOnLHSUniqueKeys, ImmutableBitSet.of(1)))
+    assertEquals(8.0E8, mq.getPopulationSize(logicalAntiJoinOnUniqueKeys, ImmutableBitSet.of(0, 1)))
+    assertEquals(8.0E8,
+      mq.getPopulationSize(logicalAntiJoinNotOnUniqueKeys, ImmutableBitSet.of(0, 2)))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdRowCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdRowCountTest.scala
@@ -204,10 +204,27 @@ class FlinkRelMdRowCountTest extends FlinkRelMdHandlerTestBase {
 
     assertEquals(8.0E8, mq.getRowCount(logicalFullJoinOnUniqueKeys))
     assertEquals(8.0E8, mq.getRowCount(logicalFullJoinNotOnUniqueKeys))
+    assertEquals(8.0E8, mq.getRowCount(logicalFullJoinOnLHSUniqueKeys))
     assertEquals(8.0E8, mq.getRowCount(logicalFullJoinOnRHSUniqueKeys))
     assertEquals(8.1E8, mq.getRowCount(logicalFullJoinWithEquiAndNonEquiCond))
     assertEquals(8.0E15, mq.getRowCount(logicalFullJoinWithoutEquiCond))
     assertEquals(8.2E8, mq.getRowCount(logicalFullJoinOnDisjointKeys))
+
+    assertEquals(50.0, mq.getRowCount(logicalSemiJoinOnUniqueKeys))
+    assertEquals(8.0E8, mq.getRowCount(logicalSemiJoinNotOnUniqueKeys))
+    assertEquals(2556.0, mq.getRowCount(logicalSemiJoinOnLHSUniqueKeys))
+    assertEquals(2.0E7, mq.getRowCount(logicalSemiJoinOnRHSUniqueKeys))
+    assertEquals(1278.0, mq.getRowCount(logicalSemiJoinWithEquiAndNonEquiCond))
+    assertEquals(4.0E8, mq.getRowCount(logicalSemiJoinWithoutEquiCond))
+    assertEquals(8.0E8, mq.getRowCount(logicalSemiJoinOnDisjointKeys))
+
+    assertEquals(7.9999995E8, mq.getRowCount(logicalAntiJoinOnUniqueKeys))
+    assertEquals(8.0E7, mq.getRowCount(logicalAntiJoinNotOnUniqueKeys))
+    assertEquals(7.99997444E8, mq.getRowCount(logicalAntiJoinOnLHSUniqueKeys))
+    assertEquals(2000000.0, mq.getRowCount(logicalAntiJoinOnRHSUniqueKeys))
+    assertEquals(6.0E8, mq.getRowCount(logicalAntiJoinWithEquiAndNonEquiCond))
+    assertEquals(6.0E8, mq.getRowCount(logicalAntiJoinWithoutEquiCond))
+    assertEquals(8.0E7, mq.getRowCount(logicalAntiJoinOnDisjointKeys))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdSelectivityTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdSelectivityTest.scala
@@ -496,6 +496,18 @@ class FlinkRelMdSelectivityTest extends FlinkRelMdHandlerTestBase {
     assertEquals(1D, mq.getSelectivity(join, pred3))
     val pred4 = relBuilder.call(LESS_THAN_OR_EQUAL, relBuilder.field(3), relBuilder.literal(0))
     assertEquals(0D, mq.getSelectivity(join, pred4))
+
+    assertEquals(3.125E-8, mq.getSelectivity(logicalSemiJoinOnUniqueKeys, pred1))
+    val pred5 = relBuilder.push(logicalSemiJoinNotOnUniqueKeys)
+        .call(GREATER_THAN, relBuilder.field(0), relBuilder.literal(100000000L))
+    assertEquals(0.5, mq.getSelectivity(logicalSemiJoinNotOnUniqueKeys, pred5))
+
+    val pred6 = relBuilder.push(logicalAntiJoinWithoutEquiCond)
+        .call(GREATER_THAN, relBuilder.field(0), relBuilder.literal(100L))
+    assertEquals(0.375, mq.getSelectivity(logicalAntiJoinWithoutEquiCond, pred6))
+    val pred7 = relBuilder.push(logicalAntiJoinNotOnUniqueKeys)
+        .call(GREATER_THAN, relBuilder.field(0), relBuilder.literal(100000000L))
+    assertEquals(0.05, mq.getSelectivity(logicalAntiJoinNotOnUniqueKeys, pred7))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdSizeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdSizeTest.scala
@@ -171,6 +171,11 @@ class FlinkRelMdSizeTest extends FlinkRelMdHandlerTestBase {
       assertEquals(Seq(4.0, 8.0, 12.0, 88.8, 4.0, 4.0, 8.0, 12.0, 10.52, 4.0),
         mq.getAverageColumnSizes(join).toList)
     }
+
+    Array(logicalSemiJoinOnUniqueKeys, logicalAntiJoinNotOnUniqueKeys).foreach { join =>
+      assertEquals(Seq(4.0, 8.0, 12.0, 88.8, 4.0),
+        mq.getAverageColumnSizes(join).toList)
+    }
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueGroupsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueGroupsTest.scala
@@ -578,7 +578,50 @@ class FlinkRelMdUniqueGroupsTest extends FlinkRelMdHandlerTestBase {
 
     // without equi join condition
     assertEquals(ImmutableBitSet.of(1, 5, 6, 7, 8, 9),
-      mq.getUniqueGroups(logicalFullWithoutCond, ImmutableBitSet.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)))
+      mq.getUniqueGroups(logicalFullJoinWithoutCond,
+        ImmutableBitSet.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)))
+
+    // semi join
+    // both left join keys and right join keys are unique
+    assertEquals(ImmutableBitSet.of(1),
+      mq.getUniqueGroups(logicalSemiJoinOnUniqueKeys, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // left join keys are not unique and right join keys are unique
+    assertEquals(ImmutableBitSet.of(0, 1, 2, 3, 4),
+      mq.getUniqueGroups(logicalSemiJoinOnRHSUniqueKeys, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // left join keys are unique and right join keys are not unique
+    assertEquals(ImmutableBitSet.of(1),
+      mq.getUniqueGroups(logicalSemiJoinOnLHSUniqueKeys, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // neither left join keys nor right join keys are unique (non join columns have unique columns)
+    assertEquals(ImmutableBitSet.of(1),
+      mq.getUniqueGroups(logicalSemiJoinNotOnUniqueKeys, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // with non-equi join condition
+    assertEquals(ImmutableBitSet.of(1),
+      mq.getUniqueGroups(logicalSemiJoinWithEquiAndNonEquiCond, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // anti join
+    // both left join keys and right join keys are unique
+    assertEquals(ImmutableBitSet.of(1),
+      mq.getUniqueGroups(logicalAntiJoinOnUniqueKeys, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // left join keys are not unique and right join keys are unique
+    assertEquals(ImmutableBitSet.of(0, 1, 2, 3, 4),
+      mq.getUniqueGroups(logicalAntiJoinOnRHSUniqueKeys, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // left join keys are unique and right join keys are not unique
+    assertEquals(ImmutableBitSet.of(1),
+      mq.getUniqueGroups(logicalAntiJoinOnLHSUniqueKeys, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // neither left join keys nor right join keys are unique (non join columns have unique columns)
+    assertEquals(ImmutableBitSet.of(1),
+      mq.getUniqueGroups(logicalAntiJoinNotOnUniqueKeys, ImmutableBitSet.of(0, 1, 2, 3, 4)))
+
+    // with non-equi join condition
+    assertEquals(ImmutableBitSet.of(1),
+      mq.getUniqueGroups(logicalAntiJoinWithEquiAndNonEquiCond, ImmutableBitSet.of(0, 1, 2, 3, 4)))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -226,6 +226,29 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
     assertEquals(uniqueKeys(), mq.getUniqueKeys(logicalFullJoinOnRHSUniqueKeys).toSet)
     assertEquals(uniqueKeys(), mq.getUniqueKeys(logicalFullJoinWithoutEquiCond).toSet)
     assertEquals(uniqueKeys(), mq.getUniqueKeys(logicalFullJoinWithEquiAndNonEquiCond).toSet)
+
+    assertEquals(uniqueKeys(Array(1)),
+      mq.getUniqueKeys(logicalSemiJoinOnUniqueKeys).toSet)
+    assertEquals(uniqueKeys(Array(1)), mq.getUniqueKeys(logicalSemiJoinNotOnUniqueKeys).toSet)
+    assertNull(mq.getUniqueKeys(logicalSemiJoinOnRHSUniqueKeys))
+    assertEquals(uniqueKeys(Array(1)), mq.getUniqueKeys(logicalSemiJoinWithoutEquiCond).toSet)
+    assertEquals(uniqueKeys(Array(1)),
+      mq.getUniqueKeys(logicalSemiJoinWithEquiAndNonEquiCond).toSet)
+
+    assertEquals(uniqueKeys(Array(1)),
+      mq.getUniqueKeys(logicalAntiJoinOnUniqueKeys).toSet)
+    assertEquals(uniqueKeys(Array(1)), mq.getUniqueKeys(logicalAntiJoinNotOnUniqueKeys).toSet)
+    assertNull(mq.getUniqueKeys(logicalAntiJoinOnRHSUniqueKeys))
+    assertEquals(uniqueKeys(Array(1)), mq.getUniqueKeys(logicalAntiJoinWithoutEquiCond).toSet)
+    assertEquals(uniqueKeys(Array(1)),
+      mq.getUniqueKeys(logicalAntiJoinWithEquiAndNonEquiCond).toSet)
+  }
+
+  @Test
+  def testGetUniqueKeysOnLookupJoin(): Unit = {
+    Array(batchLookupJoin, streamLookupJoin).foreach { join =>
+      assertEquals(uniqueKeys(), mq.getUniqueKeys(join).toSet)
+    }
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/MetadataTestUtil.scala
@@ -179,6 +179,7 @@ object MetadataTestUtil {
       new IntType(),
       new TimestampType(true, TimestampKind.PROCTIME, 3),
       new TimestampType(true, TimestampKind.ROWTIME, 3))
+    val fieldNulls = fieldNames.map(_ => true)
 
     val colStatsMap = Map[String, ColumnStats](
       "a" -> new ColumnStats(30L, 0L, 4D, 4, 45, 5),
@@ -187,7 +188,7 @@ object MetadataTestUtil {
     )
 
     val tableStats = new TableStats(50L, colStatsMap)
-    getDataStreamTable(fieldNames, fieldTypes, new FlinkStatistic(tableStats),
+    getDataStreamTable(fieldNames, fieldTypes, fieldNulls, new FlinkStatistic(tableStats),
       producesUpdates = false, isAccRetract = false)
   }
 
@@ -199,6 +200,7 @@ object MetadataTestUtil {
       new IntType(),
       new TimestampType(true, TimestampKind.PROCTIME, 3),
       new TimestampType(true, TimestampKind.ROWTIME, 3))
+    val fieldNulls = fieldNames.map(_ => true)
 
     val colStatsMap = Map[String, ColumnStats](
       "a" -> new ColumnStats(50L, 0L, 8D, 8, 55, 5),
@@ -208,8 +210,8 @@ object MetadataTestUtil {
 
     val tableStats = new TableStats(50L, colStatsMap)
     val uniqueKeys = Set(Set("a").asJava).asJava
-    getDataStreamTable(fieldNames, fieldTypes, new FlinkStatistic(tableStats, uniqueKeys),
-      producesUpdates = false, isAccRetract = false)
+    getDataStreamTable(fieldNames, fieldTypes, fieldNulls,
+      new FlinkStatistic(tableStats, uniqueKeys), producesUpdates = false, isAccRetract = false)
   }
 
   private def createTemporalTable3(): DataStreamTable[BaseRow] = {
@@ -220,6 +222,7 @@ object MetadataTestUtil {
       new VarCharType(VarCharType.MAX_LENGTH),
       new TimestampType(true, TimestampKind.PROCTIME, 3),
       new TimestampType(true, TimestampKind.ROWTIME, 3))
+    val fieldNulls = fieldNames.map(_ => true)
 
     val colStatsMap = Map[String, ColumnStats](
       "a" -> new ColumnStats(3740000000L, 0L, 4D, 4, null, null),
@@ -228,7 +231,7 @@ object MetadataTestUtil {
     )
 
     val tableStats = new TableStats(4000000000L, colStatsMap)
-    getDataStreamTable(fieldNames, fieldTypes, new FlinkStatistic(tableStats),
+    getDataStreamTable(fieldNames, fieldTypes, fieldNulls, new FlinkStatistic(tableStats),
       producesUpdates = false, isAccRetract = false)
   }
 
@@ -237,13 +240,16 @@ object MetadataTestUtil {
       statistic: FlinkStatistic,
       producesUpdates: Boolean = false,
       isAccRetract: Boolean = false): DataStreamTable[BaseRow] = {
+    val names = tableSchema.getFieldNames
     val types = tableSchema.getFieldTypes.map(fromTypeInfoToLogicalType)
-    getDataStreamTable(tableSchema.getFieldNames, types, statistic, producesUpdates, isAccRetract)
+    val nulls = Array.fill(tableSchema.getFieldCount)(true)
+    getDataStreamTable(names, types, nulls, statistic, producesUpdates, isAccRetract)
   }
 
   private def getDataStreamTable(
       fieldNames: Array[String],
       fieldTypes: Array[LogicalType],
+      fieldNullables: Array[Boolean],
       statistic: FlinkStatistic,
       producesUpdates: Boolean,
       isAccRetract: Boolean): DataStreamTable[BaseRow] = {
@@ -256,7 +262,8 @@ object MetadataTestUtil {
       isAccRetract,
       fieldTypes.indices.toArray,
       fieldNames,
-      statistic)
+      statistic,
+      Some(fieldNullables))
   }
 
 }


### PR DESCRIPTION

## What is the purpose of the change

*Introduce metadata handlers on SEMI/ANTI join and lookup join*


## Brief change log

  - *Implements metadata handlers on SEMI/ANTI join and lookup join, e.g. FlinkRelMdColumnInterval, FlinkRelMdColumnUniqueness*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended metadata handler test for logic about SEMI/ANTI join and lookup join*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
