### PR TITLE
[FLINK-12819][sql-client] Reuse TableEnvironment between different SQ…

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -242,4 +242,12 @@ public class Environment {
 
 		return enrichedEnv;
 	}
+
+	/**
+	 * Should re-new a TableEnvironment object for the execution mode is change.
+	 */
+	public static boolean isRenew(Environment before, Environment after) {
+		return ((before.getExecution().isBatchExecution() && after.getExecution().isStreamingExecution())
+				|| (before.getExecution().isStreamingExecution() && after.getExecution().isBatchExecution()));
+	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -105,6 +105,7 @@ public class ExecutionContext<T> {
 	private final RunOptions runOptions;
 	private final T clusterId;
 	private final ClusterSpecification clusterSpec;
+	private final EnvironmentInstance environmentInstance;
 
 	public ExecutionContext(Environment defaultEnvironment, SessionContext sessionContext, List<URL> dependencies,
 			Configuration flinkConfig, Options commandLineOptions, List<CustomCommandLine<?>> availableCommandLines) {
@@ -149,6 +150,9 @@ public class ExecutionContext<T> {
 		runOptions = createRunOptions(commandLine);
 		clusterId = activeCommandLine.getClusterId(commandLine);
 		clusterSpec = createClusterSpecification(activeCommandLine, commandLine);
+
+		// reuse environment instance
+		environmentInstance = createEnvironmentInstance();
 	}
 
 	public SessionContext getSessionContext() {
@@ -176,6 +180,10 @@ public class ExecutionContext<T> {
 	}
 
 	public EnvironmentInstance createEnvironmentInstance() {
+		if (environmentInstance != null) {
+			return environmentInstance;
+		}
+
 		try {
 			return wrapClassLoader(EnvironmentInstance::new);
 		} catch (Throwable t) {


### PR DESCRIPTION
…L statements

## What is the purpose of the change

reuse TableEnvironemnt instance between different SQL statements

## Brief change log

reuse TableEnvironemnt instance between different SQL statements

## Verifying this change

 - Added test to verify TableEnvironment instance is reused: org.apache.flink.table.client.gateway.local.testReuseTableEnv

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
