### PR TITLE
[hotfix][akka] Replace deprecated ExtensionKey

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/RemoteAddressExtension.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/RemoteAddressExtension.scala
@@ -18,15 +18,19 @@
 
 package org.apache.flink.runtime.akka
 
-import akka.actor.{Address, ExtensionKey, Extension, ExtendedActorSystem}
+import akka.actor.{Address, ExtendedActorSystem, Extension, ExtensionId}
 
 /** [[akka.actor.ActorSystem]] [[Extension]] used to obtain the [[Address]] on which the
   * given ActorSystem is listening.
   *
-  * @param system
+  * @param system this ActorSystem.
   */
-class RemoteAddressExtensionImplementation(system: ExtendedActorSystem) extends Extension {
+class RemoteAddressExtension(system: ExtendedActorSystem) extends Extension {
   def address: Address = system.provider.getDefaultAddress
 }
 
-object RemoteAddressExtension extends ExtensionKey[RemoteAddressExtensionImplementation]{}
+object RemoteAddressExtension extends ExtensionId[RemoteAddressExtension]{
+  override def createExtension(system: ExtendedActorSystem): RemoteAddressExtension = {
+    new RemoteAddressExtension(system)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

From akka 2.5.0, `ExtensionKey` is deprecated. We can simply replace it with a regular extension.

Besides, rename `RemoteAddressExtensionImplementation` to `RemoteAddressExtension` for simplicity.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

@tillrohrmann @zentol 
