### PR TITLE
[FLINK-12843][network] Refactor the pin logic in ReleaseOnConsumptionResultPartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartition.java
@@ -47,25 +47,8 @@ public class ReleaseOnConsumptionResultPartition extends ResultPartition {
 			ResultPartitionManager partitionManager,
 			FunctionWithException<BufferPoolOwner, BufferPool, IOException> bufferPoolFactory) {
 		super(owningTaskName, partitionId, partitionType, subpartitions, numTargetKeyGroups, partitionManager, bufferPoolFactory);
-	}
 
-	/**
-	 * The partition can only be released after each subpartition has been consumed once per pin operation.
-	 */
-	@Override
-	void pin() {
-		while (true) {
-			int refCnt = pendingReferences.get();
-
-			if (refCnt >= 0) {
-				if (pendingReferences.compareAndSet(refCnt, refCnt + subpartitions.length)) {
-					break;
-				}
-			}
-			else {
-				throw new IllegalStateException("Released.");
-			}
-		}
+		pendingReferences.set(subpartitions.length);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -330,12 +330,6 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Pins the result partition.
-	 */
-	void pin() {
-	}
-
-	/**
 	 * Notification when a subpartition is released.
 	 */
 	void onConsumedSubpartition(int subpartitionIndex) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -122,9 +122,6 @@ public class ResultPartitionFactory {
 
 		createSubpartitions(partition, type, subpartitions);
 
-		// Initially, partitions should be consumed once before release.
-		partition.pin();
-
 		LOG.debug("{}: Initialized {}", taskNameWithSubtaskAndId, this);
 
 		return partition;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartitionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link ReleaseOnConsumptionResultPartitionTest}.
+ */
+public class ReleaseOnConsumptionResultPartitionTest extends TestLogger {
+
+	@Test
+	public void testConsumptionBasedPartitionRelease() {
+		final ResultPartitionManager manager = new ResultPartitionManager();
+		final ResultPartition partition = new ResultPartitionBuilder()
+			.setNumberOfSubpartitions(2)
+			.isReleasedOnConsumption(true)
+			.setResultPartitionManager(manager)
+			.build();
+
+		manager.registerResultPartition(partition);
+
+		partition.onConsumedSubpartition(0);
+		assertThat(partition.isReleased(), is(false));
+
+		partition.onConsumedSubpartition(1);
+		assertThat(partition.isReleased(), is(true));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*The pin logic is for adding the reference counter based on number of subpartitions for `ReleaseOnConsumptionResultPartition`. It seems not necessary to do it in while loop as now, because the atomic counter would not be accessed by other threads during pin. If the `ReleaseOnConsumptionResultPartition` was not created yet, the `createSubpartitionView` would not be called actually resulting in`PartitionNotFoundException`. So we could simple increase the reference counter in `ReleaseOnConsumptionResultPartition` constructor directly.*

## Brief change log

  - *Remove `pin` method in `ResultPartition`*
  - *Remove `pin` method in `ReleaseOnConsumptionResultPartition` and adds the ref counter in constructor*

## Verifying this change

*Covered by `ReleaseOnConsumptionResultPartitionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)