### PR TITLE
[FLINK-12706] Introduce ShuffleService interface and its configuration

### DIFF
--- a/docs/_includes/generated/shuffle_service_configuration.html
+++ b/docs/_includes/generated/shuffle_service_configuration.html
@@ -1,0 +1,16 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>shuffle-service-factory.class</h5></td>
+            <td style="word-wrap: break-word;">"org.apache.flink.runtime.io.network.NettyShuffleServiceFactory"</td>
+            <td>The full class name of the shuffle service factory implementation to be used by the cluster. The default implementation uses Netty for network communication and local memory as well disk space to store results on a TaskExecutor.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -132,6 +132,10 @@ The configuration keys in this section are independent of the used resource mana
 
 {% include generated/resource_manager_configuration.html %}
 
+### Shuffle Service
+
+{% include generated/shuffle_service_configuration.html %}
+
 ### YARN
 
 {% include generated/yarn_config_configuration.html %}

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -132,6 +132,10 @@ The configuration keys in this section are independent of the used resource mana
 
 {% include generated/resource_manager_configuration.html %}
 
+### Shuffle Service
+
+{% include generated/shuffle_service_configuration.html %}
+
 ### YARN
 
 {% include generated/yarn_config_configuration.html %}

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -338,13 +338,23 @@ public final class InstantiationUtil {
 	 * @param classLoader to use for loading the class
 	 * @param <T> type of the instantiated class
 	 * @return Instance of the given class name
-	 * @throws ClassNotFoundException if the class could not be found
+	 * @throws FlinkException if the class could not be found
 	 */
-	public static <T> T instantiate(final String className, final Class<T> targetType, final ClassLoader classLoader) throws ClassNotFoundException {
-		final Class<? extends T> clazz = Class.forName(
-			className,
-			false,
-			classLoader).asSubclass(targetType);
+	public static <T> T instantiate(final String className, final Class<T> targetType, final ClassLoader classLoader) throws FlinkException {
+		final Class<? extends T> clazz;
+		try {
+			clazz = Class.forName(
+				className,
+				false,
+				classLoader).asSubclass(targetType);
+		} catch (ClassNotFoundException e) {
+			throw new FlinkException(
+				String.format(
+					"Could not instantiate class '%s' of type '%s'. Please make sure that this class is on your class path.",
+					className,
+					targetType.getName()),
+				e);
+		}
 
 		return instantiate(clazz);
 	}

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -57,6 +57,7 @@ public class ConfigOptionsDocGenerator {
 
 	static final OptionsClassLocation[] LOCATIONS = new OptionsClassLocation[]{
 		new OptionsClassLocation("flink-core", "org.apache.flink.configuration"),
+		new OptionsClassLocation("flink-runtime", "org.apache.flink.runtime.shuffle"),
 		new OptionsClassLocation("flink-yarn", "org.apache.flink.yarn.configuration"),
 		new OptionsClassLocation("flink-mesos", "org.apache.flink.mesos.configuration"),
 		new OptionsClassLocation("flink-mesos", "org.apache.flink.mesos.runtime.clusterframework"),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
@@ -35,6 +35,8 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleServiceLoader;
 
 /**
  * Singleton default factory for {@link JobManagerRunner}.
@@ -58,6 +60,7 @@ public enum DefaultJobManagerRunnerFactory implements JobManagerRunnerFactory {
 		final SlotPoolFactory slotPoolFactory = DefaultSlotPoolFactory.fromConfiguration(configuration);
 		final SchedulerFactory schedulerFactory = DefaultSchedulerFactory.fromConfiguration(configuration);
 		final SchedulerNGFactory schedulerNGFactory = SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration, jobManagerServices.getRestartStrategyFactory());
+		final ShuffleMaster<?> shuffleMaster = ShuffleServiceLoader.loadShuffleServiceFactory(configuration).createShuffleMaster(configuration);
 
 		final JobMasterServiceFactory jobMasterFactory = new DefaultJobMasterServiceFactory(
 			jobMasterConfiguration,
@@ -69,7 +72,8 @@ public enum DefaultJobManagerRunnerFactory implements JobManagerRunnerFactory {
 			heartbeatServices,
 			jobManagerJobMetricGroupFactory,
 			fatalErrorHandler,
-			schedulerNGFactory);
+			schedulerNGFactory,
+			shuffleMaster);
 
 		return new JobManagerRunner(
 			jobGraph,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -303,7 +303,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	private String jsonPlan;
 
 	/** Shuffle master to register partitions for task deployment. */
-	private final ShuffleMaster<?> shuffleMaster = NettyShuffleMaster.INSTANCE;
+	private final ShuffleMaster<?> shuffleMaster;
 
 	// --------------------------------------------------------------------------------------------
 	//   Constructors
@@ -405,7 +405,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			slotProvider,
 			userClassLoader,
 			blobWriter,
-			allocationTimeout);
+			allocationTimeout,
+			NettyShuffleMaster.INSTANCE);
 	}
 
 	public ExecutionGraph(
@@ -419,7 +420,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			SlotProvider slotProvider,
 			ClassLoader userClassLoader,
 			BlobWriter blobWriter,
-			Time allocationTimeout) throws IOException {
+			Time allocationTimeout,
+			ShuffleMaster<?> shuffleMaster) throws IOException {
 
 		checkNotNull(futureExecutor);
 
@@ -466,6 +468,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor(
 				"ExecutionGraph is not initialized with proper main thread executor. " +
 					"Call to ExecutionGraph.start(...) required.");
+
+		this.shuffleMaster = checkNotNull(shuffleMaster);
 
 		LOG.info("Job recovers via failover strategy: {}", failoverStrategy.getStrategyName());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.util.DynamicCodeLoadingException;
@@ -92,8 +93,8 @@ public class ExecutionGraphBuilder {
 			MetricGroup metrics,
 			BlobWriter blobWriter,
 			Time allocationTimeout,
-			Logger log)
-		throws JobExecutionException, JobException {
+			Logger log,
+			ShuffleMaster<?> shuffleMaster) throws JobExecutionException, JobException {
 
 		checkNotNull(jobGraph, "job graph cannot be null");
 
@@ -129,7 +130,8 @@ public class ExecutionGraphBuilder {
 					slotProvider,
 					classLoader,
 					blobWriter,
-					allocationTimeout);
+					allocationTimeout,
+					shuffleMaster);
 		} catch (IOException e) {
 			throw new JobException("Could not create the ExecutionGraph.", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -164,20 +164,10 @@ public class HighAvailabilityServicesUtils {
 		final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 		final String haServicesClassName = config.getString(HighAvailabilityOptions.HA_MODE);
 
-		final HighAvailabilityServicesFactory highAvailabilityServicesFactory;
-
-		try {
-			highAvailabilityServicesFactory = InstantiationUtil.instantiate(
-				haServicesClassName,
-				HighAvailabilityServicesFactory.class,
-				classLoader);
-		} catch (Exception e) {
-			throw new FlinkException(
-				String.format(
-					"Could not instantiate the HighAvailabilityServicesFactory '%s'. Please make sure that this class is on your class path.",
-					haServicesClassName),
-				e);
-		}
+		final HighAvailabilityServicesFactory highAvailabilityServicesFactory = InstantiationUtil.instantiate(
+			haServicesClassName,
+			HighAvailabilityServicesFactory.class,
+			classLoader);
 
 		try {
 			return highAvailabilityServicesFactory.createHAServices(config, executor);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -19,14 +19,12 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.metrics.InputBufferPoolUsageGauge;
 import org.apache.flink.runtime.io.network.metrics.InputBuffersGauge;
@@ -35,8 +33,6 @@ import org.apache.flink.runtime.io.network.metrics.InputGateMetrics;
 import org.apache.flink.runtime.io.network.metrics.OutputBufferPoolUsageGauge;
 import org.apache.flink.runtime.io.network.metrics.OutputBuffersGauge;
 import org.apache.flink.runtime.io.network.metrics.ResultPartitionMetrics;
-import org.apache.flink.runtime.io.network.netty.NettyConfig;
-import org.apache.flink.runtime.io.network.netty.NettyConnectionManager;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionFactory;
@@ -50,7 +46,6 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
-import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.util.Preconditions;
 
@@ -65,7 +60,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The implementation of {@link ShuffleEnvironment} based on netty network communication, local memory and disk files.
@@ -75,10 +69,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartition, SingleInputGate> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(NettyShuffleEnvironment.class);
-
-	private static final String METRIC_GROUP_NETWORK = "Network";
-	private static final String METRIC_TOTAL_MEMORY_SEGMENT = "TotalMemorySegments";
-	private static final String METRIC_AVAILABLE_MEMORY_SEGMENT = "AvailableMemorySegments";
 
 	private static final String METRIC_OUTPUT_QUEUE_LENGTH = "outputQueueLength";
 	private static final String METRIC_OUTPUT_POOL_USAGE = "outPoolUsage";
@@ -105,7 +95,7 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 
 	private boolean isClosed;
 
-	private NettyShuffleEnvironment(
+	NettyShuffleEnvironment(
 			ResourceID taskExecutorResourceId,
 			NettyShuffleEnvironmentConfiguration config,
 			NetworkBufferPool networkBufferPool,
@@ -122,68 +112,6 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 		this.resultPartitionFactory = resultPartitionFactory;
 		this.singleInputGateFactory = singleInputGateFactory;
 		this.isClosed = false;
-	}
-
-	public static NettyShuffleEnvironment create(
-			NettyShuffleEnvironmentConfiguration config,
-			ResourceID taskExecutorResourceId,
-			TaskEventPublisher taskEventPublisher,
-			MetricGroup metricGroup,
-			IOManager ioManager) {
-		checkNotNull(taskExecutorResourceId);
-		checkNotNull(ioManager);
-		checkNotNull(taskEventPublisher);
-		checkNotNull(config);
-
-		NettyConfig nettyConfig = config.nettyConfig();
-
-		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
-
-		ConnectionManager connectionManager = nettyConfig != null ?
-			new NettyConnectionManager(resultPartitionManager, taskEventPublisher, nettyConfig, config.isCreditBased()) :
-			new LocalConnectionManager();
-
-		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
-			config.numNetworkBuffers(),
-			config.networkBufferSize(),
-			config.networkBuffersPerChannel());
-
-		registerNetworkMetrics(metricGroup, networkBufferPool);
-
-		ResultPartitionFactory resultPartitionFactory = new ResultPartitionFactory(
-			resultPartitionManager,
-			ioManager,
-			networkBufferPool,
-			config.networkBuffersPerChannel(),
-			config.floatingNetworkBuffersPerGate(),
-			config.isForcePartitionReleaseOnConsumption());
-
-		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
-			taskExecutorResourceId,
-			config,
-			connectionManager,
-			resultPartitionManager,
-			taskEventPublisher,
-			networkBufferPool);
-
-		return new NettyShuffleEnvironment(
-			taskExecutorResourceId,
-			config,
-			networkBufferPool,
-			connectionManager,
-			resultPartitionManager,
-			resultPartitionFactory,
-			singleInputGateFactory);
-	}
-
-	private static void registerNetworkMetrics(MetricGroup metricGroup, NetworkBufferPool networkBufferPool) {
-		checkNotNull(metricGroup);
-
-		MetricGroup networkGroup = metricGroup.addGroup(METRIC_GROUP_NETWORK);
-		networkGroup.<Integer, Gauge<Integer>>gauge(METRIC_TOTAL_MEMORY_SEGMENT,
-			networkBufferPool::getTotalNumberOfMemorySegments);
-		networkGroup.<Integer, Gauge<Integer>>gauge(METRIC_AVAILABLE_MEMORY_SEGMENT,
-			networkBufferPool::getNumberOfAvailableMemorySegments);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -395,19 +323,5 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 		synchronized (lock) {
 			return isClosed;
 		}
-	}
-
-	public static NettyShuffleEnvironment fromShuffleContext(ShuffleEnvironmentContext shuffleEnvironmentContext) {
-		NettyShuffleEnvironmentConfiguration networkConfig = NettyShuffleEnvironmentConfiguration.fromConfiguration(
-			shuffleEnvironmentContext.getConfiguration(),
-			shuffleEnvironmentContext.getMaxJvmHeapMemory(),
-			shuffleEnvironmentContext.isLocalCommunicationOnly(),
-			shuffleEnvironmentContext.getHostAddress());
-		return create(
-			networkConfig,
-			shuffleEnvironmentContext.getLocation(),
-			shuffleEnvironmentContext.getEventPublisher(),
-			shuffleEnvironmentContext.getParentMetricGroup(),
-			shuffleEnvironmentContext.getIOManager());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -31,6 +32,8 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionFactory;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
 import org.apache.flink.runtime.shuffle.ShuffleServiceFactory;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
@@ -40,11 +43,16 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Netty based shuffle service implementation.
  */
-public class NettyShuffleServiceFactory implements ShuffleServiceFactory<ResultPartition, SingleInputGate> {
+public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettyShuffleDescriptor, ResultPartition, SingleInputGate> {
 
 	private static final String METRIC_GROUP_NETWORK = "Network";
 	private static final String METRIC_TOTAL_MEMORY_SEGMENT = "TotalMemorySegments";
 	private static final String METRIC_AVAILABLE_MEMORY_SEGMENT = "AvailableMemorySegments";
+
+	@Override
+	public NettyShuffleMaster createShuffleMaster(Configuration configuration) {
+		return NettyShuffleMaster.INSTANCE;
+	}
 
 	@Override
 	public NettyShuffleEnvironment createShuffleEnvironment(ShuffleEnvironmentContext shuffleEnvironmentContext) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyConfig;
+import org.apache.flink.runtime.io.network.netty.NettyConnectionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionFactory;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory;
+import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
+import org.apache.flink.runtime.shuffle.ShuffleServiceFactory;
+import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Netty based shuffle service implementation.
+ */
+public class NettyShuffleServiceFactory implements ShuffleServiceFactory<ResultPartition, SingleInputGate> {
+
+	private static final String METRIC_GROUP_NETWORK = "Network";
+	private static final String METRIC_TOTAL_MEMORY_SEGMENT = "TotalMemorySegments";
+	private static final String METRIC_AVAILABLE_MEMORY_SEGMENT = "AvailableMemorySegments";
+
+	@Override
+	public NettyShuffleEnvironment createShuffleEnvironment(ShuffleEnvironmentContext shuffleEnvironmentContext) {
+		checkNotNull(shuffleEnvironmentContext);
+		NettyShuffleEnvironmentConfiguration networkConfig = NettyShuffleEnvironmentConfiguration.fromConfiguration(
+			shuffleEnvironmentContext.getConfiguration(),
+			shuffleEnvironmentContext.getMaxJvmHeapMemory(),
+			shuffleEnvironmentContext.isLocalCommunicationOnly(),
+			shuffleEnvironmentContext.getHostAddress());
+		return createNettyShuffleEnvironment(
+			networkConfig,
+			shuffleEnvironmentContext.getTaskExecutorResourceId(),
+			shuffleEnvironmentContext.getEventPublisher(),
+			shuffleEnvironmentContext.getParentMetricGroup(),
+			shuffleEnvironmentContext.getIOManager());
+	}
+
+	@VisibleForTesting
+	static NettyShuffleEnvironment createNettyShuffleEnvironment(
+			NettyShuffleEnvironmentConfiguration config,
+			ResourceID taskExecutorResourceId,
+			TaskEventPublisher taskEventPublisher,
+			MetricGroup metricGroup,
+			IOManager ioManager) {
+		checkNotNull(config);
+		checkNotNull(taskExecutorResourceId);
+		checkNotNull(taskEventPublisher);
+		checkNotNull(metricGroup);
+		checkNotNull(ioManager);
+
+		NettyConfig nettyConfig = config.nettyConfig();
+
+		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
+
+		ConnectionManager connectionManager = nettyConfig != null ?
+			new NettyConnectionManager(resultPartitionManager, taskEventPublisher, nettyConfig, config.isCreditBased()) :
+			new LocalConnectionManager();
+
+		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
+			config.numNetworkBuffers(),
+			config.networkBufferSize(),
+			config.networkBuffersPerChannel());
+
+		registerNetworkMetrics(metricGroup, networkBufferPool);
+
+		ResultPartitionFactory resultPartitionFactory = new ResultPartitionFactory(
+			resultPartitionManager,
+			ioManager,
+			networkBufferPool,
+			config.networkBuffersPerChannel(),
+			config.floatingNetworkBuffersPerGate(),
+			config.isForcePartitionReleaseOnConsumption());
+
+		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
+			taskExecutorResourceId,
+			config,
+			connectionManager,
+			resultPartitionManager,
+			taskEventPublisher,
+			networkBufferPool);
+
+		return new NettyShuffleEnvironment(
+			taskExecutorResourceId,
+			config,
+			networkBufferPool,
+			connectionManager,
+			resultPartitionManager,
+			resultPartitionFactory,
+			singleInputGateFactory);
+	}
+
+	private static void registerNetworkMetrics(MetricGroup metricGroup, NetworkBufferPool networkBufferPool) {
+		MetricGroup networkGroup = metricGroup.addGroup(METRIC_GROUP_NETWORK);
+		networkGroup.<Integer, Gauge<Integer>>gauge(METRIC_TOTAL_MEMORY_SEGMENT,
+			networkBufferPool::getTotalNumberOfMemorySegments);
+		networkGroup.<Integer, Gauge<Integer>>gauge(METRIC_AVAILABLE_MEMORY_SEGMENT,
+			networkBufferPool::getNumberOfAvailableMemorySegments);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -42,7 +42,7 @@ import java.util.Optional;
  * Factory for {@link ResultPartition} to use in {@link NettyShuffleEnvironment}.
  */
 public class ResultPartitionFactory {
-	private static final Logger LOG = LoggerFactory.getLogger(ResultPartition.class);
+	private static final Logger LOG = LoggerFactory.getLogger(ResultPartitionFactory.class);
 
 	@Nonnull
 	private final ResultPartitionManager partitionManager;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -50,10 +50,10 @@ import static org.apache.flink.runtime.shuffle.ShuffleUtils.applyWithShuffleType
  * Factory for {@link SingleInputGate} to use in {@link NettyShuffleEnvironment}.
  */
 public class SingleInputGateFactory {
-	private static final Logger LOG = LoggerFactory.getLogger(SingleInputGate.class);
+	private static final Logger LOG = LoggerFactory.getLogger(SingleInputGateFactory.class);
 
 	@Nonnull
-	private final ResourceID taskExecutorLocation;
+	private final ResourceID taskExecutorResourceId;
 
 	private final boolean isCreditBased;
 
@@ -78,13 +78,13 @@ public class SingleInputGateFactory {
 	private final int floatingNetworkBuffersPerGate;
 
 	public SingleInputGateFactory(
-			@Nonnull ResourceID taskExecutorLocation,
+			@Nonnull ResourceID taskExecutorResourceId,
 			@Nonnull NettyShuffleEnvironmentConfiguration networkConfig,
 			@Nonnull ConnectionManager connectionManager,
 			@Nonnull ResultPartitionManager partitionManager,
 			@Nonnull TaskEventPublisher taskEventPublisher,
 			@Nonnull NetworkBufferPool networkBufferPool) {
-		this.taskExecutorLocation = taskExecutorLocation;
+		this.taskExecutorResourceId = taskExecutorResourceId;
 		this.isCreditBased = networkConfig.isCreditBased();
 		this.partitionRequestInitialBackoff = networkConfig.partitionRequestInitialBackoff();
 		this.partitionRequestMaxBackoff = networkConfig.partitionRequestMaxBackoff();
@@ -194,7 +194,7 @@ public class SingleInputGateFactory {
 			ChannelStatistics channelStatistics,
 			InputChannelMetrics metrics) {
 		ResultPartitionID partitionId = inputChannelDescriptor.getResultPartitionID();
-		if (inputChannelDescriptor.isLocalTo(taskExecutorLocation)) {
+		if (inputChannelDescriptor.isLocalTo(taskExecutorResourceId)) {
 			// Consuming task is deployed to the same TaskManager as the partition => local
 			channelStatistics.numLocalChannels++;
 			return new LocalInputChannel(
@@ -241,9 +241,9 @@ public class SingleInputGateFactory {
 	}
 
 	private static class ChannelStatistics {
-		int numLocalChannels = 0;
-		int numRemoteChannels = 0;
-		int numUnknownChannels = 0;
+		int numLocalChannels;
+		int numRemoteChannels;
+		int numUnknownChannels;
 
 		@Override
 		public String toString() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.jobmaster.slotpool.SchedulerFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
 /**
  * Default implementation of the {@link JobMasterServiceFactory}.
@@ -57,6 +58,8 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 
 	private final SchedulerNGFactory schedulerNGFactory;
 
+	private final ShuffleMaster<?> shuffleMaster;
+
 	public DefaultJobMasterServiceFactory(
 			JobMasterConfiguration jobMasterConfiguration,
 			SlotPoolFactory slotPoolFactory,
@@ -67,7 +70,8 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 			HeartbeatServices heartbeatServices,
 			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
 			FatalErrorHandler fatalErrorHandler,
-			SchedulerNGFactory schedulerNGFactory) {
+			SchedulerNGFactory schedulerNGFactory,
+			ShuffleMaster<?> shuffleMaster) {
 		this.jobMasterConfiguration = jobMasterConfiguration;
 		this.slotPoolFactory = slotPoolFactory;
 		this.schedulerFactory = schedulerFactory;
@@ -78,6 +82,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 		this.jobManagerJobMetricGroupFactory = jobManagerJobMetricGroupFactory;
 		this.fatalErrorHandler = fatalErrorHandler;
 		this.schedulerNGFactory = schedulerNGFactory;
+		this.shuffleMaster = shuffleMaster;
 	}
 
 	@Override
@@ -100,6 +105,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 			jobCompletionActions,
 			fatalErrorHandler,
 			userCodeClassloader,
-			schedulerNGFactory);
+			schedulerNGFactory,
+			shuffleMaster);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
 import org.slf4j.Logger;
 
@@ -52,7 +53,8 @@ public class DefaultScheduler extends LegacyScheduler {
 			final Time rpcTimeout,
 			final BlobWriter blobWriter,
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
-			final Time slotRequestTimeout) throws Exception {
+			final Time slotRequestTimeout,
+			final ShuffleMaster<?> shuffleMaster) throws Exception {
 
 		super(
 			log,
@@ -68,7 +70,8 @@ public class DefaultScheduler extends LegacyScheduler {
 			new ThrowingRestartStrategy.ThrowingRestartStrategyFactory(),
 			blobWriter,
 			jobManagerJobMetricGroup,
-			slotRequestTimeout);
+			slotRequestTimeout,
+			shuffleMaster);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
 import org.slf4j.Logger;
 
@@ -52,7 +53,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			final Time rpcTimeout,
 			final BlobWriter blobWriter,
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
-			final Time slotRequestTimeout) throws Exception {
+			final Time slotRequestTimeout,
+			final ShuffleMaster<?> shuffleMaster) throws Exception {
 
 		return new DefaultScheduler(
 			log,
@@ -67,7 +69,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			rpcTimeout,
 			blobWriter,
 			jobManagerJobMetricGroup,
-			slotRequestTimeout);
+			slotRequestTimeout,
+			shuffleMaster);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacySchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacySchedulerFactory.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
 import org.slf4j.Logger;
 
@@ -61,7 +62,8 @@ public class LegacySchedulerFactory implements SchedulerNGFactory {
 			final Time rpcTimeout,
 			final BlobWriter blobWriter,
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
-			final Time slotRequestTimeout) throws Exception {
+			final Time slotRequestTimeout,
+			final ShuffleMaster<?> shuffleMaster) throws Exception {
 
 		return new LegacyScheduler(
 			log,
@@ -77,6 +79,7 @@ public class LegacySchedulerFactory implements SchedulerNGFactory {
 			restartStrategyFactory,
 			blobWriter,
 			jobManagerJobMetricGroup,
-			slotRequestTimeout);
+			slotRequestTimeout,
+			shuffleMaster);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
 import org.slf4j.Logger;
 
@@ -51,6 +52,7 @@ public interface SchedulerNGFactory {
 		Time rpcTimeout,
 		BlobWriter blobWriter,
 		JobManagerJobMetricGroup jobManagerJobMetricGroup,
-		Time slotRequestTimeout) throws Exception;
+		Time slotRequestTimeout,
+		ShuffleMaster<?> shuffleMaster) throws Exception;
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
@@ -33,7 +33,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class ShuffleEnvironmentContext {
 	private final Configuration configuration;
-	private final ResourceID location;
+	private final ResourceID taskExecutorResourceId;
 	private final long maxJvmHeapMemory;
 	private final boolean localCommunicationOnly;
 	private final InetAddress hostAddress;
@@ -43,7 +43,7 @@ public class ShuffleEnvironmentContext {
 
 	public ShuffleEnvironmentContext(
 			Configuration configuration,
-			ResourceID location,
+			ResourceID taskExecutorResourceId,
 			long maxJvmHeapMemory,
 			boolean localCommunicationOnly,
 			InetAddress hostAddress,
@@ -51,7 +51,7 @@ public class ShuffleEnvironmentContext {
 			MetricGroup parentMetricGroup,
 			IOManager ioManager) {
 		this.configuration = checkNotNull(configuration);
-		this.location = checkNotNull(location);
+		this.taskExecutorResourceId = checkNotNull(taskExecutorResourceId);
 		this.maxJvmHeapMemory = maxJvmHeapMemory;
 		this.localCommunicationOnly = localCommunicationOnly;
 		this.hostAddress = checkNotNull(hostAddress);
@@ -64,8 +64,8 @@ public class ShuffleEnvironmentContext {
 		return configuration;
 	}
 
-	public ResourceID getLocation() {
-		return location;
+	public ResourceID getTaskExecutorResourceId() {
+		return taskExecutorResourceId;
 	}
 
 	public long getMaxJvmHeapMemory() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+
+/**
+ * Interface for shuffle service factory implementations.
+ *
+ * <p>This component is a light-weight factory for {@link ShuffleEnvironment}.
+ *
+ * @param <P> type of provided result partition writers
+ * @param <G> type of provided input gates
+ */
+public interface ShuffleServiceFactory<P extends ResultPartitionWriter, G extends InputGate> {
+
+	/**
+	 * Factory method to create a specific local {@link ShuffleEnvironment} implementation.
+	 *
+	 * @param shuffleEnvironmentContext local context
+	 * @return local shuffle service environment implementation
+	 */
+	ShuffleEnvironment<P, G> createShuffleEnvironment(ShuffleEnvironmentContext shuffleEnvironmentContext);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceFactory.java
@@ -18,18 +18,28 @@
 
 package org.apache.flink.runtime.shuffle;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
 /**
  * Interface for shuffle service factory implementations.
  *
- * <p>This component is a light-weight factory for {@link ShuffleEnvironment}.
+ * <p>This component is a light-weight factory for {@link ShuffleMaster} and {@link ShuffleEnvironment}.
  *
+ * @param <SD> partition shuffle descriptor used for producer/consumer deployment and their data exchange.
  * @param <P> type of provided result partition writers
  * @param <G> type of provided input gates
  */
-public interface ShuffleServiceFactory<P extends ResultPartitionWriter, G extends InputGate> {
+public interface ShuffleServiceFactory<SD extends ShuffleDescriptor, P extends ResultPartitionWriter, G extends InputGate> {
+
+	/**
+	 * Factory method to create a specific {@link ShuffleMaster} implementation.
+	 *
+	 * @param configuration Flink configuration
+	 * @return shuffle manager implementation
+	 */
+	ShuffleMaster<SD> createShuffleMaster(Configuration configuration);
 
 	/**
 	 * Factory method to create a specific local {@link ShuffleEnvironment} implementation.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoader.java
@@ -30,7 +30,7 @@ import static org.apache.flink.runtime.shuffle.ShuffleServiceOptions.SHUFFLE_SER
 public enum ShuffleServiceLoader {
 	;
 
-	public static ShuffleServiceFactory<?, ?> loadShuffleServiceFactory(Configuration configuration) throws FlinkException {
+	public static ShuffleServiceFactory<?, ?, ?> loadShuffleServiceFactory(Configuration configuration) throws FlinkException {
 		String shuffleServiceClassName = configuration.getString(SHUFFLE_SERVICE_FACTORY_CLASS);
 		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 		return InstantiationUtil.instantiate(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoader.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.InstantiationUtil;
+
+import static org.apache.flink.runtime.shuffle.ShuffleServiceOptions.SHUFFLE_SERVICE_FACTORY_CLASS;
+
+/**
+ * Utility to load the pluggable {@link ShuffleServiceFactory} implementations.
+ */
+public enum ShuffleServiceLoader {
+	;
+
+	public static ShuffleServiceFactory<?, ?> loadShuffleServiceFactory(Configuration configuration) throws FlinkException {
+		String shuffleServiceClassName = configuration.getString(SHUFFLE_SERVICE_FACTORY_CLASS);
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		return InstantiationUtil.instantiate(
+			shuffleServiceClassName,
+			ShuffleServiceFactory.class,
+			classLoader);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/**
+ *  Options to configure shuffle service.
+ */
+@SuppressWarnings("WeakerAccess")
+public class ShuffleServiceOptions {
+
+	private ShuffleServiceOptions() {
+	}
+
+	/**
+	 * The full class name of the shuffle service factory implementation to be used by the cluster.
+	 */
+	public static final ConfigOption<String> SHUFFLE_SERVICE_FACTORY_CLASS = ConfigOptions
+		.key("shuffle-service-factory.class")
+		.defaultValue("org.apache.flink.runtime.io.network.NettyShuffleServiceFactory")
+		.withDescription("The full class name of the shuffle service factory implementation to be used by the cluster. " +
+			"The default implementation uses Netty for network communication and local memory as well disk space " +
+			"to store results on a TaskExecutor.");
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
@@ -118,7 +119,8 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			timeout,
-			log);
+			log,
+			NettyShuffleMaster.INSTANCE);
 
 		assertEquals(1, eg.getCheckpointCoordinator().getNumberOfRegisteredMasterHooks());
 		assertTrue(jobGraph.getCheckpointingSettings().getDefaultStateBackend().deserializeValue(classLoader) instanceof CustomStateBackend);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -60,6 +60,7 @@ import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.operators.BatchTask;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -822,7 +823,8 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			new UnregisteredMetricsGroup(),
 			blobWriter,
 			timeout,
-			LoggerFactory.getLogger(getClass()));
+			LoggerFactory.getLogger(getClass()),
+			NettyShuffleMaster.INSTANCE);
 	}
 
 	private static final class ExecutionStageMatcher extends TypeSafeMatcher<List<ExecutionAttemptID>> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -77,7 +78,8 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
-			TEST_LOGGER);
+			TEST_LOGGER,
+			NettyShuffleMaster.INSTANCE);
 
 		for (JobVertex jv : jobVertices) {
 			assertThat(jv.getParallelism(), is(initialParallelism));
@@ -106,7 +108,8 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
-			TEST_LOGGER);
+			TEST_LOGGER,
+			NettyShuffleMaster.INSTANCE);
 
 		for (JobVertex jv : jobVertices) {
 			assertThat(jv.getParallelism(), is(1));
@@ -135,7 +138,8 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
-			TEST_LOGGER);
+			TEST_LOGGER,
+			NettyShuffleMaster.INSTANCE);
 
 		for (JobVertex jv : jobVertices) {
 			assertThat(jv.getParallelism(), is(scaleUpParallelism));
@@ -177,7 +181,8 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 				new UnregisteredMetricsGroup(),
 				VoidBlobWriter.getInstance(),
 				AkkaUtils.getDefaultTimeout(),
-				TEST_LOGGER);
+				TEST_LOGGER,
+				NettyShuffleMaster.INSTANCE);
 
 			fail("Building the ExecutionGraph with a parallelism higher than the max parallelism should fail.");
 		} catch (JobException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -589,7 +590,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			timeout,
-			log);
+			log,
+			NettyShuffleMaster.INSTANCE);
 	}
 
 	private SimpleSlot createSlot(TaskManagerGateway taskManager, JobID jobId) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
@@ -409,7 +410,8 @@ public class ExecutionGraphTestUtils {
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			timeout,
-			TEST_LOGGER);
+			TEST_LOGGER,
+			NettyShuffleMaster.INSTANCE);
 	}
 
 	public static JobVertex createNoOpVertex(int parallelism) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -224,7 +225,8 @@ public class ExecutionVertexLocalityTest extends TestLogger {
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			timeout,
-			log);
+			log,
+			NettyShuffleMaster.INSTANCE);
 	}
 
 	private void initializeLocation(ExecutionVertex vertex, TaskManagerLocation location) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/PipelinedFailoverRegionBuildingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/PipelinedFailoverRegionBuildingTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
@@ -642,6 +643,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			timeout,
-			log);
+			log,
+			NettyShuffleMaster.INSTANCE);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -118,7 +118,7 @@ public class NettyShuffleEnvironmentBuilder {
 	}
 
 	public NettyShuffleEnvironment build() {
-		return NettyShuffleEnvironment.create(
+		return NettyShuffleServiceFactory.createNettyShuffleEnvironment(
 			new NettyShuffleEnvironmentConfiguration(
 				numNetworkBuffers,
 				networkBufferSize,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -98,6 +98,7 @@ import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
 import org.apache.flink.runtime.scheduler.LegacySchedulerFactory;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
@@ -292,7 +293,8 @@ public class JobMasterTest extends TestLogger {
 				new TestingOnCompletionActions(),
 				testingFatalErrorHandler,
 				JobMasterTest.class.getClassLoader(),
-				schedulerNGFactory) {
+				schedulerNGFactory,
+				NettyShuffleMaster.INSTANCE) {
 				@Override
 				public void declineCheckpoint(DeclineCheckpoint declineCheckpoint) {
 					declineCheckpointMessageFuture.complete(declineCheckpoint.getReason());
@@ -1402,7 +1404,8 @@ public class JobMasterTest extends TestLogger {
 			new TestingOnCompletionActions(),
 			testingFatalErrorHandler,
 			JobMasterTest.class.getClassLoader(),
-			schedulerNGFactory) {
+			schedulerNGFactory,
+			NettyShuffleMaster.INSTANCE) {
 
 			@Override
 			public CompletableFuture<String> triggerSavepoint(
@@ -1860,7 +1863,8 @@ public class JobMasterTest extends TestLogger {
 			onCompletionActions,
 			testingFatalErrorHandler,
 			JobMasterTest.class.getClassLoader(),
-			schedulerNGFactory);
+			schedulerNGFactory,
+			NettyShuffleMaster.INSTANCE);
 	}
 
 	private JobGraph createSingleVertexJobWithRestartStrategy() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.NettyShuffleServiceFactory;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.util.FlinkException;
+
+import org.junit.Test;
+
+import static org.apache.flink.runtime.shuffle.ShuffleServiceOptions.SHUFFLE_SERVICE_FACTORY_CLASS;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test suite for {@link ShuffleServiceLoader} utility.
+ */
+public class ShuffleServiceLoaderTest {
+
+	@Test
+	public void testLoadDefaultNettyShuffleServiceFactory() throws FlinkException {
+		Configuration configuration = new Configuration();
+		ShuffleServiceFactory<?, ?> shuffleServiceFactory = ShuffleServiceLoader.loadShuffleServiceFactory(configuration);
+		assertThat(
+			"Loaded shuffle service factory is not the default netty implementation",
+			shuffleServiceFactory,
+			instanceOf(NettyShuffleServiceFactory.class));
+	}
+
+	@Test
+	public void testLoadCustomShuffleServiceFactory() throws FlinkException {
+		Configuration configuration = new Configuration();
+		configuration.setString(SHUFFLE_SERVICE_FACTORY_CLASS, "org.apache.flink.runtime.shuffle.ShuffleServiceLoaderTest$CustomShuffleServiceFactory");
+		ShuffleServiceFactory<?, ?> shuffleServiceFactory = ShuffleServiceLoader.loadShuffleServiceFactory(configuration);
+		assertThat(
+			"Loaded shuffle service factory is not the custom test implementation",
+			shuffleServiceFactory,
+			instanceOf(CustomShuffleServiceFactory.class));
+	}
+
+	@Test(expected = FlinkException.class)
+	public void testLoadShuffleServiceFactoryFailure() throws FlinkException {
+		Configuration configuration = new Configuration();
+		configuration.setString(SHUFFLE_SERVICE_FACTORY_CLASS, "org.apache.flink.runtime.shuffle.UnavailableShuffleServiceFactory");
+		ShuffleServiceLoader.loadShuffleServiceFactory(configuration);
+	}
+
+	/**
+	 * Stub implementation of {@link ShuffleServiceFactory} to test {@link ShuffleServiceLoader} utility.
+	 */
+	public static class CustomShuffleServiceFactory implements ShuffleServiceFactory<ResultPartitionWriter, InputGate> {
+		@Override
+		public ShuffleEnvironment<ResultPartitionWriter, InputGate> createShuffleEnvironment(
+				ShuffleEnvironmentContext shuffleEnvironmentContext) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
@@ -38,7 +38,7 @@ public class ShuffleServiceLoaderTest {
 	@Test
 	public void testLoadDefaultNettyShuffleServiceFactory() throws FlinkException {
 		Configuration configuration = new Configuration();
-		ShuffleServiceFactory<?, ?> shuffleServiceFactory = ShuffleServiceLoader.loadShuffleServiceFactory(configuration);
+		ShuffleServiceFactory<?, ?, ?> shuffleServiceFactory = ShuffleServiceLoader.loadShuffleServiceFactory(configuration);
 		assertThat(
 			"Loaded shuffle service factory is not the default netty implementation",
 			shuffleServiceFactory,
@@ -49,7 +49,7 @@ public class ShuffleServiceLoaderTest {
 	public void testLoadCustomShuffleServiceFactory() throws FlinkException {
 		Configuration configuration = new Configuration();
 		configuration.setString(SHUFFLE_SERVICE_FACTORY_CLASS, "org.apache.flink.runtime.shuffle.ShuffleServiceLoaderTest$CustomShuffleServiceFactory");
-		ShuffleServiceFactory<?, ?> shuffleServiceFactory = ShuffleServiceLoader.loadShuffleServiceFactory(configuration);
+		ShuffleServiceFactory<?, ?, ?> shuffleServiceFactory = ShuffleServiceLoader.loadShuffleServiceFactory(configuration);
 		assertThat(
 			"Loaded shuffle service factory is not the custom test implementation",
 			shuffleServiceFactory,
@@ -66,7 +66,12 @@ public class ShuffleServiceLoaderTest {
 	/**
 	 * Stub implementation of {@link ShuffleServiceFactory} to test {@link ShuffleServiceLoader} utility.
 	 */
-	public static class CustomShuffleServiceFactory implements ShuffleServiceFactory<ResultPartitionWriter, InputGate> {
+	public static class CustomShuffleServiceFactory implements ShuffleServiceFactory<ShuffleDescriptor, ResultPartitionWriter, InputGate> {
+		@Override
+		public ShuffleMaster<ShuffleDescriptor> createShuffleMaster(Configuration configuration) {
+			throw new UnsupportedOperationException();
+		}
+
 		@Override
 		public ShuffleEnvironment<ResultPartitionWriter, InputGate> createShuffleEnvironment(
 				ShuffleEnvironmentContext shuffleEnvironmentContext) {


### PR DESCRIPTION
## What is the purpose of the change

Introduce `ShuffleService` interface with two factory methods for `ShuffleMaster` and `ShuffleEnvironment` and its configuration. Implement and configure by default `NettyShuffleService`.

## Brief change log

  - Introduce `ShuffleService` interface with two factory methods for `ShuffleMaster` and `ShuffleEnvironment`
  - Introduce configuration core option with the full name of the implementation class and a `ShuffleServiceLoader` utility class to load the configured `ShuffleService` implementation from the class path 
  - Implement and configure by default `NettyShuffleService`.

## Verifying this change

Refactoring, existing unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (np)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs / JavaDocs)
