### PR TITLE
[FLINK-12831][table-planner][table-api-java] Split FunctionCatalog into Flink & Calcite specific parts

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.expressions.AggregateFunctionDefinition;
+import org.apache.flink.table.expressions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.expressions.FunctionDefinition;
+import org.apache.flink.table.expressions.ScalarFunctionDefinition;
+import org.apache.flink.table.expressions.TableFunctionDefinition;
+import org.apache.flink.table.expressions.catalog.FunctionDefinitionCatalog;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.UserDefinedAggregateFunction;
+import org.apache.flink.table.functions.UserFunctionsTypeHelper;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Simple function catalog to store {@link FunctionDefinition}s in memory.
+ */
+@Internal
+public class FunctionCatalog implements FunctionDefinitionCatalog {
+
+	private final Map<String, FunctionDefinition> userFunctions = new LinkedHashMap<>();
+
+	public void registerScalarFunction(String name, ScalarFunction function) {
+		UserFunctionsTypeHelper.validateInstantiation(function.getClass());
+		registerFunction(
+			name,
+			new ScalarFunctionDefinition(name, function)
+		);
+	}
+
+	public <T> void registerTableFunction(
+			String name,
+			TableFunction<T> function,
+			TypeInformation<T> resultType) {
+		// check if class not Scala object
+		UserFunctionsTypeHelper.validateNotSingleton(function.getClass());
+		// check if class could be instantiated
+		UserFunctionsTypeHelper.validateInstantiation(function.getClass());
+
+		registerFunction(
+			name,
+			new TableFunctionDefinition(name, function, resultType)
+		);
+	}
+
+	public <T, ACC> void registerAggregateFunction(
+			String name,
+			UserDefinedAggregateFunction<T, ACC> function,
+			TypeInformation<T> resultType,
+			TypeInformation<ACC> accType) {
+		// check if class not Scala object
+		UserFunctionsTypeHelper.validateNotSingleton(function.getClass());
+		// check if class could be instantiated
+		UserFunctionsTypeHelper.validateInstantiation(function.getClass());
+
+		registerFunction(
+			name,
+			new AggregateFunctionDefinition(name, function, resultType, accType)
+		);
+	}
+
+	public String[] getUserDefinedFunctions() {
+		return userFunctions.values().stream().map(FunctionDefinition::getName).toArray(String[]::new);
+	}
+
+	@Override
+	public Optional<FunctionDefinition> lookupFunction(String name) {
+		FunctionDefinition userCandidate = userFunctions.get(normalizeName(name));
+		if (userCandidate != null) {
+			return Optional.of(userCandidate);
+		} else {
+			return BuiltInFunctionDefinitions.getDefinitions()
+				.stream()
+				.filter(f -> normalizeName(name).equals(normalizeName(f.getName())))
+				.findFirst();
+		}
+	}
+
+	private void registerFunction(String name, FunctionDefinition functionDefinition) {
+		userFunctions.put(normalizeName(name), functionDefinition);
+	}
+
+	private String normalizeName(String name) {
+		return name.toUpperCase();
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.expressions;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.catalog.FunctionDefinitionCatalog;
 
 import java.util.List;
@@ -37,7 +38,8 @@ public class LookupCallResolver extends ApiExpressionDefaultVisitor<Expression> 
 	}
 
 	public Expression visitLookupCall(LookupCallExpression lookupCall) {
-		FunctionDefinition functionDefinition = functionCatalog.lookupFunction(lookupCall.getUnresolvedName());
+		FunctionDefinition functionDefinition = functionCatalog.lookupFunction(lookupCall.getUnresolvedName())
+			.orElseThrow(() -> new ValidationException("Undefined function: " + lookupCall.getUnresolvedName()));
 		return createResolvedCall(functionDefinition, lookupCall.getChildren());
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/catalog/FunctionDefinitionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/catalog/FunctionDefinitionCatalog.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.expressions.catalog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.expressions.FunctionDefinition;
 
+import java.util.Optional;
+
 /**
  * Catalog of functions that can resolve the name of a function to a {@link FunctionDefinition}.
  */
@@ -30,5 +32,5 @@ public interface FunctionDefinitionCatalog {
 	/**
 	 * Lookup a function by name and return the {@link FunctionDefinition}. The lookup is case insensitive.
 	 */
-	FunctionDefinition lookupFunction(String name);
+	Optional<FunctionDefinition> lookupFunction(String name);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/UserFunctionsTypeHelper.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/UserFunctionsTypeHelper.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.util.Arrays;
+
+/**
+ * Utility methods for validation and extraction of types during function registration in a
+ * {@link org.apache.flink.table.catalog.FunctionCatalog}.
+ */
+@Internal
+public class UserFunctionsTypeHelper {
+
+	/**
+	 * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
+	 *
+	 * @param aggregateFunction The AggregateFunction for which the accumulator type is inferred.
+	 * @return The inferred accumulator type of the AggregateFunction.
+	 */
+	public static <T, ACC> TypeInformation<T> getReturnTypeOfAggregateFunction(
+			UserDefinedAggregateFunction<T, ACC> aggregateFunction) {
+		return getReturnTypeOfAggregateFunction(aggregateFunction, null);
+	}
+
+	/**
+	 * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
+	 *
+	 * @param aggregateFunction The AggregateFunction for which the accumulator type is inferred.
+	 * @param scalaType The implicitly inferred type of the accumulator type.
+	 *
+	 * @return The inferred accumulator type of the AggregateFunction.
+	 */
+	public static <T, ACC> TypeInformation<T> getReturnTypeOfAggregateFunction(
+			UserDefinedAggregateFunction<T, ACC> aggregateFunction,
+			TypeInformation<T> scalaType) {
+
+		TypeInformation<T> userProvidedType = aggregateFunction.getResultType();
+		if (userProvidedType != null) {
+			return userProvidedType;
+		} else if (scalaType != null) {
+			return scalaType;
+		} else {
+			return TypeExtractor.createTypeInfo(
+				aggregateFunction,
+				UserDefinedAggregateFunction.class,
+				aggregateFunction.getClass(),
+				0);
+		}
+	}
+
+	/**
+	 * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
+	 *
+	 * @param aggregateFunction The AggregateFunction for which the accumulator type is inferred.
+	 * @return The inferred accumulator type of the AggregateFunction.
+	 */
+	public static <T, ACC> TypeInformation<ACC> getAccumulatorTypeOfAggregateFunction(
+			UserDefinedAggregateFunction<T, ACC> aggregateFunction) {
+		return getAccumulatorTypeOfAggregateFunction(aggregateFunction, null);
+	}
+
+	/**
+	 * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
+	 *
+	 * @param aggregateFunction The AggregateFunction for which the accumulator type is inferred.
+	 * @param scalaType The implicitly inferred type of the accumulator type.
+	 *
+	 * @return The inferred accumulator type of the AggregateFunction.
+	 */
+	public static <T, ACC> TypeInformation<ACC> getAccumulatorTypeOfAggregateFunction(
+			UserDefinedAggregateFunction<T, ACC> aggregateFunction,
+			TypeInformation<ACC> scalaType) {
+
+		TypeInformation<ACC> userProvidedType = aggregateFunction.getAccumulatorType();
+		if (userProvidedType != null) {
+			return userProvidedType;
+		} else if (scalaType != null) {
+			return scalaType;
+		} else {
+			return TypeExtractor.createTypeInfo(
+				aggregateFunction,
+				UserDefinedAggregateFunction.class,
+				aggregateFunction.getClass(),
+				1);
+		}
+	}
+
+	/**
+	 * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
+	 *
+	 * @param tableFunction The TableFunction for which the accumulator type is inferred.
+	 * @return The inferred accumulator type of the AggregateFunction.
+	 */
+	public static <T> TypeInformation<T> getReturnTypeOfTableFunction(TableFunction<T> tableFunction) {
+		return getReturnTypeOfTableFunction(tableFunction, null);
+	}
+
+	/**
+	 * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
+	 *
+	 * @param tableFunction The TableFunction for which the accumulator type is inferred.
+	 * @param scalaType The implicitly inferred type of the accumulator type.
+	 * @return The inferred accumulator type of the AggregateFunction.
+	 */
+	public static <T> TypeInformation<T> getReturnTypeOfTableFunction(
+			TableFunction<T> tableFunction,
+			TypeInformation<T> scalaType) {
+
+		TypeInformation<T> userProvidedType = tableFunction.getResultType();
+		if (userProvidedType != null) {
+			return userProvidedType;
+		} else if (scalaType != null) {
+			return scalaType;
+		} else {
+			return TypeExtractor.createTypeInfo(
+				tableFunction,
+				TableFunction.class,
+				tableFunction.getClass(),
+				0);
+		}
+	}
+
+	/**
+	 * Checks if a user-defined function can be easily instantiated.
+	 */
+	public static void validateInstantiation(Class<?> clazz) {
+		if (!InstantiationUtil.isPublic(clazz)) {
+			throw new ValidationException(String.format("Function class %s is not public.", clazz.getCanonicalName()));
+		} else if (!InstantiationUtil.isProperClass(clazz)) {
+			throw new ValidationException(String.format(
+				"Function class %s is no proper class," +
+					" it is either abstract, an interface, or a primitive type.", clazz.getCanonicalName()));
+		} else if (InstantiationUtil.isNonStaticInnerClass(clazz)) {
+			throw new ValidationException(String.format(
+				"The class %s is an inner class, but not statically accessible.", clazz.getCanonicalName()));
+		}
+	}
+
+	/**
+	 * Check whether this is a Scala object. It is forbidden to use {@link TableFunction} implemented
+	 * by a Scala object, since concurrent risks.
+	 */
+	public static void validateNotSingleton(Class<?> clazz) {
+		// TODO it is not a good way to check singleton. Maybe improve it further.
+		if (Arrays.stream(clazz.getFields()).anyMatch(f -> f.getName().equals("MODULE$"))) {
+			throw new ValidationException(String.format(
+				"TableFunction implemented by class %s " +
+					"is a Scala object, it is forbidden since concurrent risks.", clazz.getCanonicalName()));
+		}
+	}
+
+	private UserFunctionsTypeHelper() {
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/UserFunctionsTypeHelper.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/UserFunctionsTypeHelper.java
@@ -166,8 +166,8 @@ public class UserFunctionsTypeHelper {
 		// TODO it is not a good way to check singleton. Maybe improve it further.
 		if (Arrays.stream(clazz.getFields()).anyMatch(f -> f.getName().equals("MODULE$"))) {
 			throw new ValidationException(String.format(
-				"TableFunction implemented by class %s " +
-					"is a Scala object, it is forbidden since concurrent risks.", clazz.getCanonicalName()));
+				"TableFunction implemented by class %s is a Scala object. This is forbidden because of concurrency" +
+					" problems when using them.", clazz.getCanonicalName()));
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/catalog/CatalogOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/catalog/CatalogOperatorTable.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.calcite.FlinkTypeFactory;
+import org.apache.flink.table.expressions.AggregateFunctionDefinition;
+import org.apache.flink.table.expressions.FunctionDefinition;
+import org.apache.flink.table.expressions.ScalarFunctionDefinition;
+import org.apache.flink.table.expressions.TableFunctionDefinition;
+import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.SqlSyntax;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Thin adapter between {@link SqlOperatorTable} and {@link FunctionCatalog}.
+ */
+@Internal
+public class CatalogOperatorTable implements SqlOperatorTable {
+
+	private final FunctionCatalog functionCatalog;
+	private final FlinkTypeFactory typeFactory;
+
+	public CatalogOperatorTable(
+			FunctionCatalog functionCatalog,
+			FlinkTypeFactory typeFactory) {
+		this.functionCatalog = functionCatalog;
+		this.typeFactory = typeFactory;
+	}
+
+	@Override
+	public void lookupOperatorOverloads(
+			SqlIdentifier opName,
+			SqlFunctionCategory category,
+			SqlSyntax syntax,
+			List<SqlOperator> operatorList) {
+		if (!opName.isSimple()) {
+			return;
+		}
+
+		// We lookup only user functions via CatalogOperatorTable. Built in functions should
+		// go through BasicOperatorTable
+		if (isUserFunction(category)) {
+			return;
+		}
+
+		String name = opName.getSimple();
+		Optional<FunctionDefinition> candidateFunction = functionCatalog.lookupFunction(name);
+
+		candidateFunction.flatMap(functionDefinition ->
+			convertToSqlFunction(category, name, functionDefinition)
+		).ifPresent(operatorList::add);
+	}
+
+	private boolean isUserFunction(SqlFunctionCategory category) {
+		return category != null && !category.isUserDefinedNotSpecificFunction();
+	}
+
+	private Optional<SqlFunction> convertToSqlFunction(
+			SqlFunctionCategory category,
+			String name,
+			FunctionDefinition functionDefinition) {
+		if (functionDefinition instanceof AggregateFunctionDefinition) {
+			return convertAggregateFunction(name, (AggregateFunctionDefinition) functionDefinition);
+		} else if (functionDefinition instanceof ScalarFunctionDefinition) {
+			return convertScalarFunction(name, (ScalarFunctionDefinition) functionDefinition);
+		} else if (functionDefinition instanceof TableFunctionDefinition &&
+				category != null &&
+				category.isTableFunction()) {
+			return convertTableFunction(name, (TableFunctionDefinition) functionDefinition);
+		}
+
+		return Optional.empty();
+	}
+
+	private Optional<SqlFunction> convertAggregateFunction(
+		String name,
+		AggregateFunctionDefinition functionDefinition) {
+		AggregateFunctionDefinition aggregateFunctionDefinition = functionDefinition;
+		SqlFunction aggregateFunction = UserDefinedFunctionUtils.createAggregateSqlFunction(
+			name,
+			name,
+			aggregateFunctionDefinition.getAggregateFunction(),
+			aggregateFunctionDefinition.getResultTypeInfo(),
+			aggregateFunctionDefinition.getAccumulatorTypeInfo(),
+			typeFactory
+		);
+		return Optional.of(aggregateFunction);
+	}
+
+	private Optional<SqlFunction> convertScalarFunction(String name, ScalarFunctionDefinition functionDefinition) {
+		ScalarFunctionDefinition scalarFunctionDefinition = functionDefinition;
+		SqlFunction scalarFunction = UserDefinedFunctionUtils.createScalarSqlFunction(
+			name,
+			name,
+			scalarFunctionDefinition.getScalarFunction(),
+			typeFactory
+		);
+		return Optional.of(scalarFunction);
+	}
+
+	private Optional<SqlFunction> convertTableFunction(String name, TableFunctionDefinition functionDefinition) {
+		TableFunctionDefinition tableFunctionDefinition = functionDefinition;
+		SqlFunction tableFunction = UserDefinedFunctionUtils.createTableSqlFunction(
+			name,
+			name,
+			tableFunctionDefinition.getTableFunction(),
+			tableFunctionDefinition.getResultType(),
+			typeFactory
+		);
+		return Optional.of(tableFunction);
+	}
+
+	@Override
+	public List<SqlOperator> getOperatorList() {
+		throw new UnsupportedOperationException("This should never be called");
+	}
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/catalog/FunctionCatalogOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/catalog/FunctionCatalogOperatorTable.java
@@ -40,12 +40,12 @@ import java.util.Optional;
  * Thin adapter between {@link SqlOperatorTable} and {@link FunctionCatalog}.
  */
 @Internal
-public class CatalogOperatorTable implements SqlOperatorTable {
+public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 
 	private final FunctionCatalog functionCatalog;
 	private final FlinkTypeFactory typeFactory;
 
-	public CatalogOperatorTable(
+	public FunctionCatalogOperatorTable(
 			FunctionCatalog functionCatalog,
 			FlinkTypeFactory typeFactory) {
 		this.functionCatalog = functionCatalog;
@@ -98,38 +98,35 @@ public class CatalogOperatorTable implements SqlOperatorTable {
 	}
 
 	private Optional<SqlFunction> convertAggregateFunction(
-		String name,
-		AggregateFunctionDefinition functionDefinition) {
-		AggregateFunctionDefinition aggregateFunctionDefinition = functionDefinition;
+			String name,
+			AggregateFunctionDefinition functionDefinition) {
 		SqlFunction aggregateFunction = UserDefinedFunctionUtils.createAggregateSqlFunction(
 			name,
 			name,
-			aggregateFunctionDefinition.getAggregateFunction(),
-			aggregateFunctionDefinition.getResultTypeInfo(),
-			aggregateFunctionDefinition.getAccumulatorTypeInfo(),
+			functionDefinition.getAggregateFunction(),
+			functionDefinition.getResultTypeInfo(),
+			functionDefinition.getAccumulatorTypeInfo(),
 			typeFactory
 		);
 		return Optional.of(aggregateFunction);
 	}
 
 	private Optional<SqlFunction> convertScalarFunction(String name, ScalarFunctionDefinition functionDefinition) {
-		ScalarFunctionDefinition scalarFunctionDefinition = functionDefinition;
 		SqlFunction scalarFunction = UserDefinedFunctionUtils.createScalarSqlFunction(
 			name,
 			name,
-			scalarFunctionDefinition.getScalarFunction(),
+			functionDefinition.getScalarFunction(),
 			typeFactory
 		);
 		return Optional.of(scalarFunction);
 	}
 
 	private Optional<SqlFunction> convertTableFunction(String name, TableFunctionDefinition functionDefinition) {
-		TableFunctionDefinition tableFunctionDefinition = functionDefinition;
 		SqlFunction tableFunction = UserDefinedFunctionUtils.createTableSqlFunction(
 			name,
 			name,
-			tableFunctionDefinition.getTableFunction(),
-			tableFunctionDefinition.getResultType(),
+			functionDefinition.getTableFunction(),
+			functionDefinition.getResultType(),
 			typeFactory
 		);
 		return Optional.of(tableFunction);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
@@ -27,13 +27,15 @@ import org.apache.flink.table.calcite.FlinkRelBuilderFactory;
 import org.apache.flink.table.calcite.FlinkRelOptClusterFactory;
 import org.apache.flink.table.calcite.FlinkTypeFactory;
 import org.apache.flink.table.calcite.FlinkTypeSystem;
+import org.apache.flink.table.catalog.BasicOperatorTable;
+import org.apache.flink.table.catalog.CatalogOperatorTable;
 import org.apache.flink.table.catalog.CatalogReader;
+import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.codegen.ExpressionReducer;
 import org.apache.flink.table.expressions.ExpressionBridge;
 import org.apache.flink.table.expressions.PlannerExpression;
 import org.apache.flink.table.plan.cost.DataSetCostFactory;
 import org.apache.flink.table.util.JavaScalaConversionUtil;
-import org.apache.flink.table.validate.FunctionCatalog;
 
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.jdbc.CalciteSchema;
@@ -222,13 +224,18 @@ public class PlanningConfigurationBuilder {
 	 * Returns the operator table for this environment including a custom Calcite configuration.
 	 */
 	private SqlOperatorTable getSqlOperatorTable(CalciteConfig calciteConfig, FunctionCatalog functionCatalog) {
+		SqlOperatorTable baseOperatorTable = ChainedSqlOperatorTable.of(
+			new BasicOperatorTable(),
+			new CatalogOperatorTable(functionCatalog, typeFactory)
+		);
+
 		return JavaScalaConversionUtil.toJava(calciteConfig.sqlOperatorTable()).map(operatorTable -> {
 				if (calciteConfig.replacesSqlOperatorTable()) {
 					return operatorTable;
 				} else {
-					return ChainedSqlOperatorTable.of(functionCatalog.getSqlOperatorTable(), operatorTable);
+					return ChainedSqlOperatorTable.of(baseOperatorTable, operatorTable);
 				}
 			}
-		).orElseGet(functionCatalog::getSqlOperatorTable);
+		).orElse(baseOperatorTable);
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
@@ -28,9 +28,9 @@ import org.apache.flink.table.calcite.FlinkRelOptClusterFactory;
 import org.apache.flink.table.calcite.FlinkTypeFactory;
 import org.apache.flink.table.calcite.FlinkTypeSystem;
 import org.apache.flink.table.catalog.BasicOperatorTable;
-import org.apache.flink.table.catalog.CatalogOperatorTable;
 import org.apache.flink.table.catalog.CatalogReader;
 import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.catalog.FunctionCatalogOperatorTable;
 import org.apache.flink.table.codegen.ExpressionReducer;
 import org.apache.flink.table.expressions.ExpressionBridge;
 import org.apache.flink.table.expressions.PlannerExpression;
@@ -226,7 +226,7 @@ public class PlanningConfigurationBuilder {
 	private SqlOperatorTable getSqlOperatorTable(CalciteConfig calciteConfig, FunctionCatalog functionCatalog) {
 		SqlOperatorTable baseOperatorTable = ChainedSqlOperatorTable.of(
 			new BasicOperatorTable(),
-			new CatalogOperatorTable(functionCatalog, typeFactory)
+			new FunctionCatalogOperatorTable(functionCatalog, typeFactory)
 		);
 
 		return JavaScalaConversionUtil.toJava(calciteConfig.sqlOperatorTable()).map(operatorTable -> {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
@@ -29,10 +29,10 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable.FINAL
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.calcite.FlinkTypeFactory.{isRowtimeIndicatorType, _}
+import org.apache.flink.table.catalog.BasicOperatorTable
 import org.apache.flink.table.functions.sql.ProctimeSqlFunction
 import org.apache.flink.table.plan.logical.rel._
 import org.apache.flink.table.plan.schema.TimeIndicatorRelDataType
-import org.apache.flink.table.validate.BasicOperatorTable
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
@@ -43,7 +43,7 @@ import org.apache.flink.table.runtime.aggregate.AggregateUtil
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 import org.apache.flink.table.util.MatchUtil.{ALL_PATTERN_VARIABLE, AggregationPatternVariableFinder}
 import org.apache.flink.table.utils.EncodingUtils
-import org.apache.flink.table.validate.BasicOperatorTable.{MATCH_PROCTIME, MATCH_ROWTIME}
+import org.apache.flink.table.catalog.BasicOperatorTable.{MATCH_PROCTIME, MATCH_ROWTIME}
 import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
 import org.apache.flink.util.MathUtils.checkedDownCast

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/ExpressionBridge.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/ExpressionBridge.scala
@@ -18,13 +18,13 @@
 
 package org.apache.flink.table.expressions
 
-import org.apache.flink.table.validate.FunctionCatalog
+import org.apache.flink.table.expressions.catalog.FunctionDefinitionCatalog
 
 /**
   * Bridges between API [[Expression]]s (for both Java and Scala) and final expression stack.
   */
 class ExpressionBridge[E <: Expression](
-    functionCatalog: FunctionCatalog,
+    functionCatalog: FunctionDefinitionCatalog,
     finalVisitor: ExpressionVisitor[E]) {
 
   private val callResolver = new LookupCallResolver(functionCatalog)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/call.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/call.scala
@@ -299,9 +299,9 @@ case class PlannerTableFunctionCall(
 
   override def validateInput(): ValidationResult = {
     // check if not Scala object
-    checkNotSingleton(tableFunction.getClass)
+    UserFunctionsTypeHelper.validateNotSingleton(tableFunction.getClass)
     // check if class could be instantiated
-    checkForInstantiation(tableFunction.getClass)
+    UserFunctionsTypeHelper.validateInstantiation(tableFunction.getClass)
     // look for a signature that matches the input types
     val signature = parameters.map(_.resultType)
     val foundMethod = getUserDefinedMethod(tableFunction, "eval", typeInfoToClass(signature))

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
@@ -46,37 +46,6 @@ import scala.collection.mutable
 
 object UserDefinedFunctionUtils {
 
-  /**
-    * Checks if a user-defined function can be easily instantiated.
-    */
-  def checkForInstantiation(clazz: Class[_]): Unit = {
-    if (!InstantiationUtil.isPublic(clazz)) {
-      throw new ValidationException(s"Function class ${clazz.getCanonicalName} is not public.")
-    }
-    else if (!InstantiationUtil.isProperClass(clazz)) {
-      throw new ValidationException(
-        s"Function class ${clazz.getCanonicalName} is no proper class," +
-        " it is either abstract, an interface, or a primitive type.")
-    }
-    else if (InstantiationUtil.isNonStaticInnerClass(clazz)) {
-      throw new ValidationException(
-        s"The class ${clazz.getCanonicalName} is an inner class, but not statically accessible.")
-    }
-  }
-
-  /**
-    * Check whether this is a Scala object. It is forbidden to use [[TableFunction]] implemented
-    * by a Scala object, since concurrent risks.
-    */
-  def checkNotSingleton(clazz: Class[_]): Unit = {
-    // TODO it is not a good way to check singleton. Maybe improve it further.
-    if (clazz.getFields.map(_.getName) contains "MODULE$") {
-      throw new ValidationException(
-        s"TableFunction implemented by class ${clazz.getCanonicalName} " +
-          s"is a Scala object, it is forbidden since concurrent risks.")
-    }
-  }
-
   // ----------------------------------------------------------------------------------------------
   // Utilities for user-defined methods
   // ----------------------------------------------------------------------------------------------
@@ -560,90 +529,6 @@ object UserDefinedFunctionUtils {
           "MapView and ListView only supported in accumulators of POJO type.")
       case _ => (accType, None)
     }
-  }
-
-  /**
-    * Tries to infer the TypeInformation of an AggregateFunction's return type.
-    *
-    * @param aggregateFunction The AggregateFunction for which the return type is inferred.
-    * @param extractedType The implicitly inferred type of the result type.
-    *
-    * @return The inferred result type of the AggregateFunction.
-    */
-  def getResultTypeOfAggregateFunction(
-      aggregateFunction: UserDefinedAggregateFunction[_, _],
-      extractedType: TypeInformation[_] = null)
-    : TypeInformation[_] = {
-
-    val resultType = aggregateFunction.getResultType
-    if (resultType != null) {
-      resultType
-    } else if (extractedType != null) {
-      extractedType
-    } else {
-      try {
-        extractTypeFromAggregateFunction(aggregateFunction, 0)
-      } catch {
-        case ite: InvalidTypesException =>
-          throw new TableException(
-            "Cannot infer generic type of ${aggregateFunction.getClass}. " +
-              "You can override AggregateFunction.getResultType() to specify the type.",
-            ite
-          )
-      }
-    }
-  }
-
-  /**
-    * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
-    *
-    * @param aggregateFunction The AggregateFunction for which the accumulator type is inferred.
-    * @param extractedType The implicitly inferred type of the accumulator type.
-    *
-    * @return The inferred accumulator type of the AggregateFunction.
-    */
-  def getAccumulatorTypeOfAggregateFunction(
-    aggregateFunction: UserDefinedAggregateFunction[_, _],
-    extractedType: TypeInformation[_] = null)
-  : TypeInformation[_] = {
-
-    val accType = aggregateFunction.getAccumulatorType
-    if (accType != null) {
-      accType
-    } else if (extractedType != null) {
-      extractedType
-    } else {
-      try {
-        extractTypeFromAggregateFunction(aggregateFunction, 1)
-      } catch {
-        case ite: InvalidTypesException =>
-          throw new TableException(
-            "Cannot infer generic type of ${aggregateFunction.getClass}. " +
-              "You can override AggregateFunction.getAccumulatorType() to specify the type.",
-            ite
-          )
-      }
-    }
-  }
-
-  /**
-    * Internal method to extract a type from an AggregateFunction's type parameters.
-    *
-    * @param aggregateFunction The AggregateFunction for which the type is extracted.
-    * @param parameterTypePos The position of the type parameter for which the type is extracted.
-    *
-    * @return The extracted type.
-    */
-  @throws(classOf[InvalidTypesException])
-  private def extractTypeFromAggregateFunction(
-      aggregateFunction: UserDefinedAggregateFunction[_, _],
-      parameterTypePos: Int): TypeInformation[_] = {
-
-    TypeExtractor.createTypeInfo(
-      aggregateFunction,
-      classOf[UserDefinedAggregateFunction[_, _]],
-      aggregateFunction.getClass,
-      parameterTypePos).asInstanceOf[TypeInformation[_]]
   }
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/common/LogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/common/LogicalWindowAggregateRule.scala
@@ -26,9 +26,9 @@ import org.apache.calcite.rex._
 import org.apache.calcite.util.ImmutableBitSet
 import org.apache.flink.table.api._
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.catalog.BasicOperatorTable
 import org.apache.flink.table.plan.logical.LogicalWindow
 import org.apache.flink.table.plan.logical.rel.LogicalWindowAggregate
-import org.apache.flink.table.validate.BasicOperatorTable
 
 import _root_.scala.collection.JavaConversions._
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/common/WindowPropertiesRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/common/WindowPropertiesRule.scala
@@ -25,10 +25,10 @@ import org.apache.calcite.rex.{RexCall, RexNode}
 import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.table.api.{TableException, Types, ValidationException}
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.catalog.BasicOperatorTable
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.plan.logical.LogicalWindow
 import org.apache.flink.table.plan.logical.rel.LogicalWindowAggregate
-import org.apache.flink.table.validate.BasicOperatorTable
 
 import scala.collection.JavaConversions._
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetLogicalWindowAggregateRule.scala
@@ -24,11 +24,11 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex._
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.catalog.BasicOperatorTable
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.plan.logical.{LogicalWindow, SessionGroupWindow, SlidingGroupWindow, TumblingGroupWindow}
 import org.apache.flink.table.plan.rules.common.LogicalWindowAggregateRule
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
-import org.apache.flink.table.validate.BasicOperatorTable
 
 class DataSetLogicalWindowAggregateRule
   extends LogicalWindowAggregateRule("DataSetLogicalWindowAggregateRule") {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamLogicalWindowAggregateRule.scala
@@ -25,11 +25,11 @@ import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.{SqlTypeFamily, SqlTypeName}
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.catalog.BasicOperatorTable
 import org.apache.flink.table.expressions.{Literal, PlannerResolvedFieldReference, WindowReference}
 import org.apache.flink.table.plan.logical.{LogicalWindow, SessionGroupWindow, SlidingGroupWindow, TumblingGroupWindow}
 import org.apache.flink.table.plan.rules.common.LogicalWindowAggregateRule
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
-import org.apache.flink.table.validate.BasicOperatorTable
 
 class DataStreamLogicalWindowAggregateRule
   extends LogicalWindowAggregateRule("DataStreamLogicalWindowAggregateRule") {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
@@ -23,11 +23,11 @@ import java.util
 import org.apache.calcite.plan.RelOptRule.{none, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rex.RexProgram
+import org.apache.flink.table.catalog.FunctionCatalog
 import org.apache.flink.table.expressions.{Expression, PlannerExpression}
 import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalTableSourceScan}
 import org.apache.flink.table.plan.util.RexProgramExtractor
 import org.apache.flink.table.sources.FilterableTableSource
-import org.apache.flink.table.validate.FunctionCatalog
 import org.apache.flink.util.Preconditions
 
 import scala.collection.JavaConverters._

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -43,7 +43,7 @@ import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.aggfunctions._
 import org.apache.flink.table.functions.utils.AggSqlFunction
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
-import org.apache.flink.table.functions.{AggregateFunction, TableAggregateFunction, UserDefinedAggregateFunction}
+import org.apache.flink.table.functions.{AggregateFunction, TableAggregateFunction, UserDefinedAggregateFunction, UserFunctionsTypeHelper}
 import org.apache.flink.table.plan.logical._
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
@@ -1421,7 +1421,7 @@ object AggregateUtil {
     val (accumulatorType, accSpecs) = {
       val accType = aggregateFunction match {
         case udagg: AggSqlFunction => udagg.accType
-        case _ => getAccumulatorTypeOfAggregateFunction(aggregate)
+        case _ => UserFunctionsTypeHelper.getAccumulatorTypeOfAggregateFunction(aggregate)
       }
 
       removeStateViewFieldsFromAccTypeInfo(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/AggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/AggregateTest.scala
@@ -66,7 +66,7 @@ class AggregateTest extends TableTestBase {
     val aggFunctionDefinition = streamUtil
       .tableEnv
       .functionCatalog
-      .lookupFunction("udag")
+      .lookupFunction("udag").get()
       .asInstanceOf[AggregateFunctionDefinition]
 
     val typeInfo = aggFunctionDefinition.getAccumulatorTypeInfo
@@ -80,7 +80,7 @@ class AggregateTest extends TableTestBase {
     val aggFunctionDefinition2 = streamUtil
       .tableEnv
       .functionCatalog
-      .lookupFunction("udag2")
+      .lookupFunction("udag2").get()
       .asInstanceOf[AggregateFunctionDefinition]
 
     val typeInfo2 = aggFunctionDefinition2.getAccumulatorTypeInfo

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/RexProgramExtractorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/RexProgramExtractorTest.scala
@@ -28,10 +28,10 @@ import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.`type`.SqlTypeName.{BIGINT, INTEGER, VARCHAR}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.util.{DateString, TimeString, TimestampString}
+import org.apache.flink.table.catalog.FunctionCatalog
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.plan.util.{RexNodeToExpressionConverter, RexProgramExtractor}
 import org.apache.flink.table.utils.InputTypeBuilder.inputOf
-import org.apache.flink.table.validate.FunctionCatalog
 import org.hamcrest.CoreMatchers.is
 import org.junit.Assert.{assertArrayEquals, assertEquals, assertThat}
 import org.junit.Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
@@ -31,12 +31,11 @@ import org.apache.flink.streaming.api.transformations._
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.{KeyedOneInputStreamOperatorTestHarness, OneInputStreamOperatorTestHarness, TestHarnessUtil}
-import org.apache.flink.table.api.dataview.DataView
 import org.apache.flink.table.api.StreamQueryConfig
+import org.apache.flink.table.api.dataview.DataView
 import org.apache.flink.table.codegen.GeneratedAggregationsFunction
 import org.apache.flink.table.functions.aggfunctions.{CountAggFunction, IntSumWithRetractAggFunction, LongMaxWithRetractAggFunction, LongMinWithRetractAggFunction}
-import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils.getAccumulatorTypeOfAggregateFunction
-import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
+import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction, UserFunctionsTypeHelper}
 import org.apache.flink.table.runtime.aggregate.GeneratedAggregations
 import org.apache.flink.table.runtime.harness.HarnessTestBase.{RowResultSortComparator, RowResultSortComparatorWithWatermarks}
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
@@ -78,10 +77,12 @@ class HarnessTestBase extends StreamingWithStateTestBase {
     Array(new CountAggFunction).asInstanceOf[Array[AggregateFunction[_, _]]]
 
   protected val minMaxAggregationStateType: RowTypeInfo =
-    new RowTypeInfo(minMaxAggregates.map(getAccumulatorTypeOfAggregateFunction(_)): _*)
+    new RowTypeInfo(minMaxAggregates
+      .map(UserFunctionsTypeHelper.getAccumulatorTypeOfAggregateFunction(_)): _*)
 
   protected val sumAggregationStateType: RowTypeInfo =
-    new RowTypeInfo(sumAggregates.map(getAccumulatorTypeOfAggregateFunction(_)): _*)
+    new RowTypeInfo(sumAggregates
+      .map(UserFunctionsTypeHelper.getAccumulatorTypeOfAggregateFunction(_)): _*)
 
   protected val minMaxFuncName = "MinMaxAggregateHelper"
   protected val sumFuncName = "SumAggregationHelper"


### PR DESCRIPTION
## What is the purpose of the change

This PR splits FunctionCatalog into Flink and Calcite specific parts. This is a necessary step to move the `TableEnvironment` to api module. 


## Brief change log
- ported functions to validate & extract types from user function (ported from UserDefinedFunctionUtils)
- ported & moved `FunctionCatalog` to api-java module
- Introduced `org.apache.flink.table.catalog.CatalogOperatorTable` as a thin adapter between `FunctionCatalog` & `SqlOperatorTable`

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
