### PR TITLE
[FLINK-12864][python][tests] Improves the Python Table API test cases performance

### DIFF
--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -56,21 +56,21 @@ class CatalogTestBase(PyFlinkTestCase):
         self.assertEqual(cd1.get_properties(), cd2.get_properties())
 
     def check_catalog_table_equals(self, t1, t2):
-        self.assertEquals(t1.get_schema(), t2.get_schema())
-        self.assertEquals(t1.get_properties(), t2.get_properties())
-        self.assertEquals(t1.get_comment(), t2.get_comment())
+        self.assertEqual(t1.get_schema(), t2.get_schema())
+        self.assertEqual(t1.get_properties(), t2.get_properties())
+        self.assertEqual(t1.get_comment(), t2.get_comment())
 
     def check_catalog_view_equals(self, v1, v2):
-        self.assertEquals(v1.get_schema(), v1.get_schema())
-        self.assertEquals(v1.get_properties(), v2.get_properties())
-        self.assertEquals(v1.get_comment(), v2.get_comment())
+        self.assertEqual(v1.get_schema(), v1.get_schema())
+        self.assertEqual(v1.get_properties(), v2.get_properties())
+        self.assertEqual(v1.get_comment(), v2.get_comment())
 
     def check_catalog_function_equals(self, f1, f2):
-        self.assertEquals(f1.get_class_name(), f2.get_class_name())
-        self.assertEquals(f1.get_properties(), f2.get_properties())
+        self.assertEqual(f1.get_class_name(), f2.get_class_name())
+        self.assertEqual(f1.get_properties(), f2.get_properties())
 
     def check_catalog_partition_equals(self, p1, p2):
-        self.assertEquals(p1.get_properties(), p2.get_properties())
+        self.assertEqual(p1.get_properties(), p2.get_properties())
 
     @staticmethod
     def create_db():
@@ -246,14 +246,14 @@ class CatalogTestBase(PyFlinkTestCase):
         dbs = self.catalog.list_databases()
 
         self.check_catalog_database_equals(catalog_db, self.catalog.get_database(self.db1))
-        self.assertEquals(2, len(dbs))
-        self.assertEquals({self.db1, self.catalog.get_default_database()}, set(dbs))
+        self.assertEqual(2, len(dbs))
+        self.assertEqual({self.db1, self.catalog.get_default_database()}, set(dbs))
 
         self.catalog.create_database(self.db1, self.create_another_db(), True)
 
         self.check_catalog_database_equals(catalog_db, self.catalog.get_database(self.db1))
-        self.assertEquals(2, len(dbs))
-        self.assertEquals({self.db1, self.catalog.get_default_database()}, set(dbs))
+        self.assertEqual(2, len(dbs))
+        self.assertEqual({self.db1, self.catalog.get_default_database()}, set(dbs))
 
     def test_get_db_database_not_exist_exception(self):
         with self.assertRaises(DatabaseNotExistException):
@@ -323,12 +323,12 @@ class CatalogTestBase(PyFlinkTestCase):
         table_created = self.catalog.get_table(self.path1)
 
         self.check_catalog_table_equals(table, table_created)
-        self.assertEquals(self.test_comment, table_created.get_description())
+        self.assertEqual(self.test_comment, table_created.get_description())
 
         tables = self.catalog.list_tables(self.db1)
 
-        self.assertEquals(1, len(tables))
-        self.assertEquals(self.path1.get_object_name(), tables[0])
+        self.assertEqual(1, len(tables))
+        self.assertEqual(self.path1.get_object_name(), tables[0])
 
         self.catalog.drop_table(self.path1, False)
 
@@ -340,8 +340,8 @@ class CatalogTestBase(PyFlinkTestCase):
 
         tables = self.catalog.list_tables(self.db1)
 
-        self.assertEquals(1, len(tables))
-        self.assertEquals(self.path1.get_object_name(), tables[0])
+        self.assertEqual(1, len(tables))
+        self.assertEqual(self.path1.get_object_name(), tables[0])
 
     def test_create_table_database_not_exist_exception(self):
         self.assertFalse(self.catalog.database_exists(self.db1))
@@ -408,7 +408,7 @@ class CatalogTestBase(PyFlinkTestCase):
         new_table = self.create_another_table()
         self.catalog.alter_table(self.path1, new_table, False)
 
-        self.assertNotEquals(table, self.catalog.get_table(self.path1))
+        self.assertNotEqual(table, self.catalog.get_table(self.path1))
         self.check_catalog_table_equals(new_table, self.catalog.get_table(self.path1))
 
         self.catalog.drop_table(self.path1, False)
@@ -433,7 +433,7 @@ class CatalogTestBase(PyFlinkTestCase):
         new_view = self.create_another_view()
         self.catalog.alter_table(self.path3, new_view, False)
 
-        self.assertNotEquals(view, self.catalog.get_table(self.path3))
+        self.assertNotEqual(view, self.catalog.get_table(self.path3))
         self.check_catalog_view_equals(new_view, self.catalog.get_table(self.path3))
 
     def test_alter_table_table_not_exist_exception(self):
@@ -484,8 +484,8 @@ class CatalogTestBase(PyFlinkTestCase):
         self.catalog.create_table(self.path3, self.create_table(), False)
         self.catalog.create_table(self.path4, self.create_view(), False)
 
-        self.assertEquals(3, len(self.catalog.list_tables(self.db1)))
-        self.assertEquals(1, len(self.catalog.list_views(self.db1)))
+        self.assertEqual(3, len(self.catalog.list_tables(self.db1)))
+        self.assertEqual(1, len(self.catalog.list_views(self.db1)))
 
     def test_table_exists(self):
         self.catalog.create_database(self.db1, self.create_db(), False)
@@ -572,10 +572,10 @@ class CatalogTestBase(PyFlinkTestCase):
         self.catalog.create_table(self.path1, self.create_view(), False)
         self.catalog.create_table(self.path3, self.create_table(), False)
 
-        self.assertEquals(2, len(self.catalog.list_tables(self.db1)))
-        self.assertEquals({self.path1.get_object_name(), self.path3.get_object_name()},
-                          set(self.catalog.list_tables(self.db1)))
-        self.assertEquals([self.path1.get_object_name()], self.catalog.list_views(self.db1))
+        self.assertEqual(2, len(self.catalog.list_tables(self.db1)))
+        self.assertEqual({self.path1.get_object_name(), self.path3.get_object_name()},
+                         set(self.catalog.list_tables(self.db1)))
+        self.assertEqual([self.path1.get_object_name()], self.catalog.list_views(self.db1))
 
     def test_rename_view(self):
         self.catalog.create_database(self.db1, self.create_db(), False)
@@ -646,7 +646,7 @@ class CatalogTestBase(PyFlinkTestCase):
         func = self.create_function()
         self.catalog.create_function(self.path1, func, False)
 
