### PR TITLE
[FLINK-12868][yarn] Fix yarn cluster can not be deployed if plugins dir does not exist

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
@@ -22,6 +22,9 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -31,6 +34,8 @@ import java.util.Optional;
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class PluginConfig {
+	private static final Logger LOG = LoggerFactory.getLogger(PluginConfig.class);
+
 	private final Optional<Path> pluginsPath;
 
 	private final String[] alwaysParentFirstPatterns;
@@ -57,10 +62,14 @@ public class PluginConfig {
 	private static Optional<Path> getPluginsDirPath(Configuration configuration) {
 		String pluginsDir = configuration.getString(ConfigConstants.ENV_FLINK_PLUGINS_DIR, null);
 		if (pluginsDir == null) {
+			LOG.info("Environment variable [{}] is not set", ConfigConstants.ENV_FLINK_PLUGINS_DIR);
 			return Optional.empty();
 		}
 		File pluginsDirFile = new File(pluginsDir);
 		if (!pluginsDirFile.isDirectory()) {
+			LOG.warn("Environment variable [{}] is set to [{}] but the directory doesn't exist",
+				ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+				pluginsDir);
 			return Optional.empty();
 		}
 		return Optional.of(pluginsDirFile.toPath());

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -85,7 +85,14 @@ under the License.
 			<outputDirectory>bin</outputDirectory>
 			<fileMode>0755</fileMode>
 		</fileSet>
-		
+
+		<!-- copy plugins directory -->
+		<fileSet>
+			<directory>src/main/flink-bin/plugins</directory>
+			<outputDirectory>plugins</outputDirectory>
+			<fileMode>0755</fileMode>
+		</fileSet>
+
 		<!-- flink scala shell-->
 		<fileSet>
 			<directory>../flink-scala-shell/start-script/</directory>

--- a/flink-dist/src/main/flink-bin/plugins/README.txt
+++ b/flink-dist/src/main/flink-bin/plugins/README.txt
@@ -1,0 +1,18 @@
+The expected structure is as follows: the given plugins root folder,
+containing the plugins folder. One plugin folder contains all
+resources (jar files) belonging to a plugin. The name of the plugin
+folder becomes the plugin id. For example:
+
+plugins/ (root folder)
+    |------------plugin-a/ (folder of plugin a)
+    |                |-plugin-a-1.jar
+    |                |-plugin-a-2.jar
+    |                |-...
+    |                |-(the jars containing the classes of plugin a)
+    |
+    |------------plugin-b/
+    |                |-plugin-b-1.jar
+    |                |-...
+    ...
+
+Read more in the documentation about how to create a plugin.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
@@ -75,7 +75,12 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		addPathRecursively(flinkBinPath, TARGET_ROOT, container);
 		addPathRecursively(flinkConfPath, TARGET_ROOT, container);
 		addPathRecursively(flinkLibPath, TARGET_ROOT, container);
-		addPathRecursively(flinkPluginsPath, TARGET_ROOT, container);
+		if (flinkPluginsPath.isDirectory()) {
+			addPathRecursively(flinkPluginsPath, TARGET_ROOT, container);
+		}
+		else {
+			LOG.warn("The plugins directory '" + flinkPluginsPath + "' doesn't exist.");
+		}
 	}
 
 	public static Builder newBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
@@ -22,23 +22,24 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_BIN_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_CONF_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
-
+import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
 import static org.apache.flink.runtime.clusterframework.overlays.FlinkDistributionOverlay.TARGET_ROOT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 
@@ -47,7 +48,6 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 
 	@Test
 	public void testConfigure() throws Exception {
-
 		File binFolder = tempFolder.newFolder("bin");
 		File libFolder = tempFolder.newFolder("lib");
 		File pluginsFolder = tempFolder.newFolder("plugins");
@@ -65,6 +65,34 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 			"plugins/P1/plugin1b.jar",
 			"plugins/P2/plugin2.jar");
 
+		testConfigure(binFolder, libFolder, pluginsFolder, confFolder, files);
+	}
+
+	@Test
+	public void testConfigureWithMissingPlugins() throws Exception {
+		File binFolder = tempFolder.newFolder("bin");
+		File libFolder = tempFolder.newFolder("lib");
+		File pluginsFolder = Paths.get(tempFolder.getRoot().getAbsolutePath(), "s0m3_p4th_th4t_sh0uld_n0t_3x1sts").toFile();
+		File confFolder = tempFolder.newFolder("conf");
+
+		Path[] files = createPaths(
+			tempFolder.getRoot(),
+			"bin/config.sh",
+			"bin/taskmanager.sh",
+			"lib/foo.jar",
+			"lib/A/foo.jar",
+			"lib/B/foo.jar",
+			"lib/B/bar.jar");
+
+		testConfigure(binFolder, libFolder, pluginsFolder, confFolder, files);
+	}
+
+	private void testConfigure(
+			File binFolder,
+			File libFolder,
+			File pluginsFolder,
+			File confFolder,
+			Path[] files) throws IOException {
 		ContainerSpecification containerSpecification = new ContainerSpecification();
 		FlinkDistributionOverlay overlay = new FlinkDistributionOverlay(
 			binFolder,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -1515,30 +1515,39 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	}
 
 	protected void addEnvironmentFoldersToShipFiles(Collection<File> effectiveShipFiles) {
+		addLibFoldersToShipFiles(effectiveShipFiles);
+		addPluginsFoldersToShipFiles(effectiveShipFiles);
+	}
+
+	private void addLibFoldersToShipFiles(Collection<File> effectiveShipFiles) {
 		// Add lib folder to the ship files if the environment variable is set.
 		// This is for convenience when running from the command-line.
 		// (for other files users explicitly set the ship files)
 		String libDir = System.getenv().get(ENV_FLINK_LIB_DIR);
 		if (libDir != null) {
-			addEnvFolderToShipFiles(effectiveShipFiles, libDir, ENV_FLINK_LIB_DIR);
+			File directoryFile = new File(libDir);
+			if (directoryFile.isDirectory()) {
+				effectiveShipFiles.add(directoryFile);
+			} else {
+				throw new YarnDeploymentException("The environment variable '" + ENV_FLINK_LIB_DIR +
+					"' is set to '" + libDir + "' but the directory doesn't exist.");
+			}
 		} else if (this.shipFiles.isEmpty()) {
 			LOG.warn("Environment variable '{}' not set and ship files have not been provided manually. " +
 				"Not shipping any library files.", ENV_FLINK_LIB_DIR);
 		}
-
-		String pluginsDir = System.getenv().get(ENV_FLINK_PLUGINS_DIR);
-		if (pluginsDir != null) {
-			addEnvFolderToShipFiles(effectiveShipFiles, pluginsDir, ENV_FLINK_PLUGINS_DIR);
-		}
 	}
 
-	private void addEnvFolderToShipFiles(Collection<File> effectiveShipFiles, String directory, String environmentVariableName) {
-		File directoryFile = new File(directory);
-		if (directoryFile.isDirectory()) {
-			effectiveShipFiles.add(directoryFile);
-		} else {
-			throw new YarnDeploymentException("The environment variable '" + environmentVariableName +
-				"' is set to '" + directory + "' but the directory doesn't exist.");
+	private void addPluginsFoldersToShipFiles(Collection<File> effectiveShipFiles) {
+		String pluginsDir = System.getenv().get(ENV_FLINK_PLUGINS_DIR);
+		if (pluginsDir != null) {
+			File directoryFile = new File(pluginsDir);
+			if (directoryFile.isDirectory()) {
+				effectiveShipFiles.add(directoryFile);
+			} else {
+				LOG.warn("The environment variable '" + ENV_FLINK_PLUGINS_DIR +
+					"' is set to '" + pluginsDir + "' but the directory doesn't exist.");
+			}
 		}
 	}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -45,6 +45,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -482,6 +483,27 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			Assert.assertTrue(effectiveShipFiles.contains(libFolder));
 			Assert.assertFalse(descriptor.shipFiles.contains(libFile));
 			Assert.assertFalse(descriptor.shipFiles.contains(libFolder));
+		}
+	}
+
+	@Test
+	public void testEnvironmentEmptyPluginsShipping() throws Exception {
+		try (YarnClusterDescriptor descriptor = createYarnClusterDescriptor()) {
+			File pluginsFolder = Paths.get(temporaryFolder.getRoot().getAbsolutePath(), "s0m3_p4th_th4t_sh0uld_n0t_3x1sts").toFile();
+			Set<File> effectiveShipFiles = new HashSet<>();
+
+			final Map<String, String> oldEnv = System.getenv();
+			try {
+				Map<String, String> env = new HashMap<>(1);
+				env.put(ConfigConstants.ENV_FLINK_PLUGINS_DIR, pluginsFolder.getAbsolutePath());
+				CommonTestUtils.setEnv(env);
+				// only execute part of the deployment to test for shipped files
+				descriptor.addEnvironmentFoldersToShipFiles(effectiveShipFiles);
+			} finally {
+				CommonTestUtils.setEnv(oldEnv);
+			}
+
+			assertTrue(effectiveShipFiles.isEmpty());
 		}
 	}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -100,12 +100,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		configuration.setString(YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR, "DISABLED");
 
 		try {
-			new YarnClusterDescriptor(
-				configuration,
-				yarnConfiguration,
-				temporaryFolder.getRoot().getAbsolutePath(),
-				yarnClient,
-				true);
+			createYarnClusterDescriptor(configuration);
 			fail("Expected exception not thrown");
 		} catch (final IllegalArgumentException e) {
 			assertThat(e.getMessage(), containsString("cannot be set to DISABLED anymore"));
@@ -117,12 +112,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		final Configuration flinkConfiguration = new Configuration();
 		flinkConfiguration.setInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN, 0);
 
-		YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor(
-			flinkConfiguration,
-			yarnConfiguration,
-			temporaryFolder.getRoot().getAbsolutePath(),
-			yarnClient,
-			true);
+		YarnClusterDescriptor clusterDescriptor = createYarnClusterDescriptor(flinkConfiguration);
 
 		clusterDescriptor.setLocalJarPath(new Path(flinkJar.getPath()));
 
@@ -154,12 +144,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		configuration.setInteger(YarnConfigOptions.VCORES, Integer.MAX_VALUE);
 		configuration.setInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN, 0);
 
-		YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor(
-			configuration,
-			yarnConfiguration,
-			temporaryFolder.getRoot().getAbsolutePath(),
-			yarnClient,
-			true);
+		YarnClusterDescriptor clusterDescriptor = createYarnClusterDescriptor(configuration);
 
 		clusterDescriptor.setLocalJarPath(new Path(flinkJar.getPath()));
 
@@ -188,12 +173,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	@Test
 	public void testSetupApplicationMasterContainer() {
 		Configuration cfg = new Configuration();
-		YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor(
-			cfg,
-			yarnConfiguration,
-			temporaryFolder.getRoot().getAbsolutePath(),
-			yarnClient,
-			true);
+		YarnClusterDescriptor clusterDescriptor = createYarnClusterDescriptor(cfg);
 
 		final String java = "$JAVA_HOME/bin/java";
 		final String jvmmem = "-Xms424m -Xmx424m";
@@ -439,12 +419,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	 */
 	@Test
 	public void testExplicitFileShipping() throws Exception {
-		try (YarnClusterDescriptor descriptor = new YarnClusterDescriptor(
-			new Configuration(),
-			yarnConfiguration,
-			temporaryFolder.getRoot().getAbsolutePath(),
-			yarnClient,
-			true)) {
+		try (YarnClusterDescriptor descriptor = createYarnClusterDescriptor()) {
 			descriptor.setLocalJarPath(new Path("/path/to/flink.jar"));
 
 			File libFile = temporaryFolder.newFile("libFile.jar");
@@ -484,12 +459,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	}
 
 	public void testEnvironmentDirectoryShipping(String environmentVariable) throws Exception {
-		try (YarnClusterDescriptor descriptor = new YarnClusterDescriptor(
-			new Configuration(),
-			yarnConfiguration,
-			temporaryFolder.getRoot().getAbsolutePath(),
-			yarnClient,
-			true)) {
+		try (YarnClusterDescriptor descriptor = createYarnClusterDescriptor()) {
 			File libFolder = temporaryFolder.newFolder().getAbsoluteFile();
 			File libFile = new File(libFolder, "libFile.jar");
 			libFile.createNewFile();
@@ -520,12 +490,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	 */
 	@Test
 	public void testYarnClientShutDown() {
-		YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
-			new Configuration(),
-			yarnConfiguration,
-			temporaryFolder.getRoot().getAbsolutePath(),
-			yarnClient,
-			true);
+		YarnClusterDescriptor yarnClusterDescriptor = createYarnClusterDescriptor();
 
 		yarnClusterDescriptor.close();
 
@@ -545,5 +510,18 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		yarnClusterDescriptor.close();
 
 		assertTrue(closableYarnClient.isInState(Service.STATE.STOPPED));
+	}
+
+	private YarnClusterDescriptor createYarnClusterDescriptor() {
+		return createYarnClusterDescriptor(new Configuration());
+	}
+
+	private YarnClusterDescriptor createYarnClusterDescriptor(Configuration configuration) {
+		return new YarnClusterDescriptor(
+			configuration,
+			yarnConfiguration,
+			temporaryFolder.getRoot().getAbsolutePath(),
+			yarnClient,
+			true);
 	}
 }


### PR DESCRIPTION
Plugins dir should be optional and cluster deployment should not fail if it doesn't exist.

## Verifying this change

This PR adds a new unit test to add better coverage (apart of end to end/integration tests) for this bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no**)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no ****/ don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
