### PR TITLE
[FLINK-11869] Make buffer size in checkpoint stream factory configurable

### DIFF
--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -18,6 +18,11 @@
             <td>Option whether the state backend should use an asynchronous snapshot method where possible and configurable. Some state backends may not support asynchronous snapshots, or only support asynchronous snapshots, and ignore this option.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.fs.buffer-size</h5></td>
+            <td style="word-wrap: break-word;">4096</td>
+            <td>The default write buffer size for file checkpoint output stream created by FsCheckpointStreamFactory. And the final actual write buffer size would consider the maximum of values of this option and option 'state.backend.fs.memory-threshold'.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.fs.memory-threshold</h5></td>
             <td style="word-wrap: break-word;">1024</td>
             <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file.</td>

--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -18,14 +18,14 @@
             <td>Option whether the state backend should use an asynchronous snapshot method where possible and configurable. Some state backends may not support asynchronous snapshots, or only support asynchronous snapshots, and ignore this option.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.fs.buffer-size</h5></td>
-            <td style="word-wrap: break-word;">4096</td>
-            <td>The default write buffer size for file checkpoint output stream created by FsCheckpointStreamFactory. And the final actual write buffer size would consider the maximum of values of this option and option 'state.backend.fs.memory-threshold'.</td>
-        </tr>
-        <tr>
             <td><h5>state.backend.fs.memory-threshold</h5></td>
             <td style="word-wrap: break-word;">1024</td>
             <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.fs.write-buffer-size</h5></td>
+            <td style="word-wrap: break-word;">4096</td>
+            <td>The default write buffer size for file checkpoint output stream created by FsCheckpointStreamFactory. And the final actual write buffer size would consider the maximum of values of this option and option 'state.backend.fs.memory-threshold'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.incremental</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -129,4 +129,14 @@ public class CheckpointingOptions {
 			.defaultValue(1024)
 			.withDescription("The minimum size of state data files. All state chunks smaller than that are stored" +
 				" inline in the root checkpoint metadata file.");
+
+	/**
+	 * The default write buffer size for file checkpoint output stream created by FsCheckpointStreamFactory.
+	 */
+	public static final ConfigOption<Integer> FS_BUFFER_SIZE = ConfigOptions
+		.key("state.backend.fs.buffer-size")
+		.defaultValue(4 * 1024)
+		.withDescription(String.format("The default write buffer size for file checkpoint output stream created by FsCheckpointStreamFactory. " +
+			"And the final actual write buffer size would consider the maximum of values of this option and option '%s'.", FS_SMALL_FILE_THRESHOLD.key()));
+
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -134,7 +134,7 @@ public class CheckpointingOptions {
 	 * The default write buffer size for file checkpoint output stream created by FsCheckpointStreamFactory.
 	 */
 	public static final ConfigOption<Integer> FS_BUFFER_SIZE = ConfigOptions
-		.key("state.backend.fs.buffer-size")
+		.key("state.backend.fs.write-buffer-size")
 		.defaultValue(4 * 1024)
 		.withDescription(String.format("The default write buffer size for file checkpoint output stream created by FsCheckpointStreamFactory. " +
 			"And the final actual write buffer size would consider the maximum of values of this option and option '%s'.", FS_SMALL_FILE_THRESHOLD.key()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
@@ -50,17 +50,21 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 
 	private final int fileStateSizeThreshold;
 
+	private final int writeBufferSize;
+
 	public FsCheckpointStorageLocation(
 			FileSystem fileSystem,
 			Path checkpointDir,
 			Path sharedStateDir,
 			Path taskOwnedStateDir,
 			CheckpointStorageLocationReference reference,
-			int fileStateSizeThreshold) {
+			int fileStateSizeThreshold,
+			int writeBufferSize) {
 
-		super(fileSystem, checkpointDir, sharedStateDir, fileStateSizeThreshold);
+		super(fileSystem, checkpointDir, sharedStateDir, fileStateSizeThreshold, writeBufferSize);
 
 		checkArgument(fileStateSizeThreshold >= 0);
+		checkArgument(writeBufferSize >= 0);
 
 		this.fileSystem = checkNotNull(fileSystem);
 		this.checkpointDirectory = checkNotNull(checkpointDir);
@@ -73,6 +77,7 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 
 		this.metadataFilePath = new Path(metadataDir, AbstractFsCheckpointStorage.METADATA_FILE_NAME);
 		this.fileStateSizeThreshold = fileStateSizeThreshold;
+		this.writeBufferSize = writeBufferSize;
 	}
 
 	// ------------------------------------------------------------------------
@@ -130,6 +135,7 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 				", metadataFilePath=" + metadataFilePath +
 				", reference=" + reference +
 				", fileStateSizeThreshold=" + fileStateSizeThreshold +
+				", writeBufferSize=" + writeBufferSize +
 				'}';
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -352,7 +352,8 @@ public class PendingCheckpointTest {
 				LocalFileSystem.getSharedInstance(),
 				checkpointDir, checkpointDir, checkpointDir,
 				CheckpointStorageLocationReference.getDefault(),
-				1024);
+				1024,
+				4096);
 
 		final Map<ExecutionAttemptID, ExecutionVertex> ackTasks = new HashMap<>(ACK_TASKS);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.mock;
 public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBase {
 
 	private static final int FILE_SIZE_THRESHOLD = 1024;
+	private static final int WRITE_BUFFER_SIZE = 4096;
 
 	// ------------------------------------------------------------------------
 	//  General Fs-based checkpoint storage tests, inherited
@@ -60,12 +61,12 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 
 	@Override
 	protected CheckpointStorage createCheckpointStorage(Path checkpointDir) throws Exception {
-		return new FsCheckpointStorage(checkpointDir, null, new JobID(), FILE_SIZE_THRESHOLD);
+		return new FsCheckpointStorage(checkpointDir, null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
 	}
 
 	@Override
 	protected CheckpointStorage createCheckpointStorageWithSavepointDir(Path checkpointDir, Path savepointDir) throws Exception {
-		return new FsCheckpointStorage(checkpointDir, savepointDir, new JobID(), FILE_SIZE_THRESHOLD);
+		return new FsCheckpointStorage(checkpointDir, savepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
 	}
 
 	// ------------------------------------------------------------------------
@@ -77,7 +78,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 		final Path defaultSavepointDir = Path.fromLocalFile(tmp.newFolder());
 
 		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				Path.fromLocalFile(tmp.newFolder()), defaultSavepointDir, new JobID(), FILE_SIZE_THRESHOLD);
+				Path.fromLocalFile(tmp.newFolder()), defaultSavepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
 
 		final FsCheckpointStorageLocation savepointLocation = (FsCheckpointStorageLocation)
 				storage.initializeLocationForSavepoint(52452L, null);
@@ -96,7 +97,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 		final Path savepointDir = Path.fromLocalFile(tmp.newFolder());
 
 		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				Path.fromLocalFile(tmp.newFolder()), null, new JobID(), FILE_SIZE_THRESHOLD);
+				Path.fromLocalFile(tmp.newFolder()), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
 
 		final FsCheckpointStorageLocation savepointLocation = (FsCheckpointStorageLocation)
 				storage.initializeLocationForSavepoint(52452L, savepointDir.toString());
@@ -116,7 +117,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 
 		// we chose a small size threshold here to force the state to disk
 		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				Path.fromLocalFile(tmp.newFolder()),  null, new JobID(), 10);
+				Path.fromLocalFile(tmp.newFolder()),  null, new JobID(), 10, WRITE_BUFFER_SIZE);
 
 		final StreamStateHandle stateHandle;
 
@@ -152,7 +153,8 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 				sharedStateDir,
 				randomTempPath(),
 				CheckpointStorageLocationReference.getDefault(),
-				FILE_SIZE_THRESHOLD);
+				FILE_SIZE_THRESHOLD,
+				WRITE_BUFFER_SIZE);
 
 		assertNotEquals(storageLocation.getCheckpointDirectory(), storageLocation.getSharedStateDirectory());
 
