### PR TITLE
[hotfix][utils] Replace implemented FutureUtils#toJava with lib method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
@@ -21,10 +21,8 @@ package org.apache.flink.runtime.concurrent;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
-import scala.concurrent.ExecutionContext;
-
 /**
- * Collection of {@link Executor}, {@link ExecutorService} and {@link ExecutionContext} implementations.
+ * Collection of {@link Executor} and {@link ExecutorService} implementations.
  */
 public class Executors {
 
@@ -50,38 +48,4 @@ public class Executors {
 		return new DirectExecutorService();
 	}
 
-	/**
-	 * Return a direct execution context. The direct execution context executes the runnable directly
-	 * in the calling thread.
-	 *
-	 * @return Direct execution context.
-	 */
-	public static ExecutionContext directExecutionContext() {
-		return DirectExecutionContext.INSTANCE;
-	}
-
-	/**
-	 * Direct execution context.
-	 */
-	private static class DirectExecutionContext implements ExecutionContext {
-
-		static final DirectExecutionContext INSTANCE = new DirectExecutionContext();
-
-		private DirectExecutionContext() {}
-
-		@Override
-		public void execute(Runnable runnable) {
-			runnable.run();
-		}
-
-		@Override
-		public void reportFailure(Throwable cause) {
-			throw new IllegalStateException("Error in direct execution context.", cause);
-		}
-
-		@Override
-		public ExecutionContext prepare() {
-			return this;
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -26,8 +26,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.util.function.SupplierWithException;
 
-import akka.dispatch.OnComplete;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -807,20 +805,8 @@ public class FutureUtils {
 	 * @return Java 8 CompletableFuture
 	 */
 	public static <T, U extends T> CompletableFuture<T> toJava(Future<U> scalaFuture) {
-		final CompletableFuture<T> result = new CompletableFuture<>();
-
-		scalaFuture.onComplete(new OnComplete<U>() {
-			@Override
-			public void onComplete(Throwable failure, U success) {
-				if (failure != null) {
-					result.completeExceptionally(failure);
-				} else {
-					result.complete(success);
-				}
-			}
-		}, Executors.directExecutionContext());
-
-		return result;
+		//noinspection unchecked
+		return scala.compat.java8.FutureConverters.toJava((Future<T>) scalaFuture).toCompletableFuture();
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Replace implemented `FutureUtils#toJava` with scala's lib method.

## Brief change log

Replace `FutureUtils#toJava` with `scala.compat.java8.FutureConverters#toJava`.

For the unchecked upcast, ref https://github.com/scala/scala-java8-compat/pull/152 but it should be ok in this case.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol @GJL 
