### PR TITLE
[hotfix][FLINK-11120][table]fix the bug of timestampadd handles time

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -171,15 +171,7 @@ object ScalarOperatorGens {
         resultType.getTypeRoot match {
           case DATE =>
             generateOperatorIfNotNull(ctx, new DateType(), left, right) {
-<<<<<<< HEAD
-<<<<<<< HEAD
               (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
-=======
-              (l, r) => s"$l $op (Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
->>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
-=======
-              (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
->>>>>>> a9cc354b34c... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
             }
           case TIMESTAMP_WITHOUT_TIME_ZONE =>
             generateOperatorIfNotNull(ctx, new TimestampType(), left, right) {
@@ -194,15 +186,7 @@ object ScalarOperatorGens {
 
       case (TIME_WITHOUT_TIME_ZONE, INTERVAL_DAY_TIME) =>
         generateOperatorIfNotNull(ctx, new TimeType(), left, right) {
-<<<<<<< HEAD
-<<<<<<< HEAD
           (l, r) => s"java.lang.Math.toIntExact(($l $op $r) % ${MILLIS_PER_DAY}L)"
-=======
-          (l, r) => s"($l $op (Math.toIntExact($r))) % ${MILLIS_PER_DAY}"
->>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
-=======
-          (l, r) => s"($l $op (java.lang.Math.toIntExact($r))) % ${MILLIS_PER_DAY}"
->>>>>>> a9cc354b34c... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
         }
 
       case (TIME_WITHOUT_TIME_ZONE, INTERVAL_YEAR_MONTH) =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -172,10 +172,14 @@ object ScalarOperatorGens {
           case DATE =>
             generateOperatorIfNotNull(ctx, new DateType(), left, right) {
 <<<<<<< HEAD
+<<<<<<< HEAD
               (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
 =======
               (l, r) => s"$l $op (Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
 >>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
+=======
+              (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
+>>>>>>> a9cc354b34c... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
             }
           case TIMESTAMP_WITHOUT_TIME_ZONE =>
             generateOperatorIfNotNull(ctx, new TimestampType(), left, right) {
@@ -191,10 +195,14 @@ object ScalarOperatorGens {
       case (TIME_WITHOUT_TIME_ZONE, INTERVAL_DAY_TIME) =>
         generateOperatorIfNotNull(ctx, new TimeType(), left, right) {
 <<<<<<< HEAD
+<<<<<<< HEAD
           (l, r) => s"java.lang.Math.toIntExact(($l $op $r) % ${MILLIS_PER_DAY}L)"
 =======
           (l, r) => s"($l $op (Math.toIntExact($r))) % ${MILLIS_PER_DAY}"
 >>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
+=======
+          (l, r) => s"($l $op (java.lang.Math.toIntExact($r))) % ${MILLIS_PER_DAY}"
+>>>>>>> a9cc354b34c... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
         }
 
       case (TIME_WITHOUT_TIME_ZONE, INTERVAL_YEAR_MONTH) =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -171,7 +171,11 @@ object ScalarOperatorGens {
         resultType.getTypeRoot match {
           case DATE =>
             generateOperatorIfNotNull(ctx, new DateType(), left, right) {
-              (l, r) => s"$l $op ((int) ($r / ${MILLIS_PER_DAY}L))"
+<<<<<<< HEAD
+              (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
+=======
+              (l, r) => s"$l $op (Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
+>>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
             }
           case TIMESTAMP_WITHOUT_TIME_ZONE =>
             generateOperatorIfNotNull(ctx, new TimestampType(), left, right) {
@@ -186,7 +190,16 @@ object ScalarOperatorGens {
 
       case (TIME_WITHOUT_TIME_ZONE, INTERVAL_DAY_TIME) =>
         generateOperatorIfNotNull(ctx, new TimeType(), left, right) {
-          (l, r) => s"$l $op ((int) ($r))"
+<<<<<<< HEAD
+          (l, r) => s"java.lang.Math.toIntExact(($l $op $r) % ${MILLIS_PER_DAY}L)"
+=======
+          (l, r) => s"($l $op (Math.toIntExact($r))) % ${MILLIS_PER_DAY}"
+>>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
+        }
+
+      case (TIME_WITHOUT_TIME_ZONE, INTERVAL_YEAR_MONTH) =>
+        generateOperatorIfNotNull(ctx, new TimeType(), left, right) {
+          (l, r) => s"$l"
         }
 
       case (TIMESTAMP_WITHOUT_TIME_ZONE, INTERVAL_DAY_TIME) =>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -3572,6 +3572,26 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "'2016-03-31'.toDate - 1.week",
       "timestampadd(WEEK, -1, date '2016-03-31')",
       "2016-03-24")
+
+    // TIMESTAMPADD with time; returns a time value.The interval is positive.
+    testSqlApi("TIMESTAMPADD(SECOND, 1, time '23:59:59')", "00:00:00")
+    testSqlApi("TIMESTAMPADD(MINUTE, 1, time '00:00:00')", "00:01:00")
+    testSqlApi("TIMESTAMPADD(MINUTE, 1, time '23:59:59')", "00:00:59")
+    testSqlApi("TIMESTAMPADD(HOUR, 1, time '23:59:59')", "00:59:59")
+    testSqlApi("TIMESTAMPADD(DAY, 15, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(WEEK, 3, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(MONTH, 6, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(QUARTER, 1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(YEAR, 10, time '23:59:59')", "23:59:59")
+    // TIMESTAMPADD with time; returns a time value .The interval is negative.
+    testSqlApi("TIMESTAMPADD(SECOND, -1, time '00:00:00')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(MINUTE, -1, time '00:00:00')", "23:59:00")
+    testSqlApi("TIMESTAMPADD(HOUR, -1, time '00:00:00')", "23:00:00")
+    testSqlApi("TIMESTAMPADD(DAY, -1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(WEEK, -1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(MONTH, -1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(QUARTER, -1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(YEAR, -1, time '23:59:59')", "23:59:59")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -895,10 +895,14 @@ object ScalarOperators {
           case SqlTimeTypeInfo.DATE =>
             generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.DATE, left, right) {
 <<<<<<< HEAD
+<<<<<<< HEAD
               (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
 =======
               (l, r) => s"$l $op (Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
 >>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
+=======
+              (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
+>>>>>>> a9cc354b34c... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
             }
           case SqlTimeTypeInfo.TIMESTAMP =>
             generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.TIMESTAMP, left, right) {
@@ -920,8 +924,12 @@ object ScalarOperators {
               s"% ${MILLIS_PER_DAY}L)) % ${MILLIS_PER_DAY}L)"
 =======
             s"((($l % ${MILLIS_PER_DAY} == 0) ? ${MILLIS_PER_DAY} : $l) " +
+<<<<<<< HEAD
               s"+ (Math.toIntExact($r % ${MILLIS_PER_DAY} == 0 ? 0 : $r))) % ${MILLIS_PER_DAY}"
 >>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
+=======
+              s"+ (java.lang.Math.toIntExact($r % ${MILLIS_PER_DAY} == 0 ? 0 : $r))) % ${MILLIS_PER_DAY}"
+>>>>>>> a9cc354b34c... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
         }
 
       case (SqlTimeTypeInfo.TIME, TimeIntervalTypeInfo.INTERVAL_MONTHS) =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -894,7 +894,11 @@ object ScalarOperators {
         resultType match {
           case SqlTimeTypeInfo.DATE =>
             generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.DATE, left, right) {
-              (l, r) => s"$l $op ((int) ($r / ${MILLIS_PER_DAY}L))"
+<<<<<<< HEAD
+              (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
+=======
+              (l, r) => s"$l $op (Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
+>>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
             }
           case SqlTimeTypeInfo.TIMESTAMP =>
             generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.TIMESTAMP, left, right) {
@@ -909,7 +913,20 @@ object ScalarOperators {
 
       case (SqlTimeTypeInfo.TIME, TimeIntervalTypeInfo.INTERVAL_MILLIS) =>
         generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.TIME, left, right) {
-            (l, r) => s"$l $op ((int) ($r))"
+          (l, r) =>
+<<<<<<< HEAD
+            s"java.lang.Math.toIntExact(((($l % ${MILLIS_PER_DAY}L == 0) ? " +
+              s"${MILLIS_PER_DAY}L : $l) $op java.lang.Math.toIntExact($r " +
+              s"% ${MILLIS_PER_DAY}L)) % ${MILLIS_PER_DAY}L)"
+=======
+            s"((($l % ${MILLIS_PER_DAY} == 0) ? ${MILLIS_PER_DAY} : $l) " +
+              s"+ (Math.toIntExact($r % ${MILLIS_PER_DAY} == 0 ? 0 : $r))) % ${MILLIS_PER_DAY}"
+>>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
+        }
+
+      case (SqlTimeTypeInfo.TIME, TimeIntervalTypeInfo.INTERVAL_MONTHS) =>
+        generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.TIME, left, right) {
+          (l, r) => s"$l"
         }
 
       case (SqlTimeTypeInfo.TIMESTAMP, TimeIntervalTypeInfo.INTERVAL_MILLIS) =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -894,15 +894,7 @@ object ScalarOperators {
         resultType match {
           case SqlTimeTypeInfo.DATE =>
             generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.DATE, left, right) {
-<<<<<<< HEAD
-<<<<<<< HEAD
               (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
-=======
-              (l, r) => s"$l $op (Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
->>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
-=======
-              (l, r) => s"$l $op (java.lang.Math.toIntExact($r / ${MILLIS_PER_DAY}L))"
->>>>>>> a9cc354b34c... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
             }
           case SqlTimeTypeInfo.TIMESTAMP =>
             generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.TIMESTAMP, left, right) {
@@ -918,18 +910,9 @@ object ScalarOperators {
       case (SqlTimeTypeInfo.TIME, TimeIntervalTypeInfo.INTERVAL_MILLIS) =>
         generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.TIME, left, right) {
           (l, r) =>
-<<<<<<< HEAD
             s"java.lang.Math.toIntExact(((($l % ${MILLIS_PER_DAY}L == 0) ? " +
               s"${MILLIS_PER_DAY}L : $l) $op java.lang.Math.toIntExact($r " +
               s"% ${MILLIS_PER_DAY}L)) % ${MILLIS_PER_DAY}L)"
-=======
-            s"((($l % ${MILLIS_PER_DAY} == 0) ? ${MILLIS_PER_DAY} : $l) " +
-<<<<<<< HEAD
-              s"+ (Math.toIntExact($r % ${MILLIS_PER_DAY} == 0 ? 0 : $r))) % ${MILLIS_PER_DAY}"
->>>>>>> 5eb1bbd3cc7... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
-=======
-              s"+ (java.lang.Math.toIntExact($r % ${MILLIS_PER_DAY} == 0 ? 0 : $r))) % ${MILLIS_PER_DAY}"
->>>>>>> a9cc354b34c... [hotfix][FLINK-11120][table]fix the bug of timestampadd handles time
         }
 
       case (SqlTimeTypeInfo.TIME, TimeIntervalTypeInfo.INTERVAL_MONTHS) =>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -2857,6 +2857,26 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "'2016-03-31'.toDate - 1.week",
       "timestampadd(WEEK, -1, date '2016-03-31')",
       "2016-03-24")
+
+    // TIMESTAMPADD with time; returns a time value.The interval is positive.
+    testSqlApi("TIMESTAMPADD(SECOND, 1, time '23:59:59')", "00:00:00")
+    testSqlApi("TIMESTAMPADD(MINUTE, 1, time '00:00:00')", "00:01:00")
+    testSqlApi("TIMESTAMPADD(MINUTE, 1, time '23:59:59')", "00:00:59")
+    testSqlApi("TIMESTAMPADD(HOUR, 1, time '23:59:59')", "00:59:59")
+    testSqlApi("TIMESTAMPADD(DAY, 15, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(WEEK, 3, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(MONTH, 6, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(QUARTER, 1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(YEAR, 10, time '23:59:59')", "23:59:59")
+    // TIMESTAMPADD with time; returns a time value .The interval is negative.
+    testSqlApi("TIMESTAMPADD(SECOND, -1, time '00:00:00')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(MINUTE, -1, time '00:00:00')", "23:59:00")
+    testSqlApi("TIMESTAMPADD(HOUR, -1, time '00:00:00')", "23:00:00")
+    testSqlApi("TIMESTAMPADD(DAY, -1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(WEEK, -1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(MONTH, -1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(QUARTER, -1, time '23:59:59')", "23:59:59")
+    testSqlApi("TIMESTAMPADD(YEAR, -1, time '23:59:59')", "23:59:59")
   }
 
   // ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*Fix the casting problem for function TIMESTAMPADD in Table*

## Brief change log

- *In judging `ScalarOperators` `generateTemporalPlusMinus` function to add the following the `date` conversion `timestamp` of logic, are as follows:*

  ```scala
      case (TIME_WITHOUT_TIME_ZONE, INTERVAL_DAY_TIME) =>
        generateOperatorIfNotNull(ctx, new TimeType(), left, right) {
          (l, r) => s"($l $op ((int) ($r))) % ${MILLIS_PER_DAY}"
        }

      case (TIME_WITHOUT_TIME_ZONE, INTERVAL_YEAR_MONTH) =>
        generateOperatorIfNotNull(ctx, new TimeType(), left, right) {
          (l, r) => s"$l"
        }
  ```

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

- *`TIMESTAMPADD` with time; returns a time value.The interval is positive for `ScalarFunctionsTest`.*
- *`TIMESTAMPADD`  with time; returns a time value .The interval is negative for `ScalarFunctionsTest`.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)