### PR TITLE
[FLINK-12784][metrics] Support retention policy for InfluxDB metrics …

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -658,7 +658,7 @@ Parameters:
 - `db` - the InfluxDB database to store metrics
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
-- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server
+- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
 
 Example configuration:
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -658,7 +658,7 @@ Parameters:
 - `db` - the InfluxDB database to store metrics
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
-- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
+- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server
 
 Example configuration:
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -658,7 +658,7 @@ Parameters:
 - `db` - the InfluxDB database to store metrics
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
-- `rp` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server
+- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server
 
 Example configuration:
 
@@ -670,7 +670,7 @@ metrics.reporter.influxdb.port: 8086
 metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
-metrics.reporter.influxdb.rp: one_hr
+metrics.reporter.influxdb.retentionPolicy: one_hr
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -670,7 +670,7 @@ metrics.reporter.influxdb.port: 8086
 metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
-metrics.reporter.influxdb.retentionPolicy: one_hr
+metrics.reporter.influxdb.retentionPolicy: one_hour
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -658,6 +658,7 @@ Parameters:
 - `db` - the InfluxDB database to store metrics
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
+- `rp` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server
 
 Example configuration:
 
@@ -669,10 +670,11 @@ metrics.reporter.influxdb.port: 8086
 metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
+metrics.reporter.influxdb.rp: one_hr
 
 {% endhighlight %}
 
