### PR TITLE
[FLINK-11662] Disable task to fail on checkpoint errors

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -154,7 +154,10 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/** This flag defines if we use compression for the state snapshot data or not. Default: false */
 	private boolean useSnapshotCompression = false;
 
-	/** Determines if a task fails or not if there is an error in writing its checkpoint data. Default: true */
+	/**
+	 * @deprecated Should no longer be used because we would not support to let task directly fail on checkpoint error.
+	 */
+	@Deprecated
 	private boolean failTaskOnCheckpointError = true;
 
 	/** The default input dependency constraint to schedule tasks. */
@@ -948,20 +951,22 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	}
 
 	/**
-	 * This method is visible because of the way the configuration is currently forwarded from the checkpoint config to
-	 * the task. This should not be called by the user, please use CheckpointConfig.isFailTaskOnCheckpointError()
-	 * instead.
+	 * @deprecated This method takes no effect since we would not forward the configuration from the checkpoint config
+	 * to the task, and we have not supported task to fail on checkpoint error.
+	 * Please use CheckpointConfig.getTolerableCheckpointFailureNumber() to know the behavior on checkpoint errors.
 	 */
+	@Deprecated
 	@Internal
 	public boolean isFailTaskOnCheckpointError() {
 		return failTaskOnCheckpointError;
 	}
 
 	/**
-	 * This method is visible because of the way the configuration is currently forwarded from the checkpoint config to
-	 * the task. This should not be called by the user, please use CheckpointConfig.setFailOnCheckpointingErrors(...)
-	 * instead.
+	 * @deprecated This method takes no effect since we would not forward the configuration from the checkpoint config
+	 * to the task, and we have not supported task to fail on checkpoint error.
+	 * Please use CheckpointConfig.setTolerableCheckpointFailureNumber(int) to determine the behavior on checkpoint errors.
 	 */
