### PR TITLE
[FLINK-11775][runtime][table-runtime-blink] Introduce MemorySegmentWritable to let Segments direct copy to internal bytes

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 /**
  * A simple and efficient serializer for the {@link java.io.DataOutput} interface.
  */
-public class DataOutputSerializer implements DataOutputView {
+public class DataOutputSerializer implements DataOutputView, MemorySegmentWritable {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DataOutputSerializer.class);
 
@@ -152,6 +152,18 @@ public class DataOutputSerializer implements DataOutputView {
 			resize(len);
 		}
 		System.arraycopy(b, off, this.buffer, this.position, len);
+		this.position += len;
+	}
+
+	@Override
+	public void write(MemorySegment segment, int off, int len) throws IOException {
+		if (len < 0 || off > segment.size() - len) {
+			throw new ArrayIndexOutOfBoundsException();
+		}
+		if (this.position > this.buffer.length - len) {
+			resize(len);
+		}
+		segment.get(off, this.buffer, this.position, len);
 		this.position += len;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentWritable.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentWritable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/**
+ * Provides the interface for write(Segment).
+ */
+@Internal
+public interface MemorySegmentWritable {
+
+	/**
+	 * Writes {@code len} bytes from memory segment {@code segment} starting at offset {@code off}, in order,
+	 * to the output.
+	 *
+	 * @param segment memory segment to copy the bytes from.
+	 * @param off the start offset in the memory segment.
+	 * @param len The number of bytes to copy.
+	 * @throws IOException if an I/O error occurs.
+	 */
+	void write(MemorySegment segment, int off, int len) throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/AbstractPagedOutputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/AbstractPagedOutputView.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.memory;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentWritable;
 
 import java.io.IOException;
 import java.io.UTFDataFormatException;
@@ -33,7 +34,7 @@ import java.io.UTFDataFormatException;
  *
  * <p>The paging assumes that all memory segments are of the same size.
  */
-public abstract class AbstractPagedOutputView implements DataOutputView {
+public abstract class AbstractPagedOutputView implements DataOutputView, MemorySegmentWritable {
 
 	private MemorySegment currentSegment;			// the current memory segment to write to
 
@@ -416,6 +417,7 @@ public abstract class AbstractPagedOutputView implements DataOutputView {
 		}
 	}
 
+	@Override
 	public void write(MemorySegment segment, int off, int len) throws IOException {
 		int remaining = this.segmentSize - this.positionInSegment;
 		if (remaining >= len) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -622,7 +622,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 			if (row.getSegments().length == 1) {
 				buildSideWriteBuffer.write(row.getSegments()[0], row.getOffset(), sizeInBytes);
 			} else {
-				buildSideSerializer.serializeToPagesWithoutLength(row, buildSideWriteBuffer);
+				buildSideSerializer.serializeWithoutLengthSlow(row, buildSideWriteBuffer);
 			}
 		} else {
 			serializeToPages(row);
@@ -642,7 +642,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		if (row.getSegments().length == 1) {
 			buildSideWriteBuffer.write(row.getSegments()[0], row.getOffset(), sizeInBytes);
 		} else {
-			buildSideSerializer.serializeToPagesWithoutLength(row, buildSideWriteBuffer);
+			buildSideSerializer.serializeWithoutLengthSlow(row, buildSideWriteBuffer);
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryRowSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryRowSerializer.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.memory.MemorySegmentWritable;
 import org.apache.flink.runtime.memory.AbstractPagedInputView;
 import org.apache.flink.runtime.memory.AbstractPagedOutputView;
 import org.apache.flink.table.dataformat.BinaryRow;
@@ -83,12 +84,13 @@ public class BinaryRowSerializer extends AbstractRowSerializer<BinaryRow> {
 	@Override
 	public void serialize(BinaryRow record, DataOutputView target) throws IOException {
 		target.writeInt(record.getSizeInBytes());
-		SegmentsUtil.copyToView(
-				record.getSegments(),
-				record.getOffset(),
-				record.getSizeInBytes(),
-				target
-		);
+		if (target instanceof MemorySegmentWritable) {
+			serializeWithoutLength(record, (MemorySegmentWritable) target);
+		} else {
+			SegmentsUtil.copyToView(
+					record.getSegments(), record.getOffset(),
+					record.getSizeInBytes(), target);
+		}
 	}
 
 	@Override
@@ -133,25 +135,23 @@ public class BinaryRowSerializer extends AbstractRowSerializer<BinaryRow> {
 			BinaryRow record,
 			AbstractPagedOutputView headerLessView) throws IOException {
 		checkArgument(headerLessView.getHeaderLength() == 0);
-		int sizeInBytes = record.getSizeInBytes();
 		int skip = checkSkipWriteForFixLengthPart(headerLessView);
-		if (record.getSegments().length == 1) {
-			headerLessView.writeInt(sizeInBytes);
-			headerLessView.write(record.getSegments()[0], record.getOffset(), sizeInBytes);
-		} else {
-			headerLessView.writeInt(record.getSizeInBytes());
-			serializeToPagesWithoutLength(record, headerLessView);
-		}
+		headerLessView.writeInt(record.getSizeInBytes());
+		serializeWithoutLength(record, headerLessView);
 		return skip;
 	}
 
-	/**
-	 * Serialize row to pages without row length. The caller should make sure that the fixed-length
-	 * parit can fit in output's current segment, no skip check will be done here.
-	 */
-	public void serializeToPagesWithoutLength(
-			BinaryRow record,
-			AbstractPagedOutputView out) throws IOException {
+	private static void serializeWithoutLength(
+			BinaryRow record, MemorySegmentWritable writable) throws IOException {
+		if (record.getSegments().length == 1) {
+			writable.write(record.getSegments()[0], record.getOffset(), record.getSizeInBytes());
+		} else {
+			serializeWithoutLengthSlow(record, writable);
+		}
+	}
+
+	public static void serializeWithoutLengthSlow(
+			BinaryRow record, MemorySegmentWritable out) throws IOException {
 		int remainSize = record.getSizeInBytes();
 		int posInSegOfRecord = record.getOffset();
 		int segmentSize = record.getSegments()[0].size();


### PR DESCRIPTION

## What is the purpose of the change

Introduce MemorySegmentWritable to let BinaryRow direct copy to internal bytes

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
