### PR TITLE
[FLINK-12790] Implement KeyScope enum to distinguish the key of localKeyBy and general keyBy API

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyScope.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyScope.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+/**
+ * A key scope determines the keyed state is local or global.
+ * Different scope means different aggregation mechanism. {@link KeyScope#GLOBAL} is used for
+ * general aggregation based on hash partition. {@link KeyScope#LOCAL} is used for
+ * local pre-aggregation.
+ */
+public enum KeyScope {
+
+	GLOBAL(false),
+	LOCAL(true);
+
+	private final boolean local;
+
+	KeyScope(boolean local) {
+		this.local = local;
+	}
+
+	public boolean isLocal() {
+		return local;
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request implements KeyScope enum to distinguish the key of `localKeyBy` and general `keyBy` API*


## Brief change log

  - *Implement KeyScope enum to distinguish the key of localKeyBy and general keyBy API*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
