### PR TITLE
[FLINK-12707]Close minicluster will cause memory leak when there are StreamTask closed abnormal	

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -459,6 +459,25 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		}
 	}
 
+	@Override
+	public void close(){
+		try {
+			this.closeAsync();
+			Thread.sleep(8000);
+
+			if (taskManagers != null) {
+				for (TaskExecutor tm : taskManagers) {
+					if (tm != null) {
+						tm.shutDown();
+					}
+				}
+			}
+		} catch (Exception var2) {
+			System.out.println("mini cluster close error:"+ var2.getMessage());
+		}
+	}
+
+
 	private CompletableFuture<Void> closeMetricSystem() {
 		synchronized (lock) {
 			final ArrayList<CompletableFuture<Void>> terminationFutures = new ArrayList<>(2);
@@ -525,7 +544,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 	protected CompletableFuture<Void> terminateTaskExecutor(int index) {
 		synchronized (lock) {
 			final TaskExecutor taskExecutor = taskManagers.get(index);
-			return taskExecutor.closeAsync();
+			return taskExecutor.getTerminationFuture();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -392,6 +392,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		ExceptionUtils.tryRethrowException(exception);
 	}
 
+	public final void shutDown() {
+		this.getRpcService().stopServer(this.rpcServer);
+	}
+
 	// ======================================================================
 	//  RPC methods
 	// ======================================================================


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/FLINK-12707](https://issues.apache.org/jira/browse/FLINK-12707)
There are several threads in my application,and every thread will launch a flink job with LocalStreamEnvironment/MiniCluster.But when I interrupt these threads again and again, I found there are many residue threads,and that caused a memory leak.
When I debug it,this message appears "Recipient[Actorakka://flink/user/taskmanager_0#-584606215] had already been terminated. Sender[null] sent the message of type "org.apache.flink.runtime.rpc.messages.LocalRpcInvocation". So I think
when flink close minicluster,TaskExecutor will be closed in the first place,and this operation will cause akka message which will close StreamTask abnormal.So the work thread will be more and more.
I call Thread sleep in my application to avoid this problem,any good suggestions?