### PR TITLE
[FLINK-12657][hive] Integrate Flink with Hive UDF

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/FlinkHiveUDFException.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/FlinkHiveUDFException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+/**
+ * Hive UDF related exceptions in Flink.
+ */
+public class FlinkHiveUDFException extends FlinkRuntimeException {
+	/**
+	 * @param message the detail message.
+	 */
+	public FlinkHiveUDFException(String message) {
+		super(message);
+	}
+
+	/**
+	 * @param cause the cause.
+	 */
+	public FlinkHiveUDFException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * @param message the detail message.
+	 * @param cause the cause.
+	 */
+	public FlinkHiveUDFException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunction.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+
+/**
+ * Interface for Hive simple udf, generic udf, and generic udtf.
+ * TODO: Note: this is only a temporary interface for workaround when Flink type system and udf system
+ * 	rework is not finished. Should adapt to Flink type system and Flink UDF framework later on.
+ */
+@Internal
+public interface HiveFunction {
+
+	/**
+	 * Set arguments and argTypes for Function instance.
+	 * In this way, the correct method can be really deduced by the function instance.
+	 *
+	 * <p>Framework should guarantee that this is always called
+	 * before {@link #getHiveResultType(Object[] constantArguments, DataType[] argTypes)}.
+	 *
+	 * @param constantArguments arguments of a function call (only literal arguments
+	 *                  are passed, nulls for non-literal ones)
+	 * @param argTypes types of arguments
+	 */
+	void setArgumentTypesAndConstants(Object[] constantArguments, DataType[] argTypes);
+
+	/**
+	 * Get result type by arguments and argTypes.
+	 *
+	 * <p>We can't use getResultType(Object[], Class[]). The Class[] is the classes of what
+	 * is defined in eval(), for example, if eval() is "public Integer eval(Double)", the
+	 * argTypes would be Class[Double]. However, in our wrapper, the signature of eval() is
+	 * "public Object eval(Object... args)", which means we cannot get any info from the interface.
+	 *
+	 * <p>Framework should guarantee that this is always called
+	 * 	 after {@link #setArgumentTypesAndConstants(Object[] constantArguments, DataType[] argTypes)}.
+	 *
+	 * @param constantArguments arguments of a function call (only literal arguments
+	 *                  are passed, nulls for non-literal ones)
+	 * @param argTypes types of arguments
+	 * @return result type.
+	 */
+	DataType getHiveResultType(Object[] constantArguments, DataType[] argTypes);
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunction.java
@@ -33,9 +33,6 @@ public interface HiveFunction {
 	 * Set arguments and argTypes for Function instance.
 	 * In this way, the correct method can be really deduced by the function instance.
 	 *
-	 * <p>Framework should guarantee that this is always called
-	 * before {@link #getHiveResultType(Object[] constantArguments, DataType[] argTypes)}.
-	 *
 	 * @param constantArguments arguments of a function call (only literal arguments
 	 *                  are passed, nulls for non-literal ones)
 	 * @param argTypes types of arguments
@@ -49,9 +46,6 @@ public interface HiveFunction {
 	 * is defined in eval(), for example, if eval() is "public Integer eval(Double)", the
 	 * argTypes would be Class[Double]. However, in our wrapper, the signature of eval() is
 	 * "public Object eval(Object... args)", which means we cannot get any info from the interface.
-	 *
-	 * <p>Framework should guarantee that this is always called
-	 * 	 after {@link #setArgumentTypesAndConstants(Object[] constantArguments, DataType[] argTypes)}.
 	 *
 	 * @param constantArguments arguments of a function call (only literal arguments
 	 *                  are passed, nulls for non-literal ones)

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunctionWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunctionWrapper.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+import java.io.Serializable;
+
+/**
+ * A wrapper of Hive functions that instantiate function instances and ser/de functino instance cross process boundary.
+ *
+ * @param <UDFType> The type of UDF.
+ */
+@Internal
+public class HiveFunctionWrapper<UDFType> implements Serializable {
+
+	public static final long serialVersionUID = 393313529306818205L;
+
+	private final String className;
+
+	private transient UDFType instance = null;
+
+	public HiveFunctionWrapper(String className) {
+		this.className = className;
+	}
+
+	/**
+	 * Instantiate a Hive function instance.
+	 *
+	 * @return a Hive function instance
+	 */
+	public UDFType createFunction() {
+		if (instance != null) {
+			return instance;
+		} else {
+			UDFType func = null;
+			try {
+				func = (UDFType) Thread.currentThread().getContextClassLoader().loadClass(className).newInstance();
+			} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+				throw new FlinkHiveUDFException(
+					String.format("Failed to create function from %s", className), e);
+			}
+
+			if (!(func instanceof UDF)) {
+				// We cache the function if it is not the Simple UDF,
+				// as we always have to create new instance for Simple UDF.
+				instance = func;
+			}
+
+			return func;
+		}
+	}
+
+	/**
+	 * Get class name of the Hive function.
+	 *
+	 * @return class name of the Hive function
+	 */
+	public String getClassName() {
+		return className;
+	}
+
+	/**
+	 * Get class of the Hive function.
+	 *
+	 * @return class of the Hive function
+	 * @throws ClassNotFoundException thrown when the class is not found in classpath
+	 */
+	public Class<UDFType> getUDFClass() throws ClassNotFoundException {
+		return (Class<UDFType>) Class.forName(className);
+	}
+}
+

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunctionWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunctionWrapper.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.functions.hive;
 
 import org.apache.flink.annotation.Internal;
+
 import org.apache.hadoop.hive.ql.exec.UDF;
 
 import java.io.Serializable;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
 
 import org.apache.hadoop.hive.ql.exec.UDF;
@@ -79,7 +80,8 @@ public abstract class HiveScalarFunction<UDFType> extends ScalarFunction impleme
 	@Override
 	public void open(FunctionContext context) {
 		openInternal();
-		isArgsSingleArray = argTypes.length == 1 && (argTypes[0] instanceof CollectionDataType);
+		isArgsSingleArray = argTypes.length == 1 &&
+			(argTypes[0] instanceof CollectionDataType && argTypes[0].getLogicalType().getTypeRoot().equals(LogicalTypeRoot.ARRAY));
 	}
 
 	/**

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
+
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+
+/**
+ * Abstract class to provide more information for Hive {@link UDF} and {@link GenericUDF} functions.
+ */
+@Internal
+public abstract class HiveScalarFunction<UDFType> extends ScalarFunction implements HiveFunction {
+
+	protected final HiveFunctionWrapper<UDFType> hiveFunctionWrapper;
+
+	protected Object[] constantArguments;
+	protected DataType[] argTypes;
+
+	protected transient UDFType function;
+	protected transient ObjectInspector returnInspector;
+
+	private transient boolean isArgsSingleArray;
+
+	HiveScalarFunction(HiveFunctionWrapper<UDFType> hiveFunctionWrapper) {
+		this.hiveFunctionWrapper = hiveFunctionWrapper;
+	}
+
+	@Override
+	public void setArgumentTypesAndConstants(Object[] constantArguments, DataType[] argTypes) {
+		this.constantArguments = constantArguments;
+		this.argTypes = argTypes;
+	}
+
+	@Override
+	public boolean isDeterministic() {
+		try {
+			org.apache.hadoop.hive.ql.udf.UDFType udfType =
+				hiveFunctionWrapper.getUDFClass()
+					.getAnnotation(org.apache.hadoop.hive.ql.udf.UDFType.class);
+
+			return udfType != null && udfType.deterministic() && !udfType.stateful();
+		} catch (ClassNotFoundException e) {
+			throw new FlinkHiveUDFException(e);
+		}
+	}
+
+	@Override
+	public TypeInformation getResultType(Class[] signature) {
+		return LegacyTypeInfoDataTypeConverter.toLegacyTypeInfo(
+			getHiveResultType(this.constantArguments, this.argTypes));
+	}
+
+	@Override
+	public void open(FunctionContext context) {
+		openInternal();
+		isArgsSingleArray = argTypes.length == 1 && (argTypes[0] instanceof CollectionDataType);
+	}
+
+	/**
+	 * See {@link ScalarFunction#open(FunctionContext)}.
+	 */
+	protected abstract void openInternal();
+
+	public Object eval(Object... args) {
+
+		// When the parameter is (Integer, Array[Double]), Flink calls udf.eval(Integer, Array[Double]), which is not a problem.
+		// But when the parameter is an single array, Flink calls udf.eval(Array[Double]),
+		// at this point java's var-args will cast Array[Double] to Array[Object] and let it be
+		// Object... args, So we need wrap it.
+		if (isArgsSingleArray) {
+			args = new Object[] {args};
+		}
+
+		return evalInternal(args);
+	}
+
+	/**
+	 * Evaluation logical, args will be wrapped when is a single array.
+	 */
+	protected abstract Object evalInternal(Object[] args);
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
@@ -109,7 +109,7 @@ public class HiveSimpleUDF extends HiveScalarFunction<UDF> {
 		}
 
 		try {
-			return HiveInspectors.unwrap(returnInspector,
+			return HiveInspectors.toFlinkObject(returnInspector,
 				FunctionRegistry.invoke(method, function, conversionHelper.convertIfNecessary(args)));
 		} catch (HiveException e) {
 			throw new FlinkHiveUDFException(e);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
+import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
+import org.apache.flink.table.functions.hive.conversion.HiveObjectConversion;
+import org.apache.flink.table.functions.hive.conversion.IdentityConversion;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ *  A ScalarFunction implementation that calls Hive's {@link UDF}.
+ */
+@Internal
+public class HiveSimpleUDF extends HiveScalarFunction<UDF> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HiveSimpleUDF.class);
+
+	private transient Method method;
+	private transient GenericUDFUtils.ConversionHelper conversionHelper;
+	private transient HiveObjectConversion[] conversions;
+	private transient boolean allIdentityConverter;
+
+	public HiveSimpleUDF(HiveFunctionWrapper<UDF> hiveFunctionWrapper) {
+		super(hiveFunctionWrapper);
+		LOG.info("Creating HiveSimpleUDF from '{}'", this.hiveFunctionWrapper.getClassName());
+	}
+
+	@Override
+	public void openInternal() {
+		LOG.info("Opening HiveSimpleUDF as '{}'", hiveFunctionWrapper.getClassName());
+
+		function = hiveFunctionWrapper.createFunction();
+
+		List<TypeInfo> typeInfos = new ArrayList<>();
+
+		for (DataType arg : argTypes) {
+			typeInfos.add(HiveTypeUtil.toHiveTypeInfo(arg));
+		}
+
+		try {
+			method = function.getResolver().getEvalMethod(typeInfos);
+			returnInspector = ObjectInspectorFactory.getReflectionObjectInspector(method.getGenericReturnType(),
+				ObjectInspectorFactory.ObjectInspectorOptions.JAVA);
+			ObjectInspector[] argInspectors = new ObjectInspector[typeInfos.size()];
+
+			for (int i = 0; i < argTypes.length; i++) {
+				argInspectors[i] = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(typeInfos.get(i));
+			}
+
+			conversionHelper = new GenericUDFUtils.ConversionHelper(method, argInspectors);
+			conversions = new HiveObjectConversion[argInspectors.length];
+			for (int i = 0; i < argInspectors.length; i++) {
+				conversions[i] = HiveInspectors.getConversion(argInspectors[i]);
+			}
+
+			allIdentityConverter = Arrays.stream(conversions)
+				.allMatch(conv -> conv instanceof IdentityConversion);
+		} catch (Exception e) {
+			throw new FlinkHiveUDFException(
+				String.format("Failed to open HiveSimpleUDF from %s", hiveFunctionWrapper.getClassName()), e);
+		}
+	}
+
+	@Override
+	public Object evalInternal(Object[] args) {
+		checkArgument(args.length == conversions.length);
+
+		if (!allIdentityConverter) {
+			for (int i = 0; i < args.length; i++) {
+				args[i] = conversions[i].toHiveObject(args[i]);
+			}
+		}
+
+		try {
+			return HiveInspectors.unwrap(returnInspector,
+				FunctionRegistry.invoke(method, function, conversionHelper.convertIfNecessary(args)));
+		} catch (HiveException e) {
+			throw new FlinkHiveUDFException(e);
+		}
+	}
+
+	@Override
+	public DataType getHiveResultType(Object[] constantArguments, DataType[] argTypes) {
+		try {
+			List<TypeInfo> argTypeInfo = new ArrayList<>();
+			for (DataType argType : argTypes) {
+				argTypeInfo.add(HiveTypeUtil.toHiveTypeInfo(argType));
+			}
+			Class returnType = hiveFunctionWrapper.createFunction()
+				.getResolver().getEvalMethod(argTypeInfo).getReturnType();
+
+			return HiveInspectors.toFlinkType(
+				HiveInspectors.getObjectInspector(returnType));
+		} catch (UDFArgumentException e) {
+			throw new FlinkHiveUDFException(e);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
@@ -127,9 +127,9 @@ public class HiveInspectors {
 	}
 
 	/**
-	 * Unwraps an object from Hive object to Flink object with an ObjectInspector.
+	 * Converts a Hive object to Flink object with an ObjectInspector.
 	 */
-	public static Object unwrap(ObjectInspector inspector, Object data) {
+	public static Object toFlinkObject(ObjectInspector inspector, Object data) {
 		if (data == null) {
 			return null;
 		}
@@ -188,6 +188,8 @@ public class HiveInspectors {
 					oi.get(data) :
 					oi.getPrimitiveWritableObject(data);
 			}
+
+			// TODO: handle more primitive types like char, varchar, timestamp, date, decimal
 		}
 
 		// TODO: handle complex types like struct, list, and map

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.conversion;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
+import org.apache.flink.table.functions.hive.FlinkHiveUDFException;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.hadoop.hive.serde2.io.ByteWritable;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.ShortWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaBooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaByteObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaDoubleObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaFloatObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaIntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaLongObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaShortObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaStringObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ShortObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.VoidObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+
+
+/**
+ * Util for any ObjectInspector related inspection and conversion of Hive data to/from Flink data.
+ *
+ * <p>Hive ObjectInspector is a group of flexible APIs to inspect value in different data representation,
+ * and developers can extend those API as needed, so technically, object inspector supports arbitrary data type in java.
+ */
+@Internal
+public class HiveInspectors {
+
+	/**
+	 * Get conversion for converting Flink object to Hive object from an ObjectInspector.
+	 */
+	public static HiveObjectConversion getConversion(ObjectInspector inspector) {
+		if (inspector instanceof PrimitiveObjectInspector) {
+			if (inspector instanceof JavaBooleanObjectInspector) {
+				if (((JavaBooleanObjectInspector) inspector).preferWritable()) {
+					return o -> new BooleanWritable((Boolean) o);
+				} else {
+					return IdentityConversion.INSTANCE;
+				}
+			} else if (inspector instanceof JavaStringObjectInspector) {
+				if (((StringObjectInspector) inspector).preferWritable()) {
+					return o -> new Text((String) o);
+				} else {
+					return IdentityConversion.INSTANCE;
+				}
+			} else if (inspector instanceof JavaByteObjectInspector) {
+				if (((JavaByteObjectInspector) inspector).preferWritable()) {
+					return o -> new ByteWritable((Byte) o);
+				} else {
+					return IdentityConversion.INSTANCE;
+				}
+			} else if (inspector instanceof JavaShortObjectInspector) {
+				if (((JavaShortObjectInspector) inspector).preferWritable()) {
+					return o -> new ShortWritable((Short) o);
+				} else {
+					return IdentityConversion.INSTANCE;
+				}
+			} else if (inspector instanceof JavaIntObjectInspector) {
+				if (((JavaIntObjectInspector) inspector).preferWritable()) {
+					return o -> new IntWritable((Integer) o);
+				} else {
+					return IdentityConversion.INSTANCE;
+				}
+			} else if (inspector instanceof JavaLongObjectInspector) {
+				if (((JavaLongObjectInspector) inspector).preferWritable()) {
+					return o -> new LongWritable((Long) o);
+				} else {
+					return IdentityConversion.INSTANCE;
+				}
+			} else if (inspector instanceof JavaFloatObjectInspector) {
+				if (((JavaFloatObjectInspector) inspector).preferWritable()) {
+					return o -> new FloatWritable((Float) o);
+				} else {
+					return IdentityConversion.INSTANCE;
+				}
+			} else if (inspector instanceof JavaDoubleObjectInspector) {
+				if (((JavaDoubleObjectInspector) inspector).preferWritable()) {
+					return o -> new DoubleWritable((Double) o);
+				} else {
+					return IdentityConversion.INSTANCE;
+				}
+			}
+		}
+
+		throw new FlinkHiveUDFException(
+			String.format("Flink doesn't support convert object conversion for %s yet", inspector));
+	}
+
+	/**
+	 * Unwraps an object from Hive object to Flink object with an ObjectInspector.
+	 */
+	public static Object unwrap(ObjectInspector inspector, Object data) {
+		if (data == null) {
+			return null;
+		}
+
+		if (inspector instanceof VoidObjectInspector) {
+			return null;
+		}
+
+		if (inspector instanceof PrimitiveObjectInspector) {
+			if (inspector instanceof BooleanObjectInspector) {
+				BooleanObjectInspector oi = (BooleanObjectInspector) inspector;
+
+				return oi.preferWritable() ?
+					oi.get(data) :
+					oi.getPrimitiveJavaObject(data);
+			} else if (inspector instanceof StringObjectInspector) {
+				StringObjectInspector oi = (StringObjectInspector) inspector;
+
+				return oi.preferWritable() ?
+					oi.getPrimitiveWritableObject(data).toString() :
+					oi.getPrimitiveJavaObject(data);
+			} else if (inspector instanceof ByteObjectInspector) {
+				ByteObjectInspector oi = (ByteObjectInspector) inspector;
+
+				return oi.preferWritable() ?
+					oi.get(data) :
+					oi.getPrimitiveJavaObject(data);
+			} else if (inspector instanceof ShortObjectInspector) {
+				ShortObjectInspector oi = (ShortObjectInspector) inspector;
+
+				return oi.preferWritable() ?
+					oi.get(data) :
+					oi.getPrimitiveWritableObject(data);
+			} else if (inspector instanceof IntObjectInspector) {
+				IntObjectInspector oi = (IntObjectInspector) inspector;
+
+				return oi.preferWritable() ?
+					oi.get(data) :
+					oi.getPrimitiveWritableObject(data);
+			} else if (inspector instanceof LongObjectInspector) {
+				LongObjectInspector oi = (LongObjectInspector) inspector;
+
+				return oi.preferWritable() ?
+					oi.get(data) :
+					oi.getPrimitiveWritableObject(data);
+			} else if (inspector instanceof FloatObjectInspector) {
+				FloatObjectInspector oi = (FloatObjectInspector) inspector;
+
+				return oi.preferWritable() ?
+					oi.get(data) :
+					oi.getPrimitiveWritableObject(data);
+			} else if (inspector instanceof DoubleObjectInspector) {
+				DoubleObjectInspector oi = (DoubleObjectInspector) inspector;
+
+				return oi.preferWritable() ?
+					oi.get(data) :
+					oi.getPrimitiveWritableObject(data);
+			}
+		}
+
+		// TODO: handle complex types like struct, list, and map
+
+		throw new FlinkHiveUDFException(
+			String.format("Unwrap does not support ObjectInspector '%s' yet", inspector));
+	}
+
+	public static ObjectInspector getObjectInspector(Class clazz) {
+		TypeInfo typeInfo;
+
+		if (clazz.equals(String.class) || clazz.equals(Text.class)) {
+
+			typeInfo = TypeInfoFactory.stringTypeInfo;
+		} else if (clazz.equals(Boolean.class) || clazz.equals(BooleanWritable.class)) {
+
+			typeInfo = TypeInfoFactory.booleanTypeInfo;
+		} else if (clazz.equals(Byte.class) || clazz.equals(ByteWritable.class)) {
+
+			typeInfo = TypeInfoFactory.byteTypeInfo;
+		} else if (clazz.equals(Short.class) || clazz.equals(ShortWritable.class)) {
+
+			typeInfo = TypeInfoFactory.shortTypeInfo;
+		} else if (clazz.equals(Integer.class) || clazz.equals(IntWritable.class)) {
+
+			typeInfo = TypeInfoFactory.intTypeInfo;
+		} else if (clazz.equals(Long.class) || clazz.equals(LongWritable.class)) {
+
+			typeInfo = TypeInfoFactory.longTypeInfo;
+		} else if (clazz.equals(Float.class) || clazz.equals(FloatWritable.class)) {
+
+			typeInfo = TypeInfoFactory.floatTypeInfo;
+		} else if (clazz.equals(Double.class) || clazz.equals(DoubleWritable.class)) {
+
+			typeInfo = TypeInfoFactory.doubleTypeInfo;
+		} else {
+			throw new FlinkHiveUDFException(
+				String.format("Class %s is not supported yet", clazz.getName()));
+		}
+
+		return getObjectInspector(typeInfo);
+	}
+
+	private static ObjectInspector getObjectInspector(TypeInfo type) {
+		switch (type.getCategory()) {
+			case PRIMITIVE:
+				PrimitiveTypeInfo primitiveType = (PrimitiveTypeInfo) type;
+				return PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(primitiveType);
+			default:
+				throw new FlinkHiveUDFException(
+					String.format("TypeInfo %s is not supported yet", type));
+		}
+	}
+
+	public static DataType toFlinkType(ObjectInspector inspector) {
+		return HiveTypeUtil.toFlinkType(TypeInfoUtils.getTypeInfoFromTypeString(inspector.getTypeName()));
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveObjectConversion.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveObjectConversion.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.conversion;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Interface to convert Flink object to Hive object.
+ */
+@FunctionalInterface
+@Internal
+public interface HiveObjectConversion {
+
+	Object toHiveObject(Object o);
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/IdentityConversion.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/IdentityConversion.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.conversion;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Conversion that return the same object.
+ */
+@Internal
+public class IdentityConversion implements HiveObjectConversion {
+
+	public static final IdentityConversion INSTANCE = new IdentityConversion();
+
+	private IdentityConversion() {}
+
+	@Override
+	public Object toHiveObject(Object o) {
+		return o;
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.hadoop.hive.ql.udf.UDFBin;
+import org.apache.hadoop.hive.ql.udf.UDFJson;
+import org.apache.hadoop.hive.ql.udf.UDFMinute;
+import org.apache.hadoop.hive.ql.udf.UDFRand;
+import org.apache.hadoop.hive.ql.udf.UDFWeekOfYear;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link HiveSimpleUDF}.
+ */
+public class HiveSimpleUDFTest {
+
+	@Test
+	public void testUDFRand() {
+		HiveSimpleUDF udf = init(UDFRand.class, new DataType[0]);
+
+		double result = (double) udf.eval();
+
+		assertTrue(result >= 0 && result < 1);
+	}
+
+	@Test
+	public void testUDFBin() {
+		HiveSimpleUDF udf = init(UDFBin.class, new DataType[]{ DataTypes.INT() });
+
+		assertEquals("1100", udf.eval(12));
+	}
+
+	@Test
+	public void testUDFJson() {
+		HiveSimpleUDF udf = init(
+			UDFJson.class,
+			new DataType[]{
+				DataTypes.STRING(),
+				DataTypes.STRING()
+			});
+
+		assertEquals("amy", udf.eval("{\"store\": \"test\", \"owner\": \"amy\"}", "$.owner"));
+	}
+
+	@Test
+	public void testUDFMinute() {
+		HiveSimpleUDF udf = init(
+			UDFMinute.class,
+			new DataType[]{
+				DataTypes.STRING()
+			});
+
+		assertEquals(17, udf.eval("1969-07-20 20:17:40"));
+	}
+
+	@Test
+	public void testUDFWeekOfYear() {
+		HiveSimpleUDF udf = init(
+			UDFWeekOfYear.class,
+			new DataType[]{
+				DataTypes.STRING()
+			});
+
+		assertEquals(29, udf.eval("1969-07-20"));
+	}
+
+	private HiveSimpleUDF init(Class hiveUdfClass, DataType[] argTypes) {
+		HiveSimpleUDF udf = new HiveSimpleUDF(new HiveFunctionWrapper(hiveUdfClass.getName()));
+
+		// Hive UDF won't have literal args
+		udf.setArgumentTypesAndConstants(new Object[0], argTypes);
+		udf.getHiveResultType(new Object[0], argTypes);
+
+		udf.open(null);
+
+		return udf;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates Flink with Hive UDF.

Background: given that integrating Flink with Hive functions has some hard dependencies on function definitions and type system rework part II and is currently blocked by these dependencies, we decide to take an eager approach by merging Hive functions related code into Flink first, and then adapt to any dependencies when they are done. This way, we are more confident with the timing, and minimize our risk of not being able to make it to 1.9 release.

## Brief change log

- introduced `HiveFunction` as a temp workaround to get input/output arg types
- added `HiveFunctionWrapper` as wrapper of Hive functions
- developed `HiveSimpleUDF` to hook Hive UDF with Flink
- added `HiveInspector` for data inspection and conversions
- added unit tests for `HiveSimpleUDF` using a few real Hive UDFs

Note that the data conversion currently only covers a few basic types. Conversions of more typed data will be added later on.

## Verifying this change

This change added tests and can be verified as follows:

- added `HiveSimpleUDFTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers:(yes)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

Doc will be added later