### PR TITLE
[FLINK-12856] [table-planner-blink] Introduce planner rule to push projection into TableSource

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
@@ -215,6 +215,9 @@ object FlinkBatchRuleSets {
     * This RuleSet is a sub-set of [[LOGICAL_OPT_RULES]].
     */
   private val LOGICAL_RULES: RuleSet = RuleSets.ofList(
+    // scan optimization
+    PushProjectIntoTableSourceScanRule.INSTANCE,
+
     // reorder sort and projection
     SortProjectTransposeRule.INSTANCE,
     // remove unnecessary sort rule

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
@@ -197,6 +197,9 @@ object FlinkStreamRuleSets {
     * This RuleSet is a sub-set of [[LOGICAL_OPT_RULES]].
     */
   private val LOGICAL_RULES: RuleSet = RuleSets.ofList(
+    // scan optimization
+    PushProjectIntoTableSourceScanRule.INSTANCE,
+
     // reorder sort and projection
     SortProjectTransposeRule.INSTANCE,
     // remove unnecessary sort rule

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRule.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.flink.table.plan.schema.{FlinkRelOptTable, TableSourceTable}
+import org.apache.flink.table.plan.util._
+import org.apache.flink.table.sources._
+import org.apache.flink.util.CollectionUtil
+
+import org.apache.calcite.plan.RelOptRule.{none, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.logical.{LogicalProject, LogicalTableScan}
+import org.apache.calcite.rel.rules.ProjectRemoveRule
+
+/**
+  * Planner rule that pushes a [[LogicalProject]] into a [[LogicalTableScan]]
+  * which wraps a [[ProjectableTableSource]] or a [[NestedFieldsProjectableTableSource]].
+  */
+class PushProjectIntoTableSourceScanRule extends RelOptRule(
+  operand(classOf[LogicalProject],
+    operand(classOf[LogicalTableScan], none)),
+  "PushProjectIntoTableSourceScanRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val scan: LogicalTableScan = call.rel(1)
+    scan.getTable.unwrap(classOf[TableSourceTable[_]]) match {
+      case table: TableSourceTable[_] =>
+        table.tableSource match {
+          // projection pushdown is not supported for sources that provide time indicators
+          case r: DefinedRowtimeAttributes if !CollectionUtil.isNullOrEmpty(
+            r.getRowtimeAttributeDescriptors) => false
+          case p: DefinedProctimeAttribute if p.getProctimeAttribute != null => false
+          case _: ProjectableTableSource[_] => true
+          case _: NestedFieldsProjectableTableSource[_] => true
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
+  override def onMatch(call: RelOptRuleCall) {
+    val project: LogicalProject = call.rel(0)
+    val scan: LogicalTableScan = call.rel(1)
+
+    val usedFields = RexNodeExtractor.extractRefInputFields(project.getProjects)
+    // if no fields can be projected, we keep the original plan.
+    if (scan.getRowType.getFieldCount == usedFields.length) {
+      return
+    }
+
+    val relOptTable = scan.getTable.asInstanceOf[FlinkRelOptTable]
+    val tableSourceTable = relOptTable.unwrap(classOf[TableSourceTable[_]])
+    val newTableSource = tableSourceTable.tableSource match {
+      case nested: NestedFieldsProjectableTableSource[_] =>
+        val nestedFields = RexNodeExtractor.extractRefNestedInputFields(
+          project.getProjects, usedFields)
+        nested.projectNestedFields(usedFields, nestedFields)
+      case projecting: ProjectableTableSource[_] =>
+        projecting.projectFields(usedFields)
+    }
+    // project push down does not change the statistic, we can reuse origin statistic
+    val newTableSourceTable = new TableSourceTable(
+      newTableSource, tableSourceTable.isStreaming, tableSourceTable.statistic)
+    // row type is changed after project push down
+    val newRowType = newTableSourceTable.getRowType(scan.getCluster.getTypeFactory)
+    val newRelOptTable = relOptTable.copy(newTableSourceTable, newRowType)
+    val newScan = new LogicalTableScan(scan.getCluster, scan.getTraitSet, newRelOptTable)
+
+    // rewrite input field in projections
+    val newProjects = RexNodeRewriter.rewriteWithNewFieldInput(project.getProjects, usedFields)
+    val newProject = project.copy(
+      project.getTraitSet,
+      newScan,
+      newProjects,
+      project.getRowType)
+
+    if (ProjectRemoveRule.isTrivial(newProject)) {
+      // drop project if the transformed program merely returns its input
+      call.transformTo(newScan)
+    } else {
+      call.transformTo(newProject)
+    }
+  }
+}
+
+object PushProjectIntoTableSourceScanRule {
+  val INSTANCE: RelOptRule = new PushProjectIntoTableSourceScanRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/TableSourceTable.scala
@@ -40,7 +40,7 @@ class TableSourceTable[T](
     TableSourceUtil.getRelDataType(
       tableSource,
       None,
-      streaming = false,
+      streaming = isStreaming,
       typeFactory.asInstanceOf[FlinkTypeFactory])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/RexNodeExtractor.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.expressions.ApiExpressionUtils._
+import org.apache.flink.table.expressions.BuiltInFunctionDefinitions._
+import org.apache.flink.table.expressions._
+import org.apache.flink.table.types.LogicalTypeDataTypeConverter
+import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.utils.TypeConversions
+import org.apache.flink.table.util.Logging
+import org.apache.flink.table.validate.FunctionCatalog
+import org.apache.flink.util.Preconditions
+
+import org.apache.calcite.avatica.util.DateTimeUtils
+import org.apache.calcite.plan.RelOptUtil
+import org.apache.calcite.rex._
+import org.apache.calcite.sql.fun.{SqlStdOperatorTable, SqlTrimFunction}
+import org.apache.calcite.sql.{SqlFunction, SqlPostfixOperator}
+import org.apache.calcite.util.{DateString, TimeString, TimestampString}
+
+import java.sql.{Date, Time, Timestamp}
+import java.util.{List => JList}
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+object RexNodeExtractor extends Logging {
+
+  /**
+    * Extracts the indices of input fields which accessed by the expressions.
+    *
+    * @param exprs The RexNode list to analyze
+    * @return The indices of accessed input fields
+    */
+  def extractRefInputFields(exprs: JList[RexNode]): Array[Int] = {
+    val visitor = new InputRefVisitor
+    // extract referenced input fields from expressions
+    exprs.foreach(_.accept(visitor))
+    visitor.getFields
+  }
+
+  /**
+    * Extracts the name of nested input fields accessed by the expressions and returns the
+    * prefix of the accesses.
+    *
+    * @param exprs The expressions to analyze
+    * @param usedFields indices of used input fields
+    * @return The full names of accessed input fields. e.g. field.subfield
+    */
+  def extractRefNestedInputFields(
+      exprs: JList[RexNode],
+      usedFields: Array[Int]): Array[Array[String]] = {
+    val visitor = new RefFieldAccessorVisitor(usedFields)
+    exprs.foreach(_.accept(visitor))
+    visitor.getProjectedFields
+  }
+}
+
+/**
+  * An RexVisitor to extract all referenced input fields
+  */
+class InputRefVisitor extends RexVisitorImpl[Unit](true) {
+
+  private val fields = mutable.LinkedHashSet[Int]()
+
+  def getFields: Array[Int] = fields.toArray
+
+  override def visitInputRef(inputRef: RexInputRef): Unit =
+    fields += inputRef.getIndex
+
+  override def visitCall(call: RexCall): Unit =
+    call.operands.foreach(operand => operand.accept(this))
+}
+
+/**
+  * A RexVisitor to extract used nested input fields
+  */
+class RefFieldAccessorVisitor(usedFields: Array[Int]) extends RexVisitorImpl[Unit](true) {
+
+  private val projectedFields: Array[Array[String]] = Array.fill(usedFields.length)(Array.empty)
+
+  private val order: Map[Int, Int] = usedFields.zipWithIndex.toMap
+
+  /** Returns the prefix of the nested field accesses */
+  def getProjectedFields: Array[Array[String]] = {
+
+    projectedFields.map { nestedFields =>
+      // sort nested field accesses
+      val sorted = nestedFields.sorted
+      // get prefix field accesses
+      val prefixAccesses = sorted.foldLeft(Nil: List[String]) {
+        (prefixAccesses, nestedAccess) =>
+          prefixAccesses match {
+            // first access => add access
+            case Nil => List[String](nestedAccess)
+            // top-level access already found => return top-level access
+            case head :: Nil if head.equals("*") => prefixAccesses
+            // access is top-level access => return top-level access
+            case _ :: _ if nestedAccess.equals("*") => List("*")
+            // previous access is not prefix of this access => add access
+            case head :: _ if !nestedAccess.startsWith(head) =>
+              nestedAccess :: prefixAccesses
+            // previous access is a prefix of this access => do not add access
+            case _ => prefixAccesses
+          }
+      }
+      prefixAccesses.toArray
+    }
+  }
+
+  override def visitFieldAccess(fieldAccess: RexFieldAccess): Unit = {
+    def internalVisit(fieldAccess: RexFieldAccess): (Int, String) = {
+      fieldAccess.getReferenceExpr match {
+        case ref: RexInputRef =>
+          (ref.getIndex, fieldAccess.getField.getName)
+        case fac: RexFieldAccess =>
+          val (i, n) = internalVisit(fac)
+          (i, s"$n.${fieldAccess.getField.getName}")
+      }
+    }
+
+    val (index, fullName) = internalVisit(fieldAccess)
+    val outputIndex = order.getOrElse(index, -1)
+    val fields: Array[String] = projectedFields(outputIndex)
+    projectedFields(outputIndex) = fields :+ fullName
+  }
+
+  override def visitInputRef(inputRef: RexInputRef): Unit = {
+    val outputIndex = order.getOrElse(inputRef.getIndex, -1)
+    val fields: Array[String] = projectedFields(outputIndex)
+    projectedFields(outputIndex) = fields :+ "*"
+  }
+
+  override def visitCall(call: RexCall): Unit =
+    call.operands.foreach(operand => operand.accept(this))
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/RexNodeRewriter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/RexNodeRewriter.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.calcite.rex._
+
+import java.util.{List => JList}
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+object RexNodeRewriter {
+
+  /**
+    * Generates new expressions with used input fields.
+    *
+    * @param usedFields indices of used input fields
+    * @param exps       original expression lists
+    * @return new expression with only used input fields
+    */
+  def rewriteWithNewFieldInput(
+      exps: JList[RexNode],
+      usedFields: Array[Int]): JList[RexNode] = {
+    // rewrite input field in expressions
+    val inputRewriter = new InputRewriter(usedFields.zipWithIndex.toMap)
+    exps.map(_.accept(inputRewriter)).toList.asJava
+  }
+}
+
+/**
+  * A RexShuttle to rewrite field accesses of RexNode.
+  *
+  * @param fieldMap old input fields ref index -> new input fields ref index mappings
+  */
+class InputRewriter(fieldMap: Map[Int, Int]) extends RexShuttle {
+
+  override def visitInputRef(inputRef: RexInputRef): RexNode =
+    new RexInputRef(refNewIndex(inputRef), inputRef.getType)
+
+  override def visitLocalRef(localRef: RexLocalRef): RexNode =
+    new RexInputRef(refNewIndex(localRef), localRef.getType)
+
+  private def refNewIndex(ref: RexSlot): Int =
+    fieldMap.getOrElse(ref.getIndex,
+      throw new IllegalArgumentException("input field contains invalid index"))
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/TableSourceTest.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testNestedProject">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id,
+    deepNested.nested1.name AS nestedName,
+    nested.`value` AS nestedValue,
+    deepNested.nested2.flag AS nestedFlag,
+    deepNested.nested2.num AS nestedNum
+FROM T
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], nestedName=[$1.nested1.name], nestedValue=[$2.value], nestedFlag=[$1.nested2.flag], nestedNum=[$1.nested2.num])
++- LogicalTableScan(table=[[T, source: [TestSource(read nested fields: id.*, deepNested.*, nested.*, name.*)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[id, deepNested.nested1.name AS nestedName, nested.value AS nestedValue, deepNested.nested2.flag AS nestedFlag, deepNested.nested2.num AS nestedNum])
++- TableSourceScan(table=[[T, source: [TestSource(read nested fields: id.*, deepNested.nested2.num, deepNested.nested2.flag, deepNested.nested1.name, nested.value)]]], fields=[id, deepNested, nested])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleProject">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[MyTable, source: [TestSource(physical fields: a, c)]]], fields=[a, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithoutInputRef">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(1) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
++- LogicalProject($f0=[1])
+   +- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- LocalSortAggregate(select=[Partial_COUNT(*) AS count1$0])
+      +- TableSourceScan(table=[[MyTable, source: [TestSource(physical fields: )]]], fields=[])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testCannotProject">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c, b + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2], EXPR$2=[+($1, 1)])
++- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2], EXPR$2=[+($1, 1)])
++- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, b, c)]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedProject">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id,
+    deepNested.nested1.name AS nestedName,
+    nested.`value` AS nestedValue,
+    deepNested.nested2.flag AS nestedFlag,
+    deepNested.nested2.num AS nestedNum
+FROM T
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], nestedName=[$1.nested1.name], nestedValue=[$2.value], nestedFlag=[$1.nested2.flag], nestedNum=[$1.nested2.num])
++- LogicalTableScan(table=[[T, source: [TestSource(read nested fields: id.*, deepNested.*, nested.*, name.*)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], nestedName=[$1.nested1.name], nestedValue=[$2.value], nestedFlag=[$1.nested2.flag], nestedNum=[$1.nested2.num])
++- LogicalTableScan(table=[[T, source: [TestSource(read nested fields: id.*, deepNested.nested2.num, deepNested.nested2.flag, deepNested.nested1.name, nested.value)]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleProject">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, c)]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithoutInputRef">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(1) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
++- LogicalProject($f0=[1])
+   +- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
++- LogicalProject($f0=[1])
+   +- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: )]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithUdf">
+    <Resource name="sql">
+      <![CDATA[SELECT a, TRIM(c) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[TRIM(FLAG(BOTH), _UTF-16LE' ', $2)])
++- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[TRIM(FLAG(BOTH), _UTF-16LE' ', $1)])
++- LogicalTableScan(table=[[MyTable, source: [TestSource(physical fields: a, c)]]])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/TableSourceTest.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testNestedProject">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id,
+    deepNested.nested1.name AS nestedName,
+    nested.`value` AS nestedValue,
+    deepNested.nested2.flag AS nestedFlag,
+    deepNested.nested2.num AS nestedNum
+FROM T
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], nestedName=[$1.nested1.name], nestedValue=[$2.value], nestedFlag=[$1.nested2.flag], nestedNum=[$1.nested2.num])
++- LogicalTableScan(table=[[T, source: [TestSource(read nested fields: id.*, deepNested.*, nested.*, name.*)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[id, deepNested.nested1.name AS nestedName, nested.value AS nestedValue, deepNested.nested2.flag AS nestedFlag, deepNested.nested2.num AS nestedNum])
++- TableSourceScan(table=[[T, source: [TestSource(read nested fields: id.*, deepNested.nested2.num, deepNested.nested2.flag, deepNested.nested1.name, nested.value)]]], fields=[id, deepNested, nested])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProcTimeTableSourceSimple">
+    <Resource name="sql">
+      <![CDATA[SELECT pTime, id, name, val FROM procTimeT]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(pTime=[$1], id=[$0], name=[$3], val=[$2])
++- LogicalTableScan(table=[[procTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[PROCTIME_MATERIALIZE(pTime) AS pTime, id, name, val])
++- TableSourceScan(table=[[procTimeT]], fields=[id, pTime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithMapping">
+    <Resource name="sql">
+      <![CDATA[SELECT name, rtime, val FROM T]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$4], rtime=[$1], val=[$2])
++- LogicalTableScan(table=[[T, source: [TestSource(physical fields: p-rtime, p-id, p-name, p-val)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, rtime, val])
++- TableSourceScan(table=[[T, source: [TestSource(physical fields: p-rtime, p-id, p-name, p-val)]]], fields=[id, rtime, val, ptime, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithoutInputRef">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(1) FROM T]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
++- LogicalProject($f0=[1])
+   +- LogicalTableScan(table=[[T, source: [TestSource(physical fields: id, name)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+GroupAggregate(select=[COUNT(*) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[T, source: [TestSource(physical fields: )]]], fields=[])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithoutRowtime">
+    <Resource name="sql">
+      <![CDATA[SELECT ptime, name, val, id FROM T]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(ptime=[$3], name=[$4], val=[$2], id=[$0])
++- LogicalTableScan(table=[[T, source: [TestSource(physical fields: id, name, val, rtime)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime, name, val, id])
++- TableSourceScan(table=[[T, source: [TestSource(physical fields: id, name, val, rtime)]]], fields=[id, rtime, val, ptime, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithRowtimeProctime">
+    <Resource name="sql">
+      <![CDATA[SELECT name, val, id FROM T]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$4], val=[$2], id=[$0])
++- LogicalTableScan(table=[[T, source: [TestSource(physical fields: id, name, val, rtime)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, val, id])
++- TableSourceScan(table=[[T, source: [TestSource(physical fields: id, name, val, rtime)]]], fields=[id, rtime, val, ptime, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRowTimeTableSourceGroupWindow">
+    <Resource name="sql">
+      <![CDATA[
+SELECT name,
+    TUMBLE_END(rowtime, INTERVAL '10' MINUTE),
+    AVG(val)
+FROM rowTimeT WHERE val > 100
+   GROUP BY name, TUMBLE(rowtime, INTERVAL '10' MINUTE)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$0], EXPR$1=[TUMBLE_END($1)], EXPR$2=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[AVG($2)])
+   +- LogicalProject(name=[$3], $f1=[TUMBLE($1, 600000:INTERVAL MINUTE)], val=[$2])
+      +- LogicalFilter(condition=[>($2, 100)])
+         +- LogicalTableScan(table=[[rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, CAST(w$end) AS EXPR$1, EXPR$2])
++- GroupWindowAggregate(groupBy=[name], window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime, w$proctime], select=[name, AVG(val) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[name]])
+      +- Calc(select=[name, rowtime, val], where=[>(val, 100)])
+         +- TableSourceScan(table=[[rowTimeT]], fields=[id, rowtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableSourceWithTimestampRowTimeField">
+    <Resource name="sql">
+      <![CDATA[SELECT rowtime, id, name, val FROM rowTimeT]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(rowtime=[$1], id=[$0], name=[$3], val=[$2])
++- LogicalTableScan(table=[[rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[rowtime, id, name, val])
++- TableSourceScan(table=[[rowTimeT]], fields=[id, rowtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableSourceWithLongRowTimeField">
+    <Resource name="sql">
+      <![CDATA[SELECT rowtime, id, name, val FROM rowTimeT]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(rowtime=[$1], id=[$0], name=[$3], val=[$2])
++- LogicalTableScan(table=[[rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[rowtime, id, name, val])
++- TableSourceScan(table=[[rowTimeT]], fields=[id, rowtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/TableSourceTest.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
+import org.apache.flink.table.types.TypeInfoDataTypeConverter
+import org.apache.flink.table.util._
+import org.apache.flink.types.Row
+
+import org.junit.{Before, Test}
+
+class TableSourceTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    val tableSchema = TableSchema.builder().fields(
+      Array("a", "b", "c"),
+      Array(DataTypes.INT(), DataTypes.BIGINT(), DataTypes.VARCHAR(32))).build()
+    util.tableEnv.registerTableSource("MyTable", new TestProjectableTableSource(
+      true,
+      tableSchema,
+      new RowTypeInfo(
+        tableSchema.getFieldDataTypes.map(TypeInfoDataTypeConverter.fromDataTypeToTypeInfo),
+        tableSchema.getFieldNames),
+      Seq.empty[Row])
+    )
+  }
+
+  @Test
+  def testSimpleProject(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable")
+  }
+
+  @Test
+  def testProjectWithoutInputRef(): Unit = {
+    util.verifyPlan("SELECT COUNT(1) FROM MyTable")
+  }
+
+  @Test
+  def testNestedProject(): Unit = {
+    val nested1 = new RowTypeInfo(
+      Array(Types.STRING, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "value")
+    )
+
+    val nested2 = new RowTypeInfo(
+      Array(Types.INT, Types.BOOLEAN).asInstanceOf[Array[TypeInformation[_]]],
+      Array("num", "flag")
+    )
+
+    val deepNested = new RowTypeInfo(
+      Array(nested1, nested2).asInstanceOf[Array[TypeInformation[_]]],
+      Array("nested1", "nested2")
+    )
+
+    val tableSchema = new TableSchema(
+      Array("id", "deepNested", "nested", "name"),
+      Array(Types.INT, deepNested, nested1, Types.STRING))
+
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, deepNested, nested1, Types.STRING).asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "deepNested", "nested", "name"))
+
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestNestedProjectableTableSource(true, tableSchema, returnType, Seq()))
+
+    val sqlQuery =
+      """
+        |SELECT id,
+        |    deepNested.nested1.name AS nestedName,
+        |    nested.`value` AS nestedValue,
+        |    deepNested.nested2.flag AS nestedFlag,
+        |    deepNested.nested2.num AS nestedNum
+        |FROM T
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
+import org.apache.flink.table.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
+import org.apache.flink.table.types.TypeInfoDataTypeConverter
+import org.apache.flink.table.util.{TableTestBase, TestNestedProjectableTableSource, TestProjectableTableSource}
+import org.apache.flink.types.Row
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.tools.RuleSets
+import org.junit.{Before, Test}
+
+/**
+  * Test for [[PushProjectIntoTableSourceScanRule]].
+  */
+class PushProjectIntoTableSourceScanRuleTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    util.buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE)
+    util.tableEnv.getConfig.getCalciteConfig.getBatchProgram.get.addLast(
+      "rules",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(RuleSets.ofList(PushProjectIntoTableSourceScanRule.INSTANCE))
+        .build()
+    )
+
+    val tableSchema = TableSchema.builder().fields(
+      Array("a", "b", "c"),
+      Array(DataTypes.INT(), DataTypes.BIGINT(), DataTypes.VARCHAR(32))).build()
+    util.tableEnv.registerTableSource("MyTable", new TestProjectableTableSource(
+      true,
+      tableSchema,
+      new RowTypeInfo(
+        tableSchema.getFieldDataTypes.map(TypeInfoDataTypeConverter.fromDataTypeToTypeInfo),
+        tableSchema.getFieldNames),
+      Seq.empty[Row])
+    )
+  }
+
+  @Test
+  def testSimpleProject(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable")
+  }
+
+  @Test
+  def testCannotProject(): Unit = {
+    util.verifyPlan("SELECT a, c, b + 1 FROM MyTable")
+  }
+
+  @Test
+  def testProjectWithUdf(): Unit = {
+    util.verifyPlan("SELECT a, TRIM(c) FROM MyTable")
+  }
+
+  @Test
+  def testProjectWithoutInputRef(): Unit = {
+    util.verifyPlan("SELECT COUNT(1) FROM MyTable")
+  }
+
+  @Test
+  def testNestedProject(): Unit = {
+    val nested1 = new RowTypeInfo(
+      Array(Types.STRING, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "value")
+    )
+
+    val nested2 = new RowTypeInfo(
+      Array(Types.INT, Types.BOOLEAN).asInstanceOf[Array[TypeInformation[_]]],
+      Array("num", "flag")
+    )
+
+    val deepNested = new RowTypeInfo(
+      Array(nested1, nested2).asInstanceOf[Array[TypeInformation[_]]],
+      Array("nested1", "nested2")
+    )
+
+    val tableSchema = new TableSchema(
+      Array("id", "deepNested", "nested", "name"),
+      Array(Types.INT, deepNested, nested1, Types.STRING))
+
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, deepNested, nested1, Types.STRING).asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "deepNested", "nested", "name"))
+
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestNestedProjectableTableSource(true, tableSchema, returnType, Seq()))
+
+    val sqlQuery =
+      """
+        |SELECT id,
+        |    deepNested.nested1.name AS nestedName,
+        |    nested.`value` AS nestedValue,
+        |    deepNested.nested2.flag AS nestedFlag,
+        |    deepNested.nested2.num AS nestedNum
+        |FROM T
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/TableSourceTest.scala
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stream.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.{TableSchema, Types}
+import org.apache.flink.table.util._
+import org.apache.flink.types.Row
+
+import org.junit.Test
+
+class TableSourceTest extends TableTestBase {
+
+  @Test
+  def testTableSourceWithLongRowTimeField(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rowtime", "val", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.LONG, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "rowtime", "val", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "rowTimeT",
+      new TestTableSourceWithTime[Row](false, tableSchema, returnType, Seq(), rowtime = "rowtime"))
+
+    util.verifyPlan("SELECT rowtime, id, name, val FROM rowTimeT")
+  }
+
+  @Test
+  def testTableSourceWithTimestampRowTimeField(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rowtime", "val", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "rowtime", "val", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "rowTimeT",
+      new TestTableSourceWithTime[Row](false, tableSchema, returnType, Seq(), rowtime = "rowtime"))
+
+    util.verifyPlan("SELECT rowtime, id, name, val FROM rowTimeT")
+  }
+
+  @Test
+  def testRowTimeTableSourceGroupWindow(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rowtime", "val", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "rowtime", "val", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "rowTimeT",
+      new TestTableSourceWithTime[Row](false, tableSchema, returnType, Seq(), rowtime = "rowtime"))
+
+    val sqlQuery =
+      """
+        |SELECT name,
+        |    TUMBLE_END(rowtime, INTERVAL '10' MINUTE),
+        |    AVG(val)
+        |FROM rowTimeT WHERE val > 100
+        |   GROUP BY name, TUMBLE(rowtime, INTERVAL '10' MINUTE)
+      """.stripMargin
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testProcTimeTableSourceSimple(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "pTime", "val", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.LONG, Types.STRING).asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "val", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "procTimeT",
+      new TestTableSourceWithTime[Row](false, tableSchema, returnType, Seq(), proctime = "pTime"))
+
+    util.verifyPlan("SELECT pTime, id, name, val FROM procTimeT")
+  }
+
+  @Test
+  def testProjectWithRowtimeProctime(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.STRING, Types.LONG, Types.LONG)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "name", "val", "rtime"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, Seq(), "rtime", "ptime"))
+
+    util.verifyPlan("SELECT name, val, id FROM T")
+  }
+
+  @Test
+  def testProjectWithoutRowtime(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.STRING, Types.LONG, Types.LONG)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "name", "val", "rtime"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, Seq(), "rtime", "ptime"))
+
+    util.verifyPlan("SELECT ptime, name, val, id FROM T")
+  }
+
+  def testProjectWithoutProctime(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.LONG, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "rtime", "val", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, Seq(), "rtime", "ptime"))
+
+    util.verifyPlan("select name, val, rtime, id from T")
+  }
+
+  def testProjectOnlyProctime(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.LONG, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "rtime", "val", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, Seq(), "rtime", "ptime"))
+
+    util.verifyPlan("SELECT ptime FROM T")
+  }
+
+  def testProjectOnlyRowtime(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.LONG, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "rtime", "val", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, Seq(), "rtime", "ptime"))
+
+    util.verifyPlan("SELECT rtime FROM T")
+  }
+
+  @Test
+  def testProjectWithMapping(): Unit = {
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.LONG, Types.INT, Types.STRING, Types.LONG)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("p-rtime", "p-id", "p-name", "p-val"))
+    val mapping = Map("rtime" -> "p-rtime", "id" -> "p-id", "val" -> "p-val", "name" -> "p-name")
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(
+        false, tableSchema, returnType, Seq(), "rtime", "ptime", mapping))
+
+    util.verifyPlan("SELECT name, rtime, val FROM T")
+  }
+
+  @Test
+  def testNestedProject(): Unit = {
+    val nested1 = new RowTypeInfo(
+      Array(Types.STRING, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "value")
+    )
+
+    val nested2 = new RowTypeInfo(
+      Array(Types.INT, Types.BOOLEAN).asInstanceOf[Array[TypeInformation[_]]],
+      Array("num", "flag")
+    )
+
+    val deepNested = new RowTypeInfo(
+      Array(nested1, nested2).asInstanceOf[Array[TypeInformation[_]]],
+      Array("nested1", "nested2")
+    )
+
+    val tableSchema = new TableSchema(
+      Array("id", "deepNested", "nested", "name"),
+      Array(Types.INT, deepNested, nested1, Types.STRING))
+
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, deepNested, nested1, Types.STRING).asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "deepNested", "nested", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestNestedProjectableTableSource(false, tableSchema, returnType, Seq()))
+
+    val sqlQuery =
+      """
+        |SELECT id,
+        |    deepNested.nested1.name AS nestedName,
+        |    nested.`value` AS nestedValue,
+        |    deepNested.nested2.flag AS nestedFlag,
+        |    deepNested.nested2.num AS nestedNum
+        |FROM T
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testProjectWithoutInputRef(): Unit = {
+    val tableSchema = new TableSchema(Array("id", "name"), Array(Types.INT, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.STRING).asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "name"))
+
+    val util = streamTestUtil()
+    util.tableEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, Seq(), null, null))
+
+    util.verifyPlan("SELECT COUNT(1) FROM T")
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/InputTypeBuilder.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/InputTypeBuilder.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.calcite.adapter.java.JavaTypeFactory
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.sql.`type`.SqlTypeName
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+class InputTypeBuilder(typeFactory: JavaTypeFactory) {
+
+  private val names = mutable.ListBuffer[String]()
+  private val types = mutable.ListBuffer[RelDataType]()
+
+  def field(name: String, `type`: SqlTypeName): InputTypeBuilder = {
+    names += name
+    types += typeFactory.createSqlType(`type`)
+    this
+  }
+
+  def nestedField(name: String, `type`: RelDataType): InputTypeBuilder = {
+    names += name
+    types += `type`
+    this
+  }
+
+  def build: RelDataType = {
+    typeFactory.createStructType(types.asJava, names.asJava)
+  }
+}
+
+object InputTypeBuilder {
+
+  def inputOf(typeFactory: JavaTypeFactory) = new InputTypeBuilder(typeFactory)
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/RexNodeExtractorTest.scala
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.table.plan.util.InputTypeBuilder.inputOf
+
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.sql.`type`.SqlTypeName.{BIGINT, INTEGER, VARCHAR}
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.hamcrest.CoreMatchers.is
+import org.junit.Assert.{assertArrayEquals, assertThat}
+import org.junit.Test
+
+import java.math.BigDecimal
+import java.util.{List => JList}
+
+import scala.collection.JavaConverters._
+
+/**
+  * Test for [[RexNodeExtractor]].
+  */
+class RexNodeExtractorTest extends RexNodeTestBase {
+
+  @Test
+  def testExtractRefInputFields(): Unit = {
+    val usedFields = RexNodeExtractor.extractRefInputFields(buildExprs())
+    assertArrayEquals(usedFields, Array(2, 3, 1))
+  }
+
+  @Test
+  def testExtractRefNestedInputFields(): Unit = {
+    val rexProgram = buildExprsWithNesting()
+
+    val usedFields = RexNodeExtractor.extractRefInputFields(rexProgram)
+    val usedNestedFields = RexNodeExtractor.extractRefNestedInputFields(rexProgram, usedFields)
+
+    val expected = Array(Array("amount"), Array("*"))
+    assertThat(usedNestedFields, is(expected))
+  }
+
+  @Test
+  def testExtractRefNestedInputFieldsWithNoNesting(): Unit = {
+    val exprs = buildExprs()
+
+    val usedFields = RexNodeExtractor.extractRefInputFields(exprs)
+    val usedNestedFields = RexNodeExtractor.extractRefNestedInputFields(exprs, usedFields)
+
+    val expected = Array(Array("*"), Array("*"), Array("*"))
+    assertThat(usedNestedFields, is(expected))
+  }
+
+  @Test
+  def testExtractDeepRefNestedInputFields(): Unit = {
+    val rexProgram = buildExprsWithDeepNesting()
+
+    val usedFields = RexNodeExtractor.extractRefInputFields(rexProgram)
+    val usedNestedFields = RexNodeExtractor.extractRefNestedInputFields(rexProgram, usedFields)
+
+    val expected = Array(
+      Array("amount"),
+      Array("*"),
+      Array("with.deeper.entry", "with.deep.entry"))
+
+    assertThat(usedFields, is(Array(1, 0, 2)))
+    assertThat(usedNestedFields, is(expected))
+  }
+
+  private def buildExprsWithDeepNesting(): JList[RexNode] = {
+
+    // person input
+    val passportRow = inputOf(typeFactory)
+      .field("id", VARCHAR)
+      .field("status", VARCHAR)
+      .build
+
+    val personRow = inputOf(typeFactory)
+      .field("name", VARCHAR)
+      .field("age", INTEGER)
+      .nestedField("passport", passportRow)
+      .build
+
+    // payment input
+    val paymentRow = inputOf(typeFactory)
+      .field("id", BIGINT)
+      .field("amount", INTEGER)
+      .build
+
+    // deep field input
+    val deepRowType = inputOf(typeFactory)
+      .field("entry", VARCHAR)
+      .build
+
+    val entryRowType = inputOf(typeFactory)
+      .nestedField("inside", deepRowType)
+      .build
+
+    val deeperRowType = inputOf(typeFactory)
+      .nestedField("entry", entryRowType)
+      .build
+
+    val withRowType = inputOf(typeFactory)
+      .nestedField("deep", deepRowType)
+      .nestedField("deeper", deeperRowType)
+      .build
+
+    val fieldRowType = inputOf(typeFactory)
+      .nestedField("with", withRowType)
+      .build
+
+    // inputRowType
+    //
+    // [ persons:  [ name: VARCHAR, age:  INT, passport: [id: VARCHAR, status: VARCHAR ] ],
+    //   payments: [ id: BIGINT, amount: INT ],
+    //   field:    [ with: [ deep: [ entry: VARCHAR ],
+    //                       deeper: [ entry: [ inside: [entry: VARCHAR ] ] ]
+    //             ] ]
+    // ]
+
+    val t0 = rexBuilder.makeInputRef(personRow, 0)
+    val t1 = rexBuilder.makeInputRef(paymentRow, 1)
+    val t2 = rexBuilder.makeInputRef(fieldRowType, 2)
+    val t3 = rexBuilder.makeExactLiteral(BigDecimal.valueOf(10L))
+
+    // person
+    val person$pass = rexBuilder.makeFieldAccess(t0, "passport", false)
+    val person$pass$stat = rexBuilder.makeFieldAccess(person$pass, "status", false)
+
+    // payment
+    val pay$amount = rexBuilder.makeFieldAccess(t1, "amount", false)
+    val multiplyAmount = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, pay$amount, t3)
+
+    // field
+    val field$with = rexBuilder.makeFieldAccess(t2, "with", false)
+    val field$with$deep = rexBuilder.makeFieldAccess(field$with, "deep", false)
+    val field$with$deeper = rexBuilder.makeFieldAccess(field$with, "deeper", false)
+    val field$with$deep$entry = rexBuilder.makeFieldAccess(field$with$deep, "entry", false)
+    val field$with$deeper$entry = rexBuilder.makeFieldAccess(field$with$deeper, "entry", false)
+    val field$with$deeper$entry$inside = rexBuilder
+      .makeFieldAccess(field$with$deeper$entry, "inside", false)
+    val field$with$deeper$entry$inside$entry = rexBuilder
+      .makeFieldAccess(field$with$deeper$entry$inside, "entry", false)
+
+    // Program
+    // (
+    //   payments.amount * 10),
+    //   persons.passport.status,
+    //   field.with.deep.entry
+    //   field.with.deeper.entry.inside.entry
+    //   field.with.deeper.entry
+    //   persons
+    // )
+    List(multiplyAmount, person$pass$stat, field$with$deep$entry,
+      field$with$deeper$entry$inside$entry, field$with$deeper$entry, t0).asJava
+
+  }
+
+  private def buildExprsWithNesting(): JList[RexNode] = {
+    val personRow = inputOf(typeFactory)
+      .field("name", INTEGER)
+      .field("age", VARCHAR)
+      .build
+
+    val paymentRow = inputOf(typeFactory)
+      .field("id", BIGINT)
+      .field("amount", INTEGER)
+      .build
+
+    val types = List(personRow, paymentRow).asJava
+
+    val t0 = rexBuilder.makeInputRef(types.get(0), 0)
+    val t1 = rexBuilder.makeInputRef(types.get(1), 1)
+    val t2 = rexBuilder.makeExactLiteral(BigDecimal.valueOf(100L))
+
+    val payment$amount = rexBuilder.makeFieldAccess(t1, "amount", false)
+
+    List(payment$amount, t0, t2).asJava
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/RexNodeRewriterTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/RexNodeRewriterTest.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.calcite.rex.RexProgram
+import org.apache.flink.table.plan.util.RexNodeRewriter
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+/**
+  * Test for [[RexNodeRewriter]].
+  */
+class RexNodeRewriterTest extends RexNodeTestBase {
+
+  @Test
+  def testRewriteRexProgram(): Unit = {
+    val rexProgram = buildSimpleRexProgram()
+    val exprs = rexProgram.getExprList
+    assertTrue(exprs.asScala.map(_.toString) == wrapRefArray(Array(
+      "$0",
+      "$1",
+      "$2",
+      "$3",
+      "$4",
+      "*($t2, $t3)",
+      "100",
+      "<($t5, $t6)",
+      "6",
+      ">($t1, $t8)",
+      "AND($t7, $t9)")))
+
+    // use amount, id, price fields to create a new RexProgram
+    val usedFields = Array(2, 3, 1)
+    val projectExprs = rexProgram.getProjectList.map(expr => rexProgram.expandLocalRef(expr))
+    val newProjectExprs = RexNodeRewriter.rewriteWithNewFieldInput(projectExprs, usedFields)
+    val conditionExpr = rexProgram.expandLocalRef(rexProgram.getCondition)
+    val newConditionExpr = RexNodeRewriter.rewriteWithNewFieldInput(
+      List(conditionExpr).asJava,
+      usedFields).head
+    val types = usedFields.map(allFieldTypes.get).toList.asJava
+    val names = usedFields.map(allFieldNames.get).toList.asJava
+    val inputRowType = typeFactory.createStructType(types, names)
+    val newProgram = RexProgram.create(
+      inputRowType, newProjectExprs, newConditionExpr, rexProgram.getOutputRowType, rexBuilder)
+    val newExprs = newProgram.getExprList
+    assertTrue(newExprs.asScala.map(_.toString) == wrapRefArray(Array(
+      "$0",
+      "$1",
+      "$2",
+      "*($t0, $t1)",
+      "100",
+      "<($t3, $t4)",
+      "6",
+      ">($t2, $t6)",
+      "AND($t5, $t7)")))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/RexNodeTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/RexNodeTestBase.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import java.util.{List => JList}
+import java.math.BigDecimal
+
+import org.apache.calcite.adapter.java.JavaTypeFactory
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl
+import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeSystem}
+import org.apache.calcite.rex.{RexBuilder, RexNode, RexProgram, RexProgramBuilder}
+import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.calcite.sql.`type`.SqlTypeName._
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+abstract class RexNodeTestBase {
+
+  val typeFactory: JavaTypeFactory = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT)
+
+  val allFieldNames: java.util.List[String] = List("name", "id", "amount", "price", "flag").asJava
+
+  val allFieldTypes: java.util.List[RelDataType] =
+    List(VARCHAR, BIGINT, INTEGER, DOUBLE, BOOLEAN).map(typeFactory.createSqlType).asJava
+
+  var rexBuilder: RexBuilder = new RexBuilder(typeFactory)
+
+  val program: RexProgram = buildSimpleRexProgram()
+
+  protected def buildConditionExpr(): RexNode = {
+    program.expandLocalRef(program.getCondition)
+  }
+
+  protected def buildExprs(): JList[RexNode] = {
+    val exprs = program.getProjectList.map(expr => program.expandLocalRef(expr))
+    (exprs :+ buildConditionExpr()).asJava
+  }
+
+  // select amount, amount * price as total where amount * price < 100 and id > 6
+  protected def buildSimpleRexProgram(): RexProgram = {
+    val inputRowType = typeFactory.createStructType(allFieldTypes, allFieldNames)
+    val builder = new RexProgramBuilder(inputRowType, rexBuilder)
+
+    val t0 = rexBuilder.makeInputRef(allFieldTypes.get(2), 2)
+    val t1 = rexBuilder.makeInputRef(allFieldTypes.get(1), 1)
+    val t2 = rexBuilder.makeInputRef(allFieldTypes.get(3), 3)
+    val t3 = builder.addExpr(rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, t0, t2))
+    val t4 = rexBuilder.makeExactLiteral(BigDecimal.valueOf(100L))
+    val t5 = rexBuilder.makeExactLiteral(BigDecimal.valueOf(6L))
+
+    // project: amount, amount * price as total
+    builder.addProject(t0, "amount")
+    builder.addProject(t3, "total")
+
+    // condition: amount * price < 100 and id > 6
+    val t6 = builder.addExpr(rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN, t3, t4))
+    val t7 = builder.addExpr(rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, t1, t5))
+    val t8 = builder.addExpr(rexBuilder.makeCall(SqlStdOperatorTable.AND, List(t6, t7).asJava))
+    builder.addCondition(t8)
+
+    builder.getProgram
+  }
+
+  protected def makeTypes(fieldTypes: SqlTypeName*): java.util.List[RelDataType] = {
+    fieldTypes.toList.map(typeFactory.createSqlType).asJava
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.{DataTypes, TableConfigOptions, TableSchema, Types}
+import org.apache.flink.table.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.runtime.utils.{BatchTestBase, TestData}
+import org.apache.flink.table.types.TypeInfoDataTypeConverter
+import org.apache.flink.table.util.{TestNestedProjectableTableSource, TestProjectableTableSource}
+import org.apache.flink.types.Row
+
+import org.junit.{Before, Test}
+import java.lang.{Boolean => JBool, Integer => JInt, Long => JLong}
+
+
+class TableSourceITCase extends BatchTestBase {
+
+  @Before
+  def before(): Unit = {
+    tEnv.getConfig.getConf.setInteger(TableConfigOptions.SQL_RESOURCE_DEFAULT_PARALLELISM, 3)
+    env.setParallelism(1) // set sink parallelism to 1
+    val tableSchema = TableSchema.builder().fields(
+      Array("a", "b", "c"),
+      Array(DataTypes.INT(), DataTypes.BIGINT(), DataTypes.VARCHAR(Int.MaxValue))).build()
+    tEnv.registerTableSource("MyTable", new TestProjectableTableSource(
+      true,
+      tableSchema,
+      new RowTypeInfo(
+        tableSchema.getFieldDataTypes.map(TypeInfoDataTypeConverter.fromDataTypeToTypeInfo),
+        tableSchema.getFieldNames),
+      TestData.smallData3)
+    )
+  }
+
+  @Test
+  def testSimpleProject(): Unit = {
+    checkResult(
+      "SELECT a, c FROM MyTable",
+      Seq(
+        row(1, "Hi"),
+        row(2, "Hello"),
+        row(3, "Hello world"))
+    )
+  }
+
+  @Test
+  def testProjectWithoutInputRef(): Unit = {
+    checkResult(
+      "SELECT COUNT(*) FROM MyTable",
+      Seq(row(3))
+    )
+  }
+
+  @Test
+  def testNestedProject(): Unit = {
+    val data = Seq(
+      Row.of(new JLong(1),
+        Row.of(
+          Row.of("Sarah", new JInt(100)),
+          Row.of(new JInt(1000), new JBool(true))
+        ),
+        Row.of("Peter", new JInt(10000)),
+        "Mary"),
+      Row.of(new JLong(2),
+        Row.of(
+          Row.of("Rob", new JInt(200)),
+          Row.of(new JInt(2000), new JBool(false))
+        ),
+        Row.of("Lucy", new JInt(20000)),
+        "Bob"),
+      Row.of(new JLong(3),
+        Row.of(
+          Row.of("Mike", new JInt(300)),
+          Row.of(new JInt(3000), new JBool(true))
+        ),
+        Row.of("Betty", new JInt(30000)),
+        "Liz"))
+
+    val nested1 = new RowTypeInfo(
+      Array(Types.STRING, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "value")
+    )
+
+    val nested2 = new RowTypeInfo(
+      Array(Types.INT, Types.BOOLEAN).asInstanceOf[Array[TypeInformation[_]]],
+      Array("num", "flag")
+    )
+
+    val deepNested = new RowTypeInfo(
+      Array(nested1, nested2).asInstanceOf[Array[TypeInformation[_]]],
+      Array("nested1", "nested2")
+    )
+
+    val tableSchema = new TableSchema(
+      Array("id", "deepNested", "nested", "name"),
+      Array(Types.LONG, deepNested, nested1, Types.STRING))
+
+    val returnType = new RowTypeInfo(
+      Array(Types.LONG, deepNested, nested1, Types.STRING).asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "deepNested", "nested", "name"))
+
+    tEnv.registerTableSource(
+      "T",
+      new TestNestedProjectableTableSource(true, tableSchema, returnType, data))
+
+    checkResult(
+      """
+        |SELECT id,
+        |    deepNested.nested1.name AS nestedName,
+        |    nested.`value` AS nestedValue,
+        |    deepNested.nested2.flag AS nestedFlag,
+        |    deepNested.nested2.num AS nestedNum
+        |FROM T
+      """.stripMargin,
+      Seq(row(1, "Sarah", 10000, true, 1000),
+        row(2, "Rob", 20000, false, 2000),
+        row(3, "Mike", 30000, true, 3000)
+      )
+    )
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/TableSourceITCase.scala
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{TableSchema, Types}
+import org.apache.flink.table.runtime.utils.{StreamingTestBase, TestingAppendSink}
+import org.apache.flink.table.util._
+import org.apache.flink.types.Row
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.lang.{Boolean => JBool, Integer => JInt, Long => JLong}
+
+class TableSourceITCase extends StreamingTestBase {
+
+  @Test
+  def testProjectWithoutRowtimeProctime(): Unit = {
+    val data = Seq(
+      Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
+      Row.of(new JInt(2), "Bob", new JLong(20L), new JLong(2)),
+      Row.of(new JInt(3), "Mike", new JLong(30L), new JLong(2)),
+      Row.of(new JInt(4), "Liz", new JLong(40L), new JLong(2001)))
+
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.STRING, Types.LONG, Types.LONG)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "name", "val", "rtime"))
+
+    tEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, data, "rtime", "ptime"))
+
+    val result = tEnv.sqlQuery("SELECT name, val, id FROM T").toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "Mary,10,1",
+      "Bob,20,2",
+      "Mike,30,3",
+      "Liz,40,4")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testProjectWithoutProctime(): Unit = {
+    val data = Seq(
+      Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
+      Row.of(new JInt(2), "Bob", new JLong(20L), new JLong(2)),
+      Row.of(new JInt(3), "Mike", new JLong(30L), new JLong(2)),
+      Row.of(new JInt(4), "Liz", new JLong(40L), new JLong(2001)))
+
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(
+        Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.STRING, Types.LONG, Types.LONG)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "name", "val", "rtime"))
+
+    tEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, data, "rtime", "ptime"))
+
+    val result = tEnv.sqlQuery("SELECT rtime, name, id FROM T").toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "1970-01-01 00:00:00.001,Mary,1",
+      "1970-01-01 00:00:00.002,Bob,2",
+      "1970-01-01 00:00:00.002,Mike,3",
+      "1970-01-01 00:00:02.001,Liz,4")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testProjectWithoutRowtime(): Unit = {
+    val data = Seq(
+      Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
+      Row.of(new JInt(2), "Bob", new JLong(20L), new JLong(2)),
+      Row.of(new JInt(3), "Mike", new JLong(30L), new JLong(2)),
+      Row.of(new JInt(4), "Liz", new JLong(40L), new JLong(2001)))
+
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.STRING, Types.LONG, Types.LONG)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "name", "val", "rtime"))
+
+    tEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, data, "rtime", "ptime"))
+
+    val sqlQuery = "SELECT name, id FROM T"
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "Mary,1",
+      "Bob,2",
+      "Mike,3",
+      "Liz,4")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  def testProjectOnlyProctime(): Unit = {
+    val data = Seq(
+      Row.of(new JInt(1), new JLong(1), new JLong(10L), "Mary"),
+      Row.of(new JInt(2), new JLong(2L), new JLong(20L), "Bob"),
+      Row.of(new JInt(3), new JLong(2L), new JLong(30L), "Mike"),
+      Row.of(new JInt(4), new JLong(2001L), new JLong(30L), "Liz"))
+
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.LONG, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "rtime", "val", "name"))
+
+    tEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, data, "rtime", "ptime"))
+
+    val sqlQuery = "SELECT COUNT(1) FROM T WHERE ptime > 0"
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq("4")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  def testProjectOnlyRowtime(): Unit = {
+    val data = Seq(
+      Row.of(new JInt(1), new JLong(1), new JLong(10L), "Mary"),
+      Row.of(new JInt(2), new JLong(2L), new JLong(20L), "Bob"),
+      Row.of(new JInt(3), new JLong(2L), new JLong(30L), "Mike"),
+      Row.of(new JInt(4), new JLong(2001L), new JLong(30L), "Liz"))
+
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.INT, Types.LONG, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "rtime", "val", "name"))
+
+    tEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(false, tableSchema, returnType, data, "rtime", "ptime"))
+
+    val result = tEnv.sqlQuery("SELECT rtime FROM T").toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "1970-01-01 00:00:00.001",
+      "1970-01-01 00:00:00.002",
+      "1970-01-01 00:00:00.002",
+      "1970-01-01 00:00:02.001")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testProjectWithMapping(): Unit = {
+    val data = Seq(
+      Row.of(new JLong(1), new JInt(1), "Mary", new JLong(10)),
+      Row.of(new JLong(2), new JInt(2), "Bob", new JLong(20)),
+      Row.of(new JLong(2), new JInt(3), "Mike", new JLong(30)),
+      Row.of(new JLong(2001), new JInt(4), "Liz", new JLong(40)))
+
+    val tableSchema = new TableSchema(
+      Array("id", "rtime", "val", "ptime", "name"),
+      Array(Types.INT, Types.SQL_TIMESTAMP, Types.LONG, Types.SQL_TIMESTAMP, Types.STRING))
+    val returnType = new RowTypeInfo(
+      Array(Types.LONG, Types.INT, Types.STRING, Types.LONG)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      Array("p-rtime", "p-id", "p-name", "p-val"))
+    val mapping = Map("rtime" -> "p-rtime", "id" -> "p-id", "val" -> "p-val", "name" -> "p-name")
+
+    tEnv.registerTableSource(
+      "T",
+      new TestProjectableTableSource(
+        false, tableSchema, returnType, data, "rtime", "ptime", mapping))
+
+    val result = tEnv.sqlQuery("SELECT name, rtime, val FROM T").toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "Mary,1970-01-01 00:00:00.001,10",
+      "Bob,1970-01-01 00:00:00.002,20",
+      "Mike,1970-01-01 00:00:00.002,30",
+      "Liz,1970-01-01 00:00:02.001,40")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testNestedProject(): Unit = {
+    val data = Seq(
+      Row.of(new JLong(1),
+        Row.of(
+          Row.of("Sarah", new JInt(100)),
+          Row.of(new JInt(1000), new JBool(true))
+        ),
+        Row.of("Peter", new JInt(10000)),
+        "Mary"),
+      Row.of(new JLong(2),
+        Row.of(
+          Row.of("Rob", new JInt(200)),
+          Row.of(new JInt(2000), new JBool(false))
+        ),
+        Row.of("Lucy", new JInt(20000)),
+        "Bob"),
+      Row.of(new JLong(3),
+        Row.of(
+          Row.of("Mike", new JInt(300)),
+          Row.of(new JInt(3000), new JBool(true))
+        ),
+        Row.of("Betty", new JInt(30000)),
+        "Liz"))
+
+    val nested1 = new RowTypeInfo(
+      Array(Types.STRING, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "value")
+    )
+    val nested2 = new RowTypeInfo(
+      Array(Types.INT, Types.BOOLEAN).asInstanceOf[Array[TypeInformation[_]]],
+      Array("num", "flag")
+    )
+    val deepNested = new RowTypeInfo(
+      Array(nested1, nested2).asInstanceOf[Array[TypeInformation[_]]],
+      Array("nested1", "nested2")
+    )
+    val tableSchema = new TableSchema(
+      Array("id", "deepNested", "nested", "name"),
+      Array(Types.LONG, deepNested, nested1, Types.STRING))
+
+    val returnType = new RowTypeInfo(
+      Array(Types.LONG, deepNested, nested1, Types.STRING).asInstanceOf[Array[TypeInformation[_]]],
+      Array("id", "deepNested", "nested", "name"))
+
+    tEnv.registerTableSource(
+      "T",
+      new TestNestedProjectableTableSource(false, tableSchema, returnType, data))
+
+    val sqlQuery =
+      """
+        |SELECT id,
+        |    deepNested.nested1.name AS nestedName,
+        |    nested.`value` AS nestedValue,
+        |    deepNested.nested2.flag AS nestedFlag,
+        |    deepNested.nested2.num AS nestedNum
+        |FROM T
+      """.stripMargin
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "1,Sarah,10000,true,1000",
+      "2,Rob,20000,false,2000",
+      "3,Mike,30000,true,3000")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/util/testTableSources.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/util/testTableSources.scala
@@ -19,13 +19,15 @@
 package org.apache.flink.table.util
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSource}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.TableSchema
 import org.apache.flink.table.runtime.utils.TimeTestUtil.EventTimeSourceFunction
 import org.apache.flink.table.sources._
 import org.apache.flink.table.sources.tsextractors.ExistingField
 import org.apache.flink.table.sources.wmstrategies.{AscendingTimestamps, PreserveWatermarks}
+import org.apache.flink.types.Row
 
 import java.util
 import java.util.Collections
@@ -103,4 +105,131 @@ class TestPreserveWMTableSource[T](
 
   override def explainSource(): String = ""
 
+}
+
+class TestProjectableTableSource(
+    isBatch: Boolean,
+    tableSchema: TableSchema,
+    returnType: TypeInformation[Row],
+    values: Seq[Row],
+    rowtime: String = null,
+    proctime: String = null,
+    fieldMapping: Map[String, String] = null)
+  extends TestTableSourceWithTime[Row](
+    isBatch,
+    tableSchema,
+    returnType,
+    values,
+    rowtime,
+    proctime,
+    fieldMapping)
+  with ProjectableTableSource[Row] {
+
+  override def projectFields(fields: Array[Int]): TableSource[Row] = {
+    val rowType = returnType.asInstanceOf[RowTypeInfo]
+
+    val (projectedNames: Array[String], projectedMapping) = if (fieldMapping == null) {
+      val projectedNames = fields.map(rowType.getFieldNames.apply(_))
+      (projectedNames, null)
+    } else {
+      val invertedMapping = fieldMapping.map(_.swap)
+      val projectedNames = fields.map(rowType.getFieldNames.apply(_))
+
+      val projectedMapping: Map[String, String] = projectedNames.map{ f =>
+        val logField = invertedMapping(f)
+        logField -> s"remapped-$f"
+      }.toMap
+      val renamedNames = projectedNames.map(f => s"remapped-$f")
+      (renamedNames, projectedMapping)
+    }
+
+    val projectedTypes = fields.map(rowType.getFieldTypes.apply(_))
+    val projectedReturnType = new RowTypeInfo(
+      projectedTypes.asInstanceOf[Array[TypeInformation[_]]],
+      projectedNames)
+
+    val projectedDataTypes = fields.map(tableSchema.getFieldDataTypes.apply(_))
+    val newTableSchema = TableSchema.builder().fields(projectedNames, projectedDataTypes).build()
+
+    val projectedValues = values.map { fromRow =>
+      val pRow = new Row(fields.length)
+      fields.zipWithIndex.foreach{ case (from, to) => pRow.setField(to, fromRow.getField(from)) }
+      pRow
+    }
+
+    new TestProjectableTableSource(
+      isBatch,
+      newTableSchema,
+      projectedReturnType,
+      projectedValues,
+      rowtime,
+      proctime,
+      projectedMapping)
+  }
+
+  override def explainSource(): String = {
+    s"TestSource(" +
+      s"physical fields: ${getReturnType.asInstanceOf[RowTypeInfo].getFieldNames.mkString(", ")})"
+  }
+}
+
+class TestNestedProjectableTableSource(
+    isBatch: Boolean,
+    tableSchema: TableSchema,
+    returnType: TypeInformation[Row],
+    values: Seq[Row],
+    rowtime: String = null,
+    proctime: String = null)
+  extends TestTableSourceWithTime[Row](
+    isBatch,
+    tableSchema,
+    returnType,
+    values,
+    rowtime,
+    proctime,
+    null)
+  with NestedFieldsProjectableTableSource[Row] {
+
+  var readNestedFields: Seq[String] = tableSchema.getFieldNames.map(f => s"$f.*")
+
+  override def projectNestedFields(
+      fields: Array[Int],
+      nestedFields: Array[Array[String]]): TableSource[Row] = {
+    val rowType = returnType.asInstanceOf[RowTypeInfo]
+
+    val projectedNames = fields.map(rowType.getFieldNames.apply(_))
+    val projectedTypes = fields.map(rowType.getFieldTypes.apply(_))
+
+    val projectedReturnType = new RowTypeInfo(
+      projectedTypes.asInstanceOf[Array[TypeInformation[_]]],
+      projectedNames)
+
+    // update read nested fields
+    val newReadNestedFields = projectedNames.zip(nestedFields)
+      .flatMap(f => f._2.map(n => s"${f._1}.$n"))
+
+    val projectedDataTypes = fields.map(tableSchema.getFieldDataTypes.apply(_))
+    val newTableSchema = TableSchema.builder().fields(projectedNames, projectedDataTypes).build()
+
+    val projectedValues = values.map { fromRow =>
+      val pRow = new Row(fields.length)
+      fields.zipWithIndex.foreach{ case (from, to) => pRow.setField(to, fromRow.getField(from)) }
+      pRow
+    }
+
+    val copy = new TestNestedProjectableTableSource(
+      isBatch,
+      newTableSchema,
+      projectedReturnType,
+      projectedValues,
+      rowtime,
+      proctime)
+    copy.readNestedFields = newReadNestedFields
+
+    copy
+  }
+
+  override def explainSource(): String = {
+    s"TestSource(read nested fields: ${readNestedFields.mkString(", ")})"
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

*Introduce planner rule to push projection into TableSource*


## Brief change log

  - *Added PushProjectIntoTableSourceScanRule that pushes projection into TableSource*
  - *Added RexNodeExtractor to extract used field from expressions*
  - *Added RexNodeRewriter to rewrite expressions based on new indexes*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added PushProjectIntoTableSourceScanRuleTest that validates logical plan after PushProjectIntoTableSourceScanRule is applied*
  - *Added TableSourceTest that validates the physical plan for the projectable table source*
  - *Added TableSourceITCase that validates the execution result for the projectable table source*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
