### PR TITLE
[FLINK-12820][Connectors / Cassandra] Support ignoring writing nulls 

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.cassandra;
 
 import org.apache.flink.configuration.Configuration;
 
+import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -31,6 +32,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 public abstract class AbstractCassandraTupleSink<IN> extends CassandraSinkBase<IN, ResultSet> {
 	private final String insertQuery;
 	private transient PreparedStatement ps;
+	private final Boolean ignoreNullFields;
 
 	public AbstractCassandraTupleSink(
 			String insertQuery,
@@ -39,6 +41,7 @@ public abstract class AbstractCassandraTupleSink<IN> extends CassandraSinkBase<I
 			CassandraFailureHandler failureHandler) {
 		super(builder, config, failureHandler);
 		this.insertQuery = insertQuery;
+		this.ignoreNullFields = config.getIgnoreNullFields();
 	}
 
 	@Override
@@ -50,7 +53,19 @@ public abstract class AbstractCassandraTupleSink<IN> extends CassandraSinkBase<I
 	@Override
 	public ListenableFuture<ResultSet> send(IN value) {
 		Object[] fields = extract(value);
-		return session.executeAsync(ps.bind(fields));
+		return session.executeAsync(bind(fields));
+	}
+
+	private BoundStatement bind(Object[] fields) {
+		BoundStatement bs = ps.bind(fields);
+		if (ignoreNullFields) {
+			for (int i = 0; i < fields.length; i++) {
+				if (fields[i] == null) {
+					bs.unset(i);
+				}
+			}
+		}
+		return bs;
 	}
 
 	protected abstract Object[] extract(IN record);

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
@@ -32,7 +32,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 public abstract class AbstractCassandraTupleSink<IN> extends CassandraSinkBase<IN, ResultSet> {
 	private final String insertQuery;
 	private transient PreparedStatement ps;
-	private final Boolean ignoreNullFields;
+	private final boolean ignoreNullFields;
 
 	public AbstractCassandraTupleSink(
 			String insertQuery,

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -399,6 +399,19 @@ public class CassandraSink<IN> {
 		}
 
 		/**
+		 * Enables ignoring null values, treats null values as unset and avoids writing null fields
+		 * and creating tombstones.
+		 *
+		 * <p>This call has no effect if {@link CassandraSinkBuilder#enableWriteAheadLog()} is called.
+		 *
+		 * @return this builder
+		 */
+		public CassandraSinkBuilder<IN> enableIgnoreNullFields() {
+			this.configBuilder.setIgnoreNullFields(true);
+			return this;
+		}
+
+		/**
 		 * Finalizes the configuration of this sink.
 		 *
 		 * @return finalized sink

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
@@ -39,7 +39,7 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 	public static final Duration DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT = Duration.ofMillis(Long.MAX_VALUE);
 
 	/**
-	 * The default option to ignore null fields on insert. By default, {@code Boolean.FALSE}.
+	 * The default option to ignore null fields on insertion. By default, {@code Boolean.FALSE}.
 	 */
 	public static final Boolean DEFAULT_IGNORE_NULL_FIELDS = false;
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
@@ -38,6 +38,12 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 	 */
 	public static final Duration DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT = Duration.ofMillis(Long.MAX_VALUE);
 
+	/**
+	 * The default option to ignore null fields on insert. By default, {@code Boolean.FALSE}.
+	 */
+	public static final Boolean DEFAULT_IGNORE_NULL_FIELDS = false;
+
+
 	// ------------------------- Configuration Fields -------------------------
 
 	/** Maximum number of concurrent requests allowed. */
@@ -46,9 +52,13 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 	/** Timeout duration when acquiring a permit to execute. */
 	private final Duration maxConcurrentRequestsTimeout;
 
+	/** Whether to ignore null fields on insert. */
+	private final Boolean ignoreNullFields;
+
 	private CassandraSinkBaseConfig(
 			int maxConcurrentRequests,
-			Duration maxConcurrentRequestsTimeout) {
+			Duration maxConcurrentRequestsTimeout,
+			Boolean ignoreNullFields) {
 		Preconditions.checkArgument(maxConcurrentRequests > 0,
 			"Max concurrent requests is expected to be positive");
 		Preconditions.checkNotNull(maxConcurrentRequestsTimeout,
@@ -57,6 +67,7 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 			"Max concurrent requests timeout is expected to be positive");
 		this.maxConcurrentRequests = maxConcurrentRequests;
 		this.maxConcurrentRequestsTimeout = maxConcurrentRequestsTimeout;
+		this.ignoreNullFields = ignoreNullFields;
 	}
 
 	public int getMaxConcurrentRequests() {
@@ -67,11 +78,16 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 		return maxConcurrentRequestsTimeout;
 	}
 
+	public Boolean getIgnoreNullFields() {
+		return ignoreNullFields;
+	}
+
 	@Override
 	public String toString() {
 		return "CassandraSinkBaseConfig{" +
 			"maxConcurrentRequests=" + maxConcurrentRequests +
 			", maxConcurrentRequestsTimeout=" + maxConcurrentRequestsTimeout +
+			", ignoreNullFields=" + ignoreNullFields +
 			'}';
 	}
 
@@ -85,6 +101,7 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 	public static class Builder {
 		private int maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS;
 		private Duration maxConcurrentRequestsTimeout = DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT;
+		private Boolean ignoreNullFields = DEFAULT_IGNORE_NULL_FIELDS;
 
 		Builder() { }
 
@@ -98,10 +115,16 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 			return this;
 		}
 
+		public Builder setIgnoreNullFields(Boolean ignoreNullFields) {
+			this.ignoreNullFields = ignoreNullFields;
+			return this;
+		}
+
 		public CassandraSinkBaseConfig build() {
 			return new CassandraSinkBaseConfig(
 				maxConcurrentRequests,
-				maxConcurrentRequestsTimeout);
+				maxConcurrentRequestsTimeout,
+				ignoreNullFields);
 		}
 	}
 }

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
@@ -39,9 +39,9 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 	public static final Duration DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT = Duration.ofMillis(Long.MAX_VALUE);
 
 	/**
-	 * The default option to ignore null fields on insertion. By default, {@code Boolean.FALSE}.
+	 * The default option to ignore null fields on insertion. By default, {@code false}.
 	 */
