### PR TITLE
[FLINK-12647][network] Add feature flag to disable release of consumed blocking partitions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.ConfigGroup;
 import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.annotation.docs.Documentation;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -208,6 +209,11 @@ public class NettyShuffleEnvironmentOptions {
 			.defaultValue(10000)
 			.withDeprecatedKeys("taskmanager.net.request-backoff.max")
 			.withDescription("Maximum backoff in milliseconds for partition requests of input channels.");
+
+	@Documentation.ExcludeFromDocumentation("dev use only; likely temporary")
+	public static final ConfigOption<Boolean> FORCE_PARTITION_RELEASE_ON_CONSUMPTION =
+			key("taskmanager.network.partition.force-release-on-consumption")
+			.defaultValue(true);
 
 	// ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
@@ -48,6 +48,9 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 	/** Flag whether the result partition should send scheduleOrUpdateConsumer messages. */
 	private final boolean sendScheduleOrUpdateConsumersMessage;
 
+	/** Whether the result partition is released on consumption. */
+	private final boolean releasedOnConsumption;
+
 	public ResultPartitionDeploymentDescriptor(
 			PartitionDescriptor partitionDescriptor,
 			ShuffleDescriptor shuffleDescriptor,
@@ -58,6 +61,7 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 		KeyGroupRangeAssignment.checkParallelismPreconditions(maxParallelism);
 		this.maxParallelism = maxParallelism;
 		this.sendScheduleOrUpdateConsumersMessage = sendScheduleOrUpdateConsumersMessage;
+		this.releasedOnConsumption = partitionDescriptor.getPartitionType() != ResultPartitionType.BLOCKING;
 	}
 
 	public IntermediateDataSetID getResultId() {
@@ -86,6 +90,10 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 
 	public boolean sendScheduleOrUpdateConsumersMessage() {
 		return sendScheduleOrUpdateConsumersMessage;
+	}
+
+	public boolean isReleasedOnConsumption() {
+		return releasedOnConsumption;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -155,7 +155,8 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 			ioManager,
 			networkBufferPool,
 			config.networkBuffersPerChannel(),
-			config.floatingNetworkBuffersPerGate());
+			config.floatingNetworkBuffersPerGate(),
+			config.isForcePartitionReleaseOnConsumption());
 
 		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
 			taskExecutorLocation,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartition.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferPoolOwner;
+import org.apache.flink.util.function.FunctionWithException;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * ResultPartition that releases itself once all subpartitions have been consumed.
+ */
+public class ReleaseOnConsumptionResultPartition extends ResultPartition {
+
+	/**
+	 * The total number of references to subpartitions of this result. The result partition can be
+	 * safely released, iff the reference count is zero. A reference count of -1 denotes that the
+	 * result partition has been released.
+	 */
+	private final AtomicInteger pendingReferences = new AtomicInteger();
+
+	ReleaseOnConsumptionResultPartition(
+			String owningTaskName,
+			ResultPartitionID partitionId,
+			ResultPartitionType partitionType,
+			ResultSubpartition[] subpartitions,
+			int numTargetKeyGroups,
+			ResultPartitionManager partitionManager,
+			FunctionWithException<BufferPoolOwner, BufferPool, IOException> bufferPoolFactory) {
+		super(owningTaskName, partitionId, partitionType, subpartitions, numTargetKeyGroups, partitionManager, bufferPoolFactory);
+	}
+
+	/**
+	 * The partition can only be released after each subpartition has been consumed once per pin operation.
+	 */
+	@Override
+	void pin() {
+		while (true) {
+			int refCnt = pendingReferences.get();
+
+			if (refCnt >= 0) {
+				if (pendingReferences.compareAndSet(refCnt, refCnt + subpartitions.length)) {
+					break;
+				}
+			}
+			else {
+				throw new IllegalStateException("Released.");
+			}
+		}
+	}
+
+	@Override
+	public ResultSubpartitionView createSubpartitionView(int index, BufferAvailabilityListener availabilityListener) throws IOException {
+		int refCnt = pendingReferences.get();
+
+		checkState(refCnt != -1, "Partition released.");
+		checkState(refCnt > 0, "Partition not pinned.");
+
+		return super.createSubpartitionView(index, availabilityListener);
+	}
+
+	@Override
+	void onConsumedSubpartition(int subpartitionIndex) {
+		if (isReleased()) {
+			return;
+		}
+
+		int refCnt = pendingReferences.decrementAndGet();
+
+		if (refCnt == 0) {
+			partitionManager.onConsumedPartition(this);
+		} else if (refCnt < 0) {
+			throw new IllegalStateException("All references released.");
+		}
+
+		LOG.debug("{}: Received release notification for subpartition {}.",
+			this, subpartitionIndex);
+	}
+
+	@Override
+	public String toString() {
+		return "ReleaseOnConsumptionResultPartition " + partitionId.toString() + " [" + partitionType + ", "
+			+ subpartitions.length + " subpartitions, "
+			+ pendingReferences + " pending references]";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -38,7 +38,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkElementIndex;
@@ -71,32 +70,25 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 
-	private static final Logger LOG = LoggerFactory.getLogger(ResultPartition.class);
+	protected static final Logger LOG = LoggerFactory.getLogger(ResultPartition.class);
 
 	private final String owningTaskName;
 
-	private final ResultPartitionID partitionId;
+	protected final ResultPartitionID partitionId;
 
 	/** Type of this partition. Defines the concrete subpartition implementation to use. */
-	private final ResultPartitionType partitionType;
+	protected final ResultPartitionType partitionType;
 
 	/** The subpartitions of this partition. At least one. */
-	private final ResultSubpartition[] subpartitions;
+	protected final ResultSubpartition[] subpartitions;
 
-	private final ResultPartitionManager partitionManager;
+	protected final ResultPartitionManager partitionManager;
 
 	public final int numTargetKeyGroups;
 
 	// - Runtime state --------------------------------------------------------
 
 	private final AtomicBoolean isReleased = new AtomicBoolean();
-
-	/**
-	 * The total number of references to subpartitions of this result. The result partition can be
-	 * safely released, iff the reference count is zero. A reference count of -1 denotes that the
-	 * result partition has been released.
-	 */
-	private final AtomicInteger pendingReferences = new AtomicInteger();
 
 	private BufferPool bufferPool;
 
@@ -281,11 +273,6 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	 * Returns the requested subpartition.
 	 */
 	public ResultSubpartitionView createSubpartitionView(int index, BufferAvailabilityListener availabilityListener) throws IOException {
-		int refCnt = pendingReferences.get();
-
-		checkState(refCnt != -1, "Partition released.");
-		checkState(refCnt > 0, "Partition not pinned.");
-
 		checkElementIndex(index, subpartitions.length, "Subpartition not found.");
 
 		ResultSubpartitionView readView = subpartitions[index].createReadView(availabilityListener);
@@ -337,31 +324,15 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	@Override
 	public String toString() {
 		return "ResultPartition " + partitionId.toString() + " [" + partitionType + ", "
-				+ subpartitions.length + " subpartitions, "
-				+ pendingReferences + " pending references]";
+				+ subpartitions.length + " subpartitions]";
 	}
 
 	// ------------------------------------------------------------------------
 
 	/**
 	 * Pins the result partition.
-	 *
-	 * <p>The partition can only be released after each subpartition has been consumed once per pin
-	 * operation.
 	 */
 	void pin() {
-		while (true) {
-			int refCnt = pendingReferences.get();
-
-			if (refCnt >= 0) {
-				if (pendingReferences.compareAndSet(refCnt, refCnt + subpartitions.length)) {
-					break;
-				}
-			}
-			else {
-				throw new IllegalStateException("Released.");
-			}
-		}
 	}
 
 	/**
@@ -373,17 +344,8 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 			return;
 		}
 
-		int refCnt = pendingReferences.decrementAndGet();
-
-		if (refCnt == 0) {
-			partitionManager.onConsumedPartition(this);
-		}
-		else if (refCnt < 0) {
-			throw new IllegalStateException("All references released.");
-		}
-
-		LOG.debug("{}: Received release notification for subpartition {} (reference count now at: {}).",
-				this, subpartitionIndex, pendingReferences);
+		LOG.debug("{}: Received release notification for subpartition {}.",
+				this, subpartitionIndex);
 	}
 
 	public ResultSubpartition[] getAllPartitions() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -60,6 +60,8 @@ public class NettyShuffleEnvironmentConfiguration {
 
 	private final boolean isNetworkDetailedMetrics;
 
+	private final boolean forcePartitionReleaseOnConsumption;
+
 	private final NettyConfig nettyConfig;
 
 	public NettyShuffleEnvironmentConfiguration(
@@ -71,6 +73,7 @@ public class NettyShuffleEnvironmentConfiguration {
 			int floatingNetworkBuffersPerGate,
 			boolean isCreditBased,
 			boolean isNetworkDetailedMetrics,
+			boolean forcePartitionReleaseOnConsumption,
 			@Nullable NettyConfig nettyConfig) {
 
 		this.numNetworkBuffers = numNetworkBuffers;
@@ -81,6 +84,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
 		this.isCreditBased = isCreditBased;
 		this.isNetworkDetailedMetrics = isNetworkDetailedMetrics;
+		this.forcePartitionReleaseOnConsumption = forcePartitionReleaseOnConsumption;
 		this.nettyConfig = nettyConfig;
 	}
 
@@ -122,6 +126,10 @@ public class NettyShuffleEnvironmentConfiguration {
 		return isNetworkDetailedMetrics;
 	}
 
+	public boolean isForcePartitionReleaseOnConsumption() {
+		return forcePartitionReleaseOnConsumption;
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -158,6 +166,9 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		boolean isNetworkDetailedMetrics = configuration.getBoolean(NettyShuffleEnvironmentOptions.NETWORK_DETAILED_METRICS);
 
+		boolean forcePartitionReleaseOnConsumption = configuration.getBoolean(
+			NettyShuffleEnvironmentOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION);
+
 		return new NettyShuffleEnvironmentConfiguration(
 			numberOfNetworkBuffers,
 			pageSize,
@@ -167,6 +178,7 @@ public class NettyShuffleEnvironmentConfiguration {
 			extraBuffersPerGate,
 			isCreditBased,
 			isNetworkDetailedMetrics,
+			forcePartitionReleaseOnConsumption,
 			nettyConfig);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -104,6 +104,24 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 		assertThat(shuffleDescriptorCopy.getConnectionId(), is(connectionID));
 	}
 
+	@Test
+	public void testReleasedOnConsumptionFlag() {
+		for (ResultPartitionType partitionType : ResultPartitionType.values()) {
+			ResultPartitionDeploymentDescriptor partitionDescriptor = new ResultPartitionDeploymentDescriptor(
+				new PartitionDescriptor(resultId, partitionId, partitionType, numberOfSubpartitions, connectionIndex),
+				ResultPartitionID::new,
+				1,
+				true
+			);
+
+			if (partitionType == ResultPartitionType.BLOCKING) {
+				assertThat(partitionDescriptor.isReleasedOnConsumption(), is(false));
+			} else {
+				assertThat(partitionDescriptor.isReleasedOnConsumption(), is(true));
+			}
+		}
+	}
+
 	private static ResultPartitionDeploymentDescriptor createCopyAndVerifyResultPartitionDeploymentDescriptor(
 			ShuffleDescriptor shuffleDescriptor) throws IOException {
 		ResultPartitionDeploymentDescriptor orig = new ResultPartitionDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -128,6 +128,7 @@ public class NettyShuffleEnvironmentBuilder {
 				floatingNetworkBuffersPerGate,
 				isCreditBased,
 				isNetworkDetailedMetrics,
+				true,
 				nettyConfig),
 			taskManagerLocation,
 			taskEventDispatcher,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -55,6 +55,8 @@ public class ResultPartitionBuilder {
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	private Optional<FunctionWithException<BufferPoolOwner, BufferPool, IOException>> bufferPoolFactory = Optional.empty();
 
+	private boolean releasedOnConsumption;
+
 	public ResultPartitionBuilder setResultPartitionId(ResultPartitionID partitionId) {
 		this.partitionId = partitionId;
 		return this;
@@ -112,13 +114,19 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
+	public ResultPartitionBuilder isReleasedOnConsumption(boolean releasedOnConsumption) {
+		this.releasedOnConsumption = releasedOnConsumption;
+		return this;
+	}
+
 	public ResultPartition build() {
 		ResultPartitionFactory resultPartitionFactory = new ResultPartitionFactory(
 			partitionManager,
 			ioManager,
 			networkBufferPool,
 			networkBuffersPerChannel,
-			floatingNetworkBuffersPerGate);
+			floatingNetworkBuffersPerGate,
+			true);
 
 		FunctionWithException<BufferPoolOwner, BufferPool, IOException> factory = bufferPoolFactory.orElseGet(() ->
 			resultPartitionFactory.createBufferPoolFactory(numberOfSubpartitions, partitionType));
@@ -129,6 +137,7 @@ public class ResultPartitionBuilder {
 			partitionType,
 			numberOfSubpartitions,
 			numTargetKeyGroups,
+			releasedOnConsumption,
 			factory);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.disk.iomanager.NoOpIOManager;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for the {@link ResultPartitionFactory}.
+ */
+public class ResultPartitionFactoryTest extends TestLogger {
+
+	@Test
+	public void testForceConsumptionOnReleaseEnabled() {
+		testForceConsumptionOnRelease(true);
+	}
+
+	@Test
+	public void testForceConsumptionOnReleaseDisabled() {
+		testForceConsumptionOnRelease(false);
+	}
+
+	private static void testForceConsumptionOnRelease(boolean forceConsumptionOnRelease) {
+		ResultPartitionFactory factory = new ResultPartitionFactory(
+			new ResultPartitionManager(),
+			new NoOpIOManager(),
+			new NetworkBufferPool(1, 64, 1),
+			1,
+			1,
+			forceConsumptionOnRelease
+		);
+
+		final ResultPartitionDeploymentDescriptor descriptor = new ResultPartitionDeploymentDescriptor(
+			new PartitionDescriptor(
+				new IntermediateDataSetID(),
+				new IntermediateResultPartitionID(),
+				ResultPartitionType.BLOCKING,
+				1,
+				0),
+			ResultPartitionID::new,
+			1,
+			true
+		);
+
+		final ResultPartition test = factory.create("test", new ExecutionAttemptID(), descriptor);
+
+		if (forceConsumptionOnRelease) {
+			assertThat(test, instanceOf(ReleaseOnConsumptionResultPartition.class));
+		} else {
+			assertThat(test, not(instanceOf(ReleaseOnConsumptionResultPartition.class)));
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -118,7 +118,7 @@ public class ResultPartitionTest {
 
 		assertThat(manager.getUnreleasedPartitions(), contains(partition.getPartitionId()));
 
-		// an externally managed blocking partition should be consumable multiple times
+		// a blocking partition that is not released on consumption should be consumable multiple times
 		for (int x = 0; x < 2; x++) {
 			ResultSubpartitionView subpartitionView1 = partition.createSubpartitionView(0, () -> {});
 			subpartitionView1.notifySubpartitionConsumed();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -37,10 +37,13 @@ import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferConsumer;
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -98,6 +101,32 @@ public class ResultPartitionTest {
 	@Test
 	public void testAddOnFinishedBlockingPartition() throws Exception {
 		testAddOnFinishedPartition(ResultPartitionType.BLOCKING);
+	}
+
+	@Test
+	public void testBlockingPartitionIsConsumableMultipleTimesIfNotReleasedOnConsumption() throws IOException {
+		ResultPartitionManager manager = new ResultPartitionManager();
+
+		final ResultPartition partition = new ResultPartitionBuilder()
+			.isReleasedOnConsumption(false)
+			.setResultPartitionManager(manager)
+			.setResultPartitionType(ResultPartitionType.BLOCKING)
+			.build();
+
+		manager.registerResultPartition(partition);
+		partition.finish();
+
+		assertThat(manager.getUnreleasedPartitions(), contains(partition.getPartitionId()));
+
+		// an externally managed blocking partition should be consumable multiple times
+		for (int x = 0; x < 2; x++) {
+			ResultSubpartitionView subpartitionView1 = partition.createSubpartitionView(0, () -> {});
+			subpartitionView1.notifySubpartitionConsumed();
+
+			// partition should not be released on consumption
+			assertThat(manager.getUnreleasedPartitions(), contains(partition.getPartitionId()));
+			assertFalse(partition.isReleased());
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Based on #8608; only the last 2 commits are relevant.

The first commit introduces the concept of externally managed partitions, i.e. partitions that are not automatically released by the ShuffleEnvironment on consumption, but instead when instructed to do so by the TaskManager, or more generally as part of the partition lifecycle management. On it's own this commit does not change any behavior, as no part of the system makes use of this flag.
This is primarily a preparatory step for the subsequent commit and future partition lifecycle management.

The second commit introduces a dev feature flag to enable/disable the automatic release of consumed blocking result partitions by the shuffle environment.

If the flag is enabled, which is the default, then the system does not behave differently to how it does currently.
Once the partition lifecycle is fully introduced we will either switch the default to false, or remove the flag entirely.


