### PR TITLE
[BP-1.7][FLINK-12863][FLINK-12865] Remove concurrency from HeartbeatManager(Sender)Impl

### DIFF
--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -42,10 +42,8 @@ import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
@@ -319,7 +317,6 @@ public class MesosResourceManagerTest extends TestLogger {
 		 */
 		class MockResourceManagerRuntimeServices {
 
-			public final ScheduledExecutor scheduledExecutor;
 			public final TestingHighAvailabilityServices highAvailabilityServices;
 			public final HeartbeatServices heartbeatServices;
 			public final MetricRegistry metricRegistry;
@@ -332,11 +329,10 @@ public class MesosResourceManagerTest extends TestLogger {
 			public UUID rmLeaderSessionId;
 
 			MockResourceManagerRuntimeServices() throws Exception {
-				scheduledExecutor = mock(ScheduledExecutor.class);
 				highAvailabilityServices = new TestingHighAvailabilityServices();
 				rmLeaderElectionService = new TestingLeaderElectionService();
 				highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
-				heartbeatServices = new TestingHeartbeatServices(5L, 5L, scheduledExecutor);
+				heartbeatServices = new HeartbeatServices(5L, 5L);
 				metricRegistry = mock(MetricRegistryImpl.class);
 				slotManager = mock(SlotManager.class);
 				slotManagerStarted = new CompletableFuture<>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -446,6 +447,26 @@ public class FutureUtils {
 			});
 
 		return resultFuture;
+	}
+
+	/**
+	 * This function takes a {@link CompletableFuture} and a consumer to accept the result of this future. If the input
+	 * future is already done, this function returns {@link CompletableFuture#thenAccept(Consumer)}. Otherwise, the
+	 * return value is {@link CompletableFuture#thenAcceptAsync(Consumer, Executor)} with the given executor.
+	 *
+	 * @param completableFuture the completable future for which we want to call #thenAccept.
+	 * @param executor the executor to run the thenAccept function if the future is not yet done.
+	 * @param consumer the consumer function to call when the future is completed.
+	 * @param <IN> type of the input future.
+	 * @return the new completion stage.
+	 */
+	public static <IN> CompletableFuture<Void> thenAcceptAsyncIfNotDone(
+		CompletableFuture<IN> completableFuture,
+		Executor executor,
+		Consumer<? super IN> consumer) {
+		return completableFuture.isDone() ?
+			completableFuture.thenAccept(consumer) :
+			completableFuture.thenAcceptAsync(consumer, executor);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ScheduledFutureAdapter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ScheduledFutureAdapter.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import javax.annotation.Nonnull;
+
+import java.util.Objects;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * Adapter from {@link Future} to {@link ScheduledFuture}. This enriches the basic future with scheduling information.
+ * @param <V> value type of the future.
+ */
+public class ScheduledFutureAdapter<V> implements ScheduledFuture<V> {
+
+	/** The uid sequence generator. */
+	private static final AtomicLong SEQUENCE_GEN = new AtomicLong();
+
+	/** The encapsulated basic future to which execution is delegated. */
+	@Nonnull
+	private final Future<V> delegate;
+
+	/** Tie-breaker for {@link #compareTo(Delayed)}. */
+	private final long tieBreakerUid;
+
+	/** The time when this is scheduled for execution in nanoseconds.*/
+	private final long scheduleTimeNanos;
+
+	public ScheduledFutureAdapter(
+		@Nonnull Future<V> delegate,
+		long delay,
+		@Nonnull TimeUnit timeUnit) {
+		this(
+			delegate,
+			System.nanoTime() + TimeUnit.NANOSECONDS.convert(delay, timeUnit),
+			SEQUENCE_GEN.incrementAndGet());
+	}
+
+	@VisibleForTesting
+	ScheduledFutureAdapter(
+		@Nonnull Future<V> delegate,
+		long scheduleTimeNanos,
+		long tieBreakerUid) {
+
+		this.delegate = delegate;
+		this.scheduleTimeNanos = scheduleTimeNanos;
+		this.tieBreakerUid = tieBreakerUid;
+	}
+
+	@Override
+	public long getDelay(@Nonnull TimeUnit unit) {
+		return unit.convert(scheduleTimeNanos - System.nanoTime(), TimeUnit.NANOSECONDS);
+	}
+
+	@Override
+	public int compareTo(@Nonnull Delayed o) {
+
+		if (o == this) {
+			return 0;
+		}
+
+		// tie breaking for ScheduledFutureAdapter objects
+		if (o instanceof ScheduledFutureAdapter) {
+			ScheduledFutureAdapter<?> typedOther = (ScheduledFutureAdapter<?>) o;
+			int cmp = Long.compare(scheduleTimeNanos, typedOther.scheduleTimeNanos);
+			return cmp != 0 ? cmp : Long.compare(tieBreakerUid, typedOther.tieBreakerUid);
+		}
+
+		return Long.compare(getDelay(NANOSECONDS), o.getDelay(NANOSECONDS));
+	}
+
+	@Override
+	public boolean cancel(boolean mayInterruptIfRunning) {
+		return delegate.cancel(mayInterruptIfRunning);
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return delegate.isCancelled();
+	}
+
+	@Override
+	public boolean isDone() {
+		return delegate.isDone();
+	}
+
+	@Override
+	public V get() throws InterruptedException, ExecutionException {
+		return delegate.get();
+	}
+
+	@Override
+	public V get(long timeout, @Nonnull TimeUnit unit)
+		throws InterruptedException, ExecutionException, TimeoutException {
+		return delegate.get(timeout, unit);
+	}
+
+	@VisibleForTesting
+	long getTieBreakerUid() {
+		return tieBreakerUid;
+	}
+
+	@VisibleForTesting
+	long getScheduleTimeNanos() {
+		return scheduleTimeNanos;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ScheduledFutureAdapter<?> that = (ScheduledFutureAdapter<?>) o;
+		return tieBreakerUid == that.tieBreakerUid && scheduleTimeNanos == that.scheduleTimeNanos;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(tieBreakerUid, scheduleTimeNanos);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.util.Preconditions;
 
@@ -29,7 +30,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -57,15 +57,12 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 	private final HeartbeatListener<I, O> heartbeatListener;
 
 	/** Executor service used to run heartbeat timeout notifications. */
-	private final ScheduledExecutor scheduledExecutor;
+	private final ScheduledExecutor mainThreadExecutor;
 
 	protected final Logger log;
 
 	/** Map containing the heartbeat monitors associated with the respective resource ID. */
 	private final ConcurrentHashMap<ResourceID, HeartbeatManagerImpl.HeartbeatMonitor<O>> heartbeatTargets;
-
-	/** Execution context used to run future callbacks. */
-	private final Executor executor;
 
 	/** Running state of the heartbeat manager. */
 	protected volatile boolean stopped;
@@ -74,17 +71,15 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 			long heartbeatTimeoutIntervalMs,
 			ResourceID ownResourceID,
 			HeartbeatListener<I, O> heartbeatListener,
-			Executor executor,
-			ScheduledExecutor scheduledExecutor,
+			ScheduledExecutor mainThreadExecutor,
 			Logger log) {
 		Preconditions.checkArgument(heartbeatTimeoutIntervalMs > 0L, "The heartbeat timeout has to be larger than 0.");
 
 		this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
 		this.ownResourceID = Preconditions.checkNotNull(ownResourceID);
 		this.heartbeatListener = Preconditions.checkNotNull(heartbeatListener, "heartbeatListener");
-		this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor);
+		this.mainThreadExecutor = Preconditions.checkNotNull(mainThreadExecutor);
 		this.log = Preconditions.checkNotNull(log);
-		this.executor = Preconditions.checkNotNull(executor);
 		this.heartbeatTargets = new ConcurrentHashMap<>(16);
 
 		stopped = false;
@@ -96,10 +91,6 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 
 	ResourceID getOwnResourceID() {
 		return ownResourceID;
-	}
-
-	Executor getExecutor() {
-		return executor;
 	}
 
 	HeartbeatListener<I, O> getHeartbeatListener() {
@@ -123,7 +114,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 				HeartbeatManagerImpl.HeartbeatMonitor<O> heartbeatMonitor = new HeartbeatManagerImpl.HeartbeatMonitor<>(
 					resourceID,
 					heartbeatTarget,
-					scheduledExecutor,
+					mainThreadExecutor,
 					heartbeatListener,
 					heartbeatTimeoutIntervalMs);
 
@@ -174,6 +165,10 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		}
 	}
 
+	ScheduledExecutor getMainThreadExecutor() {
+		return mainThreadExecutor;
+	}
+
 	//----------------------------------------------------------------------------------------------
 	// HeartbeatTarget methods
 	//----------------------------------------------------------------------------------------------
@@ -205,9 +200,10 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 				CompletableFuture<O> futurePayload = heartbeatListener.retrievePayload(requestOrigin);
 
 				if (futurePayload != null) {
-					CompletableFuture<Void> sendHeartbeatFuture = futurePayload.thenAcceptAsync(
-						retrievedPayload ->	heartbeatTarget.receiveHeartbeat(getOwnResourceID(), retrievedPayload),
-						executor);
+					CompletableFuture<Void> sendHeartbeatFuture = FutureUtils.thenAcceptAsyncIfNotDone(
+						futurePayload,
+						mainThreadExecutor,
+						retrievedPayload ->	heartbeatTarget.receiveHeartbeat(getOwnResourceID(), retrievedPayload));
 
 					sendHeartbeatFuture.exceptionally((Throwable failure) -> {
 							log.warn("Could not send heartbeat to target with id {}.", requestOrigin, failure);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatServices.java
@@ -52,7 +52,7 @@ public class HeartbeatServices {
 	 * @param resourceId Resource Id which identifies the owner of the heartbeat manager
 	 * @param heartbeatListener Listener which will be notified upon heartbeat timeouts for registered
 	 *                          targets
-	 * @param scheduledExecutor Scheduled executor to be used for scheduling heartbeat timeouts
+	 * @param mainThreadExecutor Scheduled executor to be used for scheduling heartbeat timeouts
 	 * @param log Logger to be used for the logging
 	 * @param <I> Type of the incoming payload
 	 * @param <O> Type of the outgoing payload
@@ -61,15 +61,14 @@ public class HeartbeatServices {
 	public <I, O> HeartbeatManager<I, O> createHeartbeatManager(
 		ResourceID resourceId,
 		HeartbeatListener<I, O> heartbeatListener,
-		ScheduledExecutor scheduledExecutor,
+		ScheduledExecutor mainThreadExecutor,
 		Logger log) {
 
 		return new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			resourceId,
 			heartbeatListener,
-			scheduledExecutor,
-			scheduledExecutor,
+			mainThreadExecutor,
 			log);
 	}
 
@@ -79,7 +78,8 @@ public class HeartbeatServices {
 	 * @param resourceId Resource Id which identifies the owner of the heartbeat manager
 	 * @param heartbeatListener Listener which will be notified upon heartbeat timeouts for registered
 	 *                          targets
-	 * @param scheduledExecutor Scheduled executor to be used for scheduling heartbeat timeouts
+	 * @param mainThreadExecutor Scheduled executor to be used for scheduling heartbeat timeouts and
+	 *                           periodically send heartbeat requests
 	 * @param log Logger to be used for the logging
 	 * @param <I> Type of the incoming payload
 	 * @param <O> Type of the outgoing payload
@@ -88,7 +88,7 @@ public class HeartbeatServices {
 	public <I, O> HeartbeatManager<I, O> createHeartbeatManagerSender(
 		ResourceID resourceId,
 		HeartbeatListener<I, O> heartbeatListener,
-		ScheduledExecutor scheduledExecutor,
+		ScheduledExecutor mainThreadExecutor,
 		Logger log) {
 
 		return new HeartbeatManagerSenderImpl<>(
@@ -96,8 +96,7 @@ public class HeartbeatServices {
 			heartbeatTimeout,
 			resourceId,
 			heartbeatListener,
-			scheduledExecutor,
-			scheduledExecutor,
+			mainThreadExecutor,
 			log);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -108,7 +108,6 @@ import org.apache.flink.types.SerializableOptional;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
-import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 
@@ -166,11 +165,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private final BlobServer blobServer;
 
+	private final HeartbeatServices heartbeatServices;
+
 	private final JobManagerJobMetricGroupFactory jobMetricGroupFactory;
-
-	private final HeartbeatManager<AccumulatorReport, AllocatedSlotReport> taskManagerHeartbeatManager;
-
-	private final HeartbeatManager<Void, Void> resourceManagerHeartbeatManager;
 
 	private final ScheduledExecutorService scheduledExecutorService;
 
@@ -201,6 +198,10 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	// -------- Mutable fields ---------
 
 	private ExecutionGraph executionGraph;
+
+	private HeartbeatManager<AccumulatorReport, AllocatedSlotReport> taskManagerHeartbeatManager;
+
+	private HeartbeatManager<Void, Void> resourceManagerHeartbeatManager;
 
 	@Nullable
 	private JobManagerJobStatusListener jobStatusListener;
@@ -239,8 +240,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		super(rpcService, AkkaRpcServiceUtils.createRandomName(JOB_MANAGER_NAME));
 
-		final JobMasterGateway selfGateway = getSelfGateway(JobMasterGateway.class);
-
 		this.jobMasterConfiguration = checkNotNull(jobMasterConfiguration);
 		this.resourceId = checkNotNull(resourceId);
 		this.jobGraph = checkNotNull(jobGraph);
@@ -251,19 +250,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		this.jobCompletionActions = checkNotNull(jobCompletionActions);
 		this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
 		this.userCodeLoader = checkNotNull(userCodeLoader);
+		this.heartbeatServices = checkNotNull(heartbeatServices);
 		this.jobMetricGroupFactory = checkNotNull(jobMetricGroupFactory);
-
-		this.taskManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
-			resourceId,
-			new TaskManagerHeartbeatListener(selfGateway),
-			rpcService.getScheduledExecutor(),
-			log);
-
-		this.resourceManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
-				resourceId,
-				new ResourceManagerHeartbeatListener(),
-				rpcService.getScheduledExecutor(),
-				log);
 
 		final String jobName = jobGraph.getName();
 		final JobID jid = jobGraph.getJobID();
@@ -359,9 +347,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		for (ResourceID taskManagerResourceId : taskManagerResourceIds) {
 			disconnectTaskManager(taskManagerResourceId, cause);
 		}
-
-		taskManagerHeartbeatManager.stop();
-		resourceManagerHeartbeatManager.stop();
 
 		// make sure there is a graceful exit
 		suspendExecution(new FlinkException("JobManager is shutting down."));
@@ -1036,6 +1021,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	private void startJobMasterServices() throws Exception {
+		startHeartbeatServices();
+
 		// start the slot pool make sure the slot pool now accepts messages for this leader
 		slotPool.start(getFencingToken(), getAddress());
 
@@ -1097,7 +1084,35 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		// disconnect from resource manager:
 		closeResourceManagerConnection(cause);
 
+		stopHeartbeatServices();
+
 		return Acknowledge.get();
+	}
+
+	private void stopHeartbeatServices() {
+		if (taskManagerHeartbeatManager != null) {
+			taskManagerHeartbeatManager.stop();
+			taskManagerHeartbeatManager = null;
+		}
+
+		if (resourceManagerHeartbeatManager != null) {
+			resourceManagerHeartbeatManager.stop();
+			resourceManagerHeartbeatManager = null;
+		}
+	}
+
+	private void startHeartbeatServices() {
+		taskManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
+			resourceId,
+			new TaskManagerHeartbeatListener(),
+			getMainThreadExecutor(),
+			log);
+
+		resourceManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
+			resourceId,
+			new ResourceManagerHeartbeatListener(),
+			getMainThreadExecutor(),
+			log);
 	}
 
 	private void assignExecutionGraph(
@@ -1620,21 +1635,17 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private class TaskManagerHeartbeatListener implements HeartbeatListener<AccumulatorReport, AllocatedSlotReport> {
 
-		private final JobMasterGateway jobMasterGateway;
-
-		private TaskManagerHeartbeatListener(JobMasterGateway jobMasterGateway) {
-			this.jobMasterGateway = Preconditions.checkNotNull(jobMasterGateway);
-		}
-
 		@Override
 		public void notifyHeartbeatTimeout(ResourceID resourceID) {
-			jobMasterGateway.disconnectTaskManager(
+			validateRunsInMainThread();
+			disconnectTaskManager(
 				resourceID,
 				new TimeoutException("Heartbeat of TaskManager with id " + resourceID + " timed out."));
 		}
 
 		@Override
 		public void reportPayload(ResourceID resourceID, AccumulatorReport payload) {
+			validateRunsInMainThread();
 			for (AccumulatorSnapshot snapshot : payload.getAccumulatorSnapshots()) {
 				executionGraph.updateAccumulators(snapshot);
 			}
@@ -1642,6 +1653,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		@Override
 		public CompletableFuture<AllocatedSlotReport> retrievePayload(ResourceID resourceID) {
+			validateRunsInMainThread();
 			return slotPoolGateway.createAllocatedSlotReport(resourceID);
 		}
 	}
@@ -1650,15 +1662,14 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceId) {
-			runAsync(() -> {
-				log.info("The heartbeat of ResourceManager with id {} timed out.", resourceId);
+			validateRunsInMainThread();
+			log.info("The heartbeat of ResourceManager with id {} timed out.", resourceId);
 
-				if (establishedResourceManagerConnection != null && establishedResourceManagerConnection.getResourceManagerResourceID().equals(resourceId)) {
-					reconnectToResourceManager(
-						new JobMasterException(
-							String.format("The heartbeat of ResourceManager with id %s timed out.", resourceId)));
-				}
-			});
+			if (establishedResourceManagerConnection != null && establishedResourceManagerConnection.getResourceManagerResourceID().equals(resourceId)) {
+				reconnectToResourceManager(
+					new JobMasterException(
+						String.format("The heartbeat of ResourceManager with id %s timed out.", resourceId)));
+			}
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -123,11 +123,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	/** High availability services for leader retrieval and election. */
 	private final HighAvailabilityServices highAvailabilityServices;
 
-	/** The heartbeat manager with task managers. */
-	private final HeartbeatManager<SlotReport, Void> taskManagerHeartbeatManager;
-
-	/** The heartbeat manager with job managers. */
-	private final HeartbeatManager<Void, Void> jobManagerHeartbeatManager;
+	private final HeartbeatServices heartbeatServices;
 
 	/** Registry to use for metrics. */
 	private final MetricRegistry metricRegistry;
@@ -147,6 +143,12 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 	/** All registered listeners for status updates of the ResourceManager. */
 	private ConcurrentMap<String, InfoMessageListenerRpcGateway> infoMessageListeners;
+
+	/** The heartbeat manager with task managers. */
+	private HeartbeatManager<SlotReport, Void> taskManagerHeartbeatManager;
+
+	/** The heartbeat manager with job managers. */
+	private HeartbeatManager<Void, Void> jobManagerHeartbeatManager;
 
 	/**
 	 * Represents asynchronous state clearing work.
@@ -173,24 +175,13 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		this.resourceId = checkNotNull(resourceId);
 		this.highAvailabilityServices = checkNotNull(highAvailabilityServices);
+		this.heartbeatServices = checkNotNull(heartbeatServices);
 		this.slotManager = checkNotNull(slotManager);
 		this.metricRegistry = checkNotNull(metricRegistry);
 		this.jobLeaderIdService = checkNotNull(jobLeaderIdService);
 		this.clusterInformation = checkNotNull(clusterInformation);
 		this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
 		this.jobManagerMetricGroup = checkNotNull(jobManagerMetricGroup);
-
-		this.taskManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
-			resourceId,
-			new TaskManagerHeartbeatListener(),
-			rpcService.getScheduledExecutor(),
-			log);
-
-		this.jobManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
-			resourceId,
-			new JobManagerHeartbeatListener(),
-			rpcService.getScheduledExecutor(),
-			log);
 
 		this.jobManagerRegistrations = new HashMap<>(4);
 		this.jmResourceIdRegistrations = new HashMap<>(4);
@@ -231,9 +222,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	public CompletableFuture<Void> postStop() {
 		Exception exception = null;
 
-		taskManagerHeartbeatManager.stop();
-
-		jobManagerHeartbeatManager.stop();
+		stopHeartbeatServices();
 
 		try {
 			slotManager.close();
@@ -970,6 +959,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 			setFencingToken(newResourceManagerId);
 
+			startHeartbeatServices();
+
 			slotManager.start(getFencingToken(), getMainThreadExecutor(), new ResourceActionsImpl());
 
 			return prepareLeadershipAsync().thenApply(ignored -> true);
@@ -992,7 +983,35 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				setFencingToken(null);
 
 				slotManager.suspend();
+
+				stopHeartbeatServices();
 			});
+	}
+
+	private void startHeartbeatServices() {
+		taskManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
+			resourceId,
+			new TaskManagerHeartbeatListener(),
+			getMainThreadExecutor(),
+			log);
+
+		jobManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
+			resourceId,
+			new JobManagerHeartbeatListener(),
+			getMainThreadExecutor(),
+			log);
+	}
+
+	private void stopHeartbeatServices() {
+		if (taskManagerHeartbeatManager != null) {
+			taskManagerHeartbeatManager.stop();
+			taskManagerHeartbeatManager = null;
+		}
+
+		if (jobManagerHeartbeatManager != null) {
+			jobManagerHeartbeatManager.stop();
+			jobManagerHeartbeatManager = null;
+		}
 	}
 
 	/**
@@ -1140,31 +1159,26 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					log.info("The heartbeat of TaskManager with id {} timed out.", resourceID);
+			validateRunsInMainThread();
+			log.info("The heartbeat of TaskManager with id {} timed out.", resourceID);
 
-					closeTaskManagerConnection(
-							resourceID,
-							new TimeoutException("The heartbeat of TaskManager with id " + resourceID + "  timed out."));
-				}
-			});
+			closeTaskManagerConnection(
+				resourceID,
+				new TimeoutException("The heartbeat of TaskManager with id " + resourceID + "  timed out."));
 		}
 
 		@Override
-		public void reportPayload(final ResourceID resourceID, final SlotReport slotReport) {
-			runAsync(() -> {
-				final WorkerRegistration<WorkerType> workerRegistration = taskExecutors.get(resourceID);
+		public void reportPayload(final ResourceID resourceID, final SlotReport payload) {
+			validateRunsInMainThread();
+			final WorkerRegistration<WorkerType> workerRegistration = taskExecutors.get(resourceID);
 
-				if (workerRegistration == null) {
-					log.debug("Received slot report from TaskManager {} which is no longer registered.", resourceID);
-				} else {
-					InstanceID instanceId = workerRegistration.getInstanceID();
+			if (workerRegistration == null) {
+				log.debug("Received slot report from TaskManager {} which is no longer registered.", resourceID);
+			} else {
+				InstanceID instanceId = workerRegistration.getInstanceID();
 
-					slotManager.reportSlotStatus(instanceId, slotReport);
-				}
-			});
+				slotManager.reportSlotStatus(instanceId, payload);
+			}
 		}
 
 		@Override
@@ -1177,22 +1191,18 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
+			validateRunsInMainThread();
+			log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
 
-					if (jmResourceIdRegistrations.containsKey(resourceID)) {
-						JobManagerRegistration jobManagerRegistration = jmResourceIdRegistrations.get(resourceID);
+			if (jmResourceIdRegistrations.containsKey(resourceID)) {
+				JobManagerRegistration jobManagerRegistration = jmResourceIdRegistrations.get(resourceID);
 
-						if (jobManagerRegistration != null) {
-							closeJobManagerConnection(
-								jobManagerRegistration.getJobID(),
-								new TimeoutException("The heartbeat of JobManager with id " + resourceID + " timed out."));
-						}
-					}
+				if (jobManagerRegistration != null) {
+					closeJobManagerConnection(
+						jobManagerRegistration.getJobID(),
+						new TimeoutException("The heartbeat of JobManager with id " + resourceID + " timed out."));
 				}
-			});
+			}
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -153,11 +153,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	/** The task manager configuration. */
 	private final TaskManagerConfiguration taskManagerConfiguration;
 
-	/** The heartbeat manager for job manager in the task manager. */
-	private final HeartbeatManager<AllocatedSlotReport, AccumulatorReport> jobManagerHeartbeatManager;
-
-	/** The heartbeat manager for resource manager in the task manager. */
-	private final HeartbeatManager<Void, SlotReport> resourceManagerHeartbeatManager;
+	private final HeartbeatServices heartbeatServices;
 
 	/** The fatal error handler to use in case of a fatal error. */
 	private final FatalErrorHandler fatalErrorHandler;
@@ -201,6 +197,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 	private FileCache fileCache;
 
+	/** The heartbeat manager for job manager in the task manager. */
+	private HeartbeatManager<AllocatedSlotReport, AccumulatorReport> jobManagerHeartbeatManager;
+
+	/** The heartbeat manager for resource manager in the task manager. */
+	private HeartbeatManager<Void, SlotReport> resourceManagerHeartbeatManager;
+
 	// --------- resource manager --------
 
 	@Nullable
@@ -231,6 +233,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		checkArgument(taskManagerConfiguration.getNumberSlots() > 0, "The number of slots has to be larger than 0.");
 
 		this.taskManagerConfiguration = checkNotNull(taskManagerConfiguration);
+		this.heartbeatServices = checkNotNull(heartbeatServices);
 		this.taskExecutorServices = checkNotNull(taskExecutorServices);
 		this.haServices = checkNotNull(haServices);
 		this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
@@ -247,20 +250,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		this.resourceManagerLeaderRetriever = haServices.getResourceManagerLeaderRetriever();
 
 		this.jobManagerConnections = new HashMap<>(4);
-
-		final ResourceID resourceId = taskExecutorServices.getTaskManagerLocation().getResourceID();
-
-		this.jobManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
-			resourceId,
-			new JobManagerHeartbeatListener(),
-			rpcService.getScheduledExecutor(),
-			log);
-
-		this.resourceManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
-			resourceId,
-			new ResourceManagerHeartbeatListener(),
-			rpcService.getScheduledExecutor(),
-			log);
 
 		this.hardwareDescription = HardwareDescription.extractFromSystem(
 			taskExecutorServices.getMemoryManager().getMemorySize());
@@ -286,6 +275,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		// start by connecting to the ResourceManager
 		try {
+			startHeartbeatServices();
+
+			// start by connecting to the ResourceManager
 			resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener());
 		} catch (Exception e) {
 			onFatalError(e);
@@ -323,10 +315,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			}
 		}
 
-		jobManagerHeartbeatManager.stop();
-
-		resourceManagerHeartbeatManager.stop();
-
 		try {
 			resourceManagerLeaderRetriever.stop();
 		} catch (Exception e) {
@@ -343,11 +331,40 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		// it will call close() recursively from the parent to children
 		taskManagerMetricGroup.close();
 
+		stopHeartbeatServices();
+
 		if (throwable != null) {
 			return FutureUtils.completedExceptionally(new FlinkException("Error while shutting the TaskExecutor down.", throwable));
 		} else {
 			log.info("Stopped TaskExecutor {}.", getAddress());
 			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	private void startHeartbeatServices() {
+		final ResourceID resourceId = taskExecutorServices.getTaskManagerLocation().getResourceID();
+		jobManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
+			resourceId,
+			new JobManagerHeartbeatListener(),
+			getMainThreadExecutor(),
+			log);
+
+		resourceManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
+			resourceId,
+			new ResourceManagerHeartbeatListener(),
+			getMainThreadExecutor(),
+			log);
+	}
+
+	private void stopHeartbeatServices() {
+		if (jobManagerHeartbeatManager != null) {
+			jobManagerHeartbeatManager.stop();
+			jobManagerHeartbeatManager = null;
+		}
+
+		if (resourceManagerHeartbeatManager != null) {
+			resourceManagerHeartbeatManager.stop();
+			resourceManagerHeartbeatManager = null;
 		}
 	}
 
@@ -1685,32 +1702,33 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
-			runAsync(() -> {
-				log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
+			validateRunsInMainThread();
+			log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
 
-				if (jobManagerConnections.containsKey(resourceID)) {
-					JobManagerConnection jobManagerConnection = jobManagerConnections.get(resourceID);
+			if (jobManagerConnections.containsKey(resourceID)) {
+				JobManagerConnection jobManagerConnection = jobManagerConnections.get(resourceID);
 
-					if (jobManagerConnection != null) {
-						closeJobManagerConnection(
-							jobManagerConnection.getJobID(),
-							new TimeoutException("The heartbeat of JobManager with id " + resourceID + " timed out."));
+				if (jobManagerConnection != null) {
+					closeJobManagerConnection(
+						jobManagerConnection.getJobID(),
+						new TimeoutException("The heartbeat of JobManager with id " + resourceID + " timed out."));
 
-						jobLeaderService.reconnect(jobManagerConnection.getJobID());
-					}
+					jobLeaderService.reconnect(jobManagerConnection.getJobID());
 				}
-			});
+			}
 		}
 
 		@Override
 		public void reportPayload(ResourceID resourceID, AllocatedSlotReport allocatedSlotReport) {
-			runAsync(() -> syncSlotsWithSnapshotFromJobMaster(allocatedSlotReport));
+			validateRunsInMainThread();
+			syncSlotsWithSnapshotFromJobMaster(allocatedSlotReport);
 		}
 
 		@Override
 		public CompletableFuture<AccumulatorReport> retrievePayload(ResourceID resourceID) {
 			validateRunsInMainThread();
 			JobManagerConnection jobManagerConnection = jobManagerConnections.get(resourceID);
+			final AccumulatorReport accumulatorReport;
 			if (jobManagerConnection != null) {
 				JobID jobId = jobManagerConnection.getJobID();
 
@@ -1721,10 +1739,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 					Task task = allTasks.next();
 					accumulatorSnapshots.add(task.getAccumulatorRegistry().getSnapshot());
 				}
-				return CompletableFuture.completedFuture(new AccumulatorReport(accumulatorSnapshots));
+				accumulatorReport = new AccumulatorReport(accumulatorSnapshots);
 			} else {
-				return CompletableFuture.completedFuture(new AccumulatorReport(Collections.emptyList()));
+				accumulatorReport = new AccumulatorReport(Collections.emptyList());
 			}
+
+			return CompletableFuture.completedFuture(accumulatorReport);
 		}
 	}
 
@@ -1732,17 +1752,16 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceId) {
-			runAsync(() -> {
-				// first check whether the timeout is still valid
-				if (establishedResourceManagerConnection != null && establishedResourceManagerConnection.getResourceManagerResourceId().equals(resourceId)) {
-					log.info("The heartbeat of ResourceManager with id {} timed out.", resourceId);
+			validateRunsInMainThread();
+			// first check whether the timeout is still valid
+			if (establishedResourceManagerConnection != null && establishedResourceManagerConnection.getResourceManagerResourceId().equals(resourceId)) {
+				log.info("The heartbeat of ResourceManager with id {} timed out.", resourceId);
 
-					reconnectToResourceManager(new TaskManagerException(
-						String.format("The heartbeat of ResourceManager with id %s timed out.", resourceId)));
-				} else {
-					log.debug("Received heartbeat timeout for outdated ResourceManager id {}. Ignoring the timeout.", resourceId);
-				}
-			});
+				reconnectToResourceManager(new TaskManagerException(
+					String.format("The heartbeat of ResourceManager with id %s timed out.", resourceId)));
+			} else {
+				log.debug("Received heartbeat timeout for outdated ResourceManager id {}. Ignoring the timeout.", resourceId);
+			}
 		}
 
 		@Override
@@ -1752,9 +1771,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public CompletableFuture<SlotReport> retrievePayload(ResourceID resourceID) {
-			return callAsync(
-					() -> taskSlotTable.createSlotReport(getResourceID()),
-					taskManagerConfiguration.getTimeout());
+			validateRunsInMainThread();
+			return CompletableFuture.completedFuture(taskSlotTable.createSlotReport(getResourceID()));
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -690,8 +690,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 	@Override
 	public void heartbeatFromJobManager(ResourceID resourceID, AllocatedSlotReport allocatedSlotReport) {
-		jobManagerHeartbeatManager.receiveHeartbeat(resourceID, allocatedSlotReport);
-		jobManagerHeartbeatManager.requestHeartbeat(resourceID, null);
+		jobManagerHeartbeatManager.requestHeartbeat(resourceID, allocatedSlotReport);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -132,6 +132,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -1100,65 +1101,69 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 					taskManagerConfiguration.getTimeout());
 
 				acceptedSlotsFuture.whenCompleteAsync(
-					(Iterable<SlotOffer> acceptedSlots, Throwable throwable) -> {
-						if (throwable != null) {
-							if (throwable instanceof TimeoutException) {
-								log.info("Slot offering to JobManager did not finish in time. Retrying the slot offering.");
-								// We ran into a timeout. Try again.
-								offerSlotsToJobManager(jobId);
-							} else {
-								log.warn("Slot offering to JobManager failed. Freeing the slots " +
-									"and returning them to the ResourceManager.", throwable);
-
-								// We encountered an exception. Free the slots and return them to the RM.
-								for (SlotOffer reservedSlot: reservedSlots) {
-									freeSlotInternal(reservedSlot.getAllocationId(), throwable);
-								}
-							}
-						} else {
-							// check if the response is still valid
-							if (isJobManagerConnectionValid(jobId, jobMasterId)) {
-								// mark accepted slots active
-								for (SlotOffer acceptedSlot : acceptedSlots) {
-									try {
-										if (!taskSlotTable.markSlotActive(acceptedSlot.getAllocationId())) {
-											// the slot is either free or releasing at the moment
-											final String message = "Could not mark slot " + jobId + " active.";
-											log.debug(message);
-											jobMasterGateway.failSlot(
-												getResourceID(),
-												acceptedSlot.getAllocationId(),
-												new FlinkException(message));
-										}
-									} catch (SlotNotFoundException e) {
-										final String message = "Could not mark slot " + jobId + " active.";
-										jobMasterGateway.failSlot(
-											getResourceID(),
-											acceptedSlot.getAllocationId(),
-											new FlinkException(message));
-									}
-
-									reservedSlots.remove(acceptedSlot);
-								}
-
-								final Exception e = new Exception("The slot was rejected by the JobManager.");
-
-								for (SlotOffer rejectedSlot : reservedSlots) {
-									freeSlotInternal(rejectedSlot.getAllocationId(), e);
-								}
-							} else {
-								// discard the response since there is a new leader for the job
-								log.debug("Discard offer slot response since there is a new leader " +
-									"for the job {}.", jobId);
-							}
-						}
-					},
+					handleAcceptedSlotOffers(jobId, jobMasterGateway, jobMasterId, reservedSlots),
 					getMainThreadExecutor());
-
 			} else {
 				log.debug("There are no unassigned slots for the job {}.", jobId);
 			}
 		}
+	}
+
+	@Nonnull
+	private BiConsumer<Iterable<SlotOffer>, Throwable> handleAcceptedSlotOffers(JobID jobId, JobMasterGateway jobMasterGateway, JobMasterId jobMasterId, Collection<SlotOffer> offeredSlots) {
+		return (Iterable<SlotOffer> acceptedSlots, Throwable throwable) -> {
+			if (throwable != null) {
+				if (throwable instanceof TimeoutException) {
+					log.info("Slot offering to JobManager did not finish in time. Retrying the slot offering.");
+					// We ran into a timeout. Try again.
+					offerSlotsToJobManager(jobId);
+				} else {
+					log.warn("Slot offering to JobManager failed. Freeing the slots " +
+						"and returning them to the ResourceManager.", throwable);
+
+					// We encountered an exception. Free the slots and return them to the RM.
+					for (SlotOffer reservedSlot: offeredSlots) {
+						freeSlotInternal(reservedSlot.getAllocationId(), throwable);
+					}
+				}
+			} else {
+				// check if the response is still valid
+				if (isJobManagerConnectionValid(jobId, jobMasterId)) {
+					// mark accepted slots active
+					for (SlotOffer acceptedSlot : acceptedSlots) {
+						try {
+							if (!taskSlotTable.markSlotActive(acceptedSlot.getAllocationId())) {
+								// the slot is either free or releasing at the moment
+								final String message = "Could not mark slot " + jobId + " active.";
+								log.debug(message);
+								jobMasterGateway.failSlot(
+									getResourceID(),
+									acceptedSlot.getAllocationId(),
+									new FlinkException(message));
+							}
+						} catch (SlotNotFoundException e) {
+							final String message = "Could not mark slot " + jobId + " active.";
+							jobMasterGateway.failSlot(
+								getResourceID(),
+								acceptedSlot.getAllocationId(),
+								new FlinkException(message));
+						}
+
+						offeredSlots.remove(acceptedSlot);
+					}
+
+					final Exception e = new Exception("The slot was rejected by the JobManager.");
+
+					for (SlotOffer rejectedSlot : offeredSlots) {
+						freeSlotInternal(rejectedSlot.getAllocationId(), e);
+					}
+				} else {
+					// discard the response since there is a new leader for the job
+					log.debug("Discard offer slot response since there is a new leader " +
+						"for the job {}.", jobId);
+				}
+			}
+		};
 	}
 
 	private void establishJobManagerConnection(JobID jobId, final JobMasterGateway jobMasterGateway, JMTMRegistrationSuccess registrationSuccess) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.clusterframework;
 
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -30,36 +28,14 @@ import org.apache.flink.runtime.clusterframework.messages.RemoveResource;
 import org.apache.flink.runtime.clusterframework.messages.ResourceRemoved;
 import org.apache.flink.runtime.clusterframework.messages.TriggerRegistrationAtJobManager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.ScheduledExecutor;
-import org.apache.flink.runtime.entrypoint.ClusterInformation;
-import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.instance.HardwareDescription;
-import org.apache.flink.runtime.jobmaster.JobMasterGateway;
-import org.apache.flink.runtime.jobmaster.JobMasterId;
-import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
-import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.metrics.MetricRegistryImpl;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.registration.RegistrationResponse;
-import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
-import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
-import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
-import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
-import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
-import org.apache.flink.runtime.rpc.RpcUtils;
-import org.apache.flink.runtime.rpc.TestingRpcService;
-import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
-import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.TestingResourceManager;
-import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
@@ -69,27 +45,16 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import scala.Option;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * General tests for the resource manager component.
@@ -102,8 +67,6 @@ public class ResourceManagerTest extends TestLogger {
 	private static ActorGateway resourceManager;
 
 	private static Configuration config = new Configuration();
-
-	private final Time timeout = Time.seconds(10L);
 
 	private TestingHighAvailabilityServices highAvailabilityServices;
 	private SettableLeaderRetrievalService jobManagerLeaderRetrievalService;
@@ -482,195 +445,5 @@ public class ResourceManagerTest extends TestLogger {
 
 		}};
 		}};
