### PR TITLE
[FLINK-12842][network] Fix invalid check released state during ResultPartition#createSubpartitionView

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartition.java
@@ -33,8 +33,7 @@ public class ReleaseOnConsumptionResultPartition extends ResultPartition {
 
 	/**
 	 * The total number of references to subpartitions of this result. The result partition can be
-	 * safely released, iff the reference count is zero. A reference count of -1 denotes that the
-	 * result partition has been released.
+	 * safely released, iff the reference count is zero.
 	 */
 	private final AtomicInteger pendingReferences = new AtomicInteger();
 
@@ -70,10 +69,7 @@ public class ReleaseOnConsumptionResultPartition extends ResultPartition {
 
 	@Override
 	public ResultSubpartitionView createSubpartitionView(int index, BufferAvailabilityListener availabilityListener) throws IOException {
-		int refCnt = pendingReferences.get();
-
-		checkState(refCnt != -1, "Partition released.");
-		checkState(refCnt > 0, "Partition not pinned.");
+		checkState(pendingReferences.get() > 0, "Partition not pinned.");
 
 		return super.createSubpartitionView(index, availabilityListener);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -274,6 +274,7 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	 */
 	public ResultSubpartitionView createSubpartitionView(int index, BufferAvailabilityListener availabilityListener) throws IOException {
 		checkElementIndex(index, subpartitions.length, "Subpartition not found.");
+		checkState(!isReleased.get(), "Partition released.");
 
 		ResultSubpartitionView readView = subpartitions[index].createReadView(availabilityListener);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -20,6 +20,13 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 
+import org.hamcrest.Matchers;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 /**
  * This class should consolidate all mocking logic for ResultPartitions.
  * While using Mockito internally (for now), the use of Mockito should not
@@ -44,5 +51,17 @@ public class PartitionTestUtils {
 			.setResultPartitionType(partitionType)
 			.setNumberOfSubpartitions(numChannels)
 			.build();
+	}
+
+	static void verifyCreateSubpartitionViewThrowsException(
+			ResultPartitionManager partitionManager,
+			ResultPartitionID partitionId) throws IOException {
+		try {
+			partitionManager.createSubpartitionView(partitionId, 0, new NoOpBufferAvailablityListener());
+
+			fail("Should throw a PartitionNotFoundException.");
+		} catch (PartitionNotFoundException notFound) {
+			assertThat(partitionId, Matchers.is(notFound.getPartitionId()));
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManagerTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.util.TestLogger;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
+import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.verifyCreateSubpartitionViewThrowsException;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -59,5 +61,20 @@ public class ResultPartitionManagerTest extends TestLogger {
 
 		partitionManager.registerResultPartition(partition);
 		partitionManager.createSubpartitionView(partition.getPartitionId(), 0, new NoOpBufferAvailablityListener());
+	}
+
+	/**
+	 * Tests {@link ResultPartitionManager#createSubpartitionView(ResultPartitionID, int, BufferAvailabilityListener)}
+	 * would throw a {@link PartitionNotFoundException} if this partition was already released before.
+	 */
+	@Test
+	public void testCreateViewForReleasedPartition() throws Exception {
+		final ResultPartitionManager partitionManager = new ResultPartitionManager();
+		final ResultPartition partition = createPartition();
+
+		partitionManager.registerResultPartition(partition);
+		partitionManager.releasePartition(partition.getPartitionId(), null);
+
+		verifyCreateSubpartitionViewThrowsException(partitionManager, partition.getPartitionId());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManagerTest.java
@@ -20,13 +20,10 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.util.TestLogger;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.verifyCreateSubpartitionViewThrowsException;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link ResultPartitionManager}.
@@ -40,14 +37,9 @@ public class ResultPartitionManagerTest extends TestLogger {
 	@Test
 	public void testThrowPartitionNotFoundException() throws Exception {
 		final ResultPartitionManager partitionManager = new ResultPartitionManager();
-		final ResultPartition partition = PartitionTestUtils.createPartition();
-		try {
-			partitionManager.createSubpartitionView(partition.getPartitionId(), 0, new NoOpBufferAvailablityListener());
+		final ResultPartition partition = createPartition();
 
-			fail("Should throw PartitionNotFoundException for unregistered partition.");
-		} catch (PartitionNotFoundException notFound) {
-			assertThat(partition.getPartitionId(), Matchers.is(notFound.getPartitionId()));
-		}
+		verifyCreateSubpartitionViewThrowsException(partitionManager, partition.getPartitionId());
 	}
 
 	/**
@@ -57,7 +49,7 @@ public class ResultPartitionManagerTest extends TestLogger {
 	@Test
 	public void testCreateViewForRegisteredPartition() throws Exception {
 		final ResultPartitionManager partitionManager = new ResultPartitionManager();
-		final ResultPartition partition = PartitionTestUtils.createPartition();
+		final ResultPartition partition = createPartition();
 
 		partitionManager.registerResultPartition(partition);
 		partitionManager.createSubpartitionView(partition.getPartitionId(), 0, new NoOpBufferAvailablityListener());


### PR DESCRIPTION
## What is the purpose of the change

*Currently in `ResultPartition#createSubpartitionView` it would check whether this partition is released before creating view. But this check is based on `refCnt != -1` which seems invalid, because the reference counter would not always reflect the released state.*

*In the case of `ResultPartition#release/fail`, the reference counter is not set to -1. Even if in the case of `ResultPartition#onConsumedSubpartition`, the reference counter seems also no chance to be -1.
So we could check the real `isReleased` state during creating view instead of reference counter.*

## Brief change log

  - *Remove check reference counter while `ReleaseOnConsumptionResultPartition#createSubpartitionView`*
  - *Add check `isReleased` state while `ResultPartition#createSubpartitionView`*
  - *Add tests in `ResultPartitionTest` and `ResultPartitionManagerTest`*

## Verifying this change

Adds new tests in `ResultPartitionTest#testCreateSubpartitionOnFailingPartition` and `ResultPartitionManagerTest#testCreateViewForReleasePartition`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)