### PR TITLE
[FLINK-12734] [table-planner-blink] remove getVolcanoPlanner method from FlinkOptimizeContext and RelNodeBlock does not depend on TableEnvironment

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
@@ -24,7 +24,6 @@ import org.apache.flink.table.plan.optimize.program.{BatchOptimizeContext, Flink
 import org.apache.flink.table.plan.schema.IntermediateRelTable
 import org.apache.flink.util.Preconditions
 
-import org.apache.calcite.plan.volcano.VolcanoPlanner
 import org.apache.calcite.rel.RelNode
 
 /**
@@ -35,7 +34,7 @@ class BatchCommonSubGraphBasedOptimizer(tEnv: BatchTableEnvironment)
 
   override protected def doOptimize(roots: Seq[RelNode]): Seq[RelNodeBlock] = {
     // build RelNodeBlock plan
-    val rootBlocks = RelNodeBlockPlanBuilder.buildRelNodeBlockPlan(roots, tEnv)
+    val rootBlocks = RelNodeBlockPlanBuilder.buildRelNodeBlockPlan(roots, tEnv.getConfig)
     // optimize recursively RelNodeBlock
     rootBlocks.foreach(optimizeBlock)
     rootBlocks
@@ -82,8 +81,6 @@ class BatchCommonSubGraphBasedOptimizer(tEnv: BatchTableEnvironment)
 
     programs.optimize(relNode, new BatchOptimizeContext {
       override def getTableConfig: TableConfig = config
-
-      override def getVolcanoPlanner: VolcanoPlanner = tEnv.getPlanner.asInstanceOf[VolcanoPlanner]
     })
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/CommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/CommonSubGraphBasedOptimizer.scala
@@ -40,6 +40,16 @@ import scala.collection.JavaConversions._
   * 2. optimize recursively each [[RelNodeBlock]] from leaf block to root(sink) block,
   * and register the optimized result of non-root block as an [[IntermediateRelTable]].
   * 3. expand [[IntermediateRelTable]] into RelNode tree in each [[RelNodeBlock]].
+  *
+  * Currently, we choose this strategy based on the following considerations:
+  * 1. In general, for multi-sinks users tend to use VIEW which is a natural common sub-graph.
+  * 2. after some optimization, like project push-down, filter push-down, there may be no common
+  * sub-graph (even table source) could be found in the final plan.
+  * however, current strategy has some deficiencies that need to be improved:
+  * 1. how to find a valid break-point for common sub-graph, e.g. some physical RelNodes are
+  * converted from several logical RelNodes, so the valid break-point could not be
+  * between those logical nodes.
+  * 2. the optimization result is local optimal (in sub-graph), not global optimal.
   */
 abstract class CommonSubGraphBasedOptimizer extends Optimizer {
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/RelNodeBlock.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/RelNodeBlock.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.plan.optimize
 
-import org.apache.flink.table.api.{PlannerConfigOptions, TableConfig, TableEnvironment}
+import org.apache.flink.table.api.{PlannerConfigOptions, TableConfig}
 import org.apache.flink.table.plan.nodes.calcite.Sink
 import org.apache.flink.table.plan.reuse.SubplanReuser.{SubplanReuseContext, SubplanReuseShuttle}
 import org.apache.flink.table.plan.rules.logical.WindowPropertiesRules
@@ -109,7 +109,7 @@ import scala.collection.mutable
   * @param outputNode A RelNode of the output in the block, which could be a [[Sink]] or
   * other RelNode which data outputs to multiple [[Sink]]s.
   */
-class RelNodeBlock(val outputNode: RelNode, tEnv: TableEnvironment) {
+class RelNodeBlock(val outputNode: RelNode) {
   // child (or input) blocks
   private val childBlocks = mutable.LinkedHashSet[RelNodeBlock]()
 
@@ -239,12 +239,12 @@ class RelNodeWrapper(relNode: RelNode) {
 /**
   * Builds [[RelNodeBlock]] plan
   */
-class RelNodeBlockPlanBuilder private(tEnv: TableEnvironment) {
+class RelNodeBlockPlanBuilder private(config: TableConfig) {
 
   private val node2Wrapper = new util.IdentityHashMap[RelNode, RelNodeWrapper]()
   private val node2Block = new util.IdentityHashMap[RelNode, RelNodeBlock]()
 
-  private val isUnionAllAsBreakPointDisabled = tEnv.config.getConf.getBoolean(
+  private val isUnionAllAsBreakPointDisabled = config.getConf.getBoolean(
     PlannerConfigOptions.SQL_OPTIMIZER_UNIONALL_AS_BREAKPOINT_DISABLED)
 
 
@@ -267,7 +267,7 @@ class RelNodeBlockPlanBuilder private(tEnv: TableEnvironment) {
   }
 
   private def buildBlockPlan(node: RelNode): RelNodeBlock = {
-    val currentBlock = new RelNodeBlock(node, tEnv)
+    val currentBlock = new RelNodeBlock(node)
     buildBlock(node, currentBlock, createNewBlockWhenMeetValidBreakPoint = false)
     currentBlock
   }
@@ -280,7 +280,7 @@ class RelNodeBlockPlanBuilder private(tEnv: TableEnvironment) {
     val validBreakPoint = isValidBreakPoint(node)
 
     if (validBreakPoint && (createNewBlockWhenMeetValidBreakPoint || hasDiffBlockOutputNodes)) {
-      val childBlock = node2Block.getOrElseUpdate(node, new RelNodeBlock(node, tEnv))
+      val childBlock = node2Block.getOrElseUpdate(node, new RelNodeBlock(node))
       currentBlock.addChild(childBlock)
       node.getInputs.foreach {
         child => buildBlock(child, childBlock, createNewBlockWhenMeetValidBreakPoint = false)
@@ -296,7 +296,7 @@ class RelNodeBlockPlanBuilder private(tEnv: TableEnvironment) {
 
   /**
     * TableFunctionScan/Snapshot/Window Aggregate cannot be optimized individually,
-    * so TableFunctionScan/Snapshot/Window Aggregate is not a break-point
+    * so TableFunctionScan/Snapshot/Window Aggregate is not a valid break-point
     * even though it has multiple parents.
     */
   private def isValidBreakPoint(node: RelNode): Boolean = node match {
@@ -377,15 +377,15 @@ object RelNodeBlockPlanBuilder {
     */
   def buildRelNodeBlockPlan(
       sinkNodes: Seq[RelNode],
-      tEnv: TableEnvironment): Seq[RelNodeBlock] = {
+      config: TableConfig): Seq[RelNodeBlock] = {
     require(sinkNodes.nonEmpty)
 
     if (sinkNodes.size == 1) {
-      Seq(new RelNodeBlock(sinkNodes.head, tEnv))
+      Seq(new RelNodeBlock(sinkNodes.head))
     } else {
       // merge multiple RelNode trees to RelNode dag
-      val relNodeDag = reuseRelNodes(sinkNodes, tEnv.getConfig)
-      val builder = new RelNodeBlockPlanBuilder(tEnv)
+      val relNodeDag = reuseRelNodes(sinkNodes, config)
+      val builder = new RelNodeBlockPlanBuilder(config)
       builder.buildRelNodeBlockPlan(relNodeDag)
     }
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkOptimizeContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkOptimizeContext.scala
@@ -20,15 +20,9 @@ package org.apache.flink.table.plan.optimize.program
 
 import org.apache.flink.table.calcite.FlinkContext
 
-import org.apache.calcite.plan.volcano.VolcanoPlanner
-
 /**
   * A FlinkOptimizeContext allows to obtain table environment information when optimizing.
   */
 trait FlinkOptimizeContext extends FlinkContext {
 
-  /**
-    * Gets [[VolcanoPlanner]] instance defined in [[org.apache.flink.table.api.TableEnvironment]].
-    */
-  def getVolcanoPlanner: VolcanoPlanner
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkVolcanoProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkVolcanoProgram.scala
@@ -26,6 +26,7 @@ import org.apache.flink.util.Preconditions
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptPlanner.CannotPlanException
 import org.apache.calcite.plan.RelTrait
+import org.apache.calcite.plan.volcano.VolcanoPlanner
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.tools.{Programs, RuleSet}
 
@@ -51,8 +52,11 @@ class FlinkVolcanoProgram[OC <: FlinkOptimizeContext] extends FlinkRuleSetProgra
     }
 
     val targetTraits = root.getTraitSet.plusAll(requiredOutputTraits.get).simplify()
-    // reuse VolcanoPlanner instance defined in context
-    val planner = Preconditions.checkNotNull(context.getVolcanoPlanner)
+    // VolcanoPlanner limits that the planer a RelNode tree belongs to and
+    // the VolcanoPlanner used to optimize the RelNode tree should be same instance.
+    // see: VolcanoPlanner#registerImpl
+    // here, use the planner in cluster directly
+    val planner = root.getCluster.getPlanner.asInstanceOf[VolcanoPlanner]
     val optProgram = Programs.ofRules(rules)
 
     try {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/AggregateReduceGroupingITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/agg/AggregateReduceGroupingITCase.scala
@@ -124,6 +124,8 @@ class AggregateReduceGroupingITCase extends BatchTestBase {
     tEnv.getConfig.getConf.setString(TableConfigOptions.SQL_EXEC_DISABLED_OPERATORS, "SortAgg")
     tEnv.getConfig.getConf.setString(
       PlannerConfigOptions.SQL_OPTIMIZER_AGG_PHASE_ENFORCER, "TWO_PHASE")
+    // set smaller parallelism to avoid MemoryAllocationException
+    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 2)
     tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_HASH_AGG_TABLE_MEM, 2) // 1M
     testSingleAggOnTable()
   }


### PR DESCRIPTION
## What is the purpose of the change

*remove getVolcanoPlanner method from FlinkOptimizeContext and RelNodeBlock does not depend on TableEnvironment*


## Brief change log

  - *remove getVolcanoPlanner method from FlinkOptimizeContext.
VolcanoPlanner limits that the planer a RelNode tree belongs to and the VolcanoPlanner used to optimize the RelNode tree should be same instance. (see: VolcanoPlanner#registerImpl)
so, we can use planner instance in RelNode's cluster directly instead of planner from getVolcanoPlanner method in FlinkOptimizeContext.*
  - *RelNodeBlock does not depend on TableEnvironment*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
