### PR TITLE
[FLINK-12612][coordination] Track stored partition on the TaskExecutor 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.taskexecutor.partition.PartitionTable;
 import org.apache.flink.runtime.taskmanager.MemoryLogger;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.EnvironmentInformation;
@@ -384,7 +385,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			taskManagerMetricGroup.f0,
 			metricQueryServiceAddress,
 			blobCacheService,
-			fatalErrorHandler);
+			fatalErrorHandler,
+			new PartitionTable());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/partition/PartitionTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/partition/PartitionTable.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.partition;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe Utility for tracking partitions.
+ */
+@ThreadSafe
+public class PartitionTable {
+
+	private final Map<JobID, Set<ResultPartitionID>> trackedPartitionsPerJob = new ConcurrentHashMap<>(8);
+
+	/**
+	 * Returns whether any partitions are being tracked for the given job.
+	 */
+	public boolean hasTrackedPartitions(JobID jobId) {
+		return trackedPartitionsPerJob.containsKey(jobId);
+	}
+
+	/**
+	 * Starts the tracking of the given partition for the given job.
+	 */
+	public void startTrackingPartitions(JobID jobId, Collection<ResultPartitionID> newPartitionIds) {
+		Preconditions.checkNotNull(jobId);
+		Preconditions.checkNotNull(newPartitionIds);
+
+		trackedPartitionsPerJob.compute(jobId, (ignored, partitionIds) -> {
+			if (partitionIds == null) {
+				partitionIds = new HashSet<>(8);
+			}
+			partitionIds.addAll(newPartitionIds);
+			return partitionIds;
+		});
+	}
+
+	/**
+	 * Stops the tracking of all partition for the given job.
+	 */
+	public Collection<ResultPartitionID> stopTrackingPartitions(JobID jobId) {
+		Preconditions.checkNotNull(jobId);
+
+		Set<ResultPartitionID> storedPartitions = trackedPartitionsPerJob.remove(jobId);
+		return storedPartitions == null
+			? Collections.emptyList()
+			: storedPartitions;
+	}
+
+	/**
+	 * Stops the tracking of the given set of partitions for the given job.
+	 */
+	public void stopTrackingPartitions(JobID jobId, Collection<ResultPartitionID> partitionIds) {
+		Preconditions.checkNotNull(jobId);
+		Preconditions.checkNotNull(partitionIds);
+
+		// If the JobID is unknown we do not fail here, in line with ShuffleEnvironment#releaseFinishedPartitions
+		trackedPartitionsPerJob.computeIfPresent(
+			jobId,
+			(key, resultPartitionIDS) -> {
+				resultPartitionIDS.removeAll(partitionIds);
+				return resultPartitionIDS.isEmpty()
+					? null
+					: resultPartitionIDS;
+			});
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -70,7 +70,7 @@ public class PartitionTestUtils {
 		}
 	}
 
-	static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(ResultPartitionType partitionType) {
+	public static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(ResultPartitionType partitionType) {
 		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().buildLocal();
 		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
 			new IntermediateDataSetID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -18,7 +18,12 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 
 import org.hamcrest.Matchers;
 
@@ -63,5 +68,20 @@ public class PartitionTestUtils {
 		} catch (PartitionNotFoundException notFound) {
 			assertThat(partitionId, Matchers.is(notFound.getPartitionId()));
 		}
+	}
+
+	static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(ResultPartitionType partitionType) {
+		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().buildLocal();
+		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
+			new IntermediateDataSetID(),
+			shuffleDescriptor.getResultPartitionID().getPartitionId(),
+			partitionType,
+			1,
+			0);
+		return new ResultPartitionDeploymentDescriptor(
+			partitionDescriptor,
+			shuffleDescriptor,
+			1,
+			true);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -19,20 +19,15 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.shuffle.PartitionDescriptor;
-import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.taskmanager.ConsumableNotifyingResultPartitionWriterDecorator;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.runtime.taskmanager.TaskActions;
-import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -188,7 +183,7 @@ public class ResultPartitionTest {
 		TaskActions taskActions = new NoOpTaskActions();
 		ResultPartition partition = createPartition(partitionType);
 		ResultPartitionWriter consumableNotifyingPartitionWriter = ConsumableNotifyingResultPartitionWriterDecorator.decorate(
-			Collections.singleton(createPartitionDeploymentDescriptor(partitionType)),
+			Collections.singleton(PartitionTestUtils.createPartitionDeploymentDescriptor(partitionType)),
 			new ResultPartitionWriter[] {partition},
 			taskActions,
 			jobId,
@@ -317,25 +312,10 @@ public class ResultPartitionTest {
 			JobID jobId,
 			ResultPartitionConsumableNotifier notifier) {
 		return ConsumableNotifyingResultPartitionWriterDecorator.decorate(
-			Collections.singleton(createPartitionDeploymentDescriptor(partitionType)),
+			Collections.singleton(PartitionTestUtils.createPartitionDeploymentDescriptor(partitionType)),
 			new ResultPartitionWriter[] {createPartition(partitionType)},
 			taskActions,
 			jobId,
 			notifier)[0];
-	}
-
-	private ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(ResultPartitionType partitionType) {
-		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().buildLocal();
-		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
-			new IntermediateDataSetID(),
-			shuffleDescriptor.getResultPartitionID().getPartitionId(),
-			partitionType,
-			1,
-			0);
-		return new ResultPartitionDeploymentDescriptor(
-			partitionDescriptor,
-			shuffleDescriptor,
-			1,
-			true);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.BlockerSync;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.blob.BlobCacheService;
+import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.entrypoint.ClusterInformation;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.PartitionInfo;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
+import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmaster.JMTMRegistrationSuccess;
+import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
+import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
+import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.shuffle.ShuffleIOOwnerContext;
+import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
+import org.apache.flink.runtime.taskexecutor.partition.PartitionTable;
+import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
+import org.apache.flink.runtime.taskexecutor.slot.TimerService;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.TriConsumer;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+/**
+ * Tests for the partition-lifecycle logic in the {@link TaskExecutor}.
+ */
+public class TaskExecutorPartitionLifecycleTest extends TestLogger {
+
+	private static final Time timeout = Time.seconds(10L);
+
+	private static final TestingRpcService RPC = new TestingRpcService();
+
+	private final TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
+	private final SettableLeaderRetrievalService jobManagerLeaderRetriever = new SettableLeaderRetrievalService();
+	private final SettableLeaderRetrievalService resourceManagerLeaderRetriever = new SettableLeaderRetrievalService();
+	private final JobID jobId = new JobID();
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Before
+	public void setup() {
+		haServices.setResourceManagerLeaderRetriever(resourceManagerLeaderRetriever);
+		haServices.setJobMasterLeaderRetriever(jobId, jobManagerLeaderRetriever);
+	}
+
+	@After
+	public void shutdown() {
+		RPC.clearGateways();
+	}
+
+	@AfterClass
+	public static void shutdownClass() throws ExecutionException, InterruptedException {
+		RPC.stopService().get();
+	}
+
+	@Test
+	public void testPartitionReleaseAfterDisconnect() throws Exception {
+		testPartitionRelease(
+			(jobId, partitionId, taskExecutorGateway) -> taskExecutorGateway.disconnectJobManager(jobId, new Exception("test")),
+			true);
+	}
+
+	@Test
+	public void testPartitionReleaseAfterReleaseCall() throws Exception {
+		testPartitionRelease(
+			(jobId, partitionId, taskExecutorGateway) -> taskExecutorGateway.releasePartitions(jobId, Collections.singletonList(partitionId)),
+			true);
+	}
+
+	@Test
+	public void testPartitionReleaseAfterShutdown() throws Exception {
+		// don't do any explicit release action, so that the partition must be cleaned up on shutdown
+		testPartitionRelease(
+			(jobId, partitionId, taskExecutorGateway) -> { },
+			false);
+	}
+
+	private void testPartitionRelease(
+		TriConsumer<JobID, ResultPartitionID, TaskExecutorGateway> releaseAction,
+		boolean waitForRelease) throws Exception {
+
+		final ResultPartitionDeploymentDescriptor taskResultPartitionDescriptor =
+			PartitionTestUtils.createPartitionDeploymentDescriptor(ResultPartitionType.BLOCKING);
+		final ExecutionAttemptID eid1 = taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID().getProducerId();
+
+		final TaskDeploymentDescriptor taskDeploymentDescriptor =
+			TaskExecutorSubmissionTest.createTaskDeploymentDescriptor(
+				jobId,
+				"job",
+				eid1,
+				new SerializedValue<>(new ExecutionConfig()),
+				"Sender",
+				1,
+				0,
+				1,
+				0,
+				new Configuration(),
+				new Configuration(),
+				TestingInvokable.class.getName(),
+				Collections.singletonList(taskResultPartitionDescriptor),
+				Collections.emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
+				0);
+
+		final TaskSlotTable taskSlotTable = createTaskSlotTable();
+
+		final TaskExecutorLocalStateStoresManager localStateStoresManager = new TaskExecutorLocalStateStoresManager(
+			false,
+			new File[]{tmp.newFolder()},
+			Executors.directExecutor());
+
+		final TestingShuffleEnvironment shuffleEnvironment = new TestingShuffleEnvironment();
+
+		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
+			.setTaskSlotTable(taskSlotTable)
+			.setTaskStateManager(localStateStoresManager)
+			.setShuffleEnvironment(shuffleEnvironment)
+			.build();
+
+		final CompletableFuture<Void> taskFinishedFuture = new CompletableFuture<>();
+
+		final TestingJobMasterGateway jobMasterGateway = new TestingJobMasterGatewayBuilder()
+			.setRegisterTaskManagerFunction((s, location) -> CompletableFuture.completedFuture(new JMTMRegistrationSuccess(ResourceID.generate())))
+			.setOfferSlotsFunction((resourceID, slotOffers) -> CompletableFuture.completedFuture(slotOffers))
+			.setUpdateTaskExecutionStateFunction(taskExecutionState -> {
+				if (taskExecutionState.getExecutionState() == ExecutionState.FINISHED) {
+					taskFinishedFuture.complete(null);
+				}
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			})
+			.build();
+
+		final PartitionTable partitionTable = new PartitionTable();
+
+		final TestingTaskExecutor taskExecutor = createTestingTaskExecutor(taskManagerServices, partitionTable);
+
+		final CompletableFuture<SlotReport> initialSlotReportFuture = new CompletableFuture<>();
+
+		final TestingResourceManagerGateway testingResourceManagerGateway = new TestingResourceManagerGateway();
+		testingResourceManagerGateway.setSendSlotReportFunction(resourceIDInstanceIDSlotReportTuple3 -> {
+			initialSlotReportFuture.complete(resourceIDInstanceIDSlotReportTuple3.f2);
+			return CompletableFuture.completedFuture(Acknowledge.get());
+		});
+		testingResourceManagerGateway.setRegisterTaskExecutorFunction(input -> CompletableFuture.completedFuture(
+			new TaskExecutorRegistrationSuccess(
+				new InstanceID(),
+				testingResourceManagerGateway.getOwnResourceId(),
+				new ClusterInformation("blobServerHost", 55555))));
+
+		try {
+			taskExecutor.start();
+			taskExecutor.waitUntilStarted();
+
+			final TaskExecutorGateway taskExecutorGateway = taskExecutor.getSelfGateway(TaskExecutorGateway.class);
+
+			final String jobMasterAddress = "jm";
+			RPC.registerGateway(jobMasterAddress, jobMasterGateway);
+			RPC.registerGateway(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway);
+
+			// inform the task manager about the job leader
+			taskManagerServices.getJobLeaderService().addJob(jobId, jobMasterAddress);
+			jobManagerLeaderRetriever.notifyListener(jobMasterAddress, UUID.randomUUID());
+			resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway.getFencingToken().toUUID());
+
+			final Optional<SlotStatus> slotStatusOptional = StreamSupport.stream(initialSlotReportFuture.get().spliterator(), false)
+				.findAny();
+
+			assertTrue(slotStatusOptional.isPresent());
+
+			final SlotStatus slotStatus = slotStatusOptional.get();
+
+			while (true) {
+				try {
+					taskExecutorGateway.requestSlot(
+						slotStatus.getSlotID(),
+						jobId,
+						taskDeploymentDescriptor.getAllocationId(),
+						jobMasterAddress,
+						testingResourceManagerGateway.getFencingToken(),
+						timeout
+					).get();
+					break;
+				} catch (Exception e) {
+					// the proper establishment of the RM connection is tracked
+					// asynchronously, so we have to poll here until it went through
+					// until then, slot requests will fail with an exception
+					Thread.sleep(50);
+				}
+			}
+
+			TestingInvokable.sync = new BlockerSync();
+
+			taskExecutorGateway.submitTask(taskDeploymentDescriptor, jobMasterGateway.getFencingToken(), timeout)
+				.get();
+
+			TestingInvokable.sync.awaitBlocker();
+
+			// the task is still running => the partition is in in-progress
+			runInTaskExecutorThreadAndWait(
+				taskExecutor,
+				() -> assertTrue(partitionTable.hasTrackedPartitions(jobId)));
+
+			TestingInvokable.sync.releaseBlocker();
+			taskFinishedFuture.get(timeout.getSize(), timeout.getUnit());
+
+			// the task is finished => the partition should be finished now
+			runInTaskExecutorThreadAndWait(
+				taskExecutor,
+				() -> assertTrue(partitionTable.hasTrackedPartitions(jobId)));
+
+			final CompletableFuture<Collection<ResultPartitionID>> releasePartitionsFuture = new CompletableFuture<>();
+			runInTaskExecutorThreadAndWait(
+				taskExecutor,
+				() -> shuffleEnvironment.releasePartitionsLocallyFuture = releasePartitionsFuture);
+
+			releaseAction.accept(
+				jobId,
+				taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID(),
+				taskExecutorGateway);
+
+			if (waitForRelease) {
+				Collection<ResultPartitionID> resultPartitionIDS = releasePartitionsFuture.get();
+				assertThat(resultPartitionIDS, contains(taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID()));
+			}
+		} finally {
+			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+		}
+
+		// the shutdown of the backing shuffle environment releases all partitions
+		// the book-keeping is not aware of this
+		assertTrue(shuffleEnvironment.getPartitionsOccupyingLocalResources().isEmpty());
+	}
+
+	/**
+	 * Test invokable which completes the given future when executed.
+	 */
+	public static class TestingInvokable extends AbstractInvokable {
+
+		static BlockerSync sync;
+
+		public TestingInvokable(Environment environment) {
+			super(environment);
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			sync.block();
+		}
+	}
+
+	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices, PartitionTable partitionTable) throws IOException {
+		return new TestingTaskExecutor(
+			RPC,
+			TaskManagerConfiguration.fromConfiguration(new Configuration()),
+			haServices,
+			taskManagerServices,
+			new HeartbeatServices(10_000L, 30_000L),
+			UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
+			null,
+			new BlobCacheService(
+				new Configuration(),
+				new VoidBlobStore(),
+				null),
+			new TestingFatalErrorHandler(),
+			partitionTable);
+	}
+
+	private static TaskSlotTable createTaskSlotTable() {
+		return new TaskSlotTable(
+			Collections.singletonList(ResourceProfile.UNKNOWN),
+			new TimerService<>(TestingUtils.defaultExecutor(), timeout.toMilliseconds()));
+
+	}
+
+	private static void runInTaskExecutorThreadAndWait(TaskExecutor taskExecutor, Runnable runnable) throws ExecutionException, InterruptedException {
+		taskExecutor.getRpcService().scheduleRunnable(
+			runnable,
+			0,
+			TimeUnit.SECONDS
+		).get();
+	}
+
+	private static class TestingShuffleEnvironment implements ShuffleEnvironment<ResultPartition, SingleInputGate> {
+
+		private final ShuffleEnvironment<ResultPartition, SingleInputGate> backingShuffleEnvironment =
+			new NettyShuffleEnvironmentBuilder().build();
+
+		CompletableFuture<Collection<ResultPartitionID>> releasePartitionsLocallyFuture = null;
+
+		@Override
+		public int start() throws IOException {
+			return backingShuffleEnvironment.start();
+		}
+
+		@Override
+		public ShuffleIOOwnerContext createShuffleIOOwnerContext(String ownerName, ExecutionAttemptID executionAttemptID, MetricGroup parentGroup) {
+			return backingShuffleEnvironment.createShuffleIOOwnerContext(ownerName, executionAttemptID, parentGroup);
+		}
+
+		@Override
+		public Collection<ResultPartition> createResultPartitionWriters(ShuffleIOOwnerContext ownerContext, Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors) {
+			return backingShuffleEnvironment.createResultPartitionWriters(ownerContext, resultPartitionDeploymentDescriptors);
+		}
+
+		@Override
+		public void releasePartitionsLocally(Collection<ResultPartitionID> partitionIds) {
+			backingShuffleEnvironment.releasePartitionsLocally(partitionIds);
+			if (releasePartitionsLocallyFuture != null) {
+				releasePartitionsLocallyFuture.complete(partitionIds);
+			}
+		}
+
+		@Override
+		public Collection<ResultPartitionID> getPartitionsOccupyingLocalResources() {
+			return backingShuffleEnvironment.getPartitionsOccupyingLocalResources();
+		}
+
+		@Override
+		public Collection<SingleInputGate> createInputGates(ShuffleIOOwnerContext ownerContext, PartitionProducerStateProvider partitionProducerStateProvider, Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
+			return backingShuffleEnvironment.createInputGates(ownerContext, partitionProducerStateProvider, inputGateDeploymentDescriptors);
+		}
+
+		@Override
+		public boolean updatePartitionInfo(ExecutionAttemptID consumerID, PartitionInfo partitionInfo) throws IOException, InterruptedException {
+			return backingShuffleEnvironment.updatePartitionInfo(consumerID, partitionInfo);
+		}
+
+		@Override
+		public void close() throws Exception {
+			backingShuffleEnvironment.close();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -775,7 +775,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			0);
 	}
 
-	private static TaskDeploymentDescriptor createTaskDeploymentDescriptor(
+	static TaskDeploymentDescriptor createTaskDeploymentDescriptor(
 			JobID jobId,
 			String jobName,
 			ExecutionAttemptID executionAttemptId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -87,6 +87,7 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.exceptions.RegistrationTimeoutException;
 import org.apache.flink.runtime.taskexecutor.exceptions.TaskManagerException;
+import org.apache.flink.runtime.taskexecutor.partition.PartitionTable;
 import org.apache.flink.runtime.taskexecutor.slot.SlotNotFoundException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
@@ -1866,7 +1867,8 @@ public class TaskExecutorTest extends TestLogger {
 			UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
 			null,
 			dummyBlobCacheService,
-			testingFatalErrorHandler);
+			testingFatalErrorHandler,
+			new PartitionTable());
 	}
 
 	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices) {
@@ -1883,7 +1885,8 @@ public class TaskExecutorTest extends TestLogger {
 			UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
 			null,
 			dummyBlobCacheService,
-			testingFatalErrorHandler);
+			testingFatalErrorHandler,
+			new PartitionTable());
 	}
 
 	private static final class StartStopNotifyingLeaderRetrievalService implements LeaderRetrievalService {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
+import org.apache.flink.runtime.taskexecutor.partition.PartitionTable;
 import org.apache.flink.runtime.taskexecutor.rpc.RpcResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
@@ -205,11 +206,12 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 			UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
 			null,
 			blobCacheService,
-			testingFatalErrorHandler
+			testingFatalErrorHandler,
+			new PartitionTable()
 		);
 	}
 
