### PR TITLE
[FLINK-12867] Add insert overwrite grammar as HIVE dialect

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -27,6 +27,7 @@
     "org.apache.flink.sql.parser.ddl.SqlCreateTable.TableCreationContext",
     "org.apache.flink.sql.parser.ddl.SqlTableColumn",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
+    "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.type.SqlArrayType",
     "org.apache.flink.sql.parser.type.SqlMapType",
     "org.apache.flink.sql.parser.type.SqlRowType",
@@ -50,6 +51,7 @@
     "FROM_SOURCE",
     "BOUNDED",
     "DELAY",
+    "OVERWRITE",
     "JSON_PRETTY",
     "JSON_TYPE",
     "JSON_DEPTH"
@@ -371,7 +373,8 @@
     "ASCENDING",
     "FROM_SOURCE",
     "BOUNDED",
-    "DELAY"
+    "DELAY",
+    "OVERWRITE"
   ]
 
   # List of methods for parsing custom SQL statements.

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.SqlProperty;
 import org.apache.flink.sql.parser.error.SqlParseException;
 
 import org.apache.calcite.sql.SqlInsert;
+import org.apache.calcite.sql.SqlInsertKeyword;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
@@ -30,18 +31,23 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 
 /** A {@link SqlInsert} that have some extension functions like partition, overwrite. **/
 public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 	private final SqlNodeList staticPartitions;
 
+	private final SqlNodeList extendedKeywords;
+
 	public RichSqlInsert(SqlParserPos pos,
 			SqlNodeList keywords,
+			SqlNodeList extendedKeywords,
 			SqlNode targetTable,
 			SqlNode source,
 			SqlNodeList columnList,
 			SqlNodeList staticPartitions) {
 		super(pos, keywords, targetTable, source, columnList);
+		this.extendedKeywords = extendedKeywords;
 		this.staticPartitions = staticPartitions;
 	}
 
@@ -77,7 +83,13 @@ public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 
 	@Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
 		writer.startList(SqlWriter.FrameTypeEnum.SELECT);
-		writer.sep(isUpsert() ? "UPSERT INTO" : "INSERT INTO");
+		String insertKeyword = "INSERT INTO";
+		if (isUpsert()) {
+			insertKeyword = "UPSERT INTO";
+		} else if (isOverwrite()) {
+			insertKeyword = "INSERT OVERWRITE";
+		}
+		writer.sep(insertKeyword);
 		final int opLeft = getOperator().getLeftPrec();
 		final int opRight = getOperator().getRightPrec();
 		getTargetTable().unparse(writer, opLeft, opRight);
@@ -91,6 +103,39 @@ public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 			writer.newlineAndIndent();
 		}
 		getSource().unparse(writer, 0, 0);
+	}
+
+	//~ Tools ------------------------------------------------------------------
+
+	public static boolean isUpsert(List<SqlLiteral> keywords) {
+		for (SqlNode keyword : keywords) {
+			SqlInsertKeyword keyword2 =
+				((SqlLiteral) keyword).symbolValue(SqlInsertKeyword.class);
+			if (keyword2 == SqlInsertKeyword.UPSERT) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns whether the insert mode is overwrite (for whole table or for specific partitions).
+	 *
+	 * @return true if this is overwrite mode
+	 */
+	public boolean isOverwrite() {
+		return getModifierNode(RichSqlInsertKeyword.OVERWRITE) != null;
+	}
+
+	private SqlNode getModifierNode(RichSqlInsertKeyword modifier) {
+		for (SqlNode keyword : extendedKeywords) {
+			RichSqlInsertKeyword keyword2 =
+				((SqlLiteral) keyword).symbolValue(RichSqlInsertKeyword.class);
+			if (keyword2 == modifier) {
+				return keyword;
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsertKeyword.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsertKeyword.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dml;
+
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Defines the keywords that can occur immediately after the "INSERT" keyword.
+ *
+ * <p>Standard SQL has no such keywords, but extension projects may define them.
+ *
+ * <p>This class is almost an extension of {@link org.apache.calcite.sql.SqlInsertKeyword}.
+ */
+public enum RichSqlInsertKeyword {
+	OVERWRITE;
+
+	/**
+	 * Creates a parse-tree node representing an occurrence of this keyword
+	 * at a particular position in the parsed text.
+	 */
+	public SqlLiteral symbol(SqlParserPos pos) {
+		return SqlLiteral.createSymbol(this, pos);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
@@ -156,4 +156,15 @@ public enum FlinkSqlConformance implements SqlConformance {
 		}
 		return false;
 	}
+
+	/**
+	 * Whether to allow "insert overwrite tbl1 partition(col1=val1)" grammar.
+	 */
+	public boolean allowInsertOverwrite() {
+		switch (this) {
+			case HIVE:
+				return true;
+		}
+		return false;
+	}
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -559,6 +559,30 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				+ "\t\t\t\t+ \"equal number of source items \\\\(2\\\\)\""));
 	}
 
+	@Test
+	public void testInsertOverwrite() {
+		conformance0 = FlinkSqlConformance.HIVE;
+		// non-partitioned
+		check("INSERT OVERWRITE myDB.myTbl SELECT * FROM src",
+			"INSERT OVERWRITE `MYDB`.`MYTBL`\n"
+				+ "(SELECT *\n"
+				+ "FROM `SRC`)");
+
+		// partitioned
+		check("INSERT OVERWRITE myTbl PARTITION (p1='v1',p2='v2') SELECT * FROM src",
+			"INSERT OVERWRITE `MYTBL`\n"
+				+ "PARTITION (`P1` = 'v1', `P2` = 'v2')\n"
+				+ "(SELECT *\n"
+				+ "FROM `SRC`)");
+	}
+
+	@Test
+	public void testInvalidUpsertOverwrite() {
+		conformance0 = FlinkSqlConformance.HIVE;
+		checkFails("UPSERT OVERWRITE myDB.myTbl SELECT * FROM src",
+			"OVERWRITE expression is only used with INSERT mode");
+	}
+
 	/** Matcher that invokes the #validate() of the produced SqlNode. **/
 	private static class ValidationMatcher extends BaseMatcher<SqlNode> {
 		private String expectedColumnSql;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/PreValidateReWriter.scala
@@ -39,7 +39,7 @@ import java.util
 
 import scala.collection.JavaConversions._
 
-/** Implements [[org.apache.calcite.sql.util.SqlShuttle]]
+/** Implements [[org.apache.calcite.sql.util.SqlVisitor]]
   * interface to do some rewrite work before sql node validation. */
 class PreValidateReWriter(
     val catalogReader: CatalogReader,


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add a new grammar insert overwrite as HIVE dialect, this overwrite can take the whole table or specific partition as effective scope, that means use can overwrite the whole table or a single partition.*


## Brief change log

  - Add new `OVERWRITE` keyword to insert sql statement


## Verifying this change

See test cases in FlinkSqlParserImplTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? no
