### PR TITLE
[FLINK-12710][table] Prepare expressions for a new resolved expression

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrdered.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrdered.java
@@ -19,14 +19,14 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionParser;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 
 /**
  * Partially defined over window with (optional) partitioning and order.
@@ -83,7 +83,7 @@ public final class OverWindowPartitionedOrdered {
 			alias,
 			partitionBy,
 			orderBy,
-			new CallExpression(BuiltInFunctionDefinitions.UNBOUNDED_RANGE, Collections.emptyList()),
+			call(BuiltInFunctionDefinitions.UNBOUNDED_RANGE),
 			Optional.empty());
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrdered.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrdered.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 
 /**
  * Partially defined over window with (optional) partitioning and order.
@@ -83,7 +83,7 @@ public final class OverWindowPartitionedOrdered {
 			alias,
 			partitionBy,
 			orderBy,
-			call(BuiltInFunctionDefinitions.UNBOUNDED_RANGE),
+			unresolvedCall(BuiltInFunctionDefinitions.UNBOUNDED_RANGE),
 			Optional.empty());
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionDefaultVisitor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionDefaultVisitor.java
@@ -27,8 +27,8 @@ import org.apache.flink.annotation.Internal;
 @Internal
 public abstract class ApiExpressionDefaultVisitor<T> extends ApiExpressionVisitor<T> {
 	@Override
-	public T visit(CallExpression call) {
-		return defaultMethod(call);
+	public T visit(UnresolvedCallExpression unresolvedCall) {
+		return defaultMethod(unresolvedCall);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionDefaultVisitor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionDefaultVisitor.java
@@ -27,42 +27,42 @@ import org.apache.flink.annotation.Internal;
 @Internal
 public abstract class ApiExpressionDefaultVisitor<T> extends ApiExpressionVisitor<T> {
 	@Override
-	public T visitCall(CallExpression call) {
+	public T visit(CallExpression call) {
 		return defaultMethod(call);
 	}
 
 	@Override
-	public T visitValueLiteral(ValueLiteralExpression valueLiteralExpression) {
+	public T visit(ValueLiteralExpression valueLiteralExpression) {
 		return defaultMethod(valueLiteralExpression);
 	}
 
 	@Override
-	public T visitFieldReference(FieldReferenceExpression fieldReference) {
+	public T visit(FieldReferenceExpression fieldReference) {
 		return defaultMethod(fieldReference);
 	}
 
 	@Override
-	public T visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference) {
+	public T visit(UnresolvedReferenceExpression unresolvedReference) {
 		return defaultMethod(unresolvedReference);
 	}
 
 	@Override
-	public T visitLocalReference(LocalReferenceExpression localReference) {
+	public T visit(LocalReferenceExpression localReference) {
 		return defaultMethod(localReference);
 	}
 
 	@Override
-	public T visitTypeLiteral(TypeLiteralExpression typeLiteral) {
+	public T visit(TypeLiteralExpression typeLiteral) {
 		return defaultMethod(typeLiteral);
 	}
 
 	@Override
-	public T visitTableReference(TableReferenceExpression tableReference) {
+	public T visit(TableReferenceExpression tableReference) {
 		return defaultMethod(tableReference);
 	}
 
 	@Override
-	public T visitLookupCall(LookupCallExpression lookupCall) {
+	public T visit(LookupCallExpression lookupCall) {
 		return defaultMethod(lookupCall);
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
@@ -45,8 +45,8 @@ public final class ApiExpressionUtils {
 		// private
 	}
 
-	public static CallExpression call(FunctionDefinition functionDefinition, Expression... args) {
-		return new CallExpression(functionDefinition, Arrays.asList(args));
+	public static UnresolvedCallExpression call(FunctionDefinition functionDefinition, Expression... args) {
+		return new UnresolvedCallExpression(functionDefinition, Arrays.asList(args));
 	}
 
 	public static ValueLiteralExpression valueLiteral(Object value) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
@@ -45,10 +45,6 @@ public final class ApiExpressionUtils {
 		// private
 	}
 
-	public static UnresolvedCallExpression call(FunctionDefinition functionDefinition, Expression... args) {
-		return new UnresolvedCallExpression(functionDefinition, Arrays.asList(args));
-	}
-
 	public static ValueLiteralExpression valueLiteral(Object value) {
 		return new ValueLiteralExpression(value);
 	}
@@ -63,6 +59,10 @@ public final class ApiExpressionUtils {
 
 	public static UnresolvedReferenceExpression unresolvedRef(String name) {
 		return new UnresolvedReferenceExpression(name);
+	}
+
+	public static UnresolvedCallExpression unresolvedCall(FunctionDefinition functionDefinition, Expression... args) {
+		return new UnresolvedCallExpression(functionDefinition, Arrays.asList(args));
 	}
 
 	public static TableReferenceExpression tableRef(String name, Table table) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionVisitor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionVisitor.java
@@ -26,23 +26,23 @@ import org.apache.flink.annotation.Internal;
 @Internal
 public abstract class ApiExpressionVisitor<R> implements ExpressionVisitor<R> {
 
-	public abstract R visitTableReference(TableReferenceExpression tableReference);
+	public abstract R visit(TableReferenceExpression tableReference);
 
-	public abstract R visitLocalReference(LocalReferenceExpression localReference);
+	public abstract R visit(LocalReferenceExpression localReference);
 
-	public abstract R visitLookupCall(LookupCallExpression lookupCall);
+	public abstract R visit(LookupCallExpression lookupCall);
 
-	public abstract R visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference);
+	public abstract R visit(UnresolvedReferenceExpression unresolvedReference);
 
 	public final R visit(Expression other) {
 		if (other instanceof TableReferenceExpression) {
-			return visitTableReference((TableReferenceExpression) other);
+			return visit((TableReferenceExpression) other);
 		} else if (other instanceof LocalReferenceExpression) {
-			return visitLocalReference((LocalReferenceExpression) other);
+			return visit((LocalReferenceExpression) other);
 		} else if (other instanceof LookupCallExpression) {
-			return visitLookupCall((LookupCallExpression) other);
+			return visit((LookupCallExpression) other);
 		} else if (other instanceof UnresolvedReferenceExpression) {
-			return visitUnresolvedReference((UnresolvedReferenceExpression) other);
+			return visit((UnresolvedReferenceExpression) other);
 		}
 		return visitNonApiExpression(other);
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LocalReferenceExpression.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LocalReferenceExpression.java
@@ -53,6 +53,11 @@ public class LocalReferenceExpression implements Expression {
 	}
 
 	@Override
+	public String asSummaryString() {
+		return name;
+	}
+
+	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
 	}
@@ -82,6 +87,6 @@ public class LocalReferenceExpression implements Expression {
 
 	@Override
 	public String toString() {
-		return name;
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallExpression.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallExpression.java
@@ -46,13 +46,19 @@ public final class LookupCallExpression implements Expression {
 		this.args = Collections.unmodifiableList(new ArrayList<>(Preconditions.checkNotNull(args)));
 	}
 
+	public String getUnresolvedName() {
+		return unresolvedName;
+	}
+
+	@Override
+	public String asSummaryString() {
+		final List<String> argList = args.stream().map(Object::toString).collect(Collectors.toList());
+		return unresolvedName + "(" + String.join(", ", argList) + ")";
+	}
+
 	@Override
 	public List<Expression> getChildren() {
 		return this.args;
-	}
-
-	public String getUnresolvedName() {
-		return unresolvedName;
 	}
 
 	@Override
@@ -80,7 +86,6 @@ public final class LookupCallExpression implements Expression {
 
 	@Override
 	public String toString() {
-		final List<String> argList = args.stream().map(Object::toString).collect(Collectors.toList());
-		return unresolvedName + "(" + String.join(", ", argList) + ")";
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.functions.FunctionDefinition;
 
 import java.util.List;
 
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 
 /**
  * Resolves calls with function names to calls with actual function definitions.
@@ -56,7 +56,7 @@ public class LookupCallResolver extends ApiExpressionDefaultVisitor<Expression> 
 			.map(child -> child.accept(this))
 			.toArray(Expression[]::new);
 
-		return call(functionDefinition, resolvedChildren);
+		return unresolvedCall(functionDefinition, resolvedChildren);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
@@ -39,14 +39,14 @@ public class LookupCallResolver extends ApiExpressionDefaultVisitor<Expression> 
 		this.functionLookup = functionLookup;
 	}
 
-	public Expression visitLookupCall(LookupCallExpression lookupCall) {
+	public Expression visit(LookupCallExpression lookupCall) {
 		final FunctionLookup.Result result = functionLookup.lookupFunction(lookupCall.getUnresolvedName())
 			.orElseThrow(() -> new ValidationException("Undefined function: " + lookupCall.getUnresolvedName()));
 
 		return createResolvedCall(result.getFunctionDefinition(), lookupCall.getChildren());
 	}
 
-	public Expression visitCall(CallExpression call) {
+	public Expression visit(CallExpression call) {
 		return createResolvedCall(call.getFunctionDefinition(), call.getChildren());
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
@@ -46,8 +46,8 @@ public class LookupCallResolver extends ApiExpressionDefaultVisitor<Expression> 
 		return createResolvedCall(result.getFunctionDefinition(), lookupCall.getChildren());
 	}
 
-	public Expression visit(CallExpression call) {
-		return createResolvedCall(call.getFunctionDefinition(), call.getChildren());
+	public Expression visit(UnresolvedCallExpression unresolvedCall) {
+		return createResolvedCall(unresolvedCall.getFunctionDefinition(), unresolvedCall.getChildren());
 	}
 
 	private Expression createResolvedCall(FunctionDefinition functionDefinition, List<Expression> unresolvedChildren) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LookupCallResolver.java
@@ -24,7 +24,8 @@ import org.apache.flink.table.catalog.FunctionLookup;
 import org.apache.flink.table.functions.FunctionDefinition;
 
 import java.util.List;
-import java.util.stream.Collectors;
+
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 
 /**
  * Resolves calls with function names to calls with actual function definitions.
@@ -50,12 +51,12 @@ public class LookupCallResolver extends ApiExpressionDefaultVisitor<Expression> 
 	}
 
 	private Expression createResolvedCall(FunctionDefinition functionDefinition, List<Expression> unresolvedChildren) {
-		List<Expression> resolvedChildren = unresolvedChildren
+		final Expression[] resolvedChildren = unresolvedChildren
 			.stream()
 			.map(child -> child.accept(this))
-			.collect(Collectors.toList());
+			.toArray(Expression[]::new);
 
-		return new CallExpression(functionDefinition, resolvedChildren);
+		return call(functionDefinition, resolvedChildren);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/TableReferenceExpression.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/TableReferenceExpression.java
@@ -51,6 +51,11 @@ public final class TableReferenceExpression implements Expression {
 	}
 
 	@Override
+	public String asSummaryString() {
+		return name;
+	}
+
+	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
 	}
@@ -80,6 +85,6 @@ public final class TableReferenceExpression implements Expression {
 
 	@Override
 	public String toString() {
-		return name;
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/UnresolvedReferenceExpression.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/UnresolvedReferenceExpression.java
@@ -46,6 +46,11 @@ public final class UnresolvedReferenceExpression implements Expression {
 	}
 
 	@Override
+	public String asSummaryString() {
+		return name;
+	}
+
+	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
 	}
@@ -74,6 +79,6 @@ public final class UnresolvedReferenceExpression implements Expression {
 
 	@Override
 	public String toString() {
-		return name;
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationExpressionsUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationExpressionsUtils.java
@@ -199,11 +199,11 @@ public class OperationExpressionsUtils {
 				return unresolvedRef(properties.get(call));
 			}
 
-			List<Expression> args = call.getChildren()
+			final Expression[] args = call.getChildren()
 				.stream()
 				.map(c -> c.accept(this))
-				.collect(Collectors.toList());
-			return new CallExpression(call.getFunctionDefinition(), args);
+				.toArray(Expression[]::new);
+			return call(call.getFunctionDefinition(), args);
 		}
 
 		@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationExpressionsUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationExpressionsUtils.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.apache.flink.table.expressions.ExpressionUtils.extractValue;
@@ -140,7 +140,7 @@ public class OperationExpressionsUtils {
 	private static List<Expression> nameExpressions(Map<Expression, String> expressions) {
 		return expressions.entrySet()
 			.stream()
-			.map(entry -> call(AS, entry.getKey(), valueLiteral(entry.getValue())))
+			.map(entry -> unresolvedCall(AS, entry.getKey(), valueLiteral(entry.getValue())))
 			.collect(Collectors.toList());
 	}
 
@@ -203,7 +203,7 @@ public class OperationExpressionsUtils {
 				.stream()
 				.map(c -> c.accept(this))
 				.toArray(Expression[]::new);
-			return call(unresolvedCall.getFunctionDefinition(), args);
+			return unresolvedCall(unresolvedCall.getFunctionDefinition(), args);
 		}
 
 		@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationExpressionsUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationExpressionsUtils.java
@@ -151,12 +151,12 @@ public class OperationExpressionsUtils {
 		private final Map<Expression, String> properties = new LinkedHashMap<>();
 
 		@Override
-		public Void visitLookupCall(LookupCallExpression unresolvedCall) {
+		public Void visit(LookupCallExpression unresolvedCall) {
 			throw new IllegalStateException("All calls should be resolved by now. Got: " + unresolvedCall);
 		}
 
 		@Override
-		public Void visitCall(CallExpression call) {
+		public Void visit(CallExpression call) {
 			FunctionDefinition functionDefinition = call.getFunctionDefinition();
 			if (isFunctionOfKind(call, AGGREGATE)) {
 				aggregates.computeIfAbsent(call, expr -> "EXPR$" + uniqueId++);
@@ -187,12 +187,12 @@ public class OperationExpressionsUtils {
 		}
 
 		@Override
-		public Expression visitLookupCall(LookupCallExpression unresolvedCall) {
+		public Expression visit(LookupCallExpression unresolvedCall) {
 			throw new IllegalStateException("All calls should be resolved by now. Got: " + unresolvedCall);
 		}
 
 		@Override
-		public Expression visitCall(CallExpression call) {
+		public Expression visit(CallExpression call) {
 			if (aggregates.get(call) != null) {
 				return unresolvedRef(aggregates.get(call));
 			} else if (properties.get(call) != null) {
@@ -214,7 +214,7 @@ public class OperationExpressionsUtils {
 
 	private static class ExtractNameVisitor extends ApiExpressionDefaultVisitor<Optional<String>> {
 		@Override
-		public Optional<String> visitCall(CallExpression call) {
+		public Optional<String> visit(CallExpression call) {
 			if (call.getFunctionDefinition().equals(AS)) {
 				return extractValue(call.getChildren().get(1), String.class);
 			} else {
@@ -223,17 +223,17 @@ public class OperationExpressionsUtils {
 		}
 
 		@Override
-		public Optional<String> visitLocalReference(LocalReferenceExpression localReference) {
+		public Optional<String> visit(LocalReferenceExpression localReference) {
 			return Optional.of(localReference.getName());
 		}
 
 		@Override
-		public Optional<String> visitTableReference(TableReferenceExpression tableReference) {
+		public Optional<String> visit(TableReferenceExpression tableReference) {
 			return Optional.of(tableReference.getName());
 		}
 
 		@Override
-		public Optional<String> visitFieldReference(FieldReferenceExpression fieldReference) {
+		public Optional<String> visit(FieldReferenceExpression fieldReference) {
 			return Optional.of(fieldReference.getName());
 		}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
@@ -458,13 +458,13 @@ public class FieldInfoUtils {
 		}
 
 		@Override
-		public FieldInfo visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference) {
+		public FieldInfo visit(UnresolvedReferenceExpression unresolvedReference) {
 			String fieldName = unresolvedReference.getName();
 			return new FieldInfo(fieldName, index, fromLegacyInfoToDataType(getTypeAt(unresolvedReference)));
 		}
 
 		@Override
-		public FieldInfo visitCall(CallExpression call) {
+		public FieldInfo visit(CallExpression call) {
 			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.AS) {
 				return visitAlias(call);
 			} else if (isRowTimeExpression(call)) {
@@ -541,12 +541,12 @@ public class FieldInfoUtils {
 		}
 
 		@Override
-		public FieldInfo visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference) {
+		public FieldInfo visit(UnresolvedReferenceExpression unresolvedReference) {
 			return createFieldInfo(unresolvedReference, null);
 		}
 
 		@Override
-		public FieldInfo visitCall(CallExpression call) {
+		public FieldInfo visit(CallExpression call) {
 			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.AS) {
 				return visitAlias(call);
 			} else if (isRowTimeExpression(call)) {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/QueryOperationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/QueryOperationTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.table.operations;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
 import org.junit.Test;
@@ -67,7 +67,7 @@ public class QueryOperationTest {
 		FieldReferenceExpression field = new FieldReferenceExpression("a", DataTypes.INT(), 0, 0);
 		WindowAggregateQueryOperation tableOperation = new WindowAggregateQueryOperation(
 			Collections.singletonList(field),
-			Collections.singletonList(new CallExpression(BuiltInFunctionDefinitions.SUM,
+			Collections.singletonList(new UnresolvedCallExpression(BuiltInFunctionDefinitions.SUM,
 				Collections.singletonList(field))),
 			Collections.emptyList(),
 			WindowAggregateQueryOperation.ResolvedGroupWindow.sessionWindow("w", field, intervalOfMillis(10)),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/CallExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/CallExpression.java
@@ -56,7 +56,7 @@ public final class CallExpression implements Expression {
 
 	@Override
 	public <R> R accept(ExpressionVisitor<R> visitor) {
-		return visitor.visitCall(this);
+		return visitor.visit(this);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/Expression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/Expression.java
@@ -36,6 +36,14 @@ import java.util.List;
 @PublicEvolving
 public interface Expression {
 
+	/**
+	 * Returns a string that summarizes this expression for printing to a console. An implementation
+	 * might skip very specific properties.
+	 *
+	 * @return summary string of this expression for debugging purposes
+	 */
+	String asSummaryString();
+
 	List<Expression> getChildren();
 
 	<R> R accept(ExpressionVisitor<R> visitor);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionDefaultVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionDefaultVisitor.java
