### PR TITLE
[FLINK-12686][runtime] Disentangle StreamGraph/StreamNode/StreamGraph…

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -282,7 +282,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 	}
 
 	public static void addUserArtifactEntries(Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts, JobGraph jobGraph) {
-		if (!userArtifacts.isEmpty()) {
+		if (userArtifacts != null && !userArtifacts.isEmpty()) {
 			try {
 				java.nio.file.Path tmpDir = Files.createTempDirectory("flink-distributed-cache-" + jobGraph.getJobID());
 				for (Tuple2<String, DistributedCache.DistributedCacheEntry> originalEntry : userArtifacts) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationGroup.java
@@ -63,6 +63,10 @@ public class CoLocationGroup implements java.io.Serializable {
 		Preconditions.checkNotNull(vertex);
 		this.vertices.add(vertex);
 	}
+
+	public List<JobVertex> getVertices() {
+		return vertices;
+	}
 	
 	public void mergeInto(CoLocationGroup other) {
 		Preconditions.checkNotNull(other);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -86,8 +86,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		// transform the streaming program into a JobGraph
-		StreamGraph streamGraph = getStreamGraph();
-		streamGraph.setJobName(jobName);
+		StreamGraph streamGraph = getStreamGraph(jobName);
 
 		JobGraph jobGraph = streamGraph.getJobGraph();
 		jobGraph.setAllowQueuedScheduling(true);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -223,8 +223,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		String jobName,
 		SavepointRestoreSettings savepointRestoreSettings
 	) throws ProgramInvocationException {
-		StreamGraph streamGraph = streamExecutionEnvironment.getStreamGraph();
-		streamGraph.setJobName(jobName);
+		StreamGraph streamGraph = streamExecutionEnvironment.getStreamGraph(jobName);
 		return executeRemotely(streamGraph,
 			streamExecutionEnvironment.getClass().getClassLoader(),
 			streamExecutionEnvironment.getConfig(),
@@ -304,8 +303,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws ProgramInvocationException {
-		StreamGraph streamGraph = getStreamGraph();
-		streamGraph.setJobName(jobName);
+		StreamGraph streamGraph = getStreamGraph(jobName);
 		transformations.clear();
 		return executeRemotely(streamGraph, jarFiles);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -50,8 +50,7 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Preconditions.checkNotNull(jobName, "Streaming Job name should not be null.");
 
-		StreamGraph streamGraph = this.getStreamGraph();
-		streamGraph.setJobName(jobName);
+		StreamGraph streamGraph = this.getStreamGraph(jobName);
 
 		transformations.clear();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1514,6 +1514,17 @@ public abstract class StreamExecutionEnvironment {
 		return getStreamGraphGenerator().generate();
 	}
 
+	/**
+	 * Getter of the {@link org.apache.flink.streaming.api.graph.StreamGraph} of the streaming job.
+	 *
+	 * @param jobName Desired name of the job
+	 * @return The streamgraph representing the transformations
+	 */
+	@Internal
+	public StreamGraph getStreamGraph(String jobName) {
+		return getStreamGraphGenerator().setJobName(jobName).generate();
+	}
+
 	private StreamGraphGenerator getStreamGraphGenerator() {
 		if (transformations.size() <= 0) {
 			throw new IllegalStateException("No operators defined in streaming topology. Cannot execute.");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1511,10 +1511,19 @@ public abstract class StreamExecutionEnvironment {
 	 */
 	@Internal
 	public StreamGraph getStreamGraph() {
+		return getStreamGraphGenerator().generate();
+	}
+
+	private StreamGraphGenerator getStreamGraphGenerator() {
 		if (transformations.size() <= 0) {
 			throw new IllegalStateException("No operators defined in streaming topology. Cannot execute.");
 		}
-		return StreamGraphGenerator.generate(this, transformations);
+		return new StreamGraphGenerator(transformations, config, checkpointCfg)
+			.setStateBackend(defaultStateBackend)
+			.setChaining(isChainingEnabled)
+			.setUserArtifacts(cacheFile)
+			.setTimeCharacteristic(timeCharacteristic)
+			.setDefaultBufferTimeout(bufferTimeout);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
@@ -56,8 +56,7 @@ public class StreamPlanEnvironment extends StreamExecutionEnvironment {
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 
-		StreamGraph streamGraph = getStreamGraph();
-		streamGraph.setJobName(jobName);
+		StreamGraph streamGraph = getStreamGraph(jobName);
 
 		transformations.clear();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -87,6 +88,8 @@ public class StreamGraph extends StreamingPlan {
 
 	private final ExecutionConfig executionConfig;
 	private final CheckpointConfig checkpointConfig;
+
+	private ScheduleMode scheduleMode;
 
 	private boolean chaining;
 
@@ -155,6 +158,14 @@ public class StreamGraph extends StreamingPlan {
 
 	public StateBackend getStateBackend() {
 		return this.stateBackend;
+	}
+
+	public ScheduleMode getScheduleMode() {
+		return scheduleMode;
+	}
+
+	public void setScheduleMode(ScheduleMode scheduleMode) {
+		this.scheduleMode = scheduleMode;
 	}
 
 	public Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> getUserArtifacts() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -37,7 +37,6 @@ import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
@@ -80,7 +79,7 @@ public class StreamGraph extends StreamingPlan {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamGraph.class);
 
-	private String jobName = StreamExecutionEnvironment.DEFAULT_JOB_NAME;
+	private String jobName;
 
 	private final ExecutionConfig executionConfig;
 	private final CheckpointConfig checkpointConfig;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -79,6 +79,10 @@ public class StreamGraph extends StreamingPlan {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamGraph.class);
 
+	public static final String ITERATION_SOURCE_NAME_PREFIX = "IterationSource";
+
+	public static final String ITERATION_SINK_NAME_PREFIX = "IterationSink";
+
 	private String jobName;
 
 	private final ExecutionConfig executionConfig;
@@ -620,12 +624,15 @@ public class StreamGraph extends StreamingPlan {
 		int maxParallelism,
 		ResourceSpec minResources,
 		ResourceSpec preferredResources) {
+
+		final String coLocationGroup = "IterationCoLocationGroup-" + loopId;
+
 		StreamNode source = this.addNode(sourceId,
 			null,
-			null,
+			coLocationGroup,
 			StreamIterationHead.class,
 			null,
-			"IterationSource-" + loopId);
+			ITERATION_SOURCE_NAME_PREFIX + "-" + loopId);
 		sources.add(source.getId());
 		setParallelism(source.getId(), parallelism);
 		setMaxParallelism(source.getId(), maxParallelism);
@@ -633,10 +640,10 @@ public class StreamGraph extends StreamingPlan {
 
 		StreamNode sink = this.addNode(sinkId,
 			null,
-			null,
+			coLocationGroup,
 			StreamIterationTail.class,
 			null,
-			"IterationSink-" + loopId);
+			ITERATION_SINK_NAME_PREFIX + "-" + loopId);
 		sinks.add(sink.getId());
 		setParallelism(sink.getId(), parallelism);
 		setMaxParallelism(sink.getId(), parallelism);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -260,7 +260,7 @@ public class StreamGraph extends StreamingPlan {
 			throw new RuntimeException("Duplicate vertexID " + vertexID);
 		}
 
-		StreamNode vertex = new StreamNode(environment,
+		StreamNode vertex = new StreamNode(
 			vertexID,
 			slotSharingGroup,
 			coLocationGroup,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -184,7 +184,7 @@ public class StreamGraph extends StreamingPlan {
 	}
 
 	public <IN, OUT> void addSource(Integer vertexID,
-		String slotSharingGroup,
+		@Nullable String slotSharingGroup,
 		@Nullable String coLocationGroup,
 		StreamOperatorFactory<OUT> operatorFactory,
 		TypeInformation<IN> inTypeInfo,
@@ -195,7 +195,7 @@ public class StreamGraph extends StreamingPlan {
 	}
 
 	public <IN, OUT> void addSink(Integer vertexID,
-		String slotSharingGroup,
+		@Nullable String slotSharingGroup,
 		@Nullable String coLocationGroup,
 		StreamOperatorFactory<OUT> operatorFactory,
 		TypeInformation<IN> inTypeInfo,
@@ -207,7 +207,7 @@ public class StreamGraph extends StreamingPlan {
 
 	public <IN, OUT> void addOperator(
 			Integer vertexID,
-			String slotSharingGroup,
+			@Nullable String slotSharingGroup,
 			@Nullable String coLocationGroup,
 			StreamOperatorFactory<OUT> operatorFactory,
 			TypeInformation<IN> inTypeInfo,
@@ -271,7 +271,7 @@ public class StreamGraph extends StreamingPlan {
 	}
 
 	protected StreamNode addNode(Integer vertexID,
-		String slotSharingGroup,
+		@Nullable String slotSharingGroup,
 		@Nullable String coLocationGroup,
 		Class<? extends AbstractInvokable> vertexClass,
 		StreamOperatorFactory<?> operatorFactory,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -105,9 +105,11 @@ public class StreamGraphGenerator {
 	 * Private constructor. The generator should only be invoked using {@link #generate}.
 	 */
 	private StreamGraphGenerator(StreamExecutionEnvironment env) {
-		this.streamGraph = new StreamGraph(env);
-		this.streamGraph.setChaining(env.isChainingEnabled());
-		this.streamGraph.setStateBackend(env.getStateBackend());
+		streamGraph = new StreamGraph(env.getConfig(), env.getCheckpointConfig());
+		streamGraph.setChaining(env.isChainingEnabled());
+		streamGraph.setStateBackend(env.getStateBackend());
+		streamGraph.setUserArtifacts(env.getCachedFiles());
+		streamGraph.setTimeCharacteristic(env.getStreamTimeCharacteristic());
 		this.env = env;
 		this.alreadyTransformed = new HashMap<>();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -197,7 +198,10 @@ public class StreamGraphGenerator {
 
 		if (transform.getBufferTimeout() >= 0) {
 			streamGraph.setBufferTimeout(transform.getId(), transform.getBufferTimeout());
+		} else {
+			streamGraph.setBufferTimeout(transform.getId(), env.getBufferTimeout());
 		}
+
 		if (transform.getUid() != null) {
 			streamGraph.setTransformationUID(transform.getId(), transform.getUid());
 		}
@@ -490,7 +494,9 @@ public class StreamGraphGenerator {
 			streamGraph.setInputFormat(source.getId(),
 					((InputFormatOperatorFactory<T>) source.getOperatorFactory()).getInputFormat());
 		}
-		streamGraph.setParallelism(source.getId(), source.getParallelism());
+		int parallelism = source.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT ?
+			source.getParallelism() : env.getParallelism();
+		streamGraph.setParallelism(source.getId(), parallelism);
 		streamGraph.setMaxParallelism(source.getId(), source.getMaxParallelism());
 		return Collections.singleton(source.getId());
 	}
@@ -517,7 +523,9 @@ public class StreamGraphGenerator {
 			streamGraph.setOutputFormat(sink.getId(), ((OutputFormatOperatorFactory) operatorFactory).getOutputFormat());
 		}
 
-		streamGraph.setParallelism(sink.getId(), sink.getParallelism());
+		int parallelism = sink.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT ?
+			sink.getParallelism() : env.getParallelism();
+		streamGraph.setParallelism(sink.getId(), parallelism);
 		streamGraph.setMaxParallelism(sink.getId(), sink.getMaxParallelism());
 
 		for (Integer inputId: inputIds) {
@@ -565,7 +573,9 @@ public class StreamGraphGenerator {
 			streamGraph.setOneInputStateKey(transform.getId(), transform.getStateKeySelector(), keySerializer);
 		}
 
-		streamGraph.setParallelism(transform.getId(), transform.getParallelism());
+		int parallelism = transform.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT ?
+			transform.getParallelism() : env.getParallelism();
+		streamGraph.setParallelism(transform.getId(), parallelism);
 		streamGraph.setMaxParallelism(transform.getId(), transform.getMaxParallelism());
 
 		for (Integer inputId: inputIds) {
@@ -612,7 +622,9 @@ public class StreamGraphGenerator {
 			streamGraph.setTwoInputStateKey(transform.getId(), transform.getStateKeySelector1(), transform.getStateKeySelector2(), keySerializer);
 		}
 
-		streamGraph.setParallelism(transform.getId(), transform.getParallelism());
+		int parallelism = transform.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT ?
+			transform.getParallelism() : env.getParallelism();
+		streamGraph.setParallelism(transform.getId(), parallelism);
 		streamGraph.setMaxParallelism(transform.getId(), transform.getMaxParallelism());
 
 		for (Integer inputId: inputIds1) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -89,6 +90,8 @@ public class StreamGraphGenerator {
 
 	public static final int DEFAULT_LOWER_BOUND_MAX_PARALLELISM = KeyGroupRangeAssignment.DEFAULT_LOWER_BOUND_MAX_PARALLELISM;
 
+	public static final ScheduleMode DEFAULT_SCHEDULE_MODE = ScheduleMode.EAGER;
+
 	public static final TimeCharacteristic DEFAULT_TIME_CHARACTERISTIC = TimeCharacteristic.ProcessingTime;
 
 	public static final String DEFAULT_JOB_NAME = "Flink Streaming Job";
@@ -109,6 +112,8 @@ public class StreamGraphGenerator {
 	private boolean chaining = true;
 
 	private boolean isSlotSharingEnabled = true;
+
+	private ScheduleMode scheduleMode = DEFAULT_SCHEDULE_MODE;
 
 	private Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts;
 
@@ -152,6 +157,11 @@ public class StreamGraphGenerator {
 		return this;
 	}
 
+	public StreamGraphGenerator setScheduleMode(ScheduleMode scheduleMode) {
+		this.scheduleMode = scheduleMode;
+		return this;
+	}
+
 	public StreamGraphGenerator setUserArtifacts(Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts) {
 		this.userArtifacts = userArtifacts;
 		return this;
@@ -176,6 +186,7 @@ public class StreamGraphGenerator {
 		streamGraph = new StreamGraph(executionConfig, checkpointConfig);
 		streamGraph.setStateBackend(stateBackend);
 		streamGraph.setChaining(chaining);
+		streamGraph.setScheduleMode(scheduleMode);
 		streamGraph.setUserArtifacts(userArtifacts);
 		streamGraph.setTimeCharacteristic(timeCharacteristic);
 		streamGraph.setJobName(jobName);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -55,7 +55,7 @@ public class StreamNode implements Serializable {
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
 	private long bufferTimeout;
 	private final String operatorName;
-	private String slotSharingGroup;
+	private @Nullable String slotSharingGroup;
 	private @Nullable String coLocationGroup;
 	private KeySelector<?, ?> statePartitioner1;
 	private KeySelector<?, ?> statePartitioner2;
@@ -81,7 +81,7 @@ public class StreamNode implements Serializable {
 	@VisibleForTesting
 	public StreamNode(
 			Integer id,
-			String slotSharingGroup,
+			@Nullable String slotSharingGroup,
 			@Nullable String coLocationGroup,
 			StreamOperator<?> operator,
 			String operatorName,
@@ -93,7 +93,7 @@ public class StreamNode implements Serializable {
 
 	public StreamNode(
 		Integer id,
-		String slotSharingGroup,
+		@Nullable String slotSharingGroup,
 		@Nullable String coLocationGroup,
 		StreamOperatorFactory<?> operatorFactory,
 		String operatorName,
@@ -269,10 +269,11 @@ public class StreamNode implements Serializable {
 		this.outputFormat = outputFormat;
 	}
 
-	public void setSlotSharingGroup(String slotSharingGroup) {
+	public void setSlotSharingGroup(@Nullable String slotSharingGroup) {
 		this.slotSharingGroup = slotSharingGroup;
 	}
 
+	@Nullable
 	public String getSlotSharingGroup() {
 		return slotSharingGroup;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -27,7 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
@@ -46,10 +44,8 @@ public class StreamNode implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private transient StreamExecutionEnvironment env;
-
 	private final int id;
-	private Integer parallelism = null;
+	private int parallelism;
 	/**
 	 * Maximum parallelism for this stream node. The maximum parallelism is the upper limit for
 	 * dynamic scaling and the number of key groups used for partitioned state.
@@ -57,7 +53,7 @@ public class StreamNode implements Serializable {
 	private int maxParallelism;
 	private ResourceSpec minResources = ResourceSpec.DEFAULT;
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
-	private Long bufferTimeout = null;
+	private long bufferTimeout;
 	private final String operatorName;
 	private String slotSharingGroup;
 	private @Nullable String coLocationGroup;
@@ -83,7 +79,7 @@ public class StreamNode implements Serializable {
 	private String userHash;
 
 	@VisibleForTesting
-	public StreamNode(StreamExecutionEnvironment env,
+	public StreamNode(
 			Integer id,
 			String slotSharingGroup,
 			@Nullable String coLocationGroup,
@@ -91,11 +87,11 @@ public class StreamNode implements Serializable {
 			String operatorName,
 			List<OutputSelector<?>> outputSelector,
 			Class<? extends AbstractInvokable> jobVertexClass) {
-		this(env, id, slotSharingGroup, coLocationGroup, SimpleOperatorFactory.of(operator),
+		this(id, slotSharingGroup, coLocationGroup, SimpleOperatorFactory.of(operator),
 				operatorName, outputSelector, jobVertexClass);
 	}
 
-	public StreamNode(StreamExecutionEnvironment env,
+	public StreamNode(
 		Integer id,
 		String slotSharingGroup,
 		@Nullable String coLocationGroup,
@@ -104,7 +100,6 @@ public class StreamNode implements Serializable {
 		List<OutputSelector<?>> outputSelector,
 		Class<? extends AbstractInvokable> jobVertexClass) {
 
-		this.env = env;
 		this.id = id;
 		this.operatorName = operatorName;
 		this.operatorFactory = operatorFactory;
@@ -163,11 +158,7 @@ public class StreamNode implements Serializable {
 	}
 
 	public int getParallelism() {
-		if (parallelism == ExecutionConfig.PARALLELISM_DEFAULT) {
-			return env.getParallelism();
-		} else {
-			return parallelism;
-		}
+		return parallelism;
 	}
 
 	public void setParallelism(Integer parallelism) {
@@ -205,8 +196,8 @@ public class StreamNode implements Serializable {
 		this.preferredResources = preferredResources;
 	}
 
-	public Long getBufferTimeout() {
-		return bufferTimeout != null ? bufferTimeout : env.getBufferTimeout();
+	public long getBufferTimeout() {
+		return bufferTimeout;
 	}
 
 	public void setBufferTimeout(Long bufferTimeout) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -598,22 +598,9 @@ public class StreamingJobGraphGenerator {
 				}
 
 				vertex.updateCoLocationGroup(constraint.f1);
+				constraint.f1.addVertex(vertex);
 			}
 		}
-
-		for (Tuple2<StreamNode, StreamNode> pair : streamGraph.getIterationSourceSinkPairs()) {
-
-			CoLocationGroup ccg = new CoLocationGroup();
-
-			JobVertex source = jobVertices.get(pair.f0.getId());
-			JobVertex sink = jobVertices.get(pair.f1.getId());
-
-			ccg.addVertex(source);
-			ccg.addVertex(sink);
-			source.updateCoLocationGroup(ccg);
-			sink.updateCoLocationGroup(ccg);
-		}
-
 	}
 
 	private void configureCheckpointing() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -37,7 +37,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
@@ -142,7 +141,7 @@ public class StreamingJobGraphGenerator {
 	private JobGraph createJobGraph() {
 
 		// make sure that all vertices start immediately
-		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+		jobGraph.setScheduleMode(streamGraph.getScheduleMode());
 
 		// Generate deterministic hashes for the nodes in order to identify them across
 		// submission iff they didn't change.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -164,7 +164,7 @@ public class StreamingJobGraphGenerator {
 
 		configureCheckpointing();
 
-		JobGraphGenerator.addUserArtifactEntries(streamGraph.getEnvironment().getCachedFiles(), jobGraph);
+		JobGraphGenerator.addUserArtifactEntries(streamGraph.getUserArtifacts(), jobGraph);
 
 		// set the ExecutionConfig last when it has been finalized
 		try {
@@ -464,7 +464,7 @@ public class StreamingJobGraphGenerator {
 		config.setNonChainedOutputs(nonChainableOutputs);
 		config.setChainedOutputs(chainableOutputs);
 
-		config.setTimeCharacteristic(streamGraph.getEnvironment().getStreamTimeCharacteristic());
+		config.setTimeCharacteristic(streamGraph.getTimeCharacteristic());
 
 		final CheckpointConfig checkpointCfg = streamGraph.getCheckpointConfig();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -85,16 +85,16 @@ public class StreamGraphGeneratorTest {
 			switch (node.getOperatorName()) {
 
 				case "A":
-					assertEquals(77L, node.getBufferTimeout().longValue());
+					assertEquals(77L, node.getBufferTimeout());
 					break;
 				case "B":
-					assertEquals(0L, node.getBufferTimeout().longValue());
+					assertEquals(0L, node.getBufferTimeout());
 					break;
 				case "C":
-					assertEquals(12L, node.getBufferTimeout().longValue());
+					assertEquals(12L, node.getBufferTimeout());
 					break;
 				case "D":
-					assertEquals(77L, node.getBufferTimeout().longValue());
+					assertEquals(77L, node.getBufferTimeout());
 					break;
 				default:
 					assertTrue(node.getOperator() instanceof StreamSource);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -21,8 +21,10 @@ package org.apache.flink.streaming.api.graph;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.ConnectedStreams;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.IterativeStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
@@ -49,6 +51,7 @@ import org.apache.flink.streaming.util.NoOpIntMap;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -418,6 +421,30 @@ public class StreamGraphGeneratorTest {
 		}
 		// IllegalArgumentException will be thrown without FLINK-9216
 		env.getStreamGraph().getStreamingPlanAsJSON();
+	}
+
+	/**
+	 * Test iteration job, check slot sharing group and co-location group.
+	 */
+	@Test
+	public void testIteration() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		DataStream<Integer> source = env.fromElements(1, 2, 3).name("source");
+		IterativeStream<Integer> iteration = source.iterate(3000);
+		iteration.name("iteration").setParallelism(2);
+		DataStream<Integer> map = iteration.map(x -> x + 1).name("map").setParallelism(2);
+		DataStream<Integer> filter = map.filter((x) -> false).name("filter").setParallelism(2);
+		iteration.closeWith(filter).print();
+
+		StreamGraph streamGraph = env.getStreamGraph();
+		for (Tuple2<StreamNode, StreamNode> iterationPair : streamGraph.getIterationSourceSinkPairs()) {
+			assertNotNull(iterationPair.f0.getCoLocationGroup());
+			assertEquals(iterationPair.f0.getCoLocationGroup(), iterationPair.f1.getCoLocationGroup());
+
+			assertNotNull(iterationPair.f0.getSlotSharingGroup());
+			assertEquals(iterationPair.f0.getSlotSharingGroup(), iterationPair.f1.getSlotSharingGroup());
+		}
 	}
 
 	private static class OutputTypeConfigurableOperationWithTwoInputs

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -104,8 +104,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
 		// --------- the job graph ---------
 
-		StreamGraph streamGraph = env.getStreamGraph();
-		streamGraph.setJobName("test job");
+		StreamGraph streamGraph = env.getStreamGraph("test job");
 		JobGraph jobGraph = streamGraph.getJobGraph();
 		List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -49,6 +49,7 @@ import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamTransformation;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
@@ -56,6 +57,7 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -441,6 +443,60 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 				assertNull(jobVertex.getCoLocationGroup());
 			}
 		}
+
+		assertNotNull(iterationSourceCoLocationGroup);
+		assertNotNull(iterationSinkCoLocationGroup);
+		assertEquals(iterationSourceCoLocationGroup, iterationSinkCoLocationGroup);
+	}
+
+	/**
+	 * Test slot sharing group is enabled or disabled for iteration.
+	 */
+	@Test
+	public void testDisableSlotSharingForIteration() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		DataStream<Integer> source = env.fromElements(1, 2, 3).name("source");
+		IterativeStream<Integer> iteration = source.iterate(3000);
+		iteration.name("iteration").setParallelism(2);
+		DataStream<Integer> map = iteration.map(x -> x + 1).name("map").setParallelism(2);
+		DataStream<Integer> filter = map.filter((x) -> false).name("filter").setParallelism(2);
+		iteration.closeWith(filter).print();
+
+		List<StreamTransformation<?>> transformations = new ArrayList<>();
+		transformations.add(source.getTransformation());
+		transformations.add(iteration.getTransformation());
+		transformations.add(map.getTransformation());
+		transformations.add(filter.getTransformation());
+		// when slot sharing group is disabled
+		// all job vertices except iteration vertex would have no slot sharing group
+		// iteration vertices would be set slot sharing group automatically
+		StreamGraphGenerator generator = new StreamGraphGenerator(transformations, env.getConfig(), env.getCheckpointConfig());
+		generator.setSlotSharingEnabled(false);
+
+		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(generator.generate());
+
+		SlotSharingGroup iterationSourceSlotSharingGroup = null;
+		SlotSharingGroup iterationSinkSlotSharingGroup = null;
+
+		CoLocationGroup iterationSourceCoLocationGroup = null;
+		CoLocationGroup iterationSinkCoLocationGroup = null;
+
+		for (JobVertex jobVertex : jobGraph.getVertices()) {
+			if (jobVertex.getName().startsWith(StreamGraph.ITERATION_SOURCE_NAME_PREFIX)) {
+				iterationSourceSlotSharingGroup = jobVertex.getSlotSharingGroup();
+				iterationSourceCoLocationGroup = jobVertex.getCoLocationGroup();
+			} else if (jobVertex.getName().startsWith(StreamGraph.ITERATION_SINK_NAME_PREFIX)) {
+				iterationSinkSlotSharingGroup = jobVertex.getSlotSharingGroup();
+				iterationSinkCoLocationGroup = jobVertex.getCoLocationGroup();
+			} else {
+				assertNull(jobVertex.getSlotSharingGroup());
+			}
+		}
+
+		assertNotNull(iterationSourceSlotSharingGroup);
+		assertNotNull(iterationSinkSlotSharingGroup);
+		assertEquals(iterationSourceSlotSharingGroup, iterationSinkSlotSharingGroup);
 
 		assertNotNull(iterationSourceCoLocationGroup);
 		assertNotNull(iterationSinkCoLocationGroup);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -126,7 +126,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 	@Test
 	public void testDisabledCheckpointing() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		StreamGraph streamGraph = new StreamGraph(env);
+		StreamGraph streamGraph = new StreamGraph(env.getConfig(), env.getCheckpointConfig());
 		assertFalse("Checkpointing enabled", streamGraph.getCheckpointConfig().isCheckpointingEnabled());
 
 		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.jobgraph.InputOutputFormatVertex;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
@@ -58,6 +59,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -501,5 +503,35 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		assertNotNull(iterationSourceCoLocationGroup);
 		assertNotNull(iterationSinkCoLocationGroup);
 		assertEquals(iterationSourceCoLocationGroup, iterationSinkCoLocationGroup);
+	}
+
+	/**
+	 * Test default schedule mode.
+	 */
+	@Test
+	public void testDefaultScheduleMode() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		// use eager schedule mode by default
+		StreamGraph streamGraph = new StreamGraphGenerator(Collections.emptyList(),
+			env.getConfig(), env.getCheckpointConfig())
+			.generate();
+		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+		assertEquals(ScheduleMode.EAGER, jobGraph.getScheduleMode());
+	}
+
+	/**
+	 * Test schedule mode is configurable or not.
+	 */
+	@Test
+	public void testSetScheduleMode() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		StreamGraph streamGraph = new StreamGraphGenerator(Collections.emptyList(),
+			env.getConfig(), env.getCheckpointConfig())
+			.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES)
+			.generate();
+		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+		assertEquals(ScheduleMode.LAZY_FROM_SOURCES, jobGraph.getScheduleMode());
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -794,7 +794,6 @@ public class OneInputStreamTaskTest extends TestLogger {
 
 			StreamEdge outputEdge = new StreamEdge(
 				new StreamNode(
-					null,
 					chainedIndex - 1,
 					null,
 					null,
@@ -804,7 +803,6 @@ public class OneInputStreamTaskTest extends TestLogger {
 					null
 				),
 				new StreamNode(
-					null,
 					chainedIndex,
 					null,
 					null,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -93,8 +93,8 @@ public class StreamConfigChainer {
 
 		tailConfig.setChainedOutputs(Collections.singletonList(
 			new StreamEdge(
-				new StreamNode(null, tailConfig.getChainIndex(), null, null, (StreamOperator<?>) null, null, null, null),
-				new StreamNode(null, chainIndex, null, null, (StreamOperator<?>) null, null, null, null),
+				new StreamNode(tailConfig.getChainIndex(), null, null, (StreamOperator<?>) null, null, null, null),
+				new StreamNode(chainIndex, null, null, (StreamOperator<?>) null, null, null, null),
 				0,
 				Collections.<String>emptyList(),
 				null,
@@ -120,8 +120,8 @@ public class StreamConfigChainer {
 		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
 		outEdgesInOrder.add(
 			new StreamEdge(
-				new StreamNode(null, chainIndex, null, null, (StreamOperator<?>) null, null, null, null),
-				new StreamNode(null, chainIndex , null, null, (StreamOperator<?>) null, null, null, null),
+				new StreamNode(chainIndex, null, null, (StreamOperator<?>) null, null, null, null),
+				new StreamNode(chainIndex , null, null, (StreamOperator<?>) null, null, null, null),
 				0,
 				Collections.<String>emptyList(),
 				new BroadcastPartitioner<Object>(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -195,8 +195,8 @@ public class StreamTaskTestHarness<OUT> {
 		};
 
 		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
-		StreamNode sourceVertexDummy = new StreamNode(null, 0, "group", null, dummyOperator, "source dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
-		StreamNode targetVertexDummy = new StreamNode(null, 1, "group", null, dummyOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+		StreamNode sourceVertexDummy = new StreamNode(0, "group", null, dummyOperator, "source dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+		StreamNode targetVertexDummy = new StreamNode(1, "group", null, dummyOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
 
 		outEdgesInOrder.add(new StreamEdge(sourceVertexDummy, targetVertexDummy, 0, new LinkedList<String>(), new BroadcastPartitioner<Object>(), null /* output tag */));
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -116,8 +116,8 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 			private static final long serialVersionUID = 1L;
 		};
 
-		StreamNode sourceVertexDummy = new StreamNode(null, 0, "default group", null, dummyOperator, "source dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
-		StreamNode targetVertexDummy = new StreamNode(null, 1, "default group", null, dummyOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+		StreamNode sourceVertexDummy = new StreamNode(0, "default group", null, dummyOperator, "source dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+		StreamNode targetVertexDummy = new StreamNode(1, "default group", null, dummyOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
 
 		for (int i = 0; i < numInputGates; i++) {
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -38,7 +38,6 @@ import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.api.BatchQueryConfig;
 import org.apache.flink.table.api.QueryConfig;
 import org.apache.flink.table.api.StreamQueryConfig;
@@ -376,9 +375,7 @@ public class ExecutionContext<T> {
 
 		private FlinkPlan createPlan(String name, Configuration flinkConfig) {
 			if (streamExecEnv != null) {
-				final StreamGraph graph = streamExecEnv.getStreamGraph();
-				graph.setJobName(name);
-				return graph;
+				return streamExecEnv.getStreamGraph(name);
 			} else {
 				final int parallelism = execEnv.getParallelism();
 				final Plan unoptimizedPlan = execEnv.createProgramPlan();

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -119,9 +119,15 @@ abstract class StreamTableEnvironment(
       jobName: Option[String] = None): StreamGraph = {
     mergeParameters()
 
-    val streamGraph = StreamGraphGenerator.generate(execEnv, streamingTransformations.toList)
-    streamGraph.setJobName(jobName.getOrElse(DEFAULT_JOB_NAME))
-    streamGraph
+    new StreamGraphGenerator(
+        streamingTransformations.toList, execEnv.getConfig, execEnv.getCheckpointConfig)
+      .setChaining(execEnv.isChainingEnabled)
+      .setDefaultBufferTimeout(execEnv.getBufferTimeout)
+      .setStateBackend(execEnv.getStateBackend)
+      .setTimeCharacteristic(execEnv.getStreamTimeCharacteristic)
+      .setUserArtifacts(execEnv.getCachedFiles)
+      .setJobName(jobName.getOrElse(DEFAULT_JOB_NAME))
+      .generate()
   }
 
   /**

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -66,8 +66,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
-		final StreamGraph streamGraph = getStreamGraph();
-		streamGraph.setJobName(jobName);
+		final StreamGraph streamGraph = getStreamGraph(jobName);
 		final JobGraph jobGraph = streamGraph.getJobGraph();
 
 		for (Path jarFile : jarFiles) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -362,8 +362,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 			.reduce((value1, value2) -> Tuple2.of(value1.f0, value1.f1 + value2.f1))
 			.filter(value -> value.f0.startsWith("Tuple 0"));
 
-		StreamGraph streamGraph = env.getStreamGraph();
-		streamGraph.setJobName("Test");
+		StreamGraph streamGraph = env.getStreamGraph("Test");
 
 		JobGraph jobGraph = streamGraph.getJobGraph();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -659,8 +659,7 @@ public class SavepointITCase extends TestLogger {
 
 		iteration.closeWith(iterationBody);
 
-		StreamGraph streamGraph = env.getStreamGraph();
-		streamGraph.setJobName("Test");
+		StreamGraph streamGraph = env.getStreamGraph("Test");
 
 		JobGraph jobGraph = streamGraph.getJobGraph();
 


### PR DESCRIPTION
…Generator from StreamExecutionEnvironment

## What is the purpose of the change

* Disentangle `StreamGraph/StreamNode/StreamGraphGenerator` from `StreamExecutionEnvironment`, so `StreamGraph` could support any environment

## Brief change log

* Use parameters directly in `StreamGraph/StreamNode/StreamGraphGenerator` instead of `StreamExecutionEnvironment`
* Introduce a global option to turn off slot sharing in `StreamGraphBuilder`. It's a internal API which is not exposed to user currently
* Remove hard-coded `ScheduleMode` in `StreamingJobGraphGenerator`, make it configurable

## Verifying this change

* Add unit tests in `StreamingJobGraphGeneratorTest` and `StreamGraphBuilderTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