-	public static final Boolean DEFAULT_IGNORE_NULL_FIELDS = false;
+	public static final boolean DEFAULT_IGNORE_NULL_FIELDS = false;
 
 
 	// ------------------------- Configuration Fields -------------------------
@@ -53,12 +53,12 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 	private final Duration maxConcurrentRequestsTimeout;
 
 	/** Whether to ignore null fields on insert. */
-	private final Boolean ignoreNullFields;
+	private final boolean ignoreNullFields;
 
 	private CassandraSinkBaseConfig(
 			int maxConcurrentRequests,
 			Duration maxConcurrentRequestsTimeout,
-			Boolean ignoreNullFields) {
+			boolean ignoreNullFields) {
 		Preconditions.checkArgument(maxConcurrentRequests > 0,
 			"Max concurrent requests is expected to be positive");
 		Preconditions.checkNotNull(maxConcurrentRequestsTimeout,
@@ -78,7 +78,7 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 		return maxConcurrentRequestsTimeout;
 	}
 
-	public Boolean getIgnoreNullFields() {
+	public boolean getIgnoreNullFields() {
 		return ignoreNullFields;
 	}
 
@@ -101,7 +101,7 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 	public static class Builder {
 		private int maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS;
 		private Duration maxConcurrentRequestsTimeout = DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT;
-		private Boolean ignoreNullFields = DEFAULT_IGNORE_NULL_FIELDS;
+		private boolean ignoreNullFields = DEFAULT_IGNORE_NULL_FIELDS;
 
 		Builder() { }
 
@@ -115,7 +115,7 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 			return this;
 		}
 
-		public Builder setIgnoreNullFields(Boolean ignoreNullFields) {
+		public Builder setIgnoreNullFields(boolean ignoreNullFields) {
 			this.ignoreNullFields = ignoreNullFields;
 			return this;
 		}


### PR DESCRIPTION
## What is the purpose of the change
Added support to ignore null fields when writing to c* for tuple types. 

## Brief change log
 - Added 'ignoreNullFields' config parameter which can be enabled
 - Unset nulls from bound statement.

## Verifying this change

This change added tests and can be verified as follows:
 Added a test case to CassandraConnectorITCase testing partial column updates

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