@@ -28,22 +28,22 @@ import org.apache.flink.annotation.Internal;
 public abstract class ExpressionDefaultVisitor<T> implements ExpressionVisitor<T> {
 
 	@Override
-	public T visitCall(CallExpression call) {
+	public T visit(CallExpression call) {
 		return defaultMethod(call);
 	}
 
 	@Override
-	public T visitValueLiteral(ValueLiteralExpression valueLiteralExpression) {
+	public T visit(ValueLiteralExpression valueLiteralExpression) {
 		return defaultMethod(valueLiteralExpression);
 	}
 
 	@Override
-	public T visitFieldReference(FieldReferenceExpression fieldReference) {
+	public T visit(FieldReferenceExpression fieldReference) {
 		return defaultMethod(fieldReference);
 	}
 
 	@Override
-	public T visitTypeLiteral(TypeLiteralExpression typeLiteral) {
+	public T visit(TypeLiteralExpression typeLiteral) {
 		return defaultMethod(typeLiteral);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionDefaultVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionDefaultVisitor.java
@@ -28,8 +28,8 @@ import org.apache.flink.annotation.Internal;
 public abstract class ExpressionDefaultVisitor<T> implements ExpressionVisitor<T> {
 
 	@Override
-	public T visit(CallExpression call) {
-		return defaultMethod(call);
+	public T visit(UnresolvedCallExpression unresolvedCall) {
+		return defaultMethod(unresolvedCall);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionUtils.java
@@ -54,8 +54,8 @@ public final class ExpressionUtils {
 	 * @return true if the expression is function call of given type, false otherwise
 	 */
 	public static boolean isFunctionOfKind(Expression expr, FunctionKind kind) {
-		return expr instanceof CallExpression &&
-			((CallExpression) expr).getFunctionDefinition().getKind() == kind;
+		return expr instanceof UnresolvedCallExpression &&
+			((UnresolvedCallExpression) expr).getFunctionDefinition().getKind() == kind;
 	}
 
 	private ExpressionUtils() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionVisitor.java
@@ -27,7 +27,7 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public interface ExpressionVisitor<R> {
 
-	R visit(CallExpression call);
+	R visit(UnresolvedCallExpression unresolvedCall);
 
 	R visit(ValueLiteralExpression valueLiteralExpression);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ExpressionVisitor.java
@@ -27,13 +27,13 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public interface ExpressionVisitor<R> {
 
-	R visitCall(CallExpression call);
+	R visit(CallExpression call);
 
-	R visitValueLiteral(ValueLiteralExpression valueLiteralExpression);
+	R visit(ValueLiteralExpression valueLiteralExpression);
 
-	R visitFieldReference(FieldReferenceExpression fieldReference);
+	R visit(FieldReferenceExpression fieldReference);
 
-	R visitTypeLiteral(TypeLiteralExpression typeLiteral);
+	R visit(TypeLiteralExpression typeLiteral);
 
 	R visit(Expression other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/FieldReferenceExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/FieldReferenceExpression.java
@@ -82,6 +82,11 @@ public final class FieldReferenceExpression implements Expression {
 	}
 
 	@Override
+	public String asSummaryString() {
+		return name;
+	}
+
+	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
 	}
@@ -113,6 +118,6 @@ public final class FieldReferenceExpression implements Expression {
 
 	@Override
 	public String toString() {
-		return name;
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/FieldReferenceExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/FieldReferenceExpression.java
@@ -88,7 +88,7 @@ public final class FieldReferenceExpression implements Expression {
 
 	@Override
 	public <R> R accept(ExpressionVisitor<R> visitor) {
-		return visitor.visitFieldReference(this);
+		return visitor.visit(this);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/TypeLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/TypeLiteralExpression.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Expression that wraps {@link DataType} as a literal.
  *
  * <p>Expressing a type is primarily needed for casting operations. This expression simplifies the
- * {@link Expression} design as it makes {@link CallExpression} the only expression that takes
+ * {@link Expression} design as it makes {@link UnresolvedCallExpression} the only expression that takes
  * subexpressions.
  */
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/TypeLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/TypeLiteralExpression.java
@@ -53,7 +53,7 @@ public final class TypeLiteralExpression implements Expression {
 
 	@Override
 	public <R> R accept(ExpressionVisitor<R> visitor) {
-		return visitor.visitTypeLiteral(this);
+		return visitor.visit(this);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/TypeLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/TypeLiteralExpression.java
@@ -47,6 +47,11 @@ public final class TypeLiteralExpression implements Expression {
 	}
 
 	@Override
+	public String asSummaryString() {
+		return dataType.toString();
+	}
+
+	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
 	}
@@ -75,6 +80,6 @@ public final class TypeLiteralExpression implements Expression {
 
 	@Override
 	public String toString() {
-		return dataType.toString();
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/UnresolvedCallExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/UnresolvedCallExpression.java
@@ -29,18 +29,18 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * General expression for calling a function.
+ * Unresolved call expression for calling a function identified by a {@link FunctionDefinition}.
  *
- * <p>The function can be a built-in function or a user-defined function.
+ * <p>This is a purely API facing expression with unvalidated arguments and unknown output data type.
  */
 @PublicEvolving
-public final class CallExpression implements Expression {
+public final class UnresolvedCallExpression implements Expression {
 
 	private final FunctionDefinition functionDefinition;
 
 	private final List<Expression> args;
 
-	public CallExpression(FunctionDefinition functionDefinition, List<Expression> args) {
+	public UnresolvedCallExpression(FunctionDefinition functionDefinition, List<Expression> args) {
 		this.functionDefinition = Preconditions.checkNotNull(functionDefinition);
 		this.args = Collections.unmodifiableList(new ArrayList<>(Preconditions.checkNotNull(args)));
 	}
@@ -67,7 +67,7 @@ public final class CallExpression implements Expression {
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-		CallExpression that = (CallExpression) o;
+		UnresolvedCallExpression that = (UnresolvedCallExpression) o;
 		return Objects.equals(functionDefinition, that.functionDefinition) &&
 			Objects.equals(args, that.args);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/UnresolvedCallExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/UnresolvedCallExpression.java
@@ -45,13 +45,19 @@ public final class UnresolvedCallExpression implements Expression {
 		this.args = Collections.unmodifiableList(new ArrayList<>(Preconditions.checkNotNull(args)));
 	}
 
+	public FunctionDefinition getFunctionDefinition() {
+		return functionDefinition;
+	}
+
+	@Override
+	public String asSummaryString() {
+		final List<String> argList = args.stream().map(Object::toString).collect(Collectors.toList());
+		return functionDefinition.toString() + "(" + String.join(", ", argList) + ")";
+	}
+
 	@Override
 	public List<Expression> getChildren() {
 		return this.args;
-	}
-
-	public FunctionDefinition getFunctionDefinition() {
-		return functionDefinition;
 	}
 
 	@Override
@@ -79,7 +85,6 @@ public final class UnresolvedCallExpression implements Expression {
 
 	@Override
 	public String toString() {
-		final List<String> argList = args.stream().map(Object::toString).collect(Collectors.toList());
-		return functionDefinition.toString() + "(" + String.join(", ", argList) + ")";
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -79,7 +79,7 @@ public final class ValueLiteralExpression implements Expression {
 
 	@Override
 	public <R> R accept(ExpressionVisitor<R> visitor) {
-		return visitor.visitValueLiteral(this);
+		return visitor.visit(this);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -72,38 +72,6 @@ public final class ValueLiteralExpression implements Expression {
 		return dataType;
 	}
 
-	@Override
-	public List<Expression> getChildren() {
-		return Collections.emptyList();
-	}
-
-	@Override
-	public <R> R accept(ExpressionVisitor<R> visitor) {
-		return visitor.visit(this);
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		ValueLiteralExpression that = (ValueLiteralExpression) o;
-		return Objects.equals(value, that.value) && dataType.equals(that.dataType);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(value, dataType);
-	}
-
-	@Override
-	public String toString() {
-		return stringifyValue(value);
-	}
-
 	public boolean isNull() {
 		return value == null;
 	}
@@ -187,6 +155,43 @@ public final class ValueLiteralExpression implements Expression {
 		// we can offer more conversions in the future, these conversions must not necessarily
 		// comply with the logical type conversions
 		return Optional.ofNullable((T) convertedValue);
+	}
+
+	@Override
+	public String asSummaryString() {
+		return stringifyValue(value);
+	}
+
+	@Override
+	public List<Expression> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(ExpressionVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ValueLiteralExpression that = (ValueLiteralExpression) o;
+		return Objects.equals(value, that.value) && dataType.equals(that.dataType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(value, dataType);
+	}
+
+	@Override
+	public String toString() {
+		return asSummaryString();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -144,15 +144,15 @@ public class ExpressionTest {
 	// --------------------------------------------------------------------------------------------
 
 	private static Expression createExpressionTree(Integer nestedValue) {
-		return new CallExpression(
+		return new UnresolvedCallExpression(
 			AND,
 			asList(
 				new ValueLiteralExpression(true),
-				new CallExpression(
+				new UnresolvedCallExpression(
 					EQUALS,
 					asList(
 						new FieldReferenceExpression("field", DataTypes.INT(), 0, 0),
-						new CallExpression(
+						new UnresolvedCallExpression(
 							new ScalarFunctionDefinition("dummy", DUMMY_FUNCTION),
 							singletonList(new ValueLiteralExpression(nestedValue, DataTypes.INT()))
 						)

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
@@ -21,8 +21,6 @@ package org.apache.flink.table.expressions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.DataType;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
@@ -53,31 +51,31 @@ public class ExpressionBuilder {
 	}
 
 	public static Expression literal(Object value) {
-		return new ValueLiteralExpression(value);
+		return ApiExpressionUtils.valueLiteral(value);
 	}
 
 	public static Expression literal(Object value, DataType type) {
-		return new ValueLiteralExpression(value, type);
+		return ApiExpressionUtils.valueLiteral(value, type);
 	}
 
 	public static Expression call(FunctionDefinition functionDefinition, Expression... args) {
-		return new CallExpression(functionDefinition, Arrays.asList(args));
+		return ApiExpressionUtils.call(functionDefinition, args);
 	}
 
 	public static Expression call(FunctionDefinition functionDefinition, List<Expression> args) {
-		return new CallExpression(functionDefinition, args);
+		return ApiExpressionUtils.call(functionDefinition, args.toArray(new Expression[0]));
 	}
 
 	public static Expression and(Expression arg1, Expression arg2) {
-		return new CallExpression(AND, Arrays.asList(arg1, arg2));
+		return call(AND, arg1, arg2);
 	}
 
 	public static Expression or(Expression arg1, Expression arg2) {
-		return new CallExpression(OR, Arrays.asList(arg1, arg2));
+		return call(OR, arg1, arg2);
 	}
 
 	public static Expression not(Expression arg) {
-		return new CallExpression(NOT, Collections.singletonList(arg));
+		return call(NOT, arg);
 	}
 
 	public static Expression isNull(Expression input) {
@@ -131,7 +129,7 @@ public class ExpressionBuilder {
 	}
 
 	public static TypeLiteralExpression typeLiteral(DataType type) {
-		return new TypeLiteralExpression(type);
+		return ApiExpressionUtils.typeLiteral(type);
 	}
 
 	public static Expression concat(Expression input1, Expression input2) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
@@ -59,11 +59,11 @@ public class ExpressionBuilder {
 	}
 
 	public static Expression call(FunctionDefinition functionDefinition, Expression... args) {
-		return ApiExpressionUtils.call(functionDefinition, args);
+		return ApiExpressionUtils.unresolvedCall(functionDefinition, args);
 	}
 
 	public static Expression call(FunctionDefinition functionDefinition, List<Expression> args) {
-		return ApiExpressionUtils.call(functionDefinition, args.toArray(new Expression[0]));
+		return ApiExpressionUtils.unresolvedCall(functionDefinition, args.toArray(new Expression[0]));
 	}
 
 	public static Expression and(Expression arg1, Expression arg2) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ResolvedAggInputReference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ResolvedAggInputReference.java
@@ -54,6 +54,11 @@ public class ResolvedAggInputReference implements Expression {
 	}
 
 	@Override
+	public String asSummaryString() {
+		return name;
+	}
+
+	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
 	}
@@ -86,6 +91,6 @@ public class ResolvedAggInputReference implements Expression {
 
 	@Override
 	public String toString() {
-		return name;
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ResolvedAggLocalReference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ResolvedAggLocalReference.java
@@ -55,6 +55,11 @@ public class ResolvedAggLocalReference implements Expression {
 	}
 
 	@Override
+	public String asSummaryString() {
+		return fieldTerm;
+	}
+
+	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
 	}
@@ -88,6 +93,6 @@ public class ResolvedAggLocalReference implements Expression {
 
 	@Override
 	public String toString() {
-		return fieldTerm;
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ResolvedDistinctKeyReference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ResolvedDistinctKeyReference.java
@@ -46,6 +46,11 @@ public class ResolvedDistinctKeyReference implements Expression {
 	}
 
 	@Override
+	public String asSummaryString() {
+		return name;
+	}
+
+	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
 	}
@@ -78,6 +83,6 @@ public class ResolvedDistinctKeyReference implements Expression {
 
 	@Override
 	public String toString() {
-		return name;
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/RexNodeConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/RexNodeConverter.java
@@ -79,7 +79,7 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 	}
 
 	@Override
-	public RexNode visitCall(CallExpression call) {
+	public RexNode visit(CallExpression call) {
 		switch (call.getFunctionDefinition().getKind()) {
 			case SCALAR:
 				return visitScalarFunc(call);
@@ -174,7 +174,7 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 	}
 
 	@Override
-	public RexNode visitValueLiteral(ValueLiteralExpression expr) {
+	public RexNode visit(ValueLiteralExpression expr) {
 		LogicalType type = fromDataTypeToLogicalType(expr.getOutputDataType());
 		RexBuilder rexBuilder = relBuilder.getRexBuilder();
 		FlinkTypeFactory typeFactory = (FlinkTypeFactory) relBuilder.getTypeFactory();
@@ -269,12 +269,12 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 	}
 
 	@Override
-	public RexNode visitFieldReference(FieldReferenceExpression fieldReference) {
+	public RexNode visit(FieldReferenceExpression fieldReference) {
 		return relBuilder.field(fieldReference.getName());
 	}
 
 	@Override
-	public RexNode visitTypeLiteral(TypeLiteralExpression typeLiteral) {
+	public RexNode visit(TypeLiteralExpression typeLiteral) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 
 import java.math.BigDecimal;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.div;
 import static org.apache.flink.table.expressions.ExpressionBuilder.equalTo;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
@@ -41,8 +42,8 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  */
 public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 
-	private UnresolvedReferenceExpression sum = new UnresolvedReferenceExpression("sum");
-	private UnresolvedReferenceExpression count = new UnresolvedReferenceExpression("count");
+	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
+	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
 	public abstract DataType getSumType();
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/ConcatAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/ConcatAggFunction.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.concat;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
@@ -35,8 +36,8 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
  */
 public class ConcatAggFunction extends DeclarativeAggregateFunction {
 	private int operandCount;
-	private UnresolvedReferenceExpression acc = new UnresolvedReferenceExpression("concatAcc");
-	private UnresolvedReferenceExpression accDelimiter = new UnresolvedReferenceExpression("accDelimiter");
+	private UnresolvedReferenceExpression acc = unresolvedRef("concatAcc");
+	private UnresolvedReferenceExpression accDelimiter = unresolvedRef("accDelimiter");
 	private Expression delimiter;
 	private Expression operand;
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/Count1AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/Count1AggFunction.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
 import static org.apache.flink.table.expressions.ExpressionBuilder.minus;
 import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
@@ -33,7 +34,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  * It differs in that null values are also counted.
  */
 public class Count1AggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression count1 = new UnresolvedReferenceExpression("count1");
+	private UnresolvedReferenceExpression count1 = unresolvedRef("count1");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/CountAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/CountAggFunction.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
 import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
@@ -33,7 +34,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  * built-in count aggregate function.
  */
 public class CountAggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression count = new UnresolvedReferenceExpression("count");
+	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/DeclarativeAggregateFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/DeclarativeAggregateFunction.java
@@ -29,6 +29,8 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+
 /**
  * API for aggregation functions that are expressed in terms of expressions.
  *
@@ -123,7 +125,7 @@ public abstract class DeclarativeAggregateFunction extends UserDefinedFunction {
 		for (int i = 0; i < operandCount; i++) {
 			String name = String.valueOf(i);
 			validateOperandName(name);
-			ret[i] = new UnresolvedReferenceExpression(name);
+			ret[i] = unresolvedRef(name);
 		}
 		return ret;
 	}
@@ -137,7 +139,7 @@ public abstract class DeclarativeAggregateFunction extends UserDefinedFunction {
 			throw new IllegalStateException(
 				String.format("Agg buffer name(%s) should not same to operands.", name));
 		}
-		return new UnresolvedReferenceExpression(name);
+		return unresolvedRef(name);
 	}
 
 	/**
@@ -146,7 +148,7 @@ public abstract class DeclarativeAggregateFunction extends UserDefinedFunction {
 	public final UnresolvedReferenceExpression mergeOperand(UnresolvedReferenceExpression aggBuffer) {
 		String name = String.valueOf(Arrays.asList(aggBufferAttributes()).indexOf(aggBuffer));
 		validateOperandName(name);
-		return new UnresolvedReferenceExpression(name);
+		return unresolvedRef(name);
 	}
 
 	/**
@@ -158,7 +160,7 @@ public abstract class DeclarativeAggregateFunction extends UserDefinedFunction {
 		for (int i = 0; i < aggBuffers.length; i++) {
 			String name = String.valueOf(i);
 			validateOperandName(name);
-			ret[i] = new UnresolvedReferenceExpression(name);
+			ret[i] = unresolvedRef(name);
 		}
 		return ret;
 	}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/IncrSumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/IncrSumAggFunction.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
 import static org.apache.flink.table.expressions.ExpressionBuilder.lessThan;
@@ -39,7 +40,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  * negative number is discarded to ensure the monotonicity.
  */
 public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression sum = new UnresolvedReferenceExpression("sum");
+	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/IncrSumWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/IncrSumWithRetractAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.equalTo;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
@@ -40,8 +41,8 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  * negative number is discarded to ensure the monotonicity.
  */
 public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression sum = new UnresolvedReferenceExpression("sum");
-	private UnresolvedReferenceExpression count = new UnresolvedReferenceExpression("count");
+	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
+	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/LeadLagAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/LeadLagAggFunction.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.TimeType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.cast;
 import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
 import static org.apache.flink.table.expressions.ExpressionBuilder.typeLiteral;
@@ -56,7 +57,7 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	//If the length of function's args is 3, then the function has the default value.
 	private boolean existDefaultValue;
 
-	private UnresolvedReferenceExpression value = new UnresolvedReferenceExpression("leadlag");
+	private UnresolvedReferenceExpression value = unresolvedRef("leadlag");
 
 	public LeadLagAggFunction(int operandCount) {
 		this.operandCount = operandCount;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/MaxAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/MaxAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.TimeType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.greaterThan;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
@@ -34,7 +35,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
  * built-in max aggregate function.
  */
 public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression max = new UnresolvedReferenceExpression("max");
+	private UnresolvedReferenceExpression max = unresolvedRef("max");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/MinAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/MinAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.TimeType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
 import static org.apache.flink.table.expressions.ExpressionBuilder.lessThan;
@@ -34,7 +35,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
  * built-in min aggregate function.
  */
 public abstract class MinAggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression min = new UnresolvedReferenceExpression("min");
+	private UnresolvedReferenceExpression min = unresolvedRef("min");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/RankAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/RankAggFunction.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter;
 
 import java.util.Arrays;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.and;
 import static org.apache.flink.table.expressions.ExpressionBuilder.equalTo;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
@@ -39,7 +40,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  */
 public class RankAggFunction extends RankLikeAggFunctionBase {
 
-	private UnresolvedReferenceExpression currNumber = new UnresolvedReferenceExpression("currNumber");
+	private UnresolvedReferenceExpression currNumber = unresolvedRef("currNumber");
 
 	public RankAggFunction(LogicalType[] orderKeyTypes) {
 		super(orderKeyTypes);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/RankLikeAggFunctionBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/RankLikeAggFunctionBase.java
@@ -32,6 +32,7 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.equalTo;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
@@ -41,7 +42,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
  * built-in rank like aggregate function, e.g. rank, dense_rank
  */
 public abstract class RankLikeAggFunctionBase extends DeclarativeAggregateFunction {
-	protected UnresolvedReferenceExpression sequence = new UnresolvedReferenceExpression("sequence");
+	protected UnresolvedReferenceExpression sequence = unresolvedRef("sequence");
 	protected UnresolvedReferenceExpression[] lastValues;
 	protected LogicalType[] orderKeyTypes;
 
@@ -49,7 +50,7 @@ public abstract class RankLikeAggFunctionBase extends DeclarativeAggregateFuncti
 		this.orderKeyTypes = orderKeyTypes;
 		lastValues = new UnresolvedReferenceExpression[orderKeyTypes.length];
 		for (int i = 0; i < orderKeyTypes.length; ++i) {
-			lastValues[i] = new UnresolvedReferenceExpression("lastValue_" + i);
+			lastValues[i] = unresolvedRef("lastValue_" + i);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/RowNumberAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/RowNumberAggFunction.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
 import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
 
@@ -31,7 +32,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  * built-in row_number aggregate function.
  */
 public class RowNumberAggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression sequence = new UnresolvedReferenceExpression("seq");
+	private UnresolvedReferenceExpression sequence = unresolvedRef("seq");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/SingleValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/SingleValueAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.TimeType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.equalTo;
 import static org.apache.flink.table.expressions.ExpressionBuilder.greaterThan;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
@@ -44,8 +45,8 @@ public abstract class SingleValueAggFunction extends DeclarativeAggregateFunctio
 	private static final Expression ZERO = literal(0, DataTypes.INT());
 	private static final Expression ONE = literal(1, DataTypes.INT());
 	private static final String ERROR_MSG = "SingleValueAggFunction received more than one element.";
-	private UnresolvedReferenceExpression value = new UnresolvedReferenceExpression("value");
-	private UnresolvedReferenceExpression count = new UnresolvedReferenceExpression("count");
+	private UnresolvedReferenceExpression value = unresolvedRef("value");
+	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/Sum0AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/Sum0AggFunction.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 
 import java.math.BigDecimal;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
 import static org.apache.flink.table.expressions.ExpressionBuilder.literal;
@@ -37,7 +38,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  * built-in sum0 aggregate function.
  */
 public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression sum0 = new UnresolvedReferenceExpression("sum");
+	private UnresolvedReferenceExpression sum0 = unresolvedRef("sum");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/SumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/SumAggFunction.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
 import static org.apache.flink.table.expressions.ExpressionBuilder.nullOf;
@@ -35,7 +36,7 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  * built-in sum aggregate function.
  */
 public abstract class SumAggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression sum = new UnresolvedReferenceExpression("sum");
+	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ExpressionBuilder.equalTo;
 import static org.apache.flink.table.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.expressions.ExpressionBuilder.isNull;
@@ -37,8 +38,8 @@ import static org.apache.flink.table.expressions.ExpressionBuilder.plus;
  * built-in sum aggregate function with retraction.
  */
 public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunction {
-	private UnresolvedReferenceExpression sum = new UnresolvedReferenceExpression("sum");
-	private UnresolvedReferenceExpression count = new UnresolvedReferenceExpression("count");
+	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
+	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
 	@Override
 	public int operandCount() {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/DeclarativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/DeclarativeAggCodeGen.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.codegen.agg
 import org.apache.flink.table.codegen.CodeGenUtils.primitiveTypeTermForType
 import org.apache.flink.table.codegen.agg.AggsHandlerCodeGenerator.DISTINCT_KEY_TERM
 import org.apache.flink.table.codegen.{CodeGeneratorContext, ExprCodeGenerator, GeneratedExpression}
-import org.apache.flink.table.expressions.{ResolvedDistinctKeyReference, _}
+import org.apache.flink.table.expressions.{ApiExpressionUtils, ResolvedDistinctKeyReference, _}
 import org.apache.flink.table.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.plan.util.AggregateInfo
 import org.apache.flink.table.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
@@ -217,9 +217,9 @@ class DeclarativeAggCodeGen(
       isDistinctMerge: Boolean = false) extends ExpressionVisitor[Expression] {
 
     override def visitCall(call: CallExpression): Expression = {
-      new CallExpression(
+      ApiExpressionUtils.call(
         call.getFunctionDefinition,
-        call.getChildren.asScala.map(_.accept(this)).asJava)
+        call.getChildren.asScala.map(_.accept(this)): _*)
     }
 
     override def visitValueLiteral(valueLiteralExpression: ValueLiteralExpression): Expression = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/DeclarativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/DeclarativeAggCodeGen.scala
@@ -216,7 +216,7 @@ class DeclarativeAggCodeGen(
       isMerge: Boolean = false,
       isDistinctMerge: Boolean = false) extends ExpressionVisitor[Expression] {
 
-    override def visit(call: CallExpression): Expression = {
+    override def visit(call: UnresolvedCallExpression): Expression = {
       ApiExpressionUtils.call(
         call.getFunctionDefinition,
         call.getChildren.asScala.map(_.accept(this)): _*)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/DeclarativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/DeclarativeAggCodeGen.scala
@@ -217,7 +217,7 @@ class DeclarativeAggCodeGen(
       isDistinctMerge: Boolean = false) extends ExpressionVisitor[Expression] {
 
     override def visit(call: UnresolvedCallExpression): Expression = {
-      ApiExpressionUtils.call(
+      ApiExpressionUtils.unresolvedCall(
         call.getFunctionDefinition,
         call.getChildren.asScala.map(_.accept(this)): _*)
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/DeclarativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/DeclarativeAggCodeGen.scala
@@ -216,21 +216,21 @@ class DeclarativeAggCodeGen(
       isMerge: Boolean = false,
       isDistinctMerge: Boolean = false) extends ExpressionVisitor[Expression] {
 
-    override def visitCall(call: CallExpression): Expression = {
+    override def visit(call: CallExpression): Expression = {
       ApiExpressionUtils.call(
         call.getFunctionDefinition,
         call.getChildren.asScala.map(_.accept(this)): _*)
     }
 
-    override def visitValueLiteral(valueLiteralExpression: ValueLiteralExpression): Expression = {
+    override def visit(valueLiteralExpression: ValueLiteralExpression): Expression = {
       valueLiteralExpression
     }
 
-    override def visitFieldReference(input: FieldReferenceExpression): Expression = {
+    override def visit(input: FieldReferenceExpression): Expression = {
       input
     }
 
-    override def visitTypeLiteral(typeLiteral: TypeLiteralExpression): Expression = {
+    override def visit(typeLiteral: TypeLiteralExpression): Expression = {
       typeLiteral
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
@@ -257,7 +257,7 @@ object AggCodeGenHelper {
       aggBufferTypes: Array[Array[LogicalType]]) extends ExpressionVisitor[Expression] {
 
     override def visit(unresolvedCall: UnresolvedCallExpression): Expression = {
-      ApiExpressionUtils.call(
+      ApiExpressionUtils.unresolvedCall(
         unresolvedCall.getFunctionDefinition,
         unresolvedCall.getChildren.asScala.map(_.accept(this)): _*)
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
@@ -256,21 +256,21 @@ object AggCodeGenHelper {
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBufferTypes: Array[Array[LogicalType]]) extends ExpressionVisitor[Expression] {
 
-    override def visitCall(call: CallExpression): Expression = {
+    override def visit(call: CallExpression): Expression = {
       ApiExpressionUtils.call(
         call.getFunctionDefinition,
         call.getChildren.asScala.map(_.accept(this)): _*)
     }
 
-    override def visitValueLiteral(valueLiteralExpression: ValueLiteralExpression): Expression = {
+    override def visit(valueLiteralExpression: ValueLiteralExpression): Expression = {
       valueLiteralExpression
     }
 
-    override def visitFieldReference(input: FieldReferenceExpression): Expression = {
+    override def visit(input: FieldReferenceExpression): Expression = {
       input
     }
 
-    override def visitTypeLiteral(typeLiteral: TypeLiteralExpression): Expression = {
+    override def visit(typeLiteral: TypeLiteralExpression): Expression = {
       typeLiteral
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
@@ -18,14 +18,17 @@
 
 package org.apache.flink.table.codegen.agg.batch
 
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.runtime.util.SingleElementIterator
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
-import org.apache.flink.table.codegen.CodeGenUtils.{boxedTypeTermForExternalType, genToExternal, genToInternal, newName, primitiveTypeTermForType}
+import org.apache.flink.table.codegen.CodeGenUtils._
 import org.apache.flink.table.codegen.OperatorCodeGenerator.STREAM_RECORD
-import org.apache.flink.table.codegen.{CodeGenUtils, CodeGeneratorContext, ExprCodeGenerator, GenerateUtils, GeneratedExpression, OperatorCodeGenerator}
+import org.apache.flink.table.codegen._
 import org.apache.flink.table.dataformat.{BaseRow, GenericRow}
-import org.apache.flink.table.expressions.{CallExpression, Expression, ExpressionVisitor, FieldReferenceExpression, ResolvedAggInputReference, ResolvedAggLocalReference, RexNodeConverter, TypeLiteralExpression, UnresolvedReferenceExpression, ValueLiteralExpression}
+import org.apache.flink.table.expressions.{CallExpression, Expression, ExpressionVisitor, FieldReferenceExpression, ResolvedAggInputReference, ResolvedAggLocalReference, RexNodeConverter, TypeLiteralExpression, UnresolvedReferenceExpression, ValueLiteralExpression, _}
 import org.apache.flink.table.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils.{getAccumulatorTypeOfAggregateFunction, getAggUserDefinedInputTypes}
 import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
@@ -35,10 +38,6 @@ import org.apache.flink.table.types.LogicalTypeDataTypeConverter.fromDataTypeToL
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical.{LogicalType, RowType}
 import org.apache.flink.table.types.{DataType, InternalSerializers}
-
-import org.apache.calcite.rel.core.AggregateCall
-import org.apache.calcite.rex.RexNode
-import org.apache.calcite.tools.RelBuilder
 
 import scala.collection.JavaConverters._
 
@@ -258,9 +257,9 @@ object AggCodeGenHelper {
       aggBufferTypes: Array[Array[LogicalType]]) extends ExpressionVisitor[Expression] {
 
     override def visitCall(call: CallExpression): Expression = {
-      new CallExpression(
+      ApiExpressionUtils.call(
         call.getFunctionDefinition,
-        call.getChildren.asScala.map(_.accept(this)).asJava)
+        call.getChildren.asScala.map(_.accept(this)): _*)
     }
 
     override def visitValueLiteral(valueLiteralExpression: ValueLiteralExpression): Expression = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/AggCodeGenHelper.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.codegen.CodeGenUtils._
 import org.apache.flink.table.codegen.OperatorCodeGenerator.STREAM_RECORD
 import org.apache.flink.table.codegen._
 import org.apache.flink.table.dataformat.{BaseRow, GenericRow}
-import org.apache.flink.table.expressions.{CallExpression, Expression, ExpressionVisitor, FieldReferenceExpression, ResolvedAggInputReference, ResolvedAggLocalReference, RexNodeConverter, TypeLiteralExpression, UnresolvedReferenceExpression, ValueLiteralExpression, _}
+import org.apache.flink.table.expressions.{UnresolvedCallExpression, Expression, ExpressionVisitor, FieldReferenceExpression, ResolvedAggInputReference, ResolvedAggLocalReference, RexNodeConverter, TypeLiteralExpression, UnresolvedReferenceExpression, ValueLiteralExpression, _}
 import org.apache.flink.table.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils.{getAccumulatorTypeOfAggregateFunction, getAggUserDefinedInputTypes}
 import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
@@ -256,10 +256,10 @@ object AggCodeGenHelper {
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBufferTypes: Array[Array[LogicalType]]) extends ExpressionVisitor[Expression] {
 
-    override def visit(call: CallExpression): Expression = {
+    override def visit(unresolvedCall: UnresolvedCallExpression): Expression = {
       ApiExpressionUtils.call(
-        call.getFunctionDefinition,
-        call.getChildren.asScala.map(_.accept(this)): _*)
+        unresolvedCall.getFunctionDefinition,
+        unresolvedCall.getChildren.asScala.map(_.accept(this)): _*)
     }
 
     override def visit(valueLiteralExpression: ValueLiteralExpression): Expression = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -18,14 +18,16 @@
 
 package org.apache.flink.table.codegen.agg.batch
 
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.metrics.Gauge
 import org.apache.flink.table.codegen.CodeGenUtils.{binaryRowFieldSetAccess, binaryRowSetNull}
+import org.apache.flink.table.codegen._
 import org.apache.flink.table.codegen.agg.batch.AggCodeGenHelper.buildAggregateArgsMapping
 import org.apache.flink.table.codegen.sort.SortCodeGenerator
-import org.apache.flink.table.codegen.{CodeGenUtils, CodeGeneratorContext, ExprCodeGenerator, GenerateUtils, GeneratedExpression, OperatorCodeGenerator}
 import org.apache.flink.table.dataformat.{BaseRow, BinaryRow, GenericRow, JoinedRow}
-import org.apache.flink.table.expressions.{CallExpression, Expression, ExpressionVisitor, FieldReferenceExpression, ResolvedAggInputReference, RexNodeConverter, TypeLiteralExpression, UnresolvedReferenceExpression, ValueLiteralExpression}
+import org.apache.flink.table.expressions.{CallExpression, Expression, ExpressionVisitor, FieldReferenceExpression, ResolvedAggInputReference, RexNodeConverter, TypeLiteralExpression, UnresolvedReferenceExpression, ValueLiteralExpression, _}
 import org.apache.flink.table.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.generated.{NormalizedKeyComputer, RecordComparator}
@@ -35,9 +37,6 @@ import org.apache.flink.table.runtime.sort.BufferedKVExternalSorter
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.{LogicalType, RowType}
 import org.apache.flink.table.typeutils.BinaryRowSerializer
-
-import org.apache.calcite.rel.core.AggregateCall
-import org.apache.calcite.tools.RelBuilder
 
 import scala.collection.JavaConversions._
 
@@ -334,9 +333,9 @@ object HashAggCodeGenHelper {
       aggBuffMapping: Array[Array[(Int, LogicalType)]]) extends ExpressionVisitor[Expression] {
 
     override def visitCall(call: CallExpression): Expression = {
-      new CallExpression(
+      ApiExpressionUtils.call(
         call.getFunctionDefinition,
-        call.getChildren.map(_.accept(this)))
+        call.getChildren.map(_.accept(this)): _*)
     }
 
     override def visitValueLiteral(valueLiteralExpression: ValueLiteralExpression): Expression = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -333,7 +333,7 @@ object HashAggCodeGenHelper {
       aggBuffMapping: Array[Array[(Int, LogicalType)]]) extends ExpressionVisitor[Expression] {
 
     override def visit(unresolvedCall: UnresolvedCallExpression): Expression = {
-      ApiExpressionUtils.call(
+      ApiExpressionUtils.unresolvedCall(
         unresolvedCall.getFunctionDefinition,
         unresolvedCall.getChildren.map(_.accept(this)): _*)
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -332,21 +332,21 @@ object HashAggCodeGenHelper {
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBuffMapping: Array[Array[(Int, LogicalType)]]) extends ExpressionVisitor[Expression] {
 
-    override def visitCall(call: CallExpression): Expression = {
+    override def visit(call: CallExpression): Expression = {
       ApiExpressionUtils.call(
         call.getFunctionDefinition,
         call.getChildren.map(_.accept(this)): _*)
     }
 
-    override def visitValueLiteral(valueLiteralExpression: ValueLiteralExpression): Expression = {
+    override def visit(valueLiteralExpression: ValueLiteralExpression): Expression = {
       valueLiteralExpression
     }
 
-    override def visitFieldReference(input: FieldReferenceExpression): Expression = {
+    override def visit(input: FieldReferenceExpression): Expression = {
       input
     }
 
-    override def visitTypeLiteral(typeLiteral: TypeLiteralExpression): Expression = {
+    override def visit(typeLiteral: TypeLiteralExpression): Expression = {
       typeLiteral
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.codegen._
 import org.apache.flink.table.codegen.agg.batch.AggCodeGenHelper.buildAggregateArgsMapping
 import org.apache.flink.table.codegen.sort.SortCodeGenerator
 import org.apache.flink.table.dataformat.{BaseRow, BinaryRow, GenericRow, JoinedRow}
-import org.apache.flink.table.expressions.{CallExpression, Expression, ExpressionVisitor, FieldReferenceExpression, ResolvedAggInputReference, RexNodeConverter, TypeLiteralExpression, UnresolvedReferenceExpression, ValueLiteralExpression, _}
+import org.apache.flink.table.expressions.{UnresolvedCallExpression, Expression, ExpressionVisitor, FieldReferenceExpression, ResolvedAggInputReference, RexNodeConverter, TypeLiteralExpression, UnresolvedReferenceExpression, ValueLiteralExpression, _}
 import org.apache.flink.table.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.generated.{NormalizedKeyComputer, RecordComparator}
@@ -332,10 +332,10 @@ object HashAggCodeGenHelper {
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBuffMapping: Array[Array[(Int, LogicalType)]]) extends ExpressionVisitor[Expression] {
 
-    override def visit(call: CallExpression): Expression = {
+    override def visit(unresolvedCall: UnresolvedCallExpression): Expression = {
       ApiExpressionUtils.call(
-        call.getFunctionDefinition,
-        call.getChildren.map(_.accept(this)): _*)
+        unresolvedCall.getFunctionDefinition,
+        unresolvedCall.getChildren.map(_.accept(this)): _*)
     }
 
     override def visit(valueLiteralExpression: ValueLiteralExpression): Expression = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
@@ -31,7 +31,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.table.api.{DataTypes, ValidationException}
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.expressions.ApiExpressionUtils.{call, typeLiteral}
+import org.apache.flink.table.expressions.ApiExpressionUtils.{unresolvedCall, typeLiteral}
 import org.apache.flink.table.expressions.{PlannerResolvedFieldReference, ResolvedFieldReference, RexNodeConverter}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions
 import org.apache.flink.table.types.LogicalTypeDataTypeConverter
@@ -279,7 +279,7 @@ object TableSourceUtil {
 
       val expression = tsExtractor.getExpression(fieldAccesses)
       // add cast to requested type and convert expression to RexNode
-      val castExpression = call(
+      val castExpression = unresolvedCall(
         BuiltInFunctionDefinitions.CAST,
         expression,
         typeLiteral(DataTypes.TIMESTAMP(3).bridgedTo(classOf[Timestamp])))

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
@@ -31,7 +31,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.table.api.{DataTypes, ValidationException}
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.expressions._
+import org.apache.flink.table.expressions.ApiExpressionUtils.{call, typeLiteral}
+import org.apache.flink.table.expressions.{PlannerResolvedFieldReference, ResolvedFieldReference, RexNodeConverter}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions
 import org.apache.flink.table.types.LogicalTypeDataTypeConverter
 import org.apache.flink.table.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
@@ -278,10 +279,10 @@ object TableSourceUtil {
 
       val expression = tsExtractor.getExpression(fieldAccesses)
       // add cast to requested type and convert expression to RexNode
-      val castExpression = new CallExpression(
+      val castExpression = call(
         BuiltInFunctionDefinitions.CAST,
-        List(expression, new TypeLiteralExpression(
-          DataTypes.TIMESTAMP(3).bridgedTo(classOf[Timestamp]))))
+        expression,
+        typeLiteral(DataTypes.TIMESTAMP(3).bridgedTo(classOf[Timestamp])))
       val rexExpression = castExpression.accept(new RexNodeConverter(relBuilder))
       relBuilder.clear()
       rexExpression

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
@@ -23,7 +23,7 @@ import java.util
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.descriptors.Rowtime
-import org.apache.flink.table.expressions.ApiExpressionUtils.{call, typeLiteral, valueLiteral}
+import org.apache.flink.table.expressions.ApiExpressionUtils.{unresolvedCall, typeLiteral, valueLiteral}
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
@@ -71,12 +71,12 @@ final class ExistingField(val field: String) extends TimestampExtractor {
     fieldAccess.resultType match {
       case Types.LONG =>
         // access LONG field
-        val innerDiv = call(
+        val innerDiv = unresolvedCall(
           BuiltInFunctionDefinitions.DIVIDE,
           fieldReferenceExpr,
           valueLiteral(new java.math.BigDecimal(1000)))
 
-        call(
+        unresolvedCall(
           BuiltInFunctionDefinitions.CAST,
           innerDiv,
           typeLiteral(fromLegacyInfoToDataType(Types.SQL_TIMESTAMP)))
@@ -85,7 +85,7 @@ final class ExistingField(val field: String) extends TimestampExtractor {
         fieldReferenceExpr
 
       case Types.STRING =>
-        call(
+        unresolvedCall(
           BuiltInFunctionDefinitions.CAST,
           fieldReferenceExpr,
           typeLiteral(fromLegacyInfoToDataType(Types.SQL_TIMESTAMP)))

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
@@ -18,16 +18,15 @@
 
 package org.apache.flink.table.sources.tsextractors
 
+import java.util
+
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.descriptors.Rowtime
+import org.apache.flink.table.expressions.ApiExpressionUtils.{call, typeLiteral, valueLiteral}
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
-
-import java.util
-
-import scala.collection.JavaConversions._
 
 /**
   * Converts an existing [[Long]], [[java.sql.Timestamp]], or
@@ -72,23 +71,24 @@ final class ExistingField(val field: String) extends TimestampExtractor {
     fieldAccess.resultType match {
       case Types.LONG =>
         // access LONG field
-        val innerDiv = new CallExpression(
+        val innerDiv = call(
           BuiltInFunctionDefinitions.DIVIDE,
-          List(fieldReferenceExpr,
-            new ValueLiteralExpression(new java.math.BigDecimal(1000))))
-        new CallExpression(
+          fieldReferenceExpr,
+          valueLiteral(new java.math.BigDecimal(1000)))
+
+        call(
           BuiltInFunctionDefinitions.CAST,
-          List(
-            innerDiv,
-            new TypeLiteralExpression(fromLegacyInfoToDataType(Types.SQL_TIMESTAMP))))
+          innerDiv,
+          typeLiteral(fromLegacyInfoToDataType(Types.SQL_TIMESTAMP)))
+
       case Types.SQL_TIMESTAMP =>
         fieldReferenceExpr
+
       case Types.STRING =>
-        new CallExpression(
+        call(
           BuiltInFunctionDefinitions.CAST,
-          List(
-            fieldReferenceExpr,
-            new TypeLiteralExpression(fromLegacyInfoToDataType(Types.SQL_TIMESTAMP))))
+          fieldReferenceExpr,
+          typeLiteral(fromLegacyInfoToDataType(Types.SQL_TIMESTAMP)))
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ExpandColumnFunctionsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ExpandColumnFunctionsRule.java
@@ -77,7 +77,7 @@ final class ExpandColumnFunctionsRule implements ResolverRule {
 		}
 
 		@Override
-		public List<Expression> visitCall(CallExpression call) {
+		public List<Expression> visit(CallExpression call) {
 
 			List<Expression> result;
 
@@ -149,14 +149,14 @@ final class ExpandColumnFunctionsRule implements ResolverRule {
 		}
 
 		@Override
-		public List<UnresolvedReferenceExpression> visitValueLiteral(ValueLiteralExpression valueLiteralExpression) {
+		public List<UnresolvedReferenceExpression> visit(ValueLiteralExpression valueLiteralExpression) {
 			return ExpressionUtils.extractValue(valueLiteralExpression, Integer.class)
 				.map(i -> Collections.singletonList(inputFieldReferences.get(i - 1)))
 				.orElseGet(() -> defaultMethod(valueLiteralExpression));
 		}
 
 		@Override
-		public List<UnresolvedReferenceExpression> visitUnresolvedReference(
+		public List<UnresolvedReferenceExpression> visit(
 			UnresolvedReferenceExpression unresolvedReference) {
 			if (unresolvedReference.getName().equals("*")) {
 				return inputFieldReferences;
@@ -166,7 +166,7 @@ final class ExpandColumnFunctionsRule implements ResolverRule {
 		}
 
 		@Override
-		public List<UnresolvedReferenceExpression> visitCall(CallExpression call) {
+		public List<UnresolvedReferenceExpression> visit(CallExpression call) {
 			if (isIndexRangeCall(call)) {
 				int start = ExpressionUtils.extractValue(call.getChildren().get(0), Integer.class)
 					.orElseThrow(() -> new ValidationException("Constant integer value expected."));

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ExpandColumnFunctionsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ExpandColumnFunctionsRule.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.RANGE_TO;
@@ -90,7 +90,7 @@ final class ExpandColumnFunctionsRule implements ResolverRule {
 					.stream()
 					.flatMap(c -> c.accept(this).stream())
 					.toArray(Expression[]::new);
-				result = Collections.singletonList(call(unresolvedCall.getFunctionDefinition(), args));
+				result = Collections.singletonList(unresolvedCall(unresolvedCall.getFunctionDefinition(), args));
 
 				// validate alias
 				if (definition == AS) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/FlattenCallRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/FlattenCallRule.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.util.Collections.singletonList;
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GET;
 
@@ -78,7 +78,7 @@ final class FlattenCallRule implements ResolverRule {
 
 		private List<Expression> flattenCompositeType(Expression arg, CompositeType<?> resultType) {
 			return IntStream.range(0, resultType.getArity())
-				.mapToObj(idx -> call(GET, arg, valueLiteral(resultType.getFieldNames()[idx])))
+				.mapToObj(idx -> unresolvedCall(GET, arg, valueLiteral(resultType.getFieldNames()[idx])))
 				.collect(Collectors.toList());
 		}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/FlattenCallRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/FlattenCallRule.java
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GET;
 
@@ -78,7 +78,7 @@ final class FlattenCallRule implements ResolverRule {
 
 		private List<Expression> flattenCompositeType(Expression arg, CompositeType<?> resultType) {
 			return IntStream.range(0, resultType.getArity())
-				.mapToObj(idx -> new CallExpression(GET, asList(arg, valueLiteral(resultType.getFieldNames()[idx]))))
+				.mapToObj(idx -> call(GET, arg, valueLiteral(resultType.getFieldNames()[idx])))
 				.collect(Collectors.toList());
 		}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/FlattenCallRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/FlattenCallRule.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.expressions.rules;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.PlannerExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
 import java.util.List;
@@ -56,16 +56,16 @@ final class FlattenCallRule implements ResolverRule {
 		}
 
 		@Override
-		public List<Expression> visit(CallExpression call) {
-			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.FLATTEN) {
-				return executeFlatten(call);
+		public List<Expression> visit(UnresolvedCallExpression unresolvedCall) {
+			if (unresolvedCall.getFunctionDefinition() == BuiltInFunctionDefinitions.FLATTEN) {
+				return executeFlatten(unresolvedCall);
 			}
 
-			return singletonList(call);
+			return singletonList(unresolvedCall);
 		}
 
-		private List<Expression> executeFlatten(CallExpression call) {
-			Expression arg = call.getChildren().get(0);
+		private List<Expression> executeFlatten(UnresolvedCallExpression unresolvedCall) {
+			Expression arg = unresolvedCall.getChildren().get(0);
 			PlannerExpression plannerExpression = resolutionContext.bridge(arg);
 			plannerExpression.validateInput();
 			TypeInformation<?> resultType = plannerExpression.resultType();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/FlattenCallRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/FlattenCallRule.java
@@ -56,7 +56,7 @@ final class FlattenCallRule implements ResolverRule {
 		}
 
 		@Override
-		public List<Expression> visitCall(CallExpression call) {
+		public List<Expression> visit(CallExpression call) {
 			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.FLATTEN) {
 				return executeFlatten(call);
 			}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/OverWindowResolverRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/OverWindowResolverRule.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 
 /**
  * Joins call to {@link BuiltInFunctionDefinitions#OVER} with corresponding over window
@@ -73,9 +73,9 @@ final class OverWindowResolverRule implements ResolverRule {
 
 				newArgs.addAll(referenceWindow.partitionBy());
 
-				return call(unresolvedCall.getFunctionDefinition(), newArgs.toArray(new Expression[0]));
+				return unresolvedCall(unresolvedCall.getFunctionDefinition(), newArgs.toArray(new Expression[0]));
 			} else {
-				return call(
+				return unresolvedCall(
 					unresolvedCall.getFunctionDefinition(),
 					unresolvedCall.getChildren().stream()
 						.map(expr -> expr.accept(this))
@@ -87,9 +87,9 @@ final class OverWindowResolverRule implements ResolverRule {
 			return referenceWindow.following().orElseGet(() -> {
 					PlannerExpression preceding = resolutionContext.bridge(referenceWindow.preceding());
 					if (preceding.resultType() == BasicTypeInfo.LONG_TYPE_INFO) {
-						return call(BuiltInFunctionDefinitions.CURRENT_ROW);
+						return unresolvedCall(BuiltInFunctionDefinitions.CURRENT_ROW);
 					} else {
-						return call(BuiltInFunctionDefinitions.CURRENT_RANGE);
+						return unresolvedCall(BuiltInFunctionDefinitions.CURRENT_RANGE);
 					}
 				}
 			);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/OverWindowResolverRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/OverWindowResolverRule.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.expressions.rules;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.PlannerExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.plan.logical.LogicalOverWindow;
 
@@ -55,10 +55,10 @@ final class OverWindowResolverRule implements ResolverRule {
 		}
 
 		@Override
-		public Expression visit(CallExpression call) {
+		public Expression visit(UnresolvedCallExpression unresolvedCall) {
 
-			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.OVER) {
-				List<Expression> children = call.getChildren();
+			if (unresolvedCall.getFunctionDefinition() == BuiltInFunctionDefinitions.OVER) {
+				List<Expression> children = unresolvedCall.getChildren();
 				Expression alias = children.get(1);
 
 				LogicalOverWindow referenceWindow = resolutionContext.getOverWindow(alias)
@@ -73,11 +73,11 @@ final class OverWindowResolverRule implements ResolverRule {
 
 				newArgs.addAll(referenceWindow.partitionBy());
 
-				return call(call.getFunctionDefinition(), newArgs.toArray(new Expression[0]));
+				return call(unresolvedCall.getFunctionDefinition(), newArgs.toArray(new Expression[0]));
 			} else {
 				return call(
-					call.getFunctionDefinition(),
-					call.getChildren().stream()
+					unresolvedCall.getFunctionDefinition(),
+					unresolvedCall.getChildren().stream()
 						.map(expr -> expr.accept(this))
 						.toArray(Expression[]::new));
 			}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/OverWindowResolverRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/OverWindowResolverRule.java
@@ -55,7 +55,7 @@ final class OverWindowResolverRule implements ResolverRule {
 		}
 
 		@Override
-		public Expression visitCall(CallExpression call) {
+		public Expression visit(CallExpression call) {
 
 			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.OVER) {
 				List<Expression> children = call.getChildren();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 
 /**
  * Resolves {@link UnresolvedReferenceExpression} to either
@@ -60,7 +60,7 @@ final class ReferenceResolverRule implements ResolverRule {
 				.map(expr -> expr.accept(this))
 				.toArray(Expression[]::new);
 
-			return call(unresolvedCall.getFunctionDefinition(), resolvedArgs);
+			return unresolvedCall(unresolvedCall.getFunctionDefinition(), resolvedArgs);
 		}
 
 		@Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
@@ -54,7 +54,7 @@ final class ReferenceResolverRule implements ResolverRule {
 		}
 
 		@Override
-		public Expression visitCall(CallExpression call) {
+		public Expression visit(CallExpression call) {
 			final Expression[] resolvedArgs = call.getChildren()
 				.stream()
 				.map(expr -> expr.accept(this))
@@ -64,7 +64,7 @@ final class ReferenceResolverRule implements ResolverRule {
 		}
 
 		@Override
-		public Expression visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference) {
+		public Expression visit(UnresolvedReferenceExpression unresolvedReference) {
 			return resolutionContext.referenceLookup().lookupField(unresolvedReference.getName())
 				.map(expr -> (Expression) expr)
 				.orElseGet(() ->

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
@@ -20,9 +20,9 @@ package org.apache.flink.table.expressions.rules;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 
 import java.util.List;
@@ -54,13 +54,13 @@ final class ReferenceResolverRule implements ResolverRule {
 		}
 
 		@Override
-		public Expression visit(CallExpression call) {
-			final Expression[] resolvedArgs = call.getChildren()
+		public Expression visit(UnresolvedCallExpression unresolvedCall) {
+			final Expression[] resolvedArgs = unresolvedCall.getChildren()
 				.stream()
 				.map(expr -> expr.accept(this))
 				.toArray(Expression[]::new);
 
-			return call(call.getFunctionDefinition(), resolvedArgs);
+			return call(unresolvedCall.getFunctionDefinition(), resolvedArgs);
 		}
 
 		@Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ReferenceResolverRule.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 
 /**
  * Resolves {@link UnresolvedReferenceExpression} to either
@@ -54,12 +55,12 @@ final class ReferenceResolverRule implements ResolverRule {
 
 		@Override
 		public Expression visitCall(CallExpression call) {
-			List<Expression> resolvedArgs = call.getChildren()
+			final Expression[] resolvedArgs = call.getChildren()
 				.stream()
 				.map(expr -> expr.accept(this))
-				.collect(Collectors.toList());
+				.toArray(Expression[]::new);
 
-			return new CallExpression(call.getFunctionDefinition(), resolvedArgs);
+			return call(call.getFunctionDefinition(), resolvedArgs);
 		}
 
 		@Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ResolveCallByArgumentsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ResolveCallByArgumentsRule.java
@@ -63,7 +63,7 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 		}
 
 		@Override
-		public Expression visitCall(CallExpression call) {
+		public Expression visit(CallExpression call) {
 			PlannerExpression plannerCall = resolutionContext.bridge(call);
 			if (plannerCall instanceof InputTypeSpec) {
 				List<TypeInformation<?>> expectedTypes = toJava(((InputTypeSpec) plannerCall).expectedTypes());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ResolveCallByArgumentsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ResolveCallByArgumentsRule.java
@@ -35,8 +35,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.typeLiteral;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 import static org.apache.flink.table.util.JavaScalaConversionUtil.toJava;
 
@@ -83,7 +83,7 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 				.mapToObj(idx -> castIfNeeded(args.get(idx), expectedTypes.get(idx)))
 				.toArray(Expression[]::new);
 
-			return call(unresolvedCall.getFunctionDefinition(), newArgs);
+			return unresolvedCall(unresolvedCall.getFunctionDefinition(), newArgs);
 		}
 
 		private Expression validateArguments(UnresolvedCallExpression unresolvedCall, PlannerExpression plannerCall) {
@@ -120,7 +120,7 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 			if (actualType.equals(expectedType)) {
 				return childExpression;
 			} else if (TypeCoercion.canSafelyCast(actualType, expectedType)) {
-				return call(
+				return unresolvedCall(
 					BuiltInFunctionDefinitions.CAST,
 					childExpression,
 					typeLiteral(fromLegacyInfoToDataType(expectedType))

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/StarReferenceFlatteningRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/StarReferenceFlatteningRule.java
@@ -49,7 +49,7 @@ final class StarReferenceFlatteningRule implements ResolverRule {
 		}
 
 		@Override
-		public List<Expression> visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference) {
+		public List<Expression> visit(UnresolvedReferenceExpression unresolvedReference) {
 			if (unresolvedReference.getName().equals("*")) {
 				return new ArrayList<>(resolutionContext.referenceLookup().getAllInputFields());
 			} else {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRule.java
@@ -56,17 +56,17 @@ final class VerifyNoUnresolvedExpressionsRule implements ResolverRule {
 	private static class NoUnresolvedCallsChecker extends ApiExpressionDefaultVisitor<Void> {
 
 		@Override
-		public Void visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference) {
+		public Void visit(UnresolvedReferenceExpression unresolvedReference) {
 			throw getException("reference", unresolvedReference);
 		}
 
 		@Override
-		public Void visitLookupCall(LookupCallExpression lookupCall) {
+		public Void visit(LookupCallExpression lookupCall) {
 			throw getException("lookup call", lookupCall);
 		}
 
 		@Override
-		public Void visitCall(CallExpression call) {
+		public Void visit(CallExpression call) {
 			if (call.getFunctionDefinition() == OVER && call.getChildren().size() <= 2) {
 				throw getException("OVER call", call);
 			} else if (call.getFunctionDefinition() == FLATTEN) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRule.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.expressions.rules;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.ApiExpressionDefaultVisitor;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.LookupCallExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
@@ -66,13 +66,13 @@ final class VerifyNoUnresolvedExpressionsRule implements ResolverRule {
 		}
 
 		@Override
-		public Void visit(CallExpression call) {
-			if (call.getFunctionDefinition() == OVER && call.getChildren().size() <= 2) {
-				throw getException("OVER call", call);
-			} else if (call.getFunctionDefinition() == FLATTEN) {
-				throw getException("FLATTEN call", call);
+		public Void visit(UnresolvedCallExpression unresolvedCall) {
+			if (unresolvedCall.getFunctionDefinition() == OVER && unresolvedCall.getChildren().size() <= 2) {
+				throw getException("OVER call", unresolvedCall);
+			} else if (unresolvedCall.getFunctionDefinition() == FLATTEN) {
+				throw getException("FLATTEN call", unresolvedCall);
 			}
-			call.getChildren().forEach(expr -> expr.accept(this));
+			unresolvedCall.getChildren().forEach(expr -> expr.accept(this));
 
 			return null;
 		}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
@@ -417,7 +417,7 @@ public class AggregateOperationFactory {
 	private class AggregationExpressionValidator extends ApiExpressionDefaultVisitor<Void> {
 
 		@Override
-		public Void visitCall(CallExpression call) {
+		public Void visit(CallExpression call) {
 			FunctionDefinition functionDefinition = call.getFunctionDefinition();
 			if (isFunctionOfKind(call, AGGREGATE) || isFunctionOfKind(call, TABLE_AGGREGATE)) {
 				if (functionDefinition == BuiltInFunctionDefinitions.DISTINCT) {
@@ -460,7 +460,7 @@ public class AggregateOperationFactory {
 	private class ValidateDistinct extends ApiExpressionDefaultVisitor<Void> {
 
 		@Override
-		public Void visitCall(CallExpression call) {
+		public Void visit(CallExpression call) {
 			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.DISTINCT) {
 				throw new ValidationException("It's not allowed to use an aggregate function as " +
 					"input of another aggregate function");
@@ -481,7 +481,7 @@ public class AggregateOperationFactory {
 	private class NoNestedAggregates extends ApiExpressionDefaultVisitor<Void> {
 
 		@Override
-		public Void visitCall(CallExpression call) {
+		public Void visit(CallExpression call) {
 			if (isFunctionOfKind(call, AGGREGATE) || isFunctionOfKind(call, TABLE_AGGREGATE)) {
 				throw new ValidationException("It's not allowed to use an aggregate function as " +
 					"input of another aggregate function");
@@ -526,7 +526,7 @@ public class AggregateOperationFactory {
 		}
 
 		@Override
-		public Expression visitCall(CallExpression call) {
+		public Expression visit(CallExpression call) {
 			FunctionDefinition definition = call.getFunctionDefinition();
 			if (definition == BuiltInFunctionDefinitions.AS) {
 				return unwrapFromAlias(call);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AliasOperationUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AliasOperationUtils.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 
@@ -70,7 +70,7 @@ public final class AliasOperationUtils {
 				UnresolvedReferenceExpression oldField = unresolvedRef(childNames[idx]);
 				if (idx < fieldAliases.size()) {
 					ValueLiteralExpression alias = fieldAliases.get(idx);
-					return call(BuiltInFunctionDefinitions.AS, oldField, alias);
+					return unresolvedCall(BuiltInFunctionDefinitions.AS, oldField, alias);
 				} else {
 					return oldField;
 				}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AliasOperationUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AliasOperationUtils.java
@@ -22,17 +22,19 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.ApiExpressionDefaultVisitor;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionUtils;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 
 /**
  * Utility class for creating valid alias expressions that can be later used as a projection.
@@ -65,10 +67,10 @@ public final class AliasOperationUtils {
 		String[] childNames = childSchema.getFieldNames();
 		return IntStream.range(0, childNames.length)
 			.mapToObj(idx -> {
-				UnresolvedReferenceExpression oldField = new UnresolvedReferenceExpression(childNames[idx]);
+				UnresolvedReferenceExpression oldField = unresolvedRef(childNames[idx]);
 				if (idx < fieldAliases.size()) {
 					ValueLiteralExpression alias = fieldAliases.get(idx);
-					return new CallExpression(BuiltInFunctionDefinitions.AS, Arrays.asList(oldField, alias));
+					return call(BuiltInFunctionDefinitions.AS, oldField, alias);
 				} else {
 					return oldField;
 				}
@@ -100,7 +102,7 @@ public final class AliasOperationUtils {
 			if (unresolvedReference.getName().equals(ALL_REFERENCE)) {
 				throw new ValidationException("Alias can not accept '*' as name.");
 			}
-			return new ValueLiteralExpression(unresolvedReference.getName());
+			return valueLiteral(unresolvedReference.getName());
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AliasOperationUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AliasOperationUtils.java
@@ -80,7 +80,7 @@ public final class AliasOperationUtils {
 	private static class AliasLiteralValidator extends ApiExpressionDefaultVisitor<ValueLiteralExpression> {
 
 		@Override
-		public ValueLiteralExpression visitValueLiteral(ValueLiteralExpression valueLiteralExpression) {
+		public ValueLiteralExpression visit(ValueLiteralExpression valueLiteralExpression) {
 			String name = ExpressionUtils.extractValue(valueLiteralExpression, String.class)
 				.orElseThrow(() -> new ValidationException(
 					"Alias accepts only names that are not '*' reference."));
@@ -97,7 +97,7 @@ public final class AliasOperationUtils {
 		}
 
 		@Override
-		public ValueLiteralExpression visitUnresolvedReference(UnresolvedReferenceExpression unresolvedReference) {
+		public ValueLiteralExpression visit(UnresolvedReferenceExpression unresolvedReference) {
 
 			if (unresolvedReference.getName().equals(ALL_REFERENCE)) {
 				throw new ValidationException("Alias can not accept '*' as name.");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/CalculatedTableFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/CalculatedTableFactory.java
@@ -65,7 +65,7 @@ public class CalculatedTableFactory {
 		}
 
 		@Override
-		public CalculatedQueryOperation<?> visitCall(CallExpression call) {
+		public CalculatedQueryOperation<?> visit(CallExpression call) {
 			FunctionDefinition definition = call.getFunctionDefinition();
 			if (definition.equals(AS)) {
 				return unwrapFromAlias(call);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ColumnOperationUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ColumnOperationUtils.java
@@ -118,7 +118,7 @@ public final class ColumnOperationUtils {
 	private static class DropColumnsExtractor extends ApiExpressionDefaultVisitor<String> {
 
 		@Override
-		public String visitFieldReference(FieldReferenceExpression fieldReference) {
+		public String visit(FieldReferenceExpression fieldReference) {
 			return fieldReference.getName();
 		}
 
@@ -130,7 +130,7 @@ public final class ColumnOperationUtils {
 
 	private static class RenameColumnExtractor extends ApiExpressionDefaultVisitor<String> {
 		@Override
-		public String visitCall(CallExpression call) {
+		public String visit(CallExpression call) {
 			if (call.getFunctionDefinition() == AS &&
 				call.getChildren().get(0) instanceof FieldReferenceExpression) {
 				FieldReferenceExpression resolvedFieldReference = (FieldReferenceExpression) call.getChildren()

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ColumnOperationUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ColumnOperationUtils.java
@@ -21,10 +21,10 @@ package org.apache.flink.table.operations;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.ApiExpressionDefaultVisitor;
+import org.apache.flink.table.expressions.ApiExpressionUtils;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
-import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AS;
 import static org.apache.flink.table.operations.OperationExpressionsUtils.extractName;
 
@@ -57,7 +58,7 @@ public final class ColumnOperationUtils {
 	public static List<Expression> renameColumns(List<String> inputFields, List<Expression> newAliases) {
 		LinkedHashMap<String, Expression> finalFields = new LinkedHashMap<>();
 
-		inputFields.forEach(field -> finalFields.put(field, new UnresolvedReferenceExpression(field)));
+		inputFields.forEach(field -> finalFields.put(field, unresolvedRef(field)));
 		newAliases.forEach(expr -> {
 			String name = expr.accept(renameColumnExtractor);
 			finalFields.put(name, expr);
@@ -79,7 +80,7 @@ public final class ColumnOperationUtils {
 	public static List<Expression> addOrReplaceColumns(List<String> inputFields, List<Expression> newExpressions) {
 		LinkedHashMap<String, Expression> finalFields = new LinkedHashMap<>();
 
-		inputFields.forEach(field -> finalFields.put(field, new UnresolvedReferenceExpression(field)));
+		inputFields.forEach(field -> finalFields.put(field, unresolvedRef(field)));
 		newExpressions.forEach(expr -> {
 			String name = extractName(expr).orElse(expr.toString());
 			finalFields.put(name, expr);
@@ -110,7 +111,7 @@ public final class ColumnOperationUtils {
 
 		return inputFields.stream()
 			.filter(oldName -> !columnsToDrop.contains(oldName))
-			.map(UnresolvedReferenceExpression::new)
+			.map(ApiExpressionUtils::unresolvedRef)
 			.collect(Collectors.toList());
 	}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ColumnOperationUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ColumnOperationUtils.java
@@ -22,9 +22,9 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.ApiExpressionDefaultVisitor;
 import org.apache.flink.table.expressions.ApiExpressionUtils;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -130,14 +130,14 @@ public final class ColumnOperationUtils {
 
 	private static class RenameColumnExtractor extends ApiExpressionDefaultVisitor<String> {
 		@Override
-		public String visit(CallExpression call) {
-			if (call.getFunctionDefinition() == AS &&
-				call.getChildren().get(0) instanceof FieldReferenceExpression) {
-				FieldReferenceExpression resolvedFieldReference = (FieldReferenceExpression) call.getChildren()
+		public String visit(UnresolvedCallExpression unresolvedCall) {
+			if (unresolvedCall.getFunctionDefinition() == AS &&
+				unresolvedCall.getChildren().get(0) instanceof FieldReferenceExpression) {
+				FieldReferenceExpression resolvedFieldReference = (FieldReferenceExpression) unresolvedCall.getChildren()
 					.get(0);
 				return resolvedFieldReference.getName();
 			} else {
-				return defaultMethod(call);
+				return defaultMethod(unresolvedCall);
 			}
 		}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/JoinOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/JoinOperationFactory.java
@@ -119,7 +119,7 @@ public class JoinOperationFactory {
 	private class EquiJoinExistsChecker extends ApiExpressionDefaultVisitor<Boolean> {
 
 		@Override
-		public Boolean visitCall(CallExpression call) {
+		public Boolean visit(CallExpression call) {
 			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.EQUALS) {
 				return isJoinCondition(call.getChildren().get(0), call.getChildren().get(1));
 			} else if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.OR) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/JoinOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/JoinOperationFactory.java
@@ -23,12 +23,12 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.ApiExpressionDefaultVisitor;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionBridge;
 import org.apache.flink.table.expressions.ExpressionUtils;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.PlannerExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.operations.JoinQueryOperation.JoinType;
 
@@ -119,13 +119,13 @@ public class JoinOperationFactory {
 	private class EquiJoinExistsChecker extends ApiExpressionDefaultVisitor<Boolean> {
 
 		@Override
-		public Boolean visit(CallExpression call) {
-			if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.EQUALS) {
-				return isJoinCondition(call.getChildren().get(0), call.getChildren().get(1));
-			} else if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.OR) {
+		public Boolean visit(UnresolvedCallExpression unresolvedCall) {
+			if (unresolvedCall.getFunctionDefinition() == BuiltInFunctionDefinitions.EQUALS) {
+				return isJoinCondition(unresolvedCall.getChildren().get(0), unresolvedCall.getChildren().get(1));
+			} else if (unresolvedCall.getFunctionDefinition() == BuiltInFunctionDefinitions.OR) {
 				return false;
-			} else if (call.getFunctionDefinition() == BuiltInFunctionDefinitions.AND) {
-				return call.getChildren().get(0).accept(this) || call.getChildren().get(1).accept(this);
+			} else if (unresolvedCall.getFunctionDefinition() == BuiltInFunctionDefinitions.AND) {
+				return unresolvedCall.getChildren().get(0).accept(this) || unresolvedCall.getChildren().get(1).accept(this);
 			}
 
 			return false;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
@@ -43,7 +43,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CAST;
@@ -152,7 +152,7 @@ public final class ProjectionOperationFactory {
 				rename = Optional.of(getUniqueName());
 			}
 
-			return rename.map(name -> call(AS, unresolvedCall, valueLiteral(name))).orElse(unresolvedCall);
+			return rename.map(name -> unresolvedCall(AS, unresolvedCall, valueLiteral(name))).orElse(unresolvedCall);
 		}
 
 		private Optional<String> nameForGet(UnresolvedCallExpression unresolvedCall) {
@@ -169,7 +169,7 @@ public final class ProjectionOperationFactory {
 
 		@Override
 		public Expression visit(ValueLiteralExpression valueLiteralExpression) {
-			return call(AS, valueLiteralExpression, valueLiteral(getUniqueName()));
+			return unresolvedCall(AS, valueLiteralExpression, valueLiteral(getUniqueName()));
 		}
 
 		@Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
@@ -36,7 +36,6 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.logical.LogicalType;
 
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +43,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CAST;
@@ -152,7 +152,7 @@ public final class ProjectionOperationFactory {
 				rename = Optional.of(getUniqueName());
 			}
 
-			return rename.map(name -> new CallExpression(AS, Arrays.asList(call, valueLiteral(name)))).orElse(call);
+			return rename.map(name -> call(AS, call, valueLiteral(name))).orElse(call);
 		}
 
 		private Optional<String> nameForGet(CallExpression call) {
@@ -169,7 +169,7 @@ public final class ProjectionOperationFactory {
 
 		@Override
 		public Expression visitValueLiteral(ValueLiteralExpression valueLiteralExpression) {
-			return new CallExpression(AS, Arrays.asList(valueLiteralExpression, valueLiteral(getUniqueName())));
+			return call(AS, valueLiteralExpression, valueLiteral(getUniqueName()));
 		}
 
 		@Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
@@ -139,7 +139,7 @@ public final class ProjectionOperationFactory {
 	private class NamingVisitor extends ApiExpressionDefaultVisitor<Expression> {
 
 		@Override
-		public Expression visitCall(CallExpression call) {
+		public Expression visit(CallExpression call) {
 			FunctionDefinition functionDefinition = call.getFunctionDefinition();
 			final Optional<String> rename;
 			if (functionDefinition.equals(CAST)) {
@@ -168,7 +168,7 @@ public final class ProjectionOperationFactory {
 		}
 
 		@Override
-		public Expression visitValueLiteral(ValueLiteralExpression valueLiteralExpression) {
+		public Expression visit(ValueLiteralExpression valueLiteralExpression) {
 			return call(AS, valueLiteralExpression, valueLiteral(getUniqueName()));
 		}
 
@@ -181,7 +181,7 @@ public final class ProjectionOperationFactory {
 	private class StripAliases extends ApiExpressionDefaultVisitor<Expression> {
 
 		@Override
-		public Expression visitCall(CallExpression call) {
+		public Expression visit(CallExpression call) {
 			if (call.getFunctionDefinition().equals(AS)) {
 				return call.getChildren().get(0).accept(this);
 			} else {
@@ -198,7 +198,7 @@ public final class ProjectionOperationFactory {
 	private class TransitiveExtractNameVisitor extends ApiExpressionDefaultVisitor<Optional<String>> {
 
 		@Override
-		public Optional<String> visitCall(CallExpression call) {
+		public Optional<String> visit(CallExpression call) {
 			if (call.getFunctionDefinition().equals(GET)) {
 				return extractNameFromGet(call);
 			} else {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
@@ -24,13 +24,13 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.ApiExpressionDefaultVisitor;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionBridge;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.LocalReferenceExpression;
 import org.apache.flink.table.expressions.PlannerExpression;
 import org.apache.flink.table.expressions.TableReferenceExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
@@ -139,30 +139,30 @@ public final class ProjectionOperationFactory {
 	private class NamingVisitor extends ApiExpressionDefaultVisitor<Expression> {
 
 		@Override
-		public Expression visit(CallExpression call) {
-			FunctionDefinition functionDefinition = call.getFunctionDefinition();
+		public Expression visit(UnresolvedCallExpression unresolvedCall) {
+			FunctionDefinition functionDefinition = unresolvedCall.getFunctionDefinition();
 			final Optional<String> rename;
-			if (functionDefinition.equals(CAST)) {
-				rename = nameForCast(call);
-			} else if (functionDefinition.equals(GET)) {
-				rename = nameForGet(call);
-			} else if (functionDefinition.equals(AS)) {
+			if (functionDefinition == CAST) {
+				rename = nameForCast(unresolvedCall);
+			} else if (functionDefinition == GET) {
+				rename = nameForGet(unresolvedCall);
+			} else if (functionDefinition == AS) {
 				rename = Optional.empty();
 			} else {
 				rename = Optional.of(getUniqueName());
 			}
 
-			return rename.map(name -> call(AS, call, valueLiteral(name))).orElse(call);
+			return rename.map(name -> call(AS, unresolvedCall, valueLiteral(name))).orElse(unresolvedCall);
 		}
 
-		private Optional<String> nameForGet(CallExpression call) {
-			return Optional.of(call.accept(extractTransitiveNameVisitor)
+		private Optional<String> nameForGet(UnresolvedCallExpression unresolvedCall) {
+			return Optional.of(unresolvedCall.accept(extractTransitiveNameVisitor)
 				.orElseGet(ProjectionOperationFactory.this::getUniqueName));
 		}
 
-		private Optional<String> nameForCast(CallExpression call) {
-			Optional<String> innerName = call.getChildren().get(0).accept(extractTransitiveNameVisitor);
-			Expression type = call.getChildren().get(1);
+		private Optional<String> nameForCast(UnresolvedCallExpression unresolvedCall) {
+			Optional<String> innerName = unresolvedCall.getChildren().get(0).accept(extractTransitiveNameVisitor);
+			Expression type = unresolvedCall.getChildren().get(1);
 			return Optional.of(innerName.map(n -> String.format("%s-%s", n, type))
 				.orElseGet(ProjectionOperationFactory.this::getUniqueName));
 		}
@@ -181,11 +181,11 @@ public final class ProjectionOperationFactory {
 	private class StripAliases extends ApiExpressionDefaultVisitor<Expression> {
 
 		@Override
-		public Expression visit(CallExpression call) {
-			if (call.getFunctionDefinition().equals(AS)) {
-				return call.getChildren().get(0).accept(this);
+		public Expression visit(UnresolvedCallExpression unresolvedCall) {
+			if (unresolvedCall.getFunctionDefinition() == AS) {
+				return unresolvedCall.getChildren().get(0).accept(this);
 			} else {
-				return call;
+				return unresolvedCall;
 			}
 		}
 
@@ -198,11 +198,11 @@ public final class ProjectionOperationFactory {
 	private class TransitiveExtractNameVisitor extends ApiExpressionDefaultVisitor<Optional<String>> {
 
 		@Override
-		public Optional<String> visit(CallExpression call) {
-			if (call.getFunctionDefinition().equals(GET)) {
-				return extractNameFromGet(call);
+		public Optional<String> visit(UnresolvedCallExpression unresolvedCall) {
+			if (unresolvedCall.getFunctionDefinition() == GET) {
+				return extractNameFromGet(unresolvedCall);
 			} else {
-				return defaultMethod(call);
+				return defaultMethod(unresolvedCall);
 			}
 		}
 
@@ -211,9 +211,9 @@ public final class ProjectionOperationFactory {
 			return extractName(expression);
 		}
 
-		private Optional<String> extractNameFromGet(CallExpression call) {
-			Expression child = call.getChildren().get(0);
-			ValueLiteralExpression key = (ValueLiteralExpression) call.getChildren().get(1);
+		private Optional<String> extractNameFromGet(UnresolvedCallExpression unresolvedCall) {
+			Expression child = unresolvedCall.getChildren().get(0);
+			ValueLiteralExpression key = (ValueLiteralExpression) unresolvedCall.getChildren().get(1);
 
 			final LogicalType keyType = key.getOutputDataType().getLogicalType();
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/SortOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/SortOperationFactory.java
@@ -27,7 +27,7 @@ import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDERING;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDER_ASC;
 
@@ -139,7 +139,7 @@ public class SortOperationFactory {
 
 		@Override
 		protected Expression defaultMethod(Expression expression) {
-			return call(ORDER_ASC, expression);
+			return unresolvedCall(ORDER_ASC, expression);
 		}
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/SortOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/SortOperationFactory.java
@@ -129,7 +129,7 @@ public class SortOperationFactory {
 	private class OrderWrapper extends ApiExpressionDefaultVisitor<Expression> {
 
 		@Override
-		public Expression visitCall(CallExpression call) {
+		public Expression visit(CallExpression call) {
 			if (ORDERING.contains(call.getFunctionDefinition())) {
 				return call;
 			} else {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/SortOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/SortOperationFactory.java
@@ -27,9 +27,10 @@ import org.apache.flink.table.expressions.Expression;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.singletonList;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDERING;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDER_ASC;
+
 
 /**
  * Utility class for creating a valid {@link SortQueryOperation} operation.
@@ -138,7 +139,7 @@ public class SortOperationFactory {
 
 		@Override
 		protected Expression defaultMethod(Expression expression) {
-			return new CallExpression(ORDER_ASC, singletonList(expression));
+			return call(ORDER_ASC, expression);
 		}
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/SortOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/SortOperationFactory.java
@@ -21,8 +21,8 @@ package org.apache.flink.table.operations;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.ApiExpressionDefaultVisitor;
-import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -129,11 +129,11 @@ public class SortOperationFactory {
 	private class OrderWrapper extends ApiExpressionDefaultVisitor<Expression> {
 
 		@Override
-		public Expression visit(CallExpression call) {
-			if (ORDERING.contains(call.getFunctionDefinition())) {
-				return call;
+		public Expression visit(UnresolvedCallExpression unresolvedCall) {
+			if (ORDERING.contains(unresolvedCall.getFunctionDefinition())) {
+				return unresolvedCall;
 			} else {
-				return defaultMethod(call);
+				return defaultMethod(unresolvedCall);
 			}
 		}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/QueryOperationConverter.java
@@ -90,6 +90,7 @@ import scala.Some;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 import static org.apache.flink.table.expressions.ExpressionUtils.extractValue;
 import static org.apache.flink.table.expressions.ExpressionUtils.isFunctionOfKind;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AS;
@@ -387,12 +388,12 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 
 		@Override
 		public RexNode visitCall(CallExpression call) {
-			List<Expression> newChildren = call.getChildren().stream().map(expr -> {
+			final Expression[] newChildren = call.getChildren().stream().map(expr -> {
 				RexNode convertedNode = expr.accept(this);
 				return (Expression) new RexPlannerExpression(convertedNode);
-			}).collect(toList());
+			}).toArray(Expression[]::new);
 
-			CallExpression newCall = new CallExpression(call.getFunctionDefinition(), newChildren);
+			CallExpression newCall = call(call.getFunctionDefinition(), newChildren);
 			return expressionBridge.bridge(newCall).toRexNode(relBuilder);
 		}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/QueryOperationConverter.java
@@ -387,7 +387,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 		private static final int numberOfJoinInputs = 2;
 
 		@Override
-		public RexNode visitCall(CallExpression call) {
+		public RexNode visit(CallExpression call) {
 			final Expression[] newChildren = call.getChildren().stream().map(expr -> {
 				RexNode convertedNode = expr.accept(this);
 				return (Expression) new RexPlannerExpression(convertedNode);
@@ -398,7 +398,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 		}
 
 		@Override
-		public RexNode visitFieldReference(FieldReferenceExpression fieldReference) {
+		public RexNode visit(FieldReferenceExpression fieldReference) {
 			return relBuilder.field(numberOfJoinInputs, fieldReference.getInputIndex(), fieldReference.getFieldIndex());
 		}
 
@@ -411,7 +411,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 	private class AggregateVisitor extends ExpressionDefaultVisitor<AggCall> {
 
 		@Override
-		public AggCall visitCall(CallExpression call) {
+		public AggCall visit(CallExpression call) {
 			if (call.getFunctionDefinition() == AS) {
 				String aggregateName = extractValue(call.getChildren().get(1), String.class)
 					.orElseThrow(() -> new TableException("Unexpected name."));
@@ -433,7 +433,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 
 	private class TableAggregateVisitor extends AggregateVisitor {
 		@Override
-		public AggCall visitCall(CallExpression call) {
+		public AggCall visit(CallExpression call) {
 			if (isFunctionOfKind(call, TABLE_AGGREGATE)) {
 				AggFunctionCall aggFunctionCall = (AggFunctionCall) expressionBridge.bridge(call);
 				return aggFunctionCall.toAggCall(aggFunctionCall.toString(), false, relBuilder);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/QueryOperationConverter.java
@@ -90,7 +90,7 @@ import scala.Some;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ExpressionUtils.extractValue;
 import static org.apache.flink.table.expressions.ExpressionUtils.isFunctionOfKind;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AS;
@@ -393,7 +393,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 				return (Expression) new RexPlannerExpression(convertedNode);
 			}).toArray(Expression[]::new);
 
-			UnresolvedCallExpression newCall = call(unresolvedCall.getFunctionDefinition(), newChildren);
+			UnresolvedCallExpression newCall = unresolvedCall(unresolvedCall.getFunctionDefinition(), newChildren);
 			return expressionBridge.bridge(newCall).toRexNode(relBuilder);
 		}
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/BatchTableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/BatchTableEnvImpl.scala
@@ -232,7 +232,7 @@ abstract class BatchTableEnvImpl(
     if (f.exists(f =>
       f.accept(new ExpressionDefaultVisitor[Boolean] {
 
-        override def visitCall(call: CallExpression): Boolean = {
+        override def visit(call: CallExpression): Boolean = {
           TIME_ATTRIBUTES.contains(call.getFunctionDefinition) ||
             call.getChildren.asScala.exists(_.accept(this))
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/BatchTableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/BatchTableEnvImpl.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.calcite.{CalciteConfig, FlinkTypeFactory}
 import org.apache.flink.table.catalog.CatalogManager
 import org.apache.flink.table.descriptors.{BatchTableDescriptor, ConnectorDescriptor}
 import org.apache.flink.table.explain.PlanJsonParser
-import org.apache.flink.table.expressions.{CallExpression, Expression, ExpressionDefaultVisitor}
+import org.apache.flink.table.expressions.{UnresolvedCallExpression, Expression, ExpressionDefaultVisitor}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions.TIME_ATTRIBUTES
 import org.apache.flink.table.operations.DataSetQueryOperation
 import org.apache.flink.table.plan.BatchOptimizer
@@ -232,7 +232,7 @@ abstract class BatchTableEnvImpl(
     if (f.exists(f =>
       f.accept(new ExpressionDefaultVisitor[Boolean] {
 
-        override def visit(call: CallExpression): Boolean = {
+        override def visit(call: UnresolvedCallExpression): Boolean = {
           TIME_ATTRIBUTES.contains(call.getFunctionDefinition) ||
             call.getChildren.asScala.exists(_.accept(this))
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -56,42 +56,42 @@ trait ImplicitExpressionOperations {
   /**
     * Boolean AND in three-valued logic.
     */
-  def && (other: Expression): Expression = call(AND, expr, other)
+  def && (other: Expression): Expression = unresolvedCall(AND, expr, other)
 
   /**
     * Boolean OR in three-valued logic.
     */
-  def || (other: Expression): Expression = call(OR, expr, other)
+  def || (other: Expression): Expression = unresolvedCall(OR, expr, other)
 
   /**
     * Greater than.
     */
-  def > (other: Expression): Expression = call(GREATER_THAN, expr, other)
+  def > (other: Expression): Expression = unresolvedCall(GREATER_THAN, expr, other)
 
   /**
     * Greater than or equal.
     */
-  def >= (other: Expression): Expression = call(GREATER_THAN_OR_EQUAL, expr, other)
+  def >= (other: Expression): Expression = unresolvedCall(GREATER_THAN_OR_EQUAL, expr, other)
 
   /**
     * Less than.
     */
-  def < (other: Expression): Expression = call(LESS_THAN, expr, other)
+  def < (other: Expression): Expression = unresolvedCall(LESS_THAN, expr, other)
 
   /**
     * Less than or equal.
     */
-  def <= (other: Expression): Expression = call(LESS_THAN_OR_EQUAL, expr, other)
+  def <= (other: Expression): Expression = unresolvedCall(LESS_THAN_OR_EQUAL, expr, other)
 
   /**
     * Equals.
     */
-  def === (other: Expression): Expression = call(EQUALS, expr, other)
+  def === (other: Expression): Expression = unresolvedCall(EQUALS, expr, other)
 
   /**
     * Not equal.
     */
-  def !== (other: Expression): Expression = call(NOT_EQUALS, expr, other)
+  def !== (other: Expression): Expression = unresolvedCall(NOT_EQUALS, expr, other)
 
   /**
     * Returns true if the given expression is between lowerBound and upperBound (both inclusive).
@@ -102,7 +102,7 @@ trait ImplicitExpressionOperations {
     * @return boolean or null
     */
   def between(lowerBound: Expression, upperBound: Expression): Expression =
-    call(BETWEEN, expr, lowerBound, upperBound)
+    unresolvedCall(BETWEEN, expr, lowerBound, upperBound)
 
   /**
     * Returns true if the given expression is not between lowerBound and upperBound (both
@@ -114,17 +114,17 @@ trait ImplicitExpressionOperations {
     * @return boolean or null
     */
   def notBetween(lowerBound: Expression, upperBound: Expression): Expression =
-    call(NOT_BETWEEN, expr, lowerBound, upperBound)
+    unresolvedCall(NOT_BETWEEN, expr, lowerBound, upperBound)
 
   /**
     * Whether boolean expression is not true; returns null if boolean is null.
     */
-  def unary_! : Expression = call(NOT, expr)
+  def unary_! : Expression = unresolvedCall(NOT, expr)
 
   /**
     * Returns negative numeric.
     */
-  def unary_- : Expression = call(MINUS_PREFIX, expr)
+  def unary_- : Expression = unresolvedCall(MINUS_PREFIX, expr)
 
   /**
     * Returns numeric.
@@ -134,52 +134,52 @@ trait ImplicitExpressionOperations {
   /**
     * Returns true if the given expression is null.
     */
-  def isNull: Expression = call(IS_NULL, expr)
+  def isNull: Expression = unresolvedCall(IS_NULL, expr)
 
   /**
     * Returns true if the given expression is not null.
     */
-  def isNotNull: Expression = call(IS_NOT_NULL, expr)
+  def isNotNull: Expression = unresolvedCall(IS_NOT_NULL, expr)
 
   /**
     * Returns true if given boolean expression is true. False otherwise (for null and false).
     */
-  def isTrue: Expression = call(IS_TRUE, expr)
+  def isTrue: Expression = unresolvedCall(IS_TRUE, expr)
 
   /**
     * Returns true if given boolean expression is false. False otherwise (for null and true).
     */
-  def isFalse: Expression = call(IS_FALSE, expr)
+  def isFalse: Expression = unresolvedCall(IS_FALSE, expr)
 
   /**
     * Returns true if given boolean expression is not true (for null and false). False otherwise.
     */
-  def isNotTrue: Expression = call(IS_NOT_TRUE, expr)
+  def isNotTrue: Expression = unresolvedCall(IS_NOT_TRUE, expr)
 
   /**
     * Returns true if given boolean expression is not false (for null and true). False otherwise.
     */
-  def isNotFalse: Expression = call(IS_NOT_FALSE, expr)
+  def isNotFalse: Expression = unresolvedCall(IS_NOT_FALSE, expr)
 
   /**
     * Returns left plus right.
     */
-  def + (other: Expression): Expression = call(PLUS, expr, other)
+  def + (other: Expression): Expression = unresolvedCall(PLUS, expr, other)
 
   /**
     * Returns left minus right.
     */
-  def - (other: Expression): Expression = call(MINUS, expr, other)
+  def - (other: Expression): Expression = unresolvedCall(MINUS, expr, other)
 
   /**
     * Returns left divided by right.
     */
-  def / (other: Expression): Expression = call(DIVIDE, expr, other)
+  def / (other: Expression): Expression = unresolvedCall(DIVIDE, expr, other)
 
   /**
     * Returns left multiplied by right.
     */
-  def * (other: Expression): Expression = call(TIMES, expr, other)
+  def * (other: Expression): Expression = unresolvedCall(TIMES, expr, other)
 
   /**
     * Returns the remainder (modulus) of left divided by right.
@@ -191,7 +191,7 @@ trait ImplicitExpressionOperations {
     * Indicates the range from left to right, i.e. [left, right], which can be used in columns
     * selection, e.g.: withColumns(1 to 3).
     */
-  def to (other: Expression): Expression = call(RANGE_TO, expr, other)
+  def to (other: Expression): Expression = unresolvedCall(RANGE_TO, expr, other)
 
   /**
     * Similar to a SQL distinct aggregation clause such as COUNT(DISTINCT a), declares that an
@@ -205,64 +205,64 @@ trait ImplicitExpressionOperations {
     *   .select('a, 'b.sum.distinct as 'd)
     * }}}
     */
-  def distinct: Expression = call(DISTINCT, expr)
+  def distinct: Expression = unresolvedCall(DISTINCT, expr)
 
   /**
     * Returns the sum of the numeric field across all input values.
     * If all values are null, null is returned.
     */
-  def sum: Expression = call(SUM, expr)
+  def sum: Expression = unresolvedCall(SUM, expr)
 
   /**
     * Returns the sum of the numeric field across all input values.
     * If all values are null, 0 is returned.
     */
-  def sum0: Expression = call(SUM0, expr)
+  def sum0: Expression = unresolvedCall(SUM0, expr)
 
   /**
     * Returns the minimum value of field across all input values.
     */
-  def min: Expression = call(MIN, expr)
+  def min: Expression = unresolvedCall(MIN, expr)
 
   /**
     * Returns the maximum value of field across all input values.
     */
-  def max: Expression = call(MAX, expr)
+  def max: Expression = unresolvedCall(MAX, expr)
 
   /**
     * Returns the number of input rows for which the field is not null.
     */
-  def count: Expression = call(COUNT, expr)
+  def count: Expression = unresolvedCall(COUNT, expr)
 
   /**
     * Returns the average (arithmetic mean) of the numeric field across all input values.
     */
-  def avg: Expression = call(AVG, expr)
+  def avg: Expression = unresolvedCall(AVG, expr)
 
   /**
     * Returns the population standard deviation of an expression (the square root of varPop()).
     */
-  def stddevPop: Expression = call(STDDEV_POP, expr)
+  def stddevPop: Expression = unresolvedCall(STDDEV_POP, expr)
 
   /**
     * Returns the sample standard deviation of an expression (the square root of varSamp()).
     */
-  def stddevSamp: Expression = call(STDDEV_SAMP, expr)
+  def stddevSamp: Expression = unresolvedCall(STDDEV_SAMP, expr)
 
   /**
     * Returns the population standard variance of an expression.
     */
-  def varPop: Expression = call(VAR_POP, expr)
+  def varPop: Expression = unresolvedCall(VAR_POP, expr)
 
   /**
     *  Returns the sample variance of a given expression.
     */
-  def varSamp: Expression = call(VAR_SAMP, expr)
+  def varSamp: Expression = unresolvedCall(VAR_SAMP, expr)
 
   /**
     * Returns multiset aggregate of a given expression.
     */
-  def collect: Expression = call(COLLECT, expr)
+  def collect: Expression = unresolvedCall(COLLECT, expr)
 
   /**
     * Converts a value to a given data type.
@@ -272,7 +272,7 @@ trait ImplicitExpressionOperations {
     * @return casted expression
     */
   def cast(toType: DataType): Expression =
-    call(CAST, expr, typeLiteral(toType))
+    unresolvedCall(CAST, expr, typeLiteral(toType))
 
   /**
     * @deprecated This method will be removed in future versions as it uses the old type system. It
@@ -283,7 +283,7 @@ trait ImplicitExpressionOperations {
     */
   @deprecated
   def cast(toType: TypeInformation[_]): Expression =
-    call(CAST, expr, typeLiteral(fromLegacyInfoToDataType(toType)))
+    unresolvedCall(CAST, expr, typeLiteral(fromLegacyInfoToDataType(toType)))
 
   /**
     * Specifies a name for an expression i.e. a field.
@@ -293,21 +293,23 @@ trait ImplicitExpressionOperations {
     * @return field with an alias
     */
   def as(name: Symbol, extraNames: Symbol*): Expression =
-    call(AS, expr +: valueLiteral(name.name) +: extraNames.map(name => valueLiteral(name.name)): _*)
+    unresolvedCall(
+      AS,
+      expr +: valueLiteral(name.name) +: extraNames.map(name => valueLiteral(name.name)): _*)
 
   /**
     * Specifies ascending order of an expression i.e. a field for orderBy call.
     *
     * @return ascend expression
     */
-  def asc: Expression = call(ORDER_ASC, expr)
+  def asc: Expression = unresolvedCall(ORDER_ASC, expr)
 
   /**
     * Specifies descending order of an expression i.e. a field for orderBy call.
     *
     * @return descend expression
     */
-  def desc: Expression = call(ORDER_DESC, expr)
+  def desc: Expression = unresolvedCall(ORDER_DESC, expr)
 
   /**
     * Returns true if an expression exists in a given list of expressions. This is a shorthand
@@ -318,7 +320,7 @@ trait ImplicitExpressionOperations {
     *
     * e.g. "42".in(1, 2, 3) leads to false.
     */
-  def in(elements: Expression*): Expression = call(IN, expr +: elements: _*)
+  def in(elements: Expression*): Expression = unresolvedCall(IN, expr +: elements: _*)
 
   /**
     * Returns true if an expression exists in a given table sub-query. The sub-query table
@@ -326,19 +328,19 @@ trait ImplicitExpressionOperations {
     *
     * Note: This operation is not supported in a streaming environment yet.
     */
-  def in(table: Table): Expression = call(IN, expr, tableRef(table.toString, table))
+  def in(table: Table): Expression = unresolvedCall(IN, expr, tableRef(table.toString, table))
 
   /**
     * Returns the start time (inclusive) of a window when applied on a window reference.
     */
-  def start: Expression = call(WINDOW_START, expr)
+  def start: Expression = unresolvedCall(WINDOW_START, expr)
 
   /**
     * Returns the end time (exclusive) of a window when applied on a window reference.
     *
     * e.g. if a window ends at 10:59:59.999 this property will return 11:00:00.000.
     */
-  def end: Expression = call(WINDOW_END, expr)
+  def end: Expression = unresolvedCall(WINDOW_END, expr)
 
   /**
     * Ternary conditional operator that decides which of two other expressions should be
@@ -349,145 +351,146 @@ trait ImplicitExpressionOperations {
     * @param ifTrue expression to be evaluated if condition holds
     * @param ifFalse expression to be evaluated if condition does not hold
     */
-  def ?(ifTrue: Expression, ifFalse: Expression): Expression = call(IF, expr, ifTrue, ifFalse)
+  def ?(ifTrue: Expression, ifFalse: Expression): Expression =
+    unresolvedCall(IF, expr, ifTrue, ifFalse)
 
   // scalar functions
 
   /**
     * Calculates the remainder of division the given number by another one.
     */
-  def mod(other: Expression): Expression = call(MOD, expr, other)
+  def mod(other: Expression): Expression = unresolvedCall(MOD, expr, other)
 
   /**
     * Calculates the Euler's number raised to the given power.
     */
-  def exp(): Expression = call(EXP, expr)
+  def exp(): Expression = unresolvedCall(EXP, expr)
 
   /**
     * Calculates the base 10 logarithm of the given value.
     */
-  def log10(): Expression = call(LOG10, expr)
+  def log10(): Expression = unresolvedCall(LOG10, expr)
 
   /**
     * Calculates the base 2 logarithm of the given value.
     */
-  def log2(): Expression = call(LOG2, expr)
+  def log2(): Expression = unresolvedCall(LOG2, expr)
 
   /**
     * Calculates the natural logarithm of the given value.
     */
-  def ln(): Expression = call(LN, expr)
+  def ln(): Expression = unresolvedCall(LN, expr)
 
   /**
     * Calculates the natural logarithm of the given value.
     */
-  def log(): Expression = call(LOG, expr)
+  def log(): Expression = unresolvedCall(LOG, expr)
 
   /**
     * Calculates the logarithm of the given value to the given base.
     */
-  def log(base: Expression): Expression = call(LOG, base, expr)
+  def log(base: Expression): Expression = unresolvedCall(LOG, base, expr)
 
   /**
     * Calculates the given number raised to the power of the other value.
     */
-  def power(other: Expression): Expression = call(POWER, expr, other)
+  def power(other: Expression): Expression = unresolvedCall(POWER, expr, other)
 
   /**
     * Calculates the hyperbolic cosine of a given value.
     */
-  def cosh(): Expression = call(COSH, expr)
+  def cosh(): Expression = unresolvedCall(COSH, expr)
 
   /**
     * Calculates the square root of a given value.
     */
-  def sqrt(): Expression = call(SQRT, expr)
+  def sqrt(): Expression = unresolvedCall(SQRT, expr)
 
   /**
     * Calculates the absolute value of given value.
     */
-  def abs(): Expression = call(ABS, expr)
+  def abs(): Expression = unresolvedCall(ABS, expr)
 
   /**
     * Calculates the largest integer less than or equal to a given number.
     */
-  def floor(): Expression = call(FLOOR, expr)
+  def floor(): Expression = unresolvedCall(FLOOR, expr)
 
   /**
     * Calculates the hyperbolic sine of a given value.
     */
-  def sinh(): Expression = call(SINH, expr)
+  def sinh(): Expression = unresolvedCall(SINH, expr)
 
   /**
     * Calculates the smallest integer greater than or equal to a given number.
     */
-  def ceil(): Expression = call(CEIL, expr)
+  def ceil(): Expression = unresolvedCall(CEIL, expr)
 
   /**
     * Calculates the sine of a given number.
     */
-  def sin(): Expression = call(SIN, expr)
+  def sin(): Expression = unresolvedCall(SIN, expr)
 
   /**
     * Calculates the cosine of a given number.
     */
-  def cos(): Expression = call(COS, expr)
+  def cos(): Expression = unresolvedCall(COS, expr)
 
   /**
     * Calculates the tangent of a given number.
     */
-  def tan(): Expression = call(TAN, expr)
+  def tan(): Expression = unresolvedCall(TAN, expr)
 
   /**
     * Calculates the cotangent of a given number.
     */
-  def cot(): Expression = call(COT, expr)
+  def cot(): Expression = unresolvedCall(COT, expr)
 
   /**
     * Calculates the arc sine of a given number.
     */
-  def asin(): Expression = call(ASIN, expr)
+  def asin(): Expression = unresolvedCall(ASIN, expr)
 
   /**
     * Calculates the arc cosine of a given number.
     */
-  def acos(): Expression = call(ACOS, expr)
+  def acos(): Expression = unresolvedCall(ACOS, expr)
 
   /**
     * Calculates the arc tangent of a given number.
     */
-  def atan(): Expression = call(ATAN, expr)
+  def atan(): Expression = unresolvedCall(ATAN, expr)
 
   /**
     * Calculates the hyperbolic tangent of a given number.
     */
-  def tanh(): Expression = call(TANH, expr)
+  def tanh(): Expression = unresolvedCall(TANH, expr)
 
   /**
     * Converts numeric from radians to degrees.
     */
-  def degrees(): Expression = call(DEGREES, expr)
+  def degrees(): Expression = unresolvedCall(DEGREES, expr)
 
   /**
     * Converts numeric from degrees to radians.
     */
-  def radians(): Expression = call(RADIANS, expr)
+  def radians(): Expression = unresolvedCall(RADIANS, expr)
 
   /**
     * Calculates the signum of a given number.
     */
-  def sign(): Expression = call(SIGN, expr)
+  def sign(): Expression = unresolvedCall(SIGN, expr)
 
   /**
     * Rounds the given number to integer places right to the decimal point.
     */
-  def round(places: Expression): Expression = call(ROUND, expr, places)
+  def round(places: Expression): Expression = unresolvedCall(ROUND, expr, places)
 
   /**
     * Returns a string representation of an integer numeric value in binary format. Returns null if
     * numeric is null. E.g. "4" leads to "100", "12" leads to "1100".
     */
-  def bin(): Expression = call(BIN, expr)
+  def bin(): Expression = unresolvedCall(BIN, expr)
 
   /**
     * Returns a string representation of an integer numeric value or a string in hex format. Returns
@@ -496,7 +499,7 @@ trait ImplicitExpressionOperations {
     * E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", and a string "hello,world" leads
     * to "68656c6c6f2c776f726c64".
     */
-  def hex(): Expression = call(HEX, expr)
+  def hex(): Expression = unresolvedCall(HEX, expr)
 
   /**
     * Returns a number of truncated to n decimal places.
@@ -504,13 +507,13 @@ trait ImplicitExpressionOperations {
     * n can be negative to cause n digits left of the decimal point of the value to become zero.
     * E.g. truncate(42.345, 2) to 42.34.
     */
-  def truncate(n: Expression): Expression = call(TRUNCATE, expr, n)
+  def truncate(n: Expression): Expression = unresolvedCall(TRUNCATE, expr, n)
 
   /**
     * Returns a number of truncated to 0 decimal places.
     * E.g. truncate(42.345) to 42.0.
     */
-  def truncate(): Expression = call(TRUNCATE, expr)
+  def truncate(): Expression = unresolvedCall(TRUNCATE, expr)
 
   // String operations
 
@@ -522,7 +525,7 @@ trait ImplicitExpressionOperations {
     * @return substring
     */
   def substring(beginIndex: Expression, length: Expression): Expression =
-    call(SUBSTRING, expr, beginIndex, length)
+    unresolvedCall(SUBSTRING, expr, beginIndex, length)
 
   /**
     * Creates a substring of the given string beginning at the given index to the end.
@@ -531,7 +534,7 @@ trait ImplicitExpressionOperations {
     * @return substring
     */
   def substring(beginIndex: Expression): Expression =
-    call(SUBSTRING, expr, beginIndex)
+    unresolvedCall(SUBSTRING, expr, beginIndex)
 
   /**
     * Removes leading and/or trailing characters from the given string.
@@ -546,7 +549,7 @@ trait ImplicitExpressionOperations {
       removeTrailing: Boolean = true,
       character: Expression = valueLiteral(" "))
     : Expression = {
-    call(TRIM, valueLiteral(removeLeading), valueLiteral(removeTrailing), character, expr)
+    unresolvedCall(TRIM, valueLiteral(removeLeading), valueLiteral(removeTrailing), character, expr)
   }
 
   /**
@@ -554,44 +557,44 @@ trait ImplicitExpressionOperations {
     * with the replacement string (non-overlapping).
     */
   def replace(search: Expression, replacement: Expression): Expression =
-    call(REPLACE, expr, search, replacement)
+    unresolvedCall(REPLACE, expr, search, replacement)
 
   /**
     * Returns the length of a string.
     */
-  def charLength(): Expression = call(CHAR_LENGTH, expr)
+  def charLength(): Expression = unresolvedCall(CHAR_LENGTH, expr)
 
   /**
     * Returns all of the characters in a string in upper case using the rules of
     * the default locale.
     */
-  def upperCase(): Expression = call(UPPER, expr)
+  def upperCase(): Expression = unresolvedCall(UPPER, expr)
 
   /**
     * Returns all of the characters in a string in lower case using the rules of
     * the default locale.
     */
-  def lowerCase(): Expression = call(LOWER, expr)
+  def lowerCase(): Expression = unresolvedCall(LOWER, expr)
 
   /**
     * Converts the initial letter of each word in a string to uppercase.
     * Assumes a string containing only [A-Za-z0-9], everything else is treated as whitespace.
     */
-  def initCap(): Expression = call(INIT_CAP, expr)
+  def initCap(): Expression = unresolvedCall(INIT_CAP, expr)
 
   /**
     * Returns true, if a string matches the specified LIKE pattern.
     *
     * e.g. "Jo_n%" matches all strings that start with "Jo(arbitrary letter)n"
     */
-  def like(pattern: Expression): Expression = call(LIKE, expr, pattern)
+  def like(pattern: Expression): Expression = unresolvedCall(LIKE, expr, pattern)
 
   /**
     * Returns true, if a string matches the specified SQL regex pattern.
     *
     * e.g. "A+" matches all strings that consist of at least one A
     */
-  def similar(pattern: Expression): Expression = call(SIMILAR, expr, pattern)
+  def similar(pattern: Expression): Expression = unresolvedCall(SIMILAR, expr, pattern)
 
   /**
     * Returns the position of string in an other string starting at 1.
@@ -599,7 +602,7 @@ trait ImplicitExpressionOperations {
     *
     * e.g. "a".position("bbbbba") leads to 6
     */
-  def position(haystack: Expression): Expression = call(POSITION, expr, haystack)
+  def position(haystack: Expression): Expression = unresolvedCall(POSITION, expr, haystack)
 
   /**
     * Returns a string left-padded with the given pad string to a length of len characters. If
@@ -607,7 +610,7 @@ trait ImplicitExpressionOperations {
     *
     * e.g. "hi".lpad(4, '??') returns "??hi",  "hi".lpad(1, '??') returns "h"
     */
-  def lpad(len: Expression, pad: Expression): Expression = call(LPAD, expr, len, pad)
+  def lpad(len: Expression, pad: Expression): Expression = unresolvedCall(LPAD, expr, len, pad)
 
   /**
     * Returns a string right-padded with the given pad string to a length of len characters. If
@@ -615,7 +618,7 @@ trait ImplicitExpressionOperations {
     *
     * e.g. "hi".rpad(4, '??') returns "hi??",  "hi".rpad(1, '??') returns "h"
     */
-  def rpad(len: Expression, pad: Expression): Expression = call(RPAD, expr, len, pad)
+  def rpad(len: Expression, pad: Expression): Expression = unresolvedCall(RPAD, expr, len, pad)
 
   /**
     * Defines an aggregation to be used for a previously specified over window.
@@ -628,7 +631,7 @@ trait ImplicitExpressionOperations {
     *   .select('c, 'a, 'a.count over 'w, 'a.sum over 'w)
     * }}}
     */
-  def over(alias: Expression): Expression = call(OVER, expr, alias)
+  def over(alias: Expression): Expression = unresolvedCall(OVER, expr, alias)
 
   /**
     * Replaces a substring of string with a string starting at a position (starting at 1).
@@ -636,7 +639,7 @@ trait ImplicitExpressionOperations {
     * e.g. "xxxxxtest".overlay("xxxx", 6) leads to "xxxxxxxxx"
     */
   def overlay(newString: Expression, starting: Expression): Expression =
-    call(OVERLAY, expr, newString, starting)
+    unresolvedCall(OVERLAY, expr, newString, starting)
 
   /**
     * Replaces a substring of string with a string starting at a position (starting at 1).
@@ -645,52 +648,52 @@ trait ImplicitExpressionOperations {
     * e.g. "xxxxxtest".overlay("xxxx", 6, 2) leads to "xxxxxxxxxst"
     */
   def overlay(newString: Expression, starting: Expression, length: Expression): Expression =
-    call(OVERLAY, expr, newString, starting, length)
+    unresolvedCall(OVERLAY, expr, newString, starting, length)
 
   /**
     * Returns a string with all substrings that match the regular expression consecutively
     * being replaced.
     */
   def regexpReplace(regex: Expression, replacement: Expression): Expression =
-    call(REGEXP_REPLACE, expr, regex, replacement)
+    unresolvedCall(REGEXP_REPLACE, expr, regex, replacement)
 
   /**
     * Returns a string extracted with a specified regular expression and a regex match group
     * index.
     */
   def regexpExtract(regex: Expression, extractIndex: Expression): Expression =
-    call(REGEXP_EXTRACT, expr, regex, extractIndex)
+    unresolvedCall(REGEXP_EXTRACT, expr, regex, extractIndex)
 
   /**
     * Returns a string extracted with a specified regular expression.
     */
   def regexpExtract(regex: Expression): Expression =
-    call(REGEXP_EXTRACT, expr, regex)
+    unresolvedCall(REGEXP_EXTRACT, expr, regex)
 
   /**
     * Returns the base string decoded with base64.
     */
-  def fromBase64(): Expression = call(FROM_BASE64, expr)
+  def fromBase64(): Expression = unresolvedCall(FROM_BASE64, expr)
 
   /**
     * Returns the base64-encoded result of the input string.
     */
-  def toBase64(): Expression = call(TO_BASE64, expr)
+  def toBase64(): Expression = unresolvedCall(TO_BASE64, expr)
 
   /**
     * Returns a string that removes the left whitespaces from the given string.
     */
-  def ltrim(): Expression = call(LTRIM, expr)
+  def ltrim(): Expression = unresolvedCall(LTRIM, expr)
 
   /**
     * Returns a string that removes the right whitespaces from the given string.
     */
-  def rtrim(): Expression = call(RTRIM, expr)
+  def rtrim(): Expression = unresolvedCall(RTRIM, expr)
 
   /**
     * Returns a string that repeats the base string n times.
     */
-  def repeat(n: Expression): Expression = call(REPEAT, expr, n)
+  def repeat(n: Expression): Expression = unresolvedCall(REPEAT, expr, n)
 
   // Temporal operations
 
@@ -698,19 +701,19 @@ trait ImplicitExpressionOperations {
     * Parses a date string in the form "yyyy-MM-dd" to a SQL Date.
     */
   def toDate: Expression =
-    call(CAST, expr, typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.DATE)))
+    unresolvedCall(CAST, expr, typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.DATE)))
 
   /**
     * Parses a time string in the form "HH:mm:ss" to a SQL Time.
     */
   def toTime: Expression =
-    call(CAST, expr, typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.TIME)))
+    unresolvedCall(CAST, expr, typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.TIME)))
 
   /**
     * Parses a timestamp string in the form "yyyy-MM-dd HH:mm:ss[.SSS]" to a SQL Timestamp.
     */
   def toTimestamp: Expression =
-    call(CAST, expr, typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.TIMESTAMP)))
+    unresolvedCall(CAST, expr, typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.TIMESTAMP)))
 
   /**
     * Extracts parts of a time point or time interval. Returns the part as a long value.
@@ -718,7 +721,7 @@ trait ImplicitExpressionOperations {
     * e.g. "2006-06-05".toDate.extract(DAY) leads to 5
     */
   def extract(timeIntervalUnit: TimeIntervalUnit): Expression =
-    call(EXTRACT, valueLiteral(timeIntervalUnit), expr)
+    unresolvedCall(EXTRACT, valueLiteral(timeIntervalUnit), expr)
 
   /**
     * Rounds down a time point to the given unit.
@@ -726,7 +729,7 @@ trait ImplicitExpressionOperations {
     * e.g. "12:44:31".toDate.floor(MINUTE) leads to 12:44:00
     */
   def floor(timeIntervalUnit: TimeIntervalUnit): Expression =
-    call(FLOOR, valueLiteral(timeIntervalUnit), expr)
+    unresolvedCall(FLOOR, valueLiteral(timeIntervalUnit), expr)
 
   /**
     * Rounds up a time point to the given unit.
@@ -734,7 +737,7 @@ trait ImplicitExpressionOperations {
     * e.g. "12:44:31".toDate.ceil(MINUTE) leads to 12:45:00
     */
   def ceil(timeIntervalUnit: TimeIntervalUnit): Expression =
-    call(CEIL, valueLiteral(timeIntervalUnit), expr)
+    unresolvedCall(CEIL, valueLiteral(timeIntervalUnit), expr)
 
   // Interval types
 
@@ -882,7 +885,7 @@ trait ImplicitExpressionOperations {
     * @param name name of the field (similar to Flink's field expressions)
     * @return value of the field
     */
-  def get(name: String): Expression = call(GET, expr, name)
+  def get(name: String): Expression = unresolvedCall(GET, expr, name)
 
   /**
     * Accesses the field of a Flink composite type (such as Tuple, POJO, etc.) by index and
@@ -891,13 +894,13 @@ trait ImplicitExpressionOperations {
     * @param index position of the field
     * @return value of the field
     */
-  def get(index: Int): Expression = call(GET, expr, index)
+  def get(index: Int): Expression = unresolvedCall(GET, expr, index)
 
   /**
     * Converts a Flink composite type (such as Tuple, POJO, etc.) and all of its direct subtypes
     * into a flat representation where every subtype is a separate field.
     */
-  def flatten(): Expression = call(FLATTEN, expr)
+  def flatten(): Expression = unresolvedCall(FLATTEN, expr)
 
   /**
     * Accesses the element of an array or map based on a key or an index (starting at 1).
@@ -905,14 +908,14 @@ trait ImplicitExpressionOperations {
     * @param index key or position of the element (array index starting at 1)
     * @return value of the element
     */
-  def at(index: Expression): Expression = call(AT, expr, index)
+  def at(index: Expression): Expression = unresolvedCall(AT, expr, index)
 
   /**
     * Returns the number of elements of an array or number of entries of a map.
     *
     * @return number of elements or entries
     */
-  def cardinality(): Expression = call(CARDINALITY, expr)
+  def cardinality(): Expression = unresolvedCall(CARDINALITY, expr)
 
   /**
     * Returns the sole element of an array with a single element. Returns null if the array is
@@ -920,7 +923,7 @@ trait ImplicitExpressionOperations {
     *
     * @return the first and only element of an array with a single element
     */
-  def element(): Expression = call(ARRAY_ELEMENT, expr)
+  def element(): Expression = unresolvedCall(ARRAY_ELEMENT, expr)
 
   // Time definition
 
@@ -928,13 +931,13 @@ trait ImplicitExpressionOperations {
     * Declares a field as the rowtime attribute for indicating, accessing, and working in
     * Flink's event time.
     */
-  def rowtime: Expression = call(ROWTIME, expr)
+  def rowtime: Expression = unresolvedCall(ROWTIME, expr)
 
   /**
     * Declares a field as the proctime attribute for indicating, accessing, and working in
     * Flink's processing time.
     */
-  def proctime: Expression = call(PROCTIME, expr)
+  def proctime: Expression = unresolvedCall(PROCTIME, expr)
 
   // Hash functions
 
@@ -943,42 +946,42 @@ trait ImplicitExpressionOperations {
     *
     * @return string of 32 hexadecimal digits or null
     */
-  def md5(): Expression = call(MD5, expr)
+  def md5(): Expression = unresolvedCall(MD5, expr)
 
   /**
     * Returns the SHA-1 hash of the string argument; null if string is null.
     *
     * @return string of 40 hexadecimal digits or null
     */
-  def sha1(): Expression = call(SHA1, expr)
+  def sha1(): Expression = unresolvedCall(SHA1, expr)
 
   /**
     * Returns the SHA-224 hash of the string argument; null if string is null.
     *
     * @return string of 56 hexadecimal digits or null
     */
-  def sha224(): Expression = call(SHA224, expr)
+  def sha224(): Expression = unresolvedCall(SHA224, expr)
 
   /**
     * Returns the SHA-256 hash of the string argument; null if string is null.
     *
     * @return string of 64 hexadecimal digits or null
     */
-  def sha256(): Expression = call(SHA256, expr)
+  def sha256(): Expression = unresolvedCall(SHA256, expr)
 
   /**
     * Returns the SHA-384 hash of the string argument; null if string is null.
     *
     * @return string of 96 hexadecimal digits or null
     */
-  def sha384(): Expression = call(SHA384, expr)
+  def sha384(): Expression = unresolvedCall(SHA384, expr)
 
   /**
     * Returns the SHA-512 hash of the string argument; null if string is null.
     *
     * @return string of 128 hexadecimal digits or null
     */
-  def sha512(): Expression = call(SHA512, expr)
+  def sha512(): Expression = unresolvedCall(SHA512, expr)
 
   /**
     * Returns the hash for the given string expression using the SHA-2 family of hash
@@ -987,7 +990,7 @@ trait ImplicitExpressionOperations {
     * @param hashLength bit length of the result (either 224, 256, 384, or 512)
     * @return string or null if one of the arguments is null.
     */
-  def sha2(hashLength: Expression): Expression = call(SHA2, expr, hashLength)
+  def sha2(hashLength: Expression): Expression = unresolvedCall(SHA2, expr, hashLength)
 }
 
 /**
@@ -1000,27 +1003,28 @@ trait ImplicitExpressionConversions {
     * Offset constant to be used in the `preceding` clause of unbounded [[Over]] windows. Use this
     * constant for a time interval. Unbounded over windows start with the first row of a partition.
     */
-  implicit val UNBOUNDED_ROW: Expression = call(BuiltInFunctionDefinitions.UNBOUNDED_ROW)
+  implicit val UNBOUNDED_ROW: Expression = unresolvedCall(BuiltInFunctionDefinitions.UNBOUNDED_ROW)
 
   /**
     * Offset constant to be used in the `preceding` clause of unbounded [[Over]] windows. Use this
     * constant for a row-count interval. Unbounded over windows start with the first row of a
     * partition.
     */
-  implicit val UNBOUNDED_RANGE: Expression = call(BuiltInFunctionDefinitions.UNBOUNDED_RANGE)
+  implicit val UNBOUNDED_RANGE: Expression =
+    unresolvedCall(BuiltInFunctionDefinitions.UNBOUNDED_RANGE)
 
   /**
     * Offset constant to be used in the `following` clause of [[Over]] windows. Use this for setting
     * the upper bound of the window to the current row.
     */
-  implicit val CURRENT_ROW: Expression = call(BuiltInFunctionDefinitions.CURRENT_ROW)
+  implicit val CURRENT_ROW: Expression = unresolvedCall(BuiltInFunctionDefinitions.CURRENT_ROW)
 
   /**
     * Offset constant to be used in the `following` clause of [[Over]] windows. Use this for setting
     * the upper bound of the window to the sort key of the current row, i.e., all rows with the same
     * sort key as the current row are included in the window.
     */
-  implicit val CURRENT_RANGE: Expression = call(BuiltInFunctionDefinitions.CURRENT_RANGE)
+  implicit val CURRENT_RANGE: Expression = unresolvedCall(BuiltInFunctionDefinitions.CURRENT_RANGE)
 
   implicit class WithOperations(e: Expression) extends ImplicitExpressionOperations {
     def expr: Expression = e
@@ -1093,7 +1097,7 @@ trait ImplicitExpressionConversions {
       * Calls a scalar function for the given parameters.
       */
     def apply(params: Expression*): Expression = {
-      call(new ScalarFunctionDefinition(s.getClass.getName, s), params:_*)
+      unresolvedCall(new ScalarFunctionDefinition(s.getClass.getName, s), params:_*)
     }
   }
 
@@ -1105,7 +1109,7 @@ trait ImplicitExpressionConversions {
     def apply(params: Expression*): Expression = {
       val resultTypeInfo: TypeInformation[T] = UserFunctionsTypeHelper
         .getReturnTypeOfTableFunction(t, implicitly[TypeInformation[T]])
-      call(new TableFunctionDefinition(t.getClass.getName, t, resultTypeInfo), params: _*)
+      unresolvedCall(new TableFunctionDefinition(t.getClass.getName, t, resultTypeInfo), params: _*)
     }
   }
 
@@ -1133,14 +1137,14 @@ trait ImplicitExpressionConversions {
       * Calls an aggregate function for the given parameters.
       */
     def apply(params: Expression*): Expression = {
-      call(createFunctionDefinition(), params: _*)
+      unresolvedCall(createFunctionDefinition(), params: _*)
     }
 
     /**
       * Calculates the aggregate results only for distinct values.
       */
     def distinct(params: Expression*): Expression = {
-      call(DISTINCT, apply(params: _*))
+      unresolvedCall(DISTINCT, apply(params: _*))
     }
   }
 
@@ -1194,7 +1198,7 @@ trait ImplicitExpressionConversions {
   implicit def array2ArrayConstructor(array: Array[_]): Expression = {
 
     def createArray(elements: Array[_]): Expression = {
-      call(BuiltInFunctionDefinitions.ARRAY, elements.map(valueLiteral): _*)
+      unresolvedCall(BuiltInFunctionDefinitions.ARRAY, elements.map(valueLiteral): _*)
     }
 
     def convertArray(array: Array[_]): Expression = array match {
@@ -1230,7 +1234,7 @@ trait ImplicitExpressionConversions {
       case _ =>
         // nested
         if (array.length > 0 && array.head.isInstanceOf[Array[_]]) {
-          call(
+          unresolvedCall(
             BuiltInFunctionDefinitions.ARRAY,
             array.map { na => convertArray(na.asInstanceOf[Array[_]]) } :_*)
         } else {
@@ -1259,7 +1263,7 @@ object currentDate {
     * Returns the current SQL date in UTC time zone.
     */
   def apply(): Expression = {
-    call(CURRENT_DATE)
+    unresolvedCall(CURRENT_DATE)
   }
 }
 
@@ -1272,7 +1276,7 @@ object currentTime {
     * Returns the current SQL time in UTC time zone.
     */
   def apply(): Expression = {
-    call(CURRENT_TIME)
+    unresolvedCall(CURRENT_TIME)
   }
 }
 
@@ -1285,7 +1289,7 @@ object currentTimestamp {
     * Returns the current SQL timestamp in UTC time zone.
     */
   def apply(): Expression = {
-    call(CURRENT_TIMESTAMP)
+    unresolvedCall(CURRENT_TIMESTAMP)
   }
 }
 
@@ -1298,7 +1302,7 @@ object localTime {
     * Returns the current SQL time in local time zone.
     */
   def apply(): Expression = {
-    call(LOCAL_TIME)
+    unresolvedCall(LOCAL_TIME)
   }
 }
 
@@ -1311,7 +1315,7 @@ object localTimestamp {
     * Returns the current SQL timestamp in local time zone.
     */
   def apply(): Expression = {
-    call(LOCAL_TIMESTAMP)
+    unresolvedCall(LOCAL_TIMESTAMP)
   }
 }
 
@@ -1340,7 +1344,7 @@ object temporalOverlaps {
       rightTimePoint: Expression,
       rightTemporal: Expression)
     : Expression = {
-    call(TEMPORAL_OVERLAPS, leftTimePoint, leftTemporal, rightTimePoint, rightTemporal)
+    unresolvedCall(TEMPORAL_OVERLAPS, leftTimePoint, leftTemporal, rightTimePoint, rightTemporal)
   }
 }
 
@@ -1369,7 +1373,7 @@ object dateFormat {
       timestamp: Expression,
       format: Expression)
     : Expression = {
-    call(DATE_FORMAT, timestamp, format)
+    unresolvedCall(DATE_FORMAT, timestamp, format)
   }
 }
 
@@ -1397,7 +1401,7 @@ object timestampDiff {
       timePoint1: Expression,
       timePoint2: Expression)
     : Expression = {
-    call(TIMESTAMP_DIFF, timePointUnit, timePoint1, timePoint2)
+    unresolvedCall(TIMESTAMP_DIFF, timePointUnit, timePoint1, timePoint2)
   }
 }
 
@@ -1410,7 +1414,7 @@ object array {
     * Creates an array of literals. The array will be an array of objects (not primitives).
     */
   def apply(head: Expression, tail: Expression*): Expression = {
-    call(ARRAY, head +: tail: _*)
+    unresolvedCall(ARRAY, head +: tail: _*)
   }
 }
 
@@ -1423,7 +1427,7 @@ object row {
     * Creates a row of expressions.
     */
   def apply(head: Expression, tail: Expression*): Expression = {
-    call(ROW, head +: tail: _*)
+    unresolvedCall(ROW, head +: tail: _*)
   }
 }
 
@@ -1436,7 +1440,7 @@ object map {
     * Creates a map of expressions. The map will be a map between two objects (not primitives).
     */
   def apply(key: Expression, value: Expression, tail: Expression*): Expression = {
-    call(MAP, key +: value +: tail: _*)
+    unresolvedCall(MAP, key +: value +: tail: _*)
   }
 }
 
@@ -1449,7 +1453,7 @@ object pi {
     * Returns a value that is closer than any other value to pi.
     */
   def apply(): Expression = {
-    call(PI)
+    unresolvedCall(PI)
   }
 }
 
@@ -1462,7 +1466,7 @@ object e {
     * Returns a value that is closer than any other value to e.
     */
   def apply(): Expression = {
-    call(FDE)
+    unresolvedCall(FDE)
   }
 }
 
@@ -1475,7 +1479,7 @@ object rand {
     * Returns a pseudorandom double value between 0.0 (inclusive) and 1.0 (exclusive).
     */
   def apply(): Expression = {
-    call(RAND)
+    unresolvedCall(RAND)
   }
 
   /**
@@ -1484,7 +1488,7 @@ object rand {
     * have same initial seed.
     */
   def apply(seed: Expression): Expression = {
-    call(RAND, seed)
+    unresolvedCall(RAND, seed)
   }
 }
 
@@ -1499,7 +1503,7 @@ object randInteger {
     * value (exclusive).
     */
   def apply(bound: Expression): Expression = {
-    call(RAND_INTEGER, bound)
+    unresolvedCall(RAND_INTEGER, bound)
   }
 
   /**
@@ -1508,7 +1512,7 @@ object randInteger {
     * of numbers if they have same initial seed and same bound.
     */
   def apply(seed: Expression, bound: Expression): Expression = {
-    call(RAND_INTEGER, seed, bound)
+    unresolvedCall(RAND_INTEGER, seed, bound)
   }
 }
 
@@ -1523,7 +1527,7 @@ object concat {
     * Returns NULL if any argument is NULL.
     */
   def apply(string: Expression, strings: Expression*): Expression = {
-    call(CONCAT, string +: strings: _*)
+    unresolvedCall(CONCAT, string +: strings: _*)
   }
 }
 
@@ -1536,7 +1540,7 @@ object atan2 {
     * Calculates the arc tangent of a given coordinate.
     */
   def apply(y: Expression, x: Expression): Expression = {
-    call(ATAN2, y, x)
+    unresolvedCall(ATAN2, y, x)
   }
 }
 
@@ -1549,7 +1553,7 @@ object atan2 {
   **/
 object concat_ws {
   def apply(separator: Expression, string: Expression, strings: Expression*): Expression = {
-    call(CONCAT_WS, separator +: string +: strings: _*)
+    unresolvedCall(CONCAT_WS, separator +: string +: strings: _*)
   }
 }
 
@@ -1568,7 +1572,7 @@ object uuid {
     * generator.
     */
   def apply(): Expression = {
-    call(FDUUID)
+    unresolvedCall(FDUUID)
   }
 }
 
@@ -1609,14 +1613,14 @@ object log {
     * Calculates the natural logarithm of the given value.
     */
   def apply(value: Expression): Expression = {
-    call(LOG, value)
+    unresolvedCall(LOG, value)
   }
 
   /**
     * Calculates the logarithm of the given value to the given base.
     */
   def apply(base: Expression, value: Expression): Expression = {
-    call(LOG, base, value)
+    unresolvedCall(LOG, base, value)
   }
 }
 
@@ -1639,7 +1643,7 @@ object ifThenElse {
     * @param ifFalse expression to be evaluated if condition does not hold
     */
   def apply(condition: Expression, ifTrue: Expression, ifFalse: Expression): Expression = {
-    call(IF, condition, ifTrue, ifFalse)
+    unresolvedCall(IF, condition, ifTrue, ifFalse)
   }
 }
 
@@ -1649,7 +1653,7 @@ object ifThenElse {
 object withColumns {
 
   def apply(head: Expression, tail: Expression*): Expression = {
-    call(WITH_COLUMNS, head +: tail: _*)
+    unresolvedCall(WITH_COLUMNS, head +: tail: _*)
   }
 }
 
@@ -1659,7 +1663,7 @@ object withColumns {
 object withoutColumns {
 
   def apply(head: Expression, tail: Expression*): Expression = {
-    call(WITHOUT_COLUMNS, head +: tail: _*)
+    unresolvedCall(WITHOUT_COLUMNS, head +: tail: _*)
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpression.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpression.scala
@@ -75,9 +75,11 @@ abstract class PlannerExpression extends TreeNode[PlannerExpression] with Expres
     }
   }
 
-  override def accept[R](visitor: ExpressionVisitor[R]): R = visitor.visit(this)
+  override def asSummaryString(): String = toString
 
   override def getChildren: util.List[Expression] = children
+
+  override def accept[R](visitor: ExpressionVisitor[R]): R = visitor.visit(this)
 }
 
 abstract class BinaryExpression extends PlannerExpression {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -34,7 +34,7 @@ import _root_.scala.collection.JavaConverters._
   */
 class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExpression] {
 
-  override def visitCall(call: CallExpression): PlannerExpression = {
+  override def visit(call: CallExpression): PlannerExpression = {
     val func = call.getFunctionDefinition
     val children = call.getChildren.asScala
 
@@ -680,7 +680,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
     }
   }
 
-  override def visitValueLiteral(literal: ValueLiteralExpression): PlannerExpression = {
+  override def visit(literal: ValueLiteralExpression): PlannerExpression = {
     if (hasRoot(literal.getOutputDataType.getLogicalType, SYMBOL)) {
       val plannerSymbol = getSymbol(literal.getValueAs(classOf[TableSymbol]).get())
       return SymbolPlannerExpression(plannerSymbol)
@@ -762,33 +762,33 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
       throw new TableException("Unsupported symbol: " + symbol)
   }
 
-  override def visitFieldReference(fieldReference: FieldReferenceExpression): PlannerExpression = {
+  override def visit(fieldReference: FieldReferenceExpression): PlannerExpression = {
     PlannerResolvedFieldReference(
       fieldReference.getName,
       fromDataTypeToLegacyInfo(fieldReference.getOutputDataType))
   }
 
-  override def visitUnresolvedReference(fieldReference: UnresolvedReferenceExpression)
+  override def visit(fieldReference: UnresolvedReferenceExpression)
     : PlannerExpression = {
     UnresolvedFieldReference(fieldReference.getName)
   }
 
-  override def visitTypeLiteral(typeLiteral: TypeLiteralExpression): PlannerExpression = {
+  override def visit(typeLiteral: TypeLiteralExpression): PlannerExpression = {
     throw new TableException("Unsupported type literal expression: " + typeLiteral)
   }
 
-  override def visitTableReference(tableRef: TableReferenceExpression): PlannerExpression = {
+  override def visit(tableRef: TableReferenceExpression): PlannerExpression = {
     TableReference(
       tableRef.asInstanceOf[TableReferenceExpression].getName,
       tableRef.asInstanceOf[TableReferenceExpression].getQueryOperation
     )
   }
 
-  override def visitLocalReference(localReference: LocalReferenceExpression): PlannerExpression =
+  override def visit(localReference: LocalReferenceExpression): PlannerExpression =
     throw new TableException(
       "Local reference should be handled individually by a call: " + localReference)
 
-  override def visitLookupCall(lookupCall: LookupCallExpression): PlannerExpression =
+  override def visit(lookupCall: LookupCallExpression): PlannerExpression =
     throw new TableException("Unsupported function call: " + lookupCall)
 
   override def visitNonApiExpression(other: Expression): PlannerExpression = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -34,9 +34,9 @@ import _root_.scala.collection.JavaConverters._
   */
 class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExpression] {
 
-  override def visit(call: CallExpression): PlannerExpression = {
-    val func = call.getFunctionDefinition
-    val children = call.getChildren.asScala
+  override def visit(unresolvedCall: UnresolvedCallExpression): PlannerExpression = {
+    val func = unresolvedCall.getFunctionDefinition
+    val children = unresolvedCall.getChildren.asScala
 
     // special case: requires individual handling of child expressions
     func match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/composite.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/composite.scala
@@ -34,7 +34,7 @@ case class Flattening(child: PlannerExpression) extends UnaryExpression {
   override def toString = s"$child.flatten()"
 
   override private[flink] def resultType: TypeInformation[_] =
-    throw UnresolvedException(s"Invalid call to on ${this.getClass}.")
+    throw UnresolvedException(s"Invalcall to on ${this.getClass}.")
 
   override private[flink] def validateInput(): ValidationResult =
     ValidationFailure(s"Unresolved flattening of $child")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
@@ -570,7 +570,7 @@ class OperationTreeBuilder(private val tableEnv: TableEnvImpl) {
 
   class NoWindowPropertyChecker(val exceptionMessage: String)
     extends ApiExpressionDefaultVisitor[Void] {
-    override def visitCall(call: CallExpression): Void = {
+    override def visit(call: CallExpression): Void = {
       val functionDefinition = call.getFunctionDefinition
       if (BuiltInFunctionDefinitions.WINDOW_PROPERTIES
         .contains(functionDefinition)) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/util/RexProgramExtractor.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/util/RexProgramExtractor.scala
@@ -29,7 +29,7 @@ import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo}
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.catalog.FunctionCatalog
-import org.apache.flink.table.expressions.ApiExpressionUtils.call
+import org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.util.JavaScalaConversionUtil
 import org.apache.flink.util.Preconditions
@@ -281,7 +281,8 @@ class RexNodeToExpressionConverter(
       PlannerExpressionConverter.INSTANCE)
     JavaScalaConversionUtil.toScala(functionCatalog.lookupFunction(name))
       .flatMap(result =>
-        Try(expressionBridge.bridge(call(result.getFunctionDefinition, operands: _*))).toOption
+        Try(expressionBridge.bridge(
+          unresolvedCall(result.getFunctionDefinition, operands: _*))).toOption
       )
   }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRuleTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
-import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.expressions.rules.ResolverRule.ResolutionContext;
 
 import org.junit.Test;
@@ -79,7 +78,7 @@ public class VerifyNoUnresolvedExpressionsRuleTest {
 		List<Expression> expressions = singletonList(
 			call(OVER,
 				call(COUNT, new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0)),
-				new UnresolvedReferenceExpression("w")
+				unresolvedRef("w")
 			)
 		);
 		resolverRule.apply(expressions, resolutionContext);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRuleTest.java
@@ -30,8 +30,8 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.apache.flink.table.expressions.ApiExpressionUtils.call;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.lookupCall;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AS;
@@ -60,7 +60,7 @@ public class VerifyNoUnresolvedExpressionsRuleTest {
 	@Test(expected = TableException.class)
 	public void testNestedUnresolvedReferenceIsCatched() {
 		List<Expression> expressions = asList(
-			call(AS, unresolvedRef("field"), valueLiteral("fieldAlias")),
+			unresolvedCall(AS, unresolvedRef("field"), valueLiteral("fieldAlias")),
 			new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0));
 		resolverRule.apply(expressions, resolutionContext);
 	}
@@ -68,7 +68,7 @@ public class VerifyNoUnresolvedExpressionsRuleTest {
 	@Test(expected = TableException.class)
 	public void testFlattenCallIsCatched() {
 		List<Expression> expressions = singletonList(
-			call(FLATTEN, new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0))
+			unresolvedCall(FLATTEN, new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0))
 		);
 		resolverRule.apply(expressions, resolutionContext);
 	}
@@ -76,8 +76,8 @@ public class VerifyNoUnresolvedExpressionsRuleTest {
 	@Test(expected = TableException.class)
 	public void testUnresolvedOverWindowIsCatched() {
 		List<Expression> expressions = singletonList(
-			call(OVER,
-				call(COUNT, new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0)),
+			unresolvedCall(OVER,
+				unresolvedCall(COUNT, new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0)),
 				unresolvedRef("w")
 			)
 		);

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/ColumnFunctionsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/ColumnFunctionsValidationTest.scala
@@ -58,10 +58,10 @@ class ColumnFunctionsValidationTest extends TableTestBase {
 
   @Test
   def testInvalidParameters(): Unit = {
-    expectedException.expect(classOf[TableException])
+    expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage(
-      s"The parameters of $withCol() or $withoutCol() only accept column name or " +
-        "column index, but receive CallExpression.")
+      s"The parameters of $withCol() or $withoutCol() only accept column names or " +
+        "column indices.")
 
     val t = util.addTable[(Int, Long, String, Int, Long, String)]('a, 'b, 'c, 'd, 'e, 'f)
     val tab = t.select(withColumns(concat('f)))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/KeywordParseTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/KeywordParseTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.expressions
 
-import org.apache.flink.table.expressions.ApiExpressionUtils.{call, lookupCall, unresolvedRef}
+import org.apache.flink.table.expressions.ApiExpressionUtils.{unresolvedCall, lookupCall, unresolvedRef}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -31,10 +31,10 @@ class KeywordParseTest {
   @Test
   def testKeyword(): Unit = {
     assertEquals(
-      call(BuiltInFunctionDefinitions.ORDER_ASC, unresolvedRef("f0")),
+      unresolvedCall(BuiltInFunctionDefinitions.ORDER_ASC, unresolvedRef("f0")),
       ExpressionParser.parseExpression("f0.asc"))
     assertEquals(
-      call(BuiltInFunctionDefinitions.ORDER_ASC, unresolvedRef("f0")),
+      unresolvedCall(BuiltInFunctionDefinitions.ORDER_ASC, unresolvedRef("f0")),
       ExpressionParser.parseExpression("f0.asc()"))
   }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR is preparation work for FLINK-12710 that will introduce a new expression with resolved data type. This refactors the existing expression structure.

## Brief change log

See commit messages.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