-The reporter would send metrics using http protocol with default retention policy defined on InfluxDB server.
+The reporter would send metrics using http protocol to the InfluxDB server with the specified retention policy (or the default policy specified on the server).
 All Flink metrics variables (see [List of all Variables](#list-of-all-variables)) are exported as InfluxDB tags.
 
 ### Prometheus (org.apache.flink.metrics.prometheus.PrometheusReporter)

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -656,7 +656,7 @@ Parameters:
 - `db` - the InfluxDB database to store metrics
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
-- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server
+- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
 
 Example configuration:
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -656,7 +656,7 @@ Parameters:
 - `db` - the InfluxDB database to store metrics
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
-- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
+- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server
 
 Example configuration:
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -656,6 +656,7 @@ Parameters:
 - `db` - the InfluxDB database to store metrics
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
+- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server
 
 Example configuration:
 
@@ -667,6 +668,7 @@ metrics.reporter.influxdb.port: 8086
 metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
+metrics.reporter.influxdb.retentionPolicy: one_hr
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -672,7 +672,7 @@ metrics.reporter.influxdb.retentionPolicy: one_hr
 
 {% endhighlight %}
 
-The reporter would send metrics using http protocol with default retention policy defined on InfluxDB server.
+The reporter would send metrics using http protocol to the InfluxDB server with the specified retention policy (or the default policy specified on the server).
 All Flink metrics variables (see [List of all Variables](#list-of-all-variables)) are exported as InfluxDB tags.
 
 ### Prometheus (org.apache.flink.metrics.prometheus.PrometheusReporter)

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -668,7 +668,7 @@ metrics.reporter.influxdb.port: 8086
 metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
-metrics.reporter.influxdb.retentionPolicy: one_hr
+metrics.reporter.influxdb.retentionPolicy: one_hour
 
 {% endhighlight %}
 

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -42,6 +42,7 @@ import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.DB;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.HOST;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.PASSWORD;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.PORT;
+import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.RETENTION_POLICY;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.USERNAME;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.getInteger;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.getString;
@@ -53,6 +54,7 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 
 	private String database;
 	private InfluxDB influxDB;
+	private String retentionPolicy;
 
 	public InfluxdbReporter() {
 		super(new MeasurementInfoProvider());
@@ -79,6 +81,8 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 		} else {
 			influxDB = InfluxDBFactory.connect(url);
 		}
+		this.retentionPolicy = getString(config, RETENTION_POLICY);
+
 		log.info("Configured InfluxDBReporter with {host:{}, port:{}, db:{}}", host, port, database);
 	}
 
@@ -102,7 +106,7 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 	private BatchPoints buildReport() {
 		Instant timestamp = Instant.now();
 		BatchPoints.Builder report = BatchPoints.database(database);
-		report.retentionPolicy("");
+		report.retentionPolicy(retentionPolicy);
 		try {
 			for (Map.Entry<Gauge<?>, MeasurementInfo> entry : gauges.entrySet()) {
 				report.point(MetricMapper.map(entry.getValue(), timestamp, entry.getKey()));

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -83,7 +83,7 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 			influxDB = InfluxDBFactory.connect(url);
 		}
 
-		log.info("Configured InfluxDBReporter with {host:{}, port:{}, db:{}, retentionPolicy:{}}", host, port, database, retentionPolicy);
+		log.info("Configured InfluxDBReporter with {host:{}, port:{}, db:{}, and retentionPolicy:{}}", host, port, database, retentionPolicy);
 	}
 
 	@Override

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -83,7 +83,7 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 		}
 		this.retentionPolicy = getString(config, RETENTION_POLICY);
 
-		log.info("Configured InfluxDBReporter with {host:{}, port:{}, db:{}}", host, port, database);
+		log.info("Configured InfluxDBReporter with {host:{}, port:{}, db:{}, retentionPolicy:{}}", host, port, database, retentionPolicy);
 	}
 
 	@Override

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -53,8 +53,8 @@ import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.getStrin
 public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implements Scheduled {
 
 	private String database;
-	private InfluxDB influxDB;
 	private String retentionPolicy;
+	private InfluxDB influxDB;
 
 	public InfluxdbReporter() {
 		super(new MeasurementInfoProvider());
@@ -76,12 +76,12 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 		String password = getString(config, PASSWORD);
 
 		this.database = database;
+		this.retentionPolicy = getString(config, RETENTION_POLICY);
 		if (username != null && password != null) {
 			influxDB = InfluxDBFactory.connect(url, username, password);
 		} else {
 			influxDB = InfluxDBFactory.connect(url);
 		}
-		this.retentionPolicy = getString(config, RETENTION_POLICY);
 
 		log.info("Configured InfluxDBReporter with {host:{}, port:{}, db:{}, retentionPolicy:{}}", host, port, database, retentionPolicy);
 	}

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
@@ -53,9 +53,9 @@ public class InfluxdbReporterOptions {
 		.withDescription("the InfluxDB database to store metrics");
 
 	public static final ConfigOption<String> RETENTION_POLICY = ConfigOptions
-			.key("rp")
-			.defaultValue("")
-			.withDescription("(optional) the retention policy for metrics");
+		.key("retentionPolicy")
+		.defaultValue("")
+		.withDescription("(optional) the retention policy for metrics");
 
 	static String getString(MetricConfig config, ConfigOption<String> key) {
 		return config.getString(key.key(), key.defaultValue());

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
@@ -55,7 +55,7 @@ public class InfluxdbReporterOptions {
 	public static final ConfigOption<String> RETENTION_POLICY = ConfigOptions
 		.key("retentionPolicy")
 		.defaultValue("")
-		.withDescription("(optional) the retention policy for metrics");
+		.withDescription("(optional) the InfluxDB retention policy for metrics");
 
 	static String getString(MetricConfig config, ConfigOption<String> key) {
 		return config.getString(key.key(), key.defaultValue());

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
@@ -52,6 +52,11 @@ public class InfluxdbReporterOptions {
 		.noDefaultValue()
 		.withDescription("the InfluxDB database to store metrics");
 
+	public static final ConfigOption<String> RETENTION_POLICY = ConfigOptions
+			.key("rp")
+			.defaultValue("")
+			.withDescription("(optional) the retention policy for metrics");
+
 	static String getString(MetricConfig config, ConfigOption<String> key) {
 		return config.getString(key.key(), key.defaultValue());
 	}

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -66,7 +66,7 @@ public class InfluxdbReporterTest extends TestLogger {
 
 	@Test
 	public void testReporterRegistration() throws Exception {
-		MetricRegistryImpl metricRegistry = createMetricRegistry("");
+		MetricRegistryImpl metricRegistry = createMetricRegistry(InfluxdbReporterOptions.RETENTION_POLICY.defaultValue());
 		try {
 			assertEquals(1, metricRegistry.getReporters().size());
 			MetricReporter reporter = metricRegistry.getReporters().get(0);
@@ -78,7 +78,7 @@ public class InfluxdbReporterTest extends TestLogger {
 
 	@Test
 	public void testMetricRegistration() throws Exception {
-		MetricRegistryImpl metricRegistry = createMetricRegistry("");
+		MetricRegistryImpl metricRegistry = createMetricRegistry(InfluxdbReporterOptions.RETENTION_POLICY.defaultValue());
 		try {
 			String metricName = "TestCounter";
 			Counter counter = registerTestMetric(metricName, metricRegistry);
@@ -111,7 +111,7 @@ public class InfluxdbReporterTest extends TestLogger {
 			reporter.report();
 
 			verify(postRequestedFor(urlPathEqualTo("/write"))
-				.withQueryParam("db", equalTo(TEST_INFLUXDB_DB))
+				.withQueryParam(InfluxdbReporterOptions.DB.key(), equalTo(TEST_INFLUXDB_DB))
 				.withQueryParam("rp", equalTo(retentionPolicy))
 				.withHeader("Content-Type", containing("text/plain"))
 				.withRequestBody(containing("taskmanager_" + metricName + ",host=" + METRIC_HOSTNAME + ",tm_id=" + METRIC_TM_ID + " count=42i")));
@@ -122,10 +122,10 @@ public class InfluxdbReporterTest extends TestLogger {
 
 	private MetricRegistryImpl createMetricRegistry(String retentionPolicy) {
 		MetricConfig metricConfig = new MetricConfig();
-		metricConfig.setProperty("host", "localhost");
-		metricConfig.setProperty("port", String.valueOf(wireMockRule.port()));
-		metricConfig.setProperty("db", TEST_INFLUXDB_DB);
-		metricConfig.setProperty("retentionPolicy", retentionPolicy);
+		metricConfig.setProperty(InfluxdbReporterOptions.HOST.key(), "localhost");
+		metricConfig.setProperty(InfluxdbReporterOptions.PORT.key(), String.valueOf(wireMockRule.port()));
+		metricConfig.setProperty(InfluxdbReporterOptions.DB.key(), TEST_INFLUXDB_DB);
+		metricConfig.setProperty(InfluxdbReporterOptions.RETENTION_POLICY.key(), retentionPolicy);
 
 		return new MetricRegistryImpl(
 			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -111,10 +111,10 @@ public class InfluxdbReporterTest extends TestLogger {
 			reporter.report();
 
 			verify(postRequestedFor(urlPathEqualTo("/write"))
-					.withQueryParam("db", equalTo(TEST_INFLUXDB_DB))
-					.withQueryParam("rp", equalTo(retentionPolicy))
-					.withHeader("Content-Type", containing("text/plain"))
-					.withRequestBody(containing("taskmanager_" + metricName + ",host=" + METRIC_HOSTNAME + ",tm_id=" + METRIC_TM_ID + " count=42i")));
+				.withQueryParam("db", equalTo(TEST_INFLUXDB_DB))
+				.withQueryParam("rp", equalTo(retentionPolicy))
+				.withHeader("Content-Type", containing("text/plain"))
+				.withRequestBody(containing("taskmanager_" + metricName + ",host=" + METRIC_HOSTNAME + ",tm_id=" + METRIC_TM_ID + " count=42i")));
 		} finally {
 			metricRegistry.shutdown().get();
 		}

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -111,7 +111,7 @@ public class InfluxdbReporterTest extends TestLogger {
 			reporter.report();
 
 			verify(postRequestedFor(urlPathEqualTo("/write"))
-				.withQueryParam(InfluxdbReporterOptions.DB.key(), equalTo(TEST_INFLUXDB_DB))
+				.withQueryParam("db", equalTo(TEST_INFLUXDB_DB))
 				.withQueryParam("rp", equalTo(retentionPolicy))
 				.withHeader("Content-Type", containing("text/plain"))
 				.withRequestBody(containing("taskmanager_" + metricName + ",host=" + METRIC_HOSTNAME + ",tm_id=" + METRIC_TM_ID + " count=42i")));

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -96,31 +96,6 @@ public class InfluxdbReporterTest extends TestLogger {
 
 	@Test
 	public void testMetricReporting() throws Exception {
-		MetricRegistryImpl metricRegistry = createMetricRegistry("");
-		try {
-			String metricName = "TestCounter";
-			Counter counter = registerTestMetric(metricName, metricRegistry);
-			counter.inc(42);
-
-			stubFor(post(urlPathEqualTo("/write"))
-				.willReturn(aResponse()
-					.withStatus(200)));
-
-			InfluxdbReporter reporter = (InfluxdbReporter) metricRegistry.getReporters().get(0);
-			reporter.report();
-
-			verify(postRequestedFor(urlPathEqualTo("/write"))
-				.withQueryParam("db", equalTo(TEST_INFLUXDB_DB))
-				.withQueryParam("rp", equalTo(""))
-				.withHeader("Content-Type", containing("text/plain"))
-				.withRequestBody(containing("taskmanager_" + metricName + ",host=" + METRIC_HOSTNAME + ",tm_id=" + METRIC_TM_ID + " count=42i")));
-		} finally {
-			metricRegistry.shutdown().get();
-		}
-	}
-
-	@Test
-	public void testMetricReportingWithRetentionPolicy() throws Exception {
 		String retentionPolicy = "one_hour";
 		MetricRegistryImpl metricRegistry = createMetricRegistry(retentionPolicy);
 		try {

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -104,8 +104,8 @@ public class InfluxdbReporterTest extends TestLogger {
 			counter.inc(42);
 
 			stubFor(post(urlPathEqualTo("/write"))
-					.willReturn(aResponse()
-							.withStatus(200)));
+				.willReturn(aResponse()
+					.withStatus(200)));
 
 			InfluxdbReporter reporter = (InfluxdbReporter) metricRegistry.getReporters().get(0);
 			reporter.report();


### PR DESCRIPTION
## What is the purpose of the change

* Support optional retention policy for InfluxDB metric reporter (currently only default is allowed)

## Brief change log

* Added support for retention policy specification for InfluxDB metrics reporter along with supporting tests and documentation.

## Verifying this change

This change added tests and can be verified as follows:

* Running the unit test suite

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs