### PR TITLE
[FLINK-12848][core] Consider fieldNames in RowTypeInfo#equals()

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeType.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeType.java
@@ -275,6 +275,17 @@ public abstract class CompositeType<T> extends TypeInformation<T> {
 		}
 	}
 
+	public boolean typeEquals(Object obj) {
+		if (obj instanceof CompositeType) {
+			@SuppressWarnings("unchecked")
+			CompositeType<T> compositeType = (CompositeType<T>)obj;
+
+			return compositeType.canEqual(this) && typeClass == compositeType.typeClass;
+		} else {
+			return false;
+		}
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof CompositeType) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/RowTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/RowTypeInfo.java
@@ -62,7 +62,6 @@ public class RowTypeInfo extends TupleTypeInfoBase<Row> {
 
 	// --------------------------------------------------------------------------------------------
 
-	protected final String[] fieldNames;
 	/** Temporary variable for directly passing orders to comparators. */
 	private boolean[] comparatorOrders = null;
 
@@ -249,19 +248,23 @@ public class RowTypeInfo extends TupleTypeInfoBase<Row> {
 
 	@Override
 	public int hashCode() {
-		return 31 * super.hashCode();
+		return 31 * super.hashCode() + Arrays.hashCode(fieldNames);
 	}
 
-	/**
-	 * The equals method does only check for field types. Field names do not matter during
-	 * runtime so we can consider rows with the same field types as equal.
-	 * Use {@link RowTypeInfo#schemaEquals(Object)} for checking schema-equivalence.
-	 */
 	@Override
-	public boolean equals(Object obj) {
+	public boolean typeEquals(Object obj) {
 		if (obj instanceof RowTypeInfo) {
 			final RowTypeInfo other = (RowTypeInfo) obj;
-			return other.canEqual(this) && super.equals(other);
+			return other.canEqual(this) && super.typeEquals(other);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (typeEquals(obj)) {
+			return Arrays.equals(fieldNames, ((RowTypeInfo)obj).fieldNames);
 		} else {
 			return false;
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
@@ -54,7 +54,6 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 	
 	private static final long serialVersionUID = 1L;
 
-	protected final String[] fieldNames;
 
 	@SuppressWarnings("unchecked")
 	@PublicEvolving
@@ -182,15 +181,22 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 	}
 
 	// --------------------------------------------------------------------------------------------
-	
+
 	@Override
-	public boolean equals(Object obj) {
+	public boolean typeEquals(Object obj) {
 		if (obj instanceof TupleTypeInfo) {
 			@SuppressWarnings("unchecked")
 			TupleTypeInfo<T> other = (TupleTypeInfo<T>) obj;
-			return other.canEqual(this) &&
-				super.equals(other) &&
-				Arrays.equals(fieldNames, other.fieldNames);
+			return other.canEqual(this) && super.typeEquals(other);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (typeEquals(obj)) {
+			return Arrays.equals(fieldNames, ((TupleTypeInfo)obj).fieldNames);
 		} else {
 			return false;
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
@@ -44,9 +44,11 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	private static final Pattern PATTERN_NESTED_FIELDS_WILDCARD = Pattern.compile(REGEX_NESTED_FIELDS_WILDCARD);
 
 	// --------------------------------------------------------------------------------------------
-	
+
 	protected final TypeInformation<?>[] types;
-	
+
+	protected String [] fieldNames;
+
 	private final int totalFields;
 
 	public TupleTypeInfoBase(Class<T> tupleType, TypeInformation<?>... types) {
@@ -205,15 +207,24 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	}
 	
 	@Override
-	public boolean equals(Object obj) {
+	public boolean typeEquals(Object obj) {
 		if (obj instanceof TupleTypeInfoBase) {
 			@SuppressWarnings("unchecked")
 			TupleTypeInfoBase<T> other = (TupleTypeInfoBase<T>) obj;
 
 			return other.canEqual(this) &&
-				super.equals(other) &&
+				super.typeEquals(other) &&
 				Arrays.equals(types, other.types) &&
 				totalFields == other.totalFields;
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (typeEquals(obj)) {
+			return Arrays.equals(fieldNames, ((TupleTypeInfoBase)obj).fieldNames);
 		} else {
 			return false;
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/functions/SemanticPropUtil.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/functions/SemanticPropUtil.java
@@ -427,7 +427,16 @@ public final class SemanticPropUtil {
 			// simple wildcard
 			if (wcMatcher.matches()) {
 
-				if (!inType.equals(outType)) {
+				if (inType instanceof CompositeType) {
+					if (!((CompositeType<?>) inType).typeEquals(outType)) {
+						if (skipIncompatibleTypes) {
+							continue;
+						} else {
+							throw new InvalidSemanticAnnotationException("Forwarded field annotation \"" + s +
+								"\" with wildcard only allowed for identical input and output types.");
+						}
+					}
+				} else if (!inType.equals(outType)) {
 					if (skipIncompatibleTypes) {
 						continue;
 					} else {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/UnionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/UnionOperator.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.Union;
+import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.DataSet;
 
 /**
@@ -43,7 +44,12 @@ public class UnionOperator<T> extends TwoInputOperator<T, T, T, UnionOperator<T>
 	public UnionOperator(DataSet<T> input1, DataSet<T> input2, String unionLocationName) {
 		super(input1, input2, input1.getType());
 
-		if (!input1.getType().equals(input2.getType())) {
+		if (input1.getType() instanceof CompositeType) {
+			if (!((CompositeType<T>) input1.getType()).typeEquals(input2.getType())) {
+				throw new InvalidProgramException("Cannot union inputs of different types. Input1="
+					+ input1.getType() + ", input2=" + input2.getType());
+			}
+		} else if (!input1.getType().equals(input2.getType())) {
 			throw new InvalidProgramException("Cannot union inputs of different types. Input1="
 					+ input1.getType() + ", input2=" + input2.getType());
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -36,6 +36,7 @@ import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.io.CsvOutputFormat;
@@ -214,7 +215,12 @@ public class DataStream<T> {
 		unionedTransforms.add(this.transformation);
 
 		for (DataStream<T> newStream : streams) {
-			if (!getType().equals(newStream.getType())) {
+			if (getType() instanceof CompositeType) {
+				if (!((CompositeType) getType()).typeEquals(newStream.getType())) {
+					throw new IllegalArgumentException("Cannot union streams of different types: "
+						+ getType() + " and " + newStream.getType());
+				}
+			} else if (!getType().equals(newStream.getType())) {
 				throw new IllegalArgumentException("Cannot union streams of different types: "
 						+ getType() + " and " + newStream.getType());
 			}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/UnionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/UnionTransformation.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.transformations;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
@@ -50,7 +51,11 @@ public class UnionTransformation<T> extends StreamTransformation<T> {
 		super("Union", inputs.get(0).getOutputType(), inputs.get(0).getParallelism());
 
 		for (StreamTransformation<T> input: inputs) {
-			if (!input.getOutputType().equals(getOutputType())) {
+			if (input.getOutputType() instanceof CompositeType) {
+				if (!((CompositeType) input.getOutputType()).typeEquals(getOutputType())) {
+					throw new UnsupportedOperationException("Type mismatch in input " + input);
+				}
+			} else if (!input.getOutputType().equals(getOutputType())) {
 				throw new UnsupportedOperationException("Type mismatch in input " + input);
 			}
 		}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
@@ -54,6 +54,7 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem) extends JavaTypeFactoryImp
   // override more methods of RelDataTypeFactoryImpl
 
   private val seenTypes = mutable.HashMap[(TypeInformation[_], Boolean), RelDataType]()
+  private val seenTypesNew = mutable.HashMap[(TypeInformation[_],String, Boolean), RelDataType]
 
   def createTypeFromTypeInfo(
       typeInfo: TypeInformation[_],

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.plan.nodes.datastream
 import org.apache.calcite.rex.RexNode
 import org.apache.flink.api.common.functions.{MapFunction, RichMapFunction}
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.functions.ProcessFunction

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/types/CRowTypeInfo.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/types/CRowTypeInfo.scala
@@ -74,6 +74,14 @@ class CRowTypeInfo(val rowType: RowTypeInfo) extends CompositeType[CRow](classOf
     new CRowComparator(rowComparator)
   }
 
+  override def typeEquals(obj: scala.Any): Boolean = {
+    if (this.canEqual(obj)) {
+      rowType.typeEquals(obj.asInstanceOf[CRowTypeInfo].rowType)
+    } else {
+      false
+    }
+  }
+
   override def equals(obj: scala.Any): Boolean = {
     if (this.canEqual(obj)) {
       rowType.equals(obj.asInstanceOf[CRowTypeInfo].rowType)

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BaseRowTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BaseRowTypeInfo.java
@@ -41,7 +41,6 @@ public class BaseRowTypeInfo extends TupleTypeInfoBase<BaseRow> {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String[] fieldNames;
 	private final LogicalType[] logicalTypes;
 
 	public BaseRowTypeInfo(LogicalType... logicalTypes) {
@@ -97,6 +96,29 @@ public class BaseRowTypeInfo extends TupleTypeInfoBase<BaseRow> {
 			}
 		}
 		return -1;
+	}
+
+	@Override
+	public boolean typeEquals(Object obj) {
+		if (obj instanceof BaseRowTypeInfo) {
+			@SuppressWarnings("unchecked")
+			BaseRowTypeInfo other = (BaseRowTypeInfo) obj;
+
+			return other.canEqual(this) &&
+				super.typeEquals(other) &&
+				Arrays.equals(types, other.types);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (typeEquals(obj)) {
+			return Arrays.equals(fieldNames, ((BaseRowTypeInfo)obj).fieldNames);
+		} else {
+			return false;
+		}
 	}
 
 	@Override


### PR DESCRIPTION

## What is the purpose of the change

This pr fix the bug of RowTypeInfo#equals(), take `fieldNames` into consideration.


## Brief change log
take `fieldNames` into consideration in RowTypeInfo#equals()


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)