### PR TITLE
[DOC]Update 'StateTtlCon fig' to 'StateTtlConfig'

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -424,7 +424,7 @@ import org.apache.flink.api.common.state.StateTtlConfig;
  <div data-lang="scala" markdown="1">
 {% highlight scala %}
 import org.apache.flink.api.common.state.StateTtlConfig
-val ttlConfig = StateTtlCon fig
+val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .cleanupIncrementally
     .build


### PR DESCRIPTION
For this doc `flink/docs/dev/stream/state/state.md`, there is a wrong word  `StateTtlCon fig`