### PR TITLE
[FLINK-12778][table] Fix derive row type bug for table aggregate

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonTableAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonTableAggregate.scala
@@ -27,8 +27,10 @@ import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.util.{ImmutableBitSet, Pair, Util}
 import org.apache.flink.table.calcite.{FlinkRelBuilder, FlinkTypeFactory}
 import org.apache.flink.table.runtime.aggregate.AggregateUtil.CalcitePair
+import org.apache.flink.table.typeutils.FieldInfoUtils
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable.ListBuffer
 
 trait CommonTableAggregate extends CommonAggregate {
 
@@ -40,15 +42,27 @@ trait CommonTableAggregate extends CommonAggregate {
 
     val typeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
     val builder = typeFactory.builder
+    val groupNames = new ListBuffer[String]
 
     // group key fields
     groupSet.asList().foreach(e => {
       val field = child.getRowType.getFieldList.get(e)
+      groupNames.append(field.getName)
       builder.add(field)
     })
 
     // agg fields
-    aggCalls.get(0).`type`.getFieldList.foreach(builder.add)
+    val aggCall = aggCalls.get(0)
+    if (aggCall.`type`.isStruct) {
+      // only a structured type contains a field list.
+      aggCall.`type`.getFieldList.foreach(builder.add)
+    } else {
+      // A non-structured type does not have a field list, so get field name through
+      // TableEnvImpl.getFieldNames.
+      val name = FieldInfoUtils
+        .getFieldNames(FlinkTypeFactory.toTypeInfo(aggCall.`type`), groupNames).head
+      builder.add(name, aggCall.`type`)
+    }
     builder.build()
   }
 
@@ -60,8 +74,13 @@ trait CommonTableAggregate extends CommonAggregate {
     namedProperties: Seq[FlinkRelBuilder.NamedWindowProperty]): String = {
 
     val outFields = rowType.getFieldNames
-    val tableAggOutputArity = namedAggregates.head.left.getType.getFieldCount
-    val groupSize = grouping.size
+    val aggOutputType = namedAggregates.head.left.getType
+    val tableAggOutputArity = if (aggOutputType.isStruct) {
+      aggOutputType.getFieldCount
+    } else {
+      1
+    }
+    val groupSize = grouping.length
     val outFieldsOfTableAgg = outFields.subList(groupSize, groupSize + tableAggOutputArity)
     val tableAggOutputFields = Seq(s"(${outFieldsOfTableAgg.mkString(", ")})")
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TableAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TableAggregateTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.Func0
-import org.apache.flink.table.utils.{EmptyTableAggFunc, TableTestBase}
+import org.apache.flink.table.utils.{EmptyTableAggFunc, EmptyTableAggFuncWithIntResultType, TableTestBase}
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.types.Row
 import org.junit.Test
@@ -174,6 +174,31 @@ class TableAggregateTest extends TableTestBase {
         term("select", "c", "EmptyTableAggFunc(a) AS (f0, f1)")
       )
     util.verifyJavaTable(resultTable, expected)
+  }
+
+  @Test
+  def testTableAggregateWithIntResultType(): Unit = {
+
+    val table = util.addTable[(Long, Int, Long, Long)]('f0, 'f1, 'f2, 'd.rowtime, 'e.proctime)
+    val func = new EmptyTableAggFuncWithIntResultType
+
+    val resultTable = table
+      .groupBy('f0)
+      .flatAggregate(func('f1))
+      .select('f0, 'f0_0)
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupTableAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(table),
+          term("select", "f0", "f1")
+        ),
+        term("groupBy", "f0"),
+        term("select", "f0, EmptyTableAggFuncWithIntResultType(f1) AS (f0_0)")
+      )
+    util.verifyTable(resultTable, expected)
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/UserDefinedTableAggFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/UserDefinedTableAggFunctions.scala
@@ -246,6 +246,9 @@ class Top3WithMapView extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Wi
   }
 }
 
+/**
+  * Test function for plan test.
+  */
 class EmptyTableAggFuncWithoutEmit extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Accum] {
 
   override def createAccumulator(): Top3Accum = new Top3Accum
@@ -257,10 +260,16 @@ class EmptyTableAggFuncWithoutEmit extends TableAggregateFunction[JTuple2[JInt, 
   def accumulate(acc: Top3Accum, value: Int): Unit = {}
 }
 
-/**
-  * Test function for plan test.
-  */
 class EmptyTableAggFunc extends EmptyTableAggFuncWithoutEmit {
 
   def emitValue(acc: Top3Accum, out: Collector[JTuple2[JInt, JInt]]): Unit = {}
+}
+
+class EmptyTableAggFuncWithIntResultType extends TableAggregateFunction[JInt, Top3Accum] {
+
+  override def createAccumulator(): Top3Accum = new Top3Accum
+
+  def accumulate(acc: Top3Accum, value: Int): Unit = {}
+
+  def emitValue(acc: Top3Accum, out: Collector[JInt]): Unit = {}
 }


### PR DESCRIPTION

## What is the purpose of the change

This pull request fix derives row type bug for table aggregate.

Currently, we call `aggCalls.get(0).type.getFieldList.foreach(builder.add)` when derive row type for table aggregate. However, for types which are not composite types, the field list would be null. Table Aggregate should, of course, support non-composite types.

To solve the problem, we should judge whether types are structured. This is because a composite type will be converted to a RelDataType which contains field list and is structured.


## Brief change log

  - Fix `deriveTableAggRowType` method in `CommonTableAggregate`. When deriving row type, judge whether the result type of the table aggregate function is structured. Use `FieldInfoUtils.getFieldNames()` to get the field name when the result type is not structured.
  - In `AggregateOperationFactory.createAggregate()`, also use `FieldInfoUtils.getFieldNames()` to get the field name. 
  - Add tests to verify the results.


## Verifying this change

This change added tests and can be verified as follows:

  - Add plan test for table aggregate(both for window and non-window table aggregate).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
