### PR TITLE
[FLINK-11878][runtime] Implement the runtime handling of BoundedOneInput and BoundedMultiInput

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
@@ -58,9 +58,28 @@ public final class InputSelection implements Serializable {
 	}
 
 	/**
+	 * Tests if the input specified by {@code inputId} is selected.
+	 *
+	 * @param inputId The input id, see the description of {@code inputId} in {@link Builder#select(int)}.
+	 * @return {@code true} if the input is selected, {@code false} otherwise.
+	 */
+	public boolean isInputSelected(int inputId) {
+		return (inputMask & (1L << (inputId - 1))) != 0;
+	}
+
+	/**
+	 * Tests if all inputs are selected.
+	 *
+	 * @return {@code true} if the input mask equals -1, {@code false} otherwise.
+	 */
+	public boolean areAllInputsSelected() {
+		return inputMask == -1L;
+	}
+
+	/**
 	 * Tells whether or not the input mask includes all of two inputs.
 	 *
-	 * @return {@code true} if the input mask includes all of two inputs, false otherwise.
+	 * @return {@code true} if the input mask includes all of two inputs, {@code false} otherwise.
 	 */
 	public boolean isALLMaskOf2() {
 		return isALLMaskOf2;
@@ -119,6 +138,16 @@ public final class InputSelection implements Serializable {
 	public static final class Builder {
 
 		private long inputMask = 0;
+
+		/**
+		 * Returns a {@code Builder} that uses the input mask of the specified {@code selection}
+		 * as the initial mask.
+		 */
+		public static Builder from(InputSelection selection) {
+			Builder builder = new Builder();
+			builder.inputMask = selection.inputMask;
+			return builder;
+		}
 
 		/**
 		 * Selects an input identified by the given {@code inputId}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
@@ -55,13 +56,17 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 		this.chainingStrategy = ChainingStrategy.HEAD;
 	}
 
-	public void run(final Object lockingObject, final StreamStatusMaintainer streamStatusMaintainer) throws Exception {
-		run(lockingObject, streamStatusMaintainer, output);
+	public void run(final Object lockingObject,
+			final StreamStatusMaintainer streamStatusMaintainer,
+			final OperatorChain<?, ?> operatorChain) throws Exception {
+
+		run(lockingObject, streamStatusMaintainer, output, operatorChain);
 	}
 
 	public void run(final Object lockingObject,
 			final StreamStatusMaintainer streamStatusMaintainer,
-			final Output<StreamRecord<OUT>> collector) throws Exception {
+			final Output<StreamRecord<OUT>> collector,
+			final OperatorChain<?, ?> operatorChain) throws Exception {
 
 		final TimeCharacteristic timeCharacteristic = getOperatorConfig().getTimeCharacteristic();
 
@@ -96,9 +101,14 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 
 			// if we get here, then the user function either exited after being done (finite source)
 			// or the function was canceled or stopped. For the finite source case, we should emit
-			// a final watermark that indicates that we reached the end of event-time
+			// a final watermark that indicates that we reached the end of event-time, and end inputs
+			// of the operator chain
 			if (!isCanceledOrStopped()) {
 				advanceToEndOfEventTime();
+
+				synchronized (lockingObject) {
+					operatorChain.endInput(1);
+				}
 			}
 		} finally {
 			// make sure that the context is closed in any case

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -89,7 +89,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 					this.headOperator,
 					getEnvironment().getMetricGroup().getIOMetricGroup(),
 					inputWatermarkGauge,
-					getTaskNameWithSubtaskAndId());
+					getTaskNameWithSubtaskAndId(),
+					operatorChain);
 		}
 		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge);
 		// wrap watermark gauge since registered metrics must be unique

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -38,10 +38,14 @@ import org.apache.flink.streaming.api.collector.selector.DirectedOutput;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
@@ -79,6 +83,9 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 	private static final Logger LOG = LoggerFactory.getLogger(OperatorChain.class);
 
+	/**
+	 * Stores all operators on this chain in reverse order.
+	 */
 	private final StreamOperator<?>[] allOperators;
 
 	private final RecordWriterOutput<?>[] streamOutputs;
@@ -94,6 +101,9 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 	 * this value is {@link StreamStatus#IDLE}.
 	 */
 	private StreamStatus streamStatus = StreamStatus.ACTIVE;
+
+	/** The flag that tracks finished inputs. */
+	private InputSelection finishedInputs = new InputSelection.Builder().build();
 
 	public OperatorChain(
 			StreamTask<OUT, OP> containingTask,
@@ -221,6 +231,50 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			final StreamOperator<?> op = operators[i];
 			if (op != null) {
 				op.prepareSnapshotPreBarrier(checkpointId);
+			}
+		}
+	}
+
+	/**
+	 * Ends an input (specified by {@code inputId}) of the {@link StreamTask}. The {@code inputId}
+	 * is numbered starting from 1, and `1` indicates the first input.
+	 *
+	 * @param inputId The ID of the input.
+	 * @throws Exception if some exception happens in the endInput function of an operator.
+	 */
+	public void endInput(int inputId) throws Exception {
+		if (finishedInputs.areAllInputsSelected()) {
+			return;
+		}
+
+		if (headOperator instanceof TwoInputStreamOperator) {
+			if (finishedInputs.isInputSelected(inputId)) {
+				return;
+			}
+
+			if (headOperator instanceof BoundedMultiInput) {
+				((BoundedMultiInput) headOperator).endInput(inputId);
+			}
+
+			finishedInputs = InputSelection.Builder
+				.from(finishedInputs)
+				.select(finishedInputs.getInputMask() == 0 ? inputId : -1)
+				.build();
+		} else {
+			// here, the head operator is a stream source or an one-input stream operator,
+			// so all inputs are finished
+			finishedInputs = new InputSelection.Builder()
+				.select(-1)
+				.build();
+		}
+
+		if (finishedInputs.areAllInputsSelected()) {
+			// executing #endInput() happens from head to tail operator in the chain
+			for (int i = allOperators.length - 1; i >= 0; i--) {
+				StreamOperator<?> operator = allOperators[i];
+				if (operator instanceof BoundedOneInput) {
+					((BoundedOneInput) operator).endInput();
+				}
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -181,7 +181,7 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 		@Override
 		public void run() {
 			try {
-				headOperator.run(getCheckpointLock(), getStreamStatusMaintainer());
+				headOperator.run(getCheckpointLock(), getStreamStatusMaintainer(), operatorChain);
 			} catch (Throwable t) {
 				sourceExecutionThrowable = t;
 			} finally {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputSelectableStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputSelectableStreamTask.java
@@ -54,7 +54,8 @@ public class TwoInputSelectableStreamTask<IN1, IN2, OUT> extends AbstractTwoInpu
 			getStreamStatusMaintainer(),
 			this.headOperator,
 			input1WatermarkGauge,
-			input2WatermarkGauge);
+			input2WatermarkGauge,
+			operatorChain);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -59,7 +59,8 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			getEnvironment().getMetricGroup().getIOMetricGroup(),
 			input1WatermarkGauge,
 			input2WatermarkGauge,
-			getTaskNameWithSubtaskAndId());
+			getTaskNameWithSubtaskAndId(),
+			operatorChain);
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
@@ -118,6 +118,10 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 					return Optional.of(new BufferAndAvailability(buildSingleBuffer(bufferBuilder), moreAvailable, 0));
 				} else if (input != null && input.isEvent()) {
 					AbstractEvent event = input.getEvent();
+					if (event instanceof EndOfPartitionEvent) {
+						inputChannels[channelIndex].setReleased();
+					}
+
 					return Optional.of(new BufferAndAvailability(EventSerializer.toBuffer(event), moreAvailable, 0));
 				} else {
 					return Optional.empty();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.streaming.runtime.tasks.SourceStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskTest;
@@ -231,9 +232,10 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		@Override
 		public void run(Object lockingObject,
 						StreamStatusMaintainer streamStatusMaintainer,
-						Output<StreamRecord<OUT>> collector) throws Exception {
+						Output<StreamRecord<OUT>> collector,
+						OperatorChain<?, ?> operatorChain) throws Exception {
 			ACTUAL_ORDER_TRACKING.add("OPERATOR::run");
-			super.run(lockingObject, streamStatusMaintainer, collector);
+			super.run(lockingObject, streamStatusMaintainer, collector, operatorChain);
 			runStarted.trigger();
 			runFinish.await();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
@@ -31,6 +31,18 @@ import static org.junit.Assert.assertTrue;
 public class InputSelectionTest {
 
 	@Test
+	public void testIsInputSelected() {
+		assertFalse(new Builder().build().isInputSelected(1));
+		assertFalse(new Builder().select(2).build().isInputSelected(1));
+
+		assertTrue(new Builder().select(1).build().isInputSelected(1));
+		assertTrue(new Builder().select(1).select(2).build().isInputSelected(1));
+		assertTrue(new Builder().select(-1).build().isInputSelected(1));
+
+		assertTrue(new Builder().select(64).build().isInputSelected(64));
+	}
+
+	@Test
 	public void testIsALLMaskOf2() {
 		assertTrue(InputSelection.ALL.isALLMaskOf2());
 		assertTrue(new Builder().select(1).select(2).build().isALLMaskOf2());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -597,6 +597,40 @@ public class OneInputStreamTaskTest extends TestLogger {
 		timeService.shutdownService();
 	}
 
+	@Test
+	public void testHandlingEndOfInput() throws Exception {
+		final OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(
+			OneInputStreamTask::new,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness
+			.setupOperatorChain(new OperatorID(), new TestBoundedOneInputStreamOperator("Operator0"))
+			.chain(
+				new OperatorID(),
+				new TestBoundedOneInputStreamOperator("Operator1"),
+				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+			.finish();
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		testHarness.processElement(new StreamRecord<>("Hello"));
+		testHarness.endInput();
+
+		testHarness.waitForTaskCompletion();
+
+		expectedOutput.add(new StreamRecord<>("Hello"));
+		expectedOutput.add(new StreamRecord<>("[Operator0]: Bye"));
+		expectedOutput.add(new StreamRecord<>("[Operator1]: Bye"));
+
+		TestHarnessUtil.assertOutputEquals("Output was not correct.",
+			expectedOutput,
+			testHarness.getOutput());
+	}
+
 	private static class TestOperator
 			extends AbstractStreamOperator<String>
 			implements OneInputStreamOperator<String, String> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -18,33 +18,45 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.functions.source.FromElementsFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * These tests verify that the RichFunction methods are called (in correct order). And that
@@ -71,7 +83,7 @@ public class SourceStreamTaskTest {
 		testHarness.invoke();
 		testHarness.waitForTaskCompletion();
 
-		Assert.assertTrue("RichFunction methods where not called.", OpenCloseTestSource.closeCalled);
+		assertTrue("RichFunction methods where not called.", OpenCloseTestSource.closeCalled);
 
 		List<String> resultElements = TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
 		Assert.assertEquals(10, resultElements.size());
@@ -145,6 +157,78 @@ public class SourceStreamTaskTest {
 		finally {
 			executor.shutdown();
 		}
+	}
+
+	@Test
+	public void testMarkingEndOfInput() throws Exception {
+		final StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(
+			SourceStreamTask::new,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness
+			.setupOperatorChain(
+				new OperatorID(),
+				new StreamSource<>(new FromElementsFunction<>(
+					BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()), "Hello")))
+			.chain(
+				new OperatorID(),
+				new TestBoundedOneInputStreamOperator("Operator1"),
+				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+			.finish();
+
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.invoke();
+		testHarness.waitForTaskCompletion();
+
+		expectedOutput.add(new StreamRecord<>("Hello"));
+		expectedOutput.add(new StreamRecord<>("[Operator1]: Bye"));
+
+		TestHarnessUtil.assertOutputEquals("Output was not correct.",
+			expectedOutput,
+			testHarness.getOutput());
+	}
+
+	@Test
+	public void testNotMarkingEndOfInputWhenTaskCancelled () throws Exception {
+		final StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(
+			SourceStreamTask::new,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness
+			.setupOperatorChain(
+				new OperatorID(),
+				new StreamSource<>(new CancelTestSource(
+					BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()), "Hello")))
+			.chain(
+				new OperatorID(),
+				new TestBoundedOneInputStreamOperator("Operator1"),
+				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+			.finish();
+
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.invoke();
+		CancelTestSource.getDataProcessing().get();
+		testHarness.getTask().cancel();
+
+		try {
+			testHarness.waitForTaskCompletion();
+		} catch (Throwable t) {
+			assertTrue(ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent());
+		}
+
+		expectedOutput.add(new StreamRecord<>("Hello"));
+
+		TestHarnessUtil.assertOutputEquals("Output was not correct.",
+			expectedOutput,
+			testHarness.getOutput());
 	}
 
 	private static class MockSource implements SourceFunction<Tuple2<Long, Integer>>, ListCheckpointed<Serializable> {
@@ -290,6 +374,37 @@ public class SourceStreamTaskTest {
 
 		@Override
 		public void cancel() {}
+	}
+
+	private static class CancelTestSource extends FromElementsFunction<String> {
+		private static final long serialVersionUID = 8713065281092996067L;
+
+		private static CompletableFuture<Void> dataProcessing = new CompletableFuture<>();
+
+		private static CompletableFuture<Void> cancellationWaiting = new CompletableFuture<>();
+
+		public CancelTestSource(TypeSerializer<String> serializer, String... elements) throws IOException {
+			super(serializer, elements);
+		}
+
+		@Override
+		public void run(SourceContext<String> ctx) throws Exception {
+			super.run(ctx);
+
+			dataProcessing.complete(null);
+			cancellationWaiting.get();
+		}
+
+		@Override
+		public void cancel() {
+			super.cancel();
+
+			cancellationWaiting.complete(null);
+		}
+
+		public static CompletableFuture<Void> getDataProcessing() {
+			return dataProcessing;
+		}
 	}
 }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -967,7 +967,8 @@ public class StreamTaskTest extends TestLogger {
 		@Override
 		public void run(Object lockingObject,
 						StreamStatusMaintainer streamStatusMaintainer,
-						Output<StreamRecord<Long>> collector) throws Exception {
+						Output<StreamRecord<Long>> collector,
+						OperatorChain<?, ?> operatorChain) throws Exception {
 			while (!canceled) {
 				try {
 					Thread.sleep(500);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -42,9 +43,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
-import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
@@ -426,13 +425,14 @@ public class StreamTaskTestHarness<OUT> {
 		}
 	}
 
-	public StreamConfigChainer setupOperatorChain(OperatorID headOperatorId, OneInputStreamOperator<?, ?> headOperator) {
-		Preconditions.checkState(!setupCalled, "This harness was already setup.");
-		setupCalled = true;
-		return new StreamConfigChainer(headOperatorId, headOperator, getStreamConfig());
+	/**
+	 * Notifies the specified input channel on the specified input gate that no more data will arrive.
+	 */
+	public void endInput(int gateIndex, int channelIndex) {
+		inputGates[gateIndex].sendEvent(EndOfPartitionEvent.INSTANCE, channelIndex);
 	}
 
-	public StreamConfigChainer setupOperatorChain(OperatorID headOperatorId, TwoInputStreamOperator<?, ?, ?> headOperator) {
+	public StreamConfigChainer setupOperatorChain(OperatorID headOperatorId, StreamOperator<?> headOperator) {
 		Preconditions.checkState(!setupCalled, "This harness was already setup.");
 		setupCalled = true;
 		return new StreamConfigChainer(headOperatorId, headOperator, getStreamConfig());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestBoundedOneInputStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestBoundedOneInputStreamOperator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * A bounded one-input stream operator for test.
+ */
+public class TestBoundedOneInputStreamOperator extends AbstractStreamOperator<String>
+	implements OneInputStreamOperator<String, String>, BoundedOneInput {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String name;
+
+	public TestBoundedOneInputStreamOperator(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public void processElement(StreamRecord<String> element) {
+		output.collect(element);
+	}
+
+	@Override
+	public void endInput() {
+		output.collect(new StreamRecord<>("[" + name + "]: Bye"));
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.co.RichCoMapFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
@@ -596,6 +597,70 @@ public class TwoInputStreamTaskTest {
 		testHarness.waitForTaskCompletion();
 	}
 
+	@Test
+	public void testHandlingEndOfInput() throws Exception {
+		final TwoInputStreamTaskTestHarness<String, String, String> testHarness = new TwoInputStreamTaskTestHarness<>(
+			isInputSelectable ? TwoInputSelectableStreamTask::new : TwoInputStreamTask::new,
+			3,
+			2,
+			new int[] {1, 2, 2},
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness
+			.setupOperatorChain(
+				new OperatorID(),
+				isInputSelectable ? new TestBoundedAndSelectableTwoInputOperator("Operator0") : new TestBoundedTwoInputOperator("Operator0"))
+			.chain(
+				new OperatorID(),
+				new TestBoundedOneInputStreamOperator("Operator1"),
+				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+			.finish();
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<Object>();
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		TestBoundedTwoInputOperator headOperator = (TestBoundedTwoInputOperator) testHarness.getTask().headOperator;
+
+		testHarness.processElement(new StreamRecord<>("Hello-1"), 0, 0);
+		testHarness.endInput(0,  0);
+		testHarness.processElement(new StreamRecord<>("Hello-2"), 0, 1);
+		testHarness.endInput(0,  1);
+
+		testHarness.waitForInputProcessing();
+
+		testHarness.processElement(new StreamRecord<>("Hello-3"), 1, 0);
+		testHarness.processElement(new StreamRecord<>("Hello-4"), 1, 1);
+		testHarness.endInput(1,  0);
+		testHarness.endInput(1,  1);
+
+		testHarness.waitForInputProcessing();
+
+		testHarness.processElement(new StreamRecord<>("Hello-5"), 2, 0);
+		testHarness.processElement(new StreamRecord<>("Hello-6"), 2, 1);
+		testHarness.endInput(2,  0);
+		testHarness.endInput(2,  1);
+
+		testHarness.waitForInputProcessing();
+
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Bye"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: Hello-4"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: Hello-5"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: Hello-6"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: Bye"));
+		expectedOutput.add(new StreamRecord<>("[Operator1]: Bye"));
+
+		TestHarnessUtil.assertOutputEquals("Output was not correct.",
+			expectedOutput,
+			testHarness.getOutput());
+	}
+
 	// This must only be used in one test, otherwise the static fields will be changed
 	// by several tests concurrently
 	private static class TestOpenCloseMapFunction extends RichCoMapFunction<String, Integer, String> {
@@ -664,6 +729,49 @@ public class TwoInputStreamTaskTest {
 
 		public AnyReadingCoStreamMap(CoMapFunction<IN1, IN2, OUT> mapper) {
 			super(mapper);
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return InputSelection.ALL;
+		}
+	}
+
+	/**
+	 * Uses to test handling the EndOfInput notification.
+	 */
+	private static class TestBoundedTwoInputOperator extends AbstractStreamOperator<String>
+		implements TwoInputStreamOperator<String, String, String>, BoundedMultiInput {
+
+		private static final long serialVersionUID = 1L;
+
+		private final String name;
+
+		public TestBoundedTwoInputOperator(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public void processElement1(StreamRecord<String> element) {
+			output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
+		}
+
+		@Override
+		public void processElement2(StreamRecord<String> element) {
+			output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
+		}
+
+		@Override
+		public void endInput(int inputId) {
+			output.collect(new StreamRecord<>("[" + name + "-" + inputId + "]: Bye"));
+		}
+	}
+
+	private static class TestBoundedAndSelectableTwoInputOperator
+		extends TestBoundedTwoInputOperator	implements InputSelectable {
+
+		public TestBoundedAndSelectableTwoInputOperator(String name) {
+			super(name);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements the runtime handling of the BoundedOneInput and BoundedMultiInput 
 interfaces. This will give the bounded stream operators an opportunity to process certain logic when the EndOfInput  notification arrives.  For example,  the hash join operator knows when the read to the build side has finished, then it can finish the build phase and prepare for the probe phase.


## Brief change log

  - Change `xInputProcessor` (`StreamInputProcessor`, `StreamTwoInputProcessor` and `StreamTwoInputSelecdtableProcessor`) to add the `endInput()` method call of the header operator on the operator chain.
  - Change `xStreamTask` (`SourceStreamTask`, `OneInputStreamTask`, `TwoInputStreamTask` and `TwoInputSelectableStreamTask`) to add the `endInput()` method calls for other non-header operators on the operator chain.


## Verifying this change

This change added tests and can be verified as follows:

  - Added test that validates that `SourceStreamTask` correctly handles `EndOfInput` notifications.
  - Added test that validates that `OneInputStreamTask` correctly handles `EndOfInput` notifications.
  - Added test that validates that `TwoInputStreamTask` correctly handles `EndOfInput` notifications.
  - Added test that validates that `TwoInputSelectableStreamTask` correctly handles `EndOfInput` notifications.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