-        self.assertEquals(self.path1.get_object_name(), self.catalog.list_functions(self.db1)[0])
+        self.assertEqual(self.path1.get_object_name(), self.catalog.list_functions(self.db1)[0])
 
     def test_list_functions_database_not_exist_exception(self):
         with self.assertRaises(DatabaseNotExistException):
@@ -754,7 +754,7 @@ class CatalogTestBase(PyFlinkTestCase):
 
         self.catalog.drop_partition(self.path1, self.create_partition_spec(), False)
 
-        self.assertEquals([], self.catalog.list_partitions(self.path1))
+        self.assertEqual([], self.catalog.list_partitions(self.path1))
 
     def test_drop_partition_table_not_exist(self):
         self.catalog.create_database(self.db1, self.create_db(), False)
@@ -815,7 +815,7 @@ class CatalogTestBase(PyFlinkTestCase):
 
         cp = self.catalog.get_partition(self.path1, self.create_partition_spec())
         self.check_catalog_partition_equals(another, cp)
-        self.assertEquals("v", cp.get_properties().get("k"))
+        self.assertEqual("v", cp.get_properties().get("k"))
 
     def test_alter_partition_table_not_exist(self):
         self.catalog.create_database(self.db1, self.create_db(), False)
@@ -922,9 +922,9 @@ class CatalogTestBase(PyFlinkTestCase):
         self.catalog.create_partition(self.path1, self.create_another_partition_spec(),
                                       self.create_partition(), False)
 
