### PR TITLE
[FLINK-12646][runtime] Change the test IP of RestClientTest to 240.0.0.0

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertThat;
  */
 public class RestClientTest extends TestLogger {
 
-	private static final String unroutableIp = "10.255.255.1";
+	private static final String unroutableIp = "240.0.0.0";
 
 	private static final long TIMEOUT = 10L;
 


### PR DESCRIPTION
## What is the purpose of the change

In `org.apache.flink.runtime.rest.RestClientTest#testConnectionTimeout`
, we use an "unroutableIp" with a value of  "10.255.255.1" for test.

But sometimes this IP is reachable in a private network of a company, which is the case for me. As a result, this test failed with a following exception: 
```
java.lang.AssertionError: Expected: an instance of org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException but: <org.apache.flink.shaded.netty4.io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: /10.255.255.1:80> is a org.apache.flink.shaded.netty4.io.netty.channel.AbstractChannel$AnnotatedConnectException 
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20) 
at org.junit.Assert.assertThat(Assert.java:956) 
at org.junit.Assert.assertThat(Assert.java:923) 
at org.apache.flink.runtime.rest.RestClientTest.testConnectionTimeout(RestClientTest.java:76) 
...
```
We can change the `unroutableIp` to a reserved IP address, i.e "240.0.0.0", which is described as  reserved for future use in [wikipedia](https://en.wikipedia.org/wiki/Reserved_IP_addresses). 


## Brief change log

Change the test IP of RestClientTest from 10.255.255.1 to 240.0.0.0.


## Verifying this change


This change is already covered by existing tests, such as `org.apache.flink.runtime.rest.RestClientTest#testConnectionTimeout`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
