### PR TITLE
[FLINK-12624][table][sql] Make Flink case-insensitive to meta object names

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
@@ -150,7 +150,7 @@ public class PlanningConfigurationBuilder {
 			// and cases are preserved
 			SqlParser
 				.configBuilder()
-				.setLex(Lex.JAVA)
+				.setLex(Lex.MYSQL)
 				.build());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Note that this is not a final PR. I'm testing it

This PR makes Flink case-insensitive to meta object names.

Currently Flink is case-sensitive to meta object names. For example, for table names, "t1" and "T1" are two distinct tables in Flink.

There are two main reasons to make Flink case-insensitive to such names.
1) To make it more user-friendly for SQL users. Most popular databases nowadays are case insensitive to meta object names, to tolerate user typos in SQL commands and reduce user friction
2) We chose Hive metastore as the main persistent catalog, and Hive metastore is case insensitive.

## Brief change log

- Change SQL parser lex from JAVA to MYSQL

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
