### PR TITLE
[FLINK-12851][travis] Move gelly/kafka to separate profile 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,10 @@ jobs:
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: connectors
     - if: type in (pull_request, push)
+      script: ./tools/travis_controller.sh kafka/gelly
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
+      name: kafka/gelly
+    - if: type in (pull_request, push)
       script: ./tools/travis_controller.sh tests
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: tests
@@ -128,6 +132,10 @@ jobs:
       env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
       name: connectors - hadoop 2.4.1
     - if: type = cron
+      script: ./tools/travis_controller.sh kafka/gelly
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: kafka/gelly - hadoop 2.4.1
+    - if: type = cron
       script: ./tools/travis_controller.sh tests
       env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
       name: tests - hadoop 2.4.1
@@ -159,6 +167,10 @@ jobs:
       script: ./tools/travis_controller.sh connectors
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
       name: connectors - scala 2.12
+    - if: type = cron
+      script: ./tools/travis_controller.sh kafka/gelly
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
+      name: kafka/gelly - scala 2.12
     - if: type = cron
       script: ./tools/travis_controller.sh tests
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
@@ -200,6 +212,11 @@ jobs:
       script: ./tools/travis_controller.sh connectors
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: connectors - jdk 9
+    - if: type = cron
+      jdk: "openjdk9"
+      script: ./tools/travis_controller.sh kafka/gelly
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
+      name: kafka/gelly - jdk 9
     - if: type = cron
       jdk: "openjdk9"
       script: ./tools/travis_controller.sh tests

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -22,6 +22,7 @@ STAGE_CORE="core"
 STAGE_PYTHON="python"
 STAGE_LIBRARIES="libraries"
 STAGE_CONNECTORS="connectors"
+STAGE_KAFKA_GELLY="kafka/gelly"
 STAGE_TESTS="tests"
 STAGE_MISC="misc"
 STAGE_CLEANUP="cleanup"
@@ -108,6 +109,13 @@ flink-metrics/flink-metrics-slf4j,\
 flink-queryable-state/flink-queryable-state-runtime,\
 flink-queryable-state/flink-queryable-state-client-java"
 
+MODULES_KAFKA_GELLY="\
+flink-libraries/flink-gelly,\
+flink-libraries/flink-gelly-scala,\
+flink-libraries/flink-gelly-examples,\
+flink-connectors/flink-connector-kafka,\
+flink-connectors/flink-sql-connector-kafka,"
+
 MODULES_CONNECTORS_JDK9_EXCLUSIONS="\
 !flink-filesystems/flink-s3-fs-hadoop,\
 !flink-filesystems/flink-s3-fs-presto,\
@@ -115,9 +123,6 @@ MODULES_CONNECTORS_JDK9_EXCLUSIONS="\
 !flink-connectors/flink-hbase"
 
 MODULES_TESTS="\
-flink-libraries/flink-gelly,\
-flink-libraries/flink-gelly-scala,\
-flink-libraries/flink-gelly-examples,\
 flink-tests"
 
 if [[ ${PROFILE} == *"include-kinesis"* ]]; then
@@ -147,6 +152,9 @@ function get_compile_modules_for_stage() {
         (${STAGE_CONNECTORS})
             echo "-pl $MODULES_CONNECTORS -am"
         ;;
+        (${STAGE_KAFKA_GELLY})
+            echo "-pl $MODULES_KAFKA_GELLY -am"
+        ;;
         (${STAGE_TESTS})
             echo "-pl $MODULES_TESTS -am"
         ;;
@@ -167,9 +175,10 @@ function get_test_modules_for_stage() {
     local modules_tests=$MODULES_TESTS
     local negated_core=\!${MODULES_CORE//,/,\!}
     local negated_libraries=\!${MODULES_LIBRARIES//,/,\!}
+    local negated_kafka_gelly=\!${MODULES_KAFKA_GELLY//,/,\!}
     local negated_connectors=\!${MODULES_CONNECTORS//,/,\!}
     local negated_tests=\!${MODULES_TESTS//,/,\!}
-    local modules_misc="$negated_core,$negated_libraries,$negated_connectors,$negated_tests"
+    local modules_misc="$negated_core,$negated_libraries,$negated_connectors,$negated_kafka_gelly,$negated_tests"
 
     # various modules fail testing on JDK 9; exclude them
     if [[ ${PROFILE} == *"jdk9"* ]]; then
@@ -185,6 +194,9 @@ function get_test_modules_for_stage() {
         ;;
         (${STAGE_CONNECTORS})
             echo "-pl $modules_connectors"
+        ;;
+        (${STAGE_KAFKA_GELLY})
+            echo "-pl $MODULES_KAFKA_GELLY"
         ;;
         (${STAGE_TESTS})
             echo "-pl $modules_tests"

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -126,26 +126,6 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
         echo "=============================================================================="
     fi
 
-    if [[ ${PROFILE} == *"jdk9"* ]]; then
-        printf "\n\n==============================================================================\n"
-        printf "Skipping end-to-end tests since they fail on Java 9.\n"
-        printf "==============================================================================\n"
-    else
-        if [ $EXIT_CODE == 0 ]; then
-            printf "\n\n==============================================================================\n"
-            printf "Running end-to-end tests\n"
-            printf "==============================================================================\n"
-
-            FLINK_DIR=build-target flink-end-to-end-tests/run-pre-commit-tests.sh
-
-            EXIT_CODE=$?
-        else
-            printf "\n==============================================================================\n"
-            printf "Previous build failure detected, skipping end-to-end tests.\n"
-            printf "==============================================================================\n"
-        fi
-    fi
-
     if [ $EXIT_CODE == 0 ]; then
         echo "Creating cache build directory $CACHE_FLINK_DIR"
         mkdir -p "$CACHE_FLINK_DIR"

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -280,5 +280,30 @@ upload_artifacts_s3
 # we are going back to
 cd ../../
 
+# only run end-to-end tests in misc because we only have flink-dist here
+if [[ ${PROFILE} == *"jdk9"* ]]; then
+    printf "\n\n==============================================================================\n"
+    printf "Skipping end-to-end tests since they fail on Java 9.\n"
+    printf "==============================================================================\n"
+else
+    case $TEST in
+        (misc)
+            if [ $EXIT_CODE == 0 ]; then
+                printf "\n\n==============================================================================\n"
+                printf "Running end-to-end tests\n"
+                printf "==============================================================================\n"
+    
+                FLINK_DIR=build-target flink-end-to-end-tests/run-pre-commit-tests.sh
+    
+                EXIT_CODE=$?
+            else
+                printf "\n==============================================================================\n"
+                printf "Previous build failure detected, skipping end-to-end tests.\n"
+                printf "==============================================================================\n"
+            fi
+        ;;
+    esac
+fi
+
 # Exit code for Travis build success/failure
 exit $EXIT_CODE


### PR DESCRIPTION
Introduces another test profile for running gelly and kafka (universal) tests.

Additionally, now that kafka is out of misc. the pre-commit tests are moved back into misc.