### PR TITLE
[FLINK-9955] Kubernetes ClusterDescriptor

### DIFF
--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-parent</artifactId>
+		<version>1.9-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-kubernetes_${scala.binary.version}</artifactId>
+	<name>flink-kubernetes</name>
+	<packaging>jar</packaging>
+
+	<properties>
+		<kubernetes.version>1.0.1</kubernetes.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- set all Flink dependencies to provided, so they and their transitive  -->
+		<!-- dependencies do not get promoted to direct dependencies during shading -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.7.5</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.7.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>kubernetes-client</artifactId>
+			<version>4.0.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>0.1.0</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.squareup.okhttp3</groupId>
+					<artifactId>okhttp</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>kubernetes-server-mock</artifactId>
+			<version>4.0.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/FlinkKubernetesOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/FlinkKubernetesOptions.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Parameters that will be used in Flink on k8s cluster.
+ * */
+public class FlinkKubernetesOptions {
+
+	private Configuration configuration;
+
+	public Configuration getConfiguration() {
+		return configuration;
+	}
+
+	public FlinkKubernetesOptions(Configuration configuration) {
+		this.configuration = configuration;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cluster/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cluster/KubernetesClusterDescriptor.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.cluster;
+
+import org.apache.flink.client.deployment.ClusterDeploymentException;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.ClusterRetrieveException;
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
+import org.apache.flink.kubernetes.kubeclient.FlinkService;
+import org.apache.flink.kubernetes.kubeclient.KubeClient;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Kubernetes specific {@link ClusterDescriptor} implementation.
+ */
+public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KubernetesClusterDescriptor.class);
+
+	private static final String CLUSTER_ID_PREFIX = "flink-session-cluster-";
+
+	private static final String CLUSTER_DESCRIPTION = "Kubernetes cluster";
+
+	private FlinkKubernetesOptions options;
+
+	private KubeClient client;
+
+	public KubernetesClusterDescriptor(@Nonnull FlinkKubernetesOptions options) {
+		//TODO create client from options, should be done in FLINK-10935
+		this(options, null);
+	}
+
+	public KubernetesClusterDescriptor(@Nonnull FlinkKubernetesOptions options, @Nonnull KubeClient client) {
+		this.options = options;
+		this.client = client;
+		this.client.initialize();
+	}
+
+	private String generateClusterId() {
+		return CLUSTER_ID_PREFIX + UUID.randomUUID();
+	}
+
+	@Override
+	public String getClusterDescription() {
+		return CLUSTER_DESCRIPTION;
+	}
+
+	private ClusterClient<String> createClusterClient(FlinkService clusterService, String clusterId) throws Exception {
+
+		Configuration configuration = new Configuration(this.options.getConfiguration());
+
+		//now update the access info of new service: JM.addr, JM.port, rest.port
+		Map<ConfigOption<Integer>, Endpoint> endpointMappings = this.client.extractEndpoints(clusterService);
+
+		if (endpointMappings.containsKey(RestOptions.PORT)) {
+			configuration.setString(RestOptions.ADDRESS, endpointMappings.get(RestOptions.PORT).getAddress());
+			configuration.setInteger(RestOptions.PORT, endpointMappings.get(RestOptions.PORT).getPort());
+		}
+		if (endpointMappings.containsKey(JobManagerOptions.PORT)) {
+			configuration.setString(JobManagerOptions.ADDRESS, endpointMappings.get(JobManagerOptions.PORT).getAddress());
+			configuration.setInteger(JobManagerOptions.PORT, endpointMappings.get(JobManagerOptions.PORT).getPort());
+		}
+
+		return new RestClusterClient<>(configuration, clusterId);
+	}
+
+	@Override
+	public ClusterClient<String> retrieve(String clusterId) throws ClusterRetrieveException {
+		try {
+			FlinkService clusterService = this.client.getFlinkService(clusterId);
+			return this.createClusterClient(clusterService, clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			throw new ClusterRetrieveException("Could not create the RestClusterClient.", e);
+		}
+	}
+
+	@Override
+	public ClusterClient<String> deploySessionCluster(ClusterSpecification clusterSpecification)
+		throws ClusterDeploymentException {
+
+		String clusterId = this.generateClusterId();
+		return this.deployClusterInternal(clusterId);
+	}
+
+	@Override
+	public ClusterClient<String> deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph, boolean detached) {
+		throw new NotImplementedException();
+	}
+
+	@Nonnull
+	private ClusterClient<String> deployClusterInternal(String clusterId) throws ClusterDeploymentException {
+		try {
+			FlinkService clusterService = this.client.createClusterService(clusterId).get();
+			this.client.createClusterPod();
+			return this.createClusterClient(clusterService, clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			this.tryKillCluster(clusterId);
+			throw new ClusterDeploymentException("Could not create Kubernetes cluster " + clusterId, e);
+		}
+	}
+
+	/**
+	 * Try to kill cluster without throw exception.
+	 */
+	private void tryKillCluster(String clusterId) {
+		try {
+			this.killCluster(clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+		}
+	}
+
+	@Override
+	public void killCluster(String clusterId) throws FlinkException {
+		try {
+			this.client.stopAndCleanupCluster(clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			throw new FlinkException("Could not create Kubernetes cluster " + clusterId);
+		}
+	}
+
+	@Override
+	public void close() {
+		try {
+			this.client.close();
+		} catch (Exception e) {
+			this.client.logException(e);
+			LOG.error("failed to close client, exception {}", e.toString());
+		}
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Endpoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Endpoint.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+/**
+ * Represent an endpoint.
+ * */
+public class Endpoint {
+
+	private String address;
+
+	private int port;
+
+	public Endpoint(String address, int port) {
+		this.address = address;
+		this.port = port;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public int getPort() {
+		return port;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkPod.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkPod.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+
+import io.fabric8.kubernetes.api.model.Pod;
+
+/**
+ * represent FlinkPod resource in kubernetes.
+ * */
+public class FlinkPod extends Resource<Pod> {
+
+	public FlinkPod(FlinkKubernetesOptions flinkOptions) {
+		super(flinkOptions);
+		this.internalResource = new Pod();
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkService.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+
+import io.fabric8.kubernetes.api.model.Service;
+
+/**
+ * represent Service resource in kubernetes.
+ * */
+public class FlinkService extends Resource<Service> {
+
+	public FlinkService(FlinkKubernetesOptions flinkOptions) {
+		super(flinkOptions);
+		this.internalResource = new Service();
+	}
+
+	public FlinkService(FlinkKubernetesOptions flinkOptions, Service service) {
+		super(flinkOptions);
+		this.internalResource = service;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClient.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.kubernetes.kubeclient;
 
+import org.apache.flink.configuration.ConfigOption;
+
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The client to talk with kubernetes.
@@ -33,7 +37,7 @@ public interface KubeClient extends AutoCloseable {
 	/**
 	 * Create kubernetes services and expose endpoints for access outside cluster.
 	 */
-	void createClusterService(String clusterId) throws Exception;
+	CompletableFuture<FlinkService> createClusterService(String clusterId) throws Exception;
 
 	/**
 	 * List all running sessions in current kubernetes cluster.
@@ -59,5 +63,16 @@ public interface KubeClient extends AutoCloseable {
 	 * Log exceptions.
 	 * */
 	void logException(Exception e);
+
+	/**
+	 * retrieve rest endpoint of the given flink clusterId.
+	 */
+	FlinkService getFlinkService(String flinkClusterId);
+
+	/**
+	 *  For a FlinkService, get its port mappings.
+	 * @param service
+	 */
+	Map<ConfigOption<Integer>, Endpoint> extractEndpoints(FlinkService service);
 
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClient.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import java.util.List;
+
+/**
+ * The client to talk with kubernetes.
+ * */
+public interface KubeClient extends AutoCloseable {
+
+	/**
+	 * Initialize client.
+	 * */
+	void initialize();
+
+	/**
+	 * Create kubernetes services and expose endpoints for access outside cluster.
+	 */
+	void createClusterService(String clusterId) throws Exception;
+
+	/**
+	 * List all running sessions in current kubernetes cluster.
+	 * */
+	List<String> listFlinkClusters();
+
+	/**
+	 * Create cluster pod.
+	 */
+	void createClusterPod();
+
+	/**
+	 * stop a pod.
+	 * */
+	boolean stopPod(String podName);
+
+	/**
+	 * stop cluster and clean up all resources, include services, auxiliary services and all running pods.
+	 * */
+	void stopAndCleanupCluster(String clusterId);
+
+	/**
+	 * Log exceptions.
+	 * */
+	void logException(Exception e);
+
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Resource.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Resource.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+
+/**
+ * represent a kubernetes resource.
+ * */
+public abstract class Resource<T> {
+
+	protected T internalResource;
+
+	protected FlinkKubernetesOptions flinkOptions;
+
+	public Resource(FlinkKubernetesOptions flinkOptions) {
+		this.flinkOptions = flinkOptions;
+	}
+
+	public FlinkKubernetesOptions getFlinkOptions() {
+		return flinkOptions;
+	}
+
+	public T getInternalResource() {
+		return internalResource;
+	}
+
+	public void setInternalResource(T internalResource) {
+		this.internalResource = internalResource;
+	}
+}

--- a/flink-kubernetes/src/test/java/resources/log4j-test.properties
+++ b/flink-kubernetes/src/test/java/resources/log4j-test.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+log4j.rootLogger=OFF, testlogger
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target=System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@ under the License.
 		<module>flink-docs</module>
 		<module>flink-python</module>
 		<module>flink-ml-parent</module>
+		<module>flink-kubernetes</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION

## What is the purpose of the change

*In order to start programmatically a Flink cluster on Kubernetes, we need a KubernetesClusterDescriptor implementation. Related to [FLINK-9955](https://issues.apache.org/jira/browse/FLINK-9955)*


## Brief change log

*(for example:)*
  - *Implement KubernetesClusterDescriptor*
  - *Add k8s resource*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (will add documents later)
