### PR TITLE
[travis] Increase travis cache timeout to 1200

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ dist: xenial
 
 cache:
   # default timeout is too low
-  timeout: 600
+  timeout: 1200
   directories:
   - $HOME/.m2
   - $HOME/flink_cache


### PR DESCRIPTION
 Increase Travis cache timeout to 1200, try to fix the follows error:

```
Cached flink dir /home/travis/flink_cache/37943/flink does not exist. Exiting build.
The command "./tools/travis_controller.sh core" exited with 1.
```
Detail can be found here: https://api.travis-ci.org/v3/job/547116795/log.txt