-        self.assertEquals(2,
-                          len(self.catalog.list_partitions(
-                              self.path1, self.create_partition_spec_subset())))
-        self.assertEquals(1,
-                          len(self.catalog.list_partitions(
-                              self.path1, self.create_another_partition_spec_subset())))
+        self.assertEqual(2,
+                         len(self.catalog.list_partitions(
+                             self.path1, self.create_partition_spec_subset())))
+        self.assertEqual(1,
+                         len(self.catalog.list_partitions(
+                             self.path1, self.create_another_partition_spec_subset())))

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -27,7 +27,8 @@ from pyflink.testing.test_case_utils import (PyFlinkTestCase, PyFlinkStreamTable
 
 class FileSystemDescriptorTests(PyFlinkTestCase):
 
-    def test_path(self):
+    @staticmethod
+    def test_path():
         file_system = FileSystem()
 
         file_system = file_system.path("/test.csv")
@@ -41,7 +42,8 @@ class FileSystemDescriptorTests(PyFlinkTestCase):
 
 class KafkaDescriptorTests(PyFlinkTestCase):
 
-    def test_version(self):
+    @staticmethod
+    def test_version():
         kafka = Kafka()
 
         kafka = kafka.version("0.11")
@@ -52,7 +54,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_topic(self):
+    @staticmethod
+    def test_topic():
         kafka = Kafka()
 
         kafka = kafka.topic("topic1")
@@ -63,7 +66,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_properties(self):
+    @staticmethod
+    def test_properties():
         kafka = Kafka()
 
         kafka = kafka.properties({"zookeeper.connect": "localhost:2181",
@@ -78,7 +82,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_property(self):
+    @staticmethod
+    def test_property():
         kafka = Kafka()
 
         kafka = kafka.property("group.id", "testGroup")
@@ -90,7 +95,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_start_from_earliest(self):
+    @staticmethod
+    def test_start_from_earliest():
         kafka = Kafka()
 
         kafka = kafka.start_from_earliest()
@@ -101,7 +107,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_start_from_latest(self):
+    @staticmethod
+    def test_start_from_latest():
         kafka = Kafka()
 
         kafka = kafka.start_from_latest()
@@ -112,7 +119,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_start_from_group_offsets(self):
+    @staticmethod
+    def test_start_from_group_offsets():
         kafka = Kafka()
 
         kafka = kafka.start_from_group_offsets()
@@ -123,7 +131,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_start_from_specific_offsets(self):
+    @staticmethod
+    def test_start_from_specific_offsets():
         kafka = Kafka()
 
         kafka = kafka.start_from_specific_offsets({1: 220, 3: 400})
@@ -138,7 +147,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_start_from_specific_offset(self):
+    @staticmethod
+    def test_start_from_specific_offset():
         kafka = Kafka()
 
         kafka = kafka.start_from_specific_offset(3, 300)
@@ -151,7 +161,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_sink_partitioner_fixed(self):
+    @staticmethod
+    def test_sink_partitioner_fixed():
         kafka = Kafka()
 
         kafka = kafka.sink_partitioner_fixed()
@@ -162,7 +173,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_sink_partitioner_custom(self):
+    @staticmethod
+    def test_sink_partitioner_custom():
         kafka = Kafka()
 
         kafka = kafka.sink_partitioner_custom(
@@ -177,7 +189,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_sink_partitioner_round_robin(self):
+    @staticmethod
+    def test_sink_partitioner_round_robin():
         kafka = Kafka()
 
         kafka = kafka.sink_partitioner_round_robin()
@@ -191,7 +204,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
 
 class ElasticsearchDescriptorTest(PyFlinkTestCase):
 
-    def test_version(self):
+    @staticmethod
+    def test_version():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.version("6")
@@ -202,7 +216,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_host(self):
+    @staticmethod
+    def test_host():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.host("localhost", 9200, "http")
@@ -215,7 +230,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_index(self):
+    @staticmethod
+    def test_index():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.index("MyUsers")
@@ -226,7 +242,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_document_type(self):
+    @staticmethod
+    def test_document_type():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.document_type("user")
@@ -237,7 +254,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_key_delimiter(self):
+    @staticmethod
+    def test_key_delimiter():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.key_delimiter("$")
@@ -248,7 +266,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_key_null_literal(self):
+    @staticmethod
+    def test_key_null_literal():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.key_null_literal("n/a")
@@ -259,7 +278,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_failure_handler_fail(self):
+    @staticmethod
+    def test_failure_handler_fail():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.failure_handler_fail()
@@ -270,7 +290,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_failure_handler_ignore(self):
+    @staticmethod
+    def test_failure_handler_ignore():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.failure_handler_ignore()
@@ -281,7 +302,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_failure_handler_retry_rejected(self):
+    @staticmethod
+    def test_failure_handler_retry_rejected():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.failure_handler_retry_rejected()
@@ -292,7 +314,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_failure_handler_custom(self):
+    @staticmethod
+    def test_failure_handler_custom():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.failure_handler_custom(
@@ -307,7 +330,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_disable_flush_on_checkpoint(self):
+    @staticmethod
+    def test_disable_flush_on_checkpoint():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.disable_flush_on_checkpoint()
@@ -318,7 +342,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_bulk_flush_max_actions(self):
+    @staticmethod
+    def test_bulk_flush_max_actions():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.bulk_flush_max_actions(42)
@@ -329,7 +354,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_bulk_flush_max_size(self):
+    @staticmethod
+    def test_bulk_flush_max_size():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.bulk_flush_max_size("42 mb")
@@ -341,7 +367,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
 
         assert properties == expected
 
-    def test_bulk_flush_interval(self):
+    @staticmethod
+    def test_bulk_flush_interval():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.bulk_flush_interval(2000)
@@ -352,7 +379,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_bulk_flush_backoff_exponential(self):
+    @staticmethod
+    def test_bulk_flush_backoff_exponential():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.bulk_flush_backoff_exponential()
@@ -363,7 +391,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_bulk_flush_backoff_constant(self):
+    @staticmethod
+    def test_bulk_flush_backoff_constant():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.bulk_flush_backoff_constant()
@@ -374,7 +403,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_bulk_flush_backoff_max_retries(self):
+    @staticmethod
+    def test_bulk_flush_backoff_max_retries():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.bulk_flush_backoff_max_retries(3)
@@ -385,7 +415,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_bulk_flush_backoff_delay(self):
+    @staticmethod
+    def test_bulk_flush_backoff_delay():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.bulk_flush_backoff_delay(30000)
@@ -396,7 +427,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_connection_max_retry_timeout(self):
+    @staticmethod
+    def test_connection_max_retry_timeout():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.connection_max_retry_timeout(3000)
@@ -407,7 +439,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_connection_path_prefix(self):
+    @staticmethod
+    def test_connection_path_prefix():
         elasticsearch = Elasticsearch()
 
         elasticsearch = elasticsearch.connection_path_prefix("/v1")
@@ -421,7 +454,8 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
 
 class OldCsvDescriptorTests(PyFlinkTestCase):
 
-    def test_field_delimiter(self):
+    @staticmethod
+    def test_field_delimiter():
         csv = OldCsv()
 
         csv = csv.field_delimiter("|")
@@ -432,7 +466,8 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         assert properties == expected
 
-    def test_line_delimiter(self):
+    @staticmethod
+    def test_line_delimiter():
         csv = OldCsv()
 
         csv = csv.line_delimiter(";")
@@ -444,7 +479,8 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_ignore_parse_errors(self):
+    @staticmethod
+    def test_ignore_parse_errors():
         csv = OldCsv()
 
         csv = csv.ignore_parse_errors()
@@ -455,7 +491,8 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         assert properties == expected
 
-    def test_quote_character(self):
+    @staticmethod
+    def test_quote_character():
         csv = OldCsv()
 
         csv = csv.quote_character("*")
@@ -466,7 +503,8 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         assert properties == expected
 
-    def test_comment_prefix(self):
+    @staticmethod
+    def test_comment_prefix():
         csv = OldCsv()
 
         csv = csv.comment_prefix("#")
@@ -477,7 +515,8 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         assert properties == expected
 
-    def test_ignore_first_line(self):
+    @staticmethod
+    def test_ignore_first_line():
         csv = OldCsv()
 
         csv = csv.ignore_first_line()
@@ -488,7 +527,8 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         assert properties == expected
 
-    def test_field(self):
+    @staticmethod
+    def test_field():
         csv = OldCsv()
 
         csv.field("a", DataTypes.BIGINT())
@@ -506,7 +546,8 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         assert properties == expected
 
-    def test_schema(self):
+    @staticmethod
+    def test_schema():
         csv = OldCsv()
         schema = TableSchema(["a", "b"], [DataTypes.INT(), DataTypes.STRING()])
 
@@ -525,7 +566,8 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
 
 class CsvDescriptorTests(PyFlinkTestCase):
 
-    def test_field_delimiter(self):
+    @staticmethod
+    def test_field_delimiter():
         csv = Csv()
 
         csv = csv.field_delimiter("|")
@@ -536,7 +578,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         assert properties == expected
 
-    def test_line_delimiter(self):
+    @staticmethod
+    def test_line_delimiter():
         csv = Csv()
 
         csv = csv.line_delimiter(";")
@@ -548,7 +591,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_quote_character(self):
+    @staticmethod
+    def test_quote_character():
         csv = Csv()
 
         csv = csv.quote_character("'")
@@ -560,7 +604,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_allow_comments(self):
+    @staticmethod
+    def test_allow_comments():
         csv = Csv()
 
         csv = csv.allow_comments()
@@ -572,7 +617,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_ignore_parse_errors(self):
+    @staticmethod
+    def test_ignore_parse_errors():
         csv = Csv()
 
         csv = csv.ignore_parse_errors()
@@ -584,7 +630,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_array_element_delimiter(self):
+    @staticmethod
+    def test_array_element_delimiter():
         csv = Csv()
 
         csv = csv.array_element_delimiter("/")
@@ -596,7 +643,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_escape_character(self):
+    @staticmethod
+    def test_escape_character():
         csv = Csv()
 
         csv = csv.escape_character("\\")
@@ -608,7 +656,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_null_literal(self):
+    @staticmethod
+    def test_null_literal():
         csv = Csv()
 
         csv = csv.null_literal("null")
@@ -620,7 +669,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_schema(self):
+    @staticmethod
+    def test_schema():
         csv = Csv()
 
         csv = csv.schema(DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
@@ -633,7 +683,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
         properties = csv.to_properties()
         assert properties == expected
 
-    def test_derive_schema(self):
+    @staticmethod
+    def test_derive_schema():
         csv = Csv()
 
         csv = csv.derive_schema()
@@ -648,7 +699,8 @@ class CsvDescriptorTests(PyFlinkTestCase):
 
 class AvroDescriptorTest(PyFlinkTestCase):
 
-    def test_record_class(self):
+    @staticmethod
+    def test_record_class():
         avro = Avro()
 
         avro = avro.record_class("org.apache.flink.formats.avro.generated.Address")
@@ -660,7 +712,8 @@ class AvroDescriptorTest(PyFlinkTestCase):
         properties = avro.to_properties()
         assert properties == expected
 
-    def test_avro_schema(self):
+    @staticmethod
+    def test_avro_schema():
         avro = Avro()
 
         avro = avro.avro_schema('{"type":"record",'
@@ -693,7 +746,8 @@ class AvroDescriptorTest(PyFlinkTestCase):
 
 class JsonDescriptorTests(PyFlinkTestCase):
 
-    def test_fail_on_missing_field_true(self):
+    @staticmethod
+    def test_fail_on_missing_field_true():
         json = Json()
 
         json = json.fail_on_missing_field(True)
@@ -705,7 +759,8 @@ class JsonDescriptorTests(PyFlinkTestCase):
         properties = json.to_properties()
         assert properties == expected
 
-    def test_json_schema(self):
+    @staticmethod
+    def test_json_schema():
         json = Json()
 
         json = json.json_schema("{"
@@ -744,7 +799,8 @@ class JsonDescriptorTests(PyFlinkTestCase):
         properties = json.to_properties()
         assert properties == expected
 
-    def test_schema(self):
+    @staticmethod
+    def test_schema():
         json = Json()
 
         json = json.schema(DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
@@ -757,7 +813,8 @@ class JsonDescriptorTests(PyFlinkTestCase):
         properties = json.to_properties()
         assert properties == expected
 
-    def test_derive_schema(self):
+    @staticmethod
+    def test_derive_schema():
         json = Json()
 
         json = json.derive_schema()
@@ -772,7 +829,8 @@ class JsonDescriptorTests(PyFlinkTestCase):
 
 class RowTimeDescriptorTests(PyFlinkTestCase):
 
-    def test_timestamps_from_field(self):
+    @staticmethod
+    def test_timestamps_from_field():
         rowtime = Rowtime()
 
         rowtime = rowtime.timestamps_from_field("rtime")
@@ -781,7 +839,8 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
         expect = {'rowtime.timestamps.type': 'from-field', 'rowtime.timestamps.from': 'rtime'}
         assert properties == expect
 
-    def test_timestamps_from_source(self):
+    @staticmethod
+    def test_timestamps_from_source():
         rowtime = Rowtime()
 
         rowtime = rowtime.timestamps_from_source()
@@ -790,7 +849,8 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
         expect = {'rowtime.timestamps.type': 'from-source'}
         assert properties == expect
 
-    def test_timestamps_from_extractor(self):
+    @staticmethod
+    def test_timestamps_from_extractor():
         rowtime = Rowtime()
 
         rowtime = rowtime.timestamps_from_extractor(
@@ -807,7 +867,8 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
                   'Y6piFNsGAIAAHhwdAACdHM'}
         assert properties == expect
 
-    def test_watermarks_periodic_ascending(self):
+    @staticmethod
+    def test_watermarks_periodic_ascending():
         rowtime = Rowtime()
 
         rowtime = rowtime.watermarks_periodic_ascending()
@@ -816,7 +877,8 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
         expect = {'rowtime.watermarks.type': 'periodic-ascending'}
         assert properties == expect
 
-    def test_watermarks_periodic_bounded(self):
+    @staticmethod
+    def test_watermarks_periodic_bounded():
         rowtime = Rowtime()
 
         rowtime = rowtime.watermarks_periodic_bounded(1000)
@@ -826,7 +888,8 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
                   'rowtime.watermarks.delay': '1000'}
         assert properties == expect
 
-    def test_watermarks_from_source(self):
+    @staticmethod
+    def test_watermarks_from_source():
         rowtime = Rowtime()
 
         rowtime = rowtime.watermarks_from_source()
@@ -835,7 +898,8 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
         expect = {'rowtime.watermarks.type': 'from-source'}
         assert properties == expect
 
-    def test_watermarks_from_strategy(self):
+    @staticmethod
+    def test_watermarks_from_strategy():
         rowtime = Rowtime()
 
         rowtime = rowtime.watermarks_from_strategy(
@@ -856,7 +920,8 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
 
 class SchemaDescriptorTests(PyFlinkTestCase):
 
-    def test_field(self):
+    @staticmethod
+    def test_field():
         schema = Schema()
 
         schema = schema\
@@ -897,7 +962,8 @@ class SchemaDescriptorTests(PyFlinkTestCase):
                     'schema.10.type': 'BOOLEAN'}
         assert properties == expected
 
-    def test_field_in_string(self):
+    @staticmethod
+    def test_field_in_string():
         schema = Schema()
 
         schema = schema\
@@ -938,7 +1004,8 @@ class SchemaDescriptorTests(PyFlinkTestCase):
                     'schema.10.type': 'BOOLEAN'}
         assert properties == expected
 
-    def test_from_origin_field(self):
+    @staticmethod
+    def test_from_origin_field():
         schema = Schema()
 
         schema = schema\
@@ -956,7 +1023,8 @@ class SchemaDescriptorTests(PyFlinkTestCase):
                     'schema.2.type': 'VARCHAR'}
         assert properties == expected
 
-    def test_proctime(self):
+    @staticmethod
+    def test_proctime():
         schema = Schema()
 
         schema = schema\
@@ -974,7 +1042,8 @@ class SchemaDescriptorTests(PyFlinkTestCase):
                     'schema.2.type': 'VARCHAR'}
         assert properties == expected
 
-    def test_rowtime(self):
+    @staticmethod
+    def test_rowtime():
         schema = Schema()
 
         schema = schema\
@@ -1001,7 +1070,8 @@ class SchemaDescriptorTests(PyFlinkTestCase):
                     'schema.3.type': 'VARCHAR'}
         assert properties == expected
 
-    def test_schema(self):
+    @staticmethod
+    def test_schema():
         schema = Schema()
         table_schema = TableSchema(["a", "b"], [DataTypes.INT(), DataTypes.STRING()])
 
@@ -1045,39 +1115,6 @@ class AbstractTableDescriptorTests(object):
                     'connector.type': 'filesystem',
                     'connector.property-version': '1'}
         assert properties == expected
-
-    def test_register_table_sink(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-        t_env.register_table_source("source", csv_source)
-        # connect sink
-        sink_path = os.path.join(self.tempdir + '/streaming2.csv')
-        if os.path.isfile(sink_path):
-            os.remove(sink_path)
-
-        t_env.connect(FileSystem().path(sink_path))\
-             .with_format(OldCsv()
-                          .field_delimiter(',')
-                          .field("a", DataTypes.INT())
-                          .field("b", DataTypes.STRING())
-                          .field("c", DataTypes.STRING()))\
-             .with_schema(Schema()
-                          .field("a", DataTypes.INT())
-                          .field("b", DataTypes.STRING())
-                          .field("c", DataTypes.STRING()))\
-             .register_table_sink("sink")
-        t_env.scan("source") \
-             .select("a + 1, b, c") \
-             .insert_into("sink")
-        t_env.execute()
-
-        with open(sink_path, 'r') as f:
-            lines = f.read()
-            assert lines == '2,Hi,Hello\n' + "3,Hello,Hello\n"
 
     def test_register_table_source_and_register_table_sink(self):
         source_path = os.path.join(self.tempdir + '/streaming.csv')

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -20,7 +20,6 @@ import os
 from pyflink.table.table_descriptor import (FileSystem, OldCsv, Rowtime, Schema, Kafka,
                                             Elasticsearch, Csv, Avro, Json)
 from pyflink.table.table_schema import TableSchema
-from pyflink.table.table_sink import CsvTableSink
 from pyflink.table.types import DataTypes
 from pyflink.testing.test_case_utils import (PyFlinkTestCase, PyFlinkStreamTableTestCase,
                                              PyFlinkBatchTableTestCase)
@@ -1080,21 +1079,18 @@ class AbstractTableDescriptorTests(object):
             lines = f.read()
             assert lines == '2,Hi,Hello\n' + "3,Hello,Hello\n"
 
-    def test_register_table_source(self):
+    def test_register_table_source_and_register_table_sink(self):
         source_path = os.path.join(self.tempdir + '/streaming.csv')
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
         data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
         self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
         sink_path = os.path.join(self.tempdir + '/streaming2.csv')
         if os.path.isfile(sink_path):
             os.remove(sink_path)
-        t_env.register_table_sink(
-            "sink",
-            field_names, field_types, CsvTableSink(sink_path))
 
-        # connect source
+        t_env = self.t_env
+        # register_table_source
         t_env.connect(FileSystem().path(source_path))\
              .with_format(OldCsv()
                           .field_delimiter(',')
@@ -1106,6 +1102,20 @@ class AbstractTableDescriptorTests(object):
                           .field("b", DataTypes.STRING())
                           .field("c", DataTypes.STRING()))\
              .register_table_source("source")
+
+        # register_table_sink
+        t_env.connect(FileSystem().path(sink_path))\
+             .with_format(OldCsv()
+                          .field_delimiter(',')
+                          .field("a", DataTypes.INT())
+                          .field("b", DataTypes.STRING())
+                          .field("c", DataTypes.STRING()))\
+             .with_schema(Schema()
+                          .field("a", DataTypes.INT())
+                          .field("b", DataTypes.STRING())
+                          .field("c", DataTypes.STRING()))\
+             .register_table_sink("sink")
+
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
@@ -1208,61 +1218,6 @@ class StreamTableDescriptorTests(PyFlinkStreamTableTestCase, AbstractTableDescri
 
 class BatchTableDescriptorTests(PyFlinkBatchTableTestCase, AbstractTableDescriptorTests):
     pass
-
-
-class StreamDescriptorEndToEndTests(PyFlinkStreamTableTestCase):
-
-    def test_end_to_end(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        with open(source_path, 'w') as f:
-            lines = 'a,b,c\n' + \
-                    '1,hi,hello\n' + \
-                    '#comments\n' + \
-                    "error line\n" + \
-                    '2,"hi,world!",hello\n'
-            f.write(lines)
-            f.close()
-        sink_path = os.path.join(self.tempdir + '/streaming2.csv')
-        t_env = self.t_env
-        # connect source
-        t_env.connect(FileSystem().path(source_path))\
-             .with_format(OldCsv()
-                          .field_delimiter(',')
-                          .line_delimiter("\n")
-                          .ignore_parse_errors()
-                          .quote_character('"')
-                          .comment_prefix("#")
-                          .ignore_first_line()
-                          .field("a", "INT")
-                          .field("b", "VARCHAR")
-                          .field("c", "VARCHAR"))\
-             .with_schema(Schema()
-                          .field("a", "INT")
-                          .field("b", "VARCHAR")
-                          .field("c", "VARCHAR"))\
-             .in_append_mode()\
-             .register_table_source("source")
-        # connect sink
-        t_env.connect(FileSystem().path(sink_path))\
-             .with_format(OldCsv()
-                          .field_delimiter(',')
-                          .field("a", DataTypes.INT())
-                          .field("b", DataTypes.STRING())
-                          .field("c", DataTypes.STRING()))\
-             .with_schema(Schema()
-                          .field("a", DataTypes.INT())
-                          .field("b", DataTypes.STRING())
-                          .field("c", DataTypes.STRING()))\
-             .register_table_sink("sink")
-
-        t_env.scan("source") \
-             .select("a + 1, b, c") \
-             .insert_into("sink")
-        t_env.execute()
-
-        with open(sink_path, 'r') as f:
-            lines = f.read()
-            assert lines == '2,hi,hello\n' + '3,hi,world!,hello\n'
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_distinct.py
+++ b/flink-python/pyflink/table/tests/test_distinct.py
@@ -16,30 +16,17 @@
 # limitations under the License.
 ################################################################################
 
-from pyflink.table.types import DataTypes
-from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
 class StreamTableDistinctTests(PyFlinkStreamTableTestCase):
 
     def test_distinct(self):
-        t_env = self.t_env
-        t = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello"), (2, "Hello", "Hello")],
-                                ['a', 'b', 'c'])
-        field_names = ["a", "b"]
-        field_types = [DataTypes.BIGINT(), DataTypes.STRING()]
-        t_env.register_table_sink(
-            "Results",
-            field_names, field_types, source_sink_utils.TestRetractSink())
+        t = self.t_env.from_elements([(1, "Hi", "Hello")], ['a', 'b', 'c'])
+        result = t.distinct()
 
-        result = t.distinct().select("a, c as b")
-        result.insert_into("Results")
-        t_env.execute()
-        actual = source_sink_utils.results()
-
-        expected = ['1,Hello', '2,Hello']
-        self.assert_equals(actual, expected)
+        query_operation = result._j_table.getQueryOperation()
+        self.assertEqual('DistinctQueryOperation', query_operation.getClass().getSimpleName())
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_schema_operation.py
+++ b/flink-python/pyflink/table/tests/test_schema_operation.py
@@ -17,35 +17,18 @@
 ################################################################################
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import DataTypes
-from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
 class StreamTableSchemaTests(PyFlinkStreamTableTestCase):
 
     def test_print_schema(self):
-        t_env = self.t_env
-        t = t_env.from_elements([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hello'), (2, 'Hello', 'Hello')],
-                                ['a', 'b', 'c'])
-        field_names = ["a", "b"]
-        field_types = [DataTypes.BIGINT(), DataTypes.STRING()]
-        t_env.register_table_sink(
-            "Results",
-            field_names, field_types, source_sink_utils.TestRetractSink())
-
+        t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])
         result = t.group_by("c").select("a.sum, c as b")
         result.print_schema()
 
     def test_get_schema(self):
-        t_env = self.t_env
-        t = t_env.from_elements([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hello'), (2, 'Hello', 'Hello')],
-                                ['a', 'b', 'c'])
-        field_names = ["a", "b"]
-        field_types = [DataTypes.BIGINT(), DataTypes.STRING()]
-        t_env.register_table_sink(
-            "Results",
-            field_names, field_types, source_sink_utils.TestRetractSink())
-
+        t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])
         result = t.group_by("c").select("a.sum as a, c as b")
         schema = result.get_schema()
 

--- a/flink-python/pyflink/table/tests/test_sort.py
+++ b/flink-python/pyflink/table/tests/test_sort.py
@@ -22,15 +22,13 @@ from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase
 class BatchTableSortTests(PyFlinkBatchTableTestCase):
 
     def test_order_by_offset_fetch(self):
-        t_env = self.t_env
-        t = t_env.from_elements([(1, "Hello"), (2, "Hello"), (3, "Flink"), (4, "Python")],
-                                ["a", "b"])
+        t = self.t_env.from_elements([(1, "Hello")], ["a", "b"])
+        result = t.order_by("a.desc").offset(2).fetch(2)
 
-        result = t.order_by("a.desc").offset(2).fetch(2).select("a, b")
-        actual = self.collect(result)
-
-        expected = ['2,Hello', '1,Hello']
-        self.assert_equals(actual, expected)
+        query_operation = result._j_table.getQueryOperation()
+        self.assertEqual(2, query_operation.getOffset())
+        self.assertEqual(2, query_operation.getFetch())
+        self.assertEqual('[desc(a)]', query_operation.getOrder().toString())
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -43,7 +43,7 @@ class TableAPICompletenessTests(PythonAPICompletenessTestCase, unittest.TestCase
         # complete type system, which does not exist currently. It will be implemented after
         # FLINK-12408 is merged. So we exclude this method for the time being.
         return {'map', 'flatMap', 'flatAggregate',  'aggregate', 'leftOuterJoinLateral',
-                'createTemporalTableFunction', 'joinLateral', 'getQueryOperation', 'getSchema'}
+                'createTemporalTableFunction', 'joinLateral', 'getQueryOperation'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -57,13 +57,12 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         self.assert_equals(actual, expected)
 
     def test_from_table_source(self):
-        t_env = self.t_env
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
         source_path = os.path.join(self.tempdir + '/streaming.csv')
         csv_source = self.prepare_csv_source(source_path, [], field_types, field_names)
 
-        result = t_env.from_table_source(csv_source)
+        result = self.t_env.from_table_source(csv_source)
         self.assertEqual(
             'TableSource: (fields: [a, b, c])',
             result._j_table.getQueryOperation().asSummaryString())
@@ -154,8 +153,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         self.assert_equals(actual, expected)
 
     def test_query_config(self):
-        t_env = self.t_env
-        query_config = t_env.query_config()
+        query_config = self.t_env.query_config()
 
         query_config.with_idle_state_retention_time(
             datetime.timedelta(days=1), datetime.timedelta(days=2))
@@ -163,7 +161,8 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         assert query_config.get_max_idle_state_retention_time() == 2 * 24 * 3600 * 1000
         assert query_config.get_min_idle_state_retention_time() == 24 * 3600 * 1000
 
-    def test_table_config(self):
+    @staticmethod
+    def test_table_config():
 
         table_config = TableConfig.Builder()\
             .as_streaming_execution()\
@@ -178,7 +177,8 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         assert table_config.timezone() == "Asia/Shanghai"
         assert table_config.is_stream() is True
 
-    def test_create_table_environment(self):
+    @staticmethod
+    def test_create_table_environment():
         table_config = TableConfig.Builder()\
             .set_parallelism(2)\
             .set_max_generated_code_length(32000)\

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -17,36 +17,31 @@
 ################################################################################
 import datetime
 import os
-import tempfile
 
 from py4j.compat import unicode
 from pyflink.table.table_environment import TableEnvironment
 from pyflink.table.table_config import TableConfig
-from pyflink.table.table_sink import CsvTableSink
 from pyflink.table.types import DataTypes, RowType
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase, PyFlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
 class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
 
-    def test_register_scan(self):
+    def test_register_table_source_scan(self):
         t_env = self.t_env
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
-        t_env.register_table_sink(
-            "Results",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+        source_path = os.path.join(self.tempdir + '/streaming.csv')
+        csv_source = self.prepare_csv_source(source_path, [], field_types, field_names)
+        t_env.register_table_source("Source", csv_source)
 
-        t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])\
-            .insert_into("Results")
-        t_env.execute()
-        actual = source_sink_utils.results()
+        result = t_env.scan("Source")
+        self.assertEqual(
+            'CatalogTable: (path: [default_catalog, default_database, Source], fields: [a, b, c])',
+            result._j_table.getQueryOperation().asSummaryString())
 
-        expected = ['1,Hi,Hello', '2,Hello,Hello']
-        self.assert_equals(actual, expected)
-
-    def test_register_table_source_sink(self):
+    def test_register_table_sink(self):
         t_env = self.t_env
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
@@ -65,17 +60,13 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         t_env = self.t_env
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
-        t_env.register_table_sink(
-            "Sinks",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+        source_path = os.path.join(self.tempdir + '/streaming.csv')
+        csv_source = self.prepare_csv_source(source_path, [], field_types, field_names)
 
-        t_env.from_elements([(1, "Hi", "Hello"), (2, "Hi", "Hello")], ["a", "b", "c"])\
-            .insert_into("Sinks")
-        t_env.execute()
-        actual = source_sink_utils.results()
-
-        expected = ['1,Hi,Hello', '2,Hi,Hello']
-        self.assert_equals(actual, expected)
+        result = t_env.from_table_source(csv_source)
+        self.assertEqual(
+            'TableSource: (fields: [a, b, c])',
+            result._j_table.getQueryOperation().asSummaryString())
 
     def test_list_tables(self):
         source_path = os.path.join(self.tempdir + '/streaming.csv')
@@ -111,14 +102,10 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         assert isinstance(actual, str) or isinstance(actual, unicode)
 
     def test_sql_query(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
         t_env = self.t_env
-        t_env.register_table_source("Source", csv_source)
-        source = t_env.scan("Source")
+        source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
         t_env.register_table_sink(
             "sinks",
             field_names, field_types, source_sink_utils.TestAppendSink())
@@ -132,18 +119,15 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         self.assert_equals(actual, expected)
 
     def test_sql_update(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
         t_env = self.t_env
-        t_env.register_table_source("source", csv_source)
+        source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
         t_env.register_table_sink(
             "sinks",
             field_names, field_types, source_sink_utils.TestAppendSink())
 
-        t_env.sql_update("insert into sinks select * from source")
+        t_env.sql_update("insert into sinks select * from %s" % source)
         t_env.execute("test_sql_job")
 
         actual = source_sink_utils.results()
@@ -151,13 +135,10 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         self.assert_equals(actual, expected)
 
     def test_sql_update_with_query_config(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
         t_env = self.t_env
-        t_env.register_table_source("source", csv_source)
+        source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
         t_env.register_table_sink(
             "sinks",
             field_names, field_types, source_sink_utils.TestAppendSink())
@@ -165,7 +146,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         query_config.with_idle_state_retention_time(
             datetime.timedelta(days=1), datetime.timedelta(days=2))
 
-        t_env.sql_update("insert into sinks select * from source", query_config)
+        t_env.sql_update("insert into sinks select * from %s" % source, query_config)
         t_env.execute("test_sql_job")
 
         actual = source_sink_utils.results()
@@ -214,208 +195,3 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         assert readed_table_config.max_generated_code_length() == 32000
         assert readed_table_config.timezone() == "Asia/Shanghai"
         assert readed_table_config.is_stream() is True
-
-
-class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
-
-    def test_register_scan(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-        t_env.register_table_source("Source", csv_source)
-
-        result = t_env.scan("Source")
-        actual = self.collect(result)
-
-        expected = ['1,Hi,Hello', '2,Hello,Hello']
-        self.assert_equals(actual, expected)
-
-    def test_register_table_source_sink(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-        tmp_dir = tempfile.gettempdir()
-        tmp_csv = tmp_dir + '/streaming2.csv'
-        if os.path.isfile(tmp_csv):
-            os.remove(tmp_csv)
-
-        t_env.register_table_source("Orders", csv_source)
-        t_env.register_table_sink(
-            "Results",
-            field_names, field_types, CsvTableSink(tmp_csv))
-        t_env.scan("Orders").insert_into("Results")
-        t_env.execute()
-
-        with open(tmp_csv, 'r') as f:
-            lines = f.read()
-            assert lines == '1,Hi,Hello\n'
-
-    def test_from_table_source(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hi", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-
-        source = t_env.from_table_source(csv_source)
-        actual = self.collect(source)
-
-        expected = ['1,Hi,Hello', '2,Hi,Hello']
-        self.assert_equals(actual, expected)
-
-    def test_list_tables(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = []
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-        t_env.register_table_source("Orders", csv_source)
-        tmp_dir = tempfile.gettempdir()
-        tmp_csv = tmp_dir + '/streaming2.csv'
-        t_env.register_table_sink(
-            "Sinks",
-            field_names, field_types, CsvTableSink(tmp_csv))
-        t_env.register_table_sink(
-            "Results",
-            field_names, field_types, CsvTableSink(tmp_csv))
-
-        actual = t_env.list_tables()
-
-        expected = ['Orders', 'Results', 'Sinks']
-        self.assert_equals(actual, expected)
-
-    def test_explain(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = []
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-        t_env.register_table_source("Source", csv_source)
-        source = t_env.scan("Source")
-        result = source.alias("a, b, c").select("1 + a, b, c")
-
-        actual = t_env.explain(result)
-
-        assert isinstance(actual, str) or isinstance(actual, unicode)
-
-    def test_sql_query(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-        t_env.register_table_source("Source", csv_source)
-        source = t_env.scan("Source")
-        tmp_dir = tempfile.gettempdir()
-        tmp_csv = tmp_dir + '/streaming2.csv'
-        if os.path.isfile(tmp_csv):
-            os.remove(tmp_csv)
-        t_env.register_table_sink(
-            "sinks",
-            field_names, field_types, CsvTableSink(tmp_csv))
-
-        result = t_env.sql_query("select a + 1, b, c from %s" % source)
-        result.insert_into("sinks")
-        t_env.execute()
-
-        with open(tmp_csv, 'r') as f:
-            lines = f.read()
-            assert lines == '2,Hi,Hello\n' + '3,Hello,Hello\n'
-
-    def test_sql_update(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-        t_env.register_table_source("source", csv_source)
-        tmp_dir = tempfile.gettempdir()
-        tmp_csv = tmp_dir + '/streaming2.csv'
-        if os.path.isfile(tmp_csv):
-            os.remove(tmp_csv)
-        t_env.register_table_sink(
-            "sinks",
-            field_names, field_types, CsvTableSink(tmp_csv))
-
-        t_env.sql_update("insert into sinks select * from source")
-        t_env.execute("test_sql_job")
-
-        with open(tmp_csv, 'r') as f:
-            lines = f.read()
-            assert lines == '1,Hi,Hello\n' + '2,Hello,Hello\n'
-
-    def test_sql_update_with_query_config(self):
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        csv_source = self.prepare_csv_source(source_path, data, field_types, field_names)
-        t_env = self.t_env
-        t_env.register_table_source("source", csv_source)
-        tmp_dir = tempfile.gettempdir()
-        tmp_csv = tmp_dir + '/streaming2.csv'
-        if os.path.isfile(tmp_csv):
-            os.remove(tmp_csv)
-        t_env.register_table_sink(
-            "sinks",
-            field_names, field_types, CsvTableSink(tmp_csv))
-        query_config = t_env.query_config()
-
-        t_env.sql_update("insert into sinks select * from source", query_config)
-        t_env.execute("test_sql_job")
-
-        with open(tmp_csv, 'r') as f:
-            lines = f.read()
-            assert lines == '1,Hi,Hello\n' + '2,Hello,Hello\n'
-
-    def test_table_config(self):
-
-        table_config = TableConfig.Builder()\
-            .as_batch_execution()\
-            .set_timezone("Asia/Shanghai")\
-            .set_max_generated_code_length(64000)\
-            .set_built_in_catalog_name("test_catalog") \
-            .set_built_in_database_name("test_database") \
-            .set_null_check(True)\
-            .set_parallelism(4).build()
-
-        assert table_config.parallelism() == 4
-        assert table_config.null_check() is True
-        assert table_config.max_generated_code_length() == 64000
-        assert table_config.timezone() == "Asia/Shanghai"
-        assert table_config.is_stream() is False
-        assert table_config.get_built_in_catalog_name() == "test_catalog"
-        assert table_config.get_built_in_database_name() == "test_database"
-
-    def test_create_table_environment(self):
-        table_config = TableConfig.Builder()\
-            .set_parallelism(2)\
-            .set_max_generated_code_length(32000)\
-            .set_null_check(False)\
-            .set_timezone("Asia/Shanghai") \
-            .set_built_in_catalog_name("test_catalog") \
-            .set_built_in_database_name("test_database") \
-            .as_batch_execution()\
-            .build()
-
-        t_env = TableEnvironment.create(table_config)
-
-        readed_table_config = t_env.get_config()
-        assert readed_table_config.parallelism() == 2
-        assert readed_table_config.null_check() is False
-        assert readed_table_config.max_generated_code_length() == 32000
-        assert readed_table_config.timezone() == "Asia/Shanghai"
-        assert readed_table_config.is_stream() is False
-        assert readed_table_config.get_built_in_catalog_name() == "test_catalog"
-        assert readed_table_config.get_built_in_database_name() == "test_database"

--- a/flink-python/pyflink/table/tests/test_table_schema.py
+++ b/flink-python/pyflink/table/tests/test_table_schema.py
@@ -22,7 +22,8 @@ from pyflink.testing.test_case_utils import PyFlinkTestCase
 
 class TableSchemaTests(PyFlinkTestCase):
 
-    def test_init(self):
+    @staticmethod
+    def test_init():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
@@ -32,7 +33,8 @@ class TableSchemaTests(PyFlinkTestCase):
                                                  DataTypes.BIGINT(),
                                                  DataTypes.STRING()]
 
-    def test_copy(self):
+    @staticmethod
+    def test_copy():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
@@ -42,7 +44,8 @@ class TableSchemaTests(PyFlinkTestCase):
         copied_schema._j_table_schema = None
         assert schema != copied_schema
 
-    def test_get_field_data_types(self):
+    @staticmethod
+    def test_get_field_data_types():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
@@ -66,7 +69,8 @@ class TableSchemaTests(PyFlinkTestCase):
         assert type_by_name_not_exist is None
         assert type_by_index_not_exist is None
 
-    def test_get_field_count(self):
+    @staticmethod
+    def test_get_field_count():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
@@ -74,7 +78,8 @@ class TableSchemaTests(PyFlinkTestCase):
 
         assert count == 3
 
-    def test_get_field_names(self):
+    @staticmethod
+    def test_get_field_names():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
@@ -82,7 +87,8 @@ class TableSchemaTests(PyFlinkTestCase):
 
         assert names == ["a", "b", "c"]
 
-    def test_get_field_name(self):
+    @staticmethod
+    def test_get_field_name():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
@@ -92,7 +98,8 @@ class TableSchemaTests(PyFlinkTestCase):
         assert field_name == "c"
         assert field_name_not_exist is None
 
-    def test_to_row_data_type(self):
+    @staticmethod
+    def test_to_row_data_type():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
@@ -103,7 +110,8 @@ class TableSchemaTests(PyFlinkTestCase):
                                   DataTypes.FIELD("c", DataTypes.STRING())])
         assert row_type == expected
 
-    def test_hash(self):
+    @staticmethod
+    def test_hash():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
         schema2 = TableSchema(["a", "b", "c"],
@@ -111,19 +119,22 @@ class TableSchemaTests(PyFlinkTestCase):
 
         assert hash(schema) == hash(schema2)
 
-    def test_str(self):
+    @staticmethod
+    def test_str():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         assert str(schema) == "root\n |-- a: INT\n |-- b: BIGINT\n |-- c: STRING\n"
 
-    def test_repr(self):
+    @staticmethod
+    def test_repr():
         schema = TableSchema(["a", "b", "c"],
                              [DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()])
 
         assert repr(schema) == "root\n |-- a: INT\n |-- b: BIGINT\n |-- c: STRING\n"
 
-    def test_builder(self):
+    @staticmethod
+    def test_builder():
         schema_builder = TableSchema.builder()
 
         schema = schema_builder \

--- a/flink-python/pyflink/table/tests/test_window.py
+++ b/flink-python/pyflink/table/tests/test_window.py
@@ -20,20 +20,19 @@ from py4j.protocol import Py4JJavaError
 
 from pyflink.table.window import Session, Slide, Tumble
 from pyflink.table import Over
-from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, PyFlinkBatchTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase, PyFlinkStreamTableTestCase
 
 
 class StreamTableWindowTests(PyFlinkStreamTableTestCase):
 
     def test_over_window(self):
         t_env = self.t_env
-        data = [(1, 1, "Hello"), (2, 2, "Hello"), (3, 4, "Hello"), (4, 8, "Hello")]
-        t = t_env.from_elements(data, ['a', 'b', 'c'])
+        t = t_env.from_elements([(1, 1, "Hello")], ['a', 'b', 'c'])
 
         result = t.over_window(Over.partition_by("c").order_by("a")
                                .preceding("2.rows").following("current_row").alias("w"))
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             Py4JJavaError, "Ordering must be defined on a time attribute",
             result.select, "b.sum over w")
 
@@ -41,39 +40,34 @@ class StreamTableWindowTests(PyFlinkStreamTableTestCase):
 class BatchTableWindowTests(PyFlinkBatchTableTestCase):
 
     def test_tumble_window(self):
-        t = self.t_env.from_elements(
-            [(1, 1, "Hello"), (2, 2, "Hello"), (3, 4, "Hello"), (4, 8, "Hello")],
-            ["a", "b", "c"])
+        t = self.t_env.from_elements([(1, 1, "Hello")], ["a", "b", "c"])
         result = t.window(Tumble.over("2.rows").on("a").alias("w"))\
             .group_by("w, c").select("b.sum")
-        actual = self.collect(result)
 
-        expected = ['3', '12']
-        self.assert_equals(actual, expected)
+        query_operation = result._j_table.getQueryOperation().getChildren().get(0)
+        self.assertEqual('[c]', query_operation.getGroupingExpressions().toString())
+        self.assertEqual('TumbleWindow(field: [a], size: [2])',
+                         query_operation.getGroupWindow().asSummaryString())
 
     def test_slide_window(self):
-        t = self.t_env.from_elements(
-            [(1000, 1, "Hello"), (2000, 2, "Hello"), (3000, 4, "Hello"), (4000, 8, "Hello")],
-            ["a", "b", "c"])
-
+        t = self.t_env.from_elements([(1000, 1, "Hello")], ["a", "b", "c"])
         result = t.window(Slide.over("2.seconds").every("1.seconds").on("a").alias("w"))\
             .group_by("w, c").select("b.sum")
-        actual = self.collect(result)
 
-        expected = ['1', '3', '6', '12', '8']
-        self.assert_equals(actual, expected)
+        query_operation = result._j_table.getQueryOperation().getChildren().get(0)
+        self.assertEqual('[c]', query_operation.getGroupingExpressions().toString())
+        self.assertEqual('SlideWindow(field: [a], slide: [1000], size: [2000])',
+                         query_operation.getGroupWindow().asSummaryString())
 
     def test_session_window(self):
-        t = self.t_env.from_elements(
-            [(1000, 1, "Hello"), (2000, 2, "Hello"), (4000, 4, "Hello"), (5000, 8, "Hello")],
-            ["a", "b", "c"])
-
+        t = self.t_env.from_elements([(1000, 1, "Hello")], ["a", "b", "c"])
         result = t.window(Session.with_gap("1.seconds").on("a").alias("w"))\
             .group_by("w, c").select("b.sum")
-        actual = self.collect(result)
 
-        expected = ['3', '12']
-        self.assert_equals(actual, expected)
+        query_operation = result._j_table.getQueryOperation().getChildren().get(0)
+        self.assertEqual('[c]', query_operation.getGroupingExpressions().toString())
+        self.assertEqual('SessionWindow(field: [a], gap: [1000])',
+                         query_operation.getGroupWindow().asSummaryString())
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -33,6 +33,9 @@ from pyflink.java_gateway import get_gateway
 
 if sys.version_info[0] >= 3:
     xrange = range
+else:
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+    unittest.TestCase.assertRegex = unittest.TestCase.assertRegexpMatches
 
 if os.getenv("VERBOSE"):
     log_level = logging.DEBUG


### PR DESCRIPTION
## What is the purpose of the change

*Most of the Python Table API test cases can be unit test instead of integration test. This can shorten the test time of Python Table API. This pull request tries to improve this.*


## Brief change log

  - *Convert most of the ITCase to unit test cases*

## Verifying this change

This change is a test case improve work and can be covered by the improved tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
