### PR TITLE
[FLINK-12787][python] Allow to specify directory in option -pyfs

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -90,7 +90,7 @@ public abstract class ProgramOptions extends CommandLineOptions {
 			// -------------------------------transformed-------------------------------------------------------
 			// e.g. -py wordcount.py(CLI cmd) -----------> py wordcount.py(PythonDriver args)
 			// e.g. -py wordcount.py -pyfs file:///AAA.py,hdfs:///BBB.py --input in.txt --output out.txt(CLI cmd)
-			// 	-----> py wordcount.py pyfs file:///AAA.py,hdfs:///BBB.py --input in.txt --output out.txt(PythonDriver args)
+			// 	-----> -py wordcount.py -pyfs file:///AAA.py,hdfs:///BBB.py --input in.txt --output out.txt(PythonDriver args)
 			String[] newArgs;
 			int argIndex;
 			if (line.hasOption(PYFILES_OPTION.getOpt())) {
@@ -116,8 +116,8 @@ public abstract class ProgramOptions extends CommandLineOptions {
 			}
 			// The cli cmd args which will be transferred to PythonDriver will be transformed as follows:
 			// CLI cmd : -pym ${py-module} -pyfs ${py-files} [optional] ${other args}.
-			// PythonDriver args: pym ${py-module} pyfs ${py-files} [optional] ${other args}.
-			// e.g. -pym AAA.fun -pyfs AAA.zip(CLI cmd) ----> pym AAA.fun -pyfs AAA.zip(PythonDriver args)
+			// PythonDriver args: -pym ${py-module} -pyfs ${py-files} [optional] ${other args}.
+			// e.g. -pym AAA.fun -pyfs AAA.zip(CLI cmd) ----> -pym AAA.fun -pyfs AAA.zip(PythonDriver args)
 			String[] newArgs = new String[args.length + 4];
 			newArgs[0] = "-" + PYMODULE_OPTION.getOpt();
 			newArgs[1] = line.getOptionValue(PYMODULE_OPTION.getOpt());

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -95,14 +95,14 @@ public abstract class ProgramOptions extends CommandLineOptions {
 			int argIndex;
 			if (line.hasOption(PYFILES_OPTION.getOpt())) {
 				newArgs = new String[args.length + 4];
-				newArgs[2] = PYFILES_OPTION.getOpt();
+				newArgs[2] = "-" + PYFILES_OPTION.getOpt();
 				newArgs[3] = line.getOptionValue(PYFILES_OPTION.getOpt());
 				argIndex = 4;
 			} else {
 				newArgs = new String[args.length + 2];
 				argIndex = 2;
 			}
-			newArgs[0] = PY_OPTION.getOpt();
+			newArgs[0] = "-" + PY_OPTION.getOpt();
 			newArgs[1] = line.getOptionValue(PY_OPTION.getOpt());
 			System.arraycopy(args, 0, newArgs, argIndex, args.length);
 			args = newArgs;
@@ -119,9 +119,9 @@ public abstract class ProgramOptions extends CommandLineOptions {
 			// PythonDriver args: pym ${py-module} pyfs ${py-files} [optional] ${other args}.
 			// e.g. -pym AAA.fun -pyfs AAA.zip(CLI cmd) ----> pym AAA.fun -pyfs AAA.zip(PythonDriver args)
 			String[] newArgs = new String[args.length + 4];
-			newArgs[0] = PYMODULE_OPTION.getOpt();
+			newArgs[0] = "-" + PYMODULE_OPTION.getOpt();
 			newArgs[1] = line.getOptionValue(PYMODULE_OPTION.getOpt());
-			newArgs[2] = PYFILES_OPTION.getOpt();
+			newArgs[2] = "-" + PYFILES_OPTION.getOpt();
 			newArgs[3] = line.getOptionValue(PYFILES_OPTION.getOpt());
 			System.arraycopy(args, 0, newArgs, 4, args.length);
 			args = newArgs;

--- a/flink-python/src/main/java/org/apache/flink/python/client/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/python/client/PythonDriver.java
@@ -18,7 +18,8 @@
 
 package org.apache.flink.python.client;
 
-import org.apache.flink.core.fs.Path;
+import org.apache.flink.client.program.OptimizerPlanEnvironment;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,11 +27,7 @@ import py4j.GatewayServer;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * A main class used to launch Python applications. It executes python as a
@@ -47,19 +44,29 @@ public class PythonDriver {
 			LOG.error("Required at least two arguments, only python file or python module is available.");
 			System.exit(1);
 		}
+
 		// parse args
-		Map<String, List<String>> parsedArgs = parseOptions(args);
+		final CommandLineParser<PythonDriverOptions> commandLineParser = new CommandLineParser<>(
+			new PythonDriverOptionsParserFactory());
+		PythonDriverOptions pythonDriverOptions = null;
+		try {
+			pythonDriverOptions = commandLineParser.parse(args);
+		} catch (Exception e) {
+			LOG.error("Could not parse command line arguments {}.", args, e);
+			commandLineParser.printHelp(PythonDriver.class.getSimpleName());
+			System.exit(1);
+		}
+
 		// start gateway server
 		GatewayServer gatewayServer = startGatewayServer();
 		// prepare python env
 
-		// map filename to its Path
-		Map<String, Path> filePathMap = new HashMap<>();
 		// commands which will be exec in python progress.
-		List<String> commands = constructPythonCommands(filePathMap, parsedArgs);
+		final List<String> commands = constructPythonCommands(pythonDriverOptions);
 		try {
 			// prepare the exec environment of python progress.
-			PythonEnvUtils.PythonEnvironment pythonEnv = PythonEnvUtils.preparePythonEnvironment(filePathMap);
+			PythonEnvUtils.PythonEnvironment pythonEnv = PythonEnvUtils.preparePythonEnvironment(
+				pythonDriverOptions.getPythonLibFiles());
 			// set env variable PYFLINK_GATEWAY_PORT for connecting of python gateway in python progress.
 			pythonEnv.systemEnv.put("PYFLINK_GATEWAY_PORT", String.valueOf(gatewayServer.getListeningPort()));
 			// start the python process.
@@ -70,6 +77,10 @@ public class PythonDriver {
 			}
 		} catch (Throwable e) {
 			LOG.error("Run python process failed", e);
+
+			// throw ProgramAbortException if the caller is interested in the program plan,
+			// there is no harm to throw ProgramAbortException even if it is not the case.
+			throw new OptimizerPlanEnvironment.ProgramAbortException();
 		} finally {
 			gatewayServer.shutdown();
 		}
@@ -80,7 +91,7 @@ public class PythonDriver {
 	 *
 	 * @return The created GatewayServer
 	 */
-	public static GatewayServer startGatewayServer() {
+	static GatewayServer startGatewayServer() {
 		InetAddress localhost = InetAddress.getLoopbackAddress();
 		GatewayServer gatewayServer = new GatewayServer.GatewayServerBuilder()
 			.javaPort(0)
@@ -102,67 +113,13 @@ public class PythonDriver {
 	/**
 	 * Constructs the Python commands which will be executed in python process.
 	 *
-	 * @param filePathMap stores python file name to its path
-	 * @param parsedArgs  parsed args
+	 * @param pythonDriverOptions parsed Python command options
 	 */
-	public static List<String> constructPythonCommands(Map<String, Path> filePathMap, Map<String, List<String>> parsedArgs) {
-		List<String> commands = new ArrayList<>();
-		if (parsedArgs.containsKey("py")) {
-			String pythonFile = parsedArgs.get("py").get(0);
-			Path pythonFilePath = new Path(pythonFile);
-			filePathMap.put(pythonFilePath.getName(), pythonFilePath);
-			commands.add(pythonFilePath.getName());
-		}
-		if (parsedArgs.containsKey("pym")) {
-			String pyModule = parsedArgs.get("pym").get(0);
-			commands.add("-m");
-			commands.add(pyModule);
-		}
-		if (parsedArgs.containsKey("pyfs")) {
-			List<String> pyFiles = parsedArgs.get("pyfs");
-			for (String pyFile : pyFiles) {
-				Path pyFilePath = new Path(pyFile);
-				filePathMap.put(pyFilePath.getName(), pyFilePath);
-			}
-		}
-		if (parsedArgs.containsKey("args")) {
-			commands.addAll(parsedArgs.get("args"));
-		}
+	static List<String> constructPythonCommands(final PythonDriverOptions pythonDriverOptions) {
+		final List<String> commands = new ArrayList<>();
+		commands.add("-m");
+		commands.add(pythonDriverOptions.getEntrypointModule());
+		commands.addAll(pythonDriverOptions.getProgramArgs());
 		return commands;
-	}
-
-	/**
-	 * Parses the args to the map format.
-	 *
-	 * @param args ["py", "xxx.py",
-	 *             "pyfs", "a.py,b.py,c.py",
-	 *             "--input", "in.txt"]
-	 * @return {"py"->List("xxx.py"),"pyfs"->List("a.py","b.py","c.py"),"args"->List("--input","in.txt")}
-	 */
-	public static Map<String, List<String>> parseOptions(String[] args) {
-		Map<String, List<String>> parsedArgs = new HashMap<>();
-		int argIndex = 0;
-		boolean isEntrypointSpecified = false;
-		// valid args should include python or pyModule field and their value.
-		if (args[0].equals("py") || args[0].equals("pym")) {
-			parsedArgs.put(args[0], Collections.singletonList(args[1]));
-			argIndex = 2;
-			isEntrypointSpecified = true;
-		}
-		if (isEntrypointSpecified && args.length > 2 && args[2].equals("pyfs")) {
-			List<String> pyFilesList = new ArrayList<>(Arrays.asList(args[3].split(",")));
-			parsedArgs.put(args[2], pyFilesList);
-			argIndex = 4;
-		}
-		if (!isEntrypointSpecified) {
-			throw new RuntimeException("The Python entrypoint has not been specified. It can be specified with option -py or -pym");
-		}
-		// if arg include other args, the key "args" will map to other args.
-		if (args.length > argIndex) {
-			List<String> otherArgList = new ArrayList<>(args.length - argIndex);
-			otherArgList.addAll(Arrays.asList(args).subList(argIndex, args.length));
-			parsedArgs.put("args", otherArgList);
-		}
-		return parsedArgs;
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/python/client/PythonDriverOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/client/PythonDriverOptions.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.client;
+
+import org.apache.flink.core.fs.Path;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Options for the {@link PythonDriver}.
+ */
+final class PythonDriverOptions {
+
+	@Nonnull
+	private String entrypointModule;
+
+	@Nonnull
+	private List<Path> pythonLibFiles;
+
+	@Nonnull
+	private List<String> programArgs;
+
+	PythonDriverOptions(String entrypointModule, List<Path> pythonLibFiles, List<String> programArgs) {
+		this.entrypointModule = requireNonNull(entrypointModule, "entrypointModule");
+		this.pythonLibFiles = requireNonNull(pythonLibFiles, "pythonLibFiles");
+		this.programArgs = requireNonNull(programArgs, "programArgs");
+	}
+
+	@Nonnull
+	String getEntrypointModule() {
+		return entrypointModule;
+	}
+
+	@Nonnull
+	List<Path> getPythonLibFiles() {
+		return pythonLibFiles;
+	}
+
+	@Nonnull
+	List<String> getProgramArgs() {
+		return programArgs;
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/python/client/PythonDriverOptionsParserFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/python/client/PythonDriverOptionsParserFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.client;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Parser factory which generates a {@link PythonDriverOptions} from a given
+ * list of command line arguments.
+ */
+final class PythonDriverOptionsParserFactory implements ParserResultFactory<PythonDriverOptions> {
+
+	private static final Option PY_OPTION = Option.builder("py")
+		.longOpt("python")
+		.required(false)
+		.hasArg(true)
+		.argName("entrypoint python file")
+		.desc("Python script with the program entry point. " +
+			"The dependent resources can be configured with the `--pyFiles` option.")
+		.build();
+
+	private static final Option PYMODULE_OPTION = Option.builder("pym")
+		.longOpt("pyModule")
+		.required(false)
+		.hasArg(true)
+		.argName("entrypoint module name")
+		.desc("Python module with the program entry point. " +
+			"This option must be used in conjunction with `--pyFiles`.")
+		.build();
+
+	private static final Option PYFILES_OPTION = Option.builder("pyfs")
+		.longOpt("pyFiles")
+		.required(false)
+		.hasArg(true)
+		.argName("entrypoint python file")
+		.desc("Attach custom python files for job. " +
+			"Comma can be used as the separator to specify multiple files. " +
+			"The standard python resource file suffixes such as .py/.egg/.zip are all supported." +
+			"(eg: --pyFiles file:///tmp/myresource.zip,hdfs:///$namenode_address/myresource2.zip)")
+		.build();
+
+	@Override
+	public Options getOptions() {
+		final Options options = new Options();
+		options.addOption(PY_OPTION);
+		options.addOption(PYMODULE_OPTION);
+		options.addOption(PYFILES_OPTION);
+		return options;
+	}
+
+	@Override
+	public PythonDriverOptions createResult(@Nonnull CommandLine commandLine) throws FlinkParseException {
+		String entrypointModule = null;
+		final List<Path> pythonLibFiles = new ArrayList<>();
+
+		if (commandLine.hasOption(PY_OPTION.getOpt()) && commandLine.hasOption(PYMODULE_OPTION.getOpt())) {
+			throw new FlinkParseException("Cannot use options -py and -pym simultaneously.");
+		} else if (commandLine.hasOption(PY_OPTION.getOpt())) {
+			Path file = new Path(commandLine.getOptionValue(PY_OPTION.getOpt()));
+			String fileName = file.getName();
+			if (fileName.endsWith(".py")) {
+				entrypointModule = fileName.substring(0, fileName.length() - 3);
+				pythonLibFiles.add(file);
+			}
+		} else if (commandLine.hasOption(PYMODULE_OPTION.getOpt())) {
+			entrypointModule = commandLine.getOptionValue(PYMODULE_OPTION.getOpt());
+		} else {
+			throw new FlinkParseException(
+				"The Python entrypoint has not been specified. It can be specified with options -py or -pym");
+		}
+
+		if (commandLine.hasOption(PYFILES_OPTION.getOpt())) {
+			pythonLibFiles.addAll(
+				Arrays.stream(commandLine.getOptionValue(PYFILES_OPTION.getOpt()).split(","))
+					.map(Path::new)
+					.collect(Collectors.toCollection(ArrayList::new)));
+		} else if (commandLine.hasOption(PYMODULE_OPTION.getOpt())) {
+			throw new FlinkParseException("Option -pym must be used in conjunction with `--pyFiles`");
+		}
+
+		return new PythonDriverOptions(entrypointModule, pythonLibFiles, commandLine.getArgList());
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/python/client/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/client/PythonEnvUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -38,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * The util class help to prepare Python env and run the python process.
@@ -89,10 +92,10 @@ public final class PythonEnvUtils {
 	/**
 	 * Prepares PythonEnvironment to start python process.
 	 *
-	 * @param filePathMap map file name to its file path.
+	 * @param pythonLibFiles The dependent Python files.
 	 * @return PythonEnvironment the Python environment which will be executed in Python process.
 	 */
-	public static PythonEnvironment preparePythonEnvironment(Map<String, Path> filePathMap) {
+	public static PythonEnvironment preparePythonEnvironment(List<Path> pythonLibFiles) throws IOException {
 		PythonEnvironment env = new PythonEnvironment();
 
 		// 1. setup temporary local directory for the user files
@@ -100,15 +103,11 @@ public final class PythonEnvUtils {
 			File.separator + "pyflink" + File.separator + UUID.randomUUID();
 
 		Path tmpDirPath = new Path(tmpDir);
-		try {
-			FileSystem fs = tmpDirPath.getFileSystem();
-			if (fs.exists(tmpDirPath)) {
-				fs.delete(tmpDirPath, true);
-			}
-			fs.mkdirs(tmpDirPath);
-		} catch (IOException e) {
-			LOG.error("Prepare tmp directory failed.", e);
+		FileSystem fs = tmpDirPath.getFileSystem();
+		if (fs.exists(tmpDirPath)) {
+			fs.delete(tmpDirPath, true);
 		}
+		fs.mkdirs(tmpDirPath);
 
 		env.workingDirectory = tmpDirPath.toString();
 
@@ -127,18 +126,29 @@ public final class PythonEnvUtils {
 		}
 
 		// 3. copy relevant python files to tmp dir and set them in PYTHONPATH.
-		filePathMap.forEach((sourceFileName, sourcePath) -> {
+		for (Path pythonFile : pythonLibFiles) {
+			String sourceFileName = pythonFile.getName();
 			Path targetPath = new Path(tmpDirPath, sourceFileName);
-			try {
-				FileUtils.copy(sourcePath, targetPath, true);
-			} catch (IOException e) {
-				LOG.error("Copy files to tmp dir failed", e);
-			}
-			String targetFileName = targetPath.toString();
+			FileUtils.copy(pythonFile, targetPath, true);
+			String targetFileNames = Files.walk(Paths.get(targetPath.toString()))
+				.filter(Files::isRegularFile)
+				.map(java.nio.file.Path::toString)
+				.collect(Collectors.joining(File.pathSeparator));
 			pythonPathEnv.append(File.pathSeparator);
-			pythonPathEnv.append(targetFileName);
+			pythonPathEnv.append(targetFileNames);
+		}
 
-		});
+		// 4. add the parent directory to PYTHONPATH for files suffixed with .py
+		String pyFileParents = Files.walk(Paths.get(tmpDirPath.toString()))
+			.filter(file -> file.toString().endsWith(".py"))
+			.map(java.nio.file.Path::getParent)
+			.distinct()
+			.map(java.nio.file.Path::toString)
+			.collect(Collectors.joining(File.pathSeparator));
+		if (!StringUtils.isNullOrWhitespaceOnly(pyFileParents)) {
+			pythonPathEnv.append(File.pathSeparator);
+			pythonPathEnv.append(pyFileParents);
+		}
 
 		env.pythonPath = pythonPathEnv.toString();
 		return env;
@@ -175,17 +185,14 @@ public final class PythonEnvUtils {
 	 * @param libPath          the pyflink lib file path.
 	 * @param symbolicLinkPath the symbolic link to pyflink lib.
 	 */
-	public static void createSymbolicLinkForPyflinkLib(java.nio.file.Path libPath, java.nio.file.Path symbolicLinkPath) {
+	public static void createSymbolicLinkForPyflinkLib(java.nio.file.Path libPath, java.nio.file.Path symbolicLinkPath)
+			throws IOException {
 		try {
 			Files.createSymbolicLink(symbolicLinkPath, libPath);
 		} catch (IOException e) {
 			LOG.error("Create symbol link for pyflink lib failed.", e);
 			LOG.info("Try to copy pyflink lib to working directory");
-			try {
-				Files.copy(libPath, symbolicLinkPath);
-			} catch (IOException ex) {
-				LOG.error("Copy pylink lib to working directory failed", ex);
-			}
+			Files.copy(libPath, symbolicLinkPath);
 		}
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/python/client/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/client/PythonEnvUtils.java
@@ -132,6 +132,7 @@ public final class PythonEnvUtils {
 			FileUtils.copy(pythonFile, targetPath, true);
 			String targetFileNames = Files.walk(Paths.get(targetPath.toString()))
 				.filter(Files::isRegularFile)
+				.filter(f -> !f.toString().endsWith(".py"))
 				.map(java.nio.file.Path::toString)
 				.collect(Collectors.joining(File.pathSeparator));
 			pythonPathEnv.append(File.pathSeparator);

--- a/flink-python/src/test/java/org/apache/flink/python/client/PythonDriverOptionsParserFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/client/PythonDriverOptionsParserFactoryTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.client;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for the {@link PythonDriverOptionsParserFactory}.
+ */
+public class PythonDriverOptionsParserFactoryTest {
+
+	private static final CommandLineParser<PythonDriverOptions> commandLineParser = new CommandLineParser<>(
+		new PythonDriverOptionsParserFactory());
+
+	@Test
+	public void testPythonDriverOptionsParsing() throws FlinkParseException {
+		final String[] args = {"--python", "xxx.py", "--pyFiles", "a.py,b.py,c.py", "--input", "in.txt"};
+		verifyPythonDriverOptionsParsing(args);
+	}
+
+	@Test
+	public void testPymoduleOptionParsing() throws FlinkParseException {
+		final String[] args = {"--pyModule", "xxx", "--pyFiles", "xxx.py,a.py,b.py,c.py", "--input", "in.txt"};
+		verifyPythonDriverOptionsParsing(args);
+	}
+
+	@Test
+	public void testShortOptions() throws FlinkParseException {
+		final String[] args = {"-py", "xxx.py", "-pyfs", "a.py,b.py,c.py", "--input", "in.txt"};
+		verifyPythonDriverOptionsParsing(args);
+	}
+
+	@Test(expected = FlinkParseException.class)
+	public void testMultipleEntrypointsSpecified() throws FlinkParseException {
+		final String[] args = {
+			"--python", "xxx.py", "--pyModule", "yyy", "--pyFiles", "a.py,b.py,c.py", "--input", "in.txt"};
+		commandLineParser.parse(args);
+	}
+
+	@Test(expected = FlinkParseException.class)
+	public void testEntrypointNotSpecified() throws FlinkParseException {
+		final String[] args = {"--pyFiles", "a.py,b.py,c.py", "--input", "in.txt"};
+		commandLineParser.parse(args);
+	}
+
+	@Test(expected = FlinkParseException.class)
+	public void testPyFilesNotSpecified() throws FlinkParseException {
+		final String[] args = {"--pyModule", "yyy", "--input", "in.txt"};
+		commandLineParser.parse(args);
+	}
+
+	private void verifyPythonDriverOptionsParsing(final String[] args) throws FlinkParseException {
+		final PythonDriverOptions pythonCommandOptions = commandLineParser.parse(args);
+
+		// verify the parsed python entrypoint module
+		assertEquals("xxx", pythonCommandOptions.getEntrypointModule());
+
+		// verify the parsed python library files
+		final List<Path> pythonMainFile = pythonCommandOptions.getPythonLibFiles();
+		assertNotNull(pythonMainFile);
+		assertEquals(4, pythonMainFile.size());
+		assertEquals(
+			pythonMainFile.stream().map(Path::getName).collect(Collectors.joining(",")),
+			"xxx.py,a.py,b.py,c.py");
+
+		// verify the python program arguments
+		final List<String> programArgs = pythonCommandOptions.getProgramArgs();
+		assertEquals(2, programArgs.size());
+		assertEquals("--input", programArgs.get(0));
+		assertEquals("in.txt", programArgs.get(1));
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/python/client/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/client/PythonDriverTest.java
@@ -27,10 +27,7 @@ import py4j.GatewayServer;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Tests for the {@link PythonDriver}.
@@ -51,54 +48,22 @@ public class PythonDriverTest {
 
 	@Test
 	public void testConstructCommands() {
-		Map<String, Path> filePathMap = new HashMap<>();
-		Map<String, List<String>> parseArgs = new HashMap<>();
-		parseArgs.put("py", Collections.singletonList("xxx.py"));
-		List<String> pyFilesList = new ArrayList<>();
-		pyFilesList.add("a.py");
-		pyFilesList.add("b.py");
-		pyFilesList.add("c.py");
-		parseArgs.put("pyfs", pyFilesList);
-		List<String> otherArgs = new ArrayList<>();
-		otherArgs.add("--input");
-		otherArgs.add("in.txt");
-		parseArgs.put("args", otherArgs);
-		List<String> commands = PythonDriver.constructPythonCommands(filePathMap, parseArgs);
-		Path pythonPath = filePathMap.get("xxx.py");
-		Assert.assertNotNull(pythonPath);
-		Assert.assertEquals(pythonPath.getName(), "xxx.py");
-		Path aPyFilePath = filePathMap.get("a.py");
-		Assert.assertNotNull(aPyFilePath);
-		Assert.assertEquals(aPyFilePath.getName(), "a.py");
-		Path bPyFilePath = filePathMap.get("b.py");
-		Assert.assertNotNull(bPyFilePath);
-		Assert.assertEquals(bPyFilePath.getName(), "b.py");
-		Path cPyFilePath = filePathMap.get("c.py");
-		Assert.assertNotNull(cPyFilePath);
-		Assert.assertEquals(cPyFilePath.getName(), "c.py");
-		Assert.assertEquals(3, commands.size());
-		Assert.assertEquals(commands.get(0), "xxx.py");
-		Assert.assertEquals(commands.get(1), "--input");
-		Assert.assertEquals(commands.get(2), "in.txt");
-	}
+		List<Path> pyFilesList = new ArrayList<>();
+		pyFilesList.add(new Path("a.py"));
+		pyFilesList.add(new Path("b.py"));
+		pyFilesList.add(new Path("c.py"));
+		List<String> args = new ArrayList<>();
+		args.add("--input");
+		args.add("in.txt");
 
-	@Test
-	public void testParseOptions() {
-		String[] args = {"py", "xxx.py", "pyfs", "a.py,b.py,c.py", "--input", "in.txt"};
-		Map<String, List<String>> parsedArgs = PythonDriver.parseOptions(args);
-		List<String> pythonMainFile = parsedArgs.get("py");
-		Assert.assertNotNull(pythonMainFile);
-		Assert.assertEquals(1, pythonMainFile.size());
-		Assert.assertEquals(pythonMainFile.get(0), args[1]);
-		List<String> pyFilesList = parsedArgs.get("pyfs");
-		Assert.assertEquals(3, pyFilesList.size());
-		String[] pyFiles = args[3].split(",");
-		for (int i = 0; i < pyFiles.length; i++) {
-			assert pyFilesList.get(i).equals(pyFiles[i]);
-		}
-		List<String> otherArgs = parsedArgs.get("args");
-		for (int i = 4; i < args.length; i++) {
-			Assert.assertEquals(otherArgs.get(i - 4), args[i]);
-		}
+		PythonDriverOptions pythonDriverOptions = new PythonDriverOptions(
+			"xxx", pyFilesList, args);
+		List<String> commands = PythonDriver.constructPythonCommands(pythonDriverOptions);
+		// verify the generated commands
+		Assert.assertEquals(4, commands.size());
+		Assert.assertEquals(commands.get(0), "-m");
+		Assert.assertEquals(commands.get(1), "xxx");
+		Assert.assertEquals(commands.get(2), "--input");
+		Assert.assertEquals(commands.get(3), "in.txt");
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/python/client/PythonEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/client/PythonEnvUtilsTest.java
@@ -31,7 +31,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -74,7 +77,7 @@ public class PythonEnvUtilsTest {
 		pyFilesList.add(tmpDirPath);
 
 		PythonEnvUtils.PythonEnvironment env = PythonEnvUtils.preparePythonEnvironment(pyFilesList);
-		List<String> expectedPythonPaths = new ArrayList<>();
+		Set<String> expectedPythonPaths = new HashSet<>();
 		expectedPythonPaths.add(env.workingDirectory);
 
 		String targetDir = env.workingDirectory + File.separator + tmpDirPath.getName();
@@ -84,7 +87,7 @@ public class PythonEnvUtilsTest {
 
 		// the parent dir for files suffixed with .py should also be added to PYTHONPATH
 		expectedPythonPaths.add(targetDir + File.separator + "subdir");
-		Assert.assertEquals(String.join(File.pathSeparator, expectedPythonPaths), env.pythonPath);
+		Assert.assertEquals(expectedPythonPaths, new HashSet<>(Arrays.asList(env.pythonPath.split(File.pathSeparator))));
 	}
 
 	@Test

--- a/flink-python/src/test/java/org/apache/flink/python/client/PythonEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/client/PythonEnvUtilsTest.java
@@ -82,7 +82,6 @@ public class PythonEnvUtilsTest {
 
 		String targetDir = env.workingDirectory + File.separator + tmpDirPath.getName();
 		expectedPythonPaths.add(targetDir + File.separator + a.getName());
-		expectedPythonPaths.add(targetDir + File.separator + "subdir" + File.separator + b.getName());
 		expectedPythonPaths.add(targetDir + File.separator + "subdir" + File.separator + c.getName());
 
 		// the parent dir for files suffixed with .py should also be added to PYTHONPATH

--- a/flink-python/src/test/java/org/apache/flink/python/client/PythonEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/client/PythonEnvUtilsTest.java
@@ -38,45 +38,64 @@ import java.util.UUID;
  * Tests for the {@link PythonEnvUtils}.
  */
 public class PythonEnvUtilsTest {
-	private Path sourceTmpDirPath;
-	private Path targetTmpDirPath;
-	private FileSystem sourceFs;
-	private FileSystem targetFs;
+	private Path tmpDirPath;
+	private FileSystem tmpDirFs;
 
 	@Before
 	public void prepareTestEnvironment() {
-		String sourceTmpDir = System.getProperty("java.io.tmpdir") +
-			File.separator + "source_" + UUID.randomUUID();
-		String targetTmpDir = System.getProperty("java.io.tmpdir") +
-			File.separator + "target_" + UUID.randomUUID();
+		String tmpDir = System.getProperty("java.io.tmpdir") +
+			File.separator + "pyflink" + File.separator + UUID.randomUUID();
 
-		sourceTmpDirPath = new Path(sourceTmpDir);
-		targetTmpDirPath = new Path(targetTmpDir);
+		tmpDirPath = new Path(tmpDir);
 		try {
-			sourceFs = sourceTmpDirPath.getFileSystem();
-			if (sourceFs.exists(sourceTmpDirPath)) {
-				sourceFs.delete(sourceTmpDirPath, true);
+			tmpDirFs = tmpDirPath.getFileSystem();
+			if (tmpDirFs.exists(tmpDirPath)) {
+				tmpDirFs.delete(tmpDirPath, true);
 			}
-			sourceFs.mkdirs(sourceTmpDirPath);
-			targetFs = targetTmpDirPath.getFileSystem();
-			if (targetFs.exists(targetTmpDirPath)) {
-				targetFs.delete(targetTmpDirPath, true);
-			}
-			targetFs.mkdirs(targetTmpDirPath);
+			tmpDirFs.mkdirs(tmpDirPath);
 		} catch (IOException e) {
 			throw new RuntimeException("initial PythonUtil test environment failed");
 		}
 	}
 
 	@Test
+	public void testPreparePythonEnvironment() throws IOException {
+		// xxx/a.zip, xxx/subdir/b.py, xxx/subdir/c.zip
+		File a = new File(tmpDirPath.toString() + File.separator + "a.zip");
+		a.createNewFile();
+		File subdir = new File(tmpDirPath.toString() + File.separator + "subdir");
+		subdir.mkdir();
+		File b = new File(tmpDirPath.toString() + File.separator + "subdir" + File.separator + "b.py");
+		b.createNewFile();
+		File c = new File(tmpDirPath.toString() + File.separator + "subdir" + File.separator + "c.zip");
+		c.createNewFile();
+
+		List<Path> pyFilesList = new ArrayList<>();
+		pyFilesList.add(tmpDirPath);
+
+		PythonEnvUtils.PythonEnvironment env = PythonEnvUtils.preparePythonEnvironment(pyFilesList);
+		List<String> expectedPythonPaths = new ArrayList<>();
+		expectedPythonPaths.add(env.workingDirectory);
+
+		String targetDir = env.workingDirectory + File.separator + tmpDirPath.getName();
+		expectedPythonPaths.add(targetDir + File.separator + a.getName());
+		expectedPythonPaths.add(targetDir + File.separator + "subdir" + File.separator + b.getName());
+		expectedPythonPaths.add(targetDir + File.separator + "subdir" + File.separator + c.getName());
+
+		// the parent dir for files suffixed with .py should also be added to PYTHONPATH
+		expectedPythonPaths.add(targetDir + File.separator + "subdir");
+		Assert.assertEquals(String.join(File.pathSeparator, expectedPythonPaths), env.pythonPath);
+	}
+
+	@Test
 	public void testStartPythonProcess() {
 		PythonEnvUtils.PythonEnvironment pythonEnv = new PythonEnvUtils.PythonEnvironment();
-		pythonEnv.workingDirectory = targetTmpDirPath.toString();
-		pythonEnv.pythonPath = targetTmpDirPath.toString();
+		pythonEnv.workingDirectory = tmpDirPath.toString();
+		pythonEnv.pythonPath = tmpDirPath.toString();
 		List<String> commands = new ArrayList<>();
-		Path pyPath = new Path(targetTmpDirPath, "word_count.py");
+		Path pyPath = new Path(tmpDirPath, "word_count.py");
 		try {
-			targetFs.create(pyPath, FileSystem.WriteMode.OVERWRITE);
+			tmpDirFs.create(pyPath, FileSystem.WriteMode.OVERWRITE);
 			File pyFile = new File(pyPath.toString());
 			String pyProgram = "#!/usr/bin/python\n" +
 				"# -*- coding: UTF-8 -*-\n" +
@@ -88,7 +107,7 @@ public class PythonEnvUtilsTest {
 				"\tfo.write( \"hello world\")\n" +
 				"\tfo.close()";
 			Files.write(pyFile.toPath(), pyProgram.getBytes(), StandardOpenOption.WRITE);
-			Path result = new Path(targetTmpDirPath, "word_count_result.txt");
+			Path result = new Path(tmpDirPath, "word_count_result.txt");
 			commands.add(pyFile.getName());
 			commands.add(result.getName());
 			Process pythonProcess = PythonEnvUtils.startPythonProcess(pythonEnv, commands);
@@ -99,8 +118,8 @@ public class PythonEnvUtilsTest {
 			String cmdResult = new String(Files.readAllBytes(new File(result.toString()).toPath()));
 			Assert.assertEquals(cmdResult, "hello world");
 			pythonProcess.destroyForcibly();
-			targetFs.delete(pyPath, true);
-			targetFs.delete(result, true);
+			tmpDirFs.delete(pyPath, true);
+			tmpDirFs.delete(result, true);
 		} catch (IOException | InterruptedException e) {
 			throw new RuntimeException("test start Python process failed " + e.getMessage());
 		}
@@ -109,8 +128,7 @@ public class PythonEnvUtilsTest {
 	@After
 	public void cleanEnvironment() {
 		try {
-			sourceFs.delete(sourceTmpDirPath, true);
-			targetFs.delete(targetTmpDirPath, true);
+			tmpDirFs.delete(tmpDirPath, true);
 		} catch (IOException e) {
 			throw new RuntimeException("delete tmp dir failed " + e.getMessage());
 		}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add support to allow to specify directory in option `-pyfs`*

## Brief change log

  - *Add support to allow to specify directory in option `-pyfs`*
  - *Improve PythonDriver to use CommandLineParser for the arguments parsing*

## Verifying this change

This change added tests and can be verified as follows:

  - *Existing tests in PythonDriverTest*
  - *Added tests in PythonDriverOptionsParserFactoryTest and PythonEnvUtilsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
