### PR TITLE
[FLINK-12615][coordination] Track partitions on JM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.executiongraph.metrics.NumberOfFullRestartsGauge
 import org.apache.flink.runtime.executiongraph.metrics.RestartTimeGauge;
 import org.apache.flink.runtime.executiongraph.metrics.UpTimeGauge;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -94,7 +95,8 @@ public class ExecutionGraphBuilder {
 			BlobWriter blobWriter,
 			Time allocationTimeout,
 			Logger log,
-			ShuffleMaster<?> shuffleMaster) throws JobExecutionException, JobException {
+			ShuffleMaster<?> shuffleMaster,
+			PartitionTracker partitionTracker) throws JobExecutionException, JobException {
 
 		checkNotNull(jobGraph, "job graph cannot be null");
 
@@ -135,7 +137,8 @@ public class ExecutionGraphBuilder {
 					blobWriter,
 					allocationTimeout,
 					shuffleMaster,
-					forcePartitionReleaseOnConsumption);
+					forcePartitionReleaseOnConsumption,
+					partitionTracker);
 		} catch (IOException e) {
 			throw new JobException("Could not create the ExecutionGraph.", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTracker.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+
+import java.util.Collection;
+
+/**
+ * Utility for tracking partitions and issuing release calls to task executors and shuffle masters.
+ */
+public interface PartitionTracker {
+
+	/**
+	 * Starts the tracking of the given partition for the given task executor ID.
+	 *
+	 * @param producingTaskExecutorId ID of task executor on which the partition is produced
+	 * @param resultPartitionDeploymentDescriptor deployment descriptor of the partition
+	 */
+	void startTrackingPartition(ResourceID producingTaskExecutorId, ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor);
+
+	/**
+	 * Stops the tracking of all partitions for the given task executor ID, without issuing any release calls.
+	 */
+	void stopTrackingPartitionsFor(ResourceID producingTaskExecutorId);
+
+	/**
+	 * Releases the given partitions and stop the tracking of partitions that were released.
+	 */
+	void stopTrackingAndReleasePartitions(Collection<ResultPartitionID> resultPartitionIds);
+
+	/**
+	 * Releases all partitions for the given task executor ID, and stop the tracking of partitions that were released.
+	 */
+	void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId);
+
+	/**
+	 * Returns whether any partition is being tracked for the given task executor ID.
+	 */
+	boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+
+import java.util.Optional;
+
+/**
+ * Factory for {@link PartitionTracker}.
+ */
+@FunctionalInterface
+public interface PartitionTrackerFactory {
+
+	/**
+	 * Creates a new PartitionTracker.
+	 *
+	 * @param taskExecutorGatewayLookup lookup function to access task executor gateways
+	 * @return created PartitionTracker
+	 */
+	PartitionTracker create(TaskExecutorGatewayLookup taskExecutorGatewayLookup);
+
+	/**
+	 * Lookup function for {@link TaskExecutorGateway}.
+	 */
+	@FunctionalInterface
+	interface TaskExecutorGatewayLookup {
+
+		/**
+		 * Returns a {@link TaskExecutorGateway} corresponding to the given ResourceID.
+		 *
+		 * @param taskExecutorId id of the task executor to look up.
+		 * @return optional task executor gateway
+		 */
+		Optional<TaskExecutorGateway> lookup(ResourceID taskExecutorId);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImpl.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.taskexecutor.partition.PartitionTable;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Utility for tracking partitions and issuing release calls to task executors and shuffle masters.
+ */
+public class PartitionTrackerImpl implements PartitionTracker {
+
+	private final JobID jobId;
+
+	private final PartitionTable<ResourceID> partitionTable = new PartitionTable<>();
+	private final Map<ResultPartitionID, PartitionInfo> partitionInfos = new HashMap<>();
+
+	private final ShuffleMaster<?> shuffleMaster;
+
+	private final PartitionTrackerFactory.TaskExecutorGatewayLookup taskExecutorGatewayLookup;
+
+	public PartitionTrackerImpl(
+		JobID jobId,
+		ShuffleMaster<?> shuffleMaster,
+		PartitionTrackerFactory.TaskExecutorGatewayLookup taskExecutorGatewayLookup) {
+
+		this.jobId = Preconditions.checkNotNull(jobId);
+		this.shuffleMaster = Preconditions.checkNotNull(shuffleMaster);
+		this.taskExecutorGatewayLookup = taskExecutorGatewayLookup;
+	}
+
+	@Override
+	public void startTrackingPartition(ResourceID producingTaskExecutorId, ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor) {
+		Preconditions.checkNotNull(producingTaskExecutorId);
+		Preconditions.checkNotNull(resultPartitionDeploymentDescriptor);
+
+		// if it is released on consumption we do not need to issue any release calls
+		if (resultPartitionDeploymentDescriptor.isReleasedOnConsumption()) {
+			return;
+		}
+
+		final ResultPartitionID resultPartitionId = resultPartitionDeploymentDescriptor.getShuffleDescriptor().getResultPartitionID();
+
+		partitionInfos.put(resultPartitionId, new PartitionInfo(producingTaskExecutorId, resultPartitionDeploymentDescriptor));
+		partitionTable.startTrackingPartitions(producingTaskExecutorId, Collections.singletonList(resultPartitionId));
+	}
+
+	@Override
+	public void stopTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
+		Preconditions.checkNotNull(producingTaskExecutorId);
+
+		// this is a bit icky since we make 2 calls to pT#stopTrackingPartitions
+		final Collection<ResultPartitionID> resultPartitionIds = partitionTable.stopTrackingPartitions(producingTaskExecutorId);
+
+		for (ResultPartitionID resultPartitionId : resultPartitionIds) {
+			internalStopTrackingPartition(resultPartitionId);
+		}
+	}
+
+	@Override
+	public void stopTrackingAndReleasePartitions(Collection<ResultPartitionID> resultPartitionIds) {
+		Preconditions.checkNotNull(resultPartitionIds);
+
+		// stop tracking partitions to be released and group them by task executor ID
+		Map<ResourceID, List<ResultPartitionDeploymentDescriptor>> partitionsToReleaseByResourceId = resultPartitionIds.stream()
+			.map(this::internalStopTrackingPartition)
+			.filter(Optional::isPresent)
+			.map(Optional::get)
+			.collect(Collectors.groupingBy(
+				partitionMetaData -> partitionMetaData.producingTaskExecutorResourceId,
+				Collectors.mapping(
+					partitionMetaData -> partitionMetaData.resultPartitionDeploymentDescriptor,
+					toList())));
+
+		partitionsToReleaseByResourceId.forEach(this::internalReleasePartitions);
+	}
+
+	@Override
+	public void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId) {
+		Preconditions.checkNotNull(producingTaskExecutorId);
+
+		// this is a bit icky since we make 2 calls to pT#stopTrackingPartitions
+		Collection<ResultPartitionID> resultPartitionIds = partitionTable.stopTrackingPartitions(producingTaskExecutorId);
+
+		stopTrackingAndReleasePartitions(resultPartitionIds);
+	}
+
+	@Override
+	public boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
+		Preconditions.checkNotNull(producingTaskExecutorId);
+
+		return partitionTable.hasTrackedPartitions(producingTaskExecutorId);
+	}
+
+	private Optional<PartitionInfo> internalStopTrackingPartition(ResultPartitionID resultPartitionId) {
+		final PartitionInfo partitionInfo = partitionInfos.remove(resultPartitionId);
+		if (partitionInfo == null) {
+			return Optional.empty();
+		}
+		partitionTable.stopTrackingPartitions(partitionInfo.producingTaskExecutorResourceId, Collections.singletonList(resultPartitionId));
+
+		return Optional.of(partitionInfo);
+	}
+
+	private void internalReleasePartitions(
+		ResourceID potentialPartitionLocation,
+		Collection<ResultPartitionDeploymentDescriptor> partitionDeploymentDescriptors) {
+
+		internalReleasePartitionsOnTaskExecutor(potentialPartitionLocation, partitionDeploymentDescriptors);
+		internalReleasePartitionsOnShuffleMaster(partitionDeploymentDescriptors);
+	}
+
+	private void internalReleasePartitionsOnTaskExecutor(
+		ResourceID potentialPartitionLocation,
+		Collection<ResultPartitionDeploymentDescriptor> partitionDeploymentDescriptors) {
+
+		final List<ResultPartitionID> partitionsRequiringRpcReleaseCalls = partitionDeploymentDescriptors.stream()
+			.map(ResultPartitionDeploymentDescriptor::getShuffleDescriptor)
+			.filter(descriptor -> descriptor.storesLocalResourcesOn().isPresent())
+			.map(ShuffleDescriptor::getResultPartitionID)
+			.collect(Collectors.toList());
+
+		if (!partitionsRequiringRpcReleaseCalls.isEmpty()) {
+			taskExecutorGatewayLookup
+				.lookup(potentialPartitionLocation)
+				.ifPresent(taskExecutorGateway ->
+					taskExecutorGateway.releasePartitions(jobId, partitionsRequiringRpcReleaseCalls));
+		}
+	}
+
+	private void internalReleasePartitionsOnShuffleMaster(Collection<ResultPartitionDeploymentDescriptor> partitionDeploymentDescriptors) {
+		partitionDeploymentDescriptors.stream()
+			.map(ResultPartitionDeploymentDescriptor::getShuffleDescriptor)
+			.forEach(shuffleMaster::releasePartitionExternally);
+	}
+
+	private static final class PartitionInfo {
+		public final ResourceID producingTaskExecutorResourceId;
+		public final ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor;
+
+		private PartitionInfo(ResourceID producingTaskExecutorResourceId, ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor) {
+			this.producingTaskExecutorResourceId = producingTaskExecutorResourceId;
+			this.resultPartitionDeploymentDescriptor = resultPartitionDeploymentDescriptor;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -536,7 +536,11 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private void internalFailAllocation(AllocationID allocationId, Exception cause) {
 		final Optional<ResourceID> resourceIdOptional = slotPool.failAllocation(allocationId, cause);
-		resourceIdOptional.ifPresent(this::releaseEmptyTaskManager);
+		resourceIdOptional.ifPresent(taskManagerId -> {
+			if (!partitionTracker.isTrackingPartitionsFor(taskManagerId)) {
+				releaseEmptyTaskManager(taskManagerId);
+			}
+		});
 	}
 
 	private void releaseEmptyTaskManager(ResourceID resourceId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -892,6 +892,12 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		validateRunsInMainThread();
 
 		if (newJobStatus.isGloballyTerminalState()) {
+			// other terminal job states are handled by the executions
+			if (newJobStatus == JobStatus.FINISHED) {
+				runAsync(() -> registeredTaskManagers.keySet()
+					.forEach(partitionTracker::stopTrackingAndReleasePartitionsFor));
+			}
+
 			final ArchivedExecutionGraph archivedExecutionGraph = schedulerNG.requestJob();
 			scheduledExecutorService.execute(() -> jobCompletionActions.jobReachedGloballyTerminalState(archivedExecutionGraph));
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster.factories;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.PartitionTrackerImpl;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
@@ -106,6 +107,11 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 			fatalErrorHandler,
 			userCodeClassloader,
 			schedulerNGFactory,
-			shuffleMaster);
+			shuffleMaster,
+			lookup -> new PartitionTrackerImpl(
+				jobGraph.getJobID(),
+				shuffleMaster,
+				lookup
+			));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.executiongraph.restart.ThrowingRestartStrategy;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
@@ -54,7 +55,8 @@ public class DefaultScheduler extends LegacyScheduler {
 			final BlobWriter blobWriter,
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
-			final ShuffleMaster<?> shuffleMaster) throws Exception {
+			final ShuffleMaster<?> shuffleMaster,
+			final PartitionTracker partitionTracker) throws Exception {
 
 		super(
 			log,
@@ -71,7 +73,8 @@ public class DefaultScheduler extends LegacyScheduler {
 			blobWriter,
 			jobManagerJobMetricGroup,
 			slotRequestTimeout,
-			shuffleMaster);
+			shuffleMaster,
+			partitionTracker);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
@@ -54,7 +55,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			final BlobWriter blobWriter,
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
-			final ShuffleMaster<?> shuffleMaster) throws Exception {
+			final ShuffleMaster<?> shuffleMaster,
+			final PartitionTracker partitionTracker) throws Exception {
 
 		return new DefaultScheduler(
 			log,
@@ -70,7 +72,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			blobWriter,
 			jobManagerJobMetricGroup,
 			slotRequestTimeout,
-			shuffleMaster);
+			shuffleMaster,
+			partitionTracker);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyResolving;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -144,7 +145,8 @@ public class LegacyScheduler implements SchedulerNG {
 			final BlobWriter blobWriter,
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
-			final ShuffleMaster<?> shuffleMaster) throws Exception {
+			final ShuffleMaster<?> shuffleMaster,
+			final PartitionTracker partitionTracker) throws Exception {
 
 		this.log = checkNotNull(log);
 		this.jobGraph = checkNotNull(jobGraph);
@@ -171,14 +173,15 @@ public class LegacyScheduler implements SchedulerNG {
 		this.blobWriter = checkNotNull(blobWriter);
 		this.slotRequestTimeout = checkNotNull(slotRequestTimeout);
 
-		this.executionGraph = createAndRestoreExecutionGraph(jobManagerJobMetricGroup, checkNotNull(shuffleMaster));
+		this.executionGraph = createAndRestoreExecutionGraph(jobManagerJobMetricGroup, checkNotNull(shuffleMaster), checkNotNull(partitionTracker));
 	}
 
 	private ExecutionGraph createAndRestoreExecutionGraph(
 			JobManagerJobMetricGroup currentJobManagerJobMetricGroup,
-			ShuffleMaster<?> shuffleMaster) throws Exception {
+			ShuffleMaster<?> shuffleMaster,
+			PartitionTracker partitionTracker) throws Exception {
 
-		ExecutionGraph newExecutionGraph = createExecutionGraph(currentJobManagerJobMetricGroup, shuffleMaster);
+		ExecutionGraph newExecutionGraph = createExecutionGraph(currentJobManagerJobMetricGroup, shuffleMaster, partitionTracker);
 
 		final CheckpointCoordinator checkpointCoordinator = newExecutionGraph.getCheckpointCoordinator();
 
@@ -199,7 +202,8 @@ public class LegacyScheduler implements SchedulerNG {
 
 	private ExecutionGraph createExecutionGraph(
 			JobManagerJobMetricGroup currentJobManagerJobMetricGroup,
-			ShuffleMaster<?> shuffleMaster) throws JobExecutionException, JobException {
+			ShuffleMaster<?> shuffleMaster,
+			final PartitionTracker partitionTracker) throws JobExecutionException, JobException {
 		return ExecutionGraphBuilder.buildGraph(
 			null,
 			jobGraph,
@@ -215,7 +219,8 @@ public class LegacyScheduler implements SchedulerNG {
 			blobWriter,
 			slotRequestTimeout,
 			log,
-			shuffleMaster);
+			shuffleMaster,
+			partitionTracker);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacySchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacySchedulerFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
@@ -63,7 +64,8 @@ public class LegacySchedulerFactory implements SchedulerNGFactory {
 			final BlobWriter blobWriter,
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
-			final ShuffleMaster<?> shuffleMaster) throws Exception {
+			final ShuffleMaster<?> shuffleMaster,
+			final PartitionTracker partitionTracker) throws Exception {
 
 		return new LegacyScheduler(
 			log,
@@ -80,6 +82,7 @@ public class LegacySchedulerFactory implements SchedulerNGFactory {
 			blobWriter,
 			jobManagerJobMetricGroup,
 			slotRequestTimeout,
-			shuffleMaster);
+			shuffleMaster,
+			partitionTracker);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
@@ -53,6 +54,7 @@ public interface SchedulerNGFactory {
 		BlobWriter blobWriter,
 		JobManagerJobMetricGroup jobManagerJobMetricGroup,
 		Time slotRequestTimeout,
-		ShuffleMaster<?> shuffleMaster) throws Exception;
+		ShuffleMaster<?> shuffleMaster,
+		PartitionTracker partitionTracker) throws Exception;
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -208,7 +208,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	/** The heartbeat manager for resource manager in the task manager. */
 	private HeartbeatManager<Void, SlotReport> resourceManagerHeartbeatManager;
 
-	private final PartitionTable partitionTable;
+	private final PartitionTable<JobID> partitionTable;
 
 	// --------- resource manager --------
 
@@ -238,7 +238,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			@Nullable String metricQueryServiceAddress,
 			BlobCacheService blobCacheService,
 			FatalErrorHandler fatalErrorHandler,
-			PartitionTable partitionTable) {
+			PartitionTable<JobID> partitionTable) {
 
 		super(rpcService, AkkaRpcServiceUtils.createRandomName(TASK_MANAGER_NAME));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -386,7 +386,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			metricQueryServiceAddress,
 			blobCacheService,
 			fatalErrorHandler,
-			new PartitionTable());
+			new PartitionTable<>());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.io.network.partition.NoOpPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
@@ -120,7 +121,8 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
 			VoidBlobWriter.getInstance(),
 			timeout,
 			log,
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 
 		assertEquals(1, eg.getCheckpointCoordinator().getNumberOfRegisteredMasterHooks());
 		assertTrue(jobGraph.getCheckpointingSettings().getDefaultStateBackend().deserializeValue(classLoader) instanceof CustomStateBackend);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
+import org.apache.flink.runtime.io.network.partition.NoOpPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -824,7 +825,8 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			blobWriter,
 			timeout,
 			LoggerFactory.getLogger(getClass()),
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 	}
 
 	private static final class ExecutionStageMatcher extends TypeSafeMatcher<List<ExecutionAttemptID>> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.io.network.partition.NoOpPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -79,7 +80,8 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
 			TEST_LOGGER,
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 
 		for (JobVertex jv : jobVertices) {
 			assertThat(jv.getParallelism(), is(initialParallelism));
@@ -109,7 +111,8 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
 			TEST_LOGGER,
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 
 		for (JobVertex jv : jobVertices) {
 			assertThat(jv.getParallelism(), is(1));
@@ -139,7 +142,8 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
 			TEST_LOGGER,
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 
 		for (JobVertex jv : jobVertices) {
 			assertThat(jv.getParallelism(), is(scaleUpParallelism));
@@ -182,7 +186,8 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 				VoidBlobWriter.getInstance(),
 				AkkaUtils.getDefaultTimeout(),
 				TEST_LOGGER,
-				NettyShuffleMaster.INSTANCE);
+				NettyShuffleMaster.INSTANCE,
+				NoOpPartitionTracker.INSTANCE);
 
 			fail("Building the ExecutionGraph with a parallelism higher than the max parallelism should fail.");
 		} catch (JobException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGate
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.io.network.partition.NoOpPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -591,7 +592,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			VoidBlobWriter.getInstance(),
 			timeout,
 			log,
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 	}
 
 	private SimpleSlot createSlot(TaskManagerGateway taskManager, JobID jobId) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.io.network.partition.NoOpPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -411,7 +412,8 @@ public class ExecutionGraphTestUtils {
 			VoidBlobWriter.getInstance(),
 			timeout,
 			TEST_LOGGER,
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 	}
 
 	public static JobVertex createNoOpVertex(int parallelism) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.SimpleSlotContext;
+import org.apache.flink.runtime.io.network.partition.NoOpPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -226,7 +227,8 @@ public class ExecutionVertexLocalityTest extends TestLogger {
 			VoidBlobWriter.getInstance(),
 			timeout,
 			log,
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 	}
 
 	private void initializeLocation(ExecutionVertex vertex, TaskManagerLocation location) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/PipelinedFailoverRegionBuildingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/PipelinedFailoverRegionBuildingTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.io.network.partition.NoOpPartitionTracker;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -644,6 +645,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 			VoidBlobWriter.getInstance(),
 			timeout,
 			log,
-			NettyShuffleMaster.INSTANCE);
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpPartitionTracker.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+
+import java.util.Collection;
+
+/**
+ * No-op implementation of {@link PartitionTracker}.
+ */
+public enum NoOpPartitionTracker implements PartitionTracker {
+	INSTANCE;
+
+	public static final PartitionTrackerFactory FACTORY = lookup -> INSTANCE;
+
+	@Override
+	public void startTrackingPartition(ResourceID producingTaskExecutorId, ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor) {
+	}
+
+	@Override
+	public void stopTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
+	}
+
+	@Override
+	public void stopTrackingAndReleasePartitions(Collection<ResultPartitionID> resultPartitionIds) {
+	}
+
+	@Override
+	public void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId) {
+	}
+
+	@Override
+	public boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
+		return false;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -28,6 +29,8 @@ import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Optional;
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -97,6 +100,37 @@ public class PartitionTestUtils {
 		return new ResultPartitionDeploymentDescriptor(
 			partitionDescriptor,
 			shuffleDescriptor,
+			1,
+			true,
+			releaseType);
+	}
+
+	public static ResultPartitionDeploymentDescriptor createResultPartitionDeploymentDescriptor(ResultPartitionID resultPartitionId, ShuffleDescriptor.ReleaseType releaseType, boolean hasLocalResources) {
+		return new ResultPartitionDeploymentDescriptor(
+			new PartitionDescriptor(
+				new IntermediateDataSetID(),
+				resultPartitionId.getPartitionId(),
+				ResultPartitionType.BLOCKING,
+				1,
+				0),
+			new ShuffleDescriptor() {
+				@Override
+				public ResultPartitionID getResultPartitionID() {
+					return resultPartitionId;
+				}
+
+				@Override
+				public Optional<ResourceID> storesLocalResourcesOn() {
+					return hasLocalResources
+						? Optional.of(ResourceID.generate())
+						: Optional.empty();
+				}
+
+				@Override
+				public EnumSet<ReleaseType> getSupportedReleaseTypes() {
+					return EnumSet.of(releaseType);
+				}
+			},
 			1,
 			true,
 			releaseType);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImplTest.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link PartitionTrackerImpl}.
+ */
+public class PartitionTrackerImplTest extends TestLogger {
+
+	@Test
+	public void testReleasedOnConsumptionPartitionIsNotTracked() {
+		testReleaseOnConsumptionHandling(ShuffleDescriptor.ReleaseType.AUTO);
+	}
+
+	@Test
+	public void testRetainedOnConsumptionPartitionIsTracked() {
+		testReleaseOnConsumptionHandling(ShuffleDescriptor.ReleaseType.MANUAL);
+	}
+
+	private void testReleaseOnConsumptionHandling(ShuffleDescriptor.ReleaseType releaseType) {
+		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
+			new JobID(),
+			new TestingShuffleMaster(),
+			ignored -> Optional.empty()
+		);
+
+		final ResourceID resourceId = ResourceID.generate();
+		final ResultPartitionID resultPartitionId = new ResultPartitionID();
+		partitionTracker.startTrackingPartition(
+			resourceId,
+			createResultPartitionDeploymentDescriptor(
+				resultPartitionId,
+				releaseType,
+				false));
+
+		assertThat(partitionTracker.isTrackingPartitionsFor(resourceId), is(not(releaseType)));
+	}
+
+	@Test
+	public void testStartStopTracking() {
+		final Queue<Tuple3<ResourceID, JobID, Collection<ResultPartitionID>>> taskExecutorReleaseCalls = new ArrayBlockingQueue<>(4);
+		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
+			new JobID(),
+			new TestingShuffleMaster(),
+			resourceId -> Optional.of(createTaskExecutorGateway(resourceId, taskExecutorReleaseCalls))
+		);
+
+		final ResourceID executorWithTrackedPartition = new ResourceID("tracked");
+		final ResourceID executorWithoutTrackedPartition = new ResourceID("untracked");
+
+		assertThat(partitionTracker.isTrackingPartitionsFor(executorWithTrackedPartition), is(false));
+		assertThat(partitionTracker.isTrackingPartitionsFor(executorWithoutTrackedPartition), is(false));
+
+		partitionTracker.startTrackingPartition(
+			executorWithTrackedPartition,
+			createResultPartitionDeploymentDescriptor(new ResultPartitionID(), ShuffleDescriptor.ReleaseType.MANUAL, true));
+
+		assertThat(partitionTracker.isTrackingPartitionsFor(executorWithTrackedPartition), is(true));
+		assertThat(partitionTracker.isTrackingPartitionsFor(executorWithoutTrackedPartition), is(false));
+
+		partitionTracker.stopTrackingPartitionsFor(executorWithTrackedPartition);
+
+		assertThat(partitionTracker.isTrackingPartitionsFor(executorWithTrackedPartition), is(false));
+		assertThat(partitionTracker.isTrackingPartitionsFor(executorWithoutTrackedPartition), is(false));
+	}
+
+	@Test
+	public void testReleaseCallsWithLocalResources() {
+		final TestingShuffleMaster shuffleMaster = new TestingShuffleMaster();
+		final JobID jobId = new JobID();
+
+		final Queue<Tuple3<ResourceID, JobID, Collection<ResultPartitionID>>> taskExecutorReleaseCalls = new ArrayBlockingQueue<>(4);
+		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
+			jobId,
+			shuffleMaster,
+			resourceId -> Optional.of(createTaskExecutorGateway(resourceId, taskExecutorReleaseCalls))
+		);
+
+		final ResourceID taskExecutorId1 = ResourceID.generate();
+		final ResourceID taskExecutorId2 = ResourceID.generate();
+		final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+		final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+
+		partitionTracker.startTrackingPartition(
+			taskExecutorId1,
+			createResultPartitionDeploymentDescriptor(resultPartitionId1, ShuffleDescriptor.ReleaseType.MANUAL, true));
+		partitionTracker.startTrackingPartition(
+			taskExecutorId2,
+			createResultPartitionDeploymentDescriptor(resultPartitionId2, ShuffleDescriptor.ReleaseType.MANUAL, true));
+
+		{
+			partitionTracker.stopTrackingAndReleasePartitionsFor(taskExecutorId1);
+
+			assertEquals(1, taskExecutorReleaseCalls.size());
+
+			Tuple3<ResourceID, JobID, Collection<ResultPartitionID>> taskExecutorReleaseCall = taskExecutorReleaseCalls.remove();
+			assertEquals(taskExecutorId1, taskExecutorReleaseCall.f0);
+			assertEquals(jobId, taskExecutorReleaseCall.f1);
+			assertThat(taskExecutorReleaseCall.f2, contains(resultPartitionId1));
+
+			assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
+			assertEquals(resultPartitionId1, shuffleMaster.externallyReleasedPartitions.remove());
+
+			assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId1), is(false));
+		}
+
+		{
+			partitionTracker.stopTrackingAndReleasePartitions(Collections.singletonList(resultPartitionId2));
+
+			assertEquals(1, taskExecutorReleaseCalls.size());
+
+			Tuple3<ResourceID, JobID, Collection<ResultPartitionID>> releaseCall = taskExecutorReleaseCalls.remove();
+			assertEquals(taskExecutorId2, releaseCall.f0);
+			assertEquals(jobId, releaseCall.f1);
+			assertThat(releaseCall.f2, contains(resultPartitionId2));
+
+			assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
+			assertEquals(resultPartitionId2, shuffleMaster.externallyReleasedPartitions.remove());
+
+			assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId2), is(false));
+		}
+	}
+
+	@Test
+	public void testReleaseCallsWithoutLocalResources() {
+		final TestingShuffleMaster shuffleMaster = new TestingShuffleMaster();
+
+		final Queue<Tuple3<ResourceID, JobID, Collection<ResultPartitionID>>> taskExecutorReleaseCalls = new ArrayBlockingQueue<>(4);
+		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
+			new JobID(),
+			shuffleMaster,
+			resourceId -> Optional.of(createTaskExecutorGateway(resourceId, taskExecutorReleaseCalls))
+		);
+
+		final ResourceID taskExecutorId1 = ResourceID.generate();
+		final ResourceID taskExecutorId2 = ResourceID.generate();
+		final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+		final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+
+		partitionTracker.startTrackingPartition(
+			taskExecutorId1,
+			createResultPartitionDeploymentDescriptor(resultPartitionId1, ShuffleDescriptor.ReleaseType.MANUAL, false));
+		partitionTracker.startTrackingPartition(
+			taskExecutorId2,
+			createResultPartitionDeploymentDescriptor(resultPartitionId2, ShuffleDescriptor.ReleaseType.MANUAL, false));
+
+		{
+			partitionTracker.stopTrackingAndReleasePartitionsFor(taskExecutorId1);
+
+			assertEquals(0, taskExecutorReleaseCalls.size());
+
+			assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
+			assertEquals(resultPartitionId1, shuffleMaster.externallyReleasedPartitions.remove());
+
+			assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId1), is(false));
+		}
+
+		{
+			partitionTracker.stopTrackingAndReleasePartitions(Collections.singletonList(resultPartitionId2));
+
+			assertEquals(0, taskExecutorReleaseCalls.size());
+
+			assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
+			assertEquals(resultPartitionId2, shuffleMaster.externallyReleasedPartitions.remove());
+
+			assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId2), is(false));
+		}
+	}
+
+	@Test
+	public void testStopTrackingIssuesNoReleaseCalls() {
+		final TestingShuffleMaster shuffleMaster = new TestingShuffleMaster();
+
+		final Queue<Tuple3<ResourceID, JobID, Collection<ResultPartitionID>>> taskExecutorReleaseCalls = new ArrayBlockingQueue<>(4);
+		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
+			new JobID(),
+			new TestingShuffleMaster(),
+			resourceId -> Optional.of(createTaskExecutorGateway(resourceId, taskExecutorReleaseCalls))
+		);
+
+		final ResourceID taskExecutorId1 = ResourceID.generate();
+		final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+
+		partitionTracker.startTrackingPartition(
+			taskExecutorId1,
+			createResultPartitionDeploymentDescriptor(resultPartitionId1, ShuffleDescriptor.ReleaseType.MANUAL, true));
+
+		partitionTracker.stopTrackingPartitionsFor(taskExecutorId1);
+
+		assertEquals(0, taskExecutorReleaseCalls.size());
+		assertEquals(0, shuffleMaster.externallyReleasedPartitions.size());
+	}
+
+	private static ResultPartitionDeploymentDescriptor createResultPartitionDeploymentDescriptor(
+		ResultPartitionID resultPartitionId,
+		ShuffleDescriptor.ReleaseType releaseType,
+		boolean hasLocalResources) {
+
+		return new ResultPartitionDeploymentDescriptor(
+			new PartitionDescriptor(
+				new IntermediateDataSetID(),
+				resultPartitionId.getPartitionId(),
+				ResultPartitionType.BLOCKING,
+				1,
+				0),
+			new ShuffleDescriptor() {
+				@Override
+				public ResultPartitionID getResultPartitionID() {
+					return resultPartitionId;
+				}
+
+				@Override
+				public Optional<ResourceID> storesLocalResourcesOn() {
+					return hasLocalResources
+						? Optional.of(ResourceID.generate())
+						: Optional.empty();
+				}
+
+				@Override
+				public EnumSet<ReleaseType> getSupportedReleaseTypes() {
+					return EnumSet.of(releaseType);
+				}
+			},
+			1,
+			true,
+			releaseType);
+	}
+
+	private static TaskExecutorGateway createTaskExecutorGateway(ResourceID taskExecutorId, Collection<Tuple3<ResourceID, JobID, Collection<ResultPartitionID>>> releaseCalls) {
+		return new TestingTaskExecutorGatewayBuilder()
+			.setReleasePartitionsConsumer((jobId, partitionIds) -> releaseCalls.add(Tuple3.of(taskExecutorId, jobId, partitionIds)))
+			.createTestingTaskExecutorGateway();
+	}
+
+	private static class TestingShuffleMaster implements ShuffleMaster<ShuffleDescriptor> {
+
+		final Queue<ResultPartitionID> externallyReleasedPartitions = new ArrayBlockingQueue<>(4);
+
+		@Override
+		public CompletableFuture<ShuffleDescriptor> registerPartitionWithProducer(PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+			return null;
+		}
+
+		@Override
+		public void releasePartitionExternally(ShuffleDescriptor shuffleDescriptor) {
+			externallyReleasedPartitions.add(shuffleDescriptor.getResultPartitionID());
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingPartitionTracker.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Test {@link PartitionTracker} implementation.
+ */
+public class TestingPartitionTracker implements PartitionTracker {
+
+	private Function<ResourceID, Boolean> isTrackingPartitionsForFunction = ignored -> false;
+	private Consumer<ResourceID> stopTrackingAllPartitionsConsumer = ignored -> {};
+	private Consumer<ResourceID> stopTrackingAndReleaseAllPartitionsConsumer = ignored -> {};
+	private BiConsumer<ResourceID, ResultPartitionDeploymentDescriptor> startTrackingPartitionsConsumer = (ignoredA, ignoredB) -> {};
+	private Consumer<Collection<ResultPartitionID>> stopTrackingAndReleasePartitionsConsumer = ignored -> {};
+
+	public void setStartTrackingPartitionsConsumer(BiConsumer<ResourceID, ResultPartitionDeploymentDescriptor> startTrackingPartitionsConsumer) {
+		this.startTrackingPartitionsConsumer = startTrackingPartitionsConsumer;
+	}
+
+	public void setIsTrackingPartitionsForFunction(Function<ResourceID, Boolean> isTrackingPartitionsForFunction) {
+		this.isTrackingPartitionsForFunction = isTrackingPartitionsForFunction;
+	}
+
+	public void setStopTrackingAllPartitionsConsumer(Consumer<ResourceID> stopTrackingAllPartitionsConsumer) {
+		this.stopTrackingAllPartitionsConsumer = stopTrackingAllPartitionsConsumer;
+	}
+
+	public void setStopTrackingAndReleaseAllPartitionsConsumer(Consumer<ResourceID> stopTrackingAndReleaseAllPartitionsConsumer) {
+		this.stopTrackingAndReleaseAllPartitionsConsumer = stopTrackingAndReleaseAllPartitionsConsumer;
+	}
+
+	public void setStopTrackingAndReleasePartitionsConsumer(Consumer<Collection<ResultPartitionID>> stopTrackingAndReleasePartitionsConsumer) {
+		this.stopTrackingAndReleasePartitionsConsumer = stopTrackingAndReleasePartitionsConsumer;
+	}
+
+	@Override
+	public void startTrackingPartition(ResourceID producingTaskExecutorId, ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor) {
+		this.startTrackingPartitionsConsumer.accept(producingTaskExecutorId, resultPartitionDeploymentDescriptor);
+	}
+
+	@Override
+	public void stopTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
+		stopTrackingAllPartitionsConsumer.accept(producingTaskExecutorId);
+	}
+
+	@Override
+	public void stopTrackingAndReleasePartitions(Collection<ResultPartitionID> resultPartitionIds) {
+		stopTrackingAndReleasePartitionsConsumer.accept(resultPartitionIds);
+	}
+
+	@Override
+	public void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId) {
+		stopTrackingAndReleaseAllPartitionsConsumer.accept(producingTaskExecutorId);
+	}
+
+	@Override
+	public boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
+		return isTrackingPartitionsForFunction.apply(producingTaskExecutorId);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
@@ -1828,6 +1829,60 @@ public class JobMasterTest extends TestLogger {
 
 			jobMasterGateway.disconnectTaskManager(taskManagerLocation.getResourceID(), new Exception("test"));
 			disconnectTaskExecutorFuture.get();
+
+			assertThat(partitionCleanupTaskExecutorId.get(), equalTo(taskManagerLocation.getResourceID()));
+		} finally {
+			RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+		}
+	}
+
+	@Test
+	public void testPartitionReleaseOnJobTermination() throws Exception {
+		final JobManagerSharedServices jobManagerSharedServices = new TestingJobManagerSharedServicesBuilder().build();
+		final JobGraph jobGraph = createSingleVertexJobGraph();
+
+		final CompletableFuture<ResourceID> partitionCleanupTaskExecutorId = new CompletableFuture<>();
+		final TestingPartitionTracker partitionTracker = new TestingPartitionTracker();
+		partitionTracker.setStopTrackingAndReleaseAllPartitionsConsumer(partitionCleanupTaskExecutorId::complete);
+
+		final JobMaster jobMaster = new JobMasterBuilder()
+			.withConfiguration(configuration)
+			.withJobGraph(jobGraph)
+			.withHighAvailabilityServices(haServices)
+			.withJobManagerSharedServices(jobManagerSharedServices)
+			.withHeartbeatServices(heartbeatServices)
+			.withOnCompletionActions(new TestingOnCompletionActions())
+			.withPartitionTrackerFactory(ignord -> partitionTracker)
+			.createJobMaster();
+
+		final CompletableFuture<TaskDeploymentDescriptor> taskDeploymentDescriptorFuture = new CompletableFuture<>();
+		final CompletableFuture<Tuple2<JobID, Collection<ResultPartitionID>>> releasePartitionsFuture = new CompletableFuture<>();
+		final CompletableFuture<JobID> disconnectTaskExecutorFuture = new CompletableFuture<>();
+		final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setReleasePartitionsConsumer((jobId, partitions) -> releasePartitionsFuture.complete(Tuple2.of(jobId, partitions)))
+			.setDisconnectJobManagerConsumer((jobID, throwable) -> disconnectTaskExecutorFuture.complete(jobID))
+			.setSubmitTaskConsumer((tdd, ignored) -> {
+				taskDeploymentDescriptorFuture.complete(tdd);
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			})
+			.createTestingTaskExecutorGateway();
+
+		try {
+			jobMaster.start(jobMasterId).get();
+
+			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
+
+			final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+			registerSlotsAtJobMaster(1, jobMasterGateway, testingTaskExecutorGateway, taskManagerLocation);
+
+			// update the execution state of the only execution to FINISHED
+			// this should trigger the job to finish
+			final TaskDeploymentDescriptor taskDeploymentDescriptor = taskDeploymentDescriptorFuture.get();
+			jobMasterGateway.updateTaskExecutionState(
+				new TaskExecutionState(
+					taskDeploymentDescriptor.getJobId(),
+					taskDeploymentDescriptor.getExecutionAttemptId(),
+					ExecutionState.FINISHED));
 
 			assertThat(partitionCleanupTaskExecutorId.get(), equalTo(taskManagerLocation.getResourceID()));
 		} finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -148,7 +148,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			.setTaskSlotTable(createTaskSlotTable())
 			.build();
 
-		final PartitionTable partitionTable = new PartitionTable();
+		final PartitionTable<JobID> partitionTable = new PartitionTable<>();
 		final ResultPartitionID resultPartitionId = new ResultPartitionID();
 
 		final TestingTaskExecutor taskExecutor = createTestingTaskExecutor(taskManagerServices, partitionTable);
@@ -267,7 +267,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			})
 			.build();
 
