### PR TITLE
[FLINK-12789][table][fix] Fix java docs in UserDefinedAggregateFunction

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedAggregateFunction.java
@@ -28,17 +28,18 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 public abstract class UserDefinedAggregateFunction<T, ACC> extends UserDefinedFunction {
 
 	/**
-	 * Creates and initializes the accumulator for this {@link AggregateFunction}. The accumulator
-	 * is used to keep the aggregated values which are needed to compute an aggregation result.
+	 * Creates and initializes the accumulator for this {@link UserDefinedAggregateFunction}. The
+	 * accumulator is used to keep the aggregated values which are needed to compute an aggregation
+	 * result.
 	 *
 	 * @return the accumulator with the initial value
 	 */
 	public abstract ACC createAccumulator();
 
 	/**
-	 * Returns the {@link TypeInformation} of the {@link AggregateFunction}'s result.
+	 * Returns the {@link TypeInformation} of the {@link UserDefinedAggregateFunction}'s result.
 	 *
-	 * @return The {@link TypeInformation} of the {@link AggregateFunction}'s result or
+	 * @return The {@link TypeInformation} of the {@link UserDefinedAggregateFunction}'s result or
 	 *         <code>null</code> if the result type should be automatically inferred.
 	 */
 	public TypeInformation<T> getResultType() {
@@ -46,10 +47,10 @@ public abstract class UserDefinedAggregateFunction<T, ACC> extends UserDefinedFu
 	}
 
 	/**
-	 * Returns the {@link TypeInformation} of the {@link AggregateFunction}'s accumulator.
+	 * Returns the {@link TypeInformation} of the {@link UserDefinedAggregateFunction}'s accumulator.
 	 *
-	 * @return The {@link TypeInformation} of the {@link AggregateFunction}'s accumulator or
-	 *         <code>null</code> if the accumulator type should be automatically inferred.
+	 * @return The {@link TypeInformation} of the {@link UserDefinedAggregateFunction}'s accumulator
+	 *         or <code>null</code> if the accumulator type should be automatically inferred.
 	 */
 	public TypeInformation<ACC> getAccumulatorType() {
 		return null;


### PR DESCRIPTION

## What is the purpose of the change

This pull request fix java docs in `UserDefinedAggregateFunction`.

We use UserDefinedAggregateFunction as the base class for TableAggregateFunction and AggregateFunction. However, the java docs in UserDefinedAggregateFunction are only dedicated for AggregateFunction. 


## Brief change log

  - Change all java docs about `AggregateFunction` to `UserDefinedAggregateFunction` in `UserDefinedAggregateFunction`.


## Verifying this change

This change is a hotfix for java docs.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

