### PR TITLE
[FLINK-12502] Harden JobMasterTest#testRequestNextInputSplitWithDataSourceFailover

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -926,9 +926,13 @@ public class ExecutionGraph implements AccessExecutionGraph {
 				schedulingFuture = newSchedulingFuture;
 				newSchedulingFuture.whenComplete(
 					(Void ignored, Throwable throwable) -> {
-						if (throwable != null && !(throwable instanceof CancellationException)) {
-							// only fail if the scheduling future was not canceled
-							failGlobal(ExceptionUtils.stripCompletionException(throwable));
+						if (throwable != null) {
+							final Throwable strippedThrowable = ExceptionUtils.stripCompletionException(throwable);
+
+							if (!(strippedThrowable instanceof CancellationException)) {
+								// only fail if the scheduling future was not canceled
+								failGlobal(strippedThrowable);
+							}
 						}
 					});
 			} else {


### PR DESCRIPTION

## What is the purpose of the change

Harden JobMasterTest#testRequestNextInputSplitWithDataSourceFailover


## Brief change log

 *Explicitly instantiate an InputSplitAssigner with a defined number of input splits*
 *Remove TaskDeploymentDescriptor*



## Verifying this change


This change is already covered by existing tests, such as *JobMasterTest#testRequestNextInputSplitWithDataSourceFailover*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

cc @tillrohrmann @GJL 
