### PR TITLE
[FLINK-12658][hive] Integrate Flink with Hive GenericUDF

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/DeferredObjectAdapter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/DeferredObjectAdapter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
+import org.apache.flink.table.functions.hive.conversion.HiveObjectConversion;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+/**
+ * Adapter from Java Object to Hive DeferredObject.
+ */
+@Internal
+public class DeferredObjectAdapter implements GenericUDF.DeferredObject {
+
+	private Object object;
+	private HiveObjectConversion conversion;
+
+	public DeferredObjectAdapter(ObjectInspector inspector, DataType dataType) {
+		conversion = HiveInspectors.getConversion(inspector, dataType);
+	}
+
+	public void set(Object ob) {
+		this.object = ob;
+	}
+
+	@Override
+	public void prepare(int version) {
+	}
+
+	@Override
+	public Object get() {
+		return conversion.toHiveObject(object);
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDF.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
+import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * A ScalarFunction implementation that calls Hive's {@link GenericUDF}.
+ */
+@Internal
+public class HiveGenericUDF extends HiveScalarFunction<GenericUDF> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HiveGenericUDF.class);
+
+	private transient GenericUDF.DeferredObject[] deferredObjects;
+
+	public HiveGenericUDF(HiveFunctionWrapper<GenericUDF> hiveFunctionWrapper) {
+		super(hiveFunctionWrapper);
+
+		LOG.info("Creating HiveGenericUDF from '{}'", hiveFunctionWrapper.getClassName());
+	}
+
+	@Override
+	public void openInternal() {
+
+		LOG.info("Open HiveGenericUDF as {}", hiveFunctionWrapper.getClassName());
+
+		function = hiveFunctionWrapper.createFunction();
+
+		try {
+			returnInspector = function.initializeAndFoldConstants(
+				HiveInspectors.toInspectors(constantArguments, argTypes));
+		} catch (UDFArgumentException e) {
+			throw new FlinkHiveUDFException(e);
+		}
+
+		deferredObjects = new GenericUDF.DeferredObject[argTypes.length];
+
+		for (int i = 0; i < deferredObjects.length; i++) {
+			deferredObjects[i] = new DeferredObjectAdapter(
+				TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(
+					HiveTypeUtil.toHiveTypeInfo(argTypes[i])),
+				argTypes[i]
+			);
+		}
+	}
+
+	@Override
+	public Object evalInternal(Object[] args) {
+
+		for (int i = 0; i < args.length; i++) {
+			((DeferredObjectAdapter) deferredObjects[i]).set(args[i]);
+		}
+
+		try {
+			return HiveInspectors.toFlinkObject(returnInspector, function.evaluate(deferredObjects));
+		} catch (HiveException e) {
+			throw new FlinkHiveUDFException(e);
+		}
+	}
+
+	@Override
+	public DataType getHiveResultType(Object[] constantArguments, DataType[] argTypes) {
+		LOG.info("Getting result type of HiveGenericUDF from {}", hiveFunctionWrapper.getClassName());
+
+		try {
+			ObjectInspector[] argumentInspectors = HiveInspectors.toInspectors(constantArguments, argTypes);
+
+			ObjectInspector resultObjectInspector =
+				hiveFunctionWrapper.createFunction().initializeAndFoldConstants(argumentInspectors);
+
+			return HiveTypeUtil.toFlinkType(
+				TypeInfoUtils.getTypeInfoFromObjectInspector(resultObjectInspector));
+		} catch (UDFArgumentException e) {
+			throw new FlinkHiveUDFException(e);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.hadoop.hive.ql.udf.UDFUnhex;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFAbs;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFAddMonths;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCase;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCeil;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCoalesce;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateDiff;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateFormat;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDecode;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link HiveGenericUDF}.
+ */
+public class HiveGenericUDFTest {
+
+	@Test
+	public void testAbs() {
+		HiveGenericUDF udf = init(
+			GenericUDFAbs.class,
+			new Object[] {
+				null
+			},
+			new DataType[] {
+				DataTypes.DOUBLE()
+			}
+		);
+
+		assertEquals(10.0d, udf.eval(-10.0d));
+
+		udf = init(
+			GenericUDFAbs.class,
+			new Object[] {
+				null
+			},
+			new DataType[] {
+				DataTypes.INT()
+			}
+		);
+
+		assertEquals(10, udf.eval(-10));
+
+		udf = init(
+			GenericUDFAbs.class,
+			new Object[] {
+				null
+			},
+			new DataType[] {
+				DataTypes.STRING()
+			}
+		);
+
+		assertEquals(10.0, udf.eval("-10.0"));
+	}
+
+	@Test
+	public void testAddMonths() {
+		HiveGenericUDF udf = init(
+			GenericUDFAddMonths.class,
+			new Object[] {
+				null,
+				1
+			},
+			new DataType[] {
+				DataTypes.STRING(),
+				DataTypes.INT()
+			}
+		);
+
+		assertEquals("2009-09-30", udf.eval("2009-08-31", 1));
+		assertEquals("2009-09-30", udf.eval("2009-08-31 11:11:11", 1));
+	}
+
+	@Test
+	public void testDateFormat() {
+		String constYear = "y";
+		String constMonth = "M";
+
+		HiveGenericUDF udf = init(
+			GenericUDFDateFormat.class,
+			new Object[] {
+				null,
+				constYear
+			},
+			new DataType[] {
+				DataTypes.STRING(),
+				DataTypes.STRING()
+			}
+		);
+
+		assertEquals("2009", udf.eval("2009-08-31", constYear));
+
+		udf = init(
+			GenericUDFDateFormat.class,
+			new Object[] {
+				null,
+				constMonth
+			},
+			new DataType[] {
+				DataTypes.DATE(),
+				DataTypes.STRING()
+			}
+		);
+
+		assertEquals("8", udf.eval(Date.valueOf("2019-08-31"), constMonth));
+	}
+
+	@Test
+	public void testDecode() {
+		String constDecoding = "UTF-8";
+
+		HiveGenericUDF udf = init(
+			GenericUDFDecode.class,
+			new Object[] {
+				null,
+				constDecoding
+			},
+			new DataType[] {
+				DataTypes.BYTES(),
+				DataTypes.STRING()
+			}
+		);
+
+		HiveSimpleUDF simpleUDF = HiveSimpleUDFTest.init(
+			UDFUnhex.class,
+			new DataType[]{
+				DataTypes.STRING()
+			});
+
+		assertEquals("MySQL", udf.eval(simpleUDF.eval("4D7953514C"), constDecoding));
+	}
+
+	@Test
+	public void testCase() {
+		HiveGenericUDF udf = init(
+			GenericUDFCase.class,
+			new Object[] {
+				null,
+				"1",
+				"a",
+				"b"
+			},
+			new DataType[] {
+				DataTypes.STRING(),
+				DataTypes.STRING(),
+				DataTypes.STRING(),
+				DataTypes.STRING()
+			}
+		);
+
+		assertEquals("a", udf.eval("1", "1", "a", "b"));
+		assertEquals("b", udf.eval("2", "1", "a", "b"));
+	}
+
+	@Test
+	public void testCeil() {
+		HiveGenericUDF udf = init(
+			GenericUDFCeil.class,
+			new Object[] {
+				null
+			},
+			new DataType[] {
+				DataTypes.DOUBLE()
+			}
+		);
+
+		assertEquals(0L, udf.eval(-0.1d));
+
+		// TODO: reenable the test when we support decimal for Hive functions
+//		udf = init(
+//			GenericUDFCeil.class,
+//			new Object[] {
+//				null
+//			},
+//			new DataType[] {
+//				DataTypes.DECIMAL(1, 1)
+//			}
+//		);
+//
+//		assertEquals(0L, udf.eval(BigDecimal.valueOf(-0.1)));
+	}
+
+	@Test
+	public void testCoalesce() {
+		HiveGenericUDF udf = init(
+			GenericUDFCoalesce.class,
+			new Object[] {
+				null,
+				1,
+				null
+			},
+			new DataType[] {
+				DataTypes.INT(),
+				DataTypes.INT(),
+				DataTypes.INT()
+			}
+		);
+
+		assertEquals(1, udf.eval(null, 1, null));
+	}
+
+	@Test
+	public void testDataDiff() {
+
+		String d = "1969-07-20";
+		String t1 = "1969-07-20 00:00:00";
+		String t2 = "1980-12-31 12:59:59";
+
+		HiveGenericUDF udf = init(
+			GenericUDFDateDiff.class,
+			new Object[] {
+				null,
+				null
+			},
+			new DataType[] {
+				DataTypes.VARCHAR(20),
+				DataTypes.CHAR(20),
+			}
+		);
+
+		assertEquals(-4182, udf.eval(t1, t2));
+
+		udf = init(
+			GenericUDFDateDiff.class,
+			new Object[] {
+				null,
+				null
+			},
+			new DataType[] {
+				DataTypes.DATE(),
+				DataTypes.TIMESTAMP(),
+			}
+		);
+
+		assertEquals(-4182, udf.eval(Date.valueOf(d), Timestamp.valueOf(t2)));
+
+		// Test invalid char length
+		udf = init(
+			GenericUDFDateDiff.class,
+			new Object[] {
+				null,
+				null
+			},
+			new DataType[] {
+				DataTypes.CHAR(2),
+				DataTypes.VARCHAR(2),
+			}
+		);
+
+		assertEquals(null, udf.eval(t1, t2));
+	}
+
+	private static HiveGenericUDF init(Class hiveUdfClass, Object[] constantArgs, DataType[] argTypes) {
+		HiveGenericUDF udf = new HiveGenericUDF(new HiveFunctionWrapper(hiveUdfClass.getName()));
+
+		udf.setArgumentTypesAndConstants(constantArgs, argTypes);
+		udf.getHiveResultType(constantArgs, argTypes);
+
+		udf.open(null);
+
+		return udf;
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
@@ -180,7 +180,7 @@ public class HiveSimpleUDFTest {
 		assertEquals("MySQL", new String((byte[]) udf.eval("4D7953514C"), "UTF-8"));
 	}
 
-	private HiveSimpleUDF init(Class hiveUdfClass, DataType[] argTypes) {
+	protected static HiveSimpleUDF init(Class hiveUdfClass, DataType[] argTypes) {
 		HiveSimpleUDF udf = new HiveSimpleUDF(new HiveFunctionWrapper(hiveUdfClass.getName()));
 
 		// Hive UDF won't have literal args


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates Flink with Hive GenericUDF.

Note this PR is based on https://github.com/apache/flink/pull/8769.

## Brief change log

- added `HiveGenericUDF` as impl of Flink scalar function for Hive's `GenericUDF`
- added `DeferredObjectAdapter` and a few util in `HiveInspector` to facilitate running `HiveGenericUDF`
- added tests in `HiveGenericUDFTest`

## Verifying this change

This change added tests and can be verified as follows:
- `HiveGenericUDFTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

Document will be added later
