### PR TITLE
[FLINK-12822][apis] Add explicit transformer from SerializableOptional to Optional

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/SerializableOptional.java
+++ b/flink-core/src/main/java/org/apache/flink/types/SerializableOptional.java
@@ -59,12 +59,16 @@ public final class SerializableOptional<T extends Serializable> implements Seria
 		}
 	}
 
-	public <R> Optional<R> map(Function<? super T, ? extends R> mapper) {
+	public <R extends Serializable> SerializableOptional<R> map(Function<? super T, ? extends R> mapper) {
 		if (value == null) {
-			return Optional.empty();
+			return empty();
 		} else {
-			return Optional.ofNullable(mapper.apply(value));
+			return ofNullable(mapper.apply(value));
 		}
+	}
+
+	public Optional<T> toOptional() {
+		return Optional.ofNullable(value);
 	}
 
 	public static <T extends Serializable> SerializableOptional<T> of(@Nonnull T value) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -588,7 +588,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 			final CompletableFuture<Optional<Tuple2<ResourceID, String>>> metricQueryServiceAddressFuture = taskExecutorGateway
 				.requestMetricQueryServiceAddress(timeout)
-				.thenApply(optional -> optional.map(path -> Tuple2.of(tmResourceId, path)));
+				.thenApply(o -> o.toOptional().map(address -> Tuple2.of(tmResourceId, address)));
 
 			metricQueryServiceAddressFutures.add(metricQueryServiceAddressFuture);
 		}


### PR DESCRIPTION
## What is the purpose of the change

We introduce `SerializableOptional` to represent return value that of `Optional` and transported cross network.

The purpose is reasonable. However, a wart is inside `SerializableOptional`. Calling `SerializableOptional#map` will returns a `Optional`, which might surprise contributors if they want to chain operations and get a `SerializableOptional` as final result(to another transport maybe).

Semantically return value of `SerializableOptional#map` should be `SerializableOptional`, and for interoperation, we could introduce a `SerializableOptional#toOptional` which easily adapt to the correct type.

## Brief change log

- Change return type of `SerializableOptional#map` to `SerializableOptional`
- Add method `SerializableOptional#toOptional`
- Adapt invocations.


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann 
