### PR TITLE
[FLINK-12800] Harden Tests when availableProcessors is 1

### DIFF
--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/dataexchange/DataExchangeModeClosedBranchingTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/dataexchange/DataExchangeModeClosedBranchingTest.java
@@ -159,6 +159,9 @@ public class DataExchangeModeClosedBranchingTest extends CompilerTestBase {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.getConfig().setExecutionMode(execMode);
 
+			// set parallelism to 2 to avoid chaining with source in case when available processors is 1.
+			env.setParallelism(2);
+
 			DataSet<Tuple2<Long, Long>> data = env.fromElements(33L, 44L)
 					.map(new MapFunction<Long, Tuple2<Long, Long>>() {
 						@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -126,6 +126,10 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 	@Test
 	public void testChainStartEndSetting() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		// set parallelism to 2 to avoid chaining with source in case when available processors is 1.
+		env.setParallelism(2);
+
 		// fromElements -> CHAIN(Map -> Print)
 		env.fromElements(1, 2, 3)
 			.map(new MapFunction<Integer, Integer>() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -436,6 +436,9 @@ public class AsyncWaitOperatorTest extends TestLogger {
 	private JobVertex createChainedVertex(boolean withLazyFunction) {
 		StreamExecutionEnvironment chainEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 
+		// set parallelism to 2 to avoid chaining with source in case when available processors is 1.
+		chainEnv.setParallelism(2);
+
 		// the input is only used to construct a chained operator, and they will not be used in the real tests.
 		DataStream<Integer> input = chainEnv.fromElements(1, 2, 3);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -81,6 +81,9 @@ public class StreamOperatorChainingTest {
 	 */
 	private void testMultiChaining(StreamExecutionEnvironment env) throws Exception {
 
+		// set parallelism to 2 to avoid chaining with source in case when available processors is 1.
+		env.setParallelism(2);
+
 		// the actual elements will not be used
 		DataStream<Integer> input = env.fromElements(1, 2, 3);
 
@@ -174,6 +177,9 @@ public class StreamOperatorChainingTest {
 	 * Verify that multi-chaining works with object reuse enabled.
 	 */
 	private void testMultiChainingWithSplit(StreamExecutionEnvironment env) throws Exception {
+
+		// set parallelism to 2 to avoid chaining with source in case when available processors is 1.
+		env.setParallelism(2);
 
 		// the actual elements will not be used
 		DataStream<Integer> input = env.fromElements(1, 2, 3);


### PR DESCRIPTION
## What is the purpose of the change

Harden Tests when availableProcessors is 1.


## Brief change log

Set parallelism to 4 in the following failed tests.

_AsyncWaitOperatorTest#testOperatorChainWithProcessingTime
StreamingJobGraphGeneratorTest#testChainStartEndSetting
StreamOperatorChainingTest#testMultiChainingWithObjectReuse
StreamOperatorChainingTest#testMultiChainingWithoutObjectReuse_


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (o)
  - If yes, how is the feature documented? (not documented)

cc @StephanEwen @tillrohrmann 
