### PR TITLE
[FLINK-12823][datastream] PartitionTransformation supports DataExchan…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -18,11 +18,14 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.util.OutputTag;
 
 import java.io.Serializable;
 import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * An edge in the streaming topology. One edge like this does not necessarily
@@ -70,8 +73,22 @@ public class StreamEdge implements Serializable {
 	 */
 	private final String targetOperatorName;
 
+	private final ShuffleMode shuffleMode;
+
 	public StreamEdge(StreamNode sourceVertex, StreamNode targetVertex, int typeNumber,
 			List<String> selectedNames, StreamPartitioner<?> outputPartitioner, OutputTag outputTag) {
+		this(sourceVertex,
+				targetVertex,
+				typeNumber,
+				selectedNames,
+				outputPartitioner,
+				outputTag,
+				ShuffleMode.PIPELINED);
+	}
+
+	public StreamEdge(StreamNode sourceVertex, StreamNode targetVertex, int typeNumber,
+			List<String> selectedNames, StreamPartitioner<?> outputPartitioner, OutputTag outputTag,
+			ShuffleMode shuffleMode) {
 		this.sourceId = sourceVertex.getId();
 		this.targetId = targetVertex.getId();
 		this.typeNumber = typeNumber;
@@ -80,6 +97,7 @@ public class StreamEdge implements Serializable {
 		this.outputTag = outputTag;
 		this.sourceOperatorName = sourceVertex.getOperatorName();
 		this.targetOperatorName = targetVertex.getOperatorName();
+		this.shuffleMode = checkNotNull(shuffleMode);
 
 		this.edgeId = sourceVertex + "_" + targetVertex + "_" + typeNumber + "_" + selectedNames
 				+ "_" + outputPartitioner;
@@ -107,6 +125,10 @@ public class StreamEdge implements Serializable {
 
 	public StreamPartitioner<?> getPartitioner() {
 		return outputPartitioner;
+	}
+
+	public ShuffleMode getShuffleMode() {
+		return shuffleMode;
 	}
 
 	public void setPartitioner(StreamPartitioner<?> partitioner) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -247,7 +247,8 @@ public class StreamGraphGenerator {
 		Collection<Integer> transformedIds = transform(input);
 		for (Integer transformedId: transformedIds) {
 			int virtualId = StreamTransformation.getNewNodeId();
-			streamGraph.addVirtualPartitionNode(transformedId, virtualId, partition.getPartitioner());
+			streamGraph.addVirtualPartitionNode(
+					transformedId, virtualId, partition.getPartitioner(), partition.getShuffleMode());
 			resultIds.add(virtualId);
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -51,6 +51,7 @@ import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.UdfStreamOperatorFactory;
+import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
@@ -485,17 +486,31 @@ public class StreamingJobGraphGenerator {
 		downStreamConfig.setNumberOfInputs(downStreamConfig.getNumberOfInputs() + 1);
 
 		StreamPartitioner<?> partitioner = edge.getPartitioner();
+
+		ResultPartitionType resultPartitionType;
+		switch (edge.getShuffleMode()) {
+			case PIPELINED:
+				resultPartitionType = ResultPartitionType.PIPELINED_BOUNDED;
+				break;
+			case BATCH:
+				resultPartitionType = ResultPartitionType.BLOCKING;
+				break;
+			default:
+				throw new UnsupportedOperationException("Data exchange mode " +
+					edge.getShuffleMode() + " is not supported yet.");
+		}
+
 		JobEdge jobEdge;
 		if (partitioner instanceof ForwardPartitioner || partitioner instanceof RescalePartitioner) {
 			jobEdge = downStreamVertex.connectNewDataSetAsInput(
 				headVertex,
 				DistributionPattern.POINTWISE,
-				ResultPartitionType.PIPELINED_BOUNDED);
+				resultPartitionType);
 		} else {
 			jobEdge = downStreamVertex.connectNewDataSetAsInput(
 					headVertex,
 					DistributionPattern.ALL_TO_ALL,
-					ResultPartitionType.PIPELINED_BOUNDED);
+					resultPartitionType);
 		}
 		// set strategy name so that web interface can show it.
 		jobEdge.setShipStrategyName(partitioner.toString());
@@ -521,6 +536,7 @@ public class StreamingJobGraphGenerator {
 				&& (headOperator.getChainingStrategy() == ChainingStrategy.HEAD ||
 					headOperator.getChainingStrategy() == ChainingStrategy.ALWAYS)
 				&& (edge.getPartitioner() instanceof ForwardPartitioner)
+				&& edge.getShuffleMode() != ShuffleMode.BATCH
 				&& upStreamVertex.getParallelism() == downStreamVertex.getParallelism()
 				&& streamGraph.isChainingEnabled();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
@@ -27,6 +27,8 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * This transformation represents a change of partitioning of the input elements.
  *
@@ -39,7 +41,10 @@ import java.util.List;
 public class PartitionTransformation<T> extends StreamTransformation<T> {
 
 	private final StreamTransformation<T> input;
+
 	private final StreamPartitioner<T> partitioner;
+
+	private final ShuffleMode shuffleMode;
 
 	/**
 	 * Creates a new {@code PartitionTransformation} from the given input and
@@ -49,9 +54,25 @@ public class PartitionTransformation<T> extends StreamTransformation<T> {
 	 * @param partitioner The {@code StreamPartitioner}
 	 */
 	public PartitionTransformation(StreamTransformation<T> input, StreamPartitioner<T> partitioner) {
+		this(input, partitioner, ShuffleMode.PIPELINED);
+	}
+
+	/**
+	 * Creates a new {@code PartitionTransformation} from the given input and
+	 * {@link StreamPartitioner}.
+	 *
+	 * @param input The input {@code StreamTransformation}
+	 * @param partitioner The {@code StreamPartitioner}
+	 * @param shuffleMode The {@code ShuffleMode}
+	 */
+	public PartitionTransformation(
+			StreamTransformation<T> input,
+			StreamPartitioner<T> partitioner,
+			ShuffleMode shuffleMode) {
 		super("Partition", input.getOutputType(), input.getParallelism());
 		this.input = input;
 		this.partitioner = partitioner;
+		this.shuffleMode = checkNotNull(shuffleMode);
 	}
 
 	/**
@@ -69,6 +90,13 @@ public class PartitionTransformation<T> extends StreamTransformation<T> {
 		return partitioner;
 	}
 
+	/**
+	 * Returns the {@link ShuffleMode} of this {@link PartitionTransformation}.
+	 */
+	public ShuffleMode getShuffleMode() {
+		return shuffleMode;
+	}
+
 	@Override
 	public Collection<StreamTransformation<?>> getTransitivePredecessors() {
 		List<StreamTransformation<?>> result = Lists.newArrayList();
@@ -79,6 +107,6 @@ public class PartitionTransformation<T> extends StreamTransformation<T> {
 
 	@Override
 	public final void setChainingStrategy(ChainingStrategy strategy) {
-		throw new UnsupportedOperationException("Cannot set chaining strategy on Union Transformation.");
+		throw new UnsupportedOperationException("Cannot set chaining strategy on Partition Transformation.");
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ShuffleMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ShuffleMode.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * The shuffle mode defines the data exchange mode between operators.
+ */
+@PublicEvolving
+public enum ShuffleMode {
+	/**
+	 * Producer and consumer are online at the same time.
+	 * Produced data is received by consumer immediately.
+	 */
+	PIPELINED,
+
+	/**
+	 * The producer first produces its entire result and finishes.
+	 * After that, the consumer is started and may consume the data.
+	 */
+	BATCH
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -34,6 +34,9 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
@@ -308,5 +311,33 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 				assertTrue(jobVertex.getMinResources().equals(resource5));
 			}
 		}
+	}
+
+	/**
+	 * Test manually setting shuffle mode.
+	 */
+	@Test
+	public void testShuffleMode() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		// fromElements -> Map -> Print, will not chain since the batch data exchange mode
+		DataStream<Integer> mapDataStream = env.fromElements(1, 2, 3)
+			.map((MapFunction<Integer, Integer>) value -> value).setParallelism(2);
+
+		DataStream<Integer> partitionDataStream = new DataStream<>(env, new PartitionTransformation<>(
+				mapDataStream.getTransformation(), new ForwardPartitioner<>(), ShuffleMode.BATCH));
+		partitionDataStream.print().setParallelism(2);
+
+		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+
+		List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
+		assertEquals(3, verticesSorted.size());
+
+		JobVertex sourceVertex = verticesSorted.get(0);
+		JobVertex mapVertex = verticesSorted.get(1);
+		JobVertex printVertex = verticesSorted.get(2);
+
+		assertEquals(ResultPartitionType.PIPELINED_BOUNDED, sourceVertex.getProducedDataSets().get(0).getResultType());
+		assertEquals(ResultPartitionType.PIPELINED_BOUNDED, mapVertex.getInputs().get(0).getSource().getResultType());
+		assertEquals(ResultPartitionType.BLOCKING, printVertex.getInputs().get(0).getSource().getResultType());
 	}
 }


### PR DESCRIPTION
…geMode property

## What is the purpose of the change

* Since `StreamTransformation` would also support batch runner in 1.9, the result partition type of `StreamTransformation` should not be hard-coded with `PIPELINED_BOUNDED`
* We need to provide a way for upper level API upon `StreamTransformation` to configure the result partition type of edge

## Brief change log

* Expose a property `DataExchangeMode` of `PartitionTransformation` as an internal API of `StreamTransformation`
* Pass the `DataExchangeMode` to `StreamEdge`
* `StreamingJobGraphGenerator` chooses the appropriate result partition type based on `DataExchangeMode` of `StreamEdge`

## Verifying this change

* Add an unit test of `StreamingJobGraphGeneratorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
