### PR TITLE
[FLINK-12878] [travis] Move flink-table-planner-blink/flink-table-runtime-blink to separate profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,10 @@ jobs:
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: libraries
     - if: type in (pull_request, push)
+      script: ./tools/travis_controller.sh blink_planner
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
+      name: blink_planner
+    - if: type in (pull_request, push)
       script: ./tools/travis_controller.sh connectors
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: connectors
@@ -128,6 +132,10 @@ jobs:
       env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
       name: libraries - hadoop 2.4.1
     - if: type = cron
+      script: ./tools/travis_controller.sh blink_planner
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: blink_planner - hadoop 2.4.1
+    - if: type = cron
       script: ./tools/travis_controller.sh connectors
       env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
       name: connectors - hadoop 2.4.1
@@ -163,6 +171,10 @@ jobs:
       script: ./tools/travis_controller.sh libraries
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
       name: libraries - scala 2.12
+    - if: type = cron
+      script: ./tools/travis_controller.sh blink_planner
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
+      name: blink_planner - scala 2.12
     - if: type = cron
       script: ./tools/travis_controller.sh connectors
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"
@@ -207,6 +219,11 @@ jobs:
       script: ./tools/travis_controller.sh libraries
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
       name: libraries - jdk 9
+    - if: type = cron
+      jdk: "openjdk9"
+      script: ./tools/travis_controller.sh blink_planner
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9"
+      name: blink_planner - jdk 9
     - if: type = cron
       jdk: "openjdk9"
       script: ./tools/travis_controller.sh connectors

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -21,6 +21,7 @@ STAGE_COMPILE="compile"
 STAGE_CORE="core"
 STAGE_PYTHON="python"
 STAGE_LIBRARIES="libraries"
+STAGE_BLINK_PLANNER="blink_planner"
 STAGE_CONNECTORS="connectors"
 STAGE_KAFKA_GELLY="kafka/gelly"
 STAGE_TESTS="tests"
@@ -52,9 +53,11 @@ flink-table/flink-table-api-scala,\
 flink-table/flink-table-api-java-bridge,\
 flink-table/flink-table-api-scala-bridge,\
 flink-table/flink-table-planner,\
-flink-table/flink-table-planner-blink,\
-flink-table/flink-table-runtime-blink,\
 flink-table/flink-sql-client"
+
+MODULES_BLINK_PLANNER="\
+flink-table/flink-table-planner-blink,\
+flink-table/flink-table-runtime-blink"
 
 MODULES_CONNECTORS="\
 flink-contrib/flink-connector-wikiedits,\
@@ -149,6 +152,9 @@ function get_compile_modules_for_stage() {
         (${STAGE_LIBRARIES})
             echo "-pl $MODULES_LIBRARIES -am"
         ;;
+        (${STAGE_BLINK_PLANNER})
+            echo "-pl $MODULES_BLINK_PLANNER -am"
+        ;;
         (${STAGE_CONNECTORS})
             echo "-pl $MODULES_CONNECTORS -am"
         ;;
@@ -171,14 +177,16 @@ function get_test_modules_for_stage() {
 
     local modules_core=$MODULES_CORE
     local modules_libraries=$MODULES_LIBRARIES
+    local modules_blink_planner=$MODULES_BLINK_PLANNER
     local modules_connectors=$MODULES_CONNECTORS
     local modules_tests=$MODULES_TESTS
     local negated_core=\!${MODULES_CORE//,/,\!}
     local negated_libraries=\!${MODULES_LIBRARIES//,/,\!}
+    local negated_blink_planner=\!${MODULES_BLINK_PLANNER//,/,\!}
     local negated_kafka_gelly=\!${MODULES_KAFKA_GELLY//,/,\!}
     local negated_connectors=\!${MODULES_CONNECTORS//,/,\!}
     local negated_tests=\!${MODULES_TESTS//,/,\!}
-    local modules_misc="$negated_core,$negated_libraries,$negated_connectors,$negated_kafka_gelly,$negated_tests"
+    local modules_misc="$negated_core,$negated_libraries,$negated_blink_planner,$negated_connectors,$negated_kafka_gelly,$negated_tests"
 
     # various modules fail testing on JDK 9; exclude them
     if [[ ${PROFILE} == *"jdk9"* ]]; then
@@ -191,6 +199,9 @@ function get_test_modules_for_stage() {
         ;;
         (${STAGE_LIBRARIES})
             echo "-pl $modules_libraries"
+        ;;
+        (${STAGE_BLINK_PLANNER})
+            echo "-pl $modules_blink_planner"
         ;;
         (${STAGE_CONNECTORS})
             echo "-pl $modules_connectors"


### PR DESCRIPTION

## What is the purpose of the change

*Move flink-table-planner-blink/flink-table-runtime-blink to separate profile*


## Brief change log

  - *Move flink-table-planner-blink/flink-table-runtime-blink to separate profile.
The flink-table-planner-blink module and flink-table-runtime-blink module take almost 30 minutes, and that may cause libraries profile frequently hits timeouts; we can resolve this by moving flink-table-planner-blink and flink-table-runtime-blink into a separate profile.*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
