### PR TITLE
[FLINK-12489][Deployment/Mesos] Parametrisation of the network resource

### DIFF
--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -15,6 +15,12 @@
             <td>Constraints for task placement on Mesos based on agent attributes. Takes a comma-separated list of key:value pairs corresponding to the attributes exposed by the target mesos agents. Example: az:eu-west-1a,series:t2</td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.network.resource.name</h5></td>
+            <td style="word-wrap: break-word;">"network"</td>
+            <td>String</td>
+            <td>Network resource name on Mesos cluster.</td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.tasks.bootstrap-cmd</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
@@ -73,6 +79,12 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>Optional value to define the TaskManager’s hostname. The pattern _TASK_ is replaced by the actual id of the Mesos task. This can be used to configure the TaskManager to use Mesos DNS (e.g. _TASK_.flink-service.mesos) for name lookups.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.network.bandwidth</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>Network bandwidth to assign to the Mesos workers in MB per sec.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.taskmanager-cmd</h5></td>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -142,7 +142,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		@Override
 		public double getNetworkMbps() {
-			return 0.0;
+			return params.network();
 		}
 
 		@Override
@@ -227,6 +227,10 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		if (taskRequest.getDisk() > 0.0) {
 			taskInfo.addAllResources(allocation.takeScalar("disk", taskRequest.getDisk(), roles));
+		}
+
+		if (taskRequest.getNetworkMbps() > 0.0) {
+			taskInfo.addAllResources(allocation.takeScalar("network", taskRequest.getNetworkMbps(), roles));
 		}
 
 		final Protos.CommandInfo.Builder cmd = taskInfo.getCommandBuilder();

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -57,6 +57,11 @@ public class MesosTaskManagerParameters {
 		.defaultValue(0)
 		.withDescription(Description.builder().text("Disk space to assign to the Mesos workers in MB.").build());
 
+	public static final ConfigOption<Integer> MESOS_RM_TASKS_NETWORK_MB_PER_SEC =
+		key("mesos.resourcemanager.tasks.networkBandwidth")
+			.defaultValue(0)
+			.withDescription(Description.builder().text("Network bandwidth to assign to the Mesos workers in MB per sec").build());
+
 	public static final ConfigOption<Double> MESOS_RM_TASKS_CPUS =
 		key("mesos.resourcemanager.tasks.cpus")
 		.doubleType()
@@ -144,6 +149,8 @@ public class MesosTaskManagerParameters {
 
 	private final int disk;
 
+	private final int network;
+
 	private final ContainerType containerType;
 
 	private final Option<String> containerImageName;
@@ -169,6 +176,7 @@ public class MesosTaskManagerParameters {
 	public MesosTaskManagerParameters(
 			int gpus,
 			int disk,
+			int network,
 			ContainerType containerType,
 			Option<String> containerImageName,
 			ContaineredTaskManagerParameters containeredParameters,
@@ -183,6 +191,7 @@ public class MesosTaskManagerParameters {
 
 		this.gpus = gpus;
 		this.disk = disk;
+		this.network = network;
 		this.containerType = Preconditions.checkNotNull(containerType);
 		this.containerImageName = Preconditions.checkNotNull(containerImageName);
 		this.containeredParameters = Preconditions.checkNotNull(containeredParameters);
@@ -215,6 +224,13 @@ public class MesosTaskManagerParameters {
 	 */
 	public int disk() {
 		return disk;
+	}
+
+	/**
+	 * Get the network bandwidth in MB to use for the TaskManager Process.
+	 */
+	public int network() {
+		return network;
 	}
 
 	/**
@@ -336,6 +352,8 @@ public class MesosTaskManagerParameters {
 
 		int disk = flinkConfig.getInteger(MESOS_RM_TASKS_DISK_MB);
 
+		int network = flinkConfig.getInteger(MESOS_RM_TASKS_NETWORK_MB_PER_SEC);
+
 		// parse the containerization parameters
 		String imageName = flinkConfig.getString(MESOS_RM_CONTAINER_IMAGE_NAME);
 
@@ -380,6 +398,7 @@ public class MesosTaskManagerParameters {
 		return new MesosTaskManagerParameters(
 			gpus,
 			disk,
+			network,
 			containerType,
 			Option.apply(imageName),
 			containeredParameters,

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -58,9 +58,14 @@ public class MesosTaskManagerParameters {
 		.withDescription(Description.builder().text("Disk space to assign to the Mesos workers in MB.").build());
 
 	public static final ConfigOption<Integer> MESOS_RM_TASKS_NETWORK_MB_PER_SEC =
-		key("mesos.resourcemanager.tasks.networkBandwidth")
+		key("mesos.resourcemanager.tasks.network.bandwidth")
 			.defaultValue(0)
-			.withDescription(Description.builder().text("Network bandwidth to assign to the Mesos workers in MB per sec").build());
+			.withDescription(Description.builder().text("Network bandwidth to assign to the Mesos workers in MB per sec.").build());
+
+	public static final ConfigOption<String> MESOS_RM_NETWORK_RESOURCE_NAME =
+		key("mesos.resourcemanager.network.resource.name")
+			.defaultValue("network")
+			.withDescription(Description.builder().text("Network resource name on Mesos cluster.").build());
 
 	public static final ConfigOption<Double> MESOS_RM_TASKS_CPUS =
 		key("mesos.resourcemanager.tasks.cpus")

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/Offer.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/Offer.java
@@ -62,6 +62,10 @@ public class Offer implements VirtualMachineLease {
 	private final List<Range> portRanges;
 
 	public Offer(Protos.Offer offer) {
+		this(offer, "network");
+	}
+
+	public Offer(Protos.Offer offer, String networkResourceName) {
 		this.offer = checkNotNull(offer);
 		this.hostname = offer.getHostname();
 		this.vmID = offer.getSlaveId().getValue();
@@ -98,7 +102,7 @@ public class Offer implements VirtualMachineLease {
 
 		this.cpuCores = aggregatedScalarResourceMap.remove("cpus");
 		this.memoryMB = aggregatedScalarResourceMap.remove("mem");
-		this.networkMbps = aggregatedScalarResourceMap.remove("network");
+		this.networkMbps = aggregatedScalarResourceMap.remove(networkResourceName);
 		this.diskMB = aggregatedScalarResourceMap.remove("disk");
 		this.aggregatedScalarResourceMap = Collections.unmodifiableMap(aggregatedScalarResourceMap);
 		this.portRanges = Collections.unmodifiableList(aggregateRangesResource(rangesResourceMap, "ports"));

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -113,13 +113,14 @@ public class MesosUtils {
 		log.info("TaskManagers will be created with {} task slots",
 			configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS));
 		log.info("TaskManagers will be started with container size {} MB, JVM heap size {} MB, " +
-				"JVM direct memory limit {} MB, {} cpus, {} gpus, disk space {} MB",
+				"JVM direct memory limit {} MB, {} cpus, {} gpus, disk space {} MB, network bandwidth {} MB / sec",
 			taskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes(),
 			taskExecutorProcessSpec.getJvmHeapMemorySize().getMebiBytes(),
 			taskExecutorProcessSpec.getJvmDirectMemorySize().getMebiBytes(),
 			taskManagerParameters.cpus(),
 			taskManagerParameters.gpus(),
-			taskManagerParameters.disk());
+			taskManagerParameters.disk(),
+			taskManagerParameters.network());
 
 		return taskManagerParameters;
 	}

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -284,7 +284,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(spec, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
-				1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
+				1, 0, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
 				Option.<String>empty(), Collections.<String>emptyList());


### PR DESCRIPTION
## What is the purpose of the change

Flink will be able to support network bandwidth customization. Since network resource is not standardized in Mesos we should specify the network resource name in config. By default we use name: 'network' which is used in Fenzo.

Network configuration is optional.

## Brief change log

  - *Added configuration for the network bandwidth usage*
  - *Added configuration for the network resource name on Mesos*


## Verifying this change

It is a configuration logic. The potential test would have at least the same complexity as implementation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / *no*)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / *no* / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (*yes* / no / don't know)
  - The S3 file system connector: (yes / *no* / don't know)

## Documentation

  - Does this pull request introduce a new feature? (*yes* / no)
  - If yes, how is the feature documented? (not applicable / *docs* / JavaDocs / not documented)
