### PR TITLE
[FLINK-12268][Tests] Port SharedSlotsTest to new code base

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -19,19 +19,13 @@
 package org.apache.flink.runtime.jobmanager.scheduler;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
-import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,37 +45,7 @@ public class SchedulerTestUtils {
 	private static final AtomicInteger port = new AtomicInteger(10000);
 
 	// --------------------------------------------------------------------------------------------
-	
-	public static Instance getRandomInstance(int numSlots) {
-		if (numSlots <= 0) {
-			throw new IllegalArgumentException();
-		}
-		
-		final ResourceID resourceID = ResourceID.generate();
-		final InetAddress address;
-		try {
-			address = InetAddress.getByName("127.0.0.1");
-		}
-		catch (UnknownHostException e) {
-			throw new RuntimeException("Test could not create IP address for localhost loopback.");
-		}
-		
-		int dataPort = port.getAndIncrement();
-		
-		TaskManagerLocation ci = new TaskManagerLocation(resourceID, address, dataPort);
-		
-		final long GB = 1024L*1024*1024;
-		HardwareDescription resources = new HardwareDescription(4, 4*GB, 3*GB, 2*GB);
-		
-		return new Instance(
-			new SimpleAckingTaskManagerGateway(),
-			ci,
-			new InstanceID(),
-			resources,
-			numSlots);
-	}
-	
-	
+
 	public static Execution getDummyTask() {
 		ExecutionJobVertex executionJobVertex = mock(ExecutionJobVertex.class);
 


### PR DESCRIPTION
## What is the purpose of the change

*Port SharedSlotsTest to new code base*


## Brief change log

*(for example:)*
 - *Add _getSharedSlot_ to get a new SharedSlot.*
  - *Use _getSharedSlot_ instead of Instance#allocateSharedSlot.*

## Verifying this change

This change is already covered by existing tests, such as *(SharedSlotsTest)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

cc @zentol @GJL 