-	private static JobManagerConnection createJobManagerConnection(JobID jobId, JobMasterGateway jobMasterGateway, RpcService testingRpcService, TaskManagerActions taskManagerActions, Time timeout) {
+	static JobManagerConnection createJobManagerConnection(JobID jobId, JobMasterGateway jobMasterGateway, RpcService testingRpcService, TaskManagerActions taskManagerActions, Time timeout) {
 		final LibraryCacheManager libraryCacheManager = mock(LibraryCacheManager.class);
 		when(libraryCacheManager.getClassLoader(any(JobID.class))).thenReturn(ClassLoader.getSystemClassLoader());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.taskexecutor.partition.PartitionTable;
 
 import javax.annotation.Nullable;
 
@@ -44,7 +45,8 @@ class TestingTaskExecutor extends TaskExecutor {
 			TaskManagerMetricGroup taskManagerMetricGroup,
 			@Nullable String metricQueryServiceAddress,
 			BlobCacheService blobCacheService,
-			FatalErrorHandler fatalErrorHandler) {
+			FatalErrorHandler fatalErrorHandler,
+			PartitionTable partitionTable) {
 		super(
 			rpcService,
 			taskManagerConfiguration,
@@ -54,7 +56,8 @@ class TestingTaskExecutor extends TaskExecutor {
 			taskManagerMetricGroup,
 			metricQueryServiceAddress,
 			blobCacheService,
-			fatalErrorHandler);
+			fatalErrorHandler,
+			partitionTable);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/partition/PartitionTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/partition/PartitionTableTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.partition;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for the {@link PartitionTable}.
+ */
+public class PartitionTableTest extends TestLogger {
+
+	private static final JobID JOB_ID = new JobID();
+	private static final ResultPartitionID PARTITION_ID = new ResultPartitionID();
+
+	@Test
+	public void testEmptyTable() {
+		final PartitionTable table = new PartitionTable();
+
+		// an empty table should always return an empty collection
+		Collection<ResultPartitionID> partitionsForNonExistingJob = table.stopTrackingPartitions(JOB_ID);
+		assertNotNull(partitionsForNonExistingJob);
+		assertThat(partitionsForNonExistingJob, empty());
+
+		assertFalse(table.hasTrackedPartitions(JOB_ID));
+	}
+
+	@Test
+	public void testStartTrackingPartition() {
+		final PartitionTable table = new PartitionTable();
+
+		table.startTrackingPartitions(JOB_ID, Collections.singletonList(PARTITION_ID));
+
+		assertTrue(table.hasTrackedPartitions(JOB_ID));
+	}
+
+	@Test
+	public void testStopTrackingAllPartitions() {
+		final PartitionTable table = new PartitionTable();
+
+		table.startTrackingPartitions(JOB_ID, Collections.singletonList(PARTITION_ID));
+
+		Collection<ResultPartitionID> storedPartitions = table.stopTrackingPartitions(JOB_ID);
+		assertThat(storedPartitions, contains(PARTITION_ID));
+		assertFalse(table.hasTrackedPartitions(JOB_ID));
+	}
+
+	@Test
+	public void testStopTrackingPartitions() {
+		final ResultPartitionID partitionId2 = new ResultPartitionID();
+		final PartitionTable table = new PartitionTable();
+
+		table.startTrackingPartitions(JOB_ID, Collections.singletonList(PARTITION_ID));
+		table.startTrackingPartitions(JOB_ID, Collections.singletonList(partitionId2));
+
+		table.stopTrackingPartitions(JOB_ID, Collections.singletonList(partitionId2));
+		assertTrue(table.hasTrackedPartitions(JOB_ID));
+
+		Collection<ResultPartitionID> storedPartitions = table.stopTrackingPartitions(JOB_ID);
+		assertThat(storedPartitions, contains(PARTITION_ID));
+		assertFalse(table.hasTrackedPartitions(JOB_ID));
+	}
+}


### PR DESCRIPTION
Based on ~~#8630~~, ~~#8654~~ and ~~#8680~~.

## What is the purpose of the change

Introduces partition tracking on the TaskExecutor.

We start tracking partitions after a Task has been started. Partitions
are only tracked iff.
a) they are not released on consumption (in this case the ShuffleEnvironment takes care of that automatically)
b) they have local resources (as otherwise there's nothing to release)

Partitions are tracked using a PartitionTable.

If a task fails we stop tracking any partitions for this task. No release calls will be issued, as
the task will fail their partition, which will automatically release them.

If task reaches the state FINISHED, no additional action is required. Partitions will continue to be tracked
until they are released at a later point.

The TaskExecutor is informed about the task termination via the tasks termination future, which also contains
the final execution state.

Partitions for finished tasks are only released in 2 cases:
a) An external call to TaskExecutor#releasePartitions is made.
b) The connection to a JobManager terminates for whatever reason.

For a) we stop tracking the given partitions and forward a release call to the ShuffleEnvironment.
No sanity checks are made; we assume that the whoever issued the release call has a reason to do so.

For b) we determine all partitions associated with the job corresponding to the terminated connection,
stop tracking them and issue a release call to the ShuffleEnvironment.

No additional cleanup is performed on shutdown, as the ShuffleEnvironment implicitly releases all
partitions requiring it.

Whenever a slot is freed the TaskExecutor was checking whether any other slots were allocated for a given job,
and if this isn't the case disconnects from the corresponding JobMaster.
It now additionally takes into account whether we still have any tracked partitions for the given job.

This check is also performed whenever an partition was released due to TaskExecutor#releasePartitions being called.