### PR TITLE
[FLINK-12821][table][cep] Fix the bug that fix time quantifier can not be the last element of a pattern

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
@@ -372,7 +372,7 @@ private class PatternVisitor(
       pattern.timesOrMore(startNum).consecutive()
     }
 
-    if (greedy && isOptional) {
+    if (greedy && (isOptional || startNum == endNum)) {
       newPattern
     } else if (greedy) {
       newPattern.greedy()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTest.scala
@@ -125,6 +125,17 @@ class PatternTranslatorTest extends PatternTranslatorTestBase {
         |     A as A.f0 = 1
         |)""".stripMargin,
       Pattern.begin("A", skipToNext()).times(2, 6).consecutive().greedy().next("B"))
+
+    verifyPattern(
+      """MATCH_RECOGNIZE (
+        |   ORDER BY proctime
+        |   MEASURES
+        |     A.f0 as aF0
+        |   PATTERN (A{2})
+        |   DEFINE
+        |     A as A.f0 = 1
+        |)""".stripMargin,
+      Pattern.begin("A", skipToNext()).times(2).consecutive())
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix the bug that fix time quantifier can not be the last element of a pattern. Exception will be thrown for pattern "a{2}". Actually this pattern is not greedy and we should support it.*

## Brief change log

  - *If the quantifier is fixed, we should not mark it as greedy.*

## Verifying this change


This change added tests and can be verified as follows:

  - *Added tests in PatternTranslatorTest#testQuantifiers*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
