### PR TITLE
[FLINK-12718][hive] allow users to specify hive-site.xml location to configure hive metastore client in HiveCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -112,16 +112,8 @@ public class HiveCatalog extends AbstractCatalog {
 
 	private HiveMetastoreClientWrapper client;
 
-	public HiveCatalog(String catalogName, String hiveSiteFilePath) {
-		this(catalogName, DEFAULT_DB, hiveSiteFilePath);
-	}
-
 	public HiveCatalog(String catalogName, String defaultDatabase, String hiveSiteFilePath) {
 		this(catalogName, defaultDatabase, getHiveSiteUrl(hiveSiteFilePath));
-	}
-
-	public HiveCatalog(String catalogName, URL hiveSiteUrl) {
-		this(catalogName, DEFAULT_DB, hiveSiteUrl);
 	}
 
 	public HiveCatalog(String catalogName, String defaultDatabase, URL hiveSiteUrl) {
@@ -140,6 +132,8 @@ public class HiveCatalog extends AbstractCatalog {
 	}
 
 	private static URL getHiveSiteUrl(String filePath) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(filePath), "filePath cannot be null or empty");
+
 		try {
 			URL url = new File(filePath).toURI().toURL();
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -117,7 +117,7 @@ public class HiveCatalog extends AbstractCatalog {
 	public HiveCatalog(String catalogName, @Nullable String defaultDatabase, @Nullable String hiveSiteFilePath) {
 		this(catalogName,
 			defaultDatabase == null ? DEFAULT_DB : defaultDatabase,
-			getHiveConf(hiveSiteFilePath));
+			getHiveConf(loadHiveSiteUrl(hiveSiteFilePath)));
 	}
 
 	public HiveCatalog(String catalogName, @Nullable String defaultDatabase, @Nullable URL hiveSiteUrl) {
@@ -129,12 +129,12 @@ public class HiveCatalog extends AbstractCatalog {
 	public HiveCatalog(String catalogName, @Nullable String defaultDatabase, @Nullable HiveConf hiveConf) {
 		super(catalogName, defaultDatabase == null ? DEFAULT_DB : defaultDatabase);
 
-		this.hiveConf = hiveConf == null ? getHiveConf("") : hiveConf;
+		this.hiveConf = hiveConf == null ? getHiveConf(null) : hiveConf;
 
 		LOG.info("Created HiveCatalog '{}'", catalogName);
 	}
 
-	private static HiveConf getHiveConf(String filePath) {
+	private static URL loadHiveSiteUrl(String filePath) {
 
 		URL url = null;
 
@@ -150,7 +150,7 @@ public class HiveCatalog extends AbstractCatalog {
 			}
 		}
 
-		return getHiveConf(url);
+		return url;
 	}
 
 	private static HiveConf getHiveConf(URL hiveSiteUrl) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
@@ -37,11 +37,11 @@ public class HiveTestUtils {
 	 * Create a HiveCatalog with an embedded Hive Metastore.
 	 */
 	public static HiveCatalog createHiveCatalog() throws IOException {
-		return new HiveCatalog(CatalogTestBase.TEST_CATALOG_NAME, getHiveConf());
+		return new HiveCatalog(CatalogTestBase.TEST_CATALOG_NAME, null, getHiveConf());
 	}
 
 	public static HiveCatalog createHiveCatalog(HiveConf hiveConf) {
-		return new HiveCatalog(CatalogTestBase.TEST_CATALOG_NAME, hiveConf);
+		return new HiveCatalog(CatalogTestBase.TEST_CATALOG_NAME, null, hiveConf);
 	}
 
 	public static HiveConf getHiveConf() throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

This PR enables users to specify the path of `hive-site.xml` file as param to build a HiveCatalog. `hive-site.xml` is a standard way of configuring Hive client. Configs in `hive-site` is a superset of the config `hive.metastore.uris` which we currently use to config HiveCatalog. 

## Brief change log

- supported file path and url of `hive-site.xml` as param to construct HiveCatalog

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

Documentation will be added later
