### PR TITLE
[FLINK-11937][StateBackend]Resolve small file problem in RocksDB incremental checkpoint

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_state_backend.py
+++ b/flink-python/pyflink/datastream/tests/test_state_backend.py
@@ -213,6 +213,7 @@ class CustomStateBackendTests(PyFlinkTestCase):
                                     "StreamTaskTest$TestMemoryStateBackendFactory").newInstance()
         context_classloader = gateway.jvm.Thread.currentThread().getContextClassLoader()
         state_backend = _from_j_state_backend(j_factory.createFromConfig(j_config,
-                                                                         context_classloader))
+                                                                         context_classloader,
+                                                                         1))
 
         self.assertIsInstance(state_backend, CustomStateBackend)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -306,7 +306,7 @@ public class Checkpoints {
 
 		StateBackend backend = null;
 		try {
-			backend = StateBackendLoader.loadStateBackendFromConfig(configuration, classLoader, null);
+			backend = StateBackendLoader.loadStateBackendFromConfig(configuration, classLoader, 1, null);
 
 			if (backend == null && logger != null) {
 				logger.info("No state backend configured, attempting to dispose savepoint " +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -298,10 +298,12 @@ public class ExecutionGraphBuilder {
 				}
 			}
 
+			final CheckpointCoordinatorConfiguration chkConfig = snapshotSettings.getCheckpointCoordinatorConfiguration();
+
 			final StateBackend rootBackend;
 			try {
 				rootBackend = StateBackendLoader.fromApplicationOrConfigOrDefault(
-						applicationConfiguredBackend, jobManagerConfig, classLoader, log);
+						applicationConfiguredBackend, jobManagerConfig, classLoader, chkConfig.getMaxConcurrentCheckpoints(), log);
 			}
 			catch (IllegalConfigurationException | IOException | DynamicCodeLoadingException e) {
 				throw new JobExecutionException(jobId, "Could not instantiate configured state backend", e);
@@ -338,8 +340,6 @@ public class ExecutionGraphBuilder {
 					thread.setContextClassLoader(originalClassLoader);
 				}
 			}
-
-			final CheckpointCoordinatorConfiguration chkConfig = snapshotSettings.getCheckpointCoordinatorConfiguration();
 
 			executionGraph.enableCheckpointing(
 				chkConfig,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
@@ -37,12 +37,13 @@ public interface CheckpointStreamFactory {
 	 * Creates an new {@link CheckpointStateOutputStream}. When the stream
 	 * is closed, it returns a state handle that can retrieve the state back.
 	 *
+	 * @param checkpointId The checkpointID of the given checkpoint.
 	 * @param scope The state's scope, whether it is exclusive or shared.
 	 * @return An output stream that writes state for the given checkpoint.
 	 *
 	 * @throws IOException Exceptions may occur while creating the stream and should be forwarded.
 	 */
-	CheckpointStateOutputStream createCheckpointStateOutputStream(CheckpointedStateScope scope) throws IOException;
+	CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointId, CheckpointedStateScope scope) throws IOException;
 
 	/**
 	 * A dedicated output stream that produces a {@link StreamStateHandle} when closed.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamWithResultProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamWithResultProvider.java
@@ -150,11 +150,12 @@ public interface CheckpointStreamWithResultProvider extends Closeable {
 
 	@Nonnull
 	static CheckpointStreamWithResultProvider createSimpleStream(
+		@Nonnegative long checkpointId,
 		@Nonnull CheckpointedStateScope checkpointedStateScope,
 		@Nonnull CheckpointStreamFactory primaryStreamFactory) throws IOException {
 
 		CheckpointStreamFactory.CheckpointStateOutputStream primaryOut =
-			primaryStreamFactory.createCheckpointStateOutputStream(checkpointedStateScope);
+			primaryStreamFactory.createCheckpointStateOutputStream(checkpointId, checkpointedStateScope);
 
 		return new CheckpointStreamWithResultProvider.PrimaryStreamOnly(primaryOut);
 	}
@@ -167,7 +168,7 @@ public interface CheckpointStreamWithResultProvider extends Closeable {
 		@Nonnull LocalRecoveryDirectoryProvider secondaryStreamDirProvider) throws IOException {
 
 		CheckpointStreamFactory.CheckpointStateOutputStream primaryOut =
-			primaryStreamFactory.createCheckpointStateOutputStream(checkpointedStateScope);
+			primaryStreamFactory.createCheckpointStateOutputStream(checkpointId, checkpointedStateScope);
 
 		try {
 			File outFile = new File(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
@@ -40,9 +40,10 @@ public interface ConfigurableStateBackend {
 	 *
 	 * @param config The configuration to pick the values from.
 	 * @param classLoader The class loader that should be used to load the state backend.
+	 * @param maxConcurrentCheckpoints Maximum number of checkpoint attempts in progress at the same time.
 	 * @return A reconfigured state backend.
 	 *
 	 * @throws IllegalConfigurationException Thrown if the configuration contained invalid entries.
 	 */
-	StateBackend configure(Configuration config, ClassLoader classLoader) throws IllegalConfigurationException;
+	StateBackend configure(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) throws IllegalConfigurationException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
@@ -111,7 +111,7 @@ class DefaultOperatorStateBackendSnapshotStrategy extends AbstractSnapshotStrate
 				protected SnapshotResult<OperatorStateHandle> callInternal() throws Exception {
 
 					CheckpointStreamFactory.CheckpointStateOutputStream localOut =
-						streamFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
+						streamFactory.createCheckpointStateOutputStream(checkpointId, CheckpointedStateScope.EXCLUSIVE);
 					snapshotCloseableRegistry.registerCloseable(localOut);
 
 					// get the registered operator state infos ...

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalKeyedStateHandle.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state;
 
 import javax.annotation.Nonnull;
 
-import java.util.Set;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -35,7 +35,7 @@ public interface IncrementalKeyedStateHandle extends KeyedStateHandle {
 	@Nonnull
 	UUID getBackendIdentifier();
 
-	/** Returns a set of ids of all registered shared states in the backend at the time this was created. */
+	/** Returns a map of (ids -> statehandle) of all registered shared states in the backend at the time this was created. */
 	@Nonnull
-	Set<StateHandleID> getSharedStateHandleIDs();
+	Map<StateHandleID, StreamStateHandle> getSharedState();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalLocalKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalLocalKeyedStateHandle.java
@@ -23,7 +23,7 @@ import org.apache.flink.util.ExceptionUtils;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
-import java.util.Set;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -49,7 +49,7 @@ public class IncrementalLocalKeyedStateHandle extends DirectoryKeyedStateHandle 
 
 	/** Set with the ids of all shared state handles created by the checkpoint. */
 	@Nonnull
-	private final Set<StateHandleID> sharedStateHandleIDs;
+	private final Map<StateHandleID, StreamStateHandle> sharedState;
 
 	public IncrementalLocalKeyedStateHandle(
 		@Nonnull UUID backendIdentifier,
@@ -57,13 +57,13 @@ public class IncrementalLocalKeyedStateHandle extends DirectoryKeyedStateHandle 
 		@Nonnull DirectoryStateHandle directoryStateHandle,
 		@Nonnull KeyGroupRange keyGroupRange,
 		@Nonnull StreamStateHandle metaDataState,
-		@Nonnull Set<StateHandleID> sharedStateHandleIDs) {
+		@Nonnull Map<StateHandleID, StreamStateHandle> sharedState) {
 
 		super(directoryStateHandle, keyGroupRange);
 		this.backendIdentifier = backendIdentifier;
 		this.checkpointId = checkpointId;
 		this.metaDataState = metaDataState;
-		this.sharedStateHandleIDs = sharedStateHandleIDs;
+		this.sharedState = sharedState;
 	}
 
 	@Nonnull
@@ -82,10 +82,10 @@ public class IncrementalLocalKeyedStateHandle extends DirectoryKeyedStateHandle 
 		return backendIdentifier;
 	}
 
-	@Override
 	@Nonnull
-	public Set<StateHandleID> getSharedStateHandleIDs() {
-		return sharedStateHandleIDs;
+	@Override
+	public Map<StateHandleID, StreamStateHandle> getSharedState() {
+		return sharedState;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandle.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -129,6 +128,7 @@ public class IncrementalRemoteKeyedStateHandle implements IncrementalKeyedStateH
 		return checkpointId;
 	}
 
+	@Override
 	public Map<StateHandleID, StreamStateHandle> getSharedState() {
 		return sharedState;
 	}
@@ -141,15 +141,10 @@ public class IncrementalRemoteKeyedStateHandle implements IncrementalKeyedStateH
 		return metaStateHandle;
 	}
 
+	@Override
 	@Nonnull
 	public UUID getBackendIdentifier() {
 		return backendIdentifier;
-	}
-
-	@Nonnull
-	@Override
-	public Set<StateHandleID> getSharedStateHandleIDs() {
-		return getSharedState().keySet();
 	}
 
 	public SharedStateRegistry getSharedStateRegistry() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java
@@ -41,6 +41,7 @@ public interface StateBackendFactory<T extends StateBackend> {
 	 * 
 	 * @param config The Flink configuration (loaded by the TaskManager).
 	 * @param classLoader The class loader that should be used to load the state backend.
+	 * @param maxConcurrentCheckpoints Maximum number of checkpoint attempts in progress at the same time.
 	 * @return The created state backend. 
 	 * 
 	 * @throws IllegalConfigurationException
@@ -48,5 +49,5 @@ public interface StateBackendFactory<T extends StateBackend> {
 	 * @throws IOException
 	 *             If the state backend initialization failed due to an I/O exception
 	 */
-	T createFromConfig(Configuration config, ClassLoader classLoader) throws IllegalConfigurationException, IOException;
+	T createFromConfig(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) throws IllegalConfigurationException, IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotContextSynchronousImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotContextSynchronousImpl.java
@@ -97,7 +97,7 @@ public class StateSnapshotContextSynchronousImpl implements StateSnapshotContext
 
 	private CheckpointStreamFactory.CheckpointStateOutputStream openAndRegisterNewStream() throws Exception {
 		CheckpointStreamFactory.CheckpointStateOutputStream cout =
-				streamFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
+				streamFactory.createCheckpointStateOutputStream(checkpointId, CheckpointedStateScope.EXCLUSIVE);
 
 		closableRegistry.registerCloseable(cout);
 		return cout;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -128,12 +128,13 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public FsCheckpointStateOutputStream createCheckpointStateOutputStream(CheckpointedStateScope scope) throws IOException {
+	public FsCheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointId, CheckpointedStateScope scope) {
 		Path target = scope == CheckpointedStateScope.EXCLUSIVE ? checkpointDirectory : sharedStateDirectory;
 		int bufferSize = Math.max(writeBufferSize, fileStateThreshold);
 
 		return new FsCheckpointStateOutputStream(target, filesystem, bufferSize, fileStateThreshold);
 	}
+
 
 	// ------------------------------------------------------------------------
 	//  utilities

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStorage.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.CheckpointStorageLocation;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An implementation of durable checkpoint storage to file systems supporting segments.
+ */
+public class FsSegmentCheckpointStorage extends AbstractFsCheckpointStorage {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FsSegmentCheckpointStorage.class);
+
+	private final FileSystem fileSystem;
+
+	private final Path checkpointsDirectory;
+
+	private final Path sharedStateDirectory;
+
+	private final Path taskOwnedStateDirectory;
+
+	/** file size thread for FsCheckpointStorageLocation. */
+	private final int fileSizeThreshold;
+
+	/** write buffer size for checkpoint output stream. */
+	private final int writeBufferSize;
+
+	private volatile boolean directoriesInitialized = false;
+
+	private final int maxConcurrentCheckpoints;
+
+	public FsSegmentCheckpointStorage(
+		Path checkpointBaseDirectory,
+		@Nullable Path defaultSavepointDirectory,
+		JobID jobId,
+		int fileSizeThreshold,
+		int writeBufferSize,
+		int maxConcurrentCheckpoints) throws IOException {
+		this(checkpointBaseDirectory.getFileSystem(), checkpointBaseDirectory, defaultSavepointDirectory, jobId, fileSizeThreshold, writeBufferSize, maxConcurrentCheckpoints);
+	}
+
+	public FsSegmentCheckpointStorage(
+		FileSystem fs,
+		Path checkpointBaseDirectory,
+		@Nullable Path defaultSavepointDirectory,
+		JobID jobId,
+		int fileSizeThreshold,
+		int writeBufferSize,
+		int maxConcurrentCheckpoints) {
+		super(jobId, defaultSavepointDirectory);
+
+		checkNotNull(fs);
+		checkNotNull(checkpointBaseDirectory);
+		checkArgument(fileSizeThreshold >= 0);
+		checkArgument(writeBufferSize >= 0);
+		checkArgument(maxConcurrentCheckpoints > 0);
+
+		this.fileSystem = fs;
+		this.checkpointsDirectory = getCheckpointDirectoryForJob(checkpointBaseDirectory, jobId);
+		this.sharedStateDirectory = new Path(checkpointsDirectory, CHECKPOINT_SHARED_STATE_DIR);
+		this.taskOwnedStateDirectory = new Path(checkpointsDirectory, CHECKPOINT_TASK_OWNED_STATE_DIR);
+		this.fileSizeThreshold = fileSizeThreshold;
+		this.writeBufferSize = writeBufferSize;
+		this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
+	}
+
+	@Override
+	protected CheckpointStorageLocation createSavepointLocation(FileSystem fs, Path location) {
+		final CheckpointStorageLocationReference reference = encodePathAsReference(location);
+		// for savepoint, we would not use sharing file mechanism.
+		return new FsCheckpointStorageLocation(fs, location, location, location, reference, fileSizeThreshold, writeBufferSize);
+	}
+
+	@Override
+	public boolean supportsHighlyAvailableStorage() {
+		return true;
+	}
+
+	public Path getCheckpointsDirectory() {
+		return checkpointsDirectory;
+	}
+
+	@Override
+	public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) throws IOException {
+		checkArgument(checkpointId > 0);
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Initializing location for checkpoint {} with sharedStateDirectory {}, taskOwnedStateDirectory {}",
+				checkpointId, sharedStateDirectory, taskOwnedStateDirectory);
+		}
+		if (!directoriesInitialized) {
+			fileSystem.mkdirs(checkpointsDirectory);
+			fileSystem.mkdirs(sharedStateDirectory);
+			fileSystem.mkdirs(taskOwnedStateDirectory);
+			directoriesInitialized = true;
+		}
+
+		// prepare all the paths needed for the checkpoints
+		final Path checkpointDir = createCheckpointDirectory(checkpointsDirectory, checkpointId);
+
+		// create the checkpoint exclusive directory
+		fileSystem.mkdirs(checkpointDir);
+
+		return new FsSegmentCheckpointStorageLocation(fileSystem,
+			checkpointDir,
+			sharedStateDirectory,
+			taskOwnedStateDirectory,
+			CheckpointStorageLocationReference.getDefault(),
+			fileSizeThreshold,
+			maxConcurrentCheckpoints);
+	}
+
+	@Override
+	public CheckpointStreamFactory resolveCheckpointStorageLocation(
+		long checkpointId,
+		CheckpointStorageLocationReference reference) throws IOException {
+
+		if (reference.isDefaultReference()) {
+			// default reference, construct the default location for that particular checkpoint
+			final Path checkpointDir = createCheckpointDirectory(checkpointsDirectory, checkpointId);
+
+			return new FsSegmentCheckpointStorageLocation(
+					fileSystem,
+					checkpointDir,
+					sharedStateDirectory,
+					taskOwnedStateDirectory,
+					reference,
+					fileSizeThreshold,
+					maxConcurrentCheckpoints);
+		}
+		else {
+			// location encoded in the reference, means savepoint,
+			// savepoint uses FsCheckpointStorageLocation.
+			final Path path = decodePathFromReference(reference);
+
+			return new FsCheckpointStorageLocation(
+				path.getFileSystem(),
+				path,
+				path,
+				path,
+				reference,
+				fileSizeThreshold,
+				writeBufferSize);
+		}
+	}
+
+	@Override
+	public CheckpointStreamFactory.CheckpointStateOutputStream createTaskOwnedStateStream() {
+		// task owned state use FsCheckpointStateOutputStream.
+		return new FsCheckpointStreamFactory.FsCheckpointStateOutputStream(
+			taskOwnedStateDirectory,
+			fileSystem,
+			writeBufferSize,
+			fileSizeThreshold);
+	}
+
+	@Override
+	public String toString() {
+		return "FsSegmentCheckpointStorage{" +
+			"fileSystem=" + fileSystem +
+			", checkpointsDirectory=" + checkpointsDirectory +
+			", sharedStateDirectory=" + sharedStateDirectory +
+			", taskOwnedStateDirectory=" + taskOwnedStateDirectory +
+			", fileSizeThreshold=" + fileSizeThreshold +
+			", writeBufferSize=" + writeBufferSize +
+			'}';
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStorageLocation.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.core.fs.EntropyInjector;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
+import org.apache.flink.runtime.state.CheckpointStorageLocation;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A storage location supporting sharing segments for checkpoints on a file system.
+ */
+public class FsSegmentCheckpointStorageLocation extends FsSegmentCheckpointStreamFactory implements CheckpointStorageLocation {
+	private final FileSystem fileSystem;
+
+	private final Path checkpointDirectory;
+
+	private final Path metadataFilePath;
+
+	private final CheckpointStorageLocationReference reference;
+
+	public FsSegmentCheckpointStorageLocation(
+		FileSystem fileSystem,
+		Path checkpointDir,
+		Path sharedStateDir,
+		Path taskOwnedStateDirectory,
+		CheckpointStorageLocationReference reference,
+		int fileSizeThreshold,
+		int maxConcurrentCheckpoints) {
+		super(fileSystem, checkpointDir, sharedStateDir, taskOwnedStateDirectory, fileSizeThreshold, maxConcurrentCheckpoints);
+
+		this.fileSystem = checkNotNull(fileSystem);
+		this.checkpointDirectory = checkNotNull(checkpointDir);
+		this.reference = checkNotNull(reference);
+
+		// the metadata file should not have entropy in its path
+		Path metadataDir = EntropyInjector.removeEntropyMarkerIfPresent(fileSystem, checkpointDir);
+		this.metadataFilePath = new Path(metadataDir, AbstractFsCheckpointStorage.METADATA_FILE_NAME);
+	}
+
+	@Override
+	public CheckpointMetadataOutputStream createMetadataOutputStream() throws IOException {
+		return new FsCheckpointMetadataOutputStream(fileSystem, metadataFilePath, checkpointDirectory);
+	}
+
+	@Override
+	public void disposeOnFailure() throws IOException {
+		// on a failure, no chunk in the checkpoint directory needs to be saved, so
+		// we can drop it as a whole
+		fileSystem.delete(checkpointDirectory, true);
+	}
+
+	public Path getCheckpointDirectory() {
+		return checkpointDirectory;
+	}
+
+	public Path getMetadataFilePath() {
+		return metadataFilePath;
+	}
+
+	@Override
+	public CheckpointStorageLocationReference getLocationReference() {
+		return reference;
+	}
+
+	@Override
+	public String toString() {
+		return "FsSegmentCheckpointStorageLocation{" +
+			"fileSystem=" + fileSystem +
+			", checkpointDirectory=" + checkpointDirectory +
+			", metadataFilePath=" + metadataFilePath +
+			'}';
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStreamFactory.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.EntropyInjector;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.OutputStreamAndPath;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link CheckpointStreamFactory} that supports to create different streams on the same underlying file.
+ */
+public class FsSegmentCheckpointStreamFactory implements CheckpointStreamFactory {
+	private static final Logger LOG = LoggerFactory.getLogger(FsSegmentCheckpointStreamFactory.class);
+
+	/** Default size for the write buffer. */
+	private static final int DEFAULT_WRITE_BUFFER_SIZE = 4 * 1024 * 1024;
+
+	/**
+	 * FileSegmentCheckpointStreamFactory-wide lock to safeguard the output stream updates.
+	 */
+	private final Object lock;
+
+	/**
+	 * Cached handle to the file system for file operations.
+	 */
+	private final FileSystem filesystem;
+
+	/** The directory for shared checkpoint data. */
+	private final Path sharedStateDirectory;
+
+	/** The directory for taskowned data. */
+	private final Path taskOwnedStateDirectory;
+
+	/** The directory for checkpoint exclusive state data. */
+	private final Path checkpointDirector;
+
+	private final int writeBufferSize;
+	/**
+	 * The paths of the file under writing.
+	 */
+	@GuardedBy("lock")
+	private final Map<Long, Path> filePaths;
+
+	/**
+	 * Map of (checkpointId -> CheckpointStateOutputStream).
+	 */
+	@GuardedBy("lock")
+	private final Map<Long, CheckpointStateOutputStream> openedOutputStreams;
+
+	/**
+	 * The currentCheckpointOutputStream of the current output stream.
+	 */
+	private final Map<Long, FSDataOutputStream> fileOutputStreams;
+
+	/** Will be used when delivery to FsCheckpointStateOutputStream. */
+	private final int fileSizeThreshold;
+
+	/** Maximum number of checkpoint attempts in progress at the same time. */
+	private final int maxConcurrentCheckpoints;
+
+	FsSegmentCheckpointStreamFactory(
+		FileSystem fileSystem,
+		Path checkpointDirectory,
+		Path sharedStateDirectory,
+		Path taskOwnedStateDirectory,
+		int fileSizeThreshold,
+		int maxConcurrentCheckpoints) {
+		this(fileSystem, checkpointDirectory, sharedStateDirectory, taskOwnedStateDirectory, DEFAULT_WRITE_BUFFER_SIZE, fileSizeThreshold, maxConcurrentCheckpoints);
+	}
+
+	FsSegmentCheckpointStreamFactory(
+		FileSystem fileSystem,
+		Path checkpointDirector,
+		Path sharedStateDirectory,
+		Path taskOwnedStateDirectory,
+		int writeBufferSize,
+		int fileSizeThreshold,
+		int maxConcurrentCheckpoints) {
+		this.filesystem = checkNotNull(fileSystem);
+		this.checkpointDirector = checkNotNull(checkpointDirector);
+		this.sharedStateDirectory = checkNotNull(sharedStateDirectory);
+		this.taskOwnedStateDirectory = checkNotNull(taskOwnedStateDirectory);
+		this.writeBufferSize = writeBufferSize;
+		this.fileSizeThreshold = fileSizeThreshold;
+		this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
+		this.lock = new Object();
+
+		this.filePaths = new HashMap<>();
+		this.fileOutputStreams = new HashMap<>();
+		this.openedOutputStreams = new HashMap<>();
+	}
+
+	@Override
+	public CheckpointStateOutputStream createCheckpointStateOutputStream(
+		long checkpointId,
+		CheckpointedStateScope scope) throws IOException {
+		// delivery to FsCheckpointStateOutputStream for EXCLUSIVE scope
+		if (CheckpointedStateScope.EXCLUSIVE.equals(scope)) {
+			return new FsCheckpointStreamFactory.FsCheckpointStateOutputStream(
+				checkpointDirector,
+				filesystem,
+				writeBufferSize,
+				fileSizeThreshold);
+		}
+		synchronized (lock) {
+			try {
+				closeEarlyCheckpointFiles(checkpointId - maxConcurrentCheckpoints + 1);
+				CheckpointStateOutputStream outputStream = new FsSegmentCheckpointStateOutputStream(checkpointId, sharedStateDirectory);
+				openedOutputStreams.put(checkpointId, outputStream);
+				return outputStream;
+			} catch (IOException e) {
+				closeFileOutputStream(checkpointId);
+				throw e;
+			}
+		}
+	}
+
+	public void closeFileOutputStream(long checkpointId) {
+		// currently we reuse a single underlying file for a checkpoint,
+		// we need to close the underlying file when checkpoint succeed.
+		// TODO: close the underlying file when abort/cancel a checkpoint
+		// when FLINK-8871 has been resolved.
+		synchronized (fileOutputStreams) {
+			try {
+				FSDataOutputStream outputStream = fileOutputStreams.get(checkpointId);
+				if (outputStream != null) {
+					outputStream.close();
+				}
+			} catch (IOException e) {
+				LOG.warn("Can not close the checkpoint file for checkpoint {}.", checkpointId);
+			} finally {
+				openedOutputStreams.remove(checkpointId);
+				fileOutputStreams.remove(checkpointId);
+				filePaths.remove(checkpointId);
+			}
+		}
+	}
+
+	public Path getSharedStateDirectory() {
+		return sharedStateDirectory;
+	}
+
+	public Path getTaskOwnedStateDirectory() {
+		return taskOwnedStateDirectory;
+	}
+
+	public FileSystem getFileSystem() {
+		return filesystem;
+	}
+
+	@VisibleForTesting
+	public Map<Long, FSDataOutputStream> getFileOutputStreams() {
+		return fileOutputStreams;
+	}
+
+	private Path createStatePath(Path basePath) {
+		return new Path(basePath, UUID.randomUUID().toString());
+	}
+
+	/**
+	 * Close all the file used by the checkpoint whose checkpoint id less than checkpointId.
+	 */
+	private void closeEarlyCheckpointFiles(long smallestUsedCheckpointId) {
+		for (Long checkpointId : openedOutputStreams.keySet()) {
+			if (checkpointId < smallestUsedCheckpointId) {
+				closeFileOutputStream(checkpointId);
+			}
+		}
+	}
+
+	private void createFileOutputStream(long checkpointId, Path basePath) throws IOException {
+		Exception latestException = null;
+		for (int attempt = 0; attempt < 10; attempt++) {
+			try {
+				if (!filePaths.containsKey(checkpointId)) {
+					// we know we're guarded by the lock, so no need to sync here.
+					Path nextFilePath = createStatePath(basePath);
+
+					OutputStreamAndPath streamAndPath = EntropyInjector.createEntropyAware(
+						filesystem, nextFilePath, FileSystem.WriteMode.NO_OVERWRITE);
+
+					FSDataOutputStream nextFileOutputStream = streamAndPath.stream();
+
+					filePaths.put(checkpointId, streamAndPath.path());
+					fileOutputStreams.put(checkpointId, nextFileOutputStream);
+				}
+				return;
+			} catch (Exception e) {
+				latestException = e;
+			}
+		}
+
+		throw new IOException("Could not open output stream for state backend", latestException);
+	}
+
+	/**
+	 * A {@link org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream} will reuse the underlying file if possible.
+	 */
+	public final class FsSegmentCheckpointStateOutputStream extends CheckpointStreamFactory.CheckpointStateOutputStream {
+		/** Base path for current checkpoint. */
+		private final Path checkpointBasePath;
+
+		/** Current checkpoint ID. */
+		private final long checkpointId;
+		/**
+		 * The owner thread of the output stream.
+		 */
+		private final long ownerThreadID;
+
+		/** Buffer contains the checkpoint data before flush to file. */
+		private final byte[] buffer;
+
+		/** Index of buffer which will be written into. */
+		private int bufferIndex;
+
+		/**
+		 * start position of the underlying file which current output stream will write to.
+		 */
+		private final long startPos;
+
+		/** Whether current output stream is closed or not. */
+		private boolean closed;
+
+		/** The underlying file output stream used for current checkpoint. */
+		private FSDataOutputStream currentFileOutputStream;
+
+		FsSegmentCheckpointStateOutputStream(long checkpointId, Path basePath) throws IOException {
+			this.checkpointId = checkpointId;
+			this.checkpointBasePath = checkNotNull(basePath);
+			this.ownerThreadID = Thread.currentThread().getId();
+
+			this.closed = false;
+
+			this.buffer = new byte[writeBufferSize];
+			this.bufferIndex = 0;
+
+			this.currentFileOutputStream = fileOutputStreams.get(checkpointId);
+			this.startPos = currentFileOutputStream == null ? 0 : currentFileOutputStream.getPos();
+		}
+
+		@Nullable
+		@Override
+		public StreamStateHandle closeAndGetHandle() throws IOException {
+			checkState(Thread.currentThread().getId() == ownerThreadID);
+			checkState(!closed);
+
+			synchronized (lock) {
+				Preconditions.checkState(openedOutputStreams.get(checkpointId) == this);
+
+				try {
+					flush();
+					long endPos = currentFileOutputStream.getPos();
+					return new FsSegmentStateHandle(filePaths.get(checkpointId), startPos, endPos);
+				} finally {
+					closed = true;
+					currentFileOutputStream = null;
+				}
+			}
+		}
+
+		@Override
+		public void close() {
+			if (closed) {
+				return;
+			}
+
+			synchronized (lock) {
+				try {
+					closeFileOutputStream(checkpointId);
+				} finally {
+					closed = true;
+					currentFileOutputStream = null;
+				}
+			}
+		}
+
+		/**
+		 * Checks whether the stream is closed.
+		 *
+		 * @return True if the stream was closed, false if it is still open.
+		 */
+		public boolean isClosed() {
+			return closed;
+		}
+
+		@Override
+		public long getPos() throws IOException {
+			checkState(Thread.currentThread().getId() == ownerThreadID);
+			checkState(!closed);
+
+			if (currentFileOutputStream == null) {
+				return bufferIndex;
+			} else {
+				synchronized (lock) {
+					checkState(openedOutputStreams.get(checkpointId) == this);
+
+					try {
+						return bufferIndex + currentFileOutputStream.getPos() - startPos;
+					} catch (IOException e) {
+						closeFileOutputStream(checkpointId);
+						throw e;
+					}
+				}
+			}
+		}
+
+		@Override
+		public void flush() throws IOException {
+			checkState(Thread.currentThread().getId() == ownerThreadID);
+			checkState(!closed);
+
+			synchronized (lock) {
+				checkState(openedOutputStreams.get(checkpointId) == this);
+
+				// create a new file if there does not exist an opened one
+				if (currentFileOutputStream == null && bufferIndex > 0) {
+					createFileOutputStream(checkpointId, checkpointBasePath);
+					currentFileOutputStream = fileOutputStreams.get(checkpointId);
+				}
+
+				// flush the data in the buffer to the file.
+				if (bufferIndex > 0) {
+					try {
+						currentFileOutputStream.write(buffer, 0, bufferIndex);
+						currentFileOutputStream.flush();
+
+						bufferIndex = 0;
+					} catch (IOException e) {
+						closeFileOutputStream(checkpointId);
+						throw e;
+					}
+				}
+			}
+		}
+
+		@Override
+		public void sync() throws IOException {
+			checkState(Thread.currentThread().getId() == ownerThreadID);
+			checkState(!closed);
+
+			synchronized (lock) {
+				Preconditions.checkState(openedOutputStreams.get(checkpointId) == this);
+
+				try {
+					currentFileOutputStream.sync();
+				} catch (Exception e) {
+					closeFileOutputStream(checkpointId);
+					throw e;
+				}
+			}
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			checkState(Thread.currentThread().getId() == ownerThreadID);
+			checkState(!closed);
+
+			if (bufferIndex >= buffer.length) {
+				flush();
+			}
+
+			if (!closed) {
+				buffer[bufferIndex++] = (byte) b;
+			}
+		}
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateBackend.java
@@ -35,6 +35,16 @@ import java.net.URI;
 public class FsSegmentStateBackend extends FsStateBackend {
 	private final int maxConcurrentCheckpoints;
 
+	public FsSegmentStateBackend(URI checkpointDataUri) {
+		super(checkpointDataUri);
+		this.maxConcurrentCheckpoints = 1;
+	}
+
+	public FsSegmentStateBackend(String checkpointDirURIStr) {
+		super(checkpointDirURIStr);
+		this.maxConcurrentCheckpoints = 1;
+	}
+
 	public FsSegmentStateBackend(
 		URI checkpointDirectory,
 		@Nullable URI defaultSavepointDirectory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateBackend.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TernaryBoolean;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * The file state backend is a state backend like {@link FsStateBackend}, but stores the state of streaming jobs in segments on file system.
+ */
+public class FsSegmentStateBackend extends FsStateBackend {
+	private final int maxConcurrentCheckpoints;
+
+	public FsSegmentStateBackend(
+		URI checkpointDirectory,
+		@Nullable URI defaultSavepointDirectory,
+		int fileStateSizeThreshold,
+		int writeBufferSize,
+		TernaryBoolean asynchronousSnapshots,
+		int maxConcurrentCheckpoints) {
+
+		super(checkpointDirectory, defaultSavepointDirectory, fileStateSizeThreshold, writeBufferSize, asynchronousSnapshots);
+		this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
+	}
+
+	@Override
+	public FsSegmentStateBackend configure(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
+
+		FsStateBackend configured = super.configure(config, classLoader, maxConcurrentCheckpoints);
+
+		return new FsSegmentStateBackend(
+			configured.getCheckpointPath().toUri(),
+			configured.getSavepointPath() == null ? null : configured.getSavepointPath().toUri(),
+			configured.getMinFileSizeThreshold(),
+			configured.getWriteBufferSize(),
+			TernaryBoolean.fromBoolean(configured.isUsingAsynchronousSnapshots()),
+			maxConcurrentCheckpoints);
+	}
+
+	@Override
+	public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
+		Preconditions.checkNotNull(jobId, "jobId can't be null when creating checkpoint storage.");
+		return new FsSegmentCheckpointStorage(
+			getCheckpointPath(),
+			getSavepointPath(),
+			jobId,
+			getMinFileSizeThreshold(),
+			getWriteBufferSize(),
+			this.maxConcurrentCheckpoints);
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateHandle.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StreamStateHandle;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A state handle used in {@link FsSegmentCheckpointStreamFactory}.
+ */
+public class FsSegmentStateHandle implements StreamStateHandle {
+	private static final long serialVersionUID = 26L;
+
+	/** The file where the segment locates. */
+	private final Path filePath;
+
+	/** The start position(inclusive) of the snapshot data in the file. */
+	private final long startPosition;
+
+	/** The end position(exclusive) of the snapshot data in the file. */
+	private final long endPosition;
+
+	/** The state size of this state handle. */
+	private final long stateSize;
+
+	public FsSegmentStateHandle(
+		final Path filePath,
+		final long startPosition,
+		final long endPosition) {
+		checkArgument(filePath != null);
+		checkArgument(startPosition >= 0 && endPosition > startPosition);
+		this.filePath = checkNotNull(filePath);
+		this.startPosition = startPosition;
+		this.endPosition = endPosition;
+		this.stateSize = endPosition - startPosition;
+	}
+
+	@Override
+	public FSDataInputStream openInputStream() throws IOException {
+		FileSystem fileSystem = FileSystem.get(filePath.toUri());
+		FSDataInputStream inputStream = fileSystem.open(filePath);
+		inputStream.seek(startPosition);
+		return inputStream;
+	}
+
+	@Override
+	public void discardState() throws Exception {
+		// avoid to delete the underlying file, it will be deleted by JM.
+	}
+
+	@Override
+	public long getStateSize() {
+		return stateSize;
+	}
+
+	public Path getFilePath() {
+		return filePath;
+	}
+
+	public long getStartPosition() {
+		return startPosition;
+	}
+
+	public long getEndPosition() {
+		return endPosition;
+	}
+
+	@Override
+	public String toString() {
+		return "FileSegmentStateHandle{" +
+			"filePath=" + filePath +
+			", startPosition=" + startPosition +
+			", endPosition=" + endPosition +
+			", stateSize=" + getStateSize() +
+			"}";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof FsSegmentStateHandle)) {
+			return false;
+		}
+
+		FsSegmentStateHandle that = (FsSegmentStateHandle) o;
+		return filePath.equals(that.filePath) &&
+			startPosition == that.startPosition &&
+			endPosition == that.endPosition;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = filePath.hashCode();
+		result = 31 * result + (int) (startPosition ^ (startPosition >>> 32));
+		result = 31 * result + (int) (endPosition ^ (endPosition >>> 32));
+		return result;
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -93,7 +93,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * parameters from the Flink configuration. For example, if the backend if configured in the application
  * without a default savepoint directory, it will pick up a default savepoint directory specified in the
  * Flink configuration of the running job/cluster. That behavior is implemented via the
- * {@link #configure(Configuration, ClassLoader)} method.
+ * {@link #configure(Configuration, ClassLoader, int)} method.
  */
 @PublicEvolving
 public class FsStateBackend extends AbstractFileStateBackend implements ConfigurableStateBackend {
@@ -354,8 +354,9 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	 *
 	 * @param original The state backend to re-configure
 	 * @param configuration The configuration
+	 * @param maxConcurrentCheckpoints Maximum number of checkpoint attempts in progress at the same time.
 	 */
-	private FsStateBackend(FsStateBackend original, Configuration configuration, ClassLoader classLoader) {
+	private FsStateBackend(FsStateBackend original, Configuration configuration, ClassLoader classLoader, int maxConcurrentCheckpoints) {
 		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
 
 		// if asynchronous snapshots were configured, use that setting,
@@ -468,11 +469,13 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	 * for fields where that were not specified in this state backend.
 	 *
 	 * @param config the configuration
+	 * @param classLoader The class loader that should be used to load the state backend.
+	 * @param maxConcurrentCheckpoints Maximum number of checkpoint attempts in progress at the same time.
 	 * @return The re-configured variant of the state backend
 	 */
 	@Override
-	public FsStateBackend configure(Configuration config, ClassLoader classLoader) {
-		return new FsStateBackend(this, config, classLoader);
+	public FsStateBackend configure(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
+		return new FsStateBackend(this, config, classLoader, maxConcurrentCheckpoints);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.state.StateBackendFactory;
 public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend> {
 
 	@Override
-	public FsStateBackend createFromConfig(Configuration config, ClassLoader classLoader) throws IllegalConfigurationException {
+	public FsStateBackend createFromConfig(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) throws IllegalConfigurationException {
 		// we need to explicitly read the checkpoint directory here, because that
 		// is a required constructor parameter
 		final String checkpointDir = config.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY);
@@ -42,7 +42,7 @@ public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend
 		}
 
 		try {
-			return new FsStateBackend(checkpointDir).configure(config, classLoader);
+			return new FsStateBackend(checkpointDir).configure(config, classLoader, maxConcurrentCheckpoints);
 		}
 		catch (IllegalArgumentException e) {
 			throw new IllegalConfigurationException("Invalid configuration for the state backend", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -149,6 +149,7 @@ class HeapSnapshotStrategy<K>
 					localRecoveryConfig.getLocalStateDirectoryProvider()) :
 
 				() -> CheckpointStreamWithResultProvider.createSimpleStream(
+					checkpointId,
 					CheckpointedStateScope.EXCLUSIVE,
 					primaryStreamFactory);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemCheckpointStreamFactory.java
@@ -49,7 +49,8 @@ public class MemCheckpointStreamFactory implements CheckpointStreamFactory {
 
 	@Override
 	public CheckpointStateOutputStream createCheckpointStateOutputStream(
-			CheckpointedStateScope scope) throws IOException
+		long checkpointId,
+		CheckpointedStateScope scope) throws IOException
 	{
 		return new MemoryCheckpointOutputStream(maxStateSize);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -100,7 +100,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * parameters from the Flink configuration. For example, if the backend if configured in the application
  * without a default savepoint directory, it will pick up a default savepoint directory specified in the
  * Flink configuration of the running job/cluster. That behavior is implemented via the
- * {@link #configure(Configuration, ClassLoader)} method.
+ * {@link #configure(Configuration, ClassLoader, int)} method.
  */
 @PublicEvolving
 public class MemoryStateBackend extends AbstractFileStateBackend implements ConfigurableStateBackend {
@@ -233,8 +233,13 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	 * @param original The state backend to re-configure
 	 * @param configuration The configuration
 	 * @param classLoader The class loader
+	 * @param maxConcurrentCheckpoints Maximum number of checkpoint attempts in progress at the same time
 	 */
-	private MemoryStateBackend(MemoryStateBackend original, Configuration configuration, ClassLoader classLoader) {
+	private MemoryStateBackend(
+		MemoryStateBackend original,
+		Configuration configuration,
+		ClassLoader classLoader,
+		int maxConcurrentCheckpoints) {
 		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
 
 		this.maxStateSize = original.maxStateSize;
@@ -279,11 +284,12 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	 *
 	 * @param config The configuration
 	 * @param classLoader The class loader
+	 * @param maxConcurrentCheckpoints Maximum number of checkpoint attempts in progress at the same time
 	 * @return The re-configured variant of the state backend
 	 */
 	@Override
-	public MemoryStateBackend configure(Configuration config, ClassLoader classLoader) {
-		return new MemoryStateBackend(this, config, classLoader);
+	public MemoryStateBackend configure(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
+		return new MemoryStateBackend(this, config, classLoader, maxConcurrentCheckpoints);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackendFactory.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.state.StateBackendFactory;
 public class MemoryStateBackendFactory implements StateBackendFactory<MemoryStateBackend> {
 
 	@Override
-	public MemoryStateBackend createFromConfig(Configuration config, ClassLoader classLoader) {
-		return new MemoryStateBackend().configure(config, classLoader);
+	public MemoryStateBackend createFromConfig(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
+		return new MemoryStateBackend().configure(config, classLoader, maxConcurrentCheckpoints);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2SerializerTest.java
@@ -24,7 +24,10 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -40,6 +43,9 @@ import static org.junit.Assert.assertEquals;
  * Various tests for the version 2 format serializer of a checkpoint. 
  */
 public class SavepointV2SerializerTest {
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
 
 	@Test
 	public void testCheckpointWithNoState() throws Exception {
@@ -84,7 +90,7 @@ public class SavepointV2SerializerTest {
 			final int numTasks = rnd.nextInt(maxTaskStates) + 1;
 			final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
 			final Collection<OperatorState> taskStates = 
-					CheckpointTestUtils.createOperatorStates(rnd, numTasks, numSubtasks);
+					CheckpointTestUtils.createOperatorStates(rnd, numTasks, numSubtasks, folder);
 
 			final Collection<MasterState> masterStates = Collections.emptyList();
 
@@ -106,7 +112,7 @@ public class SavepointV2SerializerTest {
 			final int numTasks = rnd.nextInt(maxTaskStates) + 1;
 			final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
 			final Collection<OperatorState> taskStates =
-					CheckpointTestUtils.createOperatorStates(rnd, numTasks, numSubtasks);
+					CheckpointTestUtils.createOperatorStates(rnd, numTasks, numSubtasks, folder);
 
 			final int numMasterStates = rnd.nextInt(maxNumMasterStates) + 1;
 			final Collection<MasterState> masterStates =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2Test.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2Test.java
@@ -21,7 +21,9 @@ package org.apache.flink.runtime.checkpoint.savepoint;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.util.Collection;
 import java.util.Random;
@@ -31,6 +33,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SavepointV2Test {
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	/**
 	 * Simple test of savepoint methods.
@@ -45,7 +49,7 @@ public class SavepointV2Test {
 		final int numMasterStates = 7;
 
 		Collection<OperatorState> taskStates =
-				CheckpointTestUtils.createOperatorStates(rnd, numTaskStates, numSubtaskStates);
+				CheckpointTestUtils.createOperatorStates(rnd, numTaskStates, numSubtaskStates, temporaryFolder);
 
 		Collection<MasterState> masterStates =
 				CheckpointTestUtils.createRandomMasterStates(rnd, numMasterStates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStreamWithResultProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStreamWithResultProviderTest.java
@@ -60,6 +60,7 @@ public class CheckpointStreamWithResultProviderTest extends TestLogger {
 		try (
 			CheckpointStreamWithResultProvider primaryOnly =
 				CheckpointStreamWithResultProvider.createSimpleStream(
+					1,
 					CheckpointedStateScope.EXCLUSIVE,
 					primaryFactory)) {
 
@@ -84,7 +85,7 @@ public class CheckpointStreamWithResultProviderTest extends TestLogger {
 		CheckpointStreamFactory primaryFactory = createCheckpointStreamFactory();
 
 		CheckpointStreamWithResultProvider resultProvider =
-			CheckpointStreamWithResultProvider.createSimpleStream(CheckpointedStateScope.EXCLUSIVE, primaryFactory);
+			CheckpointStreamWithResultProvider.createSimpleStream(1, CheckpointedStateScope.EXCLUSIVE, primaryFactory);
 
 		SnapshotResult<StreamStateHandle> result = writeCheckpointTestData(resultProvider);
 
@@ -130,16 +131,16 @@ public class CheckpointStreamWithResultProviderTest extends TestLogger {
 		CheckpointStreamFactory primaryFactory = createCheckpointStreamFactory();
 
 		testCloseBeforeComplete(new CheckpointStreamWithResultProvider.PrimaryStreamOnly(
-			primaryFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)));
+			primaryFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE)));
 		testCompleteBeforeClose(new CheckpointStreamWithResultProvider.PrimaryStreamOnly(
-			primaryFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)));
+			primaryFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE)));
 
 		testCloseBeforeComplete(new CheckpointStreamWithResultProvider.PrimaryAndSecondaryStream(
-				primaryFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE),
-				primaryFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)));
+				primaryFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE),
+				primaryFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE)));
 		testCompleteBeforeClose(new CheckpointStreamWithResultProvider.PrimaryAndSecondaryStream(
-				primaryFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE),
-				primaryFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)));
+				primaryFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE),
+				primaryFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE)));
 	}
 
 	@Test
@@ -151,7 +152,7 @@ public class CheckpointStreamWithResultProviderTest extends TestLogger {
 			CheckpointStreamWithResultProvider.PrimaryStreamOnly::new,
 			() -> {
 				try {
-					return streamFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
+					return streamFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE);
 				} catch (IOException e) {
 					throw new RuntimeException(e);
 				}
@@ -163,8 +164,8 @@ public class CheckpointStreamWithResultProviderTest extends TestLogger {
 			() -> {
 				try {
 					return new DuplicatingCheckpointOutputStream(
-						streamFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE),
-						streamFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE));
+						streamFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE),
+						streamFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE));
 				} catch (IOException e) {
 					throw new RuntimeException(e);
 				}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -20,15 +20,30 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.core.fs.FSDataInputStream;
-import org.junit.Test;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.runtime.state.filesystem.FsSegmentStateHandle;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Map;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class SharedStateRegistryTest {
+
+	@Rule
+	public final TemporaryFolder folder = new TemporaryFolder();
 
 	/**
 	 * Validate that all states can be correctly registered at the registry.
@@ -88,6 +103,414 @@ public class SharedStateRegistryTest {
 	public void testUnregisterWithUnexistedKey() {
 		SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
 		sharedStateRegistry.unregisterReference(new SharedStateRegistryKey("non-existent"));
+	}
+
+	@Test
+	public void testRegisterForFsSegmentStateHandle() throws IOException {
+		// We'll test the scenario that of 5 checkpoint for one operator.
+		// checkpoint 1 includes 1.sst, 2.sst 3.sst
+		// checkpoint 2 includes 2.sst 3.sst 4.sst
+		// checkpoint 3 includes 3.sst 5.sst, 6.sst 7.sst
+		// checkpoint 4 includes 6.sst, 7.sst, 8.sst 9.sst
+		// checkpoint 5 includes 10.sst, 11.sst, 12.sst 13.sst
+
+		String content = "Hello,World, It's 42!";
+
+		FileSystem fs = new LocalFileSystem();
+		// checkpoint 1, includes 1.sst, 2.sst 3.sst
+		Path firstPath = createPathWithContent(folder, "first", content);
+		FsSegmentStateHandle handle1 = new FsSegmentStateHandle(firstPath, 0, 3);
+		FsSegmentStateHandle handle2 = new FsSegmentStateHandle(firstPath, 3, 8);
+		FsSegmentStateHandle handle3 = new FsSegmentStateHandle(firstPath, 8, content.length());
+
+		SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+		SharedStateRegistryKey firstKey = new SharedStateRegistryKey("1.sst");
+		SharedStateRegistry.Result result = sharedStateRegistry.registerReference(firstKey, handle1);
+		assertEquals(handle1, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		SharedStateRegistryKey secondKey = new SharedStateRegistryKey("2.sst");
+		result = sharedStateRegistry.registerReference(secondKey, handle2);
+		assertEquals(handle2, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		SharedStateRegistryKey thirdKey = new SharedStateRegistryKey("3.sst");
+		result = sharedStateRegistry.registerReference(thirdKey, handle3);
+		assertEquals(handle3, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+		sharedStateRegistry.delUselessUnderlyingFile();
+
+		assertTrue(fs.exists(firstPath));
+
+		// checkpoint 2 includes 2.sst 3.sst 4.sst
+		Path secondPath = createPathWithContent(folder, "second", content);
+		result = sharedStateRegistry.registerReference(secondKey, handle2);
+		assertEquals(handle2, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		result = sharedStateRegistry.registerReference(thirdKey, handle3);
+		assertEquals(handle3, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		FsSegmentStateHandle handle4 = new FsSegmentStateHandle(secondPath, 0, content.length());
+		SharedStateRegistryKey fourthKey = new SharedStateRegistryKey("4.sst");
+		result = sharedStateRegistry.registerReference(fourthKey, handle4);
+		assertEquals(handle4, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+		sharedStateRegistry.delUselessUnderlyingFile();
+
+		assertTrue(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+
+		// try to unregister the state handle of checkpoint 1.
+		result = sharedStateRegistry.unregisterReference(firstKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(secondKey);
+		assertEquals(handle2, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(thirdKey);
+		assertEquals(handle3, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		// we have (2.sst, 3.sst) from checkpoint 1 and 4.sst from checkpoint 2
+		assertTrue(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+
+		// checkpoint 3 includes 3.sst 5.sst, 6.sst 7.sst
+		Path thirdPath = createPathWithContent(folder, "third", content);
+		// 3.sst
+		result = sharedStateRegistry.registerReference(thirdKey, handle3);
+		assertEquals(handle3, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		FsSegmentStateHandle handle5 = new FsSegmentStateHandle(thirdPath, 0, 4);
+		SharedStateRegistryKey fivethKey = new SharedStateRegistryKey("5.sst");
+		result = sharedStateRegistry.registerReference(fivethKey, handle5);
+		assertEquals(handle5, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		FsSegmentStateHandle handle6 = new FsSegmentStateHandle(thirdPath, 4, 9);
+		SharedStateRegistryKey sixthKey = new SharedStateRegistryKey("6.sst");
+		result = sharedStateRegistry.registerReference(sixthKey, handle6);
+		assertEquals(handle6, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		FsSegmentStateHandle handle7 = new FsSegmentStateHandle(thirdPath, 9, content.length());
+		SharedStateRegistryKey seventhKey = new SharedStateRegistryKey("7.sst");
+		result = sharedStateRegistry.registerReference(seventhKey, handle7);
+		assertEquals(handle7, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		sharedStateRegistry.delUselessUnderlyingFile();
+
+		assertTrue(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+		assertTrue(fs.exists(thirdPath));
+
+		// try to unregister state handle of checkpoint 2.
+		result = sharedStateRegistry.unregisterReference(secondKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+
+		result = sharedStateRegistry.unregisterReference(thirdKey);
+		assertEquals(handle3, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		result = sharedStateRegistry.unregisterReference(fourthKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+
+		// we have (3.sst) from checkpoint 1 and (5.sst, 6.sst, 7.sst) from checkpoint 3
+		assertTrue(fs.exists(firstPath));
+		assertFalse(fs.exists(secondPath));
+		assertTrue(fs.exists(thirdPath));
+
+		// checkpoint 4 includes 6.sst, 7.sst, 8.sst 9.sst
+		Path fourthPath = createPathWithContent(folder, "fourth", content);
+		// 6.sst
+		result = sharedStateRegistry.registerReference(sixthKey, handle6);
+		assertEquals(handle6, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		// 7.sst
+		result = sharedStateRegistry.registerReference(seventhKey, handle7);
+		assertEquals(handle7, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		FsSegmentStateHandle handle8 = new FsSegmentStateHandle(fourthPath, 0, 9);
+		SharedStateRegistryKey eighthKey = new SharedStateRegistryKey("8.sst");
+		result = sharedStateRegistry.registerReference(eighthKey, handle8);
+		assertEquals(handle8, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		FsSegmentStateHandle handle9 = new FsSegmentStateHandle(fourthPath, 9, content.length());
+		SharedStateRegistryKey ninethKey = new SharedStateRegistryKey("9.sst");
+		result = sharedStateRegistry.registerReference(ninethKey, handle9);
+		assertEquals(handle9, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		// try to unregister state handles of checkpoint 3.
+		result = sharedStateRegistry.unregisterReference(thirdKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(fivethKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(sixthKey);
+		assertEquals(handle6, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(seventhKey);
+		assertEquals(handle7, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		// we have (6.sst, 7.sst) from checkpoint 3, and (8.sst, 9.sst) from checkpoint 4
+		assertFalse(fs.exists(firstPath));
+		assertFalse(fs.exists(secondPath));
+		assertTrue(fs.exists(thirdPath));
+		assertTrue(fs.exists(fourthPath));
+
+		// checkpoint 5 includes 10.sst, 11.sst, 12.sst 13.sst
+		Path fivethPath = createPathWithContent(folder, "fiveth", content);
+		FsSegmentStateHandle handle10 = new FsSegmentStateHandle(fivethPath, 0, 5);
+		SharedStateRegistryKey tenthKey = new SharedStateRegistryKey("10.sst");
+		result = sharedStateRegistry.registerReference(tenthKey, handle10);
+		assertEquals(handle10, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		FsSegmentStateHandle handle11 = new FsSegmentStateHandle(fivethPath, 5, 8);
+		SharedStateRegistryKey eleventhKey = new SharedStateRegistryKey("11.sst");
+		result = sharedStateRegistry.registerReference(eleventhKey, handle11);
+		assertEquals(handle11, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		FsSegmentStateHandle handle12 = new FsSegmentStateHandle(fivethPath, 8, 13);
+		SharedStateRegistryKey twelvethKey = new SharedStateRegistryKey("12.sst");
+		result = sharedStateRegistry.registerReference(twelvethKey, handle12);
+		assertEquals(handle12, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		FsSegmentStateHandle handle13 = new FsSegmentStateHandle(fivethPath, 13, content.length());
+		SharedStateRegistryKey thirteenthKey = new SharedStateRegistryKey("13.sst");
+		result = sharedStateRegistry.registerReference(thirteenthKey, handle13);
+		assertEquals(handle13, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		// try to unregister state handles of checkpoint 4.
+		result = sharedStateRegistry.unregisterReference(sixthKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+
+		result = sharedStateRegistry.unregisterReference(seventhKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+
+		result = sharedStateRegistry.unregisterReference(eighthKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+
+		result = sharedStateRegistry.unregisterReference(ninethKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+
+		// we only have (10.sst, 11.sst, 12.sst, 13.sst) from checkpoint 5
+		assertFalse(fs.exists(firstPath));
+		assertFalse(fs.exists(secondPath));
+		assertFalse(fs.exists(thirdPath));
+		assertFalse(fs.exists(fourthPath));
+		assertTrue(fs.exists(fivethPath));
+	}
+
+	@Test
+	public void testRegisterForFsSegmentStateHandleConcurrentCheckpoint() throws IOException {
+		// max concurrent checkpoint = 2, max retained checkpoint = 2
+		// checkpoint 1 includes 1.sst, 2.sst, 3.sst
+		// checkpoint 2 includes 2.sst, 3.sst, 4.sst
+		// checkpoint 3 includes 4.sst
+		// checkpoint 4 includes 4.sst, 5.sst
+		// checkpoint 5 includes 4.sst, 6.sst, 5.sst
+		// checkpoint 2 and checkpoint 3 are both do incremental based on checkpoint 1.
+		// file generated in checkpoint 3 will be deleted(4.sst will be replace by the statehandle of checkpoint 2).
+		// checkpoint 4 and checkpoint 5 are both do incremental based on checkpoint 3.
+		// file generated in checkpoint 5 will exist(because 6.sst used it).
+		String content = "Hello,World, It's 42!";
+
+		FileSystem fs = new LocalFileSystem();
+		// checkpoint 1(1.sst, 2.sst 3.sst)
+		Path firstPath = createPathWithContent(folder, "first", content);
+		FsSegmentStateHandle handle1 = new FsSegmentStateHandle(firstPath, 0, 3);
+		FsSegmentStateHandle handle2 = new FsSegmentStateHandle(firstPath, 3, 8);
+		FsSegmentStateHandle handle3 = new FsSegmentStateHandle(firstPath, 8, content.length());
+
+		SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+		Map<String, Integer> fileRefCount = sharedStateRegistry.getFileRefCounts();
+		SharedStateRegistryKey firstKey = new SharedStateRegistryKey("1.sst");
+		SharedStateRegistry.Result result = sharedStateRegistry.registerReference(firstKey, handle1);
+		assertEquals(handle1, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		SharedStateRegistryKey secondKey = new SharedStateRegistryKey("2.sst");
+		result = sharedStateRegistry.registerReference(secondKey, handle2);
+		assertEquals(handle2, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		SharedStateRegistryKey thirdKey = new SharedStateRegistryKey("3.sst");
+		result = sharedStateRegistry.registerReference(thirdKey, handle3);
+		assertEquals(handle3, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+		sharedStateRegistry.delUselessUnderlyingFile();
+
+		assertTrue(fs.exists(firstPath));
+		assertEquals(1, fileRefCount.size());
+		assertEquals((Integer) 3, fileRefCount.get(firstPath.toUri().toString()));
+
+		// checkpoint 2(2.sst, 3.sst, 4.sst) based on checkpoint 1(1.sst, 2.sst, 3.sst)
+		result = sharedStateRegistry.registerReference(secondKey, handle2);
+		assertEquals(handle2, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		result = sharedStateRegistry.registerReference(thirdKey, handle3);
+		assertEquals(handle3, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		Path secondPath = createPathWithContent(folder, "second", content);
+		FsSegmentStateHandle handle4 = new FsSegmentStateHandle(secondPath, 0, content.length());
+		SharedStateRegistryKey fourthKey = new SharedStateRegistryKey("4.sst");
+		result = sharedStateRegistry.registerReference(fourthKey, handle4);
+		assertEquals(handle4, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+		sharedStateRegistry.delUselessUnderlyingFile();
+
+		assertTrue(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+		assertEquals(2, fileRefCount.size());
+		assertEquals((Integer) 5, fileRefCount.get(firstPath.toUri().toString()));
+		assertEquals((Integer) 1, fileRefCount.get(secondPath.toUri().toString()));
+
+		// checkpoint 3(4.sst) based on checkpoint 1(1.sst, 2.sst, 3.sst)
+		Path thirdPath = createPathWithContent(folder, "third", content);
+		FsSegmentStateHandle handle43 = new FsSegmentStateHandle(thirdPath, 0, content.length());
+		SharedStateRegistryKey fourthKey43 = new SharedStateRegistryKey("4.sst");
+		result = sharedStateRegistry.registerReference(fourthKey43, handle43);
+		assertEquals(handle4, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+		sharedStateRegistry.delUselessUnderlyingFile();
+
+		assertTrue(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+		assertFalse(fs.exists(thirdPath));
+		assertEquals(2, fileRefCount.size());
+		assertEquals((Integer) 5, fileRefCount.get(firstPath.toUri().toString()));
+		assertEquals((Integer) 2, fileRefCount.get(secondPath.toUri().toString()));
+
+		// try do subsume checkpoint 1(1.sst, 2.sst, 3.sst).
+		result = sharedStateRegistry.unregisterReference(firstKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(secondKey);
+		assertEquals(handle2, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(thirdKey);
+		assertEquals(handle3, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		assertTrue(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+		assertFalse(fs.exists(thirdPath));
+		assertEquals(2, fileRefCount.size());
+		assertEquals((Integer) 2, fileRefCount.get(firstPath.toUri().toString()));
+		assertEquals((Integer) 2, fileRefCount.get(secondPath.toUri().toString()));
+
+		// checkpoint 4(4.sst, 5.sst) based on checkpoint 3(4.sst)
+		result = sharedStateRegistry.registerReference(fourthKey, handle4);
+		assertEquals(handle4, result.getReference());
+		assertEquals(3, result.getReferenceCount());
+		Path fourthPath = createPathWithContent(folder, "four", content);
+		FsSegmentStateHandle handle5 = new FsSegmentStateHandle(fourthPath, 0, content.length());
+		SharedStateRegistryKey fivethKey = new SharedStateRegistryKey("5.sst");
+		result = sharedStateRegistry.registerReference(fivethKey, handle5);
+		assertEquals(handle5, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+
+		sharedStateRegistry.delUselessUnderlyingFile();
+
+		assertTrue(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+		assertFalse(fs.exists(thirdPath));
+		assertTrue(fs.exists(fourthPath));
+		assertEquals(3, fileRefCount.size());
+		assertEquals((Integer) 2, fileRefCount.get(firstPath.toUri().toString()));
+		assertEquals((Integer) 3, fileRefCount.get(secondPath.toUri().toString()));
+		assertEquals((Integer) 1, fileRefCount.get(fourthPath.toUri().toString()));
+
+		// try to unregister checkpoint 2(2.sst, 3.sst, 4.sst)
+		result = sharedStateRegistry.unregisterReference(secondKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(thirdKey);
+		assertNull(result.getReference());
+		assertEquals(0, result.getReferenceCount());
+		result = sharedStateRegistry.unregisterReference(fourthKey);
+		assertEquals(handle4, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		assertFalse(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+		assertFalse(fs.exists(thirdPath));
+		assertTrue(fs.exists(fourthPath));
+		assertEquals(2, fileRefCount.size());
+		assertEquals((Integer) 2, fileRefCount.get(secondPath.toUri().toString()));
+		assertEquals((Integer) 1, fileRefCount.get(fourthPath.toUri().toString()));
+
+		// checkpoint 5(4.sst, 5.sst, 6.sst) based on checkpoint 3(4.sst)
+		Path fivethPath = createPathWithContent(folder, "five", content);
+		FsSegmentStateHandle handle6 = new FsSegmentStateHandle(fivethPath, 8, content.length());
+		SharedStateRegistryKey sixthKey = new SharedStateRegistryKey("6.sst");
+		result = sharedStateRegistry.registerReference(sixthKey, handle6);
+		assertEquals(handle6, result.getReference());
+		assertEquals(1, result.getReferenceCount());
+		result = sharedStateRegistry.registerReference(fourthKey, handle4);
+		assertEquals(handle4, result.getReference());
+		assertEquals(3, result.getReferenceCount());
+		FsSegmentStateHandle handle55 = new FsSegmentStateHandle(fivethPath, 0, 8);
+		result = sharedStateRegistry.registerReference(fivethKey, handle55);
+		assertEquals(handle5, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+		sharedStateRegistry.delUselessUnderlyingFile();
+
+		assertFalse(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+		assertFalse(fs.exists(thirdPath));
+		assertTrue(fs.exists(fourthPath));
+		assertTrue(fs.exists(fivethPath));
+		assertEquals(3, fileRefCount.size());
+		assertEquals((Integer) 3, fileRefCount.get(secondPath.toUri().toString()));
+		assertEquals((Integer) 2, fileRefCount.get(fourthPath.toUri().toString()));
+		assertEquals((Integer) 1, fileRefCount.get(fivethPath.toUri().toString()));
+
+		// try to subsume checkpoint 3(4.sst)
+		result = sharedStateRegistry.unregisterReference(fourthKey);
+		assertEquals(handle4, result.getReference());
+		assertEquals(2, result.getReferenceCount());
+
+		assertFalse(fs.exists(firstPath));
+		assertTrue(fs.exists(secondPath));
+		assertFalse(fs.exists(thirdPath));
+		assertTrue(fs.exists(fourthPath));
+		assertTrue(fs.exists(fivethPath));
+		assertEquals(3, fileRefCount.size());
+		assertEquals((Integer) 2, fileRefCount.get(secondPath.toUri().toString()));
+		assertEquals((Integer) 2, fileRefCount.get(fourthPath.toUri().toString()));
+		assertEquals((Integer) 1, fileRefCount.get(fivethPath.toUri().toString()));
+	}
+
+	private Path createPathWithContent(TemporaryFolder folder, String fileName, String content) throws IOException {
+		File file = folder.newFile(fileName);
+		BufferedWriter writer = new BufferedWriter(new FileWriter(file.getAbsoluteFile(), true));
+		writer.append(content);
+		writer.close();
+
+		return Path.fromLocalFile(file);
 	}
 
 	private static class TestSharedState implements StreamStateHandle {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -62,13 +62,13 @@ public class StateBackendLoadingTest {
 
 	@Test
 	public void testNoStateBackendDefined() throws Exception {
-		assertNull(StateBackendLoader.loadStateBackendFromConfig(new Configuration(), cl, null));
+		assertNull(StateBackendLoader.loadStateBackendFromConfig(new Configuration(), cl, 1, null));
 	}
 
 	@Test
 	public void testInstantiateMemoryBackendByDefault() throws Exception {
 		StateBackend backend =
-				StateBackendLoader.fromApplicationOrConfigOrDefault(null, new Configuration(), cl, null);
+				StateBackendLoader.fromApplicationOrConfigOrDefault(null, new Configuration(), cl, 1, null);
 
 		assertTrue(backend instanceof MemoryStateBackend);
 	}
@@ -80,7 +80,7 @@ public class StateBackendLoadingTest {
 		final Configuration config = new Configuration();
 		config.setString(backendKey, "jobmanager");
 
-		StateBackend backend = StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config, cl, null);
+		StateBackend backend = StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config, cl, 1, null);
 		assertEquals(appBackend, backend);
 	}
 
@@ -102,8 +102,8 @@ public class StateBackendLoadingTest {
 		final Configuration config2 = new Configuration();
 		config2.setString(backendKey, MemoryStateBackendFactory.class.getName());
 
-		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
-		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
+		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, 1, null);
+		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, 1, null);
 
 		assertTrue(backend1 instanceof MemoryStateBackend);
 		assertTrue(backend2 instanceof MemoryStateBackend);
@@ -137,9 +137,9 @@ public class StateBackendLoadingTest {
 		config2.setBoolean(CheckpointingOptions.ASYNC_SNAPSHOTS, async);
 
 		MemoryStateBackend backend1 = (MemoryStateBackend)
-				StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
+				StateBackendLoader.loadStateBackendFromConfig(config1, cl, 1, null);
 		MemoryStateBackend backend2 = (MemoryStateBackend)
-				StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
+				StateBackendLoader.loadStateBackendFromConfig(config2, cl, 1, null);
 
 		assertNotNull(backend1);
 		assertNotNull(backend2);
@@ -174,7 +174,7 @@ public class StateBackendLoadingTest {
 		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 		config.setBoolean(CheckpointingOptions.ASYNC_SNAPSHOTS, !async);
 
-		StateBackend loadedBackend = StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+		StateBackend loadedBackend = StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, 1, null);
 		assertTrue(loadedBackend instanceof MemoryStateBackend);
 
 		final MemoryStateBackend memBackend = (MemoryStateBackend) loadedBackend;
@@ -205,7 +205,7 @@ public class StateBackendLoadingTest {
 		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir); // this parameter should not be picked up
 		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 
-		StateBackend loadedBackend = StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+		StateBackend loadedBackend = StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, 1, null);
 		assertTrue(loadedBackend instanceof MemoryStateBackend);
 
 		final MemoryStateBackend memBackend = (MemoryStateBackend) loadedBackend;
@@ -248,8 +248,8 @@ public class StateBackendLoadingTest {
 		config1.setInteger(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
 		config2.setBoolean(CheckpointingOptions.ASYNC_SNAPSHOTS, async);
 
-		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
-		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
+		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, 1, null);
+		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, 1, null);
 
 		assertTrue(backend1 instanceof FsStateBackend);
 		assertTrue(backend2 instanceof FsStateBackend);
@@ -296,7 +296,7 @@ public class StateBackendLoadingTest {
 		config.setInteger(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, 3000000); // this should not be picked up
 
 		final StateBackend loadedBackend =
-				StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+				StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, 1, null);
 		assertTrue(loadedBackend instanceof FsStateBackend);
 
 		final FsStateBackend fs = (FsStateBackend) loadedBackend;
@@ -320,7 +320,7 @@ public class StateBackendLoadingTest {
 		// try a value that is neither recognized as a name, nor corresponds to a class
 		config.setString(backendKey, "does.not.exist");
 		try {
-			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
+			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, 1, null);
 			fail("should fail with an exception");
 		} catch (DynamicCodeLoadingException ignored) {
 			// expected
@@ -329,7 +329,7 @@ public class StateBackendLoadingTest {
 		// try a class that is not a factory
 		config.setString(backendKey, java.io.File.class.getName());
 		try {
-			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
+			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, 1, null);
 			fail("should fail with an exception");
 		} catch (DynamicCodeLoadingException ignored) {
 			// expected
@@ -338,7 +338,7 @@ public class StateBackendLoadingTest {
 		// a factory that fails
 		config.setString(backendKey, FailingFactory.class.getName());
 		try {
-			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
+			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, 1, null);
 			fail("should fail with an exception");
 		} catch (IOException ignored) {
 			// expected
@@ -391,9 +391,9 @@ public class StateBackendLoadingTest {
 
 		final MemoryStateBackend appBackend = new MemoryStateBackend();
 
-		final StateBackend loaded1 = StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config1, cl, null);
-		final StateBackend loaded2 = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config1, cl, null);
-		final StateBackend loaded3 = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config2, cl, null);
+		final StateBackend loaded1 = StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config1, cl, 1, null);
+		final StateBackend loaded2 = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config1, cl, 1, null);
+		final StateBackend loaded3 = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config2, cl, 1, null);
 
 		assertTrue(loaded1 instanceof MemoryStateBackend);
 		assertTrue(loaded2 instanceof MemoryStateBackend);
@@ -427,7 +427,7 @@ public class StateBackendLoadingTest {
 	static final class FailingFactory implements StateBackendFactory<StateBackend> {
 
 		@Override
-		public StateBackend createFromConfig(Configuration config, ClassLoader classLoader) throws IOException {
+		public StateBackend createFromConfig(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) throws IOException {
 			throw new IOException("fail!");
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
@@ -164,7 +164,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 		// create exclusive state
 
 		CheckpointStateOutputStream exclusiveStream =
-				storageLocation.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
+				storageLocation.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE);
 
 		exclusiveStream.write(42);
 		exclusiveStream.flush();
@@ -176,7 +176,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 		// create shared state
 
 		CheckpointStateOutputStream sharedStream =
-				storageLocation.createCheckpointStateOutputStream(CheckpointedStateScope.SHARED);
+				storageLocation.createCheckpointStateOutputStream(1, CheckpointedStateScope.SHARED);
 
 		sharedStream.write(42);
 		sharedStream.flush();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStorageTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.StreamStateHandle;
+
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the {@link FsSegmentCheckpointStorage}, which implements the checkpoint storage
+ *  * aspects of the {@link FsSegmentStateBackend}.
+ */
+public class FsSegmentCheckpointStorageTest extends AbstractFileCheckpointStorageTestBase {
+	private static final int FILE_SIZE_THRESHOLD = 1024;
+	private static final int WRITE_BUFFER_SIZE = 1024;
+
+	// ------------------------------------------------------------------------
+	//  General Fs-based checkpoint storage tests, inherited
+	// ------------------------------------------------------------------------
+
+	@Override
+	protected CheckpointStorage createCheckpointStorage(Path checkpointDir) throws Exception {
+		return new FsSegmentCheckpointStorage(checkpointDir, null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, 1);
+	}
+
+	@Override
+	protected CheckpointStorage createCheckpointStorageWithSavepointDir(Path checkpointDir, Path savepointDir) throws Exception {
+		return new FsSegmentCheckpointStorage(checkpointDir, savepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, 1);
+	}
+
+	// ------------------------------------------------------------------------
+	//  FsSegmentCheckpointStorage-specific tests
+	// ------------------------------------------------------------------------
+
+	@Test
+	public void testSavepointsInOneDirectoryDefaultLocation() throws Exception {
+		final Path defaultSavepointDir = Path.fromLocalFile(tmp.newFolder());
+
+		final FsSegmentCheckpointStorage storage = new FsSegmentCheckpointStorage(
+			Path.fromLocalFile(tmp.newFolder()), defaultSavepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, 1);
+
+		final FsCheckpointStorageLocation savepointLocation = (FsCheckpointStorageLocation)
+			storage.initializeLocationForSavepoint(52452L, null);
+
+		// all state types should be in the expected location
+		assertParent(defaultSavepointDir, savepointLocation.getCheckpointDirectory());
+		assertParent(defaultSavepointDir, savepointLocation.getSharedStateDirectory());
+		assertParent(defaultSavepointDir, savepointLocation.getTaskOwnedStateDirectory());
+
+		// cleanup
+		savepointLocation.disposeOnFailure();
+	}
+
+	@Test
+	public void testSavepointsInOneDirectoryCustomLocation() throws Exception {
+		final Path savepointDir = Path.fromLocalFile(tmp.newFolder());
+
+		final FsSegmentCheckpointStorage storage = new FsSegmentCheckpointStorage(
+			Path.fromLocalFile(tmp.newFolder()), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, 1);
+
+		final FsCheckpointStorageLocation savepointLocation = (FsCheckpointStorageLocation)
+			storage.initializeLocationForSavepoint(52452L, savepointDir.toString());
+
+		// all state types should be in the expected location
+		assertParent(savepointDir, savepointLocation.getCheckpointDirectory());
+		assertParent(savepointDir, savepointLocation.getSharedStateDirectory());
+		assertParent(savepointDir, savepointLocation.getTaskOwnedStateDirectory());
+
+		// cleanup
+		savepointLocation.disposeOnFailure();
+	}
+
+	@Test
+	public void testTaskOwnedStateStream() throws Exception {
+		final List<String> state = Arrays.asList("Flopsy", "Mopsy", "Cotton Tail", "Peter");
+
+		// we chose a small size threshold here to force the state to disk
+		// because we'll use FsCheckpointStateOutputStream for task owned state.
+		final FsSegmentCheckpointStorage storage = new FsSegmentCheckpointStorage(
+			Path.fromLocalFile(tmp.newFolder()),  null, new JobID(), 10, WRITE_BUFFER_SIZE, 1);
+
+		final StreamStateHandle stateHandle;
+
+		try (CheckpointStreamFactory.CheckpointStateOutputStream stream = storage.createTaskOwnedStateStream()) {
+			assertTrue(stream instanceof FsCheckpointStreamFactory.FsCheckpointStateOutputStream);
+
+			new ObjectOutputStream(stream).writeObject(state);
+			stateHandle = stream.closeAndGetHandle();
+		}
+
+		// the state must have gone to disk
+		FileStateHandle fileStateHandle = (FileStateHandle) stateHandle;
+
+		// check that the state is in the correct directory
+		String parentDirName = fileStateHandle.getFilePath().getParent().getName();
+		assertEquals(FsCheckpointStorage.CHECKPOINT_TASK_OWNED_STATE_DIR, parentDirName);
+
+		// validate the contents
+		try (ObjectInputStream in = new ObjectInputStream(stateHandle.openInputStream())) {
+			assertEquals(state, in.readObject());
+		}
+	}
+
+	@Test
+	public void testDirectoriesForExclusiveAndSharedState() throws Exception {
+		final FileSystem fs = LocalFileSystem.getSharedInstance();
+		final Path checkpointDir = randomTempPath();
+		final Path sharedStateDir = randomTempPath();
+
+		FsSegmentCheckpointStorageLocation storageLocation = new FsSegmentCheckpointStorageLocation(
+			fs,
+			checkpointDir,
+			sharedStateDir,
+			randomTempPath(),
+			CheckpointStorageLocationReference.getDefault(),
+			1024,
+			1);
+
+		assertNotEquals(storageLocation.getCheckpointDirectory(), storageLocation.getSharedStateDirectory());
+
+		assertEquals(0, fs.listStatus(storageLocation.getCheckpointDirectory()).length);
+		assertEquals(0, fs.listStatus(storageLocation.getSharedStateDirectory()).length);
+
+		// create exclusive state
+
+		CheckpointStreamFactory.CheckpointStateOutputStream exclusiveStream =
+			storageLocation.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE);
+
+		exclusiveStream.write(42);
+		exclusiveStream.flush();
+		StreamStateHandle exclusiveHandle = exclusiveStream.closeAndGetHandle();
+
+		assertEquals(1, fs.listStatus(storageLocation.getCheckpointDirectory()).length);
+		assertEquals(0, fs.listStatus(storageLocation.getSharedStateDirectory()).length);
+
+		// create shared state
+
+		CheckpointStreamFactory.CheckpointStateOutputStream sharedStream =
+			storageLocation.createCheckpointStateOutputStream(1, CheckpointedStateScope.SHARED);
+
+		sharedStream.write(42);
+		sharedStream.flush();
+		StreamStateHandle sharedHandle = sharedStream.closeAndGetHandle();
+
+		assertEquals(1, fs.listStatus(storageLocation.getCheckpointDirectory()).length);
+		assertEquals(1, fs.listStatus(storageLocation.getSharedStateDirectory()).length);
+
+		// drop state
+
+		exclusiveHandle.discardState();
+		sharedHandle.discardState();
+	}
+
+	/**
+	 * This test checks that no mkdirs is called by the checkpoint storage location when resolved.
+	 */
+	@Test
+	public void testStorageLocationDoesNotMkdirs() throws Exception {
+		FsSegmentCheckpointStorage storage = new FsSegmentCheckpointStorage(
+			randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, 1);
+
+		File baseDir =  new File(storage.getCheckpointsDirectory().getPath());
+		assertFalse(baseDir.exists());
+
+		FsSegmentCheckpointStorageLocation location = (FsSegmentCheckpointStorageLocation)
+			storage.resolveCheckpointStorageLocation(177, CheckpointStorageLocationReference.getDefault());
+
+		Path checkpointPath = location.getCheckpointDirectory();
+		File checkpointDir = new File(checkpointPath.getPath());
+		assertFalse(checkpointDir.exists());
+	}
+
+	@Test
+	public void testResolveCheckpointStorageLocation() throws Exception {
+		final FileSystem checkpointFileSystem = mock(FileSystem.class);
+		final FsSegmentCheckpointStorage storage = new FsSegmentCheckpointStorage(
+			new TestingPath("hdfs:///checkpoint/", checkpointFileSystem),
+			null,
+			new JobID(),
+			FILE_SIZE_THRESHOLD,
+			WRITE_BUFFER_SIZE,
+			1);
+
+		final FsSegmentCheckpointStorageLocation checkpointStreamFactory =
+			(FsSegmentCheckpointStorageLocation) storage.resolveCheckpointStorageLocation(1L, CheckpointStorageLocationReference.getDefault());
+		assertEquals(checkpointFileSystem, checkpointStreamFactory.getFileSystem());
+
+		final CheckpointStorageLocationReference savepointLocationReference =
+			AbstractFsCheckpointStorage.encodePathAsReference(new Path("file:///savepoint/"));
+
+		final FsCheckpointStorageLocation savepointStreamFactory =
+			(FsCheckpointStorageLocation) storage.resolveCheckpointStorageLocation(2L, savepointLocationReference);
+		final FileSystem fileSystem = savepointStreamFactory.getFileSystem();
+		assertTrue(fileSystem instanceof LocalFileSystem);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	private void assertParent(Path parent, Path child) {
+		Path path = new Path(parent, child.getName());
+		assertEquals(path, child);
+	}
+
+	private static final class TestingPath extends Path {
+
+		private static final long serialVersionUID = 2560119808844230488L;
+
+		@SuppressWarnings("TransientFieldNotInitialized")
+		@Nonnull
+		private final transient FileSystem fileSystem;
+
+		TestingPath(String pathString, @Nonnull FileSystem fileSystem) {
+			super(pathString);
+			this.fileSystem = fileSystem;
+		}
+
+		@Override
+		public FileSystem getFileSystem() throws IOException {
+			return fileSystem;
+		}
+	}
+}
+

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStreamFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsSegmentCheckpointStreamFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test for {@link FsSegmentCheckpointStreamFactory}.
+ */
+public class FsSegmentCheckpointStreamFactoryTest {
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testCloseOldCheckpointFile() throws Exception {
+		int writeBufferSize = 1024;
+		FsSegmentCheckpointStreamFactory checkpointStreamFactory = new FsSegmentCheckpointStreamFactory(
+			LocalFileSystem.getLocalFileSystem(),
+			Path.fromLocalFile(temporaryFolder.newFolder()),
+			Path.fromLocalFile(temporaryFolder.newFolder()),
+			Path.fromLocalFile(temporaryFolder.newFolder()),
+			writeBufferSize,
+			1024,
+			1);
+
+		CheckpointStreamFactory.CheckpointStateOutputStream outputStream = checkpointStreamFactory.createCheckpointStateOutputStream(1, CheckpointedStateScope.SHARED);
+		// write writeBufferSize + 10 ensure that we create a file for checkpoint 1.
+		for (int i = 0; i < writeBufferSize + 10; ++i) {
+			outputStream.write(ThreadLocalRandom.current().nextInt());
+		}
+		Map<Long, FSDataOutputStream> rawOutputSteams = checkpointStreamFactory.getFileOutputStreams();
+		FSDataOutputStream rawOutputSteam = rawOutputSteams.get(1L);
+		FSDataOutputStream spyOutputStream = spy(rawOutputSteam);
+		// reset the outputstream, so that we can verify its close.
+		rawOutputSteams.put(1L, spyOutputStream);
+
+		checkpointStreamFactory.createCheckpointStateOutputStream(2, CheckpointedStateScope.SHARED);
+		verify(spyOutputStream).close();
+	}
+}
+

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateBackendEntropyTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.EntropyInjectingFileSystem;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests verifying that the FsStateBackend passes the entropy injection option
+ * to the FileSystem for state payload files, but not for metadata files.
+ */
+public class FsSegmentStateBackendEntropyTest {
+	static final String ENTROPY_MARKER = "__ENTROPY__";
+	static final String RESOLVED_MARKER = "+RESOLVED+";
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testEntropyInjection() throws Exception {
+		final FileSystem fs = new TestEntropyAwareFs();
+
+		final Path checkpointDir = new Path(Path.fromLocalFile(tmp.newFolder()), ENTROPY_MARKER + "/checkpoints");
+		final String checkpointDirStr = checkpointDir.toString();
+
+		FsSegmentCheckpointStorage storage = new FsSegmentCheckpointStorage(
+			fs, checkpointDir, checkpointDir, new JobID(), 1024, 1024, 1);
+
+		FsSegmentCheckpointStorageLocation location = (FsSegmentCheckpointStorageLocation)
+			storage.initializeLocationForCheckpoint(96562);
+
+		assertThat(location.getCheckpointDirectory().toString(), startsWith(checkpointDirStr));
+		assertThat(location.getSharedStateDirectory().toString(), startsWith(checkpointDirStr));
+		assertThat(location.getTaskOwnedStateDirectory().toString(), startsWith(checkpointDirStr));
+		assertThat(location.getMetadataFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+
+		// check entropy in task-owned state, task owned state use FsCheckpointStateOutputStream.
+		try (CheckpointStreamFactory.CheckpointStateOutputStream stream = storage.createTaskOwnedStateStream()) {
+			stream.flush();
+			FileStateHandle handle = (FileStateHandle) stream.closeAndGetHandle();
+
+			assertNotNull(handle);
+			assertThat(handle.getFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+			assertThat(handle.getFilePath().toString(), containsString(RESOLVED_MARKER));
+		}
+
+		// check entropy in the exclusive/shared state
+		try (CheckpointStreamFactory.CheckpointStateOutputStream stream =
+				 location.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE)) {
+
+			stream.flush();
+			FileStateHandle handle = (FileStateHandle) stream.closeAndGetHandle();
+
+			assertNotNull(handle);
+			assertThat(handle.getFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+			assertThat(handle.getFilePath().toString(), containsString(RESOLVED_MARKER));
+		}
+
+		// check entropy in the exclusive/shared state
+		try (CheckpointStreamFactory.CheckpointStateOutputStream stream =
+				 location.createCheckpointStateOutputStream(1, CheckpointedStateScope.SHARED)) {
+
+			// write one byte, so that we'll create the underlying file.
+			stream.write(1);
+			FsSegmentStateHandle handle = (FsSegmentStateHandle) stream.closeAndGetHandle();
+
+			assertNotNull(handle);
+			assertThat(handle.getFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+			assertThat(handle.getFilePath().toString(), containsString(RESOLVED_MARKER));
+		}
+
+		// check that there is no entropy in the metadata
+		// check entropy in the exclusive/shared state
+		try (CheckpointMetadataOutputStream stream = location.createMetadataOutputStream()) {
+			stream.flush();
+			FsCompletedCheckpointStorageLocation handle =
+				(FsCompletedCheckpointStorageLocation) stream.closeAndFinalizeCheckpoint();
+
+			assertNotNull(handle);
+
+			// metadata files have no entropy
+			assertThat(handle.getMetadataHandle().getFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+			assertThat(handle.getMetadataHandle().getFilePath().toString(), not(containsString(RESOLVED_MARKER)));
+
+			// external location is the same as metadata, without the file name
+			assertEquals(handle.getMetadataHandle().getFilePath().getParent().toString(), handle.getExternalPointer());
+		}
+	}
+
+	private static class TestEntropyAwareFs extends LocalFileSystem implements EntropyInjectingFileSystem {
+
+		@Override
+		public String getEntropyInjectionKey() {
+			return ENTROPY_MARKER;
+		}
+
+		@Override
+		public String generateEntropy() {
+			return RESOLVED_MARKER;
+		}
+	}
+}
+

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsSegmentStateHandleTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.core.fs.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Random;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link FsSegmentStateHandle}.
+ */
+public class FsSegmentStateHandleTest {
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testDisposeDeletesFile() throws Exception {
+		File file = temporaryFolder.newFile();
+		writeTestData(file);
+		assertTrue(file.exists());
+
+		FsSegmentStateHandle handle = new FsSegmentStateHandle(Path.fromLocalFile(file), 0, file.length());
+		handle.discardState();
+		// Discard handle does not delete the underlying file.
+		assertTrue(file.exists());
+	}
+
+	private static void writeTestData(File file) throws IOException {
+		final Random rnd = new Random();
+
+		byte[] data = new byte[rnd.nextInt(1024) + 1];
+		rnd.nextBytes(data);
+
+		try (OutputStream out = new FileOutputStream(file)) {
+			out.write(data);
+		}
+	}
+}
+

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -80,7 +80,7 @@ public class FsStateBackendEntropyTest {
 
 		// check entropy in the exclusive/shared state
 		try (CheckpointStateOutputStream stream =
-				location.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)) {
+				location.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE)) {
 
 			stream.flush();
 			FileStateHandle handle = (FileStateHandle) stream.closeAndGetHandle();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
@@ -119,7 +119,7 @@ public class BackendForTestStream extends MemoryStateBackend {
 		}
 
 		@Override
-		public CheckpointStateOutputStream createCheckpointStateOutputStream(CheckpointedStateScope scope) throws IOException {
+		public CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointId, CheckpointedStateScope scope) throws IOException {
 			return streamFactory.get();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
@@ -56,7 +56,7 @@ public class BackendForTestStream extends MemoryStateBackend {
 
 	// make no reconfiguration!
 	@Override
-	public MemoryStateBackend configure(Configuration config, ClassLoader classLoader) {
+	public MemoryStateBackend configure(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
 		return this;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/TestCheckpointStreamFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/TestCheckpointStreamFactory.java
@@ -38,7 +38,7 @@ public class TestCheckpointStreamFactory implements CheckpointStreamFactory {
 	}
 
 	@Override
-	public CheckpointStateOutputStream createCheckpointStateOutputStream(CheckpointedStateScope scope) {
+	public CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointId, CheckpointedStateScope scope) {
 		return supplier.get();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -78,7 +78,7 @@ public class MockStateBackend extends AbstractStateBackend {
 				return new CheckpointStorageLocation() {
 
 					@Override
-					public CheckpointStateOutputStream createCheckpointStateOutputStream(CheckpointedStateScope scope) {
+					public CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointId, CheckpointedStateScope scope) {
 						return null;
 					}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockerCheckpointStreamFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockerCheckpointStreamFactory.java
@@ -74,6 +74,7 @@ public class BlockerCheckpointStreamFactory implements CheckpointStreamFactory {
 
 	@Override
 	public CheckpointStateOutputStream createCheckpointStateOutputStream(
+		long checkpointId,
 		CheckpointedStateScope scope) throws IOException {
 
 		BlockingCheckpointOutputStream blockingStream = new BlockingCheckpointOutputStream(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
 import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
@@ -68,7 +69,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -256,7 +256,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 		try {
 			// Variables for snapshot strategy when incremental checkpoint is enabled
 			UUID backendUID = UUID.randomUUID();
-			SortedMap<Long, Set<StateHandleID>> materializedSstFiles = new TreeMap<>();
+			SortedMap<Long, Map<StateHandleID, StreamStateHandle>> materializedSstFiles = new TreeMap<>();
 			long lastCompletedCheckpointId = -1L;
 			if (injectedTestDB != null) {
 				db = injectedTestDB;
@@ -425,7 +425,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 		int keyGroupPrefixBytes,
 		RocksDB db,
 		UUID backendUID,
-		SortedMap<Long, Set<StateHandleID>> materializedSstFiles,
+		SortedMap<Long, Map<StateHandleID, StreamStateHandle>> materializedSstFiles,
 		long lastCompletedCheckpointId) {
 		RocksDBSnapshotStrategyBase<K> savepointSnapshotStrategy = new RocksFullSnapshotStrategy<>(
 			db,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSegmentStateBackendFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSegmentStateBackendFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.state.StateBackendFactory;
+import org.apache.flink.runtime.state.filesystem.FsSegmentStateBackend;
+
+/**
+ * A factory that creates an {@link org.apache.flink.contrib.streaming.state.RocksDBStateBackend}
+ * from a configuration, and use {@link FsSegmentStateBackend} for checkpoint.
+ */
+public class RocksDBSegmentStateBackendFactory implements StateBackendFactory<RocksDBStateBackend> {
+	@Override
+	public RocksDBStateBackend createFromConfig(
+		Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) throws IllegalConfigurationException {
+		// we need to explicitly read the checkpoint directory here, because that
+		// is a required constructor parameter
+		final String checkpointDirURI = config.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY);
+		if (checkpointDirURI == null) {
+			throw new IllegalConfigurationException(
+				"Cannot create the RocksDB state backend: The configuration does not specify the " +
+					"checkpoint directory '" + CheckpointingOptions.CHECKPOINTS_DIRECTORY.key() + '\'');
+		}
+
+		return new RocksDBStateBackend(new FsSegmentStateBackend(checkpointDirURI)).configure(config, classLoader, maxConcurrentCheckpoints);
+	}
+}
+

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.filesystem.FsSegmentStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.AbstractID;
@@ -197,8 +198,26 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * @param enableIncrementalCheckpointing True if incremental checkpointing is enabled.
 	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
-	public RocksDBStateBackend(String checkpointDataUri, boolean enableIncrementalCheckpointing) throws IOException {
+	public RocksDBStateBackend(String checkpointDataUri, boolean enableIncrementalCheckpointing) {
 		this(new Path(checkpointDataUri).toUri(), enableIncrementalCheckpointing);
+	}
+
+	/**
+	 * Creates a new {@code RocksDBStateBackend} that stores its checkpoint data in the
+	 * file system and location defined by the given URI.
+	 *
+	 * <p>A state backend that stores checkpoints in HDFS or S3 must specify the file system
+	 * host and port in the URI, or have the Hadoop configuration that describes the file system
+	 * (host / high-availability group / possibly credentials) either referenced from the Flink
+	 * config, or included in the classpath.
+	 *
+	 * @param checkpointDataUri The URI describing the filesystem and path to the checkpoint data directory.
+	 * @param enableIncrementalCheckpointing True if incremental checkpointing is enabled.
+	 * @param useSegmentStreamFactory True if we use FsSegmentStateBackend, otherwise will use FsStateBackend.
+	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
+	 */
+	public RocksDBStateBackend(String checkpointDataUri, boolean enableIncrementalCheckpointing, boolean useSegmentStreamFactory) {
+		this(new Path(checkpointDataUri).toUri(), enableIncrementalCheckpointing, useSegmentStreamFactory);
 	}
 
 	/**
@@ -214,7 +233,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
 	@SuppressWarnings("deprecation")
-	public RocksDBStateBackend(URI checkpointDataUri) throws IOException {
+	public RocksDBStateBackend(URI checkpointDataUri) {
 		this(new FsStateBackend(checkpointDataUri));
 	}
 
@@ -232,8 +251,28 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
 	@SuppressWarnings("deprecation")
-	public RocksDBStateBackend(URI checkpointDataUri, boolean enableIncrementalCheckpointing) throws IOException {
+	public RocksDBStateBackend(URI checkpointDataUri, boolean enableIncrementalCheckpointing) {
 		this(new FsStateBackend(checkpointDataUri), enableIncrementalCheckpointing);
+	}
+
+	/**
+	 * Creates a new {@code RocksDBStateBackend} that stores its checkpoint data in the
+	 * file system and location defined by the given URI.
+	 *
+	 * <p>A state backend that stores checkpoints in HDFS or S3 must specify the file system
+	 * host and port in the URI, or have the Hadoop configuration that describes the file system
+	 * (host / high-availability group / possibly credentials) either referenced from the Flink
+	 * config, or included in the classpath.
+	 *
+	 * @param checkpointDataUri The URI describing the filesystem and path to the checkpoint data directory.
+	 * @param enableIncrementalCheckpointing True if incremental checkpointing is enabled.
+	 * @param useSegmentStreamFactory True if we use FsSegmentStateBackend, otherwise will use FsStateBackend.
+	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
+	 */
+	@SuppressWarnings("deprecation")
+	public RocksDBStateBackend(URI checkpointDataUri, boolean enableIncrementalCheckpointing, boolean useSegmentStreamFactory) {
+		this(useSegmentStreamFactory ? new FsSegmentStateBackend(checkpointDataUri) : new FsStateBackend(checkpointDataUri),
+			enableIncrementalCheckpointing);
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -293,12 +293,17 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * @param original The state backend to re-configure.
 	 * @param config The configuration.
 	 * @param classLoader The class loader.
+	 * @param maxConcurrentCheckpoints Maximum number of checkpoint attempts in progress at the same time.
 	 */
-	private RocksDBStateBackend(RocksDBStateBackend original, Configuration config, ClassLoader classLoader) {
+	private RocksDBStateBackend(
+		RocksDBStateBackend original,
+		Configuration config,
+		ClassLoader classLoader,
+		int maxConcurrentCheckpoints) {
 		// reconfigure the state backend backing the streams
 		final StateBackend originalStreamBackend = original.checkpointStreamBackend;
 		this.checkpointStreamBackend = originalStreamBackend instanceof ConfigurableStateBackend ?
-				((ConfigurableStateBackend) originalStreamBackend).configure(config, classLoader) :
+				((ConfigurableStateBackend) originalStreamBackend).configure(config, classLoader, maxConcurrentCheckpoints) :
 				originalStreamBackend;
 
 		// configure incremental checkpoints
@@ -368,11 +373,12 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 *
 	 * @param config The configuration.
 	 * @param classLoader The class loader.
+	 * @param maxConcurrentCheckpoints Maximum number of checkpoint attempts in progress at the same time.
 	 * @return The re-configured variant of the state backend
 	 */
 	@Override
-	public RocksDBStateBackend configure(Configuration config, ClassLoader classLoader) {
-		return new RocksDBStateBackend(this, config, classLoader);
+	public RocksDBStateBackend configure(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
+		return new RocksDBStateBackend(this, config, classLoader, maxConcurrentCheckpoints);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 public class RocksDBStateBackendFactory implements StateBackendFactory<RocksDBStateBackend> {
 
 	@Override
-	public RocksDBStateBackend createFromConfig(Configuration config, ClassLoader classLoader)
+	public RocksDBStateBackend createFromConfig(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints)
 			throws IllegalConfigurationException, IOException {
 
 		// we need to explicitly read the checkpoint directory here, because that
@@ -44,6 +44,6 @@ public class RocksDBStateBackendFactory implements StateBackendFactory<RocksDBSt
 				"checkpoint directory '" + CheckpointingOptions.CHECKPOINTS_DIRECTORY.key() + '\'');
 		}
 
-		return new RocksDBStateBackend(checkpointDirURI).configure(config, classLoader);
+		return new RocksDBStateBackend(checkpointDirURI).configure(config, classLoader, maxConcurrentCheckpoints);
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloader.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloader.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FsSegmentStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.function.ThrowingRunnable;
@@ -131,13 +132,26 @@ public class RocksDBStateDownloader extends RocksDBStateDataTransfer {
 			closeableRegistry.registerCloseable(outputStream);
 
 			byte[] buffer = new byte[8 * 1024];
-			while (true) {
-				int numBytes = inputStream.read(buffer);
-				if (numBytes == -1) {
-					break;
+			if (remoteFileHandle instanceof FsSegmentStateHandle) {
+				FsSegmentStateHandle fileSegmentStateHandle = (FsSegmentStateHandle) remoteFileHandle;
+				int bytesRead;
+				long bytesLeft = fileSegmentStateHandle.getStateSize();
+				while (bytesLeft > 0) {
+					bytesRead = inputStream.read(buffer, 0, (int) Math.min(buffer.length, bytesLeft));
+					if (bytesRead == -1) {
+						throw new IOException("Unexcepted end of file.");
+					}
+					outputStream.write(buffer, 0, bytesRead);
+					bytesLeft -= bytesRead;
 				}
-
-				outputStream.write(buffer, 0, numBytes);
+			} else {
+				while (true) {
+					int numBytes = inputStream.read(buffer);
+					if (numBytes == -1) {
+						break;
+					}
+					outputStream.write(buffer, 0, numBytes);
+				}
 			}
 		} finally {
 			if (closeableRegistry.unregisterCloseable(inputStream)) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -70,7 +70,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -85,7 +84,7 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 	private static final Logger LOG = LoggerFactory.getLogger(RocksDBIncrementalRestoreOperation.class);
 
 	private final String operatorIdentifier;
-	private final SortedMap<Long, Set<StateHandleID>> restoredSstFiles;
+	private final SortedMap<Long, Map<StateHandleID, StreamStateHandle>> restoredSstFiles;
 	private long lastCompletedCheckpointId;
 	private UUID backendUID;
 
@@ -176,7 +175,7 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 		backendUID = localKeyedStateHandle.getBackendIdentifier();
 		restoredSstFiles.put(
 			localKeyedStateHandle.getCheckpointId(),
-			localKeyedStateHandle.getSharedStateHandleIDs());
+			localKeyedStateHandle.getSharedState());
 		lastCompletedCheckpointId = localKeyedStateHandle.getCheckpointId();
 	}
 
@@ -235,7 +234,7 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 			new DirectoryStateHandle(temporaryRestoreInstancePath),
 			restoreStateHandle.getKeyGroupRange(),
 			restoreStateHandle.getMetaStateHandle(),
-			restoreStateHandle.getSharedState().keySet());
+			restoreStateHandle.getSharedState());
 	}
 
 	private void cleanUpPathQuietly(@Nonnull Path path) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBRestoreResult.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBRestoreResult.java
@@ -20,11 +20,12 @@ package org.apache.flink.contrib.streaming.state.restore;
 
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricMonitor;
 import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.StreamStateHandle;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 
-import java.util.Set;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.UUID;
 
@@ -39,7 +40,7 @@ public class RocksDBRestoreResult {
 	// fields only for incremental restore
 	private final long lastCompletedCheckpointId;
 	private final UUID backendUID;
-	private final SortedMap<Long, Set<StateHandleID>> restoredSstFiles;
+	private final SortedMap<Long, Map<StateHandleID, StreamStateHandle>> restoredSstFiles;
 
 	public RocksDBRestoreResult(
 		RocksDB db,
@@ -47,7 +48,7 @@ public class RocksDBRestoreResult {
 		RocksDBNativeMetricMonitor nativeMetricMonitor,
 		long lastCompletedCheckpointId,
 		UUID backendUID,
-		SortedMap<Long, Set<StateHandleID>> restoredSstFiles) {
+		SortedMap<Long, Map<StateHandleID, StreamStateHandle>> restoredSstFiles) {
 		this.db = db;
 		this.defaultColumnFamilyHandle = defaultColumnFamilyHandle;
 		this.nativeMetricMonitor = nativeMetricMonitor;
@@ -68,7 +69,7 @@ public class RocksDBRestoreResult {
 		return backendUID;
 	}
 
-	public SortedMap<Long, Set<StateHandleID>> getRestoredSstFiles() {
+	public SortedMap<Long, Map<StateHandleID, StreamStateHandle>> getRestoredSstFiles() {
 		return restoredSstFiles;
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
@@ -164,6 +164,7 @@ public class RocksFullSnapshotStrategy<K> extends RocksDBSnapshotStrategyBase<K>
 				localRecoveryConfig.getLocalStateDirectoryProvider()) :
 
 			() -> CheckpointStreamWithResultProvider.createSimpleStream(
+				checkpointId,
 				CheckpointedStateScope.EXCLUSIVE,
 				primaryStreamFactory);
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -422,10 +422,12 @@ public class RocksIncrementalSnapshotStrategy<K> extends RocksDBSnapshotStrategy
 				createUploadFilePaths(fileStatuses, sstFiles, sstFilePaths, miscFilePaths);
 
 				sstFiles.putAll(stateUploader.uploadFilesToCheckpointFs(
+					checkpointId,
 					sstFilePaths,
 					checkpointStreamFactory,
 					snapshotCloseableRegistry));
 				miscFiles.putAll(stateUploader.uploadFilesToCheckpointFs(
+					checkpointId,
 					miscFilePaths,
 					checkpointStreamFactory,
 					snapshotCloseableRegistry));
@@ -472,6 +474,7 @@ public class RocksIncrementalSnapshotStrategy<K> extends RocksDBSnapshotStrategy
 						localRecoveryConfig.getLocalStateDirectoryProvider()) :
 
 					CheckpointStreamWithResultProvider.createSimpleStream(
+						checkpointId,
 						CheckpointedStateScope.EXCLUSIVE,
 						checkpointStreamFactory);
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -286,7 +286,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 			int count = skipStreams;
 
 			@Override
-			public CheckpointStateOutputStream createCheckpointStateOutputStream(CheckpointedStateScope scope) throws IOException {
+			public CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointId, CheckpointedStateScope scope) throws IOException {
 				if (count > 0) {
 					--count;
 					return new BlockingCheckpointOutputStream(
@@ -295,7 +295,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 						null,
 						Integer.MAX_VALUE);
 				} else {
-					return super.createCheckpointStateOutputStream(scope);
+					return super.createCheckpointStateOutputStream(checkpointId, scope);
 				}
 			}
 		};
@@ -499,7 +499,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 
 		@Override
 		public CheckpointStateOutputStream get() throws IOException {
-			return factory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
+			return factory.createCheckpointStateOutputStream(1, CheckpointedStateScope.EXCLUSIVE);
 		}
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBSegmentStateBackendFactoryTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBSegmentStateBackendFactoryTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.StateBackendLoader;
+import org.apache.flink.runtime.state.filesystem.AbstractFileStateBackend;
+import org.apache.flink.runtime.state.filesystem.FsSegmentStateBackend;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link RocksDBSegmentStateBackendFactory}.
+ */
+public class RocksDBSegmentStateBackendFactoryTest extends TestLogger {
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	private final ClassLoader cl = getClass().getClassLoader();
+
+	private final String backendKey = CheckpointingOptions.STATE_BACKEND.key();
+
+	// ------------------------------------------------------------------------
+
+	@Test
+	public void testFactoryName() {
+		// construct the name such that it will not be automatically adjusted on refactorings
+		String factoryName = "org.apache.flink.contrib.streaming.state.Roc";
+		factoryName += "ksDBSegmentStateBackendFactory";
+
+		// !!! if this fails, the code in RocksDBSegmentStateBackendFactory must be adjusted
+		assertEquals(factoryName, RocksDBSegmentStateBackendFactory.class.getName());
+	}
+
+	/**
+	 * Validates loading a file system state backend with additional parameters from the cluster configuration.
+	 */
+	@Test
+	public void testLoadFileSystemStateBackend() throws Exception {
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String localDir1 = tmp.newFolder().getAbsolutePath();
+		final String localDir2 = tmp.newFolder().getAbsolutePath();
+		final String localDirs = localDir1 + File.pathSeparator + localDir2;
+		final boolean incremental = !CheckpointingOptions.INCREMENTAL_CHECKPOINTS.defaultValue();
+
+		final Path expectedCheckpointsPath = new Path(checkpointDir);
+		final Path expectedSavepointsPath = new Path(savepointDir);
+
+		// we configure with the explicit string (rather than AbstractStateBackend#X_STATE_BACKEND_NAME)
+		// to guard against config-breaking changes of the name
+		final Configuration config1 = new Configuration();
+		config1.setString(backendKey, "rocksdb-segment");
+		config1.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config1.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config1.setString(RocksDBOptions.LOCAL_DIRECTORIES, localDirs);
+		config1.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, incremental);
+
+		final Configuration config2 = new Configuration();
+		config2.setString(backendKey, RocksDBSegmentStateBackendFactory.class.getName());
+		config2.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config2.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config2.setString(RocksDBOptions.LOCAL_DIRECTORIES, localDirs);
+		config2.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, incremental);
+
+		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, 1, null);
+		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, 1, null);
+
+		assertTrue(backend1 instanceof RocksDBStateBackend);
+		assertTrue(backend2 instanceof RocksDBStateBackend);
+
+		RocksDBStateBackend fs1 = (RocksDBStateBackend) backend1;
+		RocksDBStateBackend fs2 = (RocksDBStateBackend) backend2;
+
+		AbstractFileStateBackend fs1back = (AbstractFileStateBackend) fs1.getCheckpointBackend();
+		assertTrue(fs1back instanceof FsSegmentStateBackend);
+		AbstractFileStateBackend fs2back = (AbstractFileStateBackend) fs2.getCheckpointBackend();
+		assertTrue(fs2back instanceof FsSegmentStateBackend);
+
+		assertEquals(expectedCheckpointsPath, fs1back.getCheckpointPath());
+		assertEquals(expectedCheckpointsPath, fs2back.getCheckpointPath());
+		assertEquals(expectedSavepointsPath, fs1back.getSavepointPath());
+		assertEquals(expectedSavepointsPath, fs2back.getSavepointPath());
+		assertEquals(incremental, fs1.isIncrementalCheckpointsEnabled());
+		assertEquals(incremental, fs2.isIncrementalCheckpointsEnabled());
+		checkPaths(fs1.getDbStoragePaths(), localDir1, localDir2);
+		checkPaths(fs2.getDbStoragePaths(), localDir1, localDir2);
+	}
+
+	/**
+	 * Validates taking the application-defined file system state backend and adding with additional
+	 * parameters from the cluster configuration, but giving precedence to application-defined
+	 * parameters over configuration-defined parameters.
+	 */
+	@Test
+	public void testLoadFileSystemStateBackendMixed() throws Exception {
+		final String appCheckpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+
+		final String localDir1 = tmp.newFolder().getAbsolutePath();
+		final String localDir2 = tmp.newFolder().getAbsolutePath();
+		final String localDir3 = tmp.newFolder().getAbsolutePath();
+		final String localDir4 = tmp.newFolder().getAbsolutePath();
+
+		final boolean incremental = !CheckpointingOptions.INCREMENTAL_CHECKPOINTS.defaultValue();
+
+		final Path expectedCheckpointsPath = new Path(appCheckpointDir);
+		final Path expectedSavepointsPath = new Path(savepointDir);
+
+		final RocksDBStateBackend backend = new RocksDBStateBackend(appCheckpointDir, incremental, true);
+		assertTrue(backend.getCheckpointBackend() instanceof FsSegmentStateBackend);
+		backend.setDbStoragePaths(localDir1, localDir2);
+
+		final Configuration config = new Configuration();
+		config.setString(backendKey, "jobmanager"); // this should not be picked up
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir); // this should not be picked up
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, !incremental);  // this should not be picked up
+		config.setString(RocksDBOptions.LOCAL_DIRECTORIES, localDir3 + ":" + localDir4);  // this should not be picked up
+
+		final StateBackend loadedBackend =
+			StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, 1, null);
+		assertTrue(loadedBackend instanceof RocksDBStateBackend);
+
+		final RocksDBStateBackend loadedRocks = (RocksDBStateBackend) loadedBackend;
+
+		assertEquals(incremental, loadedRocks.isIncrementalCheckpointsEnabled());
+		checkPaths(loadedRocks.getDbStoragePaths(), localDir1, localDir2);
+
+		AbstractFileStateBackend fsBackend = (AbstractFileStateBackend) loadedRocks.getCheckpointBackend();
+		assertTrue(fsBackend instanceof FsSegmentStateBackend);
+		assertEquals(expectedCheckpointsPath, fsBackend.getCheckpointPath());
+		assertEquals(expectedSavepointsPath, fsBackend.getSavepointPath());
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static void checkPaths(String[] pathsArray, String... paths) {
+		assertNotNull(pathsArray);
+		assertNotNull(paths);
+
+		assertEquals(pathsArray.length, paths.length);
+
+		HashSet<String> pathsSet = new HashSet<>(Arrays.asList(pathsArray));
+
+		for (String path : paths) {
+			assertTrue(pathsSet.contains(path));
+		}
+	}
+}
+

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -164,7 +164,7 @@ public class RocksDBStateBackendConfigTest {
 			RocksDBOptions.TIMER_SERVICE_FACTORY,
 			RocksDBStateBackend.PriorityQueueStateType.ROCKSDB.toString());
 
-		rocksDbBackend = rocksDbBackend.configure(conf, Thread.currentThread().getContextClassLoader());
+		rocksDbBackend = rocksDbBackend.configure(conf, Thread.currentThread().getContextClassLoader(), 1);
 		keyedBackend = createKeyedStateBackend(rocksDbBackend, env);
 		Assert.assertEquals(
 			RocksDBPriorityQueueSetFactory.class,
@@ -410,7 +410,7 @@ public class RocksDBStateBackendConfigTest {
 		Configuration configuration = new Configuration();
 		configuration.setString(RocksDBOptions.PREDEFINED_OPTIONS, PredefinedOptions.FLASH_SSD_OPTIMIZED.name());
 		rocksDbBackend = new RocksDBStateBackend(checkpointPath);
-		rocksDbBackend = rocksDbBackend.configure(configuration, getClass().getClassLoader());
+		rocksDbBackend = rocksDbBackend.configure(configuration, getClass().getClassLoader(), 1);
 		assertEquals(PredefinedOptions.FLASH_SSD_OPTIMIZED, rocksDbBackend.getPredefinedOptions());
 
 		// verify that predefined options could be set programmatically and override pre-configured one.
@@ -534,7 +534,7 @@ public class RocksDBStateBackendConfigTest {
 		config.setString(RocksDBOptions.OPTIONS_FACTORY.key(), TestOptionsFactory.class.getName());
 		config.setInteger(TestOptionsFactory.BACKGROUND_JOBS_OPTION, 4);
 
-		rocksDbBackend = rocksDbBackend.configure(config, getClass().getClassLoader());
+		rocksDbBackend = rocksDbBackend.configure(config, getClass().getClassLoader(), 1);
 
 		assertTrue(rocksDbBackend.getOptions() instanceof TestOptionsFactory);
 		try (DBOptions dbOptions = rocksDbBackend.getDbOptions()) {
@@ -619,7 +619,7 @@ public class RocksDBStateBackendConfigTest {
 				tempFolder.newFolder().getAbsolutePath(), tempFolder.newFolder().getAbsolutePath() };
 		original.setDbStoragePaths(localDirs);
 
-		RocksDBStateBackend copy = original.configure(new Configuration(), Thread.currentThread().getContextClassLoader());
+		RocksDBStateBackend copy = original.configure(new Configuration(), Thread.currentThread().getContextClassLoader(), 1);
 
 		assertEquals(original.isIncrementalCheckpointsEnabled(), copy.isIncrementalCheckpointsEnabled());
 		assertArrayEquals(original.getDbStoragePaths(), copy.getDbStoragePaths());

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
@@ -92,8 +92,8 @@ public class RocksDBStateBackendFactoryTest {
 		config2.setString(RocksDBOptions.LOCAL_DIRECTORIES, localDirs);
 		config2.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, incremental);
 
-		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
-		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
+		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, 1, null);
+		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, 1, null);
 
 		assertTrue(backend1 instanceof RocksDBStateBackend);
 		assertTrue(backend2 instanceof RocksDBStateBackend);
@@ -146,7 +146,7 @@ public class RocksDBStateBackendFactoryTest {
 		config.setString(RocksDBOptions.LOCAL_DIRECTORIES, localDir3 + ":" + localDir4);  // this should not be picked up
 
 		final StateBackend loadedBackend =
-				StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+				StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, 1, null);
 		assertTrue(loadedBackend instanceof RocksDBStateBackend);
 
 		final RocksDBStateBackend loadedRocks = (RocksDBStateBackend) loadedBackend;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendMigrationTest.java
@@ -56,7 +56,7 @@ public class RocksDBStateBackendMigrationTest extends StateBackendMigrationTestB
 		configuration.setString(
 			RocksDBOptions.TIMER_SERVICE_FACTORY,
 			RocksDBStateBackend.PriorityQueueStateType.ROCKSDB.toString());
-		backend = backend.configure(configuration, Thread.currentThread().getContextClassLoader());
+		backend = backend.configure(configuration, Thread.currentThread().getContextClassLoader(), 1);
 		backend.setDbStoragePath(dbPath);
 		return backend;
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -151,7 +151,7 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 		configuration.setString(
 			RocksDBOptions.TIMER_SERVICE_FACTORY,
 			RocksDBStateBackend.PriorityQueueStateType.ROCKSDB.toString());
-		backend = backend.configure(configuration, Thread.currentThread().getContextClassLoader());
+		backend = backend.configure(configuration, Thread.currentThread().getContextClassLoader(), 1);
 		backend.setDbStoragePath(dbPath);
 		return backend;
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
@@ -65,7 +65,7 @@ public class RocksDBStateUploaderTest extends TestLogger {
 		SpecifiedException expectedException = new SpecifiedException("throw exception while multi thread upload states.");
 
 		CheckpointStreamFactory.CheckpointStateOutputStream outputStream = createFailingCheckpointStateOutputStream(expectedException);
-		CheckpointStreamFactory checkpointStreamFactory = (CheckpointedStateScope scope) -> outputStream;
+		CheckpointStreamFactory checkpointStreamFactory = (long checkpointId, CheckpointedStateScope scope) -> outputStream;
 
 		File file = temporaryFolder.newFile(String.valueOf(UUID.randomUUID()));
 		generateRandomFileContent(file.getPath(), 20);
@@ -73,7 +73,7 @@ public class RocksDBStateUploaderTest extends TestLogger {
 		Map<StateHandleID, Path> filePaths = new HashMap<>(1);
 		filePaths.put(new StateHandleID("mockHandleID"), new Path(file.getPath()));
 		try (RocksDBStateUploader rocksDBStateUploader = new RocksDBStateUploader(5)) {
-			rocksDBStateUploader.uploadFilesToCheckpointFs(filePaths, checkpointStreamFactory, new CloseableRegistry());
+			rocksDBStateUploader.uploadFilesToCheckpointFs(1, filePaths, checkpointStreamFactory, new CloseableRegistry());
 			fail();
 		} catch (Exception e) {
 			assertEquals(expectedException, e);
@@ -106,7 +106,7 @@ public class RocksDBStateUploaderTest extends TestLogger {
 
 		try (RocksDBStateUploader rocksDBStateUploader = new RocksDBStateUploader(5)) {
 			Map<StateHandleID, StreamStateHandle> sstFiles =
-				rocksDBStateUploader.uploadFilesToCheckpointFs(sstFilePaths, checkpointStreamFactory, new CloseableRegistry());
+				rocksDBStateUploader.uploadFilesToCheckpointFs(1, sstFilePaths, checkpointStreamFactory, new CloseableRegistry());
 
 			for (Map.Entry<StateHandleID, Path> entry : sstFilePaths.entrySet()) {
 				assertStateContentEqual(entry.getValue(), sstFiles.get(entry.getKey()).openInputStream());

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
@@ -71,7 +71,7 @@ public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
 		RocksDBStateBackend backend = new RocksDBStateBackend(new FsStateBackend(checkpointPath), enableIncrementalCheckpointing);
 		Configuration config = new Configuration();
 		config.setBoolean(TTL_COMPACT_FILTER_ENABLED, true);
-		backend = backend.configure(config, Thread.currentThread().getContextClassLoader());
+		backend = backend.configure(config, Thread.currentThread().getContextClassLoader(), 1);
 		backend.setDbStoragePath(dbPath);
 		return backend;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -84,6 +84,7 @@ public class StreamConfig implements Serializable {
 
 	private static final String CHECKPOINTING_ENABLED = "checkpointing";
 	private static final String CHECKPOINT_MODE = "checkpointMode";
+	private static final String MAX_CONCURRENT_CHECKPOINTS = "maxConcurrentCheckpoints";
 
 	private static final String STATE_BACKEND = "statebackend";
 	private static final String STATE_PARTITIONER = "statePartitioner";
@@ -98,6 +99,7 @@ public class StreamConfig implements Serializable {
 
 	private static final long DEFAULT_TIMEOUT = 100;
 	private static final CheckpointingMode DEFAULT_CHECKPOINTING_MODE = CheckpointingMode.EXACTLY_ONCE;
+	private static final int DEFAULT_MAX_CONCURRENT_CHECKPOINTS = 1;
 
 
 	// ------------------------------------------------------------------------
@@ -391,6 +393,14 @@ public class StreamConfig implements Serializable {
 		} else {
 			return DEFAULT_CHECKPOINTING_MODE;
 		}
+	}
+
+	public void setMaxConcurrentCheckpoints(int maxConcurrentCheckpoints) {
+		config.setInteger(MAX_CONCURRENT_CHECKPOINTS, maxConcurrentCheckpoints);
+	}
+
+	public int getMaxConcurrentCheckpoints() {
+		return config.getInteger(MAX_CONCURRENT_CHECKPOINTS, DEFAULT_MAX_CONCURRENT_CHECKPOINTS);
 	}
 
 	public void setOutEdgesInOrder(List<StreamEdge> outEdgeList) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -470,6 +470,7 @@ public class StreamingJobGraphGenerator {
 
 		config.setStateBackend(streamGraph.getStateBackend());
 		config.setCheckpointingEnabled(checkpointCfg.isCheckpointingEnabled());
+		config.setMaxConcurrentCheckpoints(checkpointCfg.getMaxConcurrentCheckpoints());
 		if (checkpointCfg.isCheckpointingEnabled()) {
 			config.setCheckpointMode(checkpointCfg.getCheckpointingMode());
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -875,6 +875,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				fromApplication,
 				getEnvironment().getTaskManagerInfo().getConfiguration(),
 				getUserCodeClassLoader(),
+				configuration.getMaxConcurrentCheckpoints(),
 				LOG);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateSnapshotContextSynchronousImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateSnapshotContextSynchronousImplTest.java
@@ -87,7 +87,7 @@ public class StateSnapshotContextSynchronousImplTest extends TestLogger {
 		CheckpointStreamFactory.CheckpointStateOutputStream outputStream2 = mock(CheckpointStreamFactory.CheckpointStateOutputStream.class);
 
 		CheckpointStreamFactory streamFactory = mock(CheckpointStreamFactory.class);
-		when(streamFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)).thenReturn(outputStream1, outputStream2);
+		when(streamFactory.createCheckpointStateOutputStream(checkpointId, CheckpointedStateScope.EXCLUSIVE)).thenReturn(outputStream1, outputStream2);
 
 		InsightCloseableRegistry closableRegistry = new InsightCloseableRegistry();
 
@@ -104,7 +104,7 @@ public class StateSnapshotContextSynchronousImplTest extends TestLogger {
 		context.getRawKeyedOperatorStateOutput();
 		context.getRawOperatorStateOutput();
 
-		verify(streamFactory, times(2)).createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
+		verify(streamFactory, times(2)).createCheckpointStateOutputStream(checkpointId, CheckpointedStateScope.EXCLUSIVE);
 
 		assertEquals(2, closableRegistry.size());
 		assertTrue(closableRegistry.contains(outputStream1));
@@ -128,7 +128,7 @@ public class StateSnapshotContextSynchronousImplTest extends TestLogger {
 		CheckpointStreamFactory.CheckpointStateOutputStream outputStream2 = mock(CheckpointStreamFactory.CheckpointStateOutputStream.class);
 
 		CheckpointStreamFactory streamFactory = mock(CheckpointStreamFactory.class);
-		when(streamFactory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)).thenReturn(outputStream1, outputStream2);
+		when(streamFactory.createCheckpointStateOutputStream(checkpointId, CheckpointedStateScope.EXCLUSIVE)).thenReturn(outputStream1, outputStream2);
 
 		InsightCloseableRegistry closableRegistry = new InsightCloseableRegistry();
 
@@ -145,7 +145,7 @@ public class StateSnapshotContextSynchronousImplTest extends TestLogger {
 		context.getRawKeyedOperatorStateOutput();
 		context.getRawOperatorStateOutput();
 
-		verify(streamFactory, times(2)).createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
+		verify(streamFactory, times(2)).createCheckpointStateOutputStream(checkpointId, CheckpointedStateScope.EXCLUSIVE);
 
 		assertEquals(2, closableRegistry.size());
 		assertTrue(closableRegistry.contains(outputStream1));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1004,7 +1004,7 @@ public class StreamTaskTest extends TestLogger {
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public AbstractStateBackend createFromConfig(Configuration config, ClassLoader classLoader) {
+		public AbstractStateBackend createFromConfig(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
 			return new TestSpyWrapperStateBackend(createInnerBackend(config));
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -314,7 +314,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 		}
 
 		@Override
-		public SyncFailureInducingStateBackend configure(Configuration config, ClassLoader classLoader) {
+		public SyncFailureInducingStateBackend configure(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
 			// retain this instance, no re-configuration!
 			return this;
 		}
@@ -366,7 +366,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 		}
 
 		@Override
-		public AsyncFailureInducingStateBackend configure(Configuration config, ClassLoader classLoader) {
+		public AsyncFailureInducingStateBackend configure(Configuration config, ClassLoader classLoader, int maxConcurrentCheckpoints) {
 			// retain this instance, no re-configuration!
 			return this;
 		}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/HarnessTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/HarnessTestBase.scala
@@ -49,7 +49,7 @@ class HarnessTestBase(mode: StateBackendMode) extends StreamingTestBase {
       case HEAP_BACKEND =>
         val conf = new Configuration()
         conf.setBoolean(CheckpointingOptions.ASYNC_SNAPSHOTS, true)
-        new MemoryStateBackend().configure(conf, classLoader)
+        new MemoryStateBackend().configure(conf, classLoader, 1)
 
       case ROCKSDB_BACKEND =>
         new RocksDBStateBackend("file://" + tempFolder.newFolder().getAbsoluteFile)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -65,12 +65,12 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
         val conf = new Configuration()
         conf.setBoolean(CheckpointingOptions.ASYNC_SNAPSHOTS, true)
         env.setStateBackend(new MemoryStateBackend(
-          "file://" + baseCheckpointPath, null).configure(conf, classLoader))
+          "file://" + baseCheckpointPath, null).configure(conf, classLoader, 1))
       case ROCKSDB_BACKEND =>
         val conf = new Configuration()
         conf.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true)
         env.setStateBackend(new RocksDBStateBackend(
-          "file://" + baseCheckpointPath).configure(conf, classLoader))
+          "file://" + baseCheckpointPath).configure(conf, classLoader, 1))
     }
     this.tEnv = StreamTableEnvironment.create(env)
     FailingCollectionSource.failedBefore = true

--- a/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
@@ -98,7 +98,7 @@ public class PojoSerializerUpgradeTest extends TestLogger {
 		Configuration config = new Configuration();
 		config.setString(CheckpointingOptions.STATE_BACKEND, backendType);
 		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, temporaryFolder.newFolder().toURI().toString());
-		stateBackend = StateBackendLoader.loadStateBackendFromConfig(config, Thread.currentThread().getContextClassLoader(), null);
+		stateBackend = StateBackendLoader.loadStateBackendFromConfig(config, Thread.currentThread().getContextClassLoader(), 1, null);
 	}
 
 	private static final String POJO_NAME = "Pojo";


### PR DESCRIPTION
## What is the purpose of the change

This pr wants to fix the problem of too many small files in RocksDB incremental checkpoint.
- Resue the same underlying file in one checkpoint of one operator, this means we just generate a single file for one checkpoint.
- Do not support to use `ByteStreamStateHandle` in the new feature FSCSOS, will always flush state to file.

This PR  includes 7 commits:
- 924a60c   Add a parameter checkpointId for CheckpointStreamFactory#createCheckpointStateOutputStream, this is a pre-work for the new feature FSCSOS
- a150108   Expose maxConcurrentCheckpoints from StreamConfig, a pre-work for the new feature FSCSOS, used to close the earlier opened underlying file which used in a failed checkpoint.
- a020eed Introduce all the necessary components for the new feature FSCSOS and some necessary tests to verify it.
- 5609d30  Add a new statehandle type in SvaepointV2Serializer, **DO NOT** change the layout, and some tests to verify it
- 969a58d  Expose getSharedState() in IncrementalKeyedStateHandle, this is a pre-work to enable the FSCSOS feature.
- 68fa3be  Enable the new feature FSCSOS — includes  introduce RocksDBSegmentStateBackendFactory, and modify SharedStateRegisty,  StateBackendLoader, RocksDBStateBackend, RocksIncrementalSnapshotStrategy , and so on
- 82127e2  Add some tests to verify the new introduced feature FSCSOS, includes SharedStateRegistryTest, RocksDBSegmentStateBackendFactoryTest and RocksDBStateBackendTest.

## Brief change log

This pr introduces some necessary classes, such as
- FsSegmentCheckpointStorage
- FsCheckpointStreamFactory
- FsSegmentCheckpointStorageLocation
- FsSegmentCheckpointStreamFactory
- FsSegmentStateBackend
- FsSegmentStateHandle
This pr modifies some exist classes to support this feature, such as:
- SharedStateRegistry
- RocksDBStateBackend
and add some tests to verify the correct.

## Verifying this change
This pr introduces some test and modified some exist test to verify the changes.
- SharedStateRegistryTest
- RocksDBStateBackendTest
- FsSegmentCheckpointStorageTest
- FsSegmentCheckpointStorageTest.java
- FsSegmentStateBackendEntropyTest.java
- FsSegmentStateHandleTest.java
- RocksDBSegmentStateBackendFactoryTest.java
- SavepointV2SerializerTest.java


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**JavaDocs**)
