### PR TITLE
[FLINK-12650][docs] Redirect Users to Documentation Homepage if Requested Resource Does Not Exist

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,26 @@
+---
+title: "404"
+permalink: /404.html
+layout: 404_base
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!--
+Force the 404 page to render
+-->

--- a/docs/_layouts/404_base.html
+++ b/docs/_layouts/404_base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https:{{ site.stable_baseurl }}">
+    <script type="text/javascript">
+      window.location.href = "https:{{ site.stable_baseurl }}"
+    </script>
+    <title>404</title>
+  </head>
+  <body>
+    <a href='https:{{ site.stable_baseurl }}'>Home</a>.
+  </body>
+</html>


### PR DESCRIPTION
## What is the purpose of the change

Currently, if you go open a documentation page, which does not exist like

https://ci.apache.org/projects/flink/flink-docs-release-1.8/dev/event_timed.html

the reply is 404. In preparation of a larger restructuring, it would be good if instead of a 404 we would redirect the user to the documentation homepage for this version of the docs.

**Important** Depending on the current configuration of the apache infra servers we may require a follow-up INFRA ticket to enable serving our 404 page. Regardless of whether or not that needs to be done, this is pre-requisite work so it does not need to be blocked on discovery. 

## Brief change log

Add a 404 redirect to the documentation

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.