### PR TITLE
[FLINK-12798][table-planner] Extracted the logic of converting from a Row type info to expected type

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableEnvImpl.scala
@@ -31,12 +31,9 @@ import org.apache.calcite.sql._
 import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.tools._
 import org.apache.flink.annotation.VisibleForTesting
-import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.java.typeutils.{GenericTypeInfo, PojoTypeInfo, TupleTypeInfoBase}
 import org.apache.flink.table.calcite._
 import org.apache.flink.table.catalog._
-import org.apache.flink.table.codegen.{FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.factories.{TableFactoryService, TableFactoryUtil, TableSinkFactory}
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
@@ -44,14 +41,11 @@ import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, Tabl
 import org.apache.flink.table.operations.{CatalogQueryOperation, OperationTreeBuilder, PlannerQueryOperation, TableSourceQueryOperation}
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.rules.FlinkRuleSets
-import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.planner.PlanningConfigurationBuilder
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.sources.TableSource
-import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 import org.apache.flink.table.util.JavaScalaConversionUtil
 import org.apache.flink.table.validate.FunctionCatalog
-import org.apache.flink.types.Row
 import org.apache.flink.util.StringUtils
 
 import _root_.scala.collection.JavaConverters._
@@ -781,118 +775,5 @@ abstract class TableEnvImpl(
     val currentDatabase = catalogManager.getCurrentDatabase
 
     planningConfigurationBuilder.createFlinkPlanner(currentCatalogName, currentDatabase)
-  }
-
-  protected def generateRowConverterFunction[OUT](
-      inputTypeInfo: TypeInformation[Row],
-      schema: RowSchema,
-      requestedTypeInfo: TypeInformation[OUT],
-      functionName: String)
-    : Option[GeneratedFunction[MapFunction[Row, OUT], OUT]] = {
-
-    // validate that at least the field types of physical and logical type match
-    // we do that here to make sure that plan translation was correct
-    if (schema.typeInfo != inputTypeInfo) {
-      throw new TableException(
-        s"The field types of physical and logical row types do not match. " +
-        s"Physical type is [${schema.typeInfo}], Logical type is [$inputTypeInfo]. " +
-        s"This is a bug and should not happen. Please file an issue.")
-    }
-
-    // generic row needs no conversion
-    if (requestedTypeInfo.isInstanceOf[GenericTypeInfo[_]] &&
-        requestedTypeInfo.getTypeClass == classOf[Row]) {
-      return None
-    }
-
-    val fieldTypes = schema.fieldTypeInfos
-    val fieldNames = schema.fieldNames
-
-    // check for valid type info
-    if (requestedTypeInfo.getArity != fieldTypes.length) {
-      throw new TableException(
-        s"Arity [${fieldTypes.length}] of result [$fieldTypes] does not match " +
-        s"the number[${requestedTypeInfo.getArity}] of requested type [$requestedTypeInfo].")
-    }
-
-    // check requested types
-
-    def validateFieldType(fieldType: TypeInformation[_]): Unit = fieldType match {
-      case _: TimeIndicatorTypeInfo =>
-        throw new TableException("The time indicator type is an internal type only.")
-      case _ => // ok
-    }
-
-    requestedTypeInfo match {
-      // POJO type requested
-      case pt: PojoTypeInfo[_] =>
-        fieldNames.zip(fieldTypes) foreach {
-          case (fName, fType) =>
-            val pojoIdx = pt.getFieldIndex(fName)
-            if (pojoIdx < 0) {
-              throw new TableException(s"POJO does not define field name: $fName")
-            }
-            val requestedTypeInfo = pt.getTypeAt(pojoIdx)
-            validateFieldType(requestedTypeInfo)
-            if (fType != requestedTypeInfo) {
-              throw new TableException(s"Result field does not match requested type. " +
-                s"Requested: $requestedTypeInfo; Actual: $fType")
-            }
-        }
-
-      // Tuple/Case class/Row type requested
-      case tt: TupleTypeInfoBase[_] =>
-        fieldTypes.zipWithIndex foreach {
-          case (fieldTypeInfo, i) =>
-            val requestedTypeInfo = tt.getTypeAt(i)
-            validateFieldType(requestedTypeInfo)
-            if (fieldTypeInfo != requestedTypeInfo) {
-              throw new TableException(s"Result field does not match requested type. " +
-                s"Requested: $requestedTypeInfo; Actual: $fieldTypeInfo")
-            }
-        }
-
-      // atomic type requested
-      case t: TypeInformation[_] =>
-        if (fieldTypes.size != 1) {
-          throw new TableException(s"Requested result type is an atomic type but " +
-            s"result[$fieldTypes] has more or less than a single field.")
-        }
-        val requestedTypeInfo = fieldTypes.head
-        validateFieldType(requestedTypeInfo)
-        if (requestedTypeInfo != t) {
-          throw new TableException(s"Result field does not match requested type. " +
-            s"Requested: $t; Actual: $requestedTypeInfo")
-        }
-
-      case _ =>
-        throw new TableException(s"Unsupported result type: $requestedTypeInfo")
-    }
-
-    // code generate MapFunction
-    val generator = new FunctionCodeGenerator(
-      config,
-      false,
-      inputTypeInfo,
-      None,
-      None)
-
-    val conversion = generator.generateConverterResultExpression(
-      requestedTypeInfo,
-      fieldNames)
-
-    val body =
-      s"""
-         |${conversion.code}
-         |return ${conversion.resultTerm};
-         |""".stripMargin
-
-    val generated = generator.generateFunction(
-      functionName,
-      classOf[MapFunction[Row, OUT]],
-      body,
-      requestedTypeInfo)
-
-    Some(generated)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/Conversions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/Conversions.scala
@@ -26,8 +26,14 @@ import org.apache.flink.table.codegen.{FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 import org.apache.flink.types.Row
 
+
 object Conversions {
 
+  /**
+    * Utility method for generating converter [[MapFunction]] that converts from
+    * given input [[TypeInformation]] of type [[Row]] to requested type, based on a
+    * logical [[TableSchema]] of the input type.
+    */
   def generateRowConverterFunction[OUT](
     physicalInputType: TypeInformation[Row],
     logicalInputSchema: TableSchema,
@@ -130,9 +136,9 @@ object Conversions {
 
     val body =
       s"""
-         	|${conversion.code}
-         	|return ${conversion.resultTerm};
-         	|""".stripMargin
+         |${conversion.code}
+         |return ${conversion.resultTerm};
+         |""".stripMargin
 
     val generated = generator.generateFunction(
       functionName,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/Conversions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/Conversions.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner
+
+import org.apache.flink.api.common.functions.MapFunction
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.{GenericTypeInfo, PojoTypeInfo, TupleTypeInfoBase}
+import org.apache.flink.table.api.{TableConfig, TableException, TableSchema}
+import org.apache.flink.table.codegen.{FunctionCodeGenerator, GeneratedFunction}
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
+import org.apache.flink.types.Row
+
+object Conversions {
+
+  def generateRowConverterFunction[OUT](
+    physicalInputType: TypeInformation[Row],
+    logicalInputSchema: TableSchema,
+    requestedOutputType: TypeInformation[OUT],
+    functionName: String,
+    config: TableConfig)
+  : Option[GeneratedFunction[MapFunction[Row, OUT], OUT]] = {
+
+    // validate that at least the field types of physical and logical type match
+    // we do that here to make sure that plan translation was correct
+    val typeInfo = logicalInputSchema.toRowType
+    if (typeInfo != physicalInputType) {
+      throw new TableException(
+        s"The field types of physical and logical row types do not match. " +
+          s"Physical type is [$typeInfo], Logical type is [$physicalInputType]. " +
+          s"This is a bug and should not happen. Please file an issue.")
+    }
+
+    // generic row needs no conversion
+    if (requestedOutputType.isInstanceOf[GenericTypeInfo[_]] &&
+      requestedOutputType.getTypeClass == classOf[Row]) {
+      return None
+    }
+
+    val fieldTypes = logicalInputSchema.getFieldTypes
+    val fieldNames = logicalInputSchema.getFieldNames
+
+    // check for valid type info
+    if (requestedOutputType.getArity != fieldTypes.length) {
+      throw new TableException(
+        s"Arity [${fieldTypes.length}] of result [$fieldTypes] does not match " +
+          s"the number[${requestedOutputType.getArity}] of requested type [$requestedOutputType].")
+    }
+
+    // check requested types
+
+    def validateFieldType(fieldType: TypeInformation[_]): Unit = fieldType match {
+      case _: TimeIndicatorTypeInfo =>
+        throw new TableException("The time indicator type is an internal type only.")
+      case _ => // ok
+    }
+
+    requestedOutputType match {
+      // POJO type requested
+      case pt: PojoTypeInfo[_] =>
+        fieldNames.zip(fieldTypes) foreach {
+          case (fName, fType) =>
+            val pojoIdx = pt.getFieldIndex(fName)
+            if (pojoIdx < 0) {
+              throw new TableException(s"POJO does not define field name: $fName")
+            }
+            val requestedTypeInfo = pt.getTypeAt(pojoIdx)
+            validateFieldType(requestedTypeInfo)
+            if (fType != requestedTypeInfo) {
+              throw new TableException(s"Result field does not match requested type. " +
+                s"Requested: $requestedTypeInfo; Actual: $fType")
+            }
+        }
+
+      // Tuple/Case class/Row type requested
+      case tt: TupleTypeInfoBase[_] =>
+        fieldTypes.zipWithIndex foreach {
+          case (fieldTypeInfo, i) =>
+            val requestedTypeInfo = tt.getTypeAt(i)
+            validateFieldType(requestedTypeInfo)
+            if (fieldTypeInfo != requestedTypeInfo) {
+              throw new TableException(s"Result field does not match requested type. " +
+                s"Requested: $requestedTypeInfo; Actual: $fieldTypeInfo")
+            }
+        }
+
+      // atomic type requested
+      case t: TypeInformation[_] =>
+        if (fieldTypes.size != 1) {
+          throw new TableException(s"Requested result type is an atomic type but " +
+            s"result[$fieldTypes] has more or less than a single field.")
+        }
+        val requestedTypeInfo = fieldTypes.head
+        validateFieldType(requestedTypeInfo)
+        if (requestedTypeInfo != t) {
+          throw new TableException(s"Result field does not match requested type. " +
+            s"Requested: $t; Actual: $requestedTypeInfo")
+        }
+
+      case _ =>
+        throw new TableException(s"Unsupported result type: $requestedOutputType")
+    }
+
+    // code generate MapFunction
+    val generator = new FunctionCodeGenerator(
+      config,
+      false,
+      physicalInputType,
+      None,
+      None)
+
+    val conversion = generator.generateConverterResultExpression(
+      requestedOutputType,
+      fieldNames)
+
+    val body =
+      s"""
+         	|${conversion.code}
+         	|return ${conversion.resultTerm};
+         	|""".stripMargin
+
+    val generated = generator.generateFunction(
+      functionName,
+      classOf[MapFunction[Row, OUT]],
+      body,
+      requestedOutputType)
+
+    Some(generated)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/DataStreamConversions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/DataStreamConversions.scala
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner
+
+import java.lang.{Boolean => JBool}
+
+import org.apache.calcite.rel.RelNode
+import org.apache.flink.api.common.functions.MapFunction
+import org.apache.flink.api.common.typeinfo.{SqlTimeTypeInfo, TypeInformation}
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.api.java.typeutils._
+import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api._
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.runtime.conversion._
+import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
+import org.apache.flink.table.runtime.{CRowMapRunner, OutputRowtimeProcessFunction}
+
+object DataStreamConversions {
+
+  /**
+    * Translates a logical [[RelNode]] into a [[DataStream]].
+    *
+    * @param inputPlan The root node of the relational expression tree.
+    * @param logicalType The row type of the result. Since the logicalPlan can lose the
+    *                    field naming during optimization we pass the row type separately.
+    * @param withChangeFlag Set to true to emit records with change flags.
+    * @param requestedOutputType         The [[TypeInformation]] of the resulting [[DataStream]].
+    * @tparam A The type of the resulting [[DataStream]].
+    * @return The [[DataStream]] that corresponds to the translated [[Table]].
+    */
+  def convert[A](
+      inputPlan: DataStream[CRow],
+      logicalType: TableSchema,
+      withChangeFlag: Boolean,
+      requestedOutputType: TypeInformation[A],
+      config: TableConfig)
+    : DataStream[A] = {
+
+    val rowtimeFields = logicalType.getFieldTypes.zip(logicalType.getFieldNames).zipWithIndex
+      .filter(f => FlinkTypeFactory.isRowtimeIndicatorType(f._1._1))
+
+    // convert the input type for the conversion mapper
+    // the input will be changed in the OutputRowtimeProcessFunction later
+    val convType = if (rowtimeFields.length > 1) {
+      throw new TableException(
+        s"Found more than one rowtime field: [${rowtimeFields.map(_._1._2).mkString(", ")}] in " +
+          s"the table that should be converted to a DataStream.\n" +
+          s"Please select the rowtime field that should be used as event-time timestamp for the " +
+          s"DataStream by casting all other fields to TIMESTAMP.")
+    } else if (rowtimeFields.length == 1) {
+      val origRowType = inputPlan.getType.asInstanceOf[CRowTypeInfo].rowType
+      val convFieldTypes = origRowType.getFieldTypes.map { t =>
+        if (FlinkTypeFactory.isRowtimeIndicatorType(t)) {
+          SqlTimeTypeInfo.TIMESTAMP
+        } else {
+          t
+        }
+      }
+      CRowTypeInfo(new RowTypeInfo(convFieldTypes, origRowType.getFieldNames))
+    } else {
+      inputPlan.getType
+    }
+
+    // convert CRow to output type
+    val conversion: MapFunction[CRow, A] = if (withChangeFlag) {
+      DataStreamConversions.getConversionMapperWithChanges(
+        convType,
+        logicalType,
+        requestedOutputType,
+        "DataStreamSinkConversion",
+        config)
+    } else {
+      getConversionMapper(
+        convType,
+        logicalType,
+        requestedOutputType,
+        "DataStreamSinkConversion",
+        config)
+    }
+
+    val rootParallelism = inputPlan.getParallelism
+
+    val withRowtime = if (rowtimeFields.isEmpty) {
+      // no rowtime field to set
+      inputPlan.map(conversion)
+    } else {
+      // set the only rowtime field as event-time timestamp for DataStream
+      // and convert it to SQL timestamp
+      inputPlan.process(new OutputRowtimeProcessFunction[A](conversion, rowtimeFields.head._2))
+    }
+
+    withRowtime
+      .returns(requestedOutputType)
+      .name(s"to: ${requestedOutputType.getTypeClass.getSimpleName}")
+      .setParallelism(rootParallelism)
+  }
+
+  /**
+    * Creates a final converter that maps the internal row type to external type.
+    *
+    * @param physicalInputType the input of the sink
+    * @param logicalInputSchema the input schema with correct field names (esp. for POJO field mapping)
+    * @param requestedOutputType the output type of the sink
+    * @param functionName name of the map function. Must not be unique but has to be a
+    *                     valid Java class identifier.
+    */
+  private def getConversionMapper[OUT](
+    physicalInputType: TypeInformation[CRow],
+    logicalInputSchema: TableSchema,
+    requestedOutputType: TypeInformation[OUT],
+    functionName: String,
+    config: TableConfig)
+  : MapFunction[CRow, OUT] = {
+
+    val converterFunction = Conversions.generateRowConverterFunction[OUT](
+      physicalInputType.asInstanceOf[CRowTypeInfo].rowType,
+      logicalInputSchema,
+      requestedOutputType,
+      functionName,
+      config
+    )
+
+    converterFunction match {
+
+      case Some(func) =>
+        new CRowMapRunner[OUT](func.name, func.code, func.returnType)
+
+      case _ =>
+        new CRowToRowMapFunction().asInstanceOf[MapFunction[CRow, OUT]]
+    }
+  }
+
+  /**
+    * Creates a converter that maps the internal CRow type to Scala or Java Tuple2 with change flag.
+    *
+    * @param physicalInputType the input of the sink
+    * @param logicalInputSchema the input schema with correct field names (esp. for POJO field mapping)
+    * @param requestedOutputType the output type of the sink.
+    * @param functionName name of the map function. Must not be unique but has to be a
+    *                     valid Java class identifier.
+    */
+  private def getConversionMapperWithChanges[OUT](
+    physicalInputType: TypeInformation[CRow],
+    logicalInputSchema: TableSchema,
+    requestedOutputType: TypeInformation[OUT],
+    functionName: String,
+    config: TableConfig)
+  : MapFunction[CRow, OUT] = requestedOutputType match {
+
+    // Scala tuple
+    case t: CaseClassTypeInfo[_]
+      if t.getTypeClass == classOf[(_, _)] && t.getTypeAt(0) == Types.BOOLEAN =>
+
+      val reqType = t.getTypeAt[Any](1)
+
+      // convert Row into requested type and wrap result in Tuple2
+      val converterFunction = Conversions.generateRowConverterFunction(
+        physicalInputType.asInstanceOf[CRowTypeInfo].rowType,
+        logicalInputSchema,
+        reqType,
+        functionName,
+        config
+      )
+
+      converterFunction match {
+
+        case Some(func) =>
+          new CRowToScalaTupleMapRunner(
+            func.name,
+            func.code,
+            requestedOutputType.asInstanceOf[TypeInformation[(Boolean, Any)]]
+          ).asInstanceOf[MapFunction[CRow, OUT]]
+
+        case _ =>
+          new CRowToScalaTupleMapFunction().asInstanceOf[MapFunction[CRow, OUT]]
+      }
+
+    // Java tuple
+    case t: TupleTypeInfo[_]
+      if t.getTypeClass == classOf[JTuple2[_, _]] && t.getTypeAt(0) == Types.BOOLEAN =>
+
+      val reqType = t.getTypeAt[Any](1)
+
+      // convert Row into requested type and wrap result in Tuple2
+      val converterFunction = Conversions.generateRowConverterFunction(
+        physicalInputType.asInstanceOf[CRowTypeInfo].rowType,
+        logicalInputSchema,
+        reqType,
+        functionName,
+        config
+      )
+
+      converterFunction match {
+
+        case Some(func) =>
+          new CRowToJavaTupleMapRunner(
+            func.name,
+            func.code,
+            requestedOutputType.asInstanceOf[TypeInformation[JTuple2[JBool, Any]]]
+          ).asInstanceOf[MapFunction[CRow, OUT]]
+
+        case _ =>
+          new CRowToJavaTupleMapFunction().asInstanceOf[MapFunction[CRow, OUT]]
+      }
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/DataStreamConversions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/DataStreamConversions.scala
@@ -81,7 +81,7 @@ object DataStreamConversions {
 
     // convert CRow to output type
     val conversion: MapFunction[CRow, A] = if (withChangeFlag) {
-      DataStreamConversions.getConversionMapperWithChanges(
+      getConversionMapperWithChanges(
         convType,
         logicalType,
         requestedOutputType,


### PR DESCRIPTION
## What is the purpose of the change
This PR extract the logic of converting from type info of the plan generated by optimizer to a given type. This further modularize the `TableEnvironments` and make it easier to port it.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
