### PR TITLE
[FLINK-12814][sql-client] Support a traditional and scrolling view of…

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.types.Row;
 
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
@@ -464,6 +465,7 @@ public class CliClient {
 	}
 
 	private void callSelect(SqlCommandCall cmdCall) {
+		final long start = System.currentTimeMillis();
 		final ResultDescriptor resultDesc;
 		try {
 			resultDesc = executor.executeQuery(context, cmdCall.operands[0]);
@@ -471,21 +473,30 @@ public class CliClient {
 			printExecutionException(e);
 			return;
 		}
-		final CliResultView view;
-		if (resultDesc.isMaterialized()) {
-			view = new CliTableResultView(this, resultDesc);
+		final long end = System.currentTimeMillis();
+
+		if (resultDesc.isFinalized()) {
+			printRows(resultDesc, start, end);
+			executor.cancelQuery(context, resultDesc.getResultId());
+		} else if (resultDesc.isMaterialized()) {
+			final CliResultView view;
+			if (resultDesc.isMaterialized()) {
+				view = new CliTableResultView(this, resultDesc);
+			} else {
+				view = new CliChangelogResultView(this, resultDesc);
+			}
+
+			// enter view
+			try {
+				view.open();
+
+				// view left
+				printInfo(CliStrings.MESSAGE_RESULT_QUIT);
+			} catch (SqlExecutionException e) {
+				printExecutionException(e);
+			}
 		} else {
-			view = new CliChangelogResultView(this, resultDesc);
-		}
-
-		// enter view
-		try {
-			view.open();
-
-			// view left
-			printInfo(CliStrings.MESSAGE_RESULT_QUIT);
-		} catch (SqlExecutionException e) {
-			printExecutionException(e);
+			throw new SqlExecutionException("Unsupported result type");
 		}
 	}
 
@@ -611,6 +622,20 @@ public class CliClient {
 	private void printInfo(String message) {
 		terminal.writer().println(CliStrings.messageInfo(message).toAnsi());
 		terminal.flush();
+	}
+
+	/**
+	 * Output Results in non-interactive way.
+	 *
+	 * @return
+	 */
+	void printRows(final ResultDescriptor desc, long start, long end) {
+		final String msg = "Time taken: %.03f seconds, Fetched %d row(s).";
+		List<Row> result = this.executor.retrieveResult(desc.getResultId());
+		terminal.writer().println("OK");
+		result.forEach((row) -> terminal.writer().println(row.toString()));
+		terminal.writer().println(String.format(msg, (end - start) / 1000.0, result.size()));
+		terminal.writer().flush();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ExecutionEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ExecutionEntry.java
@@ -108,6 +108,10 @@ public class ExecutionEntry extends ConfigEntry {
 
 	public static final String EXECUTION_CURRENT_DATABASE = "current-database";
 
+	private static final String EXECUTION_INTERACTIVE_VIEW_ENABLED = "interactive-view.enabled";
+
+	private static final String EXECUTION_MAX_QUERY_TIMEOUT_MS = "max-query-timeout-ms";
+
 	private ExecutionEntry(DescriptorProperties properties) {
 		super(properties);
 	}
@@ -152,6 +156,8 @@ public class ExecutionEntry extends ConfigEntry {
 		properties.validateInt(EXECUTION_RESTART_STRATEGY_MAX_FAILURES_PER_INTERVAL, true, 1);
 		properties.validateString(EXECUTION_CURRENT_CATALOG, true, 1);
 		properties.validateString(EXECUTION_CURRENT_DATABASE, true, 1);
+		properties.validateBoolean(EXECUTION_INTERACTIVE_VIEW_ENABLED, true);
+		properties.validateInt(EXECUTION_MAX_QUERY_TIMEOUT_MS, true, -1);
 	}
 
 	public EnvironmentSettings getEnvironmentSettings() {
@@ -310,6 +316,12 @@ public class ExecutionEntry extends ConfigEntry {
 		return properties.getOptionalString(EXECUTION_CURRENT_DATABASE);
 	}
 
+	public int getMaxQueryTimeoutMs() {
+		// defaultValue -1 means do not timeout
+		return properties.getOptionalInt(EXECUTION_MAX_QUERY_TIMEOUT_MS)
+			.orElseGet(() -> useDefaultValue(EXECUTION_MAX_QUERY_TIMEOUT_MS, -1));
+	}
+
 	public boolean isChangelogMode() {
 		return properties.getOptionalString(EXECUTION_RESULT_MODE)
 			.map((v) -> v.equals(EXECUTION_RESULT_MODE_VALUE_CHANGELOG))
@@ -320,6 +332,11 @@ public class ExecutionEntry extends ConfigEntry {
 		return properties.getOptionalString(EXECUTION_RESULT_MODE)
 			.map((v) -> v.equals(EXECUTION_RESULT_MODE_VALUE_TABLE))
 			.orElse(false);
+	}
+
+	public boolean isInteractiveViewEnabled() {
+		return properties.getOptionalBoolean(EXECUTION_INTERACTIVE_VIEW_ENABLED)
+			.orElseGet(() -> useDefaultValue(EXECUTION_INTERACTIVE_VIEW_ENABLED, true));
 	}
 
 	public Map<String, String> asTopLevelMap() {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -108,6 +108,11 @@ public interface Executor {
 	List<Row> retrieveResultPage(String resultId, int page) throws SqlExecutionException;
 
 	/**
+	 * Returns the finalized rows. Throws an exception if the Finalized Result has been removed.
+	 */
+	List<Row> retrieveResult(String resultId) throws SqlExecutionException;
+
+	/**
 	 * Cancels a table program and stops the result retrieval. Blocking until cancellation command has
 	 * been sent to cluster.
 	 */

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ResultDescriptor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ResultDescriptor.java
@@ -31,10 +31,13 @@ public class ResultDescriptor {
 
 	private final boolean isMaterialized;
 
-	public ResultDescriptor(String resultId, TableSchema resultSchema, boolean isMaterialized) {
+	private final boolean isFinalized;
+
+	public ResultDescriptor(String resultId, TableSchema resultSchema, boolean isMaterialized, boolean isFinalized) {
 		this.resultId = resultId;
 		this.resultSchema = resultSchema;
 		this.isMaterialized = isMaterialized;
+		this.isFinalized = isFinalized;
 	}
 
 	public String getResultId() {
@@ -47,5 +50,9 @@ public class ResultDescriptor {
 
 	public boolean isMaterialized() {
 		return isMaterialized;
+	}
+
+	public boolean isFinalized() {
+		return isFinalized;
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
@@ -52,6 +52,11 @@ public class ChangelogCollectStreamResult<C> extends CollectStreamResult<C> impl
 	}
 
 	@Override
+	public boolean isFinalized() {
+		return false;
+	}
+
+	@Override
 	public TypedResult<List<Tuple2<Boolean, Row>>> retrieveChanges() {
 		synchronized (resultLock) {
 			// retrieval thread is alive return a record if available

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectBatchResult.java
@@ -155,8 +155,7 @@ public class CollectBatchResult<C> extends BasicResult<C> implements Materialize
 			if (executionException != null) {
 				throw executionException;
 			}
-			// wait until retrievalT
-			//hread finished.
+			// wait until retrievalThread finished.
 			resultLatch.await();
 			return resultTable.subList(0, resultTable.size());
 		} catch (InterruptedException e) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectBatchResult.java
@@ -34,17 +34,20 @@ import org.apache.flink.util.AbstractID;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Collects results using accumulators and returns them as table snapshots.
  */
-public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements MaterializedResult<C> {
+public class CollectBatchResult<C> extends BasicResult<C> implements MaterializedResult<C>, FinalizedResult<C> {
 
 	private final TypeInformation<Row> outputType;
 	private final String accumulatorName;
 	private final CollectBatchTableSink tableSink;
 	private final Object resultLock;
+	private final CountDownLatch resultLatch;
 	private final Thread retrievalThread;
+	private final ResultType resultType;
 
 	private ProgramDeployer<C> deployer;
 	private int pageSize;
@@ -54,21 +57,41 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 
 	private volatile boolean snapshotted = false;
 
-	public MaterializedCollectBatchResult(RowTypeInfo outputType, ExecutionConfig config) {
+	public CollectBatchResult(RowTypeInfo outputType, ExecutionConfig config) {
+		this(outputType, config, ResultType.MATERIALIZED);
+	}
+
+	public CollectBatchResult(
+			RowTypeInfo outputType,
+			ExecutionConfig config,
+			ResultType resultType) {
 		this.outputType = outputType;
+		this.resultType = resultType;
 
 		accumulatorName = new AbstractID().toString();
 		tableSink = new CollectBatchTableSink(accumulatorName, outputType.createSerializer(config))
 			.configure(outputType.getFieldNames(), outputType.getFieldTypes());
 		resultLock = new Object();
-		retrievalThread = new ResultRetrievalThread();
+		resultLatch = new CountDownLatch(1);
+		if (ResultType.MATERIALIZED == resultType) {
+			retrievalThread = new MaterializedResultRetrievalThread();
+		} else if (ResultType.FINALIZED == resultType) {
+			retrievalThread = new FinalizedResultRetrievalThread();
+		} else {
+			throw new SqlExecutionException("Unsupported result type: '" + resultType.name() + "'.");
+		}
 
 		pageCount = 0;
 	}
 
 	@Override
 	public boolean isMaterialized() {
-		return true;
+		return ResultType.MATERIALIZED == resultType;
+	}
+
+	@Override
+	public boolean isFinalized() {
+		return ResultType.FINALIZED == resultType;
 	}
 
 	@Override
@@ -126,9 +149,24 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 		}
 	}
 
+	@Override
+	public List<Row> retrieveResult() {
+		try {
+			if (executionException != null) {
+				throw executionException;
+			}
+			// wait until retrievalT
+			//hread finished.
+			resultLatch.await();
+			return resultTable.subList(0, resultTable.size());
+		} catch (InterruptedException e) {
+			throw new SqlExecutionException("Could not retrieve finalized result.", e);
+		}
+	}
+
 	// --------------------------------------------------------------------------------------------
 
-	private class ResultRetrievalThread extends Thread {
+	private class MaterializedResultRetrievalThread extends Thread {
 
 		@Override
 		public void run() {
@@ -142,8 +180,32 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 				final List<Row> resultTable = SerializedListAccumulator.deserializeList(accResult, tableSink.getSerializer());
 				// sets the result table all at once
 				synchronized (resultLock) {
-					MaterializedCollectBatchResult.this.resultTable = resultTable;
+					CollectBatchResult.this.resultTable = resultTable;
 				}
+			} catch (ClassNotFoundException | IOException e) {
+				executionException = new SqlExecutionException("Serialization error while deserializing collected data.", e);
+			} catch (SqlExecutionException e) {
+				executionException = e;
+			}
+		}
+	}
+
+	private class FinalizedResultRetrievalThread extends Thread {
+
+		@Override
+		public void run() {
+			try {
+				deployer.run();
+				final JobExecutionResult result = deployer.fetchExecutionResult();
+				final ArrayList<byte[]> accResult = result.getAccumulatorResult(accumulatorName);
+				if (accResult == null) {
+					throw new SqlExecutionException("The accumulator could not retrieve the result.");
+				}
+				final List<Row> resultTable = SerializedListAccumulator.deserializeList(accResult, tableSink.getSerializer());
+				// sets the result table all at once
+				CollectBatchResult.this.resultTable = resultTable;
+				// notify result is ready to read
+				resultLatch.countDown();
 			} catch (ClassNotFoundException | IOException e) {
 				executionException = new SqlExecutionException("Serialization error while deserializing collected data.", e);
 			} catch (SqlExecutionException e) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
@@ -39,6 +39,11 @@ public interface DynamicResult<C> extends Result<C> {
 	boolean isMaterialized();
 
 	/**
+	 * Returns whether this result is finalized such that all results can be retrieved at one time.
+	 */
+	boolean isFinalized();
+
+	/**
 	 * Returns the output type as defined by the query.
 	 */
 	TypeInformation<Row> getOutputType();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/FinalizedCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/FinalizedCollectStreamResult.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local.result;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.experimental.SocketStreamIterator;
+import org.apache.flink.table.client.SqlClientException;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.client.gateway.local.CollectStreamTableSink;
+import org.apache.flink.table.client.gateway.local.ProgramDeployer;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.types.Row;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Collects results and returns them as finalized table.
+ *
+ * @param <C> cluster id to which this result belongs to
+ */
+public class FinalizedCollectStreamResult<C> extends BasicResult<C> implements DynamicResult<C>, FinalizedResult<C> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FinalizedCollectStreamResult.class);
+	private final TypeInformation<Row> outputType;
+	private final SocketStreamIterator<Tuple2<Boolean, Row>> iterator;
+	private final CollectStreamTableSink collectTableSink;
+	private final ResultRetrievalThread retrievalThread;
+	private final CountDownLatch resultLatch;
+	private final List<Row> finalizedTable;
+	/**
+	 * Caches the last row position for faster access. The position might not be exact (if rows
+	 * with smaller position are deleted) nor complete (for deletes of duplicates). However, the
+	 * cache narrows the search in the finalized table.
+	 */
+	private final Map<Row, Integer> rowPositionCache;
+
+	private final ExecutorService executor;
+	private final int queryTimeoutMS;
+
+	private static final Signal SIGNAL_INT = new Signal("INT");
+
+	public FinalizedCollectStreamResult(
+			RowTypeInfo outputType,
+			ExecutionConfig config,
+			InetAddress gatewayAddress,
+			int gatewayPort) {
+		this(outputType, config, gatewayAddress, gatewayPort, -1);
+	}
+
+	public FinalizedCollectStreamResult(
+			RowTypeInfo outputType,
+			ExecutionConfig config,
+			InetAddress gatewayAddress,
+			int gatewayPort,
+			int queryTimeoutMs) {
+		this.outputType = outputType;
+		this.resultLatch = new CountDownLatch(1);
+		this.finalizedTable = new ArrayList<>();
+		this.rowPositionCache = new HashMap<>();
+		this.executor = Executors.newSingleThreadExecutor();
+		this.queryTimeoutMS = queryTimeoutMs;
+
+		// create socket stream iterator
+		final TypeInformation<Tuple2<Boolean, Row>> socketType = Types.TUPLE(Types.BOOLEAN, outputType);
+		final TypeSerializer<Tuple2<Boolean, Row>> serializer = socketType.createSerializer(config);
+		try {
+			// pass gateway port and address such that iterator knows where to bind to
+			iterator = new SocketStreamIterator<>(gatewayPort, gatewayAddress, serializer);
+		} catch (IOException e) {
+			throw new SqlClientException("Could not start socket for result retrieval.", e);
+		}
+
+		// create table sink
+		// pass binding address and port such that sink knows where to send to
+		collectTableSink = new CollectStreamTableSink(iterator.getBindAddress(), iterator.getPort(), serializer)
+			.configure(outputType.getFieldNames(), outputType.getFieldTypes());
+		retrievalThread = new ResultRetrievalThread();
+	}
+
+	@Override
+	public List<Row> retrieveResult() {
+		try {
+			// wait for the retrievalThread finished
+			resultLatch.await();
+
+			return finalizedTable;
+		} catch (InterruptedException e) {
+			throw new SqlExecutionException("Could not retrieve finalized result.", e);
+		}
+	}
+
+	@Override
+	public boolean isMaterialized() {
+		return false;
+	}
+
+	@Override
+	public boolean isFinalized() {
+		return true;
+	}
+
+	@Override
+	public TypeInformation<Row> getOutputType() {
+		return outputType;
+	}
+
+	@Override
+	public void startRetrieval(ProgramDeployer<C> deployer) {
+
+		retrievalThread.start();
+
+		final Future<?> deployFuture = executor.submit(deployer);
+
+		final SignalHandler previousHandler = Signal.handle(SIGNAL_INT, new SignalHandler() {
+			@Override
+			public void handle(Signal signal) {
+				deployFuture.cancel(true);
+				retrievalThread.isRunning = false;
+				retrievalThread.interrupt();
+			}
+		});
+
+		try {
+			if (queryTimeoutMS > 0) {
+				LOG.info("Waiting for job finish or timeout in " + queryTimeoutMS + " ms.");
+				try {
+					deployFuture.get(queryTimeoutMS, TimeUnit.MILLISECONDS);
+				} catch (final TimeoutException e) {
+					deployFuture.cancel(true);
+					retrievalThread.isRunning = false;
+					retrievalThread.interrupt();
+				}
+			} else {
+				LOG.info("Waiting for job finished.");
+				deployFuture.get();
+			}
+		} catch (final InterruptedException | ExecutionException e) {
+			close();
+			throw new SqlExecutionException("Encounter unexpected error while deploying the job.", e);
+		} catch (final CancellationException e) {
+			LOG.info("Cancel job, fetch and display the finalized result");
+			// query cancelled, ignore cancellation exception, fetch and display the finalized result.
+		} finally {
+			if (previousHandler != null) {
+				Signal.handle(SIGNAL_INT, previousHandler);
+			}
+		}
+	}
+
+	@Override
+	public TableSink<?> getTableSink() {
+		return collectTableSink;
+	}
+
+	@Override
+	public void close() {
+		if (retrievalThread.isAlive()) {
+			retrievalThread.isRunning = false;
+			retrievalThread.interrupt();
+		}
+		iterator.close();
+		executor.shutdown();
+	}
+
+	void processInsert(Row row) {
+		finalizedTable.add(row);
+		rowPositionCache.put(row, finalizedTable.size() - 1);
+	}
+
+	void processDelete(Row row) {
+		final Integer cachedPos = rowPositionCache.get(row);
+		final int startSearchPos;
+		if (cachedPos != null) {
+			startSearchPos = Math.min(cachedPos, finalizedTable.size() - 1);
+		} else {
+			startSearchPos = finalizedTable.size() - 1;
+		}
+
+		for (int i = startSearchPos; i >= 0; i--) {
+			if (finalizedTable.get(i).equals(row)) {
+				finalizedTable.remove(i);
+				rowPositionCache.remove(row);
+				break;
+			}
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private class ResultRetrievalThread extends Thread {
+
+		public volatile boolean isRunning = true;
+
+		@Override
+		public void run() {
+			try {
+				while (isRunning && iterator.hasNext()) {
+					final Tuple2<Boolean, Row> change = iterator.next();
+					if (change.f0) {
+						processInsert(change.f1);
+					} else {
+						processDelete(change.f1);
+					}
+				}
+			} catch (RuntimeException e) {
+				// ignore socket exceptions
+			}
+
+			// no result anymore
+			// either the job is down or an error occurred.
+			isRunning = false;
+			resultLatch.countDown();
+		}
+	}
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/FinalizedResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/FinalizedResult.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,44 +19,18 @@
 
 package org.apache.flink.table.client.gateway.local.result;
 
+import org.apache.flink.types.Row;
+
+import java.util.List;
+
 /**
- * Basic result of a table program that has been submitted to a cluster.
+ * A result that represented as the finalized result consisting all latest insert records.
  *
  * @param <C> cluster id to which this result belongs to
  */
-public class BasicResult<C> implements Result<C> {
-
-	protected C clusterId;
-	protected String webInterfaceUrl;
-
-	@Override
-	public void setClusterInformation(C clusterId, String webInterfaceUrl) {
-		if (this.clusterId != null || this.webInterfaceUrl != null) {
-			throw new IllegalStateException("Cluster information is already present.");
-		}
-		this.clusterId = clusterId;
-		this.webInterfaceUrl = webInterfaceUrl;
-	}
-
-	public C getClusterId() {
-		if (this.clusterId == null) {
-			throw new IllegalStateException("Cluster ID has not been set.");
-		}
-		return clusterId;
-	}
-
-	public String getWebInterfaceUrl() {
-		if (this.webInterfaceUrl == null) {
-			throw new IllegalStateException("Cluster web interface URL has not been set.");
-		}
-		return webInterfaceUrl;
-	}
-
+public interface FinalizedResult<C> extends DynamicResult<C> {
 	/**
-	 * Result types.
+	 * Retrieves all available result records.
 	 */
-	public enum ResultType {
-		MATERIALIZED,
-		FINALIZED
-	}
+	List<Row> retrieveResult();
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
@@ -138,6 +138,11 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 	}
 
 	@Override
+	public boolean isFinalized() {
+		return false;
+	}
+
+	@Override
 	public TypedResult<Integer> snapshot(int pageSize) {
 		if (pageSize < 1) {
 			throw new SqlExecutionException("Page size must be greater than 0.");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -281,6 +281,11 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public List<Row> retrieveResult(String resultId) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException {
 			// nothing to do
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -83,6 +83,7 @@ public class CliResultViewTest {
 		final ResultDescriptor descriptor = new ResultDescriptor(
 			"result-id",
 			TableSchema.builder().field("Null Field", Types.STRING()).build(),
+			false,
 			false);
 
 		Thread resultViewRunner = null;
@@ -190,6 +191,11 @@ public class CliResultViewTest {
 		@Override
 		public List<Row> retrieveResultPage(String resultId, int page) throws SqlExecutionException {
 			return Collections.singletonList(new Row(1));
+		}
+
+		@Override
+		public List<Row> retrieveResult(String resultId) throws SqlExecutionException {
+			return null;
 		}
 
 		@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/UserDefinedFunctions.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/UserDefinedFunctions.java
@@ -48,6 +48,27 @@ public class UserDefinedFunctions {
 	}
 
 	/**
+	 * The scalar function for SQL Client test.
+	 */
+	public static class TimeConsumingUDF extends ScalarFunction {
+
+		private int timeConsuming;
+
+		public TimeConsumingUDF(Integer timeConsuming) {
+			this.timeConsuming = timeConsuming;
+		}
+
+		public String eval(Integer i) {
+			try {
+				Thread.sleep(timeConsuming * 1000);
+			} catch (final InterruptedException e) {
+				// ignore
+			}
+			return String.format("%d-sleeping-%d-seconds", i, timeConsuming);
+		}
+	}
+
+	/**
 	 * The aggregate function for SQL Client test.
 	 */
 	public static class AggregateUDF extends AggregateFunction<Long, Long> {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/UserDefinedFunctions.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/UserDefinedFunctions.java
@@ -48,27 +48,6 @@ public class UserDefinedFunctions {
 	}
 
 	/**
-	 * The scalar function for SQL Client test.
-	 */
-	public static class TimeConsumingUDF extends ScalarFunction {
-
-		private int timeConsuming;
-
-		public TimeConsumingUDF(Integer timeConsuming) {
-			this.timeConsuming = timeConsuming;
-		}
-
-		public String eval(Integer i) {
-			try {
-				Thread.sleep(timeConsuming * 1000);
-			} catch (final InterruptedException e) {
-				// ignore
-			}
-			return String.format("%d-sleeping-%d-seconds", i, timeConsuming);
-		}
-	}
-
-	/**
 	 * The aggregate function for SQL Client test.
 	 */
 	public static class AggregateUDF extends AggregateFunction<Long, Long> {


### PR DESCRIPTION
… result

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Introduce a traditional and scrolling (non-interactive) view of result in table mode. 

## Brief change log

- Introduce a new interface **FinalizedResult** which represented as the finalized result consisting all latest insert records.
- Introduce an execution option: execution.interactive-view.enabled. CliClient works in original way when it's set to 'true'. By default it is 'true'.
- Renamed **MaterializedCollectBatchResult** to **CollectBatchResult** and implements **FinalizedResult**. When execution.interactive-view.enabled is set to 'false', **CollectBatchResult** would return all fetched rows. CliClient output the rows in a non-interactive way.
- Introduce **FinalizedCollectStreamResult** which implements **FinalizedResult**. When execution.interactive-view.enabled is set to 'false', **FinalizedCollectStreamResult** would submit user's query and wait until the job finished, failed, interrupted by user(ctrl+c) or  time out(in a user defined timeout). And return all fetched rows. CliClient output the rows in a non-interactive way. 

## Verifying this change
 - Manually verified the change by running a standalone cluster with 1 JobManager and 1 TaskManager, a sql client(with execution.interactive-view.enabled=false), and submitting queries to sql client, verifying that result rows are printed in a traditional and scrolling way.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
