### PR TITLE
[FLINK-12803][python] Correct the package name for python API

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -782,7 +782,7 @@ public class CliFrontend {
 				jarFile = getJarFile(jarFilePath);
 			}
 			// The entry point class of python job is PythonDriver
-			entryPointClass = "org.apache.flink.python.client.PythonDriver";
+			entryPointClass = "org.apache.flink.client.python.PythonDriver";
 		} else {
 			if (jarFilePath == null) {
 				throw new IllegalArgumentException("Java program should be specified a JAR file.");

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -182,7 +182,7 @@ public class PackagedProgram {
 	 */
 	public PackagedProgram(File jarFile, List<URL> classpaths, @Nullable String entryPointClassName, String... args) throws ProgramInvocationException {
 		// Whether the job is a Python job.
-		isPython = entryPointClassName != null && entryPointClassName.equals("org.apache.flink.python.client.PythonDriver");
+		isPython = entryPointClassName != null && entryPointClassName.equals("org.apache.flink.client.python.PythonDriver");
 
 		URL jarFileUrl = null;
 		if (jarFile != null) {
@@ -248,7 +248,7 @@ public class PackagedProgram {
 
 		// load the entry point class
 		this.mainClass = entryPointClass;
-		isPython = entryPointClass.getCanonicalName().equals("org.apache.flink.python.client.PythonDriver");
+		isPython = entryPointClass.getCanonicalName().equals("org.apache.flink.client.python.PythonDriver");
 
 		// if the entry point is a program, instantiate the class and get the plan
 		if (Program.class.isAssignableFrom(this.mainClass)) {

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -142,11 +142,11 @@ under the License.
 							<relocations>
 								<relocation>
 									<pattern>py4j</pattern>
-									<shadedPattern>org.apache.flink.python.shaded.py4j</shadedPattern>
+									<shadedPattern>org.apache.flink.api.python.shaded.py4j</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>net.razorvine</pattern>
-									<shadedPattern>org.apache.flink.python.shaded.net.razorvine</shadedPattern>
+									<shadedPattern>org.apache.flink.api.python.shaded.net.razorvine</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -64,7 +64,7 @@ def launch_gateway():
         raise Exception("Windows system is not supported currently.")
     script = "./bin/pyflink-gateway-server.sh"
     command = [os.path.join(FLINK_HOME, script)]
-    command += ['-c', 'org.apache.flink.python.client.PythonGatewayServer']
+    command += ['-c', 'org.apache.flink.client.python.PythonGatewayServer']
 
     # Create a temporary directory where the gateway server should write the connection information.
     conn_info_dir = tempfile.mkdtemp()
@@ -114,10 +114,10 @@ def import_flink_view(gateway):
     java_import(gateway.jvm, "org.apache.flink.table.descriptors.*")
     java_import(gateway.jvm, "org.apache.flink.table.sources.*")
     java_import(gateway.jvm, "org.apache.flink.table.sinks.*")
-    java_import(gateway.jvm, "org.apache.flink.table.python.*")
     java_import(gateway.jvm, "org.apache.flink.table.types.*")
     java_import(gateway.jvm, "org.apache.flink.table.types.logical.*")
-    java_import(gateway.jvm, "org.apache.flink.python.bridge.*")
+    java_import(gateway.jvm, "org.apache.flink.table.util.python.*")
+    java_import(gateway.jvm, "org.apache.flink.api.common.python.*")
     java_import(gateway.jvm, "org.apache.flink.api.common.typeinfo.TypeInformation")
     java_import(gateway.jvm, "org.apache.flink.api.common.typeinfo.Types")
     java_import(gateway.jvm, "org.apache.flink.api.java.ExecutionEnvironment")

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1305,7 +1305,7 @@ def _is_instance_of(java_data_type, java_class):
         raise TypeError(
             "java_class must be a string, a JavaClass, or a JavaObject")
 
-    return gateway.jvm.org.apache.flink.python.shaded.py4j.reflection.TypeUtil.isInstanceOf(
+    return gateway.jvm.org.apache.flink.api.python.shaded.py4j.reflection.TypeUtil.isInstanceOf(
         param, java_data_type)
 
 

--- a/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.bridge;
+package org.apache.flink.api.common.python;
 
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.python.pickle.ArrayConstructor;
+import org.apache.flink.api.common.python.pickle.ByteArrayConstructor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.python.bridge.pickle.ArrayConstructor;
-import org.apache.flink.python.bridge.pickle.ByteArrayConstructor;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.Collector;

--- a/flink-python/src/main/java/org/apache/flink/api/common/python/pickle/ArrayConstructor.java
+++ b/flink-python/src/main/java/org/apache/flink/api/common/python/pickle/ArrayConstructor.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.bridge.pickle;
+package org.apache.flink.api.common.python.pickle;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/flink-python/src/main/java/org/apache/flink/api/common/python/pickle/ByteArrayConstructor.java
+++ b/flink-python/src/main/java/org/apache/flink/api/common/python/pickle/ByteArrayConstructor.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.bridge.pickle;
+package org.apache.flink.api.common.python.pickle;
 
 import org.apache.commons.lang3.ArrayUtils;
 

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.client;
+package org.apache.flink.client.python;
 
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
@@ -33,7 +33,7 @@ import java.util.List;
  * A main class used to launch Python applications. It executes python as a
  * subprocess and then has it connect back to the JVM to access system properties, etc.
  */
-public class PythonDriver {
+public final class PythonDriver {
 	private static final Logger LOG = LoggerFactory.getLogger(PythonDriver.class);
 
 	public static void main(String[] args) {

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptions.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.client;
+package org.apache.flink.client.python;
 
 import org.apache.flink.core.fs.Path;
 

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptionsParserFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptionsParserFactory.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.client;
+package org.apache.flink.client.python;
 
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.client;
+package org.apache.flink.client.python;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.fs.FileSystem;

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.client;
+package org.apache.flink.client.python;
 
 import py4j.GatewayServer;
 

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverOptionsParserFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverOptionsParserFactoryTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.client;
+package org.apache.flink.client.python;
 
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.client;
+package org.apache.flink.client.python;
 
 import org.apache.flink.core.fs.Path;
 

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.client;
+package org.apache.flink.client.python;
 
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.python
+package org.apache.flink.table.util.python
 
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
@@ -27,8 +27,8 @@ import org.apache.flink.api.common.typeinfo.{BasicArrayTypeInfo, BasicTypeInfo, 
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.java.typeutils.{MapTypeInfo, ObjectArrayTypeInfo, RowTypeInfo}
 import org.apache.flink.streaming.api.datastream.DataStream
-import org.apache.flink.table.api.{Table, Types}
 import org.apache.flink.table.api.java.{BatchTableEnvironment, StreamTableEnvironment}
+import org.apache.flink.table.api.{Table, Types}
 import org.apache.flink.types.Row
 
 object PythonTableUtils {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request corrects the package name of the flink-python module*


## Brief change log

  - *Changes the package name from o.a.f.python -> o.a.f.api.python*


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
