### PR TITLE
[FLINK-12846][table] Carry primary key and unique key information in TableSchema

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -307,7 +307,7 @@ public class TableSchema {
 		return Arrays.equals(fieldNames, schema.fieldNames) &&
 			Arrays.equals(fieldDataTypes, schema.fieldDataTypes) &&
 			Arrays.equals(primaryKey, schema.primaryKey) &&
-			Arrays.equals(uniqueKeys, schema.uniqueKeys);
+			Arrays.deepEquals(uniqueKeys, schema.uniqueKeys);
 	}
 
 	@Override
@@ -315,7 +315,7 @@ public class TableSchema {
 		int result = Arrays.hashCode(fieldNames);
 		result = 31 * result + Arrays.hashCode(fieldDataTypes);
 		result = 31 * result + Arrays.hashCode(primaryKey);
-		result = 31 * result + Arrays.hashCode(uniqueKeys);
+		result = 31 * result + Arrays.deepHashCode(uniqueKeys);
 		return result;
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
@@ -28,15 +28,42 @@ import static org.junit.Assert.assertEquals;
 public class TableSchemaTest {
 
 	@Test
+	public void testEqualsAndHashCode() {
+		// simple test
+		TableSchema schema1 = createBasicTableSchemaBuilder().build();
+		TableSchema schema2 = createBasicTableSchemaBuilder().build();
+		assertEquals(schema1, schema2);
+		assertEquals(schema1.hashCode(), schema2.hashCode());
+
+		// with primary key
+		TableSchema schema3 = createBasicTableSchemaBuilder()
+			.primaryKey("a")
+			.build();
+		TableSchema schema4 = createBasicTableSchemaBuilder()
+			.primaryKey("a")
+			.build();
+		assertEquals(schema3, schema4);
+		assertEquals(schema3.hashCode(), schema4.hashCode());
+
+		// with unique key
+		TableSchema schema5 = createBasicTableSchemaBuilder()
+			.uniqueKey("a", "b")
+			.uniqueKey("b", "c")
+			.build();
+		TableSchema schema6 = createBasicTableSchemaBuilder()
+			.uniqueKey("a", "b")
+			.uniqueKey("b", "c")
+			.build();
+		assertEquals(schema5, schema6);
+		assertEquals(schema5.hashCode(), schema6.hashCode());
+	}
+
+	@Test
 	public void testToString() {
-		TableSchema.Builder builder = TableSchema.builder()
-			.field("a", DataTypes.INT())
-			.field("b", DataTypes.STRING())
-			.field("c", DataTypes.BIGINT());
+		TableSchema.Builder builder = createBasicTableSchemaBuilder();
 
 		String expected = "root\n |-- a: INT\n |-- b: STRING\n |-- c: BIGINT\n";
 		assertEquals(expected, builder.build().toString());
-
 
 		builder.primaryKey("a");
 		String expected2 = expected + " |-- PRIMARY KEY (a)\n";
@@ -51,29 +78,26 @@ public class TableSchemaTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidPrimaryKeyFieldName() {
-		TableSchema.builder()
-			.field("a", DataTypes.INT())
-			.field("b", DataTypes.STRING())
-			.field("c", DataTypes.BIGINT())
+		createBasicTableSchemaBuilder()
 			.primaryKey("a", "d");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidMultiPrimaryKey() {
-		TableSchema.builder()
-			.field("a", DataTypes.INT())
-			.field("b", DataTypes.STRING())
-			.field("c", DataTypes.BIGINT())
+		createBasicTableSchemaBuilder()
 			.primaryKey("a")
 			.primaryKey("b");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidUniqueKeyFieldName() {
-		TableSchema.builder()
+		createBasicTableSchemaBuilder().uniqueKey("a", "d");
+	}
+
+	private TableSchema.Builder createBasicTableSchemaBuilder() {
+		return TableSchema.builder()
 			.field("a", DataTypes.INT())
 			.field("b", DataTypes.STRING())
-			.field("c", DataTypes.BIGINT())
-			.uniqueKey("a", "d");
+			.field("c", DataTypes.BIGINT());
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.api;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -26,6 +28,9 @@ import static org.junit.Assert.assertEquals;
  * Tests for {@link TableSchema}.
  */
 public class TableSchemaTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void testEqualsAndHashCode() {
@@ -59,6 +64,30 @@ public class TableSchemaTest {
 	}
 
 	@Test
+	public void testDuplicatePrimaryKeyAndUniqueKey() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("The primary key fields have already been declared as unique key");
+		createBasicTableSchemaBuilder()
+			.uniqueKey("a", "b")
+			.primaryKey("a", "b")
+			.build();
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("The unique key have already been declared");
+		createBasicTableSchemaBuilder()
+			.uniqueKey("a", "b")
+			.uniqueKey("a", "b")
+			.build();
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("The unique key fields have already been declared as primary key");
+		createBasicTableSchemaBuilder()
+			.primaryKey("a", "b")
+			.uniqueKey("a", "b")
+			.build();
+	}
+
+	@Test
 	public void testToString() {
 		TableSchema.Builder builder = createBasicTableSchemaBuilder();
 
@@ -76,21 +105,27 @@ public class TableSchemaTest {
 		assertEquals(expected3, builder.build().toString());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidPrimaryKeyFieldName() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("The field 'd' is not existed in the schema");
 		createBasicTableSchemaBuilder()
 			.primaryKey("a", "d");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidMultiPrimaryKey() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("A primary key [a] have been defined, can not define another primary key [b]");
 		createBasicTableSchemaBuilder()
 			.primaryKey("a")
 			.primaryKey("b");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidUniqueKeyFieldName() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("The field 'd' is not existed in the schema");
 		createBasicTableSchemaBuilder().uniqueKey("a", "d");
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link TableSchema}.
+ */
+public class TableSchemaTest {
+
+	@Test
+	public void testToString() {
+		TableSchema.Builder builder = TableSchema.builder()
+			.field("a", DataTypes.INT())
+			.field("b", DataTypes.STRING())
+			.field("c", DataTypes.BIGINT());
+
+		String expected = "root\n |-- a: INT\n |-- b: STRING\n |-- c: BIGINT\n";
+		assertEquals(expected, builder.build().toString());
+
+
+		builder.primaryKey("a");
+		String expected2 = expected + " |-- PRIMARY KEY (a)\n";
+		assertEquals(expected2, builder.build().toString());
+
+		builder
+			.uniqueKey("a", "b")
+			.uniqueKey("b", "c");
+		String expected3 = expected2 + " |-- UNIQUE KEY (a, b)\n |-- UNIQUE KEY (b, c)\n";
+		assertEquals(expected3, builder.build().toString());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidPrimaryKeyFieldName() {
+		TableSchema.builder()
+			.field("a", DataTypes.INT())
+			.field("b", DataTypes.STRING())
+			.field("c", DataTypes.BIGINT())
+			.primaryKey("a", "d");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidMultiPrimaryKey() {
+		TableSchema.builder()
+			.field("a", DataTypes.INT())
+			.field("b", DataTypes.STRING())
+			.field("c", DataTypes.BIGINT())
+			.primaryKey("a")
+			.primaryKey("b");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidUniqueKeyFieldName() {
+		TableSchema.builder()
+			.field("a", DataTypes.INT())
+			.field("b", DataTypes.STRING())
+			.field("c", DataTypes.BIGINT())
+			.uniqueKey("a", "d");
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
@@ -31,7 +31,6 @@ import org.apache.flink.table.plan.nodes.resource.batch.parallelism.BatchParalle
 import org.apache.flink.table.plan.optimize.{BatchCommonSubGraphBasedOptimizer, Optimizer}
 import org.apache.flink.table.plan.reuse.DeadlockBreakupProcessor
 import org.apache.flink.table.plan.schema.{TableSourceSinkTable, TableSourceTable}
-import org.apache.flink.table.plan.stats.FlinkStatistic
 import org.apache.flink.table.plan.util.{ExecNodePlanDumper, FlinkRelOptUtil}
 import org.apache.flink.table.sinks._
 import org.apache.flink.table.sources._
@@ -262,7 +261,6 @@ class BatchTableEnvironment(
   override protected def registerTableSourceInternal(
       name: String,
       tableSource: TableSource[_],
-      statistic: FlinkStatistic,
       replace: Boolean = false): Unit = {
 
     def register(): Unit = {
@@ -279,7 +277,7 @@ class BatchTableEnvironment(
           // wrapper contains only sink (not source)
           case _ =>
             val enrichedTable = new TableSourceSinkTable(
-              Some(new TableSourceTable(tableSource, false, statistic)),
+              Some(new TableSourceTable(tableSource, false)),
               table.tableSinkTable)
             replaceRegisteredTable(name, enrichedTable)
         }
@@ -287,7 +285,7 @@ class BatchTableEnvironment(
         // no table is registered
         case _ =>
           val newTable = new TableSourceSinkTable(
-            Some(new TableSourceTable(tableSource, false, statistic)),
+            Some(new TableSourceTable(tableSource, false)),
             None)
           registerTableInternal(name, newTable)
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -490,7 +490,6 @@ abstract class StreamTableEnvironment(
   override protected def registerTableSourceInternal(
       name: String,
       tableSource: TableSource[_],
-      statistic: FlinkStatistic,
       replace: Boolean = false): Unit = {
 
     // TODO `TableSourceUtil.hasRowtimeAttribute` depends on [Expression]
@@ -521,7 +520,7 @@ abstract class StreamTableEnvironment(
           // wrapper contains only sink (not source)
           case Some(_: TableSourceTable[_]) =>
             val enrichedTable = new TableSourceSinkTable(
-              Some(new TableSourceTable(tableSource, true, statistic)),
+              Some(new TableSourceTable(tableSource, true)),
               table.tableSinkTable)
             replaceRegisteredTable(name, enrichedTable)
         }
@@ -529,7 +528,7 @@ abstract class StreamTableEnvironment(
         // no table is registered
         case _ =>
           val newTable = new TableSourceSinkTable(
-            Some(new TableSourceTable(tableSource, true, statistic)),
+            Some(new TableSourceTable(tableSource, true)),
             None)
           registerTableInternal(name, newTable)
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -748,9 +748,6 @@ abstract class TableEnvironment(
     registerTableSourceInternal(
       name,
       tableSource,
-      FlinkStatistic.builder()
-        .tableStats(tableSource.getTableStats.orElse(null))
-        .build(),
       replace = false)
   }
 
@@ -767,9 +764,6 @@ abstract class TableEnvironment(
     registerTableSourceInternal(
       name,
       tableSource,
-      FlinkStatistic.builder()
-        .tableStats(tableSource.getTableStats.orElse(null))
-        .build(),
       replace = true)
   }
 
@@ -784,7 +778,6 @@ abstract class TableEnvironment(
   protected def registerTableSourceInternal(
       name: String,
       tableSource: TableSource[_],
-      statistic: FlinkStatistic,
       replace: Boolean): Unit
 
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -26,9 +26,8 @@ import org.apache.flink.table.plan.nodes.physical.stream._
 import org.apache.flink.table.plan.schema.FlinkRelOptTable
 import org.apache.flink.table.plan.util.{FlinkRelMdUtil, RankUtil}
 import org.apache.flink.table.runtime.rank.RankType
-import org.apache.flink.table.sources.TableSource
+import org.apache.flink.table.sources.{TableSource, TableSourceUtil}
 import org.apache.flink.table.{JArrayList, JBoolean, JHashMap, JHashSet, JList, JSet}
-
 import com.google.common.collect.ImmutableSet
 import org.apache.calcite.plan.RelOptTable
 import org.apache.calcite.plan.volcano.RelSubset
@@ -67,8 +66,12 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
   private def getTableUniqueKeys(
       tableSource: TableSource[_],
       relOptTable: RelOptTable): JSet[ImmutableBitSet] = {
-    // TODO get uniqueKeys from TableSchema of TableSource
-
+    if (tableSource != null) {
+      val uniqueKeySet = TableSourceUtil.getUniqueKeys(tableSource)
+      if (uniqueKeySet.isDefined) {
+        return uniqueKeySet.get
+      }
+    }
     relOptTable match {
       case table: FlinkRelOptTable => table.uniqueKeysSet.orNull
       case _ => null

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
@@ -33,14 +33,6 @@ abstract class FlinkTable extends AbstractTable with TemporalTable {
   override def getStatistic: FlinkStatistic = ???
 
   /**
-    * Creates a copy of this table, changing statistic.
-    *
-    * @param statistic A new FlinkStatistic.
-    * @return Copy of this table, substituting statistic.
-    */
-  def copy(statistic: FlinkStatistic): FlinkTable
-
-  /**
     * Currently we do not need this, so we hard code it as default.
     */
   override def getSysStartFieldName: String = "sys_start"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/IntermediateRelTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/IntermediateRelTable.scala
@@ -50,15 +50,6 @@ class IntermediateRelTable(
   override def getRowType(typeFactory: RelDataTypeFactory): RelDataType = relNode.getRowType
 
   /**
-    * Creates a copy of this table, changing statistic.
-    *
-    * @param statistic A new FlinkStatistic.
-    * @return Copy of this table, substituting statistic.
-    */
-  override def copy(statistic: FlinkStatistic): FlinkTable =
-    new IntermediateRelTable(relNode, isAccRetract, statistic)
-
-  /**
     * Returns statistics of current table
     *
     * @return statistics of current table

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/TableSinkTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/TableSinkTable.scala
@@ -45,8 +45,4 @@ class TableSinkTable[T](
     * @return statistics of current table
     */
   override def getStatistic: FlinkStatistic = statistic
-
-  override def copy(statistic: FlinkStatistic): FlinkTable = {
-    new TableSinkTable[T](tableSink, statistic)
-  }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/TableSourceSinkTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/TableSourceSinkTable.scala
@@ -65,12 +65,6 @@ class TableSourceSinkTable[T1, T2](
     case _ => false
   }
 
-  override def copy(statistic: FlinkStatistic): FlinkTable = {
-    new TableSourceSinkTable[T1, T2](
-      tableSourceTable.map(source => source.copy(statistic)),
-      tableSinkTable.map(sink => sink.copy(statistic).asInstanceOf[TableSinkTable[T2]]))
-  }
-
   // Look up the tableSourceTable and tableSinkTable to find proper table type, this method must be
   // invoked every time to decide if the table source or sink can be deterministic.
   override def unwrap[T](clazz: Class[T]): T = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/RemoveCollationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/RemoveCollationTest.scala
@@ -37,22 +37,22 @@ class RemoveCollationTest extends TableTestBase {
     util.addTableSource("x",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
       Array("a", "b", "c"),
-      FlinkStatistic.builder().tableStats(new TableStats(100L)).build()
+      new TableStats(100L)
     )
     util.addTableSource("y",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
       Array("d", "e", "f"),
-      FlinkStatistic.builder().tableStats(new TableStats(100L)).build()
+      new TableStats(100L)
     )
     util.addTableSource("t1",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
       Array("a1", "b1", "c1"),
-      FlinkStatistic.builder().tableStats(new TableStats(100L)).build()
+      new TableStats(100L)
     )
     util.addTableSource("t2",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
       Array("d1", "e1", "f1"),
-      FlinkStatistic.builder().tableStats(new TableStats(100L)).build()
+      new TableStats(100L)
     )
 
     util.tableEnv.getConfig.getConf.setBoolean(
@@ -269,27 +269,32 @@ class RemoveCollationTest extends TableTestBase {
       Array[TypeInformation[_]](
         Types.STRING, Types.STRING, Types.STRING, Types.STRING, Types.STRING),
       Array("id", "key", "tb2_ids", "tb3_ids", "name"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("id"))).build()
+      null,
+      Set("id")
     )
     util.addTableSource("tb2",
       Array[TypeInformation[_]](Types.STRING, Types.STRING),
       Array("id",  "name"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("id"))).build()
+      null,
+      Set("id")
     )
     util.addTableSource("tb3",
       Array[TypeInformation[_]](Types.STRING, Types.STRING),
       Array("id",  "name"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("id"))).build()
+      null,
+      Set("id")
     )
     util.addTableSource("tb4",
       Array[TypeInformation[_]](Types.STRING, Types.STRING),
       Array("id",  "name"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("id"))).build()
+      null,
+      Set("id")
     )
     util.addTableSource("tb5",
       Array[TypeInformation[_]](Types.STRING, Types.STRING),
       Array("id",  "name"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("id"))).build()
+      null,
+      Set("id")
     )
     util.tableEnv.registerFunction("split", new StringSplit())
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/RemoveShuffleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/RemoveShuffleTest.scala
@@ -35,12 +35,12 @@ class RemoveShuffleTest extends TableTestBase {
     util.addTableSource("x",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
       Array("a", "b", "c"),
-      FlinkStatistic.builder().tableStats(new TableStats(100L)).build()
+      new TableStats(100L)
     )
     util.addTableSource("y",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
       Array("d", "e", "f"),
-      FlinkStatistic.builder().tableStats(new TableStats(100L)).build()
+      new TableStats(100L)
     )
     util.tableEnv.getConfig.getConf.setBoolean(
       PlannerConfigOptions.SQL_OPTIMIZER_REUSE_SUB_PLAN_ENABLED, false)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/common/AggregateReduceGroupingTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/common/AggregateReduceGroupingTestBase.scala
@@ -22,10 +22,9 @@ import org.apache.flink.table.api.Types
 import org.apache.flink.table.calcite.CalciteConfig
 import org.apache.flink.table.plan.optimize.program.FlinkBatchProgram
 import org.apache.flink.table.plan.rules.logical.FlinkAggregateRemoveRule
-import org.apache.flink.table.plan.stats.{FlinkStatistic, TableStats}
+import org.apache.flink.table.plan.stats.TableStats
 import org.apache.flink.table.util.{BatchTableTestUtil, TableTestBase}
 
-import com.google.common.collect.ImmutableSet
 import org.apache.calcite.tools.RuleSets
 import org.junit.{Before, Test}
 
@@ -37,33 +36,26 @@ abstract class AggregateReduceGroupingTestBase extends TableTestBase {
     util.addTableSource("T1",
       Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING, Types.STRING),
       Array("a1", "b1", "c1", "d1"),
-      FlinkStatistic.builder()
-        .tableStats(new TableStats(100000000))
-        .uniqueKeys(ImmutableSet.of(ImmutableSet.of("a1")))
-        .build()
+      new TableStats(100000000),
+      Set("a1")
     )
     util.addTableSource("T2",
       Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING),
       Array("a2", "b2", "c2"),
-      FlinkStatistic.builder()
-        .tableStats(new TableStats(100000000))
-        .uniqueKeys(ImmutableSet.of(ImmutableSet.of("b2"), ImmutableSet.of("a2", "b2")))
-        .build()
+      new TableStats(100000000),
+      Set("b2"),
+      Set("a2", "b2")
     )
     util.addTableSource("T3",
       Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING, Types.LONG),
       Array("a3", "b3", "c3", "d3"),
-      FlinkStatistic.builder()
-        .tableStats(new TableStats(1000))
-        .build()
+      new TableStats(1000)
     )
     util.addTableSource("T4",
       Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING, Types.SQL_TIMESTAMP),
       Array("a4", "b4", "c4", "d4"),
-      FlinkStatistic.builder()
-        .tableStats(new TableStats(100000000))
-        .uniqueKeys(ImmutableSet.of(ImmutableSet.of("a4")))
-        .build()
+      new TableStats(100000000),
+      Set("a4")
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -43,6 +43,27 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetUniqueKeysOnTableSourceScan(): Unit = {
+    Array(
+      studentTableSourceLogicalScan,
+      studentTableSourceFlinkLogicalScan,
+      studentTableSourceBatchScan,
+      studentTableSourceStreamScan
+    ).foreach { scan =>
+      assertEquals(uniqueKeys(Array(0)), mq.getUniqueKeys(scan).toSet)
+    }
+
+    Array(
+      empTableSourceLogicalScan,
+      empTableSourceFlinkLogicalScan,
+      empTableSourceBatchScan,
+      empTableSourceStreamScan
+    ).foreach { scan =>
+      assertNull(mq.getUniqueKeys(scan))
+    }
+  }
+
+  @Test
   def testGetUniqueKeysOnValues(): Unit = {
     assertNull(mq.getUniqueKeys(logicalValues))
     assertNull(mq.getUniqueKeys(emptyValues))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/MetadataTestUtil.scala
@@ -138,7 +138,6 @@ object MetadataTestUtil {
     new TableSourceTable[BaseRow](tableSource, false)
   }
 
-
   private def createEmpTable(): DataStreamTable[BaseRow] = {
     val schema = new TableSchema(
       Array("empno", "ename", "job", "mgr", "hiredate", "sal", "comm", "deptno"),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/nodes/resource/BatchExecResourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/nodes/resource/BatchExecResourceTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.plan.nodes.resource
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.{TableConfig, TableConfigOptions, Types}
 import org.apache.flink.table.plan.nodes.resource.batch.parallelism.NodeResourceConfig
-import org.apache.flink.table.plan.stats.{FlinkStatistic, TableStats}
+import org.apache.flink.table.plan.stats.TableStats
 import org.apache.flink.table.util.TableTestBase
 
 import org.junit.{Before, Test}
@@ -44,11 +44,13 @@ class BatchExecResourceTest(inferMode: String) extends TableTestBase {
     val table3Stats = new TableStats(5000000)
     util.addTableSource("table3",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
-      Array("a", "b", "c"), FlinkStatistic.builder().tableStats(table3Stats).build())
+      Array("a", "b", "c"),
+      table3Stats)
     val table5Stats = new TableStats(8000000)
     util.addTableSource("Table5",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.INT, Types.STRING, Types.LONG),
-      Array("d", "e", "f", "g", "h"), FlinkStatistic.builder().tableStats(table5Stats).build())
+      Array("d", "e", "f", "g", "h"),
+      table5Stats)
     BatchExecResourceTest.setResourceConfig(util.getTableEnv.getConfig)
   }
 
@@ -92,7 +94,7 @@ class BatchExecResourceTest(inferMode: String) extends TableTestBase {
     util.addTableSource("table4",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
       Array("a", "b", "c"),
-      FlinkStatistic.builder().tableStats(statsOfTable4).build())
+      statsOfTable4)
 
     val sqlQuery = "SELECT sum(a) as sum_a, g FROM " +
         "(SELECT a, b, c FROM table3 UNION ALL SELECT a, b, c FROM table4), Table5 " +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/FlinkAggregateInnerJoinTransposeRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/FlinkAggregateInnerJoinTransposeRuleTest.scala
@@ -75,7 +75,8 @@ class FlinkAggregateInnerJoinTransposeRuleTest extends TableTestBase {
     util.addTableSource("T2",
       Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING),
       Array("a2", "b2", "c2"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("b2"))).build()
+      null,
+      Set("b2")
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/FlinkAggregateRemoveRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/FlinkAggregateRemoveRuleTest.scala
@@ -25,10 +25,8 @@ import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalAggregate, FlinkLogicalCalc, FlinkLogicalExpand, FlinkLogicalJoin, FlinkLogicalSink, FlinkLogicalTableSourceScan, FlinkLogicalValues}
 import org.apache.flink.table.plan.optimize.program._
 import org.apache.flink.table.plan.rules.FlinkBatchRuleSets
-import org.apache.flink.table.plan.stats.FlinkStatistic
 import org.apache.flink.table.util.TableTestBase
 
-import com.google.common.collect.ImmutableSet
 import org.apache.calcite.plan.hep.HepMatchOrder
 import org.apache.calcite.rel.rules.{FilterCalcMergeRule, FilterToCalcRule, ProjectCalcMergeRule, ProjectToCalcRule, ReduceExpressionsRule}
 import org.apache.calcite.tools.RuleSets
@@ -87,12 +85,14 @@ class FlinkAggregateRemoveRuleTest extends TableTestBase {
     util.addTableSource("MyTable2",
       Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING),
       Array("a", "b", "c"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("a"))).build()
+      null,
+      Set("a")
     )
     util.addTableSource("MyTable3",
       Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING, Types.STRING),
       Array("a", "b", "c", "d"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("a"))).build()
+      null,
+      Set("a")
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/JoinDeriveNullFilterRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/JoinDeriveNullFilterRuleTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.plan.rules.logical
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.{PlannerConfigOptions, Types}
 import org.apache.flink.table.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
-import org.apache.flink.table.plan.stats.{ColumnStats, FlinkStatistic, TableStats}
+import org.apache.flink.table.plan.stats.{ColumnStats, TableStats}
 import org.apache.flink.table.util.TableTestBase
 
 import org.apache.calcite.plan.hep.HepMatchOrder
@@ -55,19 +55,19 @@ class JoinDeriveNullFilterRuleTest extends TableTestBase {
     util.addTableSource("MyTable1",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING, Types.INT, Types.LONG),
       Array("a1", "b1", "c1", "d1", "e1"),
-      FlinkStatistic.builder().tableStats(new TableStats(1000000000, Map(
+      new TableStats(1000000000, Map(
         "a1" -> new ColumnStats(null, 10000000L, 4.0, 4, null, null),
         "c1" -> new ColumnStats(null, 5000000L, 10.2, 16, null, null),
         "e1" -> new ColumnStats(null, 500000L, 8.0, 8, null, null)
-      ))).build())
+      )))
     util.addTableSource("MyTable2",
       Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING, Types.INT, Types.LONG),
       Array("a2", "b2", "c2", "d2", "e2"),
-      FlinkStatistic.builder().tableStats(new TableStats(2000000000, Map(
+      new TableStats(2000000000, Map(
         "b2" -> new ColumnStats(null, 10000000L, 8.0, 8, null, null),
         "c2" -> new ColumnStats(null, 3000000L, 18.6, 32, null, null),
         "e2" -> new ColumnStats(null, 1500000L, 8.0, 8, null, null)
-      ))).build())
+      )))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/PruneAggregateCallRuleTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/PruneAggregateCallRuleTestBase.scala
@@ -20,10 +20,8 @@ package org.apache.flink.table.plan.rules.logical
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.Types
-import org.apache.flink.table.plan.stats.FlinkStatistic
 import org.apache.flink.table.util.{BatchTableTestUtil, TableTestBase}
 
-import com.google.common.collect.ImmutableSet
 import org.junit.{Before, Test}
 
 /**
@@ -37,7 +35,8 @@ abstract class PruneAggregateCallRuleTestBase extends TableTestBase {
     util.addTableSource("T1",
       Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING, Types.INT),
       Array("a1", "b1", "c1", "d1"),
-      FlinkStatistic.builder().uniqueKeys(ImmutableSet.of(ImmutableSet.of("a1"))).build()
+      null,
+      Set("a1")
     )
     util.addTableSource[(Int, Int, String, Long)]("T2", 'a2, 'b2, 'c2, 'd2)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/BatchTableEnvUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/BatchTableEnvUtil.scala
@@ -73,7 +73,9 @@ object BatchTableEnvUtil {
     * @return The converted [[Table]].
     */
   def registerCollection[T](tEnv: BatchTableEnvironment,
-      tableName: String, data: Iterable[T], typeInfo: TypeInformation[T],
+      tableName: String,
+      data: Iterable[T],
+      typeInfo: TypeInformation[T],
       fieldNames: String): Unit = {
     registerCollection(
       tEnv, tableName, data, typeInfo, Some(parseFieldNames(fieldNames)), None, None)


### PR DESCRIPTION
## What is the purpose of the change

The primary key and unique key is a standard meta information in SQL. And they are important information for optimization, for example, AggregateRemove, AggregateReduceGrouping and state layout optimization for TopN and Join.

So in this PR, we extend TableSchema to carry more information about primary key and unique keys. So that the TableSource can declare this meta information.

The primary key and unique key information will only work in Blink planner currently. Flink planner will just ignore the information.

## Brief change log

This pull request contains 2 commits:

1. Add primary key and unique key to `TableSchema` with some Javadocs. 
2. Use the primary key and unique key information in Blink planner. 
   - We did some refactor to `TableSourceTable` to make it only build the `FlinkStatistic` from `TableSource` instead of passing in from outside. Along with some tests changes. 


## Verifying this change

1. Adds a `TableSchemaTest` to check the schema builder methods.
2. Adds `FlinkRelMdUniqueKeysTest#testGetUniqueKeysOnTableSourceScan`  test to check the optimizer can get the unique key information from  `TableSchema` from `TableSource`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
