### PR TITLE
[FLINK-12757][python] Improves the word_count example to use the descriptor API

### DIFF
--- a/flink-python/pyflink/table/examples/batch/word_count.py
+++ b/flink-python/pyflink/table/examples/batch/word_count.py
@@ -15,22 +15,17 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import logging
 import os
+import shutil
+import sys
 import tempfile
 
-from pyflink.table import TableEnvironment, TableConfig
-from pyflink.table.table_sink import CsvTableSink
-from pyflink.table.table_source import CsvTableSource
+from pyflink.table import TableEnvironment, TableConfig, FileSystem, OldCsv, Schema
 from pyflink.table.types import DataTypes
 
 
-# TODO: the word_count.py is just a test example for CLI.
-#  After pyflink have aligned Java Table API Connectors, this example will be improved.
 def word_count():
-    tmp_dir = tempfile.gettempdir()
-    source_path = tmp_dir + '/streaming.csv'
-    if os.path.isfile(source_path):
-        os.remove(source_path)
     content = "line Licensed to the Apache Software Foundation ASF under one " \
               "line or more contributor license agreements See the NOTICE file " \
               "line distributed with this work for additional information " \
@@ -39,41 +34,40 @@ def word_count():
               "License you may not use this file except in compliance " \
               "with the License"
 
-    with open(source_path, 'w') as f:
-        for word in content.split(" "):
-            f.write(",".join([word, "1"]))
-            f.write("\n")
-            f.flush()
-        f.close()
-
     t_config = TableConfig.Builder().as_batch_execution().build()
     t_env = TableEnvironment.create(t_config)
 
-    field_names = ["word", "cout"]
-    field_types = [DataTypes.STRING(), DataTypes.BIGINT()]
-
-    # register Orders table in table environment
-    t_env.register_table_source(
-        "Word",
-        CsvTableSource(source_path, field_names, field_types))
-
     # register Results table in table environment
     tmp_dir = tempfile.gettempdir()
-    tmp_csv = tmp_dir + '/streaming2.csv'
-    if os.path.isfile(tmp_csv):
-        os.remove(tmp_csv)
+    result_dir = tmp_dir + '/result'
+    if os.path.exists(result_dir):
+        try:
+            shutil.rmtree(result_dir)
+        except OSError as e:
+            logging.error("Error removing directory: %s - %s.", e.filename, e.strerror)
 
-    t_env.register_table_sink(
-        "Results",
-        field_names, field_types, CsvTableSink(tmp_csv))
+    logging.info("Results directory: %s", result_dir)
 
-    t_env.scan("Word") \
-        .group_by("word") \
-        .select("word, count(1) as count") \
-        .insert_into("Results")
+    t_env.connect(FileSystem().path(result_dir)) \
+        .with_format(OldCsv()
+                     .field_delimiter(',')
+                     .field("word", DataTypes.STRING())
+                     .field("count", DataTypes.BIGINT())) \
+        .with_schema(Schema()
+                     .field("word", DataTypes.STRING())
+                     .field("count", DataTypes.BIGINT())) \
+        .register_table_sink("Results")
+
+    elements = [(word, 1) for word in content.split(" ")]
+    t_env.from_elements(elements, ["word", "count"]) \
+         .group_by("word") \
+         .select("word, count(1) as count") \
+         .insert_into("Results")
 
     t_env.execute()
 
 
 if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
+
     word_count()

--- a/flink-python/pyflink/table/examples/batch/word_count.py
+++ b/flink-python/pyflink/table/examples/batch/word_count.py
@@ -39,16 +39,19 @@ def word_count():
 
     # register Results table in table environment
     tmp_dir = tempfile.gettempdir()
-    result_dir = tmp_dir + '/result'
-    if os.path.exists(result_dir):
+    result_path = tmp_dir + '/result'
+    if os.path.exists(result_path):
         try:
-            shutil.rmtree(result_dir)
+            if os.path.isfile(result_path):
+                os.remove(result_path)
+            else:
+                shutil.rmtree(result_path)
         except OSError as e:
             logging.error("Error removing directory: %s - %s.", e.filename, e.strerror)
 
-    logging.info("Results directory: %s", result_dir)
+    logging.info("Results directory: %s", result_path)
 
-    t_env.connect(FileSystem().path(result_dir)) \
+    t_env.connect(FileSystem().path(result_path)) \
         .with_format(OldCsv()
                      .field_delimiter(',')
                      .field("word", DataTypes.STRING())


### PR DESCRIPTION
## What is the purpose of the change

*This pull request improves the Python word_count example to use the latest descriptor API*


## Brief change log

  - *Improves the word_count example to use the from_element API to create a table source*
  - *Improves the word_count example to use the descriptor API to register the table sink*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
