### PR TITLE
[FLINK-12237][hive]Support Hive table stats related operations in HiveCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -1159,12 +1159,13 @@ public class HiveCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException {
+	public CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException,
+			CatalogException, TableNotPartitionedException {
 		Table hiveTable = getHiveTable(tablePath);
 		if (!isTablePartitioned(hiveTable)) {
 			return createCatalogTableStatistics(hiveTable.getParameters());
 		} else {
-			return CatalogTableStatistics.UNKNOWN;
+			throw new TableNotPartitionedException(getName(), tablePath);
 		}
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -805,7 +805,7 @@ public class HiveCatalog extends AbstractCatalog {
 	}
 
 	private void ensurePartitionedTable(ObjectPath tablePath, Table hiveTable) throws TableNotPartitionedException {
-		if (hiveTable.getPartitionKeysSize() == 0) {
+		if (!isTablePartitioned(hiveTable)) {
 			throw new TableNotPartitionedException(getName(), tablePath);
 		}
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveMetastoreClientWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveMetastoreClientWrapper.java
@@ -137,11 +137,6 @@ public class HiveMetastoreClientWrapper implements AutoCloseable {
 		client.createTable(table);
 	}
 
-	public void alter_table(String databaseName, String tableName, Table table)
-			throws InvalidOperationException, MetaException, TException {
-		client.alter_table(databaseName, tableName, table);
-	}
-
 	public void createDatabase(Database database)
 			throws InvalidObjectException, AlreadyExistsException, MetaException, TException {
 		client.createDatabase(database);
@@ -233,5 +228,11 @@ public class HiveMetastoreClientWrapper implements AutoCloseable {
 	public Function getFunction(String databaseName, String functionName) throws MetaException, TException {
 		HiveShim hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
 		return hiveShim.getFunction(client, databaseName, functionName);
+	}
+
+	public void alter_table(String databaseName, String tableName, Table table)
+			throws InvalidOperationException, MetaException, TException {
+		HiveShim hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
+		hiveShim.alterTable(client, databaseName, tableName, table);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShim.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShim.java
@@ -24,7 +24,10 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.thrift.TException;
 
@@ -83,4 +86,15 @@ public interface HiveShim {
 	 * @throws IOException if the file/directory cannot be properly moved or deleted
 	 */
 	boolean moveToTrash(FileSystem fs, Path path, Configuration conf, boolean purge) throws IOException;
+
+	/**
+	 * Alters a Hive table.
+	 *
+	 * @param client       the Hive metastore client
+	 * @param databaseName the name of the database to which the table belongs
+	 * @param tableName    the name of the table to be altered
+	 * @param table        the new Hive table
+	 */
+	void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table)
+			throws InvalidOperationException, MetaException, TException;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV1.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV1.java
@@ -24,10 +24,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.FileUtils;
+import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -94,5 +96,13 @@ public class HiveShimV1 implements HiveShim {
 		} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
 			throw new IOException("Failed to move " + path + " to trash", e);
 		}
+	}
+
+	@Override
+	public void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table) throws InvalidOperationException, MetaException, TException {
+		// For Hive-1.2.1, we need to tell HMS not to update stats. Otherwise, the stats we put in the table
+		// parameters can be overridden. The extra config we add here will be removed by HMS after it's used.
+		table.getParameters().put(StatsSetupConst.DO_NOT_UPDATE_STATS, "true");
+		client.alter_table(databaseName, tableName, table);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV2.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV2.java
@@ -29,7 +29,10 @@ import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.thrift.TException;
 
@@ -85,5 +88,10 @@ public class HiveShimV2 implements HiveShim {
 		} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 			throw new IOException("Failed to move " + path + " to trash", e);
 		}
+	}
+
+	@Override
+	public void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table) throws InvalidOperationException, MetaException, TException {
+		client.alter_table(databaseName, tableName, table);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV2.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV2.java
@@ -92,6 +92,7 @@ public class HiveShimV2 implements HiveShim {
 
 	@Override
 	public void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table) throws InvalidOperationException, MetaException, TException {
+		// For Hive-2.3.4, we don't need to tell HMS not to update stats.
 		client.alter_table(databaseName, tableName, table);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
@@ -62,6 +62,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class HiveStatsUtil {
 	private static final Logger LOG = LoggerFactory.getLogger(HiveStatsUtil.class);
 
+	public static final String DEFAULT_STATS_ZERO_CONST = "0";
+
 	private HiveStatsUtil() {}
 
 	/**

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -266,6 +266,14 @@ public class HiveCatalogGenericMetadataTest extends CatalogTestBase {
 	public void testListPartitionPartialSpec() throws Exception {
 	}
 
+	@Override
+	public void testGetPartitionStats() throws Exception {
+	}
+
+	@Override
+	public void testAlterPartitionTableStats() throws Exception {
+	}
+
 	// ------ test utils ------
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -590,9 +590,12 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 		if (!tableExists(tablePath)) {
 			throw new TableNotExistException(getName(), tablePath);
 		}
-
-		CatalogTableStatistics result = tableStats.get(tablePath);
-		return result != null ? result.copy() : CatalogTableStatistics.UNKNOWN;
+		if (!isPartitionedTable(tablePath)) {
+			CatalogTableStatistics result = tableStats.get(tablePath);
+			return result != null ? result.copy() : CatalogTableStatistics.UNKNOWN;
+		} else {
+			return CatalogTableStatistics.UNKNOWN;
+		}
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -437,8 +437,9 @@ public interface Catalog {
 	 *
 	 * @throws TableNotExistException if the table does not exist in the catalog
 	 * @throws CatalogException	in case of any runtime exception
+	 * @throws TableNotPartitionedException	if the table is not partitioned
 	 */
-	CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException;
+	CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException, TableNotPartitionedException;
 
 	/**
 	 * Get the column statistics of a table.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -437,9 +437,8 @@ public interface Catalog {
 	 *
 	 * @throws TableNotExistException if the table does not exist in the catalog
 	 * @throws CatalogException	in case of any runtime exception
-	 * @throws TableNotPartitionedException	if the table is not partitioned
 	 */
-	CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException, TableNotPartitionedException;
+	CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException;
 
 	/**
 	 * Get the column statistics of a table.

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -34,7 +34,6 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
-import org.apache.flink.table.functions.ScalarFunction;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -1095,7 +1094,7 @@ public abstract class CatalogTest {
 	@Test
 	public void testAlterTableStats_partitionedTable() throws Exception {
 		// alterTableStats() should do nothing for partitioned tables
-		// getTableStats() should return empty column stats for partitioned tables
+		// getTableStats() should return unknown column stats for partitioned tables
 		catalog.createDatabase(db1, createDb(), false);
 		CatalogTable catalogTable = createPartitionedTable();
 		catalog.createTable(path1, catalogTable, false);


### PR DESCRIPTION
## What is the purpose of the change

* This pull request makes HiveCatalog support Hive table stats related operations.


## Brief change log

  - *Support Hive table stats related operations in HiveCatalog*


## Verifying this change
This change added tests and can be verified as follows:
  - *Added test that validates that function in CatalogBaseTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)