### PR TITLE
[FLINK-12779][table] Avoid field conflicts when generate field names for non-composite Typeinformation

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
@@ -310,6 +310,37 @@ public class FieldInfoUtils {
 	}
 
 	/**
+	 * Returns field names for a given {@link TypeInformation}. If the input {@link TypeInformation}
+	 * is not a composite type, the result field name should not exist in the invalidNamesForNonCompositeType.
+	 *
+	 * @param inputType The TypeInformation extract the field names.
+	 * @param invalidNamesForNonCompositeType The invalid field names for non-composite types.
+	 * @param <A> The type of the TypeInformation.
+	 * @return An array holding the field names
+	 */
+	public static <A> String[] getFieldNames(TypeInformation<A> inputType, List<String> invalidNamesForNonCompositeType) {
+		validateInputTypeInfo(inputType);
+
+		final String[] fieldNames;
+		if (inputType instanceof CompositeType) {
+			fieldNames = ((CompositeType<A>) inputType).getFieldNames();
+		} else {
+			int i = 0;
+			String fieldName = ATOMIC_FIELD_NAME;
+			while (invalidNamesForNonCompositeType.contains(fieldName)) {
+				fieldName = ATOMIC_FIELD_NAME + "_" + i++;
+			}
+			fieldNames = new String[]{fieldName};
+		}
+
+		if (Arrays.asList(fieldNames).contains("*")) {
+			throw new TableException("Field name can not be '*'.");
+		}
+
+		return fieldNames;
+	}
+
+	/**
 	 * Validate if class represented by the typeInfo is static and globally accessible.
 	 *
 	 * @param typeInfo type to check

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -293,32 +294,19 @@ public class FieldInfoUtils {
 	 * @return An array holding the field names
 	 */
 	public static <A> String[] getFieldNames(TypeInformation<A> inputType) {
-		validateInputTypeInfo(inputType);
-
-		final String[] fieldNames;
-		if (inputType instanceof CompositeType) {
-			fieldNames = ((CompositeType<A>) inputType).getFieldNames();
-		} else {
-			fieldNames = new String[]{ATOMIC_FIELD_NAME};
-		}
-
-		if (Arrays.asList(fieldNames).contains("*")) {
-			throw new ValidationException("Field name can not be '*'.");
-		}
-
-		return fieldNames;
+		return getFieldNames(inputType, Collections.emptyList());
 	}
 
 	/**
 	 * Returns field names for a given {@link TypeInformation}. If the input {@link TypeInformation}
-	 * is not a composite type, the result field name should not exist in the invalidNamesForNonCompositeType.
+	 * is not a composite type, the result field name should not exist in the existingNames.
 	 *
 	 * @param inputType The TypeInformation extract the field names.
-	 * @param invalidNamesForNonCompositeType The invalid field names for non-composite types.
+	 * @param existingNames The existing field names for non-composite types that can not be used.
 	 * @param <A> The type of the TypeInformation.
 	 * @return An array holding the field names
 	 */
-	public static <A> String[] getFieldNames(TypeInformation<A> inputType, List<String> invalidNamesForNonCompositeType) {
+	public static <A> String[] getFieldNames(TypeInformation<A> inputType, List<String> existingNames) {
 		validateInputTypeInfo(inputType);
 
 		final String[] fieldNames;
@@ -327,7 +315,7 @@ public class FieldInfoUtils {
 		} else {
 			int i = 0;
 			String fieldName = ATOMIC_FIELD_NAME;
-			while (invalidNamesForNonCompositeType.contains(fieldName)) {
+			while (existingNames.contains(fieldName)) {
 				fieldName = ATOMIC_FIELD_NAME + "_" + i++;
 			}
 			fieldNames = new String[]{fieldName};

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
@@ -309,13 +309,13 @@ public class FieldInfoUtils {
 	public static <A> String[] getFieldNames(TypeInformation<A> inputType, List<String> existingNames) {
 		validateInputTypeInfo(inputType);
 
-		final String[] fieldNames;
+		String[] fieldNames;
 		if (inputType instanceof CompositeType) {
 			fieldNames = ((CompositeType<A>) inputType).getFieldNames();
 		} else {
 			int i = 0;
 			String fieldName = ATOMIC_FIELD_NAME;
-			while (existingNames.contains(fieldName)) {
+			while ((null != existingNames) && existingNames.contains(fieldName)) {
 				fieldName = ATOMIC_FIELD_NAME + "_" + i++;
 			}
 			fieldNames = new String[]{fieldName};

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
@@ -367,7 +367,8 @@ class OperationTreeBuilder(private val tableEnv: TableEnvImpl) {
     val resolver = resolverFor(tableCatalog, functionCatalog, left).build()
     val resolvedFunction = resolveSingleExpression(tableFunction, resolver)
 
-    val temporalTable = calculatedTableFactory.create(resolvedFunction)
+    val temporalTable =
+      calculatedTableFactory.create(resolvedFunction, left.getTableSchema.getFieldNames)
 
     join(left, temporalTable, joinType, condition, correlated = true)
   }


### PR DESCRIPTION

## What is the purpose of the change

This pull request makes the result name of table function more robust. 

We use `FieldInfoUtils.getFieldNames(resultType)` to get the relative field names of the resultType. There are no problem for composite types. For non-composite types, we always set the field name to `f0`. But the `f0` may conflict with the predefined field names. To make it more robust, we should generate a field name with no conflicts. For example, we can use `f0_0` as the field name if `f0` has been used. This is also consistent with the behavior of SQL.


## Brief change log

  - Add an another `getFieldNames` method which takes a list of invalid field names into consideration when generate result field names.
  - Use the new `getFieldNames` to generate TableFunction result field names.
  - Add tests.


## Verifying this change

This change added tests and can be verified as follows:

  - Added `CorrelateTest.testNonCompositeResultType()` to test whether field names are generated correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
