### PR TITLE
[FLINK-11879] Add validators for the uses of InputSelectable, BoundedOneInput and BoundedMultiInput

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -724,17 +724,8 @@ public class StreamGraph extends StreamingPlan {
 	/**
 	 * Gets the assembled {@link JobGraph} with a given job id.
 	 */
-	@SuppressWarnings("deprecation")
 	@Override
 	public JobGraph getJobGraph(@Nullable JobID jobID) {
-		// temporarily forbid checkpointing for iterative jobs
-		if (isIterative() && checkpointConfig.isCheckpointingEnabled() && !checkpointConfig.isForceCheckpointing()) {
-			throw new UnsupportedOperationException(
-				"Checkpointing is currently not supported by default for iterative jobs, as we cannot guarantee exactly once semantics. "
-					+ "State checkpoints happen normally, but records in-transit during the snapshot will be lost upon failure. "
-					+ "\nThe user can force enable state checkpoints with the reduced guarantees by calling: env.enableCheckpointing(interval,true)");
-		}
-
 		return StreamingJobGraphGenerator.createJobGraph(this, jobID);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -283,8 +283,9 @@ public class StreamGraph extends StreamingPlan {
 			TypeInformation<OUT> outTypeInfo,
 			String operatorName) {
 
-		Class<? extends AbstractInvokable> vertexClass = taskOperatorFactory.isOperatorSelectiveReading() ?
-			TwoInputSelectableStreamTask.class : TwoInputStreamTask.class;
+		Class<? extends AbstractInvokable> vertexClass =
+			taskOperatorFactory.isOperatorSelectiveReading(Thread.currentThread().getContextClassLoader()) ?
+				TwoInputSelectableStreamTask.class : TwoInputStreamTask.class;
 
 		addNode(vertexID, slotSharingGroup, coLocationGroup, vertexClass, taskOperatorFactory, operatorName);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
@@ -93,7 +93,7 @@ public class SimpleOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
 	}
 
 	@Override
-	public boolean isOperatorSelectiveReading() {
+	public boolean isOperatorSelectiveReading(ClassLoader classLoader) {
 		return operator instanceof InputSelectable;
 	}
 
@@ -116,5 +116,10 @@ public class SimpleOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
 	@Override
 	public void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
 		((InputTypeConfigurable) operator).setInputType(type, executionConfig);
+	}
+
+	@Override
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return operator.getClass();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactory.java
@@ -61,7 +61,7 @@ public interface StreamOperatorFactory<OUT> extends Serializable {
 	/**
 	 * Test whether the operator is selective reading one.
 	 */
-	boolean isOperatorSelectiveReading();
+	boolean isOperatorSelectiveReading(ClassLoader classLoader);
 
 	/**
 	 * If the stream operator need access to the output type information at {@link StreamGraph}
@@ -97,4 +97,9 @@ public interface StreamOperatorFactory<OUT> extends Serializable {
 	 * @param executionConfig The execution config for this parallel execution.
 	 */
 	default void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {}
+
+	/**
+	 * Returns the runtime class of the stream operator.
+	 */
+	Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -40,6 +40,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
@@ -323,6 +324,15 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 	public int getChainLength() {
 		return allOperators == null ? 0 : allOperators.length;
+	}
+
+	public boolean hasSelectiveReadingOperator() {
+		for (StreamOperator operator : allOperators) {
+			if (operator instanceof InputSelectable) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
@@ -29,7 +29,9 @@ import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.mailbox.execution.DefaultActionContext;
+import org.apache.flink.streaming.util.TestAnyModeReadingStreamOperator;
 import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.streaming.util.TestSequentialReadingStreamOperator;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Test;
@@ -57,7 +59,7 @@ public class StreamTaskSelectiveReadingTest {
 		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 3"));
 		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 4"));
 
-		testBase(new AnyReadingStreamOperator("Operator0"), true, expectedOutput, true);
+		testBase(new TestAnyModeReadingStreamOperator("Operator0"), true, expectedOutput, true);
 	}
 
 	@Test
@@ -71,7 +73,7 @@ public class StreamTaskSelectiveReadingTest {
 		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 3"));
 		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 4"));
 
-		testBase(new AnyReadingStreamOperator("Operator0"), false, expectedOutput, false);
+		testBase(new TestAnyModeReadingStreamOperator("Operator0"), false, expectedOutput, false);
 	}
 
 	@Test
@@ -85,7 +87,7 @@ public class StreamTaskSelectiveReadingTest {
 		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 3"));
 		expectedOutput.add(new StreamRecord<>("[Operator0-2]: 4"));
 
-		testBase(new SequentialReadingStreamOperator("Operator0"), false, expectedOutput, true);
+		testBase(new TestSequentialReadingStreamOperator("Operator0"), false, expectedOutput, true);
 	}
 
 	@Test
@@ -206,73 +208,6 @@ public class StreamTaskSelectiveReadingTest {
 			started = true;
 			synchronized (this) {
 				this.notifyAll();
-			}
-		}
-	}
-
-	private static class AnyReadingStreamOperator extends AbstractStreamOperator<String>
-		implements TwoInputStreamOperator<String, Integer, String>, InputSelectable {
-
-		private final String name;
-
-		AnyReadingStreamOperator(String name) {
-			super();
-
-			this.name = name;
-		}
-
-		@Override
-		public InputSelection nextSelection() {
-			return InputSelection.ALL;
-		}
-
-		@Override
-		public void processElement1(StreamRecord<String> element) {
-			output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
-		}
-
-		@Override
-		public void processElement2(StreamRecord<Integer> element) {
-			output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
-		}
-	}
-
-	/**
-	 * Test operator for sequential reading.
-	 */
-	public static class SequentialReadingStreamOperator extends AbstractStreamOperator<String>
-		implements TwoInputStreamOperator<String, Integer, String>, InputSelectable, BoundedMultiInput {
-
-		private final String name;
-
-		private InputSelection inputSelection;
-
-		public SequentialReadingStreamOperator(String name) {
-			super();
-
-			this.name = name;
-			this.inputSelection = InputSelection.FIRST;
-		}
-
-		@Override
-		public InputSelection nextSelection() {
-			return inputSelection;
-		}
-
-		@Override
-		public void processElement1(StreamRecord<String> element) {
-			output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
-		}
-
-		@Override
-		public void processElement2(StreamRecord<Integer> element) {
-			output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
-		}
-
-		@Override
-		public void endInput(int inputId) {
-			if (inputId == 1) {
-				inputSelection = InputSelection.SECOND;
 			}
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -40,7 +40,6 @@ import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.co.RichCoMapFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
@@ -48,6 +47,7 @@ import org.apache.flink.streaming.api.operators.co.CoStreamMap;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.util.TestBoundedTwoInputOperator;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 
 import org.junit.Assert;
@@ -737,38 +737,8 @@ public class TwoInputStreamTaskTest {
 		}
 	}
 
-	/**
-	 * Uses to test handling the EndOfInput notification.
-	 */
-	private static class TestBoundedTwoInputOperator extends AbstractStreamOperator<String>
-		implements TwoInputStreamOperator<String, String, String>, BoundedMultiInput {
-
-		private static final long serialVersionUID = 1L;
-
-		private final String name;
-
-		public TestBoundedTwoInputOperator(String name) {
-			this.name = name;
-		}
-
-		@Override
-		public void processElement1(StreamRecord<String> element) {
-			output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
-		}
-
-		@Override
-		public void processElement2(StreamRecord<String> element) {
-			output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
-		}
-
-		@Override
-		public void endInput(int inputId) {
-			output.collect(new StreamRecord<>("[" + name + "-" + inputId + "]: Bye"));
-		}
-	}
-
 	private static class TestBoundedAndSelectableTwoInputOperator
-		extends TestBoundedTwoInputOperator	implements InputSelectable {
+		extends TestBoundedTwoInputOperator implements InputSelectable {
 
 		public TestBoundedAndSelectableTwoInputOperator(String name) {
 			super(name);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestAnyModeReadingStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestAnyModeReadingStreamOperator.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * A test operator class for any mode reading.
+ */
+public class TestAnyModeReadingStreamOperator extends AbstractStreamOperator<String>
+	implements TwoInputStreamOperator<String, Integer, String>, InputSelectable {
+
+	private final String name;
+
+	public TestAnyModeReadingStreamOperator(String name) {
+		super();
+
+		this.name = name;
+	}
+
+	@Override
+	public InputSelection nextSelection() {
+		return InputSelection.ALL;
+	}
+
+	@Override
+	public void processElement1(StreamRecord<String> element) {
+		output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
+	}
+
+	@Override
+	public void processElement2(StreamRecord<Integer> element) {
+		output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestBoundedTwoInputOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestBoundedTwoInputOperator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * A test operator class implementing {@link BoundedMultiInput}.
+ */
+public class TestBoundedTwoInputOperator extends AbstractStreamOperator<String>
+	implements TwoInputStreamOperator<String, String, String>, BoundedMultiInput {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String name;
+
+	public TestBoundedTwoInputOperator(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public void processElement1(StreamRecord<String> element) {
+		output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
+	}
+
+	@Override
+	public void processElement2(StreamRecord<String> element) {
+		output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
+	}
+
+	@Override
+	public void endInput(int inputId) {
+		output.collect(new StreamRecord<>("[" + name + "-" + inputId + "]: Bye"));
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestSequentialReadingStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestSequentialReadingStreamOperator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * A test operator class for sequential reading.
+ */
+public class TestSequentialReadingStreamOperator extends AbstractStreamOperator<String>
+	implements TwoInputStreamOperator<String, Integer, String>, InputSelectable, BoundedMultiInput {
+
+	private final String name;
+
+	private InputSelection inputSelection;
+
+	public TestSequentialReadingStreamOperator(String name) {
+		super();
+
+		this.name = name;
+		this.inputSelection = InputSelection.FIRST;
+	}
+
+	@Override
+	public InputSelection nextSelection() {
+		return inputSelection;
+	}
+
+	@Override
+	public void processElement1(StreamRecord<String> element) {
+		output.collect(element.replace("[" + name + "-1]: " + element.getValue()));
+	}
+
+	@Override
+	public void processElement2(StreamRecord<Integer> element) {
+		output.collect(element.replace("[" + name + "-2]: " + element.getValue()));
+	}
+
+	@Override
+	public void endInput(int inputId) {
+		if (inputId == 1) {
+			inputSelection = InputSelection.SECOND;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/GeneratedClass.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/GeneratedClass.java
@@ -49,7 +49,7 @@ public abstract class GeneratedClass<T> implements Serializable {
 	@SuppressWarnings("unchecked")
 	public T newInstance(ClassLoader classLoader) {
 		try {
-			return (T) compile(classLoader).getConstructor(Object[].class)
+			return compile(classLoader).getConstructor(Object[].class)
 					// Because Constructor.newInstance(Object... initargs), we need to load
 					// references into a new Object[], otherwise it cannot be compiled.
 					.newInstance(new Object[] {references});
@@ -72,7 +72,7 @@ public abstract class GeneratedClass<T> implements Serializable {
 	/**
 	 * Compiles the generated code, the compiled class will be cached in the {@link GeneratedClass}.
 	 */
-	public Class<?> compile(ClassLoader classLoader) {
+	public Class<T> compile(ClassLoader classLoader) {
 		if (compiledClass == null) {
 			// cache the compiled class
 			compiledClass = CompileUtils.compile(classLoader, className, code);
@@ -92,7 +92,7 @@ public abstract class GeneratedClass<T> implements Serializable {
 		return references;
 	}
 
-	public Class<?> getClass(ClassLoader classLoader) {
+	public Class<T> getClass(ClassLoader classLoader) {
 		return compile(classLoader);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/CodeGenOperatorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/CodeGenOperatorFactory.java
@@ -59,8 +59,13 @@ public class CodeGenOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
 	}
 
 	@Override
-	public boolean isOperatorSelectiveReading() {
-		return InputSelectable.class.isAssignableFrom(generatedClass.getClass(Thread.currentThread().getContextClassLoader()));
+	public boolean isOperatorSelectiveReading(ClassLoader classLoader) {
+		return InputSelectable.class.isAssignableFrom(getStreamOperatorClass(classLoader));
+	}
+
+	@Override
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return generatedClass.getClass(classLoader);
 	}
 
 	public GeneratedClass<? extends StreamOperator<OUT>> getGeneratedClass() {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/generated/GeneratedCollectorWrapper.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/generated/GeneratedCollectorWrapper.java
@@ -45,7 +45,7 @@ public class GeneratedCollectorWrapper<C extends Collector<?>> extends Generated
 	}
 
 	@Override
-	public Class<?> compile(ClassLoader classLoader) {
+	public Class<C> compile(ClassLoader classLoader) {
 		return clazz;
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/generated/GeneratedFunctionWrapper.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/generated/GeneratedFunctionWrapper.java
@@ -45,7 +45,7 @@ public class GeneratedFunctionWrapper<F extends Function> extends GeneratedFunct
 	}
 
 	@Override
-	public Class<?> compile(ClassLoader classLoader) {
+	public Class<F> compile(ClassLoader classLoader) {
 		return clazz;
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/generated/GeneratedResultFutureWrapper.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/generated/GeneratedResultFutureWrapper.java
@@ -45,7 +45,7 @@ public class GeneratedResultFutureWrapper<T extends ResultFuture<?>> extends Gen
 	}
 
 	@Override
-	public Class<?> compile(ClassLoader classLoader) {
+	public Class<T> compile(ClassLoader classLoader) {
 		return clazz;
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StreamTaskSelectiveReadingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StreamTaskSelectiveReadingITCase.java
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.streaming.runtime.tasks.StreamTaskSelectiveReadingTest.SequentialReadingStreamOperator;
+import org.apache.flink.streaming.util.TestSequentialReadingStreamOperator;
 import org.apache.flink.test.streaming.runtime.util.TestListResultSink;
 
 import org.junit.Test;
@@ -60,7 +60,7 @@ public class StreamTaskSelectiveReadingITCase {
 			.setParallelism(2);
 		TestListResultSink<String> resultSink = new TestListResultSink<>();
 
-		TwoInputStreamOperator<String, Integer, String> twoInputStreamOperator = new SequentialReadingStreamOperator("Operator0");
+		TwoInputStreamOperator<String, Integer, String> twoInputStreamOperator = new TestSequentialReadingStreamOperator("Operator0");
 		twoInputStreamOperator.setChainingStrategy(ChainingStrategy.NEVER);
 
 		source0.connect(source1)


### PR DESCRIPTION
## What is the purpose of the change

This pull request add the following validators for the uses of `InputSelectable`, `BoundedOneInput` and `BoundedMultiInput`.
- Rejects the jobs containing operators which implement `InputSelectable` in case that checkpointing is enabled.
- Rejects the jobs containing operators which implement `BoundedInput` or `BoundedMultiInput` in case that checkpointing is enabled.
- Rejects the jobs containing operators which implement `InputSelectable` in case that credit-based flow control is disabled.


## Brief change log

  -  In `StreamingJobGraphGenerator`, add a validator that does not support the operators which implement `InputSelectable` or `BoundedOneInput` or `BoundedMultiInput` when checkpointing is enabled.
  -  In `StreamTask`, add a validator that does not support the operators which implement `InputSelectable` when credit-based mode is disabled.

## Verifying this change

This change added tests and can be verified as follows:

  - Added test that validates the correctness of the new validator in `StreamingJobGraphGenerator`.
  - Added test that validates the correctness of the new validator in `StreamTask`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
