### PR TITLE
[FLINK-12740][tests] Fix unstable SpillableSubpartitionTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
@@ -180,7 +180,7 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 	 */
 	@Test
 	public void testConcurrentRequestAndReleaseMemory() throws Exception {
-		final ExecutorService executor = Executors.newSingleThreadExecutor();
+		final ExecutorService executor = Executors.newFixedThreadPool(2);
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
 		try {
 			final CountDownLatch blockLatch = new CountDownLatch(1);
@@ -219,7 +219,7 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 			});
 
 			final CompletableFuture<?> firstCallFuture = partition.getFirstCallFuture();
-			firstCallFuture.thenRun(() -> {
+			firstCallFuture.thenRunAsync(() -> {
 				try {
 					// There are no available buffers in pool, so trigger release memory in SpillableSubpartition.
 					// Occupies the lock in LocalBufferPool, and trying to get the lock in SpillableSubpartition.
@@ -229,7 +229,7 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 				} catch (IOException | InterruptedException ex) {
 					fail("Should not throw any exceptions!");
 				}
-			});
+			}, executor);
 
 			future.get();
 		} finally {


### PR DESCRIPTION
## What is the purpose of the change

*`SpillableSubpartitionTest#testConcurrentRequestAndReleaseMemory` is for verifying that `ResultPartition#releaseMemory` and `LocalBufferPool#requestBufferBuilderBlocking` are concurrent in two threads. But the `Future#thenRun` is used to trigger another action which might be executed by the same previous thread to cause stuck. We could use `Future#thenRunAsync` instead to solve this unstable issue.*

## Brief change log

  - *Fix `SpillableSubpartitionTest#testConcurrentRequestAndReleaseMemory`*

## Verifying this change

Covered by itself.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
