### PR TITLE
[FLINK-12143] Fix file system dynamic class loading on create

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/ConnectionLimitingFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ConnectionLimitingFactory.java
@@ -48,6 +48,11 @@ public class ConnectionLimitingFactory implements FileSystemFactory {
 	// ------------------------------------------------------------------------
 
 	@Override
+	public ClassLoader getClassLoader() {
+		return factory.getClassLoader();
+	}
+
+	@Override
 	public String getScheme() {
 		return factory.getScheme();
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.fs.local.LocalFileSystemFactory;
 import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.TemporaryClassLoaderContext;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
@@ -432,7 +433,10 @@ public abstract class FileSystem {
 			final FileSystemFactory factory = FS_FACTORIES.get(uri.getScheme());
 
 			if (factory != null) {
-				fs = factory.create(uri);
+				ClassLoader classLoader = factory.getClassLoader();
+				try (TemporaryClassLoaderContext classLoaderContext = new TemporaryClassLoaderContext(classLoader)) {
+					fs = factory.create(uri);
+				}
 			}
 			else {
 				try {

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/Plugin.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/Plugin.java
@@ -20,6 +20,7 @@ package org.apache.flink.core.plugin;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
 
 /**
  * Interface for plugins. Plugins typically extend this interface in their SPI and the concrete implementations of a
@@ -27,6 +28,18 @@ import org.apache.flink.configuration.Configuration;
  */
 @PublicEvolving
 public interface Plugin {
+
+	/**
+	 * Helper method to get the class loader used to load the plugin. This may be needed for some plugins that use
+	 * dynamic class loading afterwards the plugin was loaded.
+	 *
+	 * @return the class loader used to load the plugin.
+	 */
+	default ClassLoader getClassLoader() {
+		return Preconditions.checkNotNull(
+			this.getClass().getClassLoader(),
+			"%s plugin with null class loader", this.getClass().getName());
+	}
 
 	/**
 	 * Optional method for plugins to pick up settings from the configuration.

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
@@ -40,12 +40,20 @@ public class PluginLoader {
 	private final ClassLoader pluginClassLoader;
 
 	@VisibleForTesting
-	public PluginLoader(PluginDescriptor pluginDescriptor, ClassLoader parentClassLoader, String[] alwaysParentFirstPatterns) {
-		this.pluginClassLoader =
-			new ChildFirstClassLoader(
-				pluginDescriptor.getPluginResourceURLs(),
-				parentClassLoader,
-				ArrayUtils.concat(alwaysParentFirstPatterns, pluginDescriptor.getLoaderExcludePatterns()));
+	public PluginLoader(ClassLoader pluginClassLoader) {
+		this.pluginClassLoader = pluginClassLoader;
+	}
+
+	@VisibleForTesting
+	public static ClassLoader createPluginClassLoader(PluginDescriptor pluginDescriptor, ClassLoader parentClassLoader, String[] alwaysParentFirstPatterns) {
+		return new ChildFirstClassLoader(
+			pluginDescriptor.getPluginResourceURLs(),
+			parentClassLoader,
+			ArrayUtils.concat(alwaysParentFirstPatterns, pluginDescriptor.getLoaderExcludePatterns()));
+	}
+
+	public static PluginLoader create(PluginDescriptor pluginDescriptor, ClassLoader parentClassLoader, String[] alwaysParentFirstPatterns) {
+		return new PluginLoader(createPluginClassLoader(pluginDescriptor, parentClassLoader, alwaysParentFirstPatterns));
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginManager.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginManager.java
@@ -66,7 +66,7 @@ public class PluginManager {
 	public <P extends Plugin> Iterator<P> load(Class<P> service) {
 		ArrayList<Iterator<P>> combinedIterators = new ArrayList<>(pluginDescriptors.size());
 		for (PluginDescriptor pluginDescriptor : pluginDescriptors) {
-			PluginLoader pluginLoader = new PluginLoader(pluginDescriptor, parentClassLoader, alwaysParentFirstPatterns);
+			PluginLoader pluginLoader = PluginLoader.create(pluginDescriptor, parentClassLoader, alwaysParentFirstPatterns);
 			combinedIterators.add(pluginLoader.load(service));
 		}
 		return Iterators.concat(combinedIterators.iterator());

--- a/flink-end-to-end-tests/test-scripts/common_dummy_fs.sh
+++ b/flink-end-to-end-tests/test-scripts/common_dummy_fs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+function dummy_fs_setup() {
+    mkdir -p "$FLINK_DIR/plugins/dummy-fs"
+    cp "${END_TO_END_DIR}/flink-plugins-test/target/flink-dummy-fs.jar" "${FLINK_DIR}/plugins/dummy-fs/"
+}

--- a/flink-end-to-end-tests/test-scripts/common_s3.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3.sh
@@ -63,7 +63,7 @@ s3util="java -jar ${END_TO_END_DIR}/flink-e2e-test-utils/target/S3UtilProgram.ja
 #   None
 ###################################
 function s3_setup {
-  add_optional_lib "s3-fs-$1"
+  add_optional_plugin "s3-fs-$1"
   set_config_key "s3.access-key" "$IT_CASE_S3_ACCESS_KEY"
   set_config_key "s3.secret-key" "$IT_CASE_S3_SECRET_KEY"
 }

--- a/flink-end-to-end-tests/test-scripts/test_azure_fs.sh
+++ b/flink-end-to-end-tests/test-scripts/test_azure_fs.sh
@@ -61,7 +61,7 @@ AZURE_TEST_DATA_WORDS_URI="wasbs://$IT_CASE_AZURE_CONTAINER@$IT_CASE_AZURE_ACCOU
 function azure_setup {
 
   echo "Copying flink azure jars and writing out configs"
-  add_optional_lib "azure-fs-hadoop"
+  add_optional_plugin "azure-fs-hadoop"
   set_config_key "fs.azure.account.key.$IT_CASE_AZURE_ACCOUNT.blob.core.windows.net" "$IT_CASE_AZURE_ACCESS_KEY"
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh
@@ -35,7 +35,8 @@ case $INPUT_TYPE in
         INPUT_LOCATION="${S3_TEST_DATA_WORDS_URI}"
     ;;
     (dummy-fs)
-        cp "${END_TO_END_DIR}/flink-plugins-test/target/flink-dummy-fs.jar" "${FLINK_DIR}/lib/"
+        source "$(dirname "$0")"/common_dummy_fs.sh
+        dummy_fs_setup
         INPUT_LOCATION="dummy://localhost/words"
     ;;
     (*)

--- a/flink-end-to-end-tests/test-scripts/test_docker_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_docker_embedded_job.sh
@@ -37,7 +37,8 @@ case $INPUT_TYPE in
         INPUT_LOCATION=${INPUT_PATH}/words
     ;;
     (dummy-fs)
-        cp "${END_TO_END_DIR}/flink-plugins-test/target/flink-dummy-fs.jar" "${FLINK_DIR}/lib/"
+        source "$(dirname "$0")"/common_dummy_fs.sh
+        dummy_fs_setup
         INPUT_LOCATION="dummy://localhost/words"
     ;;
     (*)

--- a/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
@@ -43,7 +43,8 @@ case $INPUT_TYPE in
         EXPECTED_RESULT_LOG_CONTAINS=("consummation,1" "of,14" "calamity,1")
     ;;
     (dummy-fs)
-        cp "${END_TO_END_DIR}/flink-plugins-test/target/flink-dummy-fs.jar" "${FLINK_DIR}/lib/"
+        source "$(dirname "$0")"/common_dummy_fs.sh
+        dummy_fs_setup
         INPUT_ARGS="--input dummy://localhost/words"
         EXPECTED_RESULT_LOG_CONTAINS=("my,1" "dear,2" "world,2")
     ;;


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a workaround for file system components that may involve dynamic class loading during `FileSystem` instantiation (via `FileSystemFactory.create()`) using plugins mechanism.
The plugin's class loader is set as thread's context class loader during invocation of `FileSystemFactory.create()`.

Note: an alternative approach can be to set the plugin class loader inside of concrete file system component's `FileSystemFactory.create()` implementation.

## Brief change log

  - The `Plugin` interface is extended to provide the class loader used to load the plugin;
  - For non-fallback file system factory,  the `factory.careate()` call in `FileSystem` is wrapped with the plugin's class loader set as thread's one;
  - The end-to-end fs tests are reverted to use the plugin mechanism.


## Verifying this change

This change is already covered by existing tests, such as `test_batch_wordcount.sh hadoop`
and can be verified as follows:

  - by successfully running the `test_batch_wordcount.sh hadoop|dummy-fs` using the `lib` loading mechanism;
  - by successfully running the `test_batch_wordcount.sh hadoop|dummy-fs` using the plugins' loading mechanism.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
