### PR TITLE
[FLINK-12806] Remove beta feature remark from the Universal Kafka connector

### DIFF
--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -92,12 +92,6 @@ For most users, the `FlinkKafkaConsumer08` (part of `flink-connector-kafka`) is 
         Modern Kafka clients are backwards compatible with broker versions 0.10.0 or later.
         However for Kafka 0.11.x and 0.10.x versions, we recommend using dedicated
         flink-connector-kafka-0.11{{ site.scala_version_suffix }} and flink-connector-kafka-0.10{{ site.scala_version_suffix }} respectively.
-        <div class="alert alert-warning">
-          <strong>Attention:</strong> as of Flink 1.7 the universal Kafka connector is considered to be
-          in a <strong>BETA</strong> status and might not be as stable as the 0.11 connector.
-          In case of problems with the universal connector, you can try to use flink-connector-kafka-0.11{{ site.scala_version_suffix }}
-          which should be compatible with all of the Kafka versions starting from 0.11.
-        </div>
         </td>
     </tr>
   </tbody>

--- a/docs/dev/connectors/kafka.zh.md
+++ b/docs/dev/connectors/kafka.zh.md
@@ -92,12 +92,6 @@ For most users, the `FlinkKafkaConsumer08` (part of `flink-connector-kafka`) is 
         Modern Kafka clients are backwards compatible with broker versions 0.10.0 or later.
         However for Kafka 0.11.x and 0.10.x versions, we recommend using dedicated
         flink-connector-kafka-0.11{{ site.scala_version_suffix }} and flink-connector-kafka-0.10{{ site.scala_version_suffix }} respectively.
-        <div class="alert alert-warning">
-          <strong>Attention:</strong> as of Flink 1.7 the universal Kafka connector is considered to be
-          in a <strong>BETA</strong> status and might not be as stable as the 0.11 connector.
-          In case of problems with the universal connector, you can try to use flink-connector-kafka-0.11{{ site.scala_version_suffix }}
-          which should be compatible with all of the Kafka versions starting from 0.11.
-        </div>
         </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request removed beta feature remark from the Universal Kafka connector*

## Brief change log

  - *Remove beta feature remark from the Universal Kafka connector*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