-		final PartitionTable partitionTable = new PartitionTable();
+		final PartitionTable<JobID> partitionTable = new PartitionTable<>();
 
 		final TestingTaskExecutor taskExecutor = createTestingTaskExecutor(taskManagerServices, partitionTable);
 
@@ -385,7 +385,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 		}
 	}
 
-	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices, PartitionTable partitionTable) throws IOException {
+	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices, PartitionTable<JobID> partitionTable) throws IOException {
 		return new TestingTaskExecutor(
 			RPC,
 			TaskManagerConfiguration.fromConfiguration(new Configuration()),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1868,7 +1868,7 @@ public class TaskExecutorTest extends TestLogger {
 			null,
 			dummyBlobCacheService,
 			testingFatalErrorHandler,
-			new PartitionTable());
+			new PartitionTable<>());
 	}
 
 	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices) {
@@ -1886,7 +1886,7 @@ public class TaskExecutorTest extends TestLogger {
 			null,
 			dummyBlobCacheService,
 			testingFatalErrorHandler,
-			new PartitionTable());
+			new PartitionTable<>());
 	}
 
 	private static final class StartStopNotifyingLeaderRetrievalService implements LeaderRetrievalService {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -207,7 +207,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 			null,
 			blobCacheService,
 			testingFatalErrorHandler,
-			new PartitionTable()
+			new PartitionTable<>()
 		);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -46,7 +47,7 @@ class TestingTaskExecutor extends TaskExecutor {
 			@Nullable String metricQueryServiceAddress,
 			BlobCacheService blobCacheService,
 			FatalErrorHandler fatalErrorHandler,
-			PartitionTable partitionTable) {
+			PartitionTable<JobID> partitionTable) {
 		super(
 			rpcService,
 			taskManagerConfiguration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -74,6 +74,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	private final Supplier<Boolean> canBeReleasedSupplier;
 
+	private final BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer;
+
 	TestingTaskExecutorGateway(
 			String address,
 			String hostname,
@@ -85,7 +87,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 			Consumer<ResourceID> heartbeatResourceManagerConsumer,
 			Consumer<Exception> disconnectResourceManagerConsumer,
 			Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction,
-			Supplier<Boolean> canBeReleasedSupplier) {
+			Supplier<Boolean> canBeReleasedSupplier,
+			BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer) {
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
 		this.heartbeatJobManagerConsumer = Preconditions.checkNotNull(heartbeatJobManagerConsumer);
@@ -97,6 +100,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 		this.disconnectResourceManagerConsumer = disconnectResourceManagerConsumer;
 		this.cancelTaskFunction = cancelTaskFunction;
 		this.canBeReleasedSupplier = canBeReleasedSupplier;
+		this.releasePartitionsConsumer = releasePartitionsConsumer;
 	}
 
 	@Override
@@ -106,12 +110,12 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	@Override
 	public CompletableFuture<StackTraceSampleResponse> requestStackTraceSample(
-			final ExecutionAttemptID executionAttemptId,
-			final int sampleId,
-			final int numSamples,
-			final Time delayBetweenSamples,
-			final int maxStackTraceDepth,
-			final Time timeout) {
+		final ExecutionAttemptID executionAttemptId,
+		final int sampleId,
+		final int numSamples,
+		final Time delayBetweenSamples,
+		final int maxStackTraceDepth,
+		final Time timeout) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -127,7 +131,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	@Override
 	public void releasePartitions(JobID jobId, Collection<ResultPartitionID> partitionIds) {
-		// noop
+		releasePartitionsConsumer.accept(jobId, partitionIds);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -25,11 +25,13 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -50,6 +52,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private static final Consumer<ResourceID> NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
 	private static final Consumer<Exception> NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
 	private static final Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> NOOP_CANCEL_TASK_FUNCTION = ignored -> CompletableFuture.completedFuture(Acknowledge.get());
+	private static final BiConsumer<JobID, Collection<ResultPartitionID>> NOOP_RELEASE_PARTITIONS_CONSUMER = (ignoredA, ignoredB) -> {};
 
 	private String address = "foobar:1234";
 	private String hostname = "foobar";
@@ -62,6 +65,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private Consumer<Exception> disconnectResourceManagerConsumer = NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER;
 	private Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction = NOOP_CANCEL_TASK_FUNCTION;
 	private Supplier<Boolean> canBeReleasedSupplier = () -> true;
+	private BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer = NOOP_RELEASE_PARTITIONS_CONSUMER;
 
 	public TestingTaskExecutorGatewayBuilder setAddress(String address) {
 		this.address = address;
@@ -118,6 +122,11 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
+	public TestingTaskExecutorGatewayBuilder setReleasePartitionsConsumer(BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer) {
+		this.releasePartitionsConsumer = releasePartitionsConsumer;
+		return this;
+	}
+
 	public TestingTaskExecutorGateway createTestingTaskExecutorGateway() {
 		return new TestingTaskExecutorGateway(
 			address,
@@ -130,6 +139,7 @@ public class TestingTaskExecutorGatewayBuilder {
 			heartbeatResourceManagerConsumer,
 			disconnectResourceManagerConsumer,
 			cancelTaskFunction,
-			canBeReleasedSupplier);
+			canBeReleasedSupplier,
+			releasePartitionsConsumer);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/partition/PartitionTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/partition/PartitionTableTest.java
@@ -43,7 +43,7 @@ public class PartitionTableTest extends TestLogger {
 
 	@Test
 	public void testEmptyTable() {
-		final PartitionTable table = new PartitionTable();
+		final PartitionTable<JobID> table = new PartitionTable<>();
 
 		// an empty table should always return an empty collection
 		Collection<ResultPartitionID> partitionsForNonExistingJob = table.stopTrackingPartitions(JOB_ID);
@@ -55,7 +55,7 @@ public class PartitionTableTest extends TestLogger {
 
 	@Test
 	public void testStartTrackingPartition() {
-		final PartitionTable table = new PartitionTable();
+		final PartitionTable<JobID> table = new PartitionTable<>();
 
 		table.startTrackingPartitions(JOB_ID, Collections.singletonList(PARTITION_ID));
 
@@ -64,7 +64,7 @@ public class PartitionTableTest extends TestLogger {
 
 	@Test
 	public void testStopTrackingAllPartitions() {
-		final PartitionTable table = new PartitionTable();
+		final PartitionTable<JobID> table = new PartitionTable<>();
 
 		table.startTrackingPartitions(JOB_ID, Collections.singletonList(PARTITION_ID));
 
@@ -76,7 +76,7 @@ public class PartitionTableTest extends TestLogger {
 	@Test
 	public void testStopTrackingPartitions() {
 		final ResultPartitionID partitionId2 = new ResultPartitionID();
-		final PartitionTable table = new PartitionTable();
+		final PartitionTable<JobID> table = new PartitionTable<>();
 
 		table.startTrackingPartitions(JOB_ID, Collections.singletonList(PARTITION_ID));
 		table.startTrackingPartitions(JOB_ID, Collections.singletonList(partitionId2));


### PR DESCRIPTION
Based on #8687 . When reviewing this PR, please ignore all commits preceding 
"[FLINK-12615][coordination] Support generic key in PartitionTable".

## What is the purpose of the change

With this PR we track on the JobMaster side which partitions are still on task executors, maintain the connection to a task executor until all partitions on it have been released, and issue a release call for all partitions when a job terminates.

**Attention:** The release logic in PR only serves as a MVP. It ignores the shuffle master (and thus will not work with other shuffle service implementation) and is not viable for high-volume jobs (because it requires all blocking partitions to be persisted on disk until the job is finished).

## Brief changelog

6009f00 modifies the PartitionTable to support arbitrary keys; so far it was hard-wired to use JobIDs as keys for use on the TE side, but now we want to organize them by ResourceID (== TE ID) instead.

c7193dc introduces a PartitionTable into the JM, Scheduler and EG. This commit only modifies constructor-related methods and does not contain any actual logic. This commit only exists to make reviewing easier.

ea418da contains the tracking logic. Partitions are added to the table, grouped by task executor, by an Execution when it reaches the state FINISHED, and removed again by the JM when disassociating from a TE.

3087792 introduces a call to TE#releasePartitions for when a job is finished.

d5a9f3c finally modifies the check for empty taskmanagers to take partitions into account.