### PR TITLE
FLINK-12751#File System#Implementation of HA using file system

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemCheckpointRecoveryFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.filesystem;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Checkpoint recovery factory class for file system backend to instantiate
+ * {@link CompletedCheckpointStore} and {@link CheckpointIDCounter} implementations (per JobID).
+ */
+
+public class FileSystemCheckpointRecoveryFactory  implements CheckpointRecoveryFactory {
+    private final Configuration config;
+    private final Executor executor;
+
+    /**
+     * Factory constructor.
+     *
+     * 	@param config		    Configuration
+     * 	@param executor    		Current executor
+     */
+
+    public FileSystemCheckpointRecoveryFactory(Configuration config, Executor executor) {
+        this.config = (Configuration) Preconditions.checkNotNull(config, "Configuration");
+        this.executor = (Executor)Preconditions.checkNotNull(executor, "Executor");
+    }
+
+    /**
+     * Create CompletedCheckpointStore.
+     *
+     * 	@param jobId		                        job id
+     * 	@param maxNumberOfCheckpointsToRetain    	max number of checkpoints to remember
+     * 	@param userClassLoader    	                Classloader
+     */
+
+    public CompletedCheckpointStore createCheckpointStore(JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader) throws Exception {
+        return FileSystemUtils.createCompletedCheckpoints(this.config, jobId, maxNumberOfCheckpointsToRetain, this.executor);
+    }
+
+    /**
+     * Create CompletedCheckpointStore.
+     *
+     * 	@param jobId		                        job id
+     */
+
+    public CheckpointIDCounter createCheckpointIDCounter(JobID jobId) throws Exception {
+        return FileSystemUtils.createCheckPointIDCounter(this.config, jobId);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemHAServices.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.highavailability.nonha.AbstractNonHaServices;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneRunningJobsRegistry;
@@ -93,11 +94,8 @@ public class FileSystemHAServices implements HighAvailabilityServices {
 	/** Executor */
 	private final Executor executor;
 
-	/** Used for Mini cluster (local == true) */
-	private EmbeddedHaServices miniclusterURLResolver;
-
-	/** Used for cluster (local == false) */
-	private StandaloneHaServices clusterURLResolver;
+	/** URL resolver */
+	private AbstractNonHaServices clusterURLResolver;
 
 	private final boolean local;
 
@@ -109,11 +107,11 @@ public class FileSystemHAServices implements HighAvailabilityServices {
 	 * @param blobStoreService	Blob store service
 	 */
 	public FileSystemHAServices(
-			Executor executor,
-			Configuration configuration,
-			BlobStoreService blobStoreService) {
+		Executor executor,
+		Configuration configuration,
+		BlobStoreService blobStoreService) {
 
-		miniclusterURLResolver = new EmbeddedHaServices(executor);
+		clusterURLResolver = new EmbeddedHaServices(executor);
 
 		this.executor = checkNotNull(executor);
 		this.blobStoreService = checkNotNull(blobStoreService, "blobStoreService");
@@ -136,13 +134,13 @@ public class FileSystemHAServices implements HighAvailabilityServices {
 	 * @param blobStoreService			Blob store service
 	 */
 	public FileSystemHAServices(
-			String resourceManagerAddress,
-			String dispatcherAddress,
-			String jobManagerAddress,
-			String webMonitorAddress,
-			Executor executor,
-			Configuration configuration,
-			BlobStoreService blobStoreService) {
+		String resourceManagerAddress,
+		String dispatcherAddress,
+		String jobManagerAddress,
+		String webMonitorAddress,
+		Executor executor,
+		Configuration configuration,
+		BlobStoreService blobStoreService) {
 
 		clusterURLResolver = new StandaloneHaServices(resourceManagerAddress, dispatcherAddress, jobManagerAddress, webMonitorAddress);
 
@@ -162,95 +160,48 @@ public class FileSystemHAServices implements HighAvailabilityServices {
 
 	@Override
 	public LeaderRetrievalService getResourceManagerLeaderRetriever() {
-		if (local) {
-			return miniclusterURLResolver.getResourceManagerLeaderRetriever();
-		}
-		else {
-			return clusterURLResolver.getResourceManagerLeaderRetriever();
-		}
+		return clusterURLResolver.getResourceManagerLeaderRetriever();
 	}
 
 	@Override
 	public LeaderRetrievalService getDispatcherLeaderRetriever() {
-		if(local) {
-			return miniclusterURLResolver.getDispatcherLeaderRetriever();
-		}
-		else {
-			return clusterURLResolver.getDispatcherLeaderRetriever();
-		}
+		return clusterURLResolver.getDispatcherLeaderRetriever();
 	}
 
 	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
-		if (local) {
-			return miniclusterURLResolver.getResourceManagerLeaderElectionService();
-		}
-		else {
-			return clusterURLResolver.getResourceManagerLeaderElectionService();
-		}
+		return clusterURLResolver.getResourceManagerLeaderElectionService();
 	}
 
 	@Override
 	public LeaderElectionService getDispatcherLeaderElectionService() {
-		if (local) {
-			return miniclusterURLResolver.getDispatcherLeaderElectionService();
-		}
-		else {
-			return clusterURLResolver.getDispatcherLeaderElectionService();
-		}
+		return clusterURLResolver.getDispatcherLeaderElectionService();
 	}
 
 	@Override
 	public LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID) {
-		checkNotNull(jobID);
-
-		if (local) {
-			return miniclusterURLResolver.getJobManagerLeaderRetriever(jobID);
-		}
-		else {
-			return clusterURLResolver.getJobManagerLeaderRetriever(jobID);
-		}
+		return clusterURLResolver.getJobManagerLeaderRetriever(jobID);
 	}
 
 	@Override
 	public LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID, String defaultJobManagerAddress) {
-		if (local) {
-			return miniclusterURLResolver.getJobManagerLeaderRetriever(jobID,defaultJobManagerAddress);
-		}
-		else {
-			return clusterURLResolver.getJobManagerLeaderRetriever(jobID,defaultJobManagerAddress);
-		}
+		return clusterURLResolver.getJobManagerLeaderRetriever(jobID,defaultJobManagerAddress);
 	}
 
 	@Override
 	public LeaderElectionService getJobManagerLeaderElectionService(JobID jobID) {
 
-		if (local) {
-			return miniclusterURLResolver.getJobManagerLeaderElectionService(jobID);
-		}
-		else {
-			return clusterURLResolver.getJobManagerLeaderElectionService(jobID);
-		}
+		return clusterURLResolver.getJobManagerLeaderElectionService(jobID);
 	}
 
 	@Override
 	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
-		if (local) {
-			return miniclusterURLResolver.getWebMonitorLeaderRetriever();
-		}
-		else {
-			return clusterURLResolver.getWebMonitorLeaderRetriever();
-		}
+		return clusterURLResolver.getWebMonitorLeaderRetriever();
 	}
 
 	@Override
 	public LeaderElectionService getWebMonitorLeaderElectionService() {
-		if (local) {
-			return miniclusterURLResolver.getWebMonitorLeaderElectionService();
-		}
-		else {
-			return clusterURLResolver.getWebMonitorLeaderElectionService();
-		}
+		return clusterURLResolver.getWebMonitorLeaderElectionService();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemHAServices.java
@@ -97,8 +97,6 @@ public class FileSystemHAServices implements HighAvailabilityServices {
 	/** URL resolver */
 	private AbstractNonHaServices clusterURLResolver;
 
-	private final boolean local;
-
 	/**
 	 * Creates a new services class for local usage.
 	 *
@@ -118,7 +116,6 @@ public class FileSystemHAServices implements HighAvailabilityServices {
 		this.configuration = configuration;
 		this.runningJobsRegistry = new StandaloneRunningJobsRegistry();
 
-		local = true;
 		shutdown = false;
 	}
 
@@ -149,7 +146,6 @@ public class FileSystemHAServices implements HighAvailabilityServices {
 		this.configuration = configuration;
 		this.runningJobsRegistry = new StandaloneRunningJobsRegistry();
 
-		local = false;
 		shutdown = false;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemHAServices.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.filesystem;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobStore;
+import org.apache.flink.runtime.blob.BlobStoreService;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneRunningJobsRegistry;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.util.ExceptionUtils;
+
+import javax.annotation.concurrent.GuardedBy;
+import java.io.IOException;
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An implementation of the {@link HighAvailabilityServices} using file system.
+ *
+ * <p>This implementation has no dependencies on any external services. It stores
+ * checkpoints and metadata simply on a file system and therefore relies on the high
+ * availability of the file system.
+ * Implementation is based on the following file system layout:
+ * ha									-----> root of the HA data
+ * 	checkpointcounter					-----> checkpoint counter folder
+ * 		<job ID>						-----> job id folder
+ * 			<counter file>				-----> counter file
+ * 		<another job ID>				-----> another job id folder
+ * 	...........
+ * 	completedCheckpoint					-----> completed checkpoint folder
+ * 		<job ID>						-----> job id folder
+ * 			<checkpoint file>			-----> checkpoint file
+ * 			<another checkpoint file>	-----> checkpoint file
+ * 			...........
+ * 		<another job ID>				-----> another job id folder
+ * 	...........
+ * 	submittedJobGraph					-----> submitted graph folder
+ * 		<job ID>						-----> job id folder
+ * 			<graph file>				-----> graph file
+ * 		<another job ID>				-----> another job id folder
+ * 	...........
+ *
+ * To enable FileSystem HA mode, either add configuration to flink-conf.yaml
+ *
+ * high-availability: filesystem
+ * high-availability.storageDir: ./flinkchk
+ * state.checkpoints.num-retained: 5
+ *
+ * it also trying not to modify existing urls for all Flink components
+ */
+public class FileSystemHAServices implements HighAvailabilityServices {
+
+	private final Object lock = new Object();
+
+	/** Configuration */
+	private final Configuration configuration;
+
+	/** Job Registry */
+	private final RunningJobsRegistry runningJobsRegistry;
+
+	/** Store for arbitrary blobs */
+	private final BlobStoreService blobStoreService;
+
+	/** Shutdown flag */
+	private boolean shutdown;
+
+	/** Executor */
+	private final Executor executor;
+
+	/** Used for Mini cluster (local == true) */
+	private EmbeddedHaServices miniclusterURLResolver;
+
+	/** Used for cluster (local == false) */
+	private StandaloneHaServices clusterURLResolver;
+
+	private final boolean local;
+
+	/**
+	 * Creates a new services class for local usage.
+	 *
+	 * @param executor    		Current executor
+	 * @param configuration		Configuration
+	 * @param blobStoreService	Blob store service
+	 */
+	public FileSystemHAServices(
+			Executor executor,
+			Configuration configuration,
+			BlobStoreService blobStoreService) {
+
+		miniclusterURLResolver = new EmbeddedHaServices(executor);
+
+		this.executor = checkNotNull(executor);
+		this.blobStoreService = checkNotNull(blobStoreService, "blobStoreService");
+		this.configuration = configuration;
+		this.runningJobsRegistry = new StandaloneRunningJobsRegistry();
+
+		local = true;
+		shutdown = false;
+	}
+
+	/**
+	 * Creates a new services class for cluster usage.
+	 *
+	 * @param resourceManagerAddress    The fix address of the ResourceManager
+	 * @param dispatcherAddress    		The fix address of the Dispatcher
+	 * @param jobManagerAddress    		The fix address of the Job Manager
+	 * @param webMonitorAddress			The fix address of the Web Monitor
+	 * @param executor    				Current executor
+	 * @param configuration				Configuration
+	 * @param blobStoreService			Blob store service
+	 */
+	public FileSystemHAServices(
+			String resourceManagerAddress,
+			String dispatcherAddress,
+			String jobManagerAddress,
+			String webMonitorAddress,
+			Executor executor,
+			Configuration configuration,
+			BlobStoreService blobStoreService) {
+
+		clusterURLResolver = new StandaloneHaServices(resourceManagerAddress, dispatcherAddress, jobManagerAddress, webMonitorAddress);
+
+		this.executor = checkNotNull(executor);
+		this.blobStoreService = checkNotNull(blobStoreService, "blobStoreService");
+		this.configuration = configuration;
+		this.runningJobsRegistry = new StandaloneRunningJobsRegistry();
+
+		local = false;
+		shutdown = false;
+	}
+
+
+	// ------------------------------------------------------------------------
+	//  Services
+	// ------------------------------------------------------------------------
+
+	@Override
+	public LeaderRetrievalService getResourceManagerLeaderRetriever() {
+		if (local) {
+			return miniclusterURLResolver.getResourceManagerLeaderRetriever();
+		}
+		else {
+			return clusterURLResolver.getResourceManagerLeaderRetriever();
+		}
+	}
+
+	@Override
+	public LeaderRetrievalService getDispatcherLeaderRetriever() {
+		if(local) {
+			return miniclusterURLResolver.getDispatcherLeaderRetriever();
+		}
+		else {
+			return clusterURLResolver.getDispatcherLeaderRetriever();
+		}
+	}
+
+	@Override
+	public LeaderElectionService getResourceManagerLeaderElectionService() {
+		if (local) {
+			return miniclusterURLResolver.getResourceManagerLeaderElectionService();
+		}
+		else {
+			return clusterURLResolver.getResourceManagerLeaderElectionService();
+		}
+	}
+
+	@Override
+	public LeaderElectionService getDispatcherLeaderElectionService() {
+		if (local) {
+			return miniclusterURLResolver.getDispatcherLeaderElectionService();
+		}
+		else {
+			return clusterURLResolver.getDispatcherLeaderElectionService();
+		}
+	}
+
+	@Override
+	public LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID) {
+		checkNotNull(jobID);
+
+		if (local) {
+			return miniclusterURLResolver.getJobManagerLeaderRetriever(jobID);
+		}
+		else {
+			return clusterURLResolver.getJobManagerLeaderRetriever(jobID);
+		}
+	}
+
+	@Override
+	public LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID, String defaultJobManagerAddress) {
+		if (local) {
+			return miniclusterURLResolver.getJobManagerLeaderRetriever(jobID,defaultJobManagerAddress);
+		}
+		else {
+			return clusterURLResolver.getJobManagerLeaderRetriever(jobID,defaultJobManagerAddress);
+		}
+	}
+
+	@Override
+	public LeaderElectionService getJobManagerLeaderElectionService(JobID jobID) {
+
+		if (local) {
+			return miniclusterURLResolver.getJobManagerLeaderElectionService(jobID);
+		}
+		else {
+			return clusterURLResolver.getJobManagerLeaderElectionService(jobID);
+		}
+	}
+
+	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		if (local) {
+			return miniclusterURLResolver.getWebMonitorLeaderRetriever();
+		}
+		else {
+			return clusterURLResolver.getWebMonitorLeaderRetriever();
+		}
+	}
+
+	@Override
+	public LeaderElectionService getWebMonitorLeaderElectionService() {
+		if (local) {
+			return miniclusterURLResolver.getWebMonitorLeaderElectionService();
+		}
+		else {
+			return clusterURLResolver.getWebMonitorLeaderElectionService();
+		}
+	}
+
+	@Override
+	public CheckpointRecoveryFactory getCheckpointRecoveryFactory() {
+		return new FileSystemCheckpointRecoveryFactory(configuration, executor);
+	}
+
+	@Override
+	public SubmittedJobGraphStore getSubmittedJobGraphStore() throws Exception {
+		synchronized (lock) {
+			checkNotShutdown();
+			return FileSystemUtils.createSubmittedJobGraphs(configuration);
+		}
+	}
+
+	@Override
+	public RunningJobsRegistry getRunningJobsRegistry() throws Exception {
+		synchronized (lock) {
+			checkNotShutdown();
+			return runningJobsRegistry;
+		}
+	}
+
+	@Override
+	public BlobStore createBlobStore() throws IOException {
+		synchronized (lock) {
+			checkNotShutdown();
+			return blobStoreService;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Shutdown and Cleanup
+	// ------------------------------------------------------------------------
+
+	@Override
+	public void close() throws Exception {
+		Throwable exception = null;
+
+		try {
+			blobStoreService.close();
+		} catch (Throwable t) {
+			exception = t;
+		}
+
+		internalClose();
+
+		if (exception != null) {
+			ExceptionUtils.rethrowException(exception, "Could not properly close the FileSystemHaServices.");
+		}
+	}
+
+	@Override
+	public void closeAndCleanupAllData() throws Exception {
+		Throwable exception = null;
+
+		try {
+			blobStoreService.closeAndCleanupAllData();
+		} catch (Throwable t) {
+			exception = t;
+		}
+
+		internalClose();
+
+		if (exception != null) {
+			ExceptionUtils.rethrowException(exception, "Could not properly close and clean up all data of FileSystemHaServices.");
+		}
+	}
+
+	/**
+	 * Closes components which don't distinguish between close and closeAndCleanupAllData
+	 */
+	private void internalClose() {
+		synchronized (lock) {
+			if (!shutdown) {
+				shutdown = true;
+			}
+		}
+	}
+
+	// ----------------------------------------------------------------------
+	// Helper methods
+	// ----------------------------------------------------------------------
+
+	@GuardedBy("lock")
+	private void checkNotShutdown() {
+		checkState(!shutdown, "high availability services are shut down");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemStorageHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemStorageHelper.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.filesystem;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * {@link FileSystemStorageHelper} implementation which stores the state in the given filesystem path.
+ *
+ * @param <T> The type of the data that can be stored by this storage helper.
+ */
+public class FileSystemStorageHelper<T extends Serializable> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemStorageHelper.class);
+
+
+    private final Path rootPath;
+
+    private final String prefix;
+
+    private final FileSystem fs;
+
+    /**
+     * Storage constructor.
+     *
+     * 	@param rootPath		    Root path (string)
+     * 	@param prefix    		prefix
+     */
+
+    public FileSystemStorageHelper(String rootPath, String prefix) throws IOException {
+        this(new Path(rootPath), prefix);
+    }
+
+    /**
+     * Storage constructor.
+     *
+     * 	@param rootPath		    Root path (Path)
+     * 	@param prefix    		prefix
+     */
+
+    public FileSystemStorageHelper(Path rootPath, String prefix) throws IOException {
+        this.rootPath = Preconditions.checkNotNull(rootPath, "Root path");
+        this.prefix = Preconditions.checkNotNull(prefix, "Prefix");
+
+        fs = FileSystem.get(rootPath.toUri());
+    }
+
+    /**
+     * Store data.
+     *
+     * 	@param state		                    Data to Store
+     * 	@param name    	                        Name of the file to store in
+     * 	@return handle to the file where data is stored
+     */
+
+    public File store(T state, String name) throws Exception {
+        return store(state, new Path(rootPath.getPath() + "/" + prefix + "/" + name));
+    }
+
+    /**
+     * Store data.
+     *
+     * 	@param state		                    Data to Store
+     * 	@param name    	                        Name of the file to store in
+     * 	@param JobID   	                        Job ID
+     * 	@return handle to the file where data is stored
+     */
+
+    public File store(T state, String JobID, String name) throws Exception {
+        return store(state, new Path(rootPath.getPath() + "/" + prefix + "/" + JobID + "/" + name));
+    }
+
+    /**
+     * Store data.
+     *
+     * 	@param state		                    Data to Store
+     * 	@param filePath   	                    Pathe to the file to store in
+     * 	@return handle to the file where data is stored
+     */
+
+    private File store(T state, Path filePath) throws Exception {
+
+        try (FSDataOutputStream outStream = fs.create(filePath, FileSystem.WriteMode.NO_OVERWRITE)) {
+            InstantiationUtil.serializeObject(outStream, state);
+            return new File(filePath.getPath());
+        }
+        catch (Exception e) {
+            LOG.info("Could not open output stream for state backend" );
+            throw new Exception("Could not open output stream for state backend", e);
+        }
+    }
+
+    /**
+     * Clean up directory.
+     */
+
+    public void cleanup(){
+        File folder = new File(rootPath + "/" + prefix);
+        cleanup(folder);
+    }
+
+    /**
+     * Clean up directory.
+     * 	@param folder		                    Starting folder
+     */
+    private void cleanup(File folder){
+        List<File> files = getChildren(folder, false);
+        for (File f : files) {
+            if (f.isDirectory()) {
+                cleanup(f);
+            }
+            if (f.exists()) {
+                f.delete();
+            }
+        }
+    }
+
+    /**
+     * Remove job id and all related files.
+     * 	@param jobID		                    job id
+     */
+    public void removeJobId(String jobID){
+        File folder = new File(rootPath + "/" + prefix + "/" + jobID);
+        cleanup(folder);
+    }
+
+    /**
+     * Get list of files for job ID.
+     * 	@param jobID		                    job
+     *  @return  LIst of file handles
+     */
+    public List<File> getFilesPerJob(String jobID) {
+        File folder = new File(rootPath + "/" + prefix + "/" + jobID);
+        return getChildren(folder, true);
+    }
+
+    /**
+     * Get list of files
+     *  @return  LIst of file handles
+     */
+    public List<File> getFiles() {
+        File folder = new File(rootPath + "/" + prefix);
+        return getChildren(folder, true);
+    }
+
+    /**
+     * Get list of job ids
+     *  @return  LIst of file handles
+     */
+
+    public List<String> getJobIDs() {
+        List<File> jobs = getFiles();
+        List<String> ids = new LinkedList<>();
+        for (File f : jobs) {
+            ids.add(f.getName());
+        }
+        return ids;
+    }
+
+    /**
+     * Get input stream for file
+     * 	@param file		                    File
+     *  @return  Data stream
+     */
+
+    public FSDataInputStream getInputStream(File file) throws Exception {
+        return fs.open(new Path(file.getAbsolutePath()));
+    }
+
+    /**
+     * Get a list of file children
+     * 	@param file		                        File (might be null or do not exist)
+     * 	@param skip		                        skip hidden files
+     *  @return  Data stream
+     */
+
+    private List<File> getChildren(File file, boolean skip){
+        if((file != null) && (file.exists()) && (file.isDirectory())) {
+            return filesToList(file.listFiles(), skip);
+        }
+        LOG.info("No childrens found for file " + file.getPath());
+        return new LinkedList<>();
+    }
+
+    /**
+     * Convert an array of files to to list
+     * 	@param files		                    Array of files (might be null)
+     * 	@param skip		                        skip hidden files
+     *  @return  Data stream
+     */
+
+    private List<File> filesToList(File[] files, boolean skip){
+        List<File> list = new LinkedList<>();
+        if((files != null)) {
+            for(File f : files){
+                if(skip) {
+                    if (!f.getName().startsWith(".")) {
+                        list.add(f);
+                    }
+                }
+                else {
+                    list.add(f);
+                }
+            }
+        }
+        return list;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/filesystem/FileSystemUtils.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.filesystem;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.jobmanager.FileSystemCheckpointIDCounter;
+import org.apache.flink.runtime.jobmanager.FileSystemCompletedCheckpointStore;
+import org.apache.flink.runtime.jobmanager.FileSystemSubmittedJobGraphStore;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraph;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
+
+/**
+ * Class containing helper functions to support filesystem based HA.
+ */
+
+public class FileSystemUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemUtils.class);
+
+    /**
+     * Creates a {@link FileSystemStorageHelper} instance.
+     *
+     * @param configuration {@link Configuration} object
+     * @param prefix Prefix for the created files
+     * @param <T> Type of the state objects
+     * @return {@link FileSystemStorageHelper} instance
+     * @throws IOException if file system state storage cannot be created
+     */
+    private static <T extends Serializable> FileSystemStorageHelper<T> createFileSystemStateStorage(
+            Configuration configuration,
+            String prefix) throws IOException {
+
+        String storagePath = configuration.getValue(HighAvailabilityOptions.HA_STORAGE_PATH) + "/ha";
+        if(storagePath.startsWith("file://")) {
+            storagePath = storagePath.substring(7);
+        }
+        LOG.info("Creating FileSystemStorageHelper with path " + storagePath + " prefix " + prefix);
+        if (isNullOrWhitespaceOnly(storagePath)) {
+            throw new IllegalConfigurationException("Configuration is missing the mandatory parameter: " +
+                    HighAvailabilityOptions.HA_STORAGE_PATH);
+        }
+
+        return new FileSystemStorageHelper<T>(storagePath, prefix);
+    }
+
+    /**
+     * Creates a {@link SubmittedJobGraphStore} instance.
+     *
+     * @param configuration {@link Configuration} object
+     * @return {@link SubmittedJobGraphStore} instance
+     * @throws Exception if the submitted job graph store cannot be created
+     */
+
+    public static SubmittedJobGraphStore createSubmittedJobGraphs(
+            Configuration configuration) throws Exception {
+
+        checkNotNull(configuration, "Configuration");
+        LOG.info("Creating SubmittedJobGraphStore");
+
+        FileSystemStorageHelper<SubmittedJobGraph> stateStorage = createFileSystemStateStorage(configuration, "submittedJobGraph");
+
+        return new FileSystemSubmittedJobGraphStore(stateStorage);
+    }
+
+    /**
+     * Creates a {@link CompletedCheckpointStore} instance.
+     *
+     * @param configuration                  {@link Configuration} object
+     * @param jobId                          ID of job to create the instance for
+     * @param maxNumberOfCheckpointsToRetain The maximum number of checkpoints to retain
+     * @param executor to run ZooKeeper callbacks
+     * @return {@link CompletedCheckpointStore} instance
+     * @throws Exception if the completed checkpoint store cannot be created
+     */
+
+    public static CompletedCheckpointStore createCompletedCheckpoints(
+            Configuration configuration,
+            JobID jobId,
+            int maxNumberOfCheckpointsToRetain,
+            Executor executor) throws Exception {
+
+        checkNotNull(configuration, "Configuration");
+
+        String storagePath = configuration.getValue(HighAvailabilityOptions.HA_STORAGE_PATH);
+        if (isNullOrWhitespaceOnly(storagePath)) {
+            throw new IllegalConfigurationException("Configuration is missing the mandatory parameter: " +
+                    HighAvailabilityOptions.HA_STORAGE_PATH);
+        }
+
+        String hexJobId = jobId.toHexString();
+        LOG.info("Creating CompletedCheckpointStore for job " + hexJobId);
+        FileSystemStorageHelper<CompletedCheckpoint> stateStorage = createFileSystemStateStorage(
+                configuration,
+                "completedCheckpoint/" + hexJobId);
+
+        final FileSystemCompletedCheckpointStore completedCheckpointStore = new FileSystemCompletedCheckpointStore(
+                maxNumberOfCheckpointsToRetain,
+                stateStorage,
+                executor);
+
+        return completedCheckpointStore;
+    }
+
+    /**
+     * Creates a {@link CheckpointIDCounter} instance.
+     *
+     * @param configuration                  {@link Configuration} object
+     * @return {@link CheckpointIDCounter}   instance
+     * @throws Exception if the completed checkpoint store cannot be created
+     */
+
+    public static CheckpointIDCounter createCheckPointIDCounter(
+            Configuration configuration, JobID jobId) throws Exception {
+
+        checkNotNull(configuration, "Configuration");
+
+        String hexJobId = jobId.toHexString();
+        FileSystemStorageHelper<Integer> counterStorage = createFileSystemStateStorage(
+                configuration,
+                "checkpointcounter/" + hexJobId);
+
+        LOG.info("Creating CheckpointIDCounter for job " + hexJobId);
+        return new FileSystemCheckpointIDCounter(counterStorage);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/FileSystemCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/FileSystemCheckpointIDCounter.java
@@ -122,8 +122,9 @@ public class FileSystemCheckpointIDCounter implements CheckpointIDCounter {
     private void saveAndIncrementCount(){
         try {
             File result = counterStorage.store(0, Long.toString(checkpointID));
-            if (lastID != null)
-                lastID.delete();
+            if (lastID != null) {
+				lastID.delete();
+			}
             lastID = result;
         }
         catch (Throwable t){}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/FileSystemCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/FileSystemCheckpointIDCounter.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager;
+
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.highavailability.filesystem.FileSystemStorageHelper;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * An implementation of the {@link FileSystemCheckpointIDCounter} using file system.
+ *
+ * This implementation support maintaing ID for a singele job. It stores
+ * checkpoint IDs on a file system and therefore relies on the high
+ * availability of the file system.
+ *
+ */
+
+public class FileSystemCheckpointIDCounter implements CheckpointIDCounter {
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemCheckpointIDCounter.class);
+    private final FileSystemStorageHelper<Integer> counterStorage;
+
+    /* Local counter */
+    private long checkpointID;
+    private final Object startStopLock = new Object();
+    private boolean isStarted;
+
+    /* Previous counter */
+    private File lastID = null;
+
+    /**
+     * Creates a new FileSystemCheckpointIDCounter class .
+     *
+     * @param counterStorage    		Underlying storage
+     */
+
+    public FileSystemCheckpointIDCounter(FileSystemStorageHelper<Integer> counterStorage) {
+        this.counterStorage = counterStorage;
+    }
+
+    /**
+     * Starts FileSystemCheckpointIDCounter.
+     */
+    public void start() throws Exception {
+        Object var1 = this.startStopLock;
+        synchronized(this.startStopLock) {
+            List<File> counters = counterStorage.getFiles();
+            if(counters.size() == 0){
+                checkpointID = 0;
+                lastID = null;
+            }
+            else{
+                checkpointID = Long.parseLong(counters.get(0).getName()) + 1;
+                lastID = counters.get(0);
+            }
+            if (!this.isStarted) {
+                this.isStarted = true;
+            }
+        }
+    }
+
+    /**
+     * Shutsdown FileSystemCheckpointIDCounter.
+     */
+    public void shutdown(JobStatus jobStatus) throws Exception {
+        Object var2 = this.startStopLock;
+        synchronized(this.startStopLock) {
+            if (this.isStarted) {
+                LOG.info("Shutting down.");
+                counterStorage.cleanup();
+                this.isStarted = false;
+            }
+
+        }
+    }
+
+    /**
+     * Get next counter.
+     *
+     * @return  counter
+     */
+    public long getAndIncrement() throws Exception {
+        saveAndIncrementCount();
+        return checkpointID - 1;
+    }
+
+    /**
+     * Resets counter.
+     *
+     * @param newId         New ID
+     */
+    public void setCount(long newId) throws Exception {
+        checkpointID = newId;
+        counterStorage.cleanup();
+        lastID = counterStorage.store(0, Long.toString(checkpointID));
+    }
+
+    /**
+     * Internal method to save counter.
+     */
+
+    private void saveAndIncrementCount(){
+        try {
+            File result = counterStorage.store(0, Long.toString(checkpointID));
+            if (lastID != null)
+                lastID.delete();
+            lastID = result;
+        }
+        catch (Throwable t){}
+        checkpointID ++;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/FileSystemCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/FileSystemCompletedCheckpointStore.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.highavailability.filesystem.FileSystemStorageHelper;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.util.InstantiationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * {@link CompletedCheckpointStore} for JobManagers running in {@link HighAvailabilityMode#FILESYSTEM}.
+ *
+ * This implementation support maintaing checkpoints for a singele job. It stores
+ * checkpoints on a file system and therefore relies on the high availability of the file system.
+ * During recovery, the latest checkpoint is read from filesystem. If there is more than one,
+ * only the latest one is used and older ones are discarded (even if the maximum number
+ * of retained checkpoints is greater than one).
+ */
+
+public class FileSystemCompletedCheckpointStore implements CompletedCheckpointStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemCompletedCheckpointStore.class);
+
+    /** The maximum number of checkpoints to retain (at least 1). */
+    private final int maxNumberOfCheckpointsToRetain;
+
+    /** Storage **/
+    private final FileSystemStorageHelper<CompletedCheckpoint> checkpointStorage;
+
+    /**
+     * Local copy of the completed checkpoints. This is restored from filestore
+     * when recovering and is maintained in parallel to the state in during normal
+     * operations.
+     */
+    private final ArrayDeque<File> completedCheckpoints;
+
+
+    private final Executor executor;
+
+    /**
+     * Creates a {@link FileSystemCompletedCheckpointStore} instance.
+     *
+     * @param maxNumberOfCheckpointsToRetain The maximum number of checkpoints to retain (at
+     *                                       least 1). Adding more checkpoints than this results
+     *                                       in older checkpoints being discarded. On recovery,
+     *                                       we will only start with a single checkpoint.
+     * @param checkpointStorage              Completed checkpoints in file system
+     * @param executor                       to execute blocking calls
+     */
+
+    public FileSystemCompletedCheckpointStore(
+            int maxNumberOfCheckpointsToRetain,
+            FileSystemStorageHelper<CompletedCheckpoint> checkpointStorage,
+            Executor executor) {
+
+        checkArgument(maxNumberOfCheckpointsToRetain >= 1, "Must retain at least one checkpoint.");
+
+        this.maxNumberOfCheckpointsToRetain = maxNumberOfCheckpointsToRetain;
+
+        this.checkpointStorage = checkpointStorage;
+
+        this.completedCheckpoints = new ArrayDeque<>(maxNumberOfCheckpointsToRetain + 1);
+
+        this.executor = checkNotNull(executor);
+    }
+
+    @Override
+    public boolean requiresExternalizedCheckpoints() {
+        return false;
+    }
+
+    /**
+     * Gets the latest checkpoint from ZooKeeper and removes all others.
+     *
+     * <p><strong>Important</strong>: Even if there are more than one checkpoint in ZooKeeper,
+     * this will only recover the latest and discard the others. Otherwise, there is no guarantee
+     * that the history of checkpoints is consistent.
+     */
+
+    @Override
+    public void recover() throws Exception {
+        LOG.info("Recovering checkpoints.");
+
+        // Get all there is first
+        List<File> checkpointfiles = checkpointStorage.getFiles();
+        LOG.info("Get " + checkpointfiles.size() + " checkpoint files");
+        Collections.sort(checkpointfiles, new Comparator<File>() {
+            @Override
+            public int compare(File o1, File o2) {
+                long n1 = extractNumber(o1.getName());
+                long n2 = extractNumber(o2.getName());
+                return (int) (n1 - n2);
+            }
+
+            private long extractNumber(String name) {
+                long nmbr = 0;
+                try {
+                    int s = name.indexOf('_') + 1;
+                    int e = name.lastIndexOf('.');
+                    String number = name.substring(s, e);
+                    nmbr = Long.parseLong(number);
+                } catch (Exception e) { }
+                return nmbr;
+            }
+        });
+
+        int numberOfInitialCheckpoints = checkpointfiles.size();
+        LOG.info("Found {} checkpoints.", numberOfInitialCheckpoints);
+
+        // Clear internal queue first and store existing files
+        completedCheckpoints.clear();
+        if(checkpointfiles != null) {
+            for (File f : checkpointfiles) {
+                completedCheckpoints.addLast(f);
+            }
+        }
+    }
+
+    /**
+     * Synchronously writes the new checkpoints to ZooKeeper and asynchronously removes older ones.
+     *
+     * @param checkpoint Completed checkpoint to add.
+     */
+
+    @Override
+    public void addCheckpoint(final CompletedCheckpoint checkpoint) throws Exception {
+        checkNotNull(checkpoint, "Checkpoint");
+
+        // Now add the new one. If it fails, we don't want to loose existing data.
+        Long id = checkpoint.getCheckpointID();
+        LOG.info("Adding checkpoint " + id);
+        try {
+           File file = checkpointStorage.store(checkpoint, "chk_" + id.toString());
+           completedCheckpoints.addLast(file);
+
+           // Everything worked, let's remove a previous checkpoint if necessary.
+           while (completedCheckpoints.size() > maxNumberOfCheckpointsToRetain) {
+               final File completedCheckpoint = completedCheckpoints.removeFirst();
+               completedCheckpoint.delete();
+           }
+        }
+        catch(Throwable t){
+            LOG.warn("Could not discard completed checkpoint {}.", checkpoint.getCheckpointID(), t);
+        }
+
+        LOG.debug("Added {}.", checkpoint);
+    }
+
+    /**
+     * Get checkpoint from File.
+     *
+     * @param file  File where checkpoint is stored.
+     */
+
+    private CompletedCheckpoint checkpointFromFile(File file){
+        try {
+            FSDataInputStream inputStream = checkpointStorage.getInputStream(file);
+            CompletedCheckpoint chk = InstantiationUtil.deserializeObject(inputStream, ClassLoader.getSystemClassLoader());
+            inputStream.close();
+            LOG.info("Restored checkpoint from file " + file.getPath());
+            return chk;
+        }
+        catch (Throwable t){
+            LOG.warn("Could not read checkpoint {}.", file.getName(), t);
+            return null;
+        }
+    }
+
+    /**
+     * Get latest checkpoint.
+	 * This method is removed in 1.9, but is used in 1.8
+     *
+     */
+
+    public CompletedCheckpoint getLatestCheckpoint() {
+        if (completedCheckpoints.isEmpty()) {
+            return null;
+        }
+        else {
+            return checkpointFromFile(completedCheckpoints.peekLast());
+        }
+    }
+
+    /**
+     * Get all available checkpoints.
+     */
+
+    @Override
+    public List<CompletedCheckpoint> getAllCheckpoints() throws Exception {
+        List<File> files = new ArrayList<>(completedCheckpoints);
+        List<CompletedCheckpoint> checkpoints = new ArrayList<>();
+        for(File f : files) {
+            checkpoints.add(checkpointFromFile(f));
+        }
+        return checkpoints;
+    }
+
+    /**
+     * Get amount of available checkpoints.
+     */
+
+    @Override
+    public int getNumberOfRetainedCheckpoints() {
+        return completedCheckpoints.size();
+    }
+
+    /**
+     * Get amount of checkpoints to keep.
+     */
+
+    @Override
+    public int getMaxNumberOfRetainedCheckpoints() {
+        return maxNumberOfCheckpointsToRetain;
+    }
+
+    /**
+     * Shutdown
+     */
+
+    @Override
+    public void shutdown(JobStatus jobStatus) throws Exception {
+        if (jobStatus.isGloballyTerminalState()) {
+            LOG.info("Shutting down");
+            checkpointStorage.cleanup();
+            completedCheckpoints.clear();
+        } else {
+            LOG.info("Suspending");
+
+            // Clear the local handles, but don't remove any state
+            completedCheckpoints.clear();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/FileSystemSubmittedJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/FileSystemSubmittedJobGraphStore.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.highavailability.filesystem.FileSystemStorageHelper;
+import org.apache.flink.util.InstantiationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * {@link SubmittedJobGraph} instances for jobs running in {@link HighAvailabilityMode#FILESYSTEM}.
+ *
+ * This implementation support maintaing job graphs across the cluster. It stores
+ * job graphs on a file system and therefore relies on the high availability of the file system.
+ * It also effectively maintains the list of running jobs.
+ */
+public class FileSystemSubmittedJobGraphStore implements SubmittedJobGraphStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemSubmittedJobGraphStore.class);
+
+    /** Lock to synchronize with the {@link SubmittedJobGraphListener}. */
+    private final Object cacheLock = new Object();
+
+    /** Map of current graph files */
+    Map<String, File> graphs = new HashMap<>();
+
+    /** Storage helper. */
+    private final FileSystemStorageHelper<SubmittedJobGraph> stateStorage;
+
+    /** Flag indicating whether this instance is running. */
+    private boolean isRunning;
+
+    /**
+     * FileSystemSubmittedJobGraphStore constructor backed by JobGraphStore
+     *
+     * @param stateStorage storage implementation for current job graphs
+     * @throws Exception
+     */
+    public FileSystemSubmittedJobGraphStore(FileSystemStorageHelper<SubmittedJobGraph> stateStorage) throws Exception {
+
+        checkNotNull(stateStorage, "State storage");
+
+        this.stateStorage = stateStorage;
+    }
+
+    /**
+     * Start FileSystemSubmittedJobGraphStore
+     *
+     * @param jobGraphListener  listener for job graphs
+     * @throws Exception
+     */
+
+    @Override
+    public void start(SubmittedJobGraphListener jobGraphListener) throws Exception {
+        synchronized (cacheLock) {
+            if (!isRunning) {
+                isRunning = true;
+            }
+        }
+    }
+
+    /**
+     * Stop FileSystemSubmittedJobGraphStore
+     *
+     * @throws Exception
+     */
+
+    @Override
+    public void stop() {
+        synchronized (cacheLock) {
+            if (isRunning) {
+                isRunning = false;
+            }
+        }
+    }
+
+    /**
+     * Save job graph
+     *
+     * @param jobGraph      job graph to save
+     * @throws Exception
+     */
+
+    @Override
+    public void putJobGraph(SubmittedJobGraph jobGraph) throws Exception {
+        checkNotNull(jobGraph, "Job graph");
+        String hexJobId = jobGraph.getJobId().toHexString();
+
+        synchronized (cacheLock) {
+            verifyIsRunning();
+
+            try {
+                if(graphs.containsKey(hexJobId)) {
+                    graphs.get(hexJobId).delete();
+                }
+                File file = stateStorage.store(jobGraph, hexJobId, "jobgraph");
+                graphs.put(hexJobId, file);
+            } catch (Exception e) {
+                throw new RuntimeException("Storing job graph " + hexJobId + " failed", e);
+            }
+        }
+
+        LOG.info("Added job graph {}.", jobGraph);
+    }
+
+    /**
+     * Removes the {@link SubmittedJobGraph} with the given {@link JobID} if it exists.
+     *
+     * @param jobId      job ID
+     * @throws Exception
+     */
+
+    @Override
+    public void removeJobGraph(JobID jobId) throws Exception {
+        checkNotNull(jobId, "Job ID");
+        String hexJobId = jobId.toHexString();
+
+        synchronized (cacheLock) {
+            try {
+                graphs.remove(hexJobId);
+                stateStorage.removeJobId(hexJobId);
+
+            } catch (Exception e) {
+                LOG.info("Removing job graph " + jobId + " failed.", e);
+            }
+        }
+
+        LOG.info("Removed job graph {} .", jobId);
+    }
+
+    /**
+     * Releases the locks on the graph for specified {@link JobID}.
+     *
+     * Releasing the locks allows that another instance can delete the job from
+     * the {@link SubmittedJobGraphStore}.
+     *
+     * @param jobId specifying the job to release the locks for
+     * @throws Exception if the locks cannot be released
+    */
+
+    @Override
+    public void releaseJobGraph(JobID jobId) throws Exception {
+        // Nothing to do here
+    }
+
+    /**
+     * Get list of existing job ids
+     *
+     * @return Collection<JobID>
+     * @throws Exception
+     */
+
+    @Override
+    public Collection<JobID> getJobIds() throws Exception {
+        List<String> ids = stateStorage.getJobIDs();
+        List<JobID> jobIds = new ArrayList<>(ids.size());
+        for(String id : ids) {
+            jobIds.add(JobID.fromHexString(id));
+        }
+        LOG.info("Retrieving all stored job ids. Found " + jobIds.size());
+        return jobIds;
+    }
+
+    /**
+     * Recover job graph
+     *
+     * @param  jobId                Job ID
+     * @return JobGraph
+     * @throws Exception
+     */
+
+    @Override
+    public SubmittedJobGraph recoverJobGraph(JobID jobId) throws Exception {
+        checkNotNull(jobId, "Job ID");
+        String hexJobId = jobId.toHexString();
+
+        synchronized (cacheLock) {
+            verifyIsRunning();
+
+            List<File> grFiles = stateStorage.getFilesPerJob(hexJobId);
+            if (grFiles.size() == 0) {
+                return null;
+            }
+            try {
+                FSDataInputStream inputStream = stateStorage.getInputStream(grFiles.get(0));
+                SubmittedJobGraph jobGraph = InstantiationUtil.deserializeObject(inputStream, ClassLoader.getSystemClassLoader());
+                inputStream.close();
+                graphs.put(hexJobId, grFiles.get(0));
+
+                LOG.info("Recovered {}.", hexJobId);
+
+                return jobGraph;
+            }
+            catch(Throwable t){
+                LOG.info("Error Recovered grapth for job ID " + hexJobId + " error " + t);
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Verifies that the state is running.
+     */
+    private void verifyIsRunning() {
+        checkState(isRunning, "Not running. Forgot to call start()?");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/HighAvailabilityMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/HighAvailabilityMode.java
@@ -30,13 +30,15 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
  * ZooKeeper is used to select a leader among a group of JobManager. This JobManager
  * is responsible for the job execution. Upon failure of the leader a new leader is elected
  * which will take over the responsibilities of the old leader
+ * - FILESYSTEM is used to mange graph/checkpoint information on the file system
  * - FACTORY_CLASS: Use implementation of {@link org.apache.flink.runtime.highavailability.HighAvailabilityServicesFactory}
  * specified in configuration property high-availability
  */
 public enum HighAvailabilityMode {
 	NONE(false),
 	ZOOKEEPER(true),
-	FACTORY_CLASS(true);
+	FACTORY_CLASS(true),
+	FILESYSTEM(true);
 
 	private final boolean haActive;
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements Flink HA on file system - no ZK required

## Brief change log

An implementation overwrites 2 of the Flink files:
* HighAvailabilityServicesUtils - added `FILESYSTEM` option for picking HA service
* HighAvailabilityMode - added `FILESYSTEM` to available HA options.

The actual implementation exists of the following classes:
* FileSystemHAServices - an implementation of a HighAvailabilityServices for file system
* FileSystemUtils - support class for creation of runtime components.
* FileSystemStorageHelper - file system operations implementation for filesystem based HA
* FileSystemCheckpointRecoveryFactory - an implementation of a CheckpointRecoveryFactory for file system
* FileSystemCheckpointIDCounter - an implementation of a CheckpointIDCounter for file system
* FileSystemCompletedCheckpointStore - an implementation of a CompletedCheckpointStore for file system
* FileSystemSubmittedJobGraphStore - an implementation of a SubmittedJobGraphStore for file system

## Verifying this change

Here we are using Flink's native leader election, which is fully tested by Flink. We also implement 
Flink interfaces, so connectivity between pieces is also tested by Flink.

Also manually verified the change by running a 2 node cluser with 1 JobManagers and 2 TaskManagers, a stateful streaming program, and killing one JobManager during the execution, verifying that recovery happens correctly

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes - it implements a new option for JM checkpointing and recovery
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? documented in code
This is how data is laid out on file system
 ha									-----> root of the HA data
  checkpointcounter					-----> checkpoint counter folder
  	<job ID>						-----> job id folder
  		<counter file>				-----> counter file
  	<another job ID>				-----> another job id folder
  ...........
  completedCheckpoint				-----> completed checkpoint folder
 	<job ID>						-----> job id folder
  		<checkpoint file>			-----> checkpoint file
  		<another checkpoint file>	-----> checkpoint file
 		...........
  		<another job ID>			-----> another job id folder
  ...........
  submittedJobGraph				    -----> submitted graph folder
  	<job ID>						-----> job id folder
  		<graph file>				-----> graph file
  	<another job ID>				-----> another job id folder
  ...........

