### PR TITLE
[FLINK-12721] Process integer type in json format

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowSchemaConverter.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowSchemaConverter.java
@@ -165,9 +165,7 @@ public final class JsonRowSchemaConverter {
 						typeSet.add(Types.BIG_DEC);
 						break;
 					case TYPE_INTEGER:
-						// use BigDecimal for easier interoperability
-						// without affecting the correctness of the result
-						typeSet.add(Types.BIG_DEC);
+						typeSet.add(Types.INT);
 						break;
 					case TYPE_OBJECT:
 						typeSet.add(convertObject(location, node, root));

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
@@ -78,19 +78,20 @@ public class JsonRowDeserializationSchemaTest {
 
 	@Test
 	public void testSchemaDeserialization() throws Exception {
-		final BigDecimal id = BigDecimal.valueOf(1238123899121L);
+		//final BigDecimal id = BigDecimal.valueOf(1238123899121L);
+		final int id = 12345678;
 		final String name = "asdlkjasjkdla998y1122";
-		final byte[] bytes = new byte[1024];
+		final byte[] bytes = new byte[2];
 		ThreadLocalRandom.current().nextBytes(bytes);
-		final BigDecimal[] numbers = new BigDecimal[] {
-			BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(3)};
+		final Integer[] numbers = new Integer[] {
+			1, 2, 3};
 		final String[] strings = new String[] {"one", "two", "three"};
 
 		final ObjectMapper objectMapper = new ObjectMapper();
 
 		// Root
 		ObjectNode root = objectMapper.createObjectNode();
-		root.put("id", id.longValue());
+		root.put("id", id);
 		root.putNull("idOrNull");
 		root.put("name", name);
 		root.put("date", "1990-10-14");

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSchemaConverterTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSchemaConverterTest.java
@@ -47,7 +47,7 @@ public class JsonRowSchemaConverterTest {
 				"email", "tel", "sound", "org"},
 			Types.STRING, Types.STRING, Types.BOOLEAN, Types.ROW(Types.BIG_DEC, Types.STRING, Types.STRING, Types.STRING),
 			Types.OBJECT_ARRAY(Types.STRING), Types.STRING, Types.ROW_NAMED(new String[] {"type", "value"}, Types.STRING, Types.STRING),
-			Types.ROW_NAMED(new String[] {"type", "value"}, Types.BIG_DEC, Types.STRING), Types.VOID,
+			Types.ROW_NAMED(new String[] {"type", "value"}, Types.INT, Types.STRING), Types.VOID,
 			Types.ROW_NAMED(new String[] {"organizationUnit"}, Types.ROW()));
 
 		assertEquals(expected, result);

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSerializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSerializationSchemaTest.java
@@ -136,7 +136,7 @@ public class JsonRowSerializationSchemaTest {
 			"}");
 
 		final Row row = new Row(11);
-		row.setField(0, BigDecimal.valueOf(-333));
+		row.setField(0, -333);
 		row.setField(1, BigDecimal.valueOf(12.2222));
 		row.setField(2, null);
 		row.setField(3, "");
@@ -144,11 +144,11 @@ public class JsonRowSerializationSchemaTest {
 		row.setField(5, Time.valueOf("12:12:43"));
 		row.setField(6, Timestamp.valueOf("1990-10-14 12:12:43"));
 
-		final byte[] bytes = new byte[1024];
+		final byte[] bytes = new byte[2];
 		ThreadLocalRandom.current().nextBytes(bytes);
 		row.setField(7, bytes);
-		final BigDecimal[] numbers = new BigDecimal[] {
-			BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(3)};
+		final Integer[] numbers = new Integer[] {
+			1, 2, 3};
 		row.setField(8, numbers);
 		final String[] strings = new String[] {"one", "two", "three"};
 		row.setField(9, strings);


### PR DESCRIPTION
## What is the purpose of the change

This PR aims at providing a more precisely way to process `integer` type in JSON format.


## Brief change log

- convert `integer` type in JSON Schema to `Types.INT`


## Verifying this change

This change is already covered by existing tests, such as test in flink-json module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  