### PR TITLE
[FLINK-12738][network] Remove abstract getPageSize method from InputGate

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
@@ -63,11 +63,4 @@ public interface BufferProvider {
 	 * Returns whether the buffer provider has been destroyed.
 	 */
 	boolean isDestroyed();
-
-	/**
-	 * Returns the size of the underlying memory segments. This is the maximum size a {@link Buffer}
-	 * instance can have.
-	 */
-	int getMemorySegmentSize();
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -165,11 +165,6 @@ class LocalBufferPool implements BufferPool {
 	}
 
 	@Override
-	public int getMemorySegmentSize() {
-		return networkBufferPool.getMemorySegmentSize();
-	}
-
-	@Override
 	public int getNumberOfRequiredMemorySegments() {
 		return numberOfRequiredMemorySegments;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -230,10 +230,6 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 		return isDestroyed;
 	}
 
-	public int getMemorySegmentSize() {
-		return memorySegmentSize;
-	}
-
 	public int getTotalNumberOfMemorySegments() {
 		return totalNumberOfMemorySegments;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -95,8 +95,6 @@ public abstract class InputGate implements AsyncDataInput<BufferOrEvent>, AutoCl
 
 	public abstract void sendTaskEvent(TaskEvent event) throws IOException;
 
-	public abstract int getPageSize();
-
 	/**
 	 * @return a future that is completed if there are more records available. If there are more
 	 * records available immediately, {@link #AVAILABLE} should be returned. Previously returned

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -243,16 +243,6 @@ public class SingleInputGate extends InputGate {
 		return bufferPool;
 	}
 
-	@Override
-	public int getPageSize() {
-		if (bufferPool != null) {
-			return bufferPool.getMemorySegmentSize();
-		}
-		else {
-			throw new IllegalStateException("Input gate has not been initialized with buffers.");
-		}
-	}
-
 	public int getNumberOfQueuedBuffers() {
 		// re-try 3 times, if fails, return 0 for "unknown"
 		for (int retry = 0; retry < 3; retry++) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -265,19 +265,6 @@ public class UnionInputGate extends InputGate {
 	}
 
 	@Override
-	public int getPageSize() {
-		int pageSize = -1;
-		for (InputGate gate : inputGates) {
-			if (pageSize == -1) {
-				pageSize = gate.getPageSize();
-			} else if (gate.getPageSize() != pageSize) {
-				throw new IllegalStateException("Found input gates with different page sizes.");
-			}
-		}
-		return pageSize;
-	}
-
-	@Override
 	public void setup() {
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -86,11 +86,6 @@ public class InputGateWithMetrics extends InputGate {
 	}
 
 	@Override
-	public int getPageSize() {
-		return inputGate.getPageSize();
-	}
-
-	@Override
 	public void close() throws Exception {
 		inputGate.close();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -61,7 +61,6 @@ public class NetworkBufferPoolTest extends TestLogger {
 			final int numBuffers = 10;
 
 			NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, bufferSize, 1);
-			assertEquals(bufferSize, globalPool.getMemorySegmentSize());
 			assertEquals(numBuffers, globalPool.getTotalNumberOfMemorySegments());
 			assertEquals(numBuffers, globalPool.getNumberOfAvailableMemorySegments());
 			assertEquals(0, globalPool.getNumberOfRegisteredBufferPools());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestBufferFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestBufferFactory.java
@@ -64,10 +64,6 @@ public class TestBufferFactory {
 		return numberOfCreatedBuffers;
 	}
 
-	public synchronized int getBufferSize() {
-		return bufferSize;
-	}
-
 	// ------------------------------------------------------------------------
 	// Static test helpers
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
@@ -96,11 +96,6 @@ public class TestPooledBufferProvider implements BufferProvider {
 		return false;
 	}
 
-	@Override
-	public int getMemorySegmentSize() {
-		return bufferFactory.getBufferSize();
-	}
-
 	public int getNumberOfAvailableBuffers() {
 		return buffers.size();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
 import java.io.IOException;
@@ -46,8 +47,10 @@ public class InputProcessorUtil {
 			Configuration taskManagerConfig,
 			String taskName) throws IOException {
 
+		int pageSize = ConfigurationParserUtils.getPageSize(taskManagerConfig);
+
 		BufferStorage bufferStorage = createBufferStorage(
-			checkpointMode, ioManager, inputGate.getPageSize(), taskManagerConfig, taskName);
+			checkpointMode, ioManager, pageSize, taskManagerConfig, taskName);
 		CheckpointBarrierHandler barrierHandler = createCheckpointBarrierHandler(
 			checkpointMode, inputGate.getNumberOfInputChannels(), taskName, toNotifyOnCheckpoint);
 		return new CheckpointedInputGate(inputGate, bufferStorage, barrierHandler);
@@ -66,10 +69,12 @@ public class InputProcessorUtil {
 			Configuration taskManagerConfig,
 			String taskName) throws IOException {
 
+		int pageSize = ConfigurationParserUtils.getPageSize(taskManagerConfig);
+
 		BufferStorage mainBufferStorage1 = createBufferStorage(
-			checkpointMode, ioManager, inputGate1.getPageSize(), taskManagerConfig, taskName);
+			checkpointMode, ioManager, pageSize, taskManagerConfig, taskName);
 		BufferStorage mainBufferStorage2 = createBufferStorage(
-			checkpointMode, ioManager, inputGate2.getPageSize(), taskManagerConfig, taskName);
+			checkpointMode, ioManager, pageSize, taskManagerConfig, taskName);
 		checkState(mainBufferStorage1.getMaxBufferedBytes() == mainBufferStorage2.getMaxBufferedBytes());
 
 		BufferStorage linkedBufferStorage1 = new LinkedBufferStorage(

--- a/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
@@ -21,16 +21,12 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.SpanningRecordSerializer;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
-import org.apache.flink.runtime.io.network.buffer.BufferListener;
-import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
 import org.apache.flink.runtime.io.network.partition.consumer.TestInputChannel.BufferAndAvailabilityProvider;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -79,7 +75,6 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 		inputQueues = new ConcurrentLinkedQueue[numInputChannels];
 
 		setupInputChannels();
-		inputGate.setBufferPool(new NoOpBufferPool(bufferSize));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -224,83 +219,6 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 
 		public boolean isEvent() {
 			return isEvent;
-		}
-	}
-
-	private static class NoOpBufferPool implements BufferPool {
-		private int bufferSize;
-
-		public NoOpBufferPool(int bufferSize) {
-			this.bufferSize = bufferSize;
-		}
-
-		@Override
-		public void lazyDestroy() {
-		}
-
-		@Override
-		public int getMemorySegmentSize() {
-			return bufferSize;
-		}
-
-		@Override
-		public Buffer requestBuffer() throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Buffer requestBufferBlocking() throws IOException, InterruptedException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public BufferBuilder requestBufferBuilderBlocking() throws IOException, InterruptedException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean addBufferListener(BufferListener listener) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean isDestroyed() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int getNumberOfRequiredMemorySegments() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int getMaxNumberOfMemorySegments() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int getNumBuffers() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void setNumBuffers(int numBuffers) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int getNumberOfAvailableMemorySegments() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int bestEffortGetNumOfUsedBuffers() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void recycle(MemorySegment memorySegment) {
-			throw new UnsupportedOperationException();
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerAlignmentLimitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerAlignmentLimitTest.java
@@ -115,11 +115,11 @@ public class CheckpointBarrierAlignerAlignmentLimitTest {
 		};
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		CheckpointedInputGate buffer = new CheckpointedInputGate(
 			gate,
-			new BufferSpiller(ioManager, gate.getPageSize(), 1000),
+			new BufferSpiller(ioManager, PAGE_SIZE, 1000),
 			"Testing",
 			toNotify);
 
@@ -212,11 +212,11 @@ public class CheckpointBarrierAlignerAlignmentLimitTest {
 		};
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		CheckpointedInputGate buffer = new CheckpointedInputGate(
 			gate,
-			new BufferSpiller(ioManager, gate.getPageSize(), 500),
+			new BufferSpiller(ioManager, PAGE_SIZE, 500),
 			"Testing",
 			toNotify);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
@@ -60,7 +60,7 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 					new BufferPool[] { pool1, pool2 },
 					new BarrierGenerator[] { new CountBarrier(100000), new RandomBarrier(100000) });
 
-			CheckpointedInputGate checkpointedInputGate = new CheckpointedInputGate(myIG, new BufferSpiller(ioMan, myIG.getPageSize()), "Testing: No task associated", null);
+			CheckpointedInputGate checkpointedInputGate = new CheckpointedInputGate(myIG, new BufferSpiller(ioMan, PAGE_SIZE), "Testing: No task associated", null);
 
 			for (int i = 0; i < 2000000; i++) {
 				BufferOrEvent boe = checkpointedInputGate.pollNext().get();
@@ -180,11 +180,6 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 
 		@Override
 		public void sendTaskEvent(TaskEvent event) {}
-
-		@Override
-		public int getPageSize() {
-			return PAGE_SIZE;
-		}
 
 		@Override
 		public void setup() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
@@ -76,7 +76,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 		int numberOfChannels,
 		BufferOrEvent[] sequence,
 		@Nullable AbstractInvokable toNotify) throws IOException {
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, numberOfChannels, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(numberOfChannels, Arrays.asList(sequence));
 		return createBarrierBuffer(gate, toNotify);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTrackerTest.java
@@ -373,7 +373,7 @@ public class CheckpointBarrierTrackerTest {
 			int numberOfChannels,
 			BufferOrEvent[] sequence,
 			@Nullable AbstractInvokable toNotifyOnCheckpoint) {
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, numberOfChannels, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(numberOfChannels, Arrays.asList(sequence));
 		return new CheckpointedInputGate(
 			gate,
 			new CachedBufferStorage(PAGE_SIZE, -1, "Testing"),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -33,8 +33,6 @@ import java.util.Queue;
  */
 public class MockInputGate extends InputGate {
 
-	private final int pageSize;
-
 	private final int numberOfChannels;
 
 	private final Queue<BufferOrEvent> bufferOrEvents;
@@ -43,18 +41,12 @@ public class MockInputGate extends InputGate {
 
 	private int closedChannels;
 
-	public MockInputGate(int pageSize, int numberOfChannels, List<BufferOrEvent> bufferOrEvents) {
-		this.pageSize = pageSize;
+	MockInputGate(int numberOfChannels, List<BufferOrEvent> bufferOrEvents) {
 		this.numberOfChannels = numberOfChannels;
 		this.bufferOrEvents = new ArrayDeque<BufferOrEvent>(bufferOrEvents);
 		this.closed = new boolean[numberOfChannels];
 
 		isAvailable = AVAILABLE;
-	}
-
-	@Override
-	public int getPageSize() {
-		return pageSize;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

*Currently `InputGate#getPageSize` is only used for constructing `BarrierBuffer`. In order to make abstract `InputGate` simple and clean, we should remove unnecessary abstract methods from it.
Considering the page size could be parsed directly from configuration which could also visible while constructing `BarrierBuffer`, so it is reasonable to do so.*

## Brief change log

  - *Remove `getPageSize` method from `InputGate`*
  -  *Remove `getMemorySegmentSize` method from `BufferProvider` interface*
  - *Remove unnecessary `getMemorySegmentSize` method from `NetworkBufferPool`*

## Verifying this change

*Covered by existing tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)