### PR TITLE
[FLINK-12845][sql-client] Execute multiple statements in command line…

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -641,7 +641,7 @@ public class CliClient {
 	/**
 	 * Split a SemiColon-separated String, but ignore SemiColons in quotes.
 	 */
-	private static List<String> splitSemiColon(String line) {
+	static List<String> splitSemiColon(String line) {
 		boolean inSingleQuotes = false;
 		boolean inDoubleQuotes = false;
 		boolean escape = false;

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -138,6 +138,21 @@ public class CliClientTest extends TestLogger {
 		}
 	}
 
+	@Test
+	public void testSplitStatements() {
+		final String simpleStats = "INSERT INTO MyTable SELECT * FROM MyOtherTable;\nSELECT * FROM MyOtherTable;";
+		final List<String> expectedSimpleStatements = Arrays.asList(
+			"INSERT INTO MyTable SELECT * FROM MyOtherTable", "\nSELECT * FROM MyOtherTable");
+		final List<String> actualSimpleStatements = CliClient.splitSemiColon(simpleStats);
+		assertTrue(expectedSimpleStatements.equals(actualSimpleStatements));
+
+		final String complexStats = "-- insert data from MyOtherTable to MyTable\nINSERT INTO MyTable SELECT * FROM MyOtherTable;\nSELECT * FROM MyOtherTable WHERE f1 LIKE '%;%';";
+		final List<String> expectedComplexStatements = Arrays.asList(
+			"INSERT INTO MyTable SELECT * FROM MyOtherTable", "\nSELECT * FROM MyOtherTable WHERE f1 LIKE '%;%'");
+		final List<String> actualComplexStatements = CliClient.splitSemiColon(complexStats);
+		assertTrue(expectedComplexStatements.equals(actualComplexStatements));
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	private void verifyUpdateSubmission(String statement, boolean failExecution, boolean testFailure) {


### PR DESCRIPTION
… or sql script file

## What is the purpose of the change

Allows sql client execute multiple statements from command line or sql file script.

## Brief change log
multiple statements may come from
- copy and paste to command line
- sql script files from SOURCE command (SOURCE myscript.sql)
- pipeline (sql-client.sh embedded < myscript.sql)
- incoming -f option

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
