### PR TITLE
[FLINK-12892][table][hive] serialize catalog table to properties for table discovery service

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.catalog.GenericCatalogTable;
 import org.apache.flink.table.catalog.GenericCatalogView;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.config.CatalogTableConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
@@ -488,7 +489,7 @@ public class HiveCatalog extends AbstractCatalog {
 		if (isGeneric) {
 			properties = retrieveFlinkProperties(properties);
 		}
-		String comment = properties.remove(HiveTableConfig.TABLE_COMMENT);
+		String comment = properties.remove(CatalogTableConfig.TABLE_COMMENT);
 
 		// Table schema
 		TableSchema tableSchema =
@@ -535,7 +536,7 @@ public class HiveCatalog extends AbstractCatalog {
 
 		Map<String, String> properties = new HashMap<>(table.getProperties());
 		// Table comment
-		properties.put(HiveTableConfig.TABLE_COMMENT, table.getComment());
+		properties.put(CatalogTableConfig.TABLE_COMMENT, table.getComment());
 		if (table instanceof GenericCatalogTable || table instanceof GenericCatalogView) {
 			properties = maskFlinkProperties(properties);
 		}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogTable.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogTable.java
@@ -65,11 +65,4 @@ public class HiveCatalogTable extends AbstractCatalogTable {
 		return Optional.ofNullable(getComment());
 	}
 
-	@Override
-	public Map<String, String> toProperties() {
-		// TODO: output properties that are used to auto-discover TableFactory for Hive tables.
-		Map<String, String> properties = new HashMap<>();
-		return properties;
-	}
-
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
@@ -91,7 +91,10 @@ public abstract class AbstractCatalogTable implements CatalogTable {
 
 		descriptor.putTableSchema(Schema.SCHEMA, getSchema());
 
-		descriptor.putPropertiesWithPrefix(CatalogTableConfig.TABLE_PROPERTIES, getProperties());
+		Map<String, String> properties = getProperties();
+		properties.remove(GenericInMemoryCatalog.FLINK_IS_GENERIC_KEY);
+
+		descriptor.putPropertiesWithPrefix(CatalogTableConfig.TABLE_PROPERTIES, properties);
 
 		descriptor.putString(CatalogTableConfig.TABLE_COMMENT, getComment());
 		descriptor.putString(CatalogTableConfig.TABLE_PARTITION_KEYS, String.join(",", partitionKeys));

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
@@ -19,6 +19,9 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.config.CatalogTableConfig;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.Schema;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,4 +85,17 @@ public abstract class AbstractCatalogTable implements CatalogTable {
 		return comment;
 	}
 
+	@Override
+	public Map<String, String> toProperties() {
+		DescriptorProperties descriptor = new DescriptorProperties();
+
+		descriptor.putTableSchema(Schema.SCHEMA, getSchema());
+
+		descriptor.putPropertiesWithPrefix(CatalogTableConfig.TABLE_PROPERTIES, getProperties());
+
+		descriptor.putString(CatalogTableConfig.TABLE_COMMENT, getComment());
+		descriptor.putString(CatalogTableConfig.TABLE_PARTITION_KEYS, String.join(",", partitionKeys));
+
+		return descriptor.asMap();
+	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericCatalogTable.java
@@ -54,13 +54,6 @@ public class GenericCatalogTable extends AbstractCatalogTable {
 	}
 
 	@Override
-	public Map<String, String> toProperties() {
-		// TODO: Filter out ANY properties that are not needed for table discovery.
-		Map<String, String> properties = new HashMap<>();
-		return properties;
-	}
-
-	@Override
 	public Optional<String> getDescription() {
 		return Optional.of(getComment());
 	}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/AbstractCatalogTableTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/AbstractCatalogTableTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.config.CatalogTableConfig;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.Schema;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link AbstractCatalogTable}.
+ */
+public class AbstractCatalogTableTest {
+	private static final String TEST = "test";
+
+	@Test
+	public void testToProperties() {
+		TableSchema schema = createTableSchema();
+		Map<String, String> prop = createProperties();
+		GenericCatalogTable table = new GenericCatalogTable(
+			schema,
+			createPartitionKeys(),
+			prop,
+			TEST
+		);
+
+		DescriptorProperties descriptorProperties = new DescriptorProperties();
+		descriptorProperties.putProperties(table.toProperties());
+
+		assertEquals(schema, descriptorProperties.getTableSchema(Schema.SCHEMA));
+		assertEquals(TEST, descriptorProperties.getString(CatalogTableConfig.TABLE_COMMENT));
+		assertEquals("second,third", descriptorProperties.getString(CatalogTableConfig.TABLE_PARTITION_KEYS));
+		assertEquals(prop, descriptorProperties.getPropertiesWithPrefix(CatalogTableConfig.TABLE_PROPERTIES));
+	}
+
+	private static Map<String, String> createProperties() {
+		return new HashMap<String, String>() {{
+			put("k", "v");
+		}};
+	}
+
+	private static TableSchema createTableSchema() {
+		return TableSchema.builder()
+			.field("first", DataTypes.STRING())
+			.field("second", DataTypes.INT())
+			.field("third", DataTypes.DOUBLE())
+			.build();
+	}
+
+	private static List<String> createPartitionKeys() {
+		return Arrays.asList("second", "third");
+	}
+
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/AbstractCatalogTableTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/AbstractCatalogTableTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.table.descriptors.Schema;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/config/CatalogTableConfig.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/config/CatalogTableConfig.java
@@ -16,13 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.catalog.hive;
+package org.apache.flink.table.catalog.config;
+
+import org.apache.flink.table.catalog.CatalogBaseTable;
 
 /**
- * Configs for tables in Hive metastore.
+ * Config for {@link CatalogBaseTable}.
  */
-public class HiveTableConfig {
+public class CatalogTableConfig {
 
-	public static final String DEFAULT_LIST_COLUMN_TYPES_SEPARATOR = ":";
+	// Comment of catalog table
+	public static final String TABLE_COMMENT = "comment";
 
+	// Partition keys of catalog table
+	public static final String TABLE_PARTITION_KEYS = "partition-keys";
+
+	// Prefix for properties of catalog table
+	public static final String TABLE_PROPERTIES = "properties";
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
@@ -104,7 +104,10 @@ public class DescriptorProperties {
 	}
 
 	/**
-	 * Adds a properties map by appending the given prefix to element keys.
+	 * Adds a properties map by appending the given prefix to element keys with a dot.
+	 *
+	 * <p>For example: for prefix "flink" and a map of a single property with key "k" and value "v".
+	 * The added property will be as key "flink.k" and value "v".
 	 */
 	public void putPropertiesWithPrefix(String prefix, Map<String, String> prop) {
 		checkNotNull(prefix);
@@ -720,10 +723,15 @@ public class DescriptorProperties {
 	/**
 	 * Returns a map of properties whose key starts with the given prefix,
 	 * and the prefix is removed upon return.
+	 *
+	 * <p>For example, for prefix "flink" and a map of a single property with key "flink.k" and value "v",
+	 * this method will return it as key "k" and value "v" by identifying and removing the prefix "flink".
 	 */
 	public Map<String, String> getPropertiesWithPrefix(String prefix) {
+		String prefixWithDot = prefix + '.';
+
 		return properties.entrySet().stream()
-			.filter(e -> e.getKey().startsWith(prefix))
+			.filter(e -> e.getKey().startsWith(prefixWithDot))
 			.collect(Collectors.toMap(e -> e.getKey().substring(prefix.length() + 1), Map.Entry::getValue));
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
@@ -104,6 +104,18 @@ public class DescriptorProperties {
 	}
 
 	/**
+	 * Adds a properties map by appending the given prefix to element keys.
+	 */
+	public void putPropertiesWithPrefix(String prefix, Map<String, String> prop) {
+		checkNotNull(prefix);
+		checkNotNull(prop);
+
+		for (Map.Entry<String, String> e : prop.entrySet()) {
+			put(String.format("%s.%s", prefix, e.getKey()), e.getValue());
+		}
+	}
+
+	/**
 	 * Adds a class under the given key.
 	 */
 	public void putClass(String key, Class<?> clazz) {
@@ -703,6 +715,16 @@ public class DescriptorProperties {
 	 */
 	public boolean isValue(String key, String value) {
 		return optionalGet(key).orElseThrow(exceptionSupplier(key)).equals(value);
+	}
+
+	/**
+	 * Returns a map of properties whose key starts with the given prefix,
+	 * and the prefix is removed upon return.
+	 */
+	public Map<String, String> getPropertiesWithPrefix(String prefix) {
+		return properties.entrySet().stream()
+			.filter(e -> e.getKey().startsWith(prefix))
+			.collect(Collectors.toMap(e -> e.getKey().substring(prefix.length() + 1), Map.Entry::getValue));
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This PR enables serialization of catalog table to properties for table discovery service and table factory to initiate source/sink from those properties

## Brief change log

- implemented `toProperties()` in `AbstractCatalogTable` to serialize tables to properties
- added unit tests 

## Verifying this change

This change added tests and can be verified as follows:

- `AbstractCatalogTableTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