-	}
-
-	@Test
-	public void testHeartbeatTimeoutWithTaskExecutor() throws Exception {
-		final int dataPort = 1234;
-		final HardwareDescription hardwareDescription = new HardwareDescription(1, 2L, 3L, 4L);
-		final String taskManagerAddress = "tm";
-		final ResourceID taskManagerResourceID = new ResourceID(taskManagerAddress);
-		final ResourceID resourceManagerResourceID = ResourceID.generate();
-		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
-
-		final TestingRpcService rpcService = new TestingRpcService();
-		rpcService.registerGateway(taskManagerAddress, taskExecutorGateway);
-
-		final TestingLeaderElectionService rmLeaderElectionService = new TestingLeaderElectionService();
-		final TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
-		highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
-
-		final long heartbeatInterval = 1L;
-		final long heartbeatTimeout = 5L;
-		final ScheduledExecutor scheduledExecutor = mock(ScheduledExecutor.class);
-		final HeartbeatServices heartbeatServices = new TestingHeartbeatServices(heartbeatInterval, heartbeatTimeout, scheduledExecutor);
-
-		final MetricRegistryImpl metricRegistry = mock(MetricRegistryImpl.class);
-		final JobLeaderIdService jobLeaderIdService = mock(JobLeaderIdService.class);
-		final TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
-		final SlotManager slotManager = new SlotManager(
-			rpcService.getScheduledExecutor(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime());
-
-		try {
-			final StandaloneResourceManager resourceManager = new StandaloneResourceManager(
-				rpcService,
-				FlinkResourceManager.RESOURCE_MANAGER_NAME,
-				resourceManagerResourceID,
-				highAvailabilityServices,
-				heartbeatServices,
-				slotManager,
-				metricRegistry,
-				jobLeaderIdService,
-				new ClusterInformation("localhost", 1234),
-				testingFatalErrorHandler,
-				UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup());
-
-			resourceManager.start();
-
-			final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
-
-			final UUID rmLeaderSessionId = UUID.randomUUID();
-			rmLeaderElectionService.isLeader(rmLeaderSessionId).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
-			// test registration response successful and it will trigger monitor heartbeat target, schedule heartbeat request at interval time
-			CompletableFuture<RegistrationResponse> successfulFuture = rmGateway.registerTaskExecutor(
-				taskManagerAddress,
-				taskManagerResourceID,
-				dataPort,
-				hardwareDescription,
-				timeout);
-			RegistrationResponse response = successfulFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-			assertTrue(response instanceof TaskExecutorRegistrationSuccess);
-
-			ArgumentCaptor<Runnable> heartbeatRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-			verify(scheduledExecutor, times(2)).scheduleAtFixedRate(
-				heartbeatRunnableCaptor.capture(),
-				eq(0L),
-				eq(heartbeatInterval),
-				eq(TimeUnit.MILLISECONDS));
-
-			List<Runnable> heartbeatRunnable = heartbeatRunnableCaptor.getAllValues();
-
-			ArgumentCaptor<Runnable> timeoutRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-			verify(scheduledExecutor).schedule(timeoutRunnableCaptor.capture(), eq(heartbeatTimeout), eq(TimeUnit.MILLISECONDS));
-
-			Runnable timeoutRunnable = timeoutRunnableCaptor.getValue();
-
-			// run all the heartbeat requests
-			for (Runnable runnable : heartbeatRunnable) {
-				runnable.run();
-			}
-
-			verify(taskExecutorGateway, times(1)).heartbeatFromResourceManager(eq(resourceManagerResourceID));
-
-			// run the timeout runnable to simulate a heartbeat timeout
-			timeoutRunnable.run();
-
-			verify(taskExecutorGateway, Mockito.timeout(timeout.toMilliseconds())).disconnectResourceManager(any(TimeoutException.class));
-
-		} finally {
-			RpcUtils.terminateRpcService(rpcService, timeout);
-		}
-	}
-
-	@Test
-	public void testHeartbeatTimeoutWithJobManager() throws Exception {
-		final String jobMasterAddress = "jm";
-		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
-		final ResourceID rmResourceId = ResourceID.generate();
-		final ResourceManagerId rmLeaderId = ResourceManagerId.generate();
-		final JobMasterId jobMasterId = JobMasterId.generate();
-		final JobID jobId = new JobID();
-
-		final JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
-
-		final TestingRpcService rpcService = new TestingRpcService();
-		rpcService.registerGateway(jobMasterAddress, jobMasterGateway);
-
-		final TestingLeaderElectionService rmLeaderElectionService = new TestingLeaderElectionService();
-		final SettableLeaderRetrievalService jmLeaderRetrievalService = new SettableLeaderRetrievalService(jobMasterAddress, jobMasterId.toUUID());
-		final TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
-		highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
-		highAvailabilityServices.setJobMasterLeaderRetriever(jobId, jmLeaderRetrievalService);
-
-		final long heartbeatInterval = 1L;
-		final long heartbeatTimeout = 5L;
-		final ScheduledExecutor scheduledExecutor = mock(ScheduledExecutor.class);
-		final HeartbeatServices heartbeatServices = new TestingHeartbeatServices(heartbeatInterval, heartbeatTimeout, scheduledExecutor);
-
-		final MetricRegistryImpl metricRegistry = mock(MetricRegistryImpl.class);
-		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
-			highAvailabilityServices,
-			rpcService.getScheduledExecutor(),
-			Time.minutes(5L));
-		final TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
-		final SlotManager slotManager = new SlotManager(
-			TestingUtils.defaultScheduledExecutor(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime());
-
-		try {
-			final StandaloneResourceManager resourceManager = new StandaloneResourceManager(
-				rpcService,
-				FlinkResourceManager.RESOURCE_MANAGER_NAME,
-				rmResourceId,
-				highAvailabilityServices,
-				heartbeatServices,
-				slotManager,
-				metricRegistry,
-				jobLeaderIdService,
-				new ClusterInformation("localhost", 1234),
-				testingFatalErrorHandler,
-				UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup());
-
-			resourceManager.start();
-
-			final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
-
-			rmLeaderElectionService.isLeader(rmLeaderId.toUUID()).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
-			// test registration response successful and it will trigger monitor heartbeat target, schedule heartbeat request at interval time
-			CompletableFuture<RegistrationResponse> successfulFuture = rmGateway.registerJobManager(
-				jobMasterId,
-				jmResourceId,
-				jobMasterAddress,
-				jobId,
-				timeout);
-			RegistrationResponse response = successfulFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-			assertTrue(response instanceof JobMasterRegistrationSuccess);
-
-			ArgumentCaptor<Runnable> heartbeatRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-			verify(scheduledExecutor, times(2)).scheduleAtFixedRate(
-				heartbeatRunnableCaptor.capture(),
-				eq(0L),
-				eq(heartbeatInterval),
-				eq(TimeUnit.MILLISECONDS));
-
-			List<Runnable> heartbeatRunnable = heartbeatRunnableCaptor.getAllValues();
-
-			ArgumentCaptor<Runnable> timeoutRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-			verify(scheduledExecutor).schedule(timeoutRunnableCaptor.capture(), eq(heartbeatTimeout), eq(TimeUnit.MILLISECONDS));
-
-			Runnable timeoutRunnable = timeoutRunnableCaptor.getValue();
-
-			// run all the heartbeat requests
-			for (Runnable runnable : heartbeatRunnable) {
-				runnable.run();
-			}
-
-			verify(jobMasterGateway, times(1)).heartbeatFromResourceManager(eq(rmResourceId));
-
-			// run the timeout runnable to simulate a heartbeat timeout
-			timeoutRunnable.run();
-
-			verify(jobMasterGateway, Mockito.timeout(timeout.toMilliseconds())).disconnectResourceManager(eq(rmLeaderId), any(TimeoutException.class));
-
-		} finally {
-			RpcUtils.terminateRpcService(rpcService, timeout);
-		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ScheduledFutureAdapterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ScheduledFutureAdapterTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for {@link ScheduledFutureAdapter}.
+ */
+public class ScheduledFutureAdapterTest extends TestLogger {
+
+	private ScheduledFutureAdapter<Integer> objectUnderTest;
+	private TestFuture innerDelegate;
+
+	@Before
+	public void before() {
+		this.innerDelegate = new TestFuture();
+		this.objectUnderTest = new ScheduledFutureAdapter<>(innerDelegate, 4200000321L, TimeUnit.NANOSECONDS);
+	}
+
+	@Test
+	public void testForwardedMethods() throws Exception {
+
+		Assert.assertEquals((Integer) 4711, objectUnderTest.get());
+		Assert.assertEquals(1, innerDelegate.getGetInvocationCount());
+
+		Assert.assertEquals((Integer) 4711, objectUnderTest.get(42L, TimeUnit.SECONDS));
+		Assert.assertEquals(1, innerDelegate.getGetTimeoutInvocationCount());
+
+		Assert.assertEquals(innerDelegate.isCancelExpected(), objectUnderTest.cancel(true));
+		Assert.assertEquals(1, innerDelegate.getCancelInvocationCount());
+
+		innerDelegate.setCancelResult(!innerDelegate.isCancelExpected());
+		Assert.assertEquals(innerDelegate.isCancelExpected(), objectUnderTest.cancel(true));
+		Assert.assertEquals(2, innerDelegate.getCancelInvocationCount());
+
+		Assert.assertEquals(innerDelegate.isCancelledExpected(), objectUnderTest.isCancelled());
+		Assert.assertEquals(1, innerDelegate.getIsCancelledInvocationCount());
+
+		innerDelegate.setIsCancelledResult(!innerDelegate.isCancelledExpected());
+		Assert.assertEquals(innerDelegate.isCancelledExpected(), objectUnderTest.isCancelled());
+		Assert.assertEquals(2, innerDelegate.getIsCancelledInvocationCount());
+
+		Assert.assertEquals(innerDelegate.isDoneExpected(), objectUnderTest.isDone());
+		Assert.assertEquals(1, innerDelegate.getIsDoneInvocationCount());
+
+		innerDelegate.setIsDoneExpected(!innerDelegate.isDoneExpected());
+		Assert.assertEquals(innerDelegate.isDoneExpected(), objectUnderTest.isDone());
+		Assert.assertEquals(2, innerDelegate.getIsDoneInvocationCount());
+	}
+
+	@Test
+	public void testCompareToEqualsHashCode() {
+
+		Assert.assertEquals(0, objectUnderTest.compareTo(objectUnderTest));
+		Assert.assertEquals(objectUnderTest, objectUnderTest);
+
+		ScheduledFutureAdapter<?> other = getDeepCopyWithAdjustedTime(0L , objectUnderTest.getTieBreakerUid());
+
+		Assert.assertEquals(0, objectUnderTest.compareTo(other));
+		Assert.assertEquals(0, other.compareTo(objectUnderTest));
+		Assert.assertEquals(objectUnderTest, other);
+		Assert.assertEquals(objectUnderTest.hashCode(), other.hashCode());
+
+		other = getDeepCopyWithAdjustedTime(0L , objectUnderTest.getTieBreakerUid() + 1L);
+		Assert.assertEquals(-1, Integer.signum(objectUnderTest.compareTo(other)));
+		Assert.assertEquals(+1, Integer.signum(other.compareTo(objectUnderTest)));
+		Assert.assertNotEquals(objectUnderTest, other);
+
+		other = getDeepCopyWithAdjustedTime(+1L, objectUnderTest.getTieBreakerUid());
+		Assert.assertEquals(-1, Integer.signum(objectUnderTest.compareTo(other)));
+		Assert.assertEquals(+1, Integer.signum(other.compareTo(objectUnderTest)));
+		Assert.assertNotEquals(objectUnderTest, other);
+
+		other = getDeepCopyWithAdjustedTime(-1L, objectUnderTest.getTieBreakerUid());
+		Assert.assertEquals(+1, Integer.signum(objectUnderTest.compareTo(other)));
+		Assert.assertEquals(-1, Integer.signum(other.compareTo(objectUnderTest)));
+		Assert.assertNotEquals(objectUnderTest, other);
+	}
+
+	private ScheduledFutureAdapter<Integer> getDeepCopyWithAdjustedTime(long nanoAdjust, long uid) {
+		return new ScheduledFutureAdapter<>(
+			innerDelegate,
+			objectUnderTest.getScheduleTimeNanos() + nanoAdjust,
+			uid);
+	}
+
+	/**
+	 * Implementation of {@link Future} for the unit tests in this class.
+	 */
+	static class TestFuture implements Future<Integer> {
+
+		private boolean cancelExpected = false;
+		private boolean isCancelledExpected = false;
+		private boolean isDoneExpected = false;
+
+		private int cancelInvocationCount = 0;
+		private int isCancelledInvocationCount = 0;
+		private int isDoneInvocationCount = 0;
+		private int getInvocationCount = 0;
+		private int getTimeoutInvocationCount = 0;
+
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			++cancelInvocationCount;
+			return cancelExpected;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			++isCancelledInvocationCount;
+			return isCancelledExpected;
+		}
+
+		@Override
+		public boolean isDone() {
+			++isDoneInvocationCount;
+			return isDoneExpected;
+		}
+
+		@Override
+		public Integer get() {
+			++getInvocationCount;
+			return 4711;
+		}
+
+		@Override
+		public Integer get(long timeout, @Nonnull TimeUnit unit) {
+			++getTimeoutInvocationCount;
+			return 4711;
+		}
+
+		boolean isCancelExpected() {
+			return cancelExpected;
+		}
+
+		boolean isCancelledExpected() {
+			return isCancelledExpected;
+		}
+
+		boolean isDoneExpected() {
+			return isDoneExpected;
+		}
+
+		void setCancelResult(boolean resultCancel) {
+			this.cancelExpected = resultCancel;
+		}
+
+		void setIsCancelledResult(boolean resultIsCancelled) {
+			this.isCancelledExpected = resultIsCancelled;
+		}
+
+		void setIsDoneExpected(boolean resultIsDone) {
+			this.isDoneExpected = resultIsDone;
+		}
+
+		int getCancelInvocationCount() {
+			return cancelInvocationCount;
+		}
+
+		int getIsCancelledInvocationCount() {
+			return isCancelledInvocationCount;
+		}
+
+		int getIsDoneInvocationCount() {
+			return isDoneInvocationCount;
+		}
+
+		int getGetInvocationCount() {
+			return getInvocationCount;
+		}
+
+		int getGetTimeoutInvocationCount() {
+			return getTimeoutInvocationCount;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -34,8 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -144,42 +142,37 @@ public class HeartbeatManagerTest extends TestLogger {
 
 	/**
 	 * Tests that a heartbeat timeout is signaled if the heartbeat is not reported in time.
-	 *
-	 * @throws Exception
 	 */
 	@Test
 	public void testHeartbeatTimeout() throws Exception {
 		long heartbeatTimeout = 100L;
-		int numHeartbeats = 10;
+		int numHeartbeats = 6;
 		long heartbeatInterval = 20L;
-		Object payload = new Object();
+		final int payload = 42;
 
 		ResourceID ownResourceID = new ResourceID("foobar");
 		ResourceID targetResourceID = new ResourceID("barfoo");
-		SimpleTestingHeartbeatListener heartbeatListener = new SimpleTestingHeartbeatListener(payload);
-		ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
-		ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
 
-		doReturn(scheduledFuture).when(scheduledExecutorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+		final CompletableFuture<ResourceID> timeoutFuture = new CompletableFuture<>();
+		final TestingHeartbeatListener<Integer, Integer> heartbeatListener = new TestingHeartbeatListenerBuilder<Integer, Integer>()
+			.setRetrievePayloadFunction(ignored -> CompletableFuture.completedFuture(payload))
+			.setNotifyHeartbeatTimeoutConsumer(timeoutFuture::complete)
+			.createNewTestingHeartbeatListener();
 
-		Object expectedObject = new Object();
-
-		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
+		HeartbeatManagerImpl<Integer, Integer> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			ownResourceID,
 			heartbeatListener,
-			new ScheduledExecutorServiceAdapter(new ScheduledThreadPoolExecutor(1)),
+			TestingUtils.defaultScheduledExecutor(),
 			LOG);
 
-		@SuppressWarnings("unchecked")
-		HeartbeatTarget<Object> heartbeatTarget = mock(HeartbeatTarget.class);
-
-		CompletableFuture<ResourceID> timeoutFuture = heartbeatListener.getTimeoutFuture();
+		final HeartbeatTarget<Integer> heartbeatTarget = new TestingHeartbeatTargetBuilder<Integer>()
+			.createTestingHeartbeatTarget();
 
 		heartbeatManager.monitorTarget(targetResourceID, heartbeatTarget);
 
 		for (int i = 0; i < numHeartbeats; i++) {
-			heartbeatManager.receiveHeartbeat(targetResourceID, expectedObject);
+			heartbeatManager.receiveHeartbeat(targetResourceID, payload);
 			Thread.sleep(heartbeatInterval);
 		}
 
@@ -259,34 +252,36 @@ public class HeartbeatManagerTest extends TestLogger {
 	 * Tests that after unmonitoring a target, there won't be a timeout triggered.
 	 */
 	@Test
-	public void testTargetUnmonitoring() throws InterruptedException, ExecutionException {
+	public void testTargetUnmonitoring() throws Exception {
 		// this might be too aggressive for Travis, let's see...
-		long heartbeatTimeout = 100L;
+		long heartbeatTimeout = 50L;
 		ResourceID resourceID = new ResourceID("foobar");
 		ResourceID targetID = new ResourceID("target");
-		Object object = new Object();
+		final int payload = 42;
 
-		SimpleTestingHeartbeatListener heartbeatListener = new SimpleTestingHeartbeatListener(object);
+		final CompletableFuture<ResourceID> timeoutFuture = new CompletableFuture<>();
+		final TestingHeartbeatListener<Integer, Integer> heartbeatListener = new TestingHeartbeatListenerBuilder<Integer, Integer>()
+			.setRetrievePayloadFunction(ignored -> CompletableFuture.completedFuture(payload))
+			.setNotifyHeartbeatTimeoutConsumer(timeoutFuture::complete)
+			.createNewTestingHeartbeatListener();
 
-		HeartbeatManager<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
+		HeartbeatManager<Integer, Integer> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			resourceID,
 			heartbeatListener,
-			new ScheduledExecutorServiceAdapter(new ScheduledThreadPoolExecutor(1)),
+			TestingUtils.defaultScheduledExecutor(),
 			LOG);
 
-		@SuppressWarnings("unchecked")
-		final HeartbeatTarget<Object> heartbeatTarget = mock(HeartbeatTarget.class);
+		final HeartbeatTarget<Integer> heartbeatTarget = new TestingHeartbeatTargetBuilder<Integer>()
+			.createTestingHeartbeatTarget();
 		heartbeatManager.monitorTarget(targetID, heartbeatTarget);
 
 		heartbeatManager.unmonitorTarget(targetID);
 
-		CompletableFuture<ResourceID> timeout = heartbeatListener.getTimeoutFuture();
-
 		try {
-			timeout.get(2 * heartbeatTimeout, TimeUnit.MILLISECONDS);
+			timeoutFuture.get(2 * heartbeatTimeout, TimeUnit.MILLISECONDS);
 			fail("Timeout should time out.");
-		} catch (TimeoutException e) {
+		} catch (TimeoutException ignored) {
 			// the timeout should not be completed since we unmonitored the target
 		}
 	}
@@ -514,42 +509,6 @@ public class HeartbeatManagerTest extends TestLogger {
 			} else {
 				return CompletableFuture.completedFuture(defaultResponse);
 			}
-		}
-	}
-
-	static class SimpleTestingHeartbeatListener implements HeartbeatListener<Object, Object> {
-
-		private final CompletableFuture<ResourceID> future = new CompletableFuture<>();
-
-		private final Object payload;
-
-		private int numberHeartbeatReports;
-
-		SimpleTestingHeartbeatListener(Object payload) {
-			this.payload = payload;
-		}
-
-		CompletableFuture<ResourceID> getTimeoutFuture() {
-			return future;
-		}
-
-		public int getNumberHeartbeatReports() {
-			return numberHeartbeatReports;
-		}
-
-		@Override
-		public void notifyHeartbeatTimeout(ResourceID resourceID) {
-			future.complete(resourceID);
-		}
-
-		@Override
-		public void reportPayload(ResourceID resourceID, Object payload) {
-			numberHeartbeatReports++;
-		}
-
-		@Override
-		public CompletableFuture<Object> retrievePayload(ResourceID resourceID) {
-			return CompletableFuture.completedFuture(payload);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -20,16 +20,19 @@ package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
-import org.apache.flink.runtime.util.DirectExecutorService;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -37,15 +40,18 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -63,40 +69,40 @@ public class HeartbeatManagerTest extends TestLogger {
 	 * {@link HeartbeatListener}.
 	 */
 	@Test
-	public void testRegularHeartbeat() {
-		long heartbeatTimeout = 1000L;
+	public void testRegularHeartbeat() throws InterruptedException {
+		final long heartbeatTimeout = 1000L;
 		ResourceID ownResourceID = new ResourceID("foobar");
 		ResourceID targetResourceID = new ResourceID("barfoo");
-		@SuppressWarnings("unchecked")
-		HeartbeatListener<Object, Object> heartbeatListener = mock(HeartbeatListener.class);
-		ScheduledExecutor scheduledExecutor = mock(ScheduledExecutor.class);
+		final int outputPayload = 42;
+		final ArrayBlockingQueue<String> reportedPayloads = new ArrayBlockingQueue<>(2);
+		final TestingHeartbeatListener<String, Integer> heartbeatListener = new TestingHeartbeatListenerBuilder<String, Integer>()
+			.setReportPayloadConsumer((ignored, payload) -> reportedPayloads.offer(payload))
+			.setRetrievePayloadFunction((ignored) -> CompletableFuture.completedFuture(outputPayload))
+			.createNewTestingHeartbeatListener();
 
-		Object expectedObject = new Object();
-
-		when(heartbeatListener.retrievePayload(any(ResourceID.class))).thenReturn(CompletableFuture.completedFuture(expectedObject));
-
-		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
+		HeartbeatManagerImpl<String, Integer> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			ownResourceID,
 			heartbeatListener,
-			new DirectExecutorService(),
-			scheduledExecutor,
+			TestingUtils.defaultScheduledExecutor(),
 			LOG);
 
-		@SuppressWarnings("unchecked")
-		HeartbeatTarget<Object> heartbeatTarget = mock(HeartbeatTarget.class);
+		final ArrayBlockingQueue<Integer> reportedPayloadsHeartbeatTarget = new ArrayBlockingQueue<>(2);
+		final TestingHeartbeatTarget<Integer> heartbeatTarget = new TestingHeartbeatTargetBuilder<Integer>()
+			.setReceiveHeartbeatConsumer((ignoredA, payload) -> reportedPayloadsHeartbeatTarget.offer(payload))
+			.createTestingHeartbeatTarget();
 
 		heartbeatManager.monitorTarget(targetResourceID, heartbeatTarget);
 
-		heartbeatManager.requestHeartbeat(targetResourceID, expectedObject);
+		final String inputPayload1 = "foobar";
+		heartbeatManager.requestHeartbeat(targetResourceID, inputPayload1);
 
-		verify(heartbeatListener, times(1)).reportPayload(targetResourceID, expectedObject);
-		verify(heartbeatListener, times(1)).retrievePayload(any(ResourceID.class));
-		verify(heartbeatTarget, times(1)).receiveHeartbeat(ownResourceID, expectedObject);
+		assertThat(reportedPayloads.take(), is(inputPayload1));
+		assertThat(reportedPayloadsHeartbeatTarget.take(), is(outputPayload));
 
-		heartbeatManager.receiveHeartbeat(targetResourceID, expectedObject);
-
-		verify(heartbeatListener, times(2)).reportPayload(targetResourceID, expectedObject);
+		final String inputPayload2 = "barfoo";
+		heartbeatManager.receiveHeartbeat(targetResourceID, inputPayload2);
+		assertThat(reportedPayloads.take(), is(inputPayload2));
 	}
 
 	/**
@@ -122,7 +128,6 @@ public class HeartbeatManagerTest extends TestLogger {
 			heartbeatTimeout,
 			ownResourceID,
 			heartbeatListener,
-			new DirectExecutorService(),
 			scheduledExecutor,
 			LOG);
 
@@ -151,7 +156,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		ResourceID ownResourceID = new ResourceID("foobar");
 		ResourceID targetResourceID = new ResourceID("barfoo");
-		TestingHeartbeatListener heartbeatListener = new TestingHeartbeatListener(payload);
+		SimpleTestingHeartbeatListener heartbeatListener = new SimpleTestingHeartbeatListener(payload);
 		ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
 		ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
 
@@ -163,7 +168,6 @@ public class HeartbeatManagerTest extends TestLogger {
 			heartbeatTimeout,
 			ownResourceID,
 			heartbeatListener,
-			new DirectExecutorService(),
 			new ScheduledExecutorServiceAdapter(new ScheduledThreadPoolExecutor(1)),
 			LOG);
 
@@ -198,53 +202,57 @@ public class HeartbeatManagerTest extends TestLogger {
 	public void testHeartbeatCluster() throws Exception {
 		long heartbeatTimeout = 100L;
 		long heartbeatPeriod = 20L;
-		Object object = new Object();
-		Object object2 = new Object();
-		ResourceID resourceID = new ResourceID("foobar");
-		ResourceID resourceID2 = new ResourceID("barfoo");
-		@SuppressWarnings("unchecked")
-		HeartbeatListener<Object, Object> heartbeatListener = mock(HeartbeatListener.class);
+		ResourceID resourceIdTarget = new ResourceID("foobar");
+		ResourceID resourceIDSender = new ResourceID("barfoo");
+		final int targetPayload = 42;
+		final AtomicInteger numReportPayloadCallsTarget = new AtomicInteger(0);
+		final TestingHeartbeatListener<String, Integer> heartbeatListenerTarget = new TestingHeartbeatListenerBuilder<String, Integer>()
+			.setRetrievePayloadFunction(ignored -> CompletableFuture.completedFuture(targetPayload))
+			.setReportPayloadConsumer((ignoredA, ignoredB) -> numReportPayloadCallsTarget.incrementAndGet())
+			.createNewTestingHeartbeatListener();
 
-		when(heartbeatListener.retrievePayload(any(ResourceID.class))).thenReturn(CompletableFuture.completedFuture(object));
+		final String senderPayload = "1337";
+		final CompletableFuture<ResourceID> targetHeartbeatTimeoutFuture = new CompletableFuture<>();
+		final AtomicInteger numReportPayloadCallsSender = new AtomicInteger(0);
+		final TestingHeartbeatListener<Integer, String> heartbeatListenerSender = new TestingHeartbeatListenerBuilder<Integer, String>()
+			.setRetrievePayloadFunction(ignored -> CompletableFuture.completedFuture(senderPayload))
+			.setNotifyHeartbeatTimeoutConsumer(targetHeartbeatTimeoutFuture::complete)
+			.setReportPayloadConsumer((ignoredA, ignoredB) -> numReportPayloadCallsSender.incrementAndGet())
+			.createNewTestingHeartbeatListener();
 
-		TestingHeartbeatListener heartbeatListener2 = new TestingHeartbeatListener(object2);
-
-		CompletableFuture<ResourceID> futureTimeout = heartbeatListener2.getTimeoutFuture();
-
-		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
+		HeartbeatManagerImpl<String, Integer> heartbeatManagerTarget = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
-			resourceID,
-			heartbeatListener,
-			new DirectExecutorService(),
-			new ScheduledExecutorServiceAdapter(new ScheduledThreadPoolExecutor(1)),
+			resourceIdTarget,
+			heartbeatListenerTarget,
+			TestingUtils.defaultScheduledExecutor(),
 			LOG);
 
-		HeartbeatManagerSenderImpl<Object, Object> heartbeatManager2 = new HeartbeatManagerSenderImpl<>(
+		HeartbeatManagerSenderImpl<Integer, String> heartbeatManagerSender = new HeartbeatManagerSenderImpl<>(
 			heartbeatPeriod,
 			heartbeatTimeout,
-			resourceID2,
-			heartbeatListener2,
-			new DirectExecutorService(),
-			new ScheduledExecutorServiceAdapter(new ScheduledThreadPoolExecutor(1)),
+			resourceIDSender,
+			heartbeatListenerSender,
+			TestingUtils.defaultScheduledExecutor(),
 			LOG);
 
-		heartbeatManager.monitorTarget(resourceID2, heartbeatManager2);
-		heartbeatManager2.monitorTarget(resourceID, heartbeatManager);
+		heartbeatManagerTarget.monitorTarget(resourceIDSender, heartbeatManagerSender);
+		heartbeatManagerSender.monitorTarget(resourceIdTarget, heartbeatManagerTarget);
 
 		Thread.sleep(2 * heartbeatTimeout);
 
-		assertFalse(futureTimeout.isDone());
+		assertFalse(targetHeartbeatTimeoutFuture.isDone());
 
-		heartbeatManager.stop();
+		heartbeatManagerTarget.stop();
 
-		ResourceID timeoutResourceID = futureTimeout.get(2 * heartbeatTimeout, TimeUnit.MILLISECONDS);
+		ResourceID timeoutResourceID = targetHeartbeatTimeoutFuture.get(2 * heartbeatTimeout, TimeUnit.MILLISECONDS);
 
-		assertEquals(resourceID, timeoutResourceID);
+		assertThat(timeoutResourceID, is(resourceIdTarget));
 
 		int numberHeartbeats = (int) (2 * heartbeatTimeout / heartbeatPeriod);
 
-		verify(heartbeatListener, atLeast(numberHeartbeats / 2)).reportPayload(resourceID2, object2);
-		assertTrue(heartbeatListener2.getNumberHeartbeatReports() >= numberHeartbeats / 2);
+		final Matcher<Integer> numberHeartbeatsMatcher = greaterThanOrEqualTo(numberHeartbeats / 2);
+		assertThat(numReportPayloadCallsTarget.get(), is(numberHeartbeatsMatcher));
+		assertThat(numReportPayloadCallsSender.get(), is(numberHeartbeatsMatcher));
 	}
 
 	/**
@@ -258,13 +266,12 @@ public class HeartbeatManagerTest extends TestLogger {
 		ResourceID targetID = new ResourceID("target");
 		Object object = new Object();
 
-		TestingHeartbeatListener heartbeatListener = new TestingHeartbeatListener(object);
+		SimpleTestingHeartbeatListener heartbeatListener = new SimpleTestingHeartbeatListener(object);
 
 		HeartbeatManager<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			resourceID,
 			heartbeatListener,
-			new DirectExecutorService(),
 			new ScheduledExecutorServiceAdapter(new ScheduledThreadPoolExecutor(1)),
 			LOG);
 
@@ -298,7 +305,6 @@ public class HeartbeatManagerTest extends TestLogger {
 			heartbeatTimeout,
 			resourceId,
 			heartbeatListener,
-			Executors.directExecutor(),
 			mock(ScheduledExecutor.class),
 			LOG);
 
@@ -326,7 +332,6 @@ public class HeartbeatManagerTest extends TestLogger {
 			heartbeatTimeout,
 			resourceId,
 			heartbeatListener,
-			Executors.directExecutor(),
 			mock(ScheduledExecutor.class),
 			LOG);
 
@@ -350,23 +355,35 @@ public class HeartbeatManagerTest extends TestLogger {
 	 * {@link HeartbeatManagerImpl}.
 	 */
 	@Test
-	public void testHeartbeatManagerTargetPayload() {
+	public void testHeartbeatManagerTargetPayload() throws Exception {
 		final long heartbeatTimeout = 100L;
 
 		final ResourceID someTargetId = ResourceID.generate();
 		final ResourceID specialTargetId = ResourceID.generate();
-		final TargetDependentHeartbeatReceiver someHeartbeatTarget = new TargetDependentHeartbeatReceiver();
-		final TargetDependentHeartbeatReceiver specialHeartbeatTarget = new TargetDependentHeartbeatReceiver();
 
-		final int defaultResponse = 0;
-		final int specialResponse = 1;
+		final Map<ResourceID, Integer> payloads = new HashMap<>(2);
+		payloads.put(someTargetId, 0);
+		payloads.put(specialTargetId, 1);
+
+		final CompletableFuture<Integer> someHeartbeatPayloadFuture = new CompletableFuture<>();
+		final TestingHeartbeatTarget<Integer> someHeartbeatTarget = new TestingHeartbeatTargetBuilder<Integer>()
+			.setReceiveHeartbeatConsumer((ignored, payload) -> someHeartbeatPayloadFuture.complete(payload))
+			.createTestingHeartbeatTarget();
+
+		final CompletableFuture<Integer> specialHeartbeatPayloadFuture = new CompletableFuture<>();
+		final TestingHeartbeatTarget<Integer> specialHeartbeatTarget = new TestingHeartbeatTargetBuilder<Integer>()
+			.setReceiveHeartbeatConsumer((ignored, payload) -> specialHeartbeatPayloadFuture.complete(payload))
+			.createTestingHeartbeatTarget();
+
+		final TestingHeartbeatListener<Void, Integer> testingHeartbeatListener = new TestingHeartbeatListenerBuilder<Void, Integer>()
+			.setRetrievePayloadFunction(resourceId -> CompletableFuture.completedFuture(payloads.get(resourceId)))
+			.createNewTestingHeartbeatListener();
 
 		HeartbeatManager<?, Integer> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			ResourceID.generate(),
-			new TargetDependentHeartbeatSender(specialTargetId, specialResponse, defaultResponse),
-			Executors.directExecutor(),
-			mock(ScheduledExecutor.class),
+			testingHeartbeatListener,
+			TestingUtils.defaultScheduledExecutor(),
 			LOG);
 
 		try {
@@ -374,10 +391,10 @@ public class HeartbeatManagerTest extends TestLogger {
 			heartbeatManager.monitorTarget(specialTargetId, specialHeartbeatTarget);
 
 			heartbeatManager.requestHeartbeat(someTargetId, null);
-			assertEquals(defaultResponse, someHeartbeatTarget.getLastReceivedHeartbeatPayload());
+			assertThat(someHeartbeatPayloadFuture.get(), is(payloads.get(someTargetId)));
 
 			heartbeatManager.requestHeartbeat(specialTargetId, null);
-			assertEquals(specialResponse, specialHeartbeatTarget.getLastReceivedHeartbeatPayload());
+			assertThat(specialHeartbeatPayloadFuture.get(), is(payloads.get(specialTargetId)));
 		} finally {
 			heartbeatManager.stop();
 		}
@@ -411,7 +428,6 @@ public class HeartbeatManagerTest extends TestLogger {
 			heartbeatTimeout,
 			ResourceID.generate(),
 			new TargetDependentHeartbeatSender(specialTargetId, specialResponse, defaultResponse),
-			Executors.directExecutor(),
 			new ScheduledExecutorServiceAdapter(scheduledThreadPoolExecutor),
 			LOG);
 
@@ -501,7 +517,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		}
 	}
 
-	static class TestingHeartbeatListener implements HeartbeatListener<Object, Object> {
+	static class SimpleTestingHeartbeatListener implements HeartbeatListener<Object, Object> {
 
 		private final CompletableFuture<ResourceID> future = new CompletableFuture<>();
 
@@ -509,7 +525,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		private int numberHeartbeatReports;
 
-		TestingHeartbeatListener(Object payload) {
+		SimpleTestingHeartbeatListener(Object payload) {
 			this.payload = payload;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatListener.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.heartbeat;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class TestingHeartbeatListener<I, O> implements HeartbeatListener<I, O> {
+
+	private final Consumer<ResourceID> notifyHeartbeatTimeoutConsumer;
+
+	private final BiConsumer<ResourceID, I> reportPayloadConsumer;
+
+	private final Function<ResourceID, CompletableFuture<O>> retrievePayloadFunction;
+
+	TestingHeartbeatListener(Consumer<ResourceID> notifyHeartbeatTimeoutConsumer, BiConsumer<ResourceID, I> reportPayloadConsumer, Function<ResourceID, CompletableFuture<O>> retrievePayloadFunction) {
+		this.notifyHeartbeatTimeoutConsumer = notifyHeartbeatTimeoutConsumer;
+		this.reportPayloadConsumer = reportPayloadConsumer;
+		this.retrievePayloadFunction = retrievePayloadFunction;
+	}
+
+	@Override
+	public void notifyHeartbeatTimeout(ResourceID resourceID) {
+		notifyHeartbeatTimeoutConsumer.accept(resourceID);
+	}
+
+	@Override
+	public void reportPayload(ResourceID resourceID, I payload) {
+		reportPayloadConsumer.accept(resourceID, payload);
+	}
+
+	@Override
+	public CompletableFuture<O> retrievePayload(ResourceID resourceID) {
+		return retrievePayloadFunction.apply(resourceID);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatListenerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatListenerBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.heartbeat;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+class TestingHeartbeatListenerBuilder<I, O> {
+	private Consumer<ResourceID> notifyHeartbeatTimeoutConsumer = ignored -> {};
+	private BiConsumer<ResourceID, I> reportPayloadConsumer = (ignoredA, ignoredB) -> {};
+	private Function<ResourceID, CompletableFuture<O>> retrievePayloadFunction = ignored -> CompletableFuture.completedFuture(null);
+
+	public TestingHeartbeatListenerBuilder<I, O> setNotifyHeartbeatTimeoutConsumer(Consumer<ResourceID> notifyHeartbeatTimeoutConsumer) {
+		this.notifyHeartbeatTimeoutConsumer = notifyHeartbeatTimeoutConsumer;
+		return this;
+	}
+
+	public TestingHeartbeatListenerBuilder<I, O> setReportPayloadConsumer(BiConsumer<ResourceID, I> reportPayloadConsumer) {
+		this.reportPayloadConsumer = reportPayloadConsumer;
+		return this;
+	}
+
+	public TestingHeartbeatListenerBuilder<I, O> setRetrievePayloadFunction(Function<ResourceID, CompletableFuture<O>> retrievePayloadFunction) {
+		this.retrievePayloadFunction = retrievePayloadFunction;
+		return this;
+	}
+
+	public TestingHeartbeatListener<I, O> createNewTestingHeartbeatListener() {
+		return new TestingHeartbeatListener<>(notifyHeartbeatTimeoutConsumer, reportPayloadConsumer, retrievePayloadFunction);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
@@ -18,39 +18,12 @@
 
 package org.apache.flink.runtime.heartbeat;
 
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.ScheduledExecutor;
-import org.apache.flink.util.Preconditions;
-
-import org.slf4j.Logger;
-
 /**
- * A {@link HeartbeatServices} that allows the injection of a {@link ScheduledExecutor}.
+ * A {@link HeartbeatServices} implementation for testing purposes.
  */
 public class TestingHeartbeatServices extends HeartbeatServices {
 
-	private final ScheduledExecutor scheduledExecutorToUse;
-
-	public TestingHeartbeatServices(long heartbeatInterval, long heartbeatTimeout, ScheduledExecutor scheduledExecutorToUse) {
-		super(heartbeatInterval, heartbeatTimeout);
-
-		this.scheduledExecutorToUse = Preconditions.checkNotNull(scheduledExecutorToUse);
-	}
-
-	@Override
-	public <I, O> HeartbeatManager<I, O> createHeartbeatManagerSender(
-		ResourceID resourceId,
-		HeartbeatListener<I, O> heartbeatListener,
-		ScheduledExecutor scheduledExecutor,
-		Logger log) {
-
-		return new HeartbeatManagerSenderImpl<>(
-			heartbeatInterval,
-			heartbeatTimeout,
-			resourceId,
-			heartbeatListener,
-			org.apache.flink.runtime.concurrent.Executors.directExecutor(),
-			scheduledExecutorToUse,
-			log);
+	public TestingHeartbeatServices() {
+		super(1000L, 10000L);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatTarget.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatTarget.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.heartbeat;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.util.function.BiConsumer;
+
+class TestingHeartbeatTarget<T> implements HeartbeatTarget<T> {
+	private final BiConsumer<ResourceID, T> receiveHeartbeatConsumer;
+
+	private final BiConsumer<ResourceID, T> requestHeartbeatConsumer;
+
+	TestingHeartbeatTarget(BiConsumer<ResourceID, T> receiveHeartbeatConsumer, BiConsumer<ResourceID, T> requestHeartbeatConsumer) {
+		this.receiveHeartbeatConsumer = receiveHeartbeatConsumer;
+		this.requestHeartbeatConsumer = requestHeartbeatConsumer;
+	}
+
+	@Override
+	public void receiveHeartbeat(ResourceID heartbeatOrigin, T heartbeatPayload) {
+		receiveHeartbeatConsumer.accept(heartbeatOrigin, heartbeatPayload);
+	}
+
+	@Override
+	public void requestHeartbeat(ResourceID requestOrigin, T heartbeatPayload) {
+		requestHeartbeatConsumer.accept(requestOrigin, heartbeatPayload);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatTargetBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatTargetBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.heartbeat;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.util.function.BiConsumer;
+
+class TestingHeartbeatTargetBuilder<T> {
+	private BiConsumer<ResourceID, T> receiveHeartbeatConsumer = (ignoredA, ignoredB) -> {};
+	private BiConsumer<ResourceID, T> requestHeartbeatConsumer = (ignoredA, ignoredB) -> {};
+
+	public TestingHeartbeatTargetBuilder<T> setReceiveHeartbeatConsumer(BiConsumer<ResourceID, T> receiveHeartbeatConsumer) {
+		this.receiveHeartbeatConsumer = receiveHeartbeatConsumer;
+		return this;
+	}
+
+	public TestingHeartbeatTargetBuilder<T> setRequestHeartbeatConsumer(BiConsumer<ResourceID, T> requestHeartbeatConsumer) {
+		this.requestHeartbeatConsumer = requestHeartbeatConsumer;
+		return this;
+	}
+
+	public TestingHeartbeatTarget<T> createTestingHeartbeatTarget() {
+		return new TestingHeartbeatTarget<>(receiveHeartbeatConsumer, requestHeartbeatConsumer);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -18,16 +18,24 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
+import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerBuilder;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
+import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -35,6 +43,7 @@ import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -43,19 +52,39 @@ import org.junit.Test;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Tests for the new ResourceManager.
+ */
 public class ResourceManagerTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.seconds(10L);
 
 	private TestingRpcService rpcService;
 
+	private TestingHighAvailabilityServices highAvailabilityServices;
+
 	@Before
 	public void setUp() {
+		highAvailabilityServices = new TestingHighAvailabilityServices();
 		rpcService = new TestingRpcService();
 	}
 
 	@After
-	public void tearDown() throws ExecutionException, InterruptedException {
+	public void tearDown() throws Exception {
+		if (highAvailabilityServices != null) {
+			highAvailabilityServices.closeAndCleanupAllData();
+			highAvailabilityServices = null;
+		}
+
 		if (rpcService != null) {
 			rpcService.stopService().get();
 			rpcService = null;
@@ -141,5 +170,135 @@ public class ResourceManagerTest extends TestLogger {
 			RpcUtils.terminateRpcEndpoint(resourceManager, TestingUtils.TIMEOUT());
 			highAvailabilityServices.close();
 		}
+	}
+
+	@Test
+	public void testHeartbeatTimeoutWithJobMaster() throws Exception {
+		final CompletableFuture<ResourceID> heartbeatRequestFuture = new CompletableFuture<>();
+		final CompletableFuture<ResourceManagerId> disconnectFuture = new CompletableFuture<>();
+		final TestingJobMasterGateway jobMasterGateway = new TestingJobMasterGatewayBuilder()
+			.setResourceManagerHeartbeatConsumer(heartbeatRequestFuture::complete)
+			.setDisconnectResourceManagerConsumer(disconnectFuture::complete)
+			.build();
+		rpcService.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
+		final JobID jobId = new JobID();
+		final ResourceID jobMasterResourceId = ResourceID.generate();
+		final LeaderRetrievalService jobMasterLeaderRetrievalService = new SettableLeaderRetrievalService(jobMasterGateway.getAddress(), jobMasterGateway.getFencingToken().toUUID());
+
+		highAvailabilityServices.setJobMasterLeaderRetriever(jobId, jobMasterLeaderRetrievalService);
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
+
+		runHeartbeatTimeoutTest(
+			resourceManagerId,
+			resourceManagerGateway -> {
+				final CompletableFuture<RegistrationResponse> registrationFuture = resourceManagerGateway.registerJobManager(
+					jobMasterGateway.getFencingToken(),
+					jobMasterResourceId,
+					jobMasterGateway.getAddress(),
+					jobId,
+					TIMEOUT);
+
+				assertThat(registrationFuture.get(), instanceOf(RegistrationResponse.Success.class));
+			},
+			resourceManagerResourceId -> {
+				final ResourceID optionalHeartbeatRequest = heartbeatRequestFuture.getNow(null);
+				assertThat(optionalHeartbeatRequest, anyOf(is(resourceManagerResourceId), is(nullValue())));
+				assertThat(disconnectFuture.get(), is(equalTo(resourceManagerId)));
+			});
+	}
+
+	@Test
+	public void testHeartbeatTimeoutWithTaskExecutor() throws Exception {
+		final ResourceID taskExecutorId = ResourceID.generate();
+		final CompletableFuture<ResourceID> heartbeatRequestFuture = new CompletableFuture<>();
+		final CompletableFuture<Exception> disconnectFuture = new CompletableFuture<>();
+		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setDisconnectResourceManagerConsumer(disconnectFuture::complete)
+			.setHeartbeatResourceManagerConsumer(heartbeatRequestFuture::complete)
+			.createTestingTaskExecutorGateway();
+		rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
+
+		runHeartbeatTimeoutTest(
+			ResourceManagerId.generate(),
+			resourceManagerGateway -> {
+				registerTaskExecutor(resourceManagerGateway, taskExecutorId, taskExecutorGateway.getAddress());
+			},
+			resourceManagerResourceId -> {
+				final ResourceID optionalHeartbeatRequest = heartbeatRequestFuture.getNow(null);
+				assertThat(optionalHeartbeatRequest, anyOf(is(resourceManagerResourceId), is(nullValue())));
+				assertThat(disconnectFuture.get(), instanceOf(TimeoutException.class));
+			}
+		);
+	}
+
+	private void runHeartbeatTimeoutTest(
+		ResourceManagerId resourceManagerId,
+		ThrowingConsumer<ResourceManagerGateway, Exception> registerComponentAtResourceManager,
+		ThrowingConsumer<ResourceID, Exception> verifyHeartbeatTimeout) throws Exception {
+		final TestingLeaderElectionService resourceManagerLeaderElectionService = new TestingLeaderElectionService();
+		highAvailabilityServices.setResourceManagerLeaderElectionService(resourceManagerLeaderElectionService);
+
+		final ResourceID resourceManagerResourceId = ResourceID.generate();
+		final TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
+		final org.apache.flink.runtime.resourcemanager.TestingResourceManager testingResourceManager = createAndStartResourceManager(
+			rpcService,
+			resourceManagerResourceId,
+			new HeartbeatServices(1L, 1L),
+			testingFatalErrorHandler);
+
+		// first make the ResourceManager the leader
+		resourceManagerLeaderElectionService.isLeader(resourceManagerId.toUUID()).get();
+
+		final ResourceManagerGateway resourceManagerGateway = testingResourceManager.getSelfGateway(ResourceManagerGateway.class);
+
+		try {
+			registerComponentAtResourceManager.accept(resourceManagerGateway);
+			verifyHeartbeatTimeout.accept(resourceManagerResourceId);
+		} finally {
+			RpcUtils.terminateRpcEndpoint(testingResourceManager, TIMEOUT);
+		}
+
+		testingFatalErrorHandler.rethrowError();
+	}
+
+	private org.apache.flink.runtime.resourcemanager.TestingResourceManager createAndStartResourceManager(
+		RpcService rpcService,
+		ResourceID resourceManagerResourceId,
+		HeartbeatServices heartbeatServices,
+		TestingFatalErrorHandler testingFatalErrorHandler) throws Exception {
+		final SlotManager slotManager = SlotManagerBuilder.newBuilder()
+			.setScheduledExecutor(rpcService.getScheduledExecutor())
+			.build();
+		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
+			highAvailabilityServices,
+			rpcService.getScheduledExecutor(),
+			TestingUtils.infiniteTime());
+
+		final org.apache.flink.runtime.resourcemanager.TestingResourceManager resourceManager = new org.apache.flink.runtime.resourcemanager.TestingResourceManager(
+			rpcService,
+			ResourceManager.RESOURCE_MANAGER_NAME + UUID.randomUUID(),
+			resourceManagerResourceId,
+			highAvailabilityServices,
+			heartbeatServices,
+			slotManager,
+			NoOpMetricRegistry.INSTANCE,
+			jobLeaderIdService,
+			testingFatalErrorHandler,
+			UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup());
+
+		resourceManager.start();
+
+		return resourceManager;
+	}
+
+	private void registerTaskExecutor(ResourceManagerGateway resourceManagerGateway, ResourceID taskExecutorId, String taskExecutorAddress) throws Exception {
+		final CompletableFuture<RegistrationResponse> registrationFuture = resourceManagerGateway.registerTaskExecutor(
+			taskExecutorAddress,
+			taskExecutorId,
+			1234,
+			new HardwareDescription(42, 1337L, 1337L, 0L),
+			TestingUtils.TIMEOUT());
+
+		assertThat(registrationFuture.get(), instanceOf(RegistrationResponse.Success.class));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1735,6 +1735,7 @@ public class TaskExecutorTest extends TestLogger {
 
 		final CountDownLatch slotOfferings = new CountDownLatch(2);
 		final BlockingQueue<AllocationID> failedSlotFutures = new ArrayBlockingQueue<>(2);
+		final ResourceID jobManagerResourceId = ResourceID.generate();
 		final TestingJobMasterGateway jobMasterGateway = new TestingJobMasterGatewayBuilder()
 				.setFailSlotConsumer((resourceID, allocationID, throwable) ->
 					failedSlotFutures.offer(allocationID))
@@ -1742,6 +1743,7 @@ public class TaskExecutorTest extends TestLogger {
 					slotOffers.forEach((ignored) -> slotOfferings.countDown());
 					return CompletableFuture.completedFuture(new ArrayList<>(slotOffers));
 				})
+				.setRegisterTaskManagerFunction((ignoredA, ignoredB) -> CompletableFuture.completedFuture(new JMTMRegistrationSuccess(jobManagerResourceId)))
 				.build();
 		final String jobManagerAddress = jobMasterGateway.getAddress();
 		rpc.registerGateway(jobManagerAddress, jobMasterGateway);
@@ -1770,7 +1772,7 @@ public class TaskExecutorTest extends TestLogger {
 					new AllocatedSlotInfo(1, allocationIdOnlyInJM)
 			);
 			AllocatedSlotReport allocatedSlotReport = new AllocatedSlotReport(jobId, allocatedSlotInfos);
-			taskExecutorGateway.heartbeatFromJobManager(ResourceID.generate(), allocatedSlotReport);
+			taskExecutorGateway.heartbeatFromJobManager(jobManagerResourceId, allocatedSlotReport);
 
 			assertThat(failedSlotFutures.take(), is(allocationIdOnlyInJM));
 			assertThat(allocationsNotifiedFree.take(), is(allocationIdOnlyInTM));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -125,7 +125,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -463,7 +462,6 @@ public class TaskExecutorTest extends TestLogger {
 						heartbeatTimeout,
 						taskManagerLocation.getResourceID(),
 						(HeartbeatListener<SlotReport, Void>) invocation.getArguments()[1],
-						(Executor) invocation.getArguments()[2],
 						(ScheduledExecutor) invocation.getArguments()[2],
 						(Logger) invocation.getArguments()[3]));
 				}
@@ -1837,13 +1835,12 @@ public class TaskExecutorTest extends TestLogger {
 		}
 
 		@Override
-		public <I, O> HeartbeatManager<I, O> createHeartbeatManager(ResourceID resourceId, HeartbeatListener<I, O> heartbeatListener, ScheduledExecutor scheduledExecutor, Logger log) {
+		public <I, O> HeartbeatManager<I, O> createHeartbeatManager(ResourceID resourceId, HeartbeatListener<I, O> heartbeatListener, ScheduledExecutor mainThreadExecutor, Logger log) {
 			return new RecordingHeartbeatManagerImpl<>(
 				heartbeatTimeout,
 				resourceId,
 				heartbeatListener,
-				scheduledExecutor,
-				scheduledExecutor,
+				mainThreadExecutor,
 				log,
 				unmonitoredTargets,
 				monitoredTargets);
@@ -1871,12 +1868,11 @@ public class TaskExecutorTest extends TestLogger {
 				long heartbeatTimeoutIntervalMs,
 				ResourceID ownResourceID,
 				HeartbeatListener<I, O> heartbeatListener,
-				Executor executor,
-				ScheduledExecutor scheduledExecutor,
+				ScheduledExecutor mainThreadExecutor,
 				Logger log,
 				BlockingQueue<ResourceID> unmonitoredTargets,
 				BlockingQueue<ResourceID> monitoredTargets) {
-			super(heartbeatTimeoutIntervalMs, ownResourceID, heartbeatListener, executor, scheduledExecutor, log);
+			super(heartbeatTimeoutIntervalMs, ownResourceID, heartbeatListener, mainThreadExecutor, log);
 			this.unmonitoredTargets = unmonitoredTargets;
 			this.monitoredTargets = monitoredTargets;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -81,6 +81,7 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.exceptions.RegistrationTimeoutException;
 import org.apache.flink.runtime.taskexecutor.exceptions.TaskManagerException;
+import org.apache.flink.runtime.taskexecutor.slot.SlotNotFoundException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
@@ -1705,11 +1706,13 @@ public class TaskExecutorTest extends TestLogger {
 	 * Tests that the TaskExecutor syncs its slots view with the JobMaster's view
 	 * via the AllocatedSlotReport reported by the heartbeat (See FLINK-11059).
 	 */
-	@Test(timeout = 10000L)
+	@Test
 	public void testSyncSlotsWithJobMasterByHeartbeat() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(
+		final CountDownLatch activeSlots = new CountDownLatch(2);
+		final TaskSlotTable taskSlotTable = new ActivateSlotNotifyingTaskSlotTable(
 				Arrays.asList(ResourceProfile.UNKNOWN, ResourceProfile.UNKNOWN),
-				timerService);
+				timerService,
+				activeSlots);
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder().setTaskSlotTable(taskSlotTable).build();
 
 		final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
@@ -1731,16 +1734,12 @@ public class TaskExecutorTest extends TestLogger {
 		rpc.registerGateway(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway);
 		resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway.getFencingToken().toUUID());
 
-		final CountDownLatch slotOfferings = new CountDownLatch(2);
 		final BlockingQueue<AllocationID> failedSlotFutures = new ArrayBlockingQueue<>(2);
 		final ResourceID jobManagerResourceId = ResourceID.generate();
 		final TestingJobMasterGateway jobMasterGateway = new TestingJobMasterGatewayBuilder()
 				.setFailSlotConsumer((resourceID, allocationID, throwable) ->
 					failedSlotFutures.offer(allocationID))
-				.setOfferSlotsFunction((resourceID, slotOffers) -> {
-					slotOffers.forEach((ignored) -> slotOfferings.countDown());
-					return CompletableFuture.completedFuture(new ArrayList<>(slotOffers));
-				})
+				.setOfferSlotsFunction((resourceID, slotOffers) -> CompletableFuture.completedFuture(new ArrayList<>(slotOffers)))
 				.setRegisterTaskManagerFunction((ignoredA, ignoredB) -> CompletableFuture.completedFuture(new JMTMRegistrationSuccess(jobManagerResourceId)))
 				.build();
 		final String jobManagerAddress = jobMasterGateway.getAddress();
@@ -1763,7 +1762,7 @@ public class TaskExecutorTest extends TestLogger {
 			taskExecutorGateway.requestSlot(slotId1, jobId, allocationIdInBoth, "foobar", testingResourceManagerGateway.getFencingToken(), timeout);
 			taskExecutorGateway.requestSlot(slotId2, jobId, allocationIdOnlyInTM, "foobar", testingResourceManagerGateway.getFencingToken(), timeout);
 
-			slotOfferings.await();
+			activeSlots.await();
 
 			List<AllocatedSlotInfo> allocatedSlotInfos = Arrays.asList(
 					new AllocatedSlotInfo(0, allocationIdInBoth),
@@ -1887,6 +1886,27 @@ public class TaskExecutorTest extends TestLogger {
 		public void monitorTarget(ResourceID resourceID, HeartbeatTarget<O> heartbeatTarget) {
 			super.monitorTarget(resourceID, heartbeatTarget);
 			monitoredTargets.offer(resourceID);
+		}
+	}
+
+	private static final class ActivateSlotNotifyingTaskSlotTable extends TaskSlotTable {
+
+		private final CountDownLatch slotsToActivate;
+
+		private ActivateSlotNotifyingTaskSlotTable(Collection<ResourceProfile> resourceProfiles, TimerService<AllocationID> timerService, CountDownLatch slotsToActivate) {
+			super(resourceProfiles, timerService);
+			this.slotsToActivate = slotsToActivate;
+		}
+
+		@Override
+		public boolean markSlotActive(AllocationID allocationId) throws SlotNotFoundException {
+			final boolean result = super.markSlotActive(allocationId);
+
+			if (result) {
+				slotsToActivate.countDown();
+			}
+
+			return result;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -54,6 +55,8 @@ public class TestingTaskExecutorGatewayBuilder {
 	private Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction = NOOP_REQUEST_SLOT_FUNCTION;
 	private BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction = NOOP_FREE_SLOT_FUNCTION;
 	private Supplier<Boolean> canBeReleasedSupplier = () -> true;
+	private Consumer<Exception> disconnectResourceManagerConsumer = ignored -> {};
+	private Consumer<ResourceID> heartbeatResourceManagerConsumer = ignored -> {};
 
 	public TestingTaskExecutorGatewayBuilder setAddress(String address) {
 		this.address = address;
@@ -67,6 +70,11 @@ public class TestingTaskExecutorGatewayBuilder {
 
 	public TestingTaskExecutorGatewayBuilder setHeartbeatJobManagerConsumer(BiConsumer<ResourceID, AllocatedSlotReport> heartbeatJobManagerConsumer) {
 		this.heartbeatJobManagerConsumer = heartbeatJobManagerConsumer;
+		return this;
+	}
+
+	public TestingTaskExecutorGatewayBuilder setHeartbeatResourceManagerConsumer(Consumer<ResourceID> heartbeatResourceManagerConsumer) {
+		this.heartbeatResourceManagerConsumer = heartbeatResourceManagerConsumer;
 		return this;
 	}
 
@@ -90,6 +98,11 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
+	public TestingTaskExecutorGatewayBuilder setDisconnectResourceManagerConsumer(Consumer<Exception> disconnectResourceManagerConsumer) {
+		this.disconnectResourceManagerConsumer = disconnectResourceManagerConsumer;
+		return this;
+	}
+
 	public TestingTaskExecutorGatewayBuilder setCanBeReleasedSupplier(Supplier<Boolean> canBeReleasedSupplier) {
 		this.canBeReleasedSupplier = canBeReleasedSupplier;
 		return this;
@@ -104,6 +117,8 @@ public class TestingTaskExecutorGatewayBuilder {
 			submitTaskConsumer,
 			requestSlotFunction,
 			freeSlotFunction,
-			canBeReleasedSupplier);
+			canBeReleasedSupplier,
+			disconnectResourceManagerConsumer,
+			heartbeatResourceManagerConsumer);
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -27,11 +27,9 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
-import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
@@ -292,7 +290,6 @@ public class YarnResourceManagerTest extends TestLogger {
 		 */
 		class MockResourceManagerRuntimeServices {
 
-			private final ScheduledExecutor scheduledExecutor;
 			private final TestingHighAvailabilityServices highAvailabilityServices;
 			private final HeartbeatServices heartbeatServices;
 			private final MetricRegistry metricRegistry;
@@ -303,11 +300,10 @@ public class YarnResourceManagerTest extends TestLogger {
 			private UUID rmLeaderSessionId;
 
 			MockResourceManagerRuntimeServices() throws Exception {
-				scheduledExecutor = mock(ScheduledExecutor.class);
 				highAvailabilityServices = new TestingHighAvailabilityServices();
 				rmLeaderElectionService = new TestingLeaderElectionService();
 				highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
-				heartbeatServices = new TestingHeartbeatServices(5L, 5L, scheduledExecutor);
+				heartbeatServices = new HeartbeatServices(5L, 5L);
 				metricRegistry = NoOpMetricRegistry.INSTANCE;
 				slotManager = SlotManagerBuilder.newBuilder()
 					.setScheduledExecutor(new ScheduledExecutorServiceAdapter(new DirectScheduledExecutorService()))


### PR DESCRIPTION
Backport of #8783 to `release-1.7`.

Note that we cannot remove the `CompletableFuture` from the `HeartbeatListener` because we need to ask the `SlotPool` for the `AllocatedSlotProfile` and the `SlotPool` is still a separate `RpcEndpoint`. However since we also register the slots on the `SlotPool` for which we need to switch the thread boundaries, the order should be maintained as long as we execute everything else in the `JobMaster's` main thread.