+	@Deprecated
 	@Internal
 	public void setFailTaskOnCheckpointError(boolean failTaskOnCheckpointError) {
 		this.failTaskOnCheckpointError = failTaskOnCheckpointError;

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -81,7 +81,7 @@ import static org.apache.flink.streaming.tests.TestOperatorEnum.RESULT_TYPE_QUER
  *     <li>environment.checkpoint_interval (long, default - 1000): the checkpoint interval.</li>
  *     <li>environment.externalize_checkpoint (boolean, default - false): whether or not checkpoints should be externalized.</li>
  *     <li>environment.externalize_checkpoint.cleanup (String, default - 'retain'): Configures the cleanup mode for externalized checkpoints. Can be 'retain' or 'delete'.</li>
- *     <li>environment.fail_on_checkpointing_errors (String, default - true): Sets the expected behaviour for tasks in case that they encounter an error in their checkpointing procedure.</li>
+ *     <li>environment.tolerable_checkpoint_failure_number (int, default - 0): Sets the expected behaviour for the job manager in case that it received declined checkpoints from tasks.</li>
  *     <li>environment.parallelism (int, default - 1): parallelism to use for the job.</li>
  *     <li>environment.max_parallelism (int, default - 128): max parallelism to use for the job</li>
  *     <li>environment.restart_strategy (String, default - 'fixed_delay'): The failure restart strategy to use. Can be 'fixed_delay' or 'no_restart'.</li>
@@ -150,9 +150,9 @@ public class DataStreamAllroundTestJobFactory {
 		.key("environment.externalize_checkpoint.cleanup")
 		.defaultValue("retain");
 
-	private static final ConfigOption<Boolean> ENVIRONMENT_FAIL_ON_CHECKPOINTING_ERRORS = ConfigOptions
-		.key("environment.fail_on_checkpointing_errors")
-		.defaultValue(true);
+	private static final ConfigOption<Integer> ENVIRONMENT_TOLERABLE_DECLINED_CHECKPOINT_NUMBER = ConfigOptions
+		.key("environment.tolerable_declined_checkpoint_number ")
+		.defaultValue(0);
 
 	private static final ConfigOption<Integer> ENVIRONMENT_PARALLELISM = ConfigOptions
 		.key("environment.parallelism")
@@ -272,12 +272,12 @@ public class DataStreamAllroundTestJobFactory {
 					throw new IllegalArgumentException("Unknown clean up mode for externalized checkpoints: " + cleanupModeConfig);
 			}
 			env.getCheckpointConfig().enableExternalizedCheckpoints(cleanupMode);
-		}
 
-		final boolean failOnCheckpointingErrors = pt.getBoolean(
-			ENVIRONMENT_FAIL_ON_CHECKPOINTING_ERRORS.key(),
-			ENVIRONMENT_FAIL_ON_CHECKPOINTING_ERRORS.defaultValue());
-		env.getCheckpointConfig().setFailOnCheckpointingErrors(failOnCheckpointingErrors);
+			final int tolerableDeclinedCheckpointNumber = pt.getInt(
+				ENVIRONMENT_TOLERABLE_DECLINED_CHECKPOINT_NUMBER.key(),
+				ENVIRONMENT_TOLERABLE_DECLINED_CHECKPOINT_NUMBER.defaultValue());
+			env.getCheckpointConfig().setTolerableCheckpointFailureNumber(tolerableDeclinedCheckpointNumber);
+		}
 	}
 
 	private static void setupParallelism(final StreamExecutionEnvironment env, final ParameterTool pt) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -31,7 +31,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class CheckpointFailureManager {
 
-	private final static int UNLIMITED_TOLERABLE_FAILURE_NUMBER = Integer.MAX_VALUE;
+	public final static int UNLIMITED_TOLERABLE_FAILURE_NUMBER = Integer.MAX_VALUE;
+	public final static int UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER = -1;
 
 	private final int tolerableCpFailureNumber;
 	private final FailJobCallback failureCallback;
@@ -39,10 +40,15 @@ public class CheckpointFailureManager {
 	private final Set<Long> countedCheckpointIds;
 
 	public CheckpointFailureManager(int tolerableCpFailureNumber, FailJobCallback failureCallback) {
-		checkArgument(tolerableCpFailureNumber >= 0,
+		checkArgument(tolerableCpFailureNumber >= 0 || tolerableCpFailureNumber == UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER,
 			"The tolerable checkpoint failure number is illegal, " +
 				"it must be greater than or equal to 0 .");
-		this.tolerableCpFailureNumber = tolerableCpFailureNumber;
+		// set tolerableCpFailureNumber as 0 when passing UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER.
+		if (tolerableCpFailureNumber == UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER) {
+			this.tolerableCpFailureNumber = 0;
+		} else {
+			this.tolerableCpFailureNumber = tolerableCpFailureNumber;
+		}
 		this.continuousFailureCounter = new AtomicInteger(0);
 		this.failureCallback = checkNotNull(failureCallback);
 		this.countedCheckpointIds = ConcurrentHashMap.newKeySet();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -31,8 +31,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class CheckpointFailureManager {
 
-	public final static int UNLIMITED_TOLERABLE_FAILURE_NUMBER = Integer.MAX_VALUE;
-	public final static int UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER = -1;
+	public static final int UNLIMITED_TOLERABLE_FAILURE_NUMBER = Integer.MAX_VALUE;
 
 	private final int tolerableCpFailureNumber;
 	private final FailJobCallback failureCallback;
@@ -40,15 +39,10 @@ public class CheckpointFailureManager {
 	private final Set<Long> countedCheckpointIds;
 
 	public CheckpointFailureManager(int tolerableCpFailureNumber, FailJobCallback failureCallback) {
-		checkArgument(tolerableCpFailureNumber >= 0 || tolerableCpFailureNumber == UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER,
+		checkArgument(tolerableCpFailureNumber >= 0,
 			"The tolerable checkpoint failure number is illegal, " +
 				"it must be greater than or equal to 0 .");
-		// set tolerableCpFailureNumber as 0 when passing UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER.
-		if (tolerableCpFailureNumber == UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER) {
-			this.tolerableCpFailureNumber = 0;
-		} else {
-			this.tolerableCpFailureNumber = tolerableCpFailureNumber;
-		}
+		this.tolerableCpFailureNumber = tolerableCpFailureNumber;
 		this.continuousFailureCounter = new AtomicInteger(0);
 		this.failureCallback = checkNotNull(failureCallback);
 		this.countedCheckpointIds = ConcurrentHashMap.newKeySet();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobgraph.tasks;
 
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureManager;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.util.Preconditions;
 
@@ -65,13 +66,13 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 			int maxConcurrentCheckpoints,
 			CheckpointRetentionPolicy checkpointRetentionPolicy,
 			boolean isExactlyOnce,
-			boolean isPerfetCheckpointForRecovery,
+			boolean isPreferCheckpointForRecovery,
 			int tolerableCpFailureNumber) {
 
 		// sanity checks
 		if (checkpointInterval < 10 || checkpointTimeout < 10 ||
 			minPauseBetweenCheckpoints < 0 || maxConcurrentCheckpoints < 1 ||
-			tolerableCpFailureNumber < 0) {
+			tolerableCpFailureNumber < CheckpointFailureManager.UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER) {
 			throw new IllegalArgumentException();
 		}
 
@@ -81,7 +82,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 		this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
 		this.checkpointRetentionPolicy = Preconditions.checkNotNull(checkpointRetentionPolicy);
 		this.isExactlyOnce = isExactlyOnce;
-		this.isPreferCheckpointForRecovery = isPerfetCheckpointForRecovery;
+		this.isPreferCheckpointForRecovery = isPreferCheckpointForRecovery;
 		this.tolerableCheckpointFailureNumber = tolerableCpFailureNumber;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -19,12 +19,13 @@
 package org.apache.flink.runtime.jobgraph.tasks;
 
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
-import org.apache.flink.runtime.checkpoint.CheckpointFailureManager;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
 import java.util.Objects;
+
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureManager.UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER;
 
 /**
  * Configuration settings for the {@link CheckpointCoordinator}. This includes the checkpoint
@@ -72,7 +73,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 		// sanity checks
 		if (checkpointInterval < 10 || checkpointTimeout < 10 ||
 			minPauseBetweenCheckpoints < 0 || maxConcurrentCheckpoints < 1 ||
-			tolerableCpFailureNumber < CheckpointFailureManager.UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER) {
+			(tolerableCpFailureNumber < 0 && tolerableCpFailureNumber != UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER)) {
 			throw new IllegalArgumentException();
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -25,8 +25,6 @@ import org.apache.flink.util.Preconditions;
 import java.io.Serializable;
 import java.util.Objects;
 
-import static org.apache.flink.runtime.checkpoint.CheckpointFailureManager.UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER;
-
 /**
  * Configuration settings for the {@link CheckpointCoordinator}. This includes the checkpoint
  * interval, the checkpoint timeout, the pause between checkpoints, the maximum number of
@@ -73,7 +71,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 		// sanity checks
 		if (checkpointInterval < 10 || checkpointTimeout < 10 ||
 			minPauseBetweenCheckpoints < 0 || maxConcurrentCheckpoints < 1 ||
-			(tolerableCpFailureNumber < 0 && tolerableCpFailureNumber != UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER)) {
+			tolerableCpFailureNumber < 0) {
 			throw new IllegalArgumentException();
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -23,7 +23,12 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static java.util.Objects.requireNonNull;
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureManager.UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER;
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureManager.UNLIMITED_TOLERABLE_FAILURE_NUMBER;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -33,6 +38,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CheckpointConfig implements java.io.Serializable {
 
 	private static final long serialVersionUID = -750378776078908147L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(CheckpointConfig.class);
 
 	/** The default checkpoint mode: exactly once. */
 	public static final CheckpointingMode DEFAULT_MODE = CheckpointingMode.EXACTLY_ONCE;
@@ -69,14 +76,22 @@ public class CheckpointConfig implements java.io.Serializable {
 	/** Cleanup behaviour for persistent checkpoints. */
 	private ExternalizedCheckpointCleanup externalizedCheckpointCleanup;
 
-	/** Determines if a tasks are failed or not if there is an error in their checkpointing. Default: true */
+	/**
+	 * Task would not fail if there is an error in their checkpointing.
+	 * @deprecated Use {@link #tolerableCheckpointFailureNumber}.
+	 */
+	@Deprecated
 	private boolean failOnCheckpointingErrors = true;
 
 	/** Determines if a job will fallback to checkpoint when there is a more recent savepoint. **/
 	private boolean preferCheckpointForRecovery = false;
 
-	/** Determines the threshold that we tolerance checkpoint failure number. */
-	private int tolerableCheckpointFailureNumber = 0;
+	/**
+	 * Determines the threshold that we tolerance declined checkpoint failure number.
+	 * -1 means undetermined by calling {@link #setTolerableCheckpointFailureNumber(int)} but still acts as fail the
+	 * whole job once a checkpoint fail.
+	 * */
+	private int tolerableCheckpointFailureNumber = UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER;
 
 	// ------------------------------------------------------------------------
 
@@ -239,20 +254,44 @@ public class CheckpointConfig implements java.io.Serializable {
 	}
 
 	/**
-	 * This determines the behaviour of tasks if there is an error in their local checkpointing. If this returns true,
-	 * tasks will fail as a reaction. If this returns false, task will only decline the failed checkpoint.
+	 * This determines the behaviour when meeting checkpoint errors.
+	 * If this returns true, which is equivalent to get tolerableCheckpointFailureNumber as zero, job manager would
+	 * fail the whole job once it received a decline checkpoint message.
+	 * If this returns false, which is equivalent to get tolerableCheckpointFailureNumber as the maximum of integer (means unlimited),
+	 * job manager would not fail the whole job no matter how many declined checkpoints it received.
+	 *
+	 * @deprecated Use {@link #getTolerableCheckpointFailureNumber()}.
 	 */
+	@Deprecated
 	public boolean isFailOnCheckpointingErrors() {
 		return failOnCheckpointingErrors;
 	}
 
 	/**
-	 * Sets the expected behaviour for tasks in case that they encounter an error in their checkpointing procedure.
-	 * If this is set to true, the task will fail on checkpointing error. If this is set to false, the task will only
-	 * decline a the checkpoint and continue running. The default is true.
+	 * Sets the expected behaviour for tasks in case that they encounter an error when checkpointing.
+	 * If this is set as true, which is equivalent to set tolerableCheckpointFailureNumber as zero, job manager would
+	 * fail the whole job once it received a decline checkpoint message.
+	 * If this is set as false, which is equivalent to set tolerableCheckpointFailureNumber as the maximum of integer (means unlimited),
+	 * job manager would not fail the whole job no matter how many declined checkpoints it received.
+	 *
+	 * <p>{@link #tolerableCheckpointFailureNumber} would always overrule the deprecated {@link #failOnCheckpointingErrors} if they have conflicts.
+	 *
+	 * @deprecated Use {@link #setTolerableCheckpointFailureNumber(int)}.
 	 */
+	@Deprecated
 	public void setFailOnCheckpointingErrors(boolean failOnCheckpointingErrors) {
+		if (tolerableCheckpointFailureNumber != UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER) {
+			LOG.warn("Since tolerableCheckpointFailureNumber has been configured as {}, deprecated #setFailOnCheckpointingErrors(boolean) " +
+				"method would not take any effect and please use #setTolerableCheckpointFailureNumber(int) method to " +
+				"determine your expected behaviour when checkpoint errors on task side.", tolerableCheckpointFailureNumber);
+			return;
+		}
 		this.failOnCheckpointingErrors = failOnCheckpointingErrors;
+		if (failOnCheckpointingErrors) {
+			this.tolerableCheckpointFailureNumber = 0;
+		} else {
+			this.tolerableCheckpointFailureNumber = UNLIMITED_TOLERABLE_FAILURE_NUMBER;
+		}
 	}
 
 	/**
@@ -268,6 +307,9 @@ public class CheckpointConfig implements java.io.Serializable {
 	 * we do not tolerance any checkpoint failure.
 	 */
 	public void setTolerableCheckpointFailureNumber(int tolerableCheckpointFailureNumber) {
+		if (tolerableCheckpointFailureNumber < 0) {
+			throw new IllegalArgumentException("The tolerable failure checkpoint number must be non-negative.");
+		}
 		this.tolerableCheckpointFailureNumber = tolerableCheckpointFailureNumber;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.flink.runtime.checkpoint.CheckpointFailureManager.UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureManager.UNLIMITED_TOLERABLE_FAILURE_NUMBER;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -52,6 +51,8 @@ public class CheckpointConfig implements java.io.Serializable {
 
 	/** The default limit of concurrently happening checkpoints: one. */
 	public static final int DEFAULT_MAX_CONCURRENT_CHECKPOINTS = 1;
+
+	public static final int UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER = -1;
 
 	// ------------------------------------------------------------------------
 
@@ -91,8 +92,7 @@ public class CheckpointConfig implements java.io.Serializable {
 
 	/**
 	 * Determines the threshold that we tolerance declined checkpoint failure number.
-	 * -1 means undetermined by calling {@link #setTolerableCheckpointFailureNumber(int)} but still acts as fail the
-	 * whole job once a checkpoint fail.
+	 * The default value is -1 meaning undetermined and not set via {@link #setTolerableCheckpointFailureNumber(int)}.
 	 * */
 	private int tolerableCheckpointFailureNumber = UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER;
 
@@ -300,8 +300,14 @@ public class CheckpointConfig implements java.io.Serializable {
 	/**
 	 * Get the tolerable checkpoint failure number which used by the checkpoint failure manager
 	 * to determine when we need to fail the job.
+	 *
+	 * <p>If the {@link #tolerableCheckpointFailureNumber} has not been configured, this method would return 0
+	 * which means the checkpoint failure manager would not tolerate any declined checkpoint failure.
 	 */
 	public int getTolerableCheckpointFailureNumber() {
+		if (tolerableCheckpointFailureNumber == UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER) {
+			return 0;
+		}
 		return tolerableCheckpointFailureNumber;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -78,6 +78,9 @@ public class CheckpointConfig implements java.io.Serializable {
 
 	/**
 	 * Task would not fail if there is an error in their checkpointing.
+	 *
+	 * <p>{@link #tolerableCheckpointFailureNumber} would always overrule this deprecated field if they have conflicts.
+	 *
 	 * @deprecated Use {@link #tolerableCheckpointFailureNumber}.
 	 */
 	@Deprecated
@@ -274,7 +277,7 @@ public class CheckpointConfig implements java.io.Serializable {
 	 * If this is set as false, which is equivalent to set tolerableCheckpointFailureNumber as the maximum of integer (means unlimited),
 	 * job manager would not fail the whole job no matter how many declined checkpoints it received.
 	 *
-	 * <p>{@link #tolerableCheckpointFailureNumber} would always overrule the deprecated {@link #failOnCheckpointingErrors} if they have conflicts.
+	 * <p>{@link #setTolerableCheckpointFailureNumber(int)} would always overrule this deprecated method if they have conflicts.
 	 *
 	 * @deprecated Use {@link #setTolerableCheckpointFailureNumber(int)}.
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -606,11 +605,7 @@ public class StreamingJobGraphGenerator {
 		CheckpointConfig cfg = streamGraph.getCheckpointConfig();
 
 		long interval = cfg.getCheckpointInterval();
-		if (interval >= 10) {
-			ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
-			// propagate the expected behaviour for checkpoint errors to task.
-			executionConfig.setFailTaskOnCheckpointError(cfg.isFailOnCheckpointingErrors());
-		} else {
+		if (interval < 10) {
 			// interval of max value means disable periodic checkpoint
 			interval = Long.MAX_VALUE;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -32,6 +32,8 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -419,7 +421,7 @@ public abstract class AbstractStreamOperator<OUT>
 			if (!getContainingTask().isCanceled()) {
 				LOG.info(snapshotFailMessage, snapshotException);
 			}
-			throw new Exception(snapshotFailMessage, snapshotException);
+			throw new CheckpointException(snapshotFailMessage, CheckpointFailureReason.CHECKPOINT_DECLINED, snapshotException);
 		}
 
 		return snapshotInProgress;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerFactory.java
@@ -29,32 +29,12 @@ import org.apache.flink.util.Preconditions;
 public class CheckpointExceptionHandlerFactory {
 
 	/**
-	 * Returns a {@link CheckpointExceptionHandler} that either causes a task to fail completely or to just declines
-	 * checkpoint on exception, depending on the parameter flag.
+	 * Returns a {@link CheckpointExceptionHandler} that just declines checkpoint on exception.
 	 */
 	public CheckpointExceptionHandler createCheckpointExceptionHandler(
-		boolean failTaskOnCheckpointException,
 		Environment environment) {
 
-		if (failTaskOnCheckpointException) {
-			return new FailingCheckpointExceptionHandler();
-		} else {
-			return new DecliningCheckpointExceptionHandler(environment);
-		}
-	}
-
-	/**
-	 * This handler makes the task fail by rethrowing a reported exception.
-	 */
-	static final class FailingCheckpointExceptionHandler implements CheckpointExceptionHandler {
-
-		@Override
-		public void tryHandleCheckpointException(
-			CheckpointMetaData checkpointMetaData,
-			Exception exception) throws Exception {
-
-			throw exception;
-		}
+		return new DecliningCheckpointExceptionHandler(environment);
 	}
 
 	/**
@@ -71,7 +51,7 @@ public class CheckpointExceptionHandlerFactory {
 		@Override
 		public void tryHandleCheckpointException(
 			CheckpointMetaData checkpointMetaData,
-			Exception exception) throws Exception {
+			Exception exception) {
 
 			environment.declineCheckpoint(checkpointMetaData.getCheckpointId(), exception);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
@@ -18,17 +18,11 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
-import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureManager;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.streaming.api.graph.StreamGraph;
-import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
-import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
@@ -40,82 +34,47 @@ import org.junit.Test;
 public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
 
 	@Test
-	public void testConfigurationFailOnException() throws Exception {
-		testConfigForwarding(true);
-	}
-
-	@Test
-	public void testConfigurationDeclineOnException() throws Exception {
-		testConfigForwarding(false);
-	}
-
-	@Test
-	public void testFailIsDefaultConfig() {
-		ExecutionConfig newExecutionConfig = new ExecutionConfig();
-		Assert.assertTrue(newExecutionConfig.isFailTaskOnCheckpointError());
-	}
-
-	private void testConfigForwarding(boolean failOnException) throws Exception {
-
-		final boolean expectedHandlerFlag = failOnException;
-
-		final DummyEnvironment environment = new DummyEnvironment("test", 1, 0);
-		environment.setTaskStateManager(new TestTaskStateManager());
-		environment.getExecutionConfig().setFailTaskOnCheckpointError(expectedHandlerFlag);
-
-		final CheckpointExceptionHandlerFactory inspectingFactory = new CheckpointExceptionHandlerFactory() {
-
-			@Override
-			public CheckpointExceptionHandler createCheckpointExceptionHandler(
-				boolean failTaskOnCheckpointException,
-				Environment environment) {
-
-				Assert.assertEquals(expectedHandlerFlag, failTaskOnCheckpointException);
-				return super.createCheckpointExceptionHandler(failTaskOnCheckpointException, environment);
-			}
-		};
-
-		StreamTask streamTask = new StreamTask(environment, null) {
-			@Override
-			protected void init() throws Exception {}
-
-			@Override
-			protected void performDefaultAction(ActionContext context) throws Exception {
-				context.allActionsCompleted();
-			}
-
-			@Override
-			protected void cleanup() throws Exception {}
-
-			@Override
-			protected void cancelTask() throws Exception {}
-
-			@Override
-			protected CheckpointExceptionHandlerFactory createCheckpointExceptionHandlerFactory() {
-				return inspectingFactory;
-			}
-		};
-
-		streamTask.invoke();
-	}
-
-	@Test
-	public void testCheckpointConfigDefault() throws Exception {
+	public void testCheckpointConfigDefault() {
 		StreamExecutionEnvironment streamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
-		Assert.assertTrue(streamExecutionEnvironment.getCheckpointConfig().isFailOnCheckpointingErrors());
+		CheckpointConfig checkpointConfig = streamExecutionEnvironment.getCheckpointConfig();
+		Assert.assertTrue(checkpointConfig.isFailOnCheckpointingErrors());
+		Assert.assertEquals(CheckpointFailureManager.UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER, checkpointConfig.getTolerableCheckpointFailureNumber());
 	}
 
 	@Test
-	public void testPropagationFailFromCheckpointConfig() throws Exception {
-		doTestPropagationFromCheckpointConfig(true);
+	public void testSetCheckpointConfig() {
+		StreamExecutionEnvironment streamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
+		CheckpointConfig checkpointConfig = streamExecutionEnvironment.getCheckpointConfig();
+
+		// use deprecated API to set not fail on checkpoint errors
+		checkpointConfig.setFailOnCheckpointingErrors(false);
+		Assert.assertFalse(checkpointConfig.isFailOnCheckpointingErrors());
+		Assert.assertEquals(CheckpointFailureManager.UNLIMITED_TOLERABLE_FAILURE_NUMBER, checkpointConfig.getTolerableCheckpointFailureNumber());
+
+		// use new API to set tolerable declined checkpoint number
+		checkpointConfig.setTolerableCheckpointFailureNumber(5);
+		Assert.assertEquals(5, checkpointConfig.getTolerableCheckpointFailureNumber());
+
+		// after we configure the tolerable declined checkpoint number, deprecated API would not take effect
+		checkpointConfig.setFailOnCheckpointingErrors(true);
+		Assert.assertEquals(5, checkpointConfig.getTolerableCheckpointFailureNumber());
 	}
 
 	@Test
-	public void testPropagationDeclineFromCheckpointConfig() throws Exception {
+	public void testPropagationFailFromCheckpointConfig() {
+		try {
+			doTestPropagationFromCheckpointConfig(true);
+		} catch (IllegalArgumentException ignored) {
+			// ignored
+		}
+	}
+
+	@Test
+	public void testPropagationDeclineFromCheckpointConfig() {
 		doTestPropagationFromCheckpointConfig(false);
 	}
 
-	public void doTestPropagationFromCheckpointConfig(boolean failTaskOnCheckpointErrors) throws Exception {
+	public void doTestPropagationFromCheckpointConfig(boolean failTaskOnCheckpointErrors) {
 		StreamExecutionEnvironment streamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
 		streamExecutionEnvironment.setParallelism(1);
 		streamExecutionEnvironment.getCheckpointConfig().setCheckpointInterval(1000);
@@ -123,7 +82,7 @@ public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
 		streamExecutionEnvironment.addSource(new SourceFunction<Integer>() {
 
 			@Override
-			public void run(SourceContext<Integer> ctx) throws Exception {
+			public void run(SourceContext<Integer> ctx) {
 			}
 
 			@Override
@@ -131,13 +90,5 @@ public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
 			}
 
 		}).addSink(new DiscardingSink<>());
-
-		StreamGraph streamGraph = streamExecutionEnvironment.getStreamGraph();
-		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
-		SerializedValue<ExecutionConfig> serializedExecutionConfig = jobGraph.getSerializedExecutionConfig();
-		ExecutionConfig executionConfig =
-			serializedExecutionConfig.deserializeValue(Thread.currentThread().getContextClassLoader());
-
-		Assert.assertEquals(failTaskOnCheckpointErrors, executionConfig.isFailTaskOnCheckpointError());
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
@@ -38,7 +38,7 @@ public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
 		StreamExecutionEnvironment streamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
 		CheckpointConfig checkpointConfig = streamExecutionEnvironment.getCheckpointConfig();
 		Assert.assertTrue(checkpointConfig.isFailOnCheckpointingErrors());
-		Assert.assertEquals(CheckpointFailureManager.UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER, checkpointConfig.getTolerableCheckpointFailureNumber());
+		Assert.assertEquals(0, checkpointConfig.getTolerableCheckpointFailureNumber());
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerTest.java
@@ -31,30 +31,11 @@ import org.junit.Test;
 public class CheckpointExceptionHandlerTest extends TestLogger {
 
 	@Test
-	public void testRethrowingHandler() {
-		DeclineDummyEnvironment environment = new DeclineDummyEnvironment();
-		CheckpointExceptionHandlerFactory checkpointExceptionHandlerFactory = new CheckpointExceptionHandlerFactory();
-		CheckpointExceptionHandler exceptionHandler =
-			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(true, environment);
-
-		CheckpointMetaData failedCheckpointMetaData = new CheckpointMetaData(42L, 4711L);
-		Exception testException = new Exception("test");
-		try {
-			exceptionHandler.tryHandleCheckpointException(failedCheckpointMetaData, testException);
-			Assert.fail("Exception not rethrown.");
-		} catch (Exception e) {
-			Assert.assertEquals(testException, e);
-		}
-
-		Assert.assertNull(environment.getLastDeclinedCheckpointCause());
-	}
-
-	@Test
 	public void testDecliningHandler() {
 		DeclineDummyEnvironment environment = new DeclineDummyEnvironment();
 		CheckpointExceptionHandlerFactory checkpointExceptionHandlerFactory = new CheckpointExceptionHandlerFactory();
 		CheckpointExceptionHandler exceptionHandler =
-			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(false, environment);
+			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(environment);
 
 		CheckpointMetaData failedCheckpointMetaData = new CheckpointMetaData(42L, 4711L);
 		Exception testException = new Exception("test");


### PR DESCRIPTION
## What is the purpose of the change

FLINK-11662 has been a known and urgent issue after Flink-1.8 release. There exist two parts to fix this problem, one is from task side to disable task to fail on checkpoint errors. Another part is to let JM  to decide when to fail the whole job which has been part of work in https://github.com/apache/flink/pull/8322. 

This PR mainly focus on the task side and choose to base on https://github.com/apache/flink/pull/8322 before it merged since that is very unlikely to still have significant changes at this point. Once https://github.com/apache/flink/pull/8322 merged, this PR would then rebased on the latest code.

## Brief change log

  - Deprecate `isFailTaskOnCheckpointError` and `setFailTaskOnCheckpointError` in `ExecutionConfig`. 
 - Deprecate `isFailOnCheckpointingErrors` and `setFailOnCheckpointingErrors` in `CheckpointConfig`. 
  - Remove `FailingCheckpointExceptionHandler`


## Verifying this change

This change added tests and can be verified as follows:

  - Refactor `CheckpointExceptionHandlerConfigurationTest` and `CheckpointExceptionHandlerTest` to verify the default logic changed.
 - Refactor `StreamTaskTest` to verify the default logic changed on task side.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
