### PR TITLE
[FLINK-12619][StateBackend]Support TERMINATE/SUSPEND Job with Checkpoint

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -511,9 +511,9 @@ public class CliFrontend {
 		}
 
 		if (stopOptions.hasCheckpointFlag()) {
-			LOG.info("Running 'stop-with-savepoint' command.");
+			LOG.info("Running 'stop-with-checkpoint' command.");
 		} else {
-			LOG.info("Running 'stop-with-savepoint' command.");
+			LOG.info("Running 'stop-with-checkpoint' command.");
 		}
 
 		final String[] cleanedArgs = stopOptions.getArgs();

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -513,7 +513,7 @@ public class CliFrontend {
 		if (stopOptions.hasCheckpointFlag()) {
 			LOG.info("Running 'stop-with-checkpoint' command.");
 		} else {
-			LOG.info("Running 'stop-with-checkpoint' command.");
+			LOG.info("Running 'stop-with-savepoint' command.");
 		}
 
 		final String[] cleanedArgs = stopOptions.getArgs();

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -132,6 +132,9 @@ public class CliFrontendParser {
 		"Python module with the program entry point. " +
 			"This option must be used in conjunction with `--pyFiles`.");
 
+	public static final Option STOP_WITH_CHECKPOINT = new Option("k", "withCheckpoint", false,
+		"Stop the job with checkpoint, The checkpoint will be stored in (\"" + CheckpointingOptions.CHECKPOINTS_DIRECTORY.key() + "\").");
+
 	static {
 		HELP_OPTION.setRequired(false);
 
@@ -188,6 +191,8 @@ public class CliFrontendParser {
 
 		PYMODULE_OPTION.setRequired(false);
 		PYMODULE_OPTION.setArgName("pyModule");
+
+		STOP_WITH_CHECKPOINT.setRequired(false);
 	}
 
 	private static final Options RUN_OPTIONS = getRunCommandOptions();
@@ -255,6 +260,7 @@ public class CliFrontendParser {
 	static Options getStopCommandOptions() {
 		return buildGeneralOptions(new Options())
 				.addOption(STOP_WITH_SAVEPOINT)
+				.addOption(STOP_WITH_CHECKPOINT)
 				.addOption(STOP_AND_DRAIN);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
@@ -21,7 +21,9 @@ package org.apache.flink.client.cli;
 import org.apache.commons.cli.CommandLine;
 
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_AND_DRAIN;
+import static org.apache.flink.client.cli.CliFrontendParser.STOP_WITH_CHECKPOINT;
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_WITH_SAVEPOINT;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Command line options for the STOP command.
@@ -31,6 +33,8 @@ class StopOptions extends CommandLineOptions {
 	private final String[] args;
 
 	private final boolean savepointFlag;
+
+	private final boolean checkpointFlag;
 
 	/** Optional target directory for the savepoint. Overwrites cluster default. */
 	private final String targetDirectory;
@@ -43,6 +47,10 @@ class StopOptions extends CommandLineOptions {
 
 		this.savepointFlag = line.hasOption(STOP_WITH_SAVEPOINT.getOpt());
 		this.targetDirectory = line.getOptionValue(STOP_WITH_SAVEPOINT.getOpt());
+
+		this.checkpointFlag = line.hasOption(STOP_WITH_CHECKPOINT.getOpt());
+
+		checkState(!(this.savepointFlag && this.checkpointFlag), "Can only stop with checkpoint or savepoint, can't set both.");
 
 		this.advanceToEndOfEventTime = line.hasOption(STOP_AND_DRAIN.getOpt());
 	}
@@ -57,6 +65,10 @@ class StopOptions extends CommandLineOptions {
 
 	String getTargetDirectory() {
 		return targetDirectory;
+	}
+
+	boolean hasCheckpointFlag() {
+		return checkpointFlag;
 	}
 
 	boolean shouldAdvanceToEndOfEventTime() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -391,7 +391,7 @@ public abstract class ClusterClient<T> {
 	/**
 	 * Stops a program on Flink cluster whose job-manager is configured in this client's configuration.
 	 * Stopping works only for streaming programs. Be aware, that the program might continue to run for
-	 * a while after sending the stop command, because after sources stopped to emit data ll operators
+	 * a while after sending the stop command, because after sources stopped to emit data all operators
 	 * need to finish processing.
 	 *
 	 * @param jobID the job ID of the streaming program to stop

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -389,6 +389,21 @@ public abstract class ClusterClient<T> {
 	public abstract CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) throws FlinkException;
 
 	/**
+	 * Stops a program on Flink cluster whose job-manager is configured in this client's configuration.
+	 * Stopping works only for streaming programs. Be aware, that the program might continue to run for
+	 * a while after sending the stop command, because after sources stopped to emit data ll operators
+	 * need to finish processing.
+	 *
+	 * @param jobID the job ID of the streaming program to stop
+	 * @param advanceToEndOfEventTime flag indicating if the source should inject a @{@code MAX_WATERMARK} in the pipeline
+	 * @return a {@link CompletableFuture} containing the path where the checkpoint is located
+	 * @throws Exception
+	 * 				If the job ID is invalid (ie, is unknown or refers to a batch job) or if sending the stop signal
+	 * 				failed. That might be due to an I/O problem, ie, the job-manager is unreachable.
+	 */
+	public abstract String stopWithCheckpoint(final JobID jobID, final boolean advanceToEndOfEventTime) throws Exception;
+
+	/**
 	 * Lists the currently running and finished jobs on the cluster.
 	 *
 	 * @return future collection of running and finished jobs

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -132,6 +132,11 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	}
 
 	@Override
+	public String stopWithCheckpoint(JobID jobId, boolean advanceToEndOfEventTime) throws Exception {
+		return miniCluster.stopWithCheckpoint(jobId, advanceToEndOfEventTime).get();
+	}
+
+	@Override
 	public CompletableFuture<Collection<JobStatusMessage>> listJobs() {
 		return miniCluster.listJobs();
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -508,6 +508,11 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 	}
 
 	@Override
+	public String stopWithCheckpoint(JobID jobId, boolean advanceToEndOfEventTime) {
+		throw new UnsupportedOperationException("Current stop with checkpoint can only be triggered by flink client, will support restful api in the future.");
+	}
+
+	@Override
 	public CompletableFuture<Collection<JobStatusMessage>> listJobs() {
 		return sendRequest(JobsOverviewHeaders.getInstance())
 			.thenApply(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointProperties.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointProperties.java
@@ -284,6 +284,14 @@ public class CheckpointProperties implements Serializable {
 			false,  // Retain on failure
 			false); // Retain on suspension
 
+	private static final CheckpointProperties SYNC_CHECKPOINT = new CheckpointProperties(
+		true,
+		CheckpointType.SYNC_CHECKPOINT,
+		false,
+		false,
+		false,
+		false,
+		false);
 
 	/**
 	 * Creates the checkpoint properties for a (manually triggered) savepoint.
@@ -299,6 +307,10 @@ public class CheckpointProperties implements Serializable {
 
 	public static CheckpointProperties forSyncSavepoint() {
 		return SYNC_SAVEPOINT;
+	}
+
+	public static CheckpointProperties forSyncCheckpoint() {
+		return SYNC_CHECKPOINT;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
@@ -30,7 +30,10 @@ public enum CheckpointType {
 	SAVEPOINT(true, false),
 
 	/** A savepoint taken while suspending/terminating the job. */
-	SYNC_SAVEPOINT(true, true);
+	SYNC_SAVEPOINT(true, true),
+
+	/** A checkpoint taken while suspending/terminating the job. */
+	SYNC_CHECKPOINT(false, true);
 
 	private final boolean isSavepoint;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -580,7 +580,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 		return jobMasterGatewayFuture.thenCompose(
 				(JobMasterGateway jobMasterGateway) ->
-						jobMasterGateway.stopWithSavepoint(targetDirectory, advanceToEndOfEventTime, timeout));
+						jobMasterGateway.stopWithCheckpoint(false, targetDirectory, advanceToEndOfEventTime, timeout));
 	}
 
 	@Override
@@ -593,7 +593,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 		return jobMasterGatewayFuture.thenCompose(
 			(JobMasterGateway jobMasterGateway) ->
-				jobMasterGateway.stopWithCheckpoint(advanceToEndOfEventTime, timeout));
+				jobMasterGateway.stopWithCheckpoint(true, null, advanceToEndOfEventTime, timeout));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -584,6 +584,19 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	@Override
+	public CompletableFuture<String> stopWithCheckpoint(
+		final JobID jobId,
+		final boolean advanceToEndOfEventTime,
+		final Time timeout) {
+
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
+
+		return jobMasterGatewayFuture.thenCompose(
+			(JobMasterGateway jobMasterGateway) ->
+				jobMasterGateway.stopWithCheckpoint(advanceToEndOfEventTime, timeout));
+	}
+
+	@Override
 	public CompletableFuture<Acknowledge> shutDownCluster() {
 		closeAsync();
 		return CompletableFuture.completedFuture(Acknowledge.get());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -998,15 +998,15 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * @param advanceToEndOfEventTime Flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
 	 *                              to fire any registered event-time timers
 	 */
-	public void triggerSynchronousSavepoint(long checkpointId, long timestamp, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
+	public void triggerSynchronousChecpoint(long checkpointId, long timestamp, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
 		triggerCheckpointHelper(checkpointId, timestamp, checkpointOptions, advanceToEndOfEventTime);
 	}
 
 	private void triggerCheckpointHelper(long checkpointId, long timestamp, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
 
 		final CheckpointType checkpointType = checkpointOptions.getCheckpointType();
-		if (advanceToEndOfEventTime && !(checkpointType.isSynchronous() && checkpointType.isSavepoint())) {
-			throw new IllegalArgumentException("Only synchronous savepoints are allowed to advance the watermark to MAX.");
+		if (advanceToEndOfEventTime && !(checkpointType.isSynchronous())) {
+			throw new IllegalArgumentException("Only synchronous checkpoints/savepoints are allowed to advance the watermark to MAX.");
 		}
 
 		final LogicalSlot slot = assignedResource;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -65,6 +65,8 @@ public class EventSerializer {
 
 	private static final int CHECKPOINT_TYPE_SYNC_SAVEPOINT = 2;
 
+	private static final int CHECKPOINT_TYPE_SYNC_CHECKPOINT = 3;
+
 	// ------------------------------------------------------------------------
 	//  Serialization Logic
 	// ------------------------------------------------------------------------
@@ -219,6 +221,8 @@ public class EventSerializer {
 			typeInt = CHECKPOINT_TYPE_SAVEPOINT;
 		} else if (checkpointType == CheckpointType.SYNC_SAVEPOINT) {
 			typeInt = CHECKPOINT_TYPE_SYNC_SAVEPOINT;
+		} else if (checkpointType == CheckpointType.SYNC_CHECKPOINT) {
+			typeInt = CHECKPOINT_TYPE_SYNC_CHECKPOINT;
 		} else {
 			throw new IOException("Unknown checkpoint type: " + checkpointType);
 		}
@@ -253,6 +257,8 @@ public class EventSerializer {
 			checkpointType = CheckpointType.SAVEPOINT;
 		} else if (checkpointTypeCode == CHECKPOINT_TYPE_SYNC_SAVEPOINT) {
 			checkpointType = CheckpointType.SYNC_SAVEPOINT;
+		} else if (checkpointTypeCode == CHECKPOINT_TYPE_SYNC_CHECKPOINT) {
+			checkpointType = CheckpointType.SYNC_CHECKPOINT;
 		} else {
 			throw new IOException("Unknown checkpoint type code: " + checkpointTypeCode);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -627,19 +627,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
-	public CompletableFuture<String> stopWithSavepoint(
+	public CompletableFuture<String> stopWithCheckpoint(
+			final boolean isCheckpoint,
 			@Nullable final String targetDirectory,
 			final boolean advanceToEndOfEventTime,
 			final Time timeout) {
 
-		return schedulerNG.stopWithSavepoint(targetDirectory, advanceToEndOfEventTime);
-	}
-
-	@Override
-	public CompletableFuture<String> stopWithCheckpoint(
-		final boolean advanceToEndOfEventTime,
-		final Time timeout) {
-		return schedulerNG.stopWithCheckpoint(advanceToEndOfEventTime);
+		return schedulerNG.stopWithCheckpoint(isCheckpoint, targetDirectory, advanceToEndOfEventTime);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -636,6 +636,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
+	public CompletableFuture<String> stopWithCheckpoint(
+		final boolean advanceToEndOfEventTime,
+		final Time timeout) {
+		return schedulerNG.stopWithCheckpoint(advanceToEndOfEventTime);
+	}
+
+	@Override
 	public CompletableFuture<OperatorBackPressureStatsResponse> requestOperatorBackPressureStats(final JobVertexID jobVertexId) {
 		try {
 			final Optional<OperatorBackPressureStats> operatorBackPressureStats = schedulerNG.requestOperatorBackPressureStats(jobVertexId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -230,8 +230,9 @@ public interface JobMasterGateway extends
 		@RpcTimeout final Time timeout);
 
 	/**
-	 * Stops the job with a savepoint.
+	 * Stops the job with a checkpoint/savepoint.
 	 *
+	 * @param isCheckpoint Ture for a checkpoint, false for a savepoint.
 	 * @param targetDirectory to which to write the savepoint data or null if the
 	 *                           default savepoint directory should be used
 	 * @param advanceToEndOfEventTime Flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
@@ -239,20 +240,9 @@ public interface JobMasterGateway extends
 	 * @param timeout for the rpc call
 	 * @return Future which is completed with the savepoint path once completed
 	 */
-	CompletableFuture<String> stopWithSavepoint(
-		@Nullable final String targetDirectory,
-		final boolean advanceToEndOfEventTime,
-		@RpcTimeout final Time timeout);
-
-	/**
-	 * Stops the job with a checkpoint.
-	 *
-	 * @param advanceToEndOfEventTime Flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
-	 *                                to fire any registered event-time timer
-	 * @param timeout for the rpc call
-	 * @return Future which is completed with the savepoint path once completed
-	 */
 	CompletableFuture<String> stopWithCheckpoint(
+		final boolean isCheckpoint,
+		@Nullable final String targetDirectory,
 		final boolean advanceToEndOfEventTime,
 		@RpcTimeout final Time timeout);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -245,6 +245,18 @@ public interface JobMasterGateway extends
 		@RpcTimeout final Time timeout);
 
 	/**
+	 * Stops the job with a checkpoint.
+	 *
+	 * @param advanceToEndOfEventTime Flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
+	 *                                to fire any registered event-time timer
+	 * @param timeout for the rpc call
+	 * @return Future which is completed with the savepoint path once completed
+	 */
+	CompletableFuture<String> stopWithCheckpoint(
+		final boolean advanceToEndOfEventTime,
+		@RpcTimeout final Time timeout);
+
+	/**
 	 * Requests the statistics on operator back pressure.
 	 *
 	 * @param jobVertexId JobVertex for which the stats are requested.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -563,6 +563,10 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.disposeSavepoint(savepointPath, rpcTimeout));
 	}
 
+	public CompletableFuture<String> stopWithCheckpoint(JobID jobId, boolean advanceToEndOfEventTime) {
+		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.stopWithCheckpoint(jobId, advanceToEndOfEventTime, rpcTimeout));
+	}
+
 	public CompletableFuture<? extends AccessExecutionGraph> getExecutionGraph(JobID jobId) {
 		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.requestJob(jobId, rpcTimeout));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -117,7 +117,11 @@ public interface SchedulerNG {
 
 	void declineCheckpoint(DeclineCheckpoint decline);
 
-	CompletableFuture<String> stopWithSavepoint(String targetDirectory, boolean advanceToEndOfEventTime);
-
-	CompletableFuture<String> stopWithCheckpoint(boolean advanceToEndOfEventTime);
+	/**
+	 * Stop with synchronous checkpoint and return the future.
+	 * @param isCheckpoint True for a checkpoint, false for savepoint.
+	 * @param targetDirectory Used to store the savepoint data, maybe null.
+	 * @param advanceToEndOfEventTime Whether to emit {@link org.apache.flink.streaming.api.watermark.Watermark#MAX_WATERMARK MAX_WATERMARK}
+	 */
+	CompletableFuture<String> stopWithCheckpoint(boolean isCheckpoint, @Nullable String targetDirectory, boolean advanceToEndOfEventTime);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -118,4 +118,6 @@ public interface SchedulerNG {
 	void declineCheckpoint(DeclineCheckpoint decline);
 
 	CompletableFuture<String> stopWithSavepoint(String targetDirectory, boolean advanceToEndOfEventTime);
+
+	CompletableFuture<String> stopWithCheckpoint(boolean advanceToEndOfEventTime);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -686,8 +686,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		log.debug("Trigger checkpoint {}@{} for {}.", checkpointId, checkpointTimestamp, executionAttemptID);
 
 		final CheckpointType checkpointType = checkpointOptions.getCheckpointType();
-		if (advanceToEndOfEventTime && !(checkpointType.isSynchronous() && checkpointType.isSavepoint())) {
-			throw new IllegalArgumentException("Only synchronous savepoints are allowed to advance the watermark to MAX.");
+		if (advanceToEndOfEventTime && !checkpointType.isSynchronous()) {
+			throw new IllegalArgumentException("Only synchronous checkpoint/savepoint are allowed to advance the watermark to MAX.");
 		}
 
 		final Task task = taskSlotTable.getTask(executionAttemptID);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -157,6 +157,15 @@ public interface RestfulGateway extends RpcGateway {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * Stops the job with a checkpoint.
+	 *
+	 * @param jobId ID of the job for which the checkpoint should be triggered.
+	 * @param advanceToEndOfEventTime Flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
+	 *                              to fire any registered event-time timers
+	 * @param timeout for the rpc call
+	 * @return Future which is completed with the checkpoint path once completed
+	 */
 	default CompletableFuture<String> stopWithCheckpoint(
 		final JobID jobId,
 		final boolean advanceToEndOfEventTime,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -157,6 +157,13 @@ public interface RestfulGateway extends RpcGateway {
 		throw new UnsupportedOperationException();
 	}
 
+	default CompletableFuture<String> stopWithCheckpoint(
+		final JobID jobId,
+		final boolean advanceToEndOfEventTime,
+		@RpcTimeout final Time timeout) {
+		throw new UnsupportedOperationException();
+	}
+
 	/**
 	 * Request the {@link JobStatus} of the given job.
 	 *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointPropertiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointPropertiesTest.java
@@ -70,6 +70,21 @@ public class CheckpointPropertiesTest {
 	}
 
 	/**
+	 * Test for sync checkpoint.
+	 **/
+	@Test
+	public void testSyncCheckpoint() {
+		CheckpointProperties props = CheckpointProperties.forSyncCheckpoint();
+		assertFalse(props.isSavepoint());
+		assertTrue(props.forceCheckpoint());
+		assertFalse(props.discardOnSubsumed());
+		assertFalse(props.discardOnJobFinished());
+		assertFalse(props.discardOnJobCancelled());
+		assertFalse(props.discardOnJobFailed());
+		assertFalse(props.discardOnJobSuspended());
+	}
+
+	/**
 	 * Tests the isSavepoint utility works as expected.
 	 */
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointTypeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointTypeTest.java
@@ -37,5 +37,6 @@ public class CheckpointTypeTest {
 		assertEquals(0, CheckpointType.CHECKPOINT.ordinal());
 		assertEquals(1, CheckpointType.SAVEPOINT.ordinal());
 		assertEquals(2, CheckpointType.SYNC_SAVEPOINT.ordinal());
+		assertEquals(3, CheckpointType.SYNC_CHECKPOINT.ordinal());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -120,6 +120,21 @@ public class PendingCheckpointTest {
 		}
 	}
 
+	@Test
+	public void testSyncCheckpointCannotBeSubsumed() throws Exception {
+		// Forced checkpoints cannot be subsumed
+		CheckpointProperties forced = CheckpointProperties.forSyncCheckpoint();
+		PendingCheckpoint pending = createPendingCheckpoint(forced);
+		assertFalse(pending.canBeSubsumed());
+
+		try {
+			pending.abort(CheckpointFailureReason.CHECKPOINT_SUBSUMED);
+			fail("Did not throw expected Exception");
+		} catch (IllegalStateException ignored) {
+			// Expected
+		}
+	}
+
 	/**
 	 * Tests that the completion future is succeeded on finalize and failed on
 	 * abort and failures during finalize.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.api.serialization;
 
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -26,6 +27,7 @@ import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.util.TestTaskEvent;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 
 import org.junit.Test;
 
@@ -96,6 +98,10 @@ public class EventSerializerTest {
 			EndOfPartitionEvent.INSTANCE,
 			EndOfSuperstepEvent.INSTANCE,
 			new CheckpointBarrier(1678L, 4623784L, CheckpointOptions.forCheckpointWithDefaultLocation()),
+			new CheckpointBarrier(1679L, 123433525L, new CheckpointOptions(CheckpointType.CHECKPOINT, CheckpointStorageLocationReference.getDefault())),
+			new CheckpointBarrier(1679L, 123433525L, new CheckpointOptions(CheckpointType.SAVEPOINT, CheckpointStorageLocationReference.getDefault())),
+			new CheckpointBarrier(1679L, 123433525L, new CheckpointOptions(CheckpointType.SYNC_CHECKPOINT, CheckpointStorageLocationReference.getDefault())),
+			new CheckpointBarrier(1679L, 123433525L, new CheckpointOptions(CheckpointType.SYNC_SAVEPOINT, CheckpointStorageLocationReference.getDefault())),
 			new TestTaskEvent(Math.random(), 12361231273L),
 			new CancelCheckpointMarker(287087987329842L)
 		};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -129,6 +129,9 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	private final BiFunction<String, Boolean, CompletableFuture<String>> stopWithSavepointFunction;
 
 	@Nonnull
+	private final Function<Boolean, CompletableFuture<String>> stopWithCheckpointFunction;
+
+	@Nonnull
 	private final Function<JobVertexID, CompletableFuture<OperatorBackPressureStatsResponse>> requestOperatorBackPressureStatsFunction;
 
 	@Nonnull
@@ -175,6 +178,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 			@Nonnull Supplier<CompletableFuture<ArchivedExecutionGraph>> requestJobSupplier,
 			@Nonnull BiFunction<String, Boolean, CompletableFuture<String>> triggerSavepointFunction,
 			@Nonnull BiFunction<String, Boolean, CompletableFuture<String>> stopWithSavepointFunction,
+			@Nonnull Function<Boolean, CompletableFuture<String>> stopWithCheckpointFunction,
 			@Nonnull Function<JobVertexID, CompletableFuture<OperatorBackPressureStatsResponse>> requestOperatorBackPressureStatsFunction,
 			@Nonnull BiConsumer<AllocationID, Throwable> notifyAllocationFailureConsumer,
 			@Nonnull Consumer<Tuple5<JobID, ExecutionAttemptID, Long, CheckpointMetrics, TaskStateSnapshot>> acknowledgeCheckpointConsumer,
@@ -203,6 +207,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 		this.requestJobSupplier = requestJobSupplier;
 		this.triggerSavepointFunction = triggerSavepointFunction;
 		this.stopWithSavepointFunction = stopWithSavepointFunction;
+		this.stopWithCheckpointFunction = stopWithCheckpointFunction;
 		this.requestOperatorBackPressureStatsFunction = requestOperatorBackPressureStatsFunction;
 		this.notifyAllocationFailureConsumer = notifyAllocationFailureConsumer;
 		this.acknowledgeCheckpointConsumer = acknowledgeCheckpointConsumer;
@@ -297,6 +302,12 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	@Override
 	public CompletableFuture<String> stopWithSavepoint(@Nullable final String targetDirectory, final boolean advanceToEndOfEventTime, final Time timeout) {
 		return stopWithSavepointFunction.apply(targetDirectory, advanceToEndOfEventTime);
+	}
+
+	@Override
+	public CompletableFuture<String> stopWithCheckpoint(
+		boolean advanceToEndOfEventTime, Time timeout) {
+		return stopWithCheckpointFunction.apply(advanceToEndOfEventTime);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -300,14 +300,12 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	}
 
 	@Override
-	public CompletableFuture<String> stopWithSavepoint(@Nullable final String targetDirectory, final boolean advanceToEndOfEventTime, final Time timeout) {
-		return stopWithSavepointFunction.apply(targetDirectory, advanceToEndOfEventTime);
-	}
-
-	@Override
-	public CompletableFuture<String> stopWithCheckpoint(
-		boolean advanceToEndOfEventTime, Time timeout) {
-		return stopWithCheckpointFunction.apply(advanceToEndOfEventTime);
+	public CompletableFuture<String> stopWithCheckpoint(final boolean isCheckpoint, @Nullable final String targetDirectory, final boolean advanceToEndOfEventTime, final Time timeout) {
+		if (isCheckpoint) {
+			return stopWithCheckpointFunction.apply(advanceToEndOfEventTime);
+		} else {
+			return stopWithSavepointFunction.apply(targetDirectory, advanceToEndOfEventTime);
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -91,6 +91,7 @@ public class TestingJobMasterGatewayBuilder {
 	private Supplier<CompletableFuture<ArchivedExecutionGraph>> requestJobSupplier = () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
 	private BiFunction<String, Boolean, CompletableFuture<String>> triggerSavepointFunction = (targetDirectory, ignoredB) -> CompletableFuture.completedFuture(targetDirectory != null ? targetDirectory : UUID.randomUUID().toString());
 	private BiFunction<String, Boolean, CompletableFuture<String>> stopWithSavepointFunction = (targetDirectory, ignoredB) -> CompletableFuture.completedFuture(targetDirectory != null ? targetDirectory : UUID.randomUUID().toString());
+	private Function<Boolean, CompletableFuture<String>> stopWithCheckpointFunction = (ignoreB) -> CompletableFuture.completedFuture(UUID.randomUUID().toString());
 	private Function<JobVertexID, CompletableFuture<OperatorBackPressureStatsResponse>> requestOperatorBackPressureStatsFunction = ignored -> CompletableFuture.completedFuture(OperatorBackPressureStatsResponse.of(null));
 	private BiConsumer<AllocationID, Throwable> notifyAllocationFailureConsumer = (ignoredA, ignoredB) -> {};
 	private Consumer<Tuple5<JobID, ExecutionAttemptID, Long, CheckpointMetrics, TaskStateSnapshot>> acknowledgeCheckpointConsumer = ignored -> {};
@@ -196,6 +197,11 @@ public class TestingJobMasterGatewayBuilder {
 		return this;
 	}
 
+	public TestingJobMasterGatewayBuilder setStopWithCheckpointFunction(Function<Boolean, CompletableFuture<String>> stopWithCheckpointFunction) {
+		this.stopWithCheckpointFunction = stopWithCheckpointFunction;
+		return this;
+	}
+
 	public TestingJobMasterGatewayBuilder setRequestOperatorBackPressureStatsFunction(Function<JobVertexID, CompletableFuture<OperatorBackPressureStatsResponse>> requestOperatorBackPressureStatsFunction) {
 		this.requestOperatorBackPressureStatsFunction = requestOperatorBackPressureStatsFunction;
 		return this;
@@ -242,6 +248,35 @@ public class TestingJobMasterGatewayBuilder {
 	}
 
 	public TestingJobMasterGateway build() {
-		return new TestingJobMasterGateway(address, hostname, cancelFunction, updateTaskExecutionStateFunction, requestNextInputSplitFunction, requestPartitionStateFunction, scheduleOrUpdateConsumersFunction, disconnectTaskManagerFunction, disconnectResourceManagerConsumer, classloadingPropsSupplier, offerSlotsFunction, failSlotConsumer, registerTaskManagerFunction, taskManagerHeartbeatConsumer, resourceManagerHeartbeatConsumer, requestJobDetailsSupplier, requestJobSupplier, triggerSavepointFunction, stopWithSavepointFunction, requestOperatorBackPressureStatsFunction, notifyAllocationFailureConsumer, acknowledgeCheckpointConsumer, declineCheckpointConsumer, fencingTokenSupplier, requestKvStateLocationFunction, notifyKvStateRegisteredFunction, notifyKvStateUnregisteredFunction, updateAggregateFunction);
+		return new TestingJobMasterGateway(
+			address,
+			hostname,
+			cancelFunction,
+			updateTaskExecutionStateFunction,
+			requestNextInputSplitFunction,
+			requestPartitionStateFunction,
+			scheduleOrUpdateConsumersFunction,
+			disconnectTaskManagerFunction,
+			disconnectResourceManagerConsumer,
+			classloadingPropsSupplier,
+			offerSlotsFunction,
+			failSlotConsumer,
+			registerTaskManagerFunction,
+			taskManagerHeartbeatConsumer,
+			resourceManagerHeartbeatConsumer,
+			requestJobDetailsSupplier,
+			requestJobSupplier,
+			triggerSavepointFunction,
+			stopWithSavepointFunction,
+			stopWithCheckpointFunction,
+			requestOperatorBackPressureStatsFunction,
+			notifyAllocationFailureConsumer,
+			acknowledgeCheckpointConsumer,
+			declineCheckpointConsumer,
+			fencingTokenSupplier,
+			requestKvStateLocationFunction,
+			notifyKvStateRegisteredFunction,
+			notifyKvStateUnregisteredFunction,
+			updateAggregateFunction);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointLatch.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointLatch.java
@@ -23,9 +23,9 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 
 /**
  * A synchronization primitive used by the {@link StreamTask} to wait
- * for the completion of a {@link CheckpointType#SYNC_SAVEPOINT}.
+ * for the completion of a {@link CheckpointType#SYNC_SAVEPOINT} or {@link CheckpointType#SYNC_CHECKPOINT}.
  */
-class SynchronousSavepointLatch {
+class SynchronousCheckpointLatch {
 
 	private static final long NOT_SET_CHECKPOINT_ID = -1L;
 
@@ -40,7 +40,7 @@ class SynchronousSavepointLatch {
 
 	private volatile long checkpointId;
 
-	SynchronousSavepointLatch() {
+	SynchronousCheckpointLatch() {
 		this.synchronizationPoint = new Object();
 
 		this.waiting = false;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -66,17 +66,12 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Rule;
 import org.junit.Test;
-<<<<<<< HEAD
 import org.junit.rules.Timeout;
-
-import java.util.Arrays;
-=======
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
->>>>>>> [FLINK-12619][StateBackend]Support TERMINATE/SUSPEND Job with Checkpoint
 import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -106,10 +101,6 @@ public class SynchronousCheckpointITCase {
 	@Rule
 	public final Timeout timeoutPerTest = Timeout.seconds(10);
 
-	private static AtomicReference<Throwable> error = new AtomicReference<>();
-
-	private static volatile CheckpointingStateHolder synchronousCheckpointPhase = new CheckpointingStateHolder();
-
 	@Parameterized.Parameters(name = "checkpointType = {0}")
 	public static Collection<CheckpointType> parameters () {
 		return Arrays.asList(CheckpointType.SYNC_CHECKPOINT, CheckpointType.SYNC_SAVEPOINT);
@@ -117,19 +108,6 @@ public class SynchronousCheckpointITCase {
 
 	@Parameterized.Parameter
 	public CheckpointType checkpointType;
-
-	@Before
-	public void initializeLatchesAndError() {
-		executionLatch = new OneShotLatch();
-		cancellationLatch = new OneShotLatch();
-		checkpointCompletionLatch = new OneShotLatch();
-		notifyLatch = new OneShotLatch();
-
-		checkpointLatch = new MultiShotLatch();
-
-		synchronousCheckpointPhase.setState(CheckpointingState.NONE);
-		error.set(null);
-	}
 
 	@Test
 	public void taskCachedThreadPoolAllowsForSynchronousCheckpoints() throws Exception {
@@ -154,7 +132,6 @@ public class SynchronousCheckpointITCase {
 					156865867234L,
 					new CheckpointOptions(checkpointType, CheckpointStorageLocationReference.getDefault()),
 					false);
-			checkpointLatch.await();
 
 			assertThat(eventQueue.take(), is(Event.PRE_TRIGGER_CHECKPOINT));
 			assertTrue(eventQueue.isEmpty());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -131,7 +131,7 @@ public class SynchronousCheckpointITCase {
 					42,
 					156865867234L,
 					new CheckpointOptions(checkpointType, CheckpointStorageLocationReference.getDefault()),
-					false);
+					true);
 
 			assertThat(eventQueue.take(), is(Event.PRE_TRIGGER_CHECKPOINT));
 			assertTrue(eventQueue.isEmpty());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -66,9 +66,17 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Rule;
 import org.junit.Test;
+<<<<<<< HEAD
 import org.junit.rules.Timeout;
 
 import java.util.Arrays;
+=======
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+>>>>>>> [FLINK-12619][StateBackend]Support TERMINATE/SUSPEND Job with Checkpoint
 import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -86,6 +94,7 @@ import static org.mockito.Mockito.when;
  * Tests that the cached thread pool used by the {@link Task} allows
  * synchronous checkpoints to complete successfully.
  */
+@RunWith(Parameterized.class)
 public class SynchronousCheckpointITCase {
 
 	private static OneShotLatch checkpointTriggered = new OneShotLatch();
@@ -96,6 +105,31 @@ public class SynchronousCheckpointITCase {
 
 	@Rule
 	public final Timeout timeoutPerTest = Timeout.seconds(10);
+
+	private static AtomicReference<Throwable> error = new AtomicReference<>();
+
+	private static volatile CheckpointingStateHolder synchronousCheckpointPhase = new CheckpointingStateHolder();
+
+	@Parameterized.Parameters(name = "checkpointType = {0}")
+	public static Collection<CheckpointType> parameters () {
+		return Arrays.asList(CheckpointType.SYNC_CHECKPOINT, CheckpointType.SYNC_SAVEPOINT);
+	}
+
+	@Parameterized.Parameter
+	public CheckpointType checkpointType;
+
+	@Before
+	public void initializeLatchesAndError() {
+		executionLatch = new OneShotLatch();
+		cancellationLatch = new OneShotLatch();
+		checkpointCompletionLatch = new OneShotLatch();
+		notifyLatch = new OneShotLatch();
+
+		checkpointLatch = new MultiShotLatch();
+
+		synchronousCheckpointPhase.setState(CheckpointingState.NONE);
+		error.set(null);
+	}
 
 	@Test
 	public void taskCachedThreadPoolAllowsForSynchronousCheckpoints() throws Exception {
@@ -118,8 +152,9 @@ public class SynchronousCheckpointITCase {
 			task.triggerCheckpointBarrier(
 					42,
 					156865867234L,
-					new CheckpointOptions(CheckpointType.SYNC_SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
-					true);
+					new CheckpointOptions(checkpointType, CheckpointStorageLocationReference.getDefault()),
+					false);
+			checkpointLatch.await();
 
 			assertThat(eventQueue.take(), is(Event.PRE_TRIGGER_CHECKPOINT));
 			assertTrue(eventQueue.isEmpty());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointSyncLatchTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointSyncLatchTest.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests for the {@link SynchronousSavepointLatch}.
+ * Tests for the {@link SynchronousCheckpointLatch}.
  */
-public class SynchronousSavepointSyncLatchTest {
+public class SynchronousCheckpointSyncLatchTest {
 
 	private ExecutorService executors;
 
@@ -54,7 +54,7 @@ public class SynchronousSavepointSyncLatchTest {
 
 	@Test
 	public void waitAndThenTriggerWorks() throws Exception {
-		final SynchronousSavepointLatch latchUnderTest = new SynchronousSavepointLatch();
+		final SynchronousCheckpointLatch latchUnderTest = new SynchronousCheckpointLatch();
 		final WaitingOnLatchCallable callable = new WaitingOnLatchCallable(latchUnderTest, 1L);
 
 		executors.submit(callable);
@@ -73,7 +73,7 @@ public class SynchronousSavepointSyncLatchTest {
 
 	@Test
 	public void waitAndThenCancelWorks() throws Exception {
-		final SynchronousSavepointLatch latchUnderTest = new SynchronousSavepointLatch();
+		final SynchronousCheckpointLatch latchUnderTest = new SynchronousCheckpointLatch();
 		final WaitingOnLatchCallable callable = new WaitingOnLatchCallable(latchUnderTest, 1L);
 
 		final Future<Boolean> resultFuture = executors.submit(callable);
@@ -92,7 +92,7 @@ public class SynchronousSavepointSyncLatchTest {
 
 	@Test
 	public void triggeringReturnsTrueAtMostOnce() throws Exception {
-		final SynchronousSavepointLatch latchUnderTest = new SynchronousSavepointLatch();
+		final SynchronousCheckpointLatch latchUnderTest = new SynchronousCheckpointLatch();
 
 		final WaitingOnLatchCallable firstCallable = new WaitingOnLatchCallable(latchUnderTest, 1L);
 		final WaitingOnLatchCallable secondCallable = new WaitingOnLatchCallable(latchUnderTest, 1L);
@@ -115,7 +115,7 @@ public class SynchronousSavepointSyncLatchTest {
 
 	@Test
 	public void waitAfterTriggerReturnsTrueImmediately() throws Exception {
-		final SynchronousSavepointLatch latchUnderTest = new SynchronousSavepointLatch();
+		final SynchronousCheckpointLatch latchUnderTest = new SynchronousCheckpointLatch();
 		latchUnderTest.setCheckpointId(1L);
 		latchUnderTest.acknowledgeCheckpointAndTrigger(1L);
 		final boolean triggerred = latchUnderTest.blockUntilCheckpointIsAcknowledged();
@@ -124,7 +124,7 @@ public class SynchronousSavepointSyncLatchTest {
 
 	@Test
 	public void waitAfterCancelDoesNothing() throws Exception {
-		final SynchronousSavepointLatch latchUnderTest = new SynchronousSavepointLatch();
+		final SynchronousCheckpointLatch latchUnderTest = new SynchronousCheckpointLatch();
 		latchUnderTest.setCheckpointId(1L);
 		latchUnderTest.cancelCheckpointLatch();
 		latchUnderTest.blockUntilCheckpointIsAcknowledged();
@@ -132,7 +132,7 @@ public class SynchronousSavepointSyncLatchTest {
 
 	@Test
 	public void checkpointIdIsSetOnlyOnce() throws InterruptedException {
-		final SynchronousSavepointLatch latchUnderTest = new SynchronousSavepointLatch();
+		final SynchronousCheckpointLatch latchUnderTest = new SynchronousCheckpointLatch();
 
 		final WaitingOnLatchCallable firstCallable = new WaitingOnLatchCallable(latchUnderTest, 1L);
 		executors.submit(firstCallable);
@@ -153,11 +153,11 @@ public class SynchronousSavepointSyncLatchTest {
 
 	private static final class WaitingOnLatchCallable implements Callable<Boolean> {
 
-		private final SynchronousSavepointLatch latch;
+		private final SynchronousCheckpointLatch latch;
 		private final long checkpointId;
 
 		WaitingOnLatchCallable(
-				final SynchronousSavepointLatch latch,
+				final SynchronousCheckpointLatch latch,
 				final long checkpointId) {
 			this.latch = checkNotNull(latch);
 			this.checkpointId = checkpointId;

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
@@ -78,6 +78,11 @@ public class FakeClusterClient extends ClusterClient<ApplicationId> {
 		throw new UnsupportedOperationException("Not needed in test.");
 	}
 
+	@Override
+	public String stopWithCheckpoint(JobID jobID, boolean advanceToEndOfEventTime) throws Exception {
+		throw new UnsupportedOperationException("Not needed in test.");
+	}
+
 	public void stop(final JobID jobId) {
 		// no op
 	}


### PR DESCRIPTION
## What is the purpose of the change

Inspired by the idea of [FLINK-11458](https://issues.apache.org/jira/browse/FLINK-11458), we propose to support terminate/suspend a job with checkpoint. This improvement cooperates with incremental and external checkpoint features, that if checkpoint is retained and this feature is configured, we will trigger a checkpoint before the job stops. It could accelarate job recovery a lot since:
1. No source rewinding required any more.
2. It's much faster than taking a savepoint since incremental checkpoint is enabled.

Please note that conceptually savepoints is different from checkpoint in a similar way that backups are different from recovery logs in traditional database systems. So we suggest using this feature only for job recovery, while stick with FLINK-11458 for the upgrading/cross-cluster-job-migration/state-backend-switch cases.

The current commit does not include rest API(will do this by follow up issue  [FLINK-12733](https://issues.apache.org/jira/browse/FLINK-12733).
## Verifying this change

This change added tests and can be verified as follows:
  - CliFrontendStopTest.java#{stopWithCheckpoint, testStopWithCheckpointWithMaxWM, testStopWithCheckpointAndSavepoint}
  - CheckpointPropertiesTest.java#testSyncCheckpoint
  - CheckpointTypeTest.java #testOrdinalsAreConstant
  - PendingCheckpointTest.java #testSyncCheckpointCannotBeSubsumed
  - CheckpointSerializationTest.java 
  - EventSerializerTest.java #testIsEvent
  - SynchronousCheckpointITCase.java
  - SynchronousCheckpointTest.java
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
@aljoscha @StefanRRichter 