### PR TITLE
[FLINK-12828][sql-client] Support -f option with a sql script file as…

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -118,8 +118,12 @@ public class SqlClient {
 		CliClient cli = null;
 		try {
 			cli = new CliClient(context, executor);
+			// execute sql statements from a file
+			if (options.getSqlFile() != null) {
+				cli.submitSQLFile(options.getSqlFile());
+			}
 			// interactive CLI mode
-			if (options.getUpdateStatement() == null) {
+			else if (options.getUpdateStatement() == null) {
 				cli.open();
 			}
 			// execute single update statement

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -45,6 +45,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOError;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -234,6 +236,25 @@ public class CliClient {
 					return false;
 			}
 		}).orElse(false);
+	}
+
+	/**
+	 * Submits a SQL file and prints status information and/or errors on the terminal.
+	 *
+	 * @param sqlFile a SQL file to execute
+	 */
+	public void submitSQLFile(URL sqlFile) {
+		final String stmt;
+		try {
+			final Path path = Paths.get(sqlFile.toURI());
+			byte[] encoded = Files.readAllBytes(path);
+			stmt = new String(encoded, Charset.defaultCharset());
+		} catch (final IOException | URISyntaxException e) {
+			printExecutionException(e);
+			return;
+		}
+		final Optional<SqlCommandCall> cmdCall = parseCommand(stmt);
+		cmdCall.ifPresent(this::callCommand);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptions.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptions.java
@@ -34,6 +34,7 @@ public class CliOptions {
 	private final List<URL> jars;
 	private final List<URL> libraryDirs;
 	private final String updateStatement;
+	private final URL sqlFile;
 
 	public CliOptions(
 			boolean isPrintHelp,
@@ -42,7 +43,8 @@ public class CliOptions {
 			URL defaults,
 			List<URL> jars,
 			List<URL> libraryDirs,
-			String updateStatement) {
+			String updateStatement,
+			URL sqlFile) {
 		this.isPrintHelp = isPrintHelp;
 		this.sessionId = sessionId;
 		this.environment = environment;
@@ -50,6 +52,7 @@ public class CliOptions {
 		this.jars = jars;
 		this.libraryDirs = libraryDirs;
 		this.updateStatement = updateStatement;
+		this.sqlFile = sqlFile;
 	}
 
 	public boolean isPrintHelp() {
@@ -78,5 +81,9 @@ public class CliOptions {
 
 	public String getUpdateStatement() {
 		return updateStatement;
+	}
+
+	public URL getSqlFile() {
+		return sqlFile;
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
@@ -117,6 +117,16 @@ public class CliOptionsParser {
 				"the target sink table.")
 			.build();
 
+	public static final Option OPTION_FILE = Option
+			.builder("f")
+			.required(false)
+			.longOpt("file")
+			.numberOfArgs(1)
+			.argName("SQL file")
+			.desc(
+				"A SQL file to be executed.")
+			.build();
+
 	private static final Options EMBEDDED_MODE_CLIENT_OPTIONS = getEmbeddedModeClientOptions(new Options());
 	private static final Options GATEWAY_MODE_CLIENT_OPTIONS = getGatewayModeClientOptions(new Options());
 	private static final Options GATEWAY_MODE_GATEWAY_OPTIONS = getGatewayModeGatewayOptions(new Options());
@@ -133,6 +143,7 @@ public class CliOptionsParser {
 		options.addOption(OPTION_JAR);
 		options.addOption(OPTION_LIBRARY);
 		options.addOption(OPTION_UPDATE);
+		options.addOption(OPTION_FILE);
 		return options;
 	}
 
@@ -141,6 +152,7 @@ public class CliOptionsParser {
 		options.addOption(OPTION_SESSION);
 		options.addOption(OPTION_ENVIRONMENT);
 		options.addOption(OPTION_UPDATE);
+		options.addOption(OPTION_FILE);
 		return options;
 	}
 
@@ -235,7 +247,8 @@ public class CliOptionsParser {
 				checkUrl(line, CliOptionsParser.OPTION_DEFAULTS),
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
 				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
-				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt())
+				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt()),
+				checkUrl(line, CliOptionsParser.OPTION_FILE)
 			);
 		}
 		catch (ParseException e) {
@@ -254,7 +267,8 @@ public class CliOptionsParser {
 				null,
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
 				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
-				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt())
+				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt()),
+				checkUrl(line, CliOptionsParser.OPTION_FILE)
 			);
 		}
 		catch (ParseException e) {
@@ -273,6 +287,7 @@ public class CliOptionsParser {
 				checkUrl(line, CliOptionsParser.OPTION_DEFAULTS),
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
 				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
+				null,
 				null
 			);
 		}

--- a/flink-table/flink-sql-client/src/test/resources/one-DML-statement.sql
+++ b/flink-table/flink-sql-client/src/test/resources/one-DML-statement.sql
@@ -1,0 +1,1 @@
+INSERT INTO MyTable SELECT * FROM MyOtherTable;


### PR DESCRIPTION
… input

## What is the purpose of the change

this pr allows sql client to support -f option with a sql script file as input

## Brief change log

- Introduce -f option with a sql script file as input

## Verifying this change

  - Added test that validates that CliClient works with -f option: org.apache.flink.table.client.cli.CliClientTest::testSQLFileSubmission

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
