### PR TITLE
[FLINK-12874][table-common] Improve the semantics of zero length strings

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BinaryType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BinaryType.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 
 import java.util.Collections;
@@ -91,9 +92,11 @@ public final class BinaryType extends LogicalType {
 	 * For consistent behavior, the same logic applies to binary strings.
 	 *
 	 * <p>This method enables this special kind of binary string.
+	 *
+	 * <p>Zero-length binary strings have no serializable string representation.
 	 */
 	public static BinaryType ofEmptyLiteral() {
-		return new BinaryType(EMPTY_LITERAL_LENGTH, false);
+		return new BinaryType(EMPTY_LITERAL_LENGTH, true);
 	}
 
 	public int getLength() {
@@ -107,6 +110,15 @@ public final class BinaryType extends LogicalType {
 
 	@Override
 	public String asSerializableString() {
+		if (length == EMPTY_LITERAL_LENGTH) {
+			throw new TableException(
+				"Zero-length binary strings have no serializable string representation.");
+		}
+		return withNullability(FORMAT, length);
+	}
+
+	@Override
+	public String asSummaryString() {
 		return withNullability(FORMAT, length);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/CharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/CharType.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 
 import java.util.Collections;
@@ -93,9 +94,11 @@ public final class CharType extends LogicalType {
 	 * (i.e., to contain no characters) even though it is not permitted to declare a type that is zero.
 	 *
 	 * <p>This method enables this special kind of character string.
+	 *
+	 * <p>Zero-length character strings have no serializable string representation.
 	 */
 	public static CharType ofEmptyLiteral() {
-		return new CharType(EMPTY_LITERAL_LENGTH, false);
+		return new CharType(EMPTY_LITERAL_LENGTH, true);
 	}
 
 	public int getLength() {
@@ -109,6 +112,15 @@ public final class CharType extends LogicalType {
 
 	@Override
 	public String asSerializableString() {
+		if (length == EMPTY_LITERAL_LENGTH) {
+			throw new TableException(
+				"Zero-length character strings have no serializable string representation.");
+		}
+		return withNullability(FORMAT, length);
+	}
+
+	@Override
+	public String asSummaryString() {
 		return withNullability(FORMAT, length);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarBinaryType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarBinaryType.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 
 import java.util.Collections;
@@ -33,9 +34,14 @@ import java.util.Set;
  * number of bytes. {@code n} must have a value between 1 and {@link Integer#MAX_VALUE} (both
  * inclusive). If no length is specified, {@code n} is equal to 1. {@code BYTES} is a synonym for
  * {@code VARBINARY(2147483647)}.
+ *
+ * <p>For enabling type inference of a zero-length binary string literal to a variable-length binary
+ * string, this type does also support {@code n} to be 0. However, this is not exposed through the API.
  */
 @PublicEvolving
 public final class VarBinaryType extends LogicalType {
+
+	public static final int EMPTY_LITERAL_LENGTH = 0;
 
 	public static final int MIN_LENGTH = 1;
 
@@ -75,17 +81,44 @@ public final class VarBinaryType extends LogicalType {
 		this(DEFAULT_LENGTH);
 	}
 
+	/**
+	 * Helper constructor for {@link #ofEmptyLiteral()} and {@link #copy(boolean)}.
+	 */
+	private VarBinaryType(int length, boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.VARBINARY);
+		this.length = length;
+	}
+
+	/**
+	 * The SQL standard defines that character string literals are allowed to be zero-length strings
+	 * (i.e., to contain no characters) even though it is not permitted to declare a type that is zero.
+	 * For consistent behavior, the same logic applies to binary strings. This has also implications
+	 * on variable-length binary strings during type inference because any fixed-length binary string
+	 * should be convertible to a variable-length one.
+	 *
+	 * <p>This method enables this special kind of binary string.
+	 *
+	 * <p>Zero-length binary strings have no serializable string representation.
+	 */
+	public static VarBinaryType ofEmptyLiteral() {
+		return new VarBinaryType(EMPTY_LITERAL_LENGTH, true);
+	}
+
 	public int getLength() {
 		return length;
 	}
 
 	@Override
 	public LogicalType copy(boolean isNullable) {
-		return new VarBinaryType(isNullable, length);
+		return new VarBinaryType(length, isNullable);
 	}
 
 	@Override
 	public String asSerializableString() {
+		if (length == EMPTY_LITERAL_LENGTH) {
+			throw new TableException(
+				"Zero-length binary strings have no serializable string representation.");
+		}
 		return withNullability(FORMAT, length);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 
 import java.util.Collections;
@@ -34,10 +35,15 @@ import java.util.Set;
  * inclusive). If no length is specified, {@code n} is equal to 1. {@code STRING} is a synonym for
  * {@code VARCHAR(2147483647)}.
  *
+ * <p>For enabling type inference of a zero-length character string literal to a variable-length character
+ * string, this type does also support {@code n} to be 0. However, this is not exposed through the API.
+ *
  * <p>A conversion from and to {@code byte[]} assumes UTF-8 encoding.
  */
 @PublicEvolving
 public final class VarCharType extends LogicalType {
+
+	public static final int EMPTY_LITERAL_LENGTH = 0;
 
 	public static final int MIN_LENGTH = 1;
 
@@ -78,17 +84,43 @@ public final class VarCharType extends LogicalType {
 		this(DEFAULT_LENGTH);
 	}
 
+	/**
+	 * Helper constructor for {@link #ofEmptyLiteral()} and {@link #copy(boolean)}.
+	 */
+	private VarCharType(int length, boolean isNullable) {
+		super(isNullable, LogicalTypeRoot.VARCHAR);
+		this.length = length;
+	}
+
+	/**
+	 * The SQL standard defines that character string literals are allowed to be zero-length strings
+	 * (i.e., to contain no characters) even though it is not permitted to declare a type that is zero.
+	 * This has also implications on variable-length character strings during type inference because any
+	 * fixed-length character string should be convertible to a variable-length one.
+	 *
+	 * <p>This method enables this special kind of character string.
+	 *
+	 * <p>Zero-length character strings have no serializable string representation.
+	 */
+	public static VarCharType ofEmptyLiteral() {
+		return new VarCharType(EMPTY_LITERAL_LENGTH, true);
+	}
+
 	public int getLength() {
 		return length;
 	}
 
 	@Override
 	public LogicalType copy(boolean isNullable) {
-		return new VarCharType(isNullable, length);
+		return new VarCharType(length, isNullable);
 	}
 
 	@Override
 	public String asSerializableString() {
+		if (length == EMPTY_LITERAL_LENGTH) {
+			throw new TableException(
+				"Zero-length character strings have no serializable string representation.");
+		}
 		return withNullability(FORMAT, length);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

See the JIRA issue and JavaDocs for more information.

## Brief change log

- Allow all kinds of zero-length strings
- Forbid serializability

## Verifying this change

This change added tests and can be verified as follows:

- Updated `LogicalTypesTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