@@ -195,7 +197,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 	@Test
 	public void testStorageLocationDoesNotMkdirs() throws Exception {
 		FsCheckpointStorage storage = new FsCheckpointStorage(
-				randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD);
+				randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
 
 		File baseDir =  new File(storage.getCheckpointsDirectory().getPath());
 		assertTrue(baseDir.exists());
@@ -215,7 +217,8 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 			new TestingPath("hdfs:///checkpoint/", checkpointFileSystem),
 			null,
 			new JobID(),
-			FILE_SIZE_THRESHOLD);
+			FILE_SIZE_THRESHOLD,
+			WRITE_BUFFER_SIZE);
 
 		final FsCheckpointStorageLocation checkpointStreamFactory =
 			(FsCheckpointStorageLocation) storage.resolveCheckpointStorageLocation(1L, CheckpointStorageLocationReference.getDefault());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -58,7 +58,7 @@ public class FsStateBackendEntropyTest {
 		final String checkpointDirStr = checkpointDir.toString();
 
 		FsCheckpointStorage storage = new FsCheckpointStorage(
-				fs, checkpointDir, null, new JobID(), 1024);
+				fs, checkpointDir, null, new JobID(), 1024, 4096);
 
 		FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
 				storage.initializeLocationForCheckpoint(96562);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
@@ -93,8 +93,10 @@ public class RocksDBStateUploaderTest extends TestLogger {
 
 		FileSystem fileSystem = checkpointPrivateDirectory.getFileSystem();
 		int fileStateSizeThreshold = 1024;
+		int writeBufferSize = 4096;
 		FsCheckpointStreamFactory checkpointStreamFactory =
-			new FsCheckpointStreamFactory(fileSystem, checkpointPrivateDirectory, checkpointSharedDirectory, fileStateSizeThreshold);
+			new FsCheckpointStreamFactory(
+				fileSystem, checkpointPrivateDirectory, checkpointSharedDirectory, fileStateSizeThreshold, writeBufferSize);
 
 		String localFolder = "local";
 		temporaryFolder.newFolder(localFolder);


### PR DESCRIPTION
## What is the purpose of the change

Currently, the default buffer size for `FsCheckpointStreamFactory` is only 4KB. This would case a lot of IOPS if stream is large. This PR would make that configurable.

## Brief change log

  - Add new option `state.backend.fs.buffer-size` in `CheckpointingOptions`.
  - Introduce `writeBufferSize` in the constructor of  `FsCheckpointStreamFactory` and related classes.

## Verifying this change

This change added tests and can be verified as follows:

  - Verify the `writeBufferSize` is configurable in `StateBackendLoadingTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **docs/ JavaDocs**
