### PR TITLE
[FLINK-12643] [runtime] Implement ExecutionGraph to FailoverTopology Adapter

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverEdge.java
@@ -46,8 +46,8 @@ class DefaultFailoverEdge implements FailoverEdge {
 
 		this.resultPartitionId = checkNotNull(partitionId);
 		this.partitionType = checkNotNull(partitionType);
-		this.sourceVertex = sourceVertex;
-		this.targetVertex = targetVertex;
+		this.sourceVertex = checkNotNull(sourceVertex);
+		this.targetVertex = checkNotNull(targetVertex);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverEdge.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.adapter;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverEdge;
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverVertex;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link FailoverEdge}.
+ */
+class DefaultFailoverEdge implements FailoverEdge {
+
+	private final IntermediateResultPartitionID resultPartitionId;
+
+	private final ResultPartitionType partitionType;
+
+	private final DefaultFailoverVertex sourceVertex;
+
+	private final DefaultFailoverVertex targetVertex;
+
+	DefaultFailoverEdge(
+		IntermediateResultPartitionID partitionId,
+		ResultPartitionType partitionType,
+		DefaultFailoverVertex sourceVertex,
+		DefaultFailoverVertex targetVertex) {
+
+		this.resultPartitionId = checkNotNull(partitionId);
+		this.partitionType = checkNotNull(partitionType);
+		this.sourceVertex = sourceVertex;
+		this.targetVertex = targetVertex;
+	}
+
+	@Override
+	public IntermediateResultPartitionID getResultPartitionID() {
+		return resultPartitionId;
+	}
+
+	@Override
+	public ResultPartitionType getResultPartitionType() {
+		return partitionType;
+	}
+
+	@Override
+	public FailoverVertex getSourceVertex() {
+		return sourceVertex;
+	}
+
+	@Override
+	public FailoverVertex getTargetVertex() {
+		return targetVertex;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverTopology.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.adapter;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverTopology;
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverVertex;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link FailoverTopology} which is an adaptor of {@link ExecutionGraph}.
+ */
+public class DefaultFailoverTopology implements FailoverTopology {
+
+	private final boolean containsCoLocationConstraints;
+
+	private final List<DefaultFailoverVertex> failoverVertices;
+
+	public DefaultFailoverTopology(ExecutionGraph executionGraph) {
+		checkNotNull(executionGraph);
+
+		this.containsCoLocationConstraints = executionGraph.getAllVertices().values().stream()
+			.map(ExecutionJobVertex::getCoLocationGroup)
+			.anyMatch(Objects::nonNull);
+
+		// generate vertices
+		this.failoverVertices = new ArrayList<>();
+		final Map<ExecutionVertex, DefaultFailoverVertex> failoverVertexMap = new IdentityHashMap<>();
+		for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
+			final DefaultFailoverVertex failoverVertex = new DefaultFailoverVertex(
+				new ExecutionVertexID(vertex.getJobvertexId(), vertex.getParallelSubtaskIndex()),
+				vertex.getTaskNameWithSubtaskIndex());
+			this.failoverVertices.add(failoverVertex);
+			failoverVertexMap.put(vertex, failoverVertex);
+		}
+
+		// generate edges
+		connectVerticesWithEdges(failoverVertexMap);
+	}
+
+	private void connectVerticesWithEdges(Map<ExecutionVertex, DefaultFailoverVertex> failoverVertexMap) {
+		for (ExecutionVertex vertex : failoverVertexMap.keySet()) {
+			final DefaultFailoverVertex failoverVertex = failoverVertexMap.get(vertex);
+			vertex.getProducedPartitions().values().stream()
+				.map(IntermediateResultPartition::getConsumers)
+				.flatMap(Collection::stream)
+				.flatMap(Collection::stream)
+				.forEach(e -> {
+					final DefaultFailoverVertex consumerFailoverVertex = failoverVertexMap.get(e.getTarget());
+					final DefaultFailoverEdge failoverEdge = new DefaultFailoverEdge(
+						e.getSource().getPartitionId(),
+						e.getSource().getResultType(),
+						failoverVertex,
+						consumerFailoverVertex);
+					failoverVertex.addOutputEdge(failoverEdge);
+					consumerFailoverVertex.addInputEdge(failoverEdge);
+				});
+		}
+	}
+
+	@Override
+	public Iterable<? extends FailoverVertex> getFailoverVertices() {
+		return failoverVertices;
+	}
+
+	@Override
+	public boolean containsCoLocationConstraints() {
+		return containsCoLocationConstraints;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverVertex.java
@@ -70,11 +70,11 @@ class DefaultFailoverVertex implements FailoverVertex {
 		return outputEdges;
 	}
 
-	public void addInputEdge(DefaultFailoverEdge edge) {
+	void addInputEdge(DefaultFailoverEdge edge) {
 		inputEdges.add(edge);
 	}
 
-	public void addOutputEdge(DefaultFailoverEdge edge) {
+	void addOutputEdge(DefaultFailoverEdge edge) {
 		outputEdges.add(edge);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverVertex.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.adapter;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverEdge;
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverVertex;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link FailoverVertex}.
+ */
+class DefaultFailoverVertex implements FailoverVertex {
+
+	private final ExecutionVertexID executionVertexID;
+
+	private final String executionVertexName;
+
+	private final List<DefaultFailoverEdge> inputEdges;
+
+	private final List<DefaultFailoverEdge> outputEdges;
+
+	DefaultFailoverVertex(
+		ExecutionVertexID executionVertexID,
+		String executionVertexName) {
+
+		this.executionVertexID = checkNotNull(executionVertexID);
+		this.executionVertexName = checkNotNull(executionVertexName);
+		this.inputEdges = new ArrayList<>();
+		this.outputEdges = new ArrayList<>();
+	}
+
+	@Override
+	public ExecutionVertexID getExecutionVertexID() {
+		return executionVertexID;
+	}
+
+	@Override
+	public String getExecutionVertexName() {
+		return executionVertexName;
+	}
+
+	@Override
+	public Iterable<? extends FailoverEdge> getInputEdges() {
+		return inputEdges;
+	}
+
+	@Override
+	public Iterable<? extends FailoverEdge> getOutputEdges() {
+		return outputEdges;
+	}
+
+	public void addInputEdge(DefaultFailoverEdge edge) {
+		inputEdges.add(edge);
+	}
+
+	public void addOutputEdge(DefaultFailoverEdge edge) {
+		outputEdges.add(edge);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -419,7 +419,11 @@ public class ExecutionGraphTestUtils {
 	}
 
 	public static JobVertex createNoOpVertex(int parallelism) {
-		JobVertex vertex = new JobVertex("vertex");
+		return createNoOpVertex("vertex", parallelism);
+	}
+
+	public static JobVertex createNoOpVertex(String name, int parallelism) {
+		JobVertex vertex = new JobVertex(name);
 		vertex.setInvokableClass(NoOpInvokable.class);
 		vertex.setParallelism(parallelism);
 		return vertex;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/adapter/DefaultFailoverTopologyTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.adapter;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionEdge;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.executiongraph.TestRestartStrategy;
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverEdge;
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverTopology;
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverVertex;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.util.TestLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createSimpleTestGraph;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.ALL_TO_ALL;
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.POINTWISE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link DefaultFailoverTopology}.
+ */
+public class DefaultFailoverTopologyTest extends TestLogger {
+
+	private final SimpleAckingTaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
+
+	private final TestRestartStrategy triggeredRestartStrategy = TestRestartStrategy.manuallyTriggered();
+
+	private ExecutionGraph executionGraph;
+
+	private DefaultFailoverTopology adapter;
+
+	@Before
+	public void setUp() throws Exception {
+		JobVertex[] jobVertices = new JobVertex[3];
+		int parallelism = 3;
+		jobVertices[0] = createNoOpVertex("v1", parallelism);
+		jobVertices[1] = createNoOpVertex("v2", parallelism);
+		jobVertices[2] = createNoOpVertex("v3", parallelism);
+		jobVertices[1].connectNewDataSetAsInput(jobVertices[0], ALL_TO_ALL, BLOCKING);
+		jobVertices[2].connectNewDataSetAsInput(jobVertices[1], POINTWISE, PIPELINED);
+		executionGraph = createSimpleTestGraph(
+			new JobID(),
+			taskManagerGateway,
+			triggeredRestartStrategy,
+			jobVertices);
+		adapter = new DefaultFailoverTopology(executionGraph);
+	}
+
+	@Test
+	public void testConstructor() {
+		assertGraphEquals(executionGraph, adapter);
+	}
+
+	private static void assertGraphEquals(ExecutionGraph originalGraph, FailoverTopology adaptedTopology) {
+		List<ExecutionVertex> originalVertices = StreamSupport.stream(
+			originalGraph.getAllExecutionVertices().spliterator(),
+			false).collect(Collectors.toList());
+		List<FailoverVertex> adaptedVertices = StreamSupport.stream(
+			adaptedTopology.getFailoverVertices().spliterator(),
+			false).collect(Collectors.toList());
+
+		assertEquals(originalVertices.size(), adaptedVertices.size());
+
+		// the vertices should be topologically sorted, i.e. in the same order
+		for (int i = 0; i < originalVertices.size(); i++) {
+			ExecutionVertex originalVertex = originalVertices.get(i);
+			FailoverVertex adaptedVertex = adaptedVertices.get(i);
+			assertVertexEquals(originalVertex, adaptedVertex);
+		}
+	}
+
+	private static void assertVertexEquals(ExecutionVertex originalVertex, FailoverVertex adaptedVertex) {
+		// compare vertex internal properties
+		assertTrue(compareVertexInternalProperties(originalVertex, adaptedVertex));
+
+		// compare input edges
+		List<ExecutionEdge> originalInputEdges = IntStream.range(0, originalVertex.getNumberOfInputs())
+			.mapToObj(originalVertex::getInputEdges)
+			.flatMap(Arrays::stream)
+			.collect(Collectors.toList());
+		List<FailoverEdge> adaptedInputEdges = StreamSupport.stream(
+			adaptedVertex.getInputEdges().spliterator(),
+			false).collect(Collectors.toList());
+		assertEdgesEquals(originalInputEdges, adaptedInputEdges);
+
+		// compare output edges
+		List<ExecutionEdge> originalOutputEdges = originalVertex.getProducedPartitions().values().stream()
+			.map(IntermediateResultPartition::getConsumers)
+			.flatMap(Collection::stream)
+			.flatMap(Collection::stream)
+			.collect(Collectors.toList());
+		List<FailoverEdge> adaptedOutputEdges = StreamSupport.stream(
+			adaptedVertex.getOutputEdges().spliterator(),
+			false).collect(Collectors.toList());
+		assertEdgesEquals(originalOutputEdges, adaptedOutputEdges);
+	}
+
+	private static boolean compareVertexInternalProperties(ExecutionVertex originalVertex, FailoverVertex adaptedVertex) {
+		return originalVertex.getJobvertexId().equals(adaptedVertex.getExecutionVertexID().getJobVertexId()) &&
+			originalVertex.getParallelSubtaskIndex() == adaptedVertex.getExecutionVertexID().getSubtaskIndex() &&
+			originalVertex.getTaskNameWithSubtaskIndex().equals(adaptedVertex.getExecutionVertexName());
+	}
+
+	private static void assertEdgesEquals(
+		Collection<ExecutionEdge> originalEdges,
+		Collection<FailoverEdge> adaptedEdges) {
+
+		assertEquals(originalEdges.size(), adaptedEdges.size());
+
+		for (ExecutionEdge originalEdge : originalEdges) {
+			List<FailoverEdge> matchedAdaptedEdges = adaptedEdges.stream()
+				.filter(adapted -> compareEdge(originalEdge, adapted))
+				.collect(Collectors.toList());
+
+			// there should be exactly 1 matched edge
+			// this ensures originalEdges and adaptedEdges elements have a one-to-one mapping
+			// it also helps to ensure there is no duplicated edge
+			assertEquals(1,  matchedAdaptedEdges.size());
+		}
+	}
+
+	private static boolean compareEdge(ExecutionEdge originalEdge, FailoverEdge adaptedEdge) {
+		return originalEdge.getSource().getPartitionId().equals(adaptedEdge.getResultPartitionID()) &&
+			originalEdge.getSource().getResultType().equals(adaptedEdge.getResultPartitionType()) &&
+			compareVertexInternalProperties(originalEdge.getSource().getProducer(), adaptedEdge.getSourceVertex()) &&
+			compareVertexInternalProperties(originalEdge.getTarget(), adaptedEdge.getTargetVertex());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request implements an adapter to adapts the ExecutionGraph and its sub-components(ExecutionVertex, ExecutionEdge) to the FailoverTopology interfaces.*


## Brief change log

  - *Implement DefaultFailoverTopology as an adapter for ExecutionGraph to FailoverTopology*
  - *Implement DefaultFailoverVertex as an adapter for ExecutionVertex to FailoverVertex*
  - *Implement DefaultFailoverEdge as an adapter for ExecutionEdge to FailoverEdge*


## Verifying this change

  - *unit tests for DefaultFailoverTopology*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
