### PR TITLE
[FLINK-12659][hive] Integrate Flink with Hive GenericUDTF

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.catalog.hive.util;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.types.AtomicDataType;
@@ -32,6 +33,7 @@ import org.apache.flink.table.types.logical.VarCharType;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
@@ -40,6 +42,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
 
 import java.util.ArrayList;
@@ -51,6 +54,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Utils to convert data types between Flink and Hive.
  */
+@Internal
 public class HiveTypeUtil {
 
 	private HiveTypeUtil() {
@@ -176,6 +180,16 @@ public class HiveTypeUtil {
 
 		throw new UnsupportedOperationException(
 			String.format("Flink doesn't support converting type %s to Hive type yet.", dataType.toString()));
+	}
+
+	/**
+	 * Convert a Hive ObjectInspector to a Flink data type.
+	 *
+	 * @param inspector a Hive inspector
+	 * @return the corresponding Flink data type
+	 */
+	public static DataType toFlinkType(ObjectInspector inspector) {
+		return toFlinkType(TypeInfoUtils.getTypeInfoFromTypeString(inspector.getTypeName()));
 	}
 
 	/**

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
@@ -91,7 +91,7 @@ public class HiveGenericUDTF extends TableFunction<Row> implements HiveFunction 
 			.allMatch(conv -> conv instanceof IdentityConversion);
 	}
 
-	// Will on take effect after calling open()
+	// Will only take effect after calling open()
 	@VisibleForTesting
 	protected final void setCollector(Collector collector) {
 		function.setCollector(collector);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
+import org.apache.flink.table.functions.hive.conversion.HiveObjectConversion;
+import org.apache.flink.table.functions.hive.conversion.IdentityConversion;
+import org.apache.flink.table.functions.hive.util.HiveFunctionUtil;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
+import org.apache.flink.types.Row;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.Collector;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A TableFunction implementation that calls Hive's {@link GenericUDTF}.
+ */
+@Internal
+public class HiveGenericUDTF extends TableFunction<Row> implements HiveFunction {
+	private static final Logger LOG = LoggerFactory.getLogger(HiveGenericUDTF.class);
+
+	private final HiveFunctionWrapper<GenericUDTF> hiveFunctionWrapper;
+
+	private Object[] constantArguments;
+	private DataType[] argTypes;
+
+	private transient GenericUDTF function;
+	private transient StructObjectInspector returnInspector;
+	private transient boolean isArgsSingleArray;
+
+	private transient boolean allIdentityConverter;
+	private transient HiveObjectConversion[] conversions;
+
+	public HiveGenericUDTF(HiveFunctionWrapper<GenericUDTF> hiveFunctionWrapper) {
+		this.hiveFunctionWrapper = hiveFunctionWrapper;
+	}
+
+	@Override
+	public void open(FunctionContext context) throws Exception {
+		function = hiveFunctionWrapper.createFunction();
+
+		function.setCollector(input -> {
+			Row row = (Row) HiveInspectors.toFlinkObject(returnInspector, input);
+			HiveGenericUDTF.this.collect(row);
+		});
+
+		ObjectInspector[] argumentInspectors = HiveInspectors.toInspectors(constantArguments, argTypes);
+		returnInspector = function.initialize(argumentInspectors);
+
+		isArgsSingleArray = HiveFunctionUtil.isSingleBoxedArray(argTypes);
+
+		conversions = new HiveObjectConversion[argumentInspectors.length];
+		for (int i = 0; i < argumentInspectors.length; i++) {
+			conversions[i] = HiveInspectors.getConversion(argumentInspectors[i], argTypes[i]);
+		}
+
+		allIdentityConverter = Arrays.stream(conversions)
+			.allMatch(conv -> conv instanceof IdentityConversion);
+	}
+
+	// Will on take effect after calling open()
+	@VisibleForTesting
+	protected final void setCollector(Collector collector) {
+		function.setCollector(collector);
+	}
+
+	public void eval(Object... args) throws HiveException {
+
+		// When the parameter is (Integer, Array[Double]), Flink calls udf.eval(Integer, Array[Double]), which is not a problem.
+		// But when the parameter is an single array, Flink calls udf.eval(Array[Double]),
+		// at this point java's var-args will cast Array[Double] to Array[Object] and let it be
+		// Object... args, So we need wrap it.
+		if (isArgsSingleArray) {
+			args = new Object[] {args};
+		}
+
+		checkArgument(args.length == conversions.length);
+
+		if (!allIdentityConverter) {
+			for (int i = 0; i < args.length; i++) {
+				args[i] = conversions[i].toHiveObject(args[i]);
+			}
+		}
+
+		function.process(args);
+	}
+
+	@Override
+	public void setArgumentTypesAndConstants(Object[] constantArguments, DataType[] argTypes) {
+		this.constantArguments = constantArguments;
+		this.argTypes = argTypes;
+	}
+
+	@Override
+	public DataType getHiveResultType(Object[] constantArguments, DataType[] argTypes) {
+		LOG.info("Getting result type of HiveGenericUDTF with {}", hiveFunctionWrapper.getClassName());
+
+		try {
+			ObjectInspector[] argumentInspectors = HiveInspectors.toInspectors(constantArguments, argTypes);
+			return HiveTypeUtil.toFlinkType(
+				hiveFunctionWrapper.createFunction().initialize(argumentInspectors));
+		} catch (UDFArgumentException e) {
+			throw new FlinkHiveUDFException(e);
+		}
+	}
+
+	@Override
+	public TypeInformation getResultType() {
+		return LegacyTypeInfoDataTypeConverter.toLegacyTypeInfo(
+			getHiveResultType(this.constantArguments, this.argTypes));
+	}
+
+	@Override
+	public void close() throws Exception {
+		function.close();
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.hive.util.HiveFunctionUtil;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -81,45 +82,7 @@ public abstract class HiveScalarFunction<UDFType> extends ScalarFunction impleme
 	public void open(FunctionContext context) {
 		openInternal();
 
-		for (DataType dataType : argTypes) {
-			if (isPrimitiveArray(dataType)) {
-				throw new FlinkHiveUDFException("Flink doesn't support primitive array for Hive functions yet.");
-			}
-		}
-
-		isArgsSingleArray = argTypes.length == 1 && isArrayType(argTypes[0]);
-	}
-
-	private static boolean isPrimitiveArray(DataType dataType) {
-		if (isArrayType(dataType)) {
-			ArrayType arrayType = (ArrayType) dataType.getLogicalType();
-
-			LogicalType elementType = arrayType.getElementType();
-			return !(elementType.isNullable() || !isPrimitive(elementType));
-		} else {
-			return false;
-		}
-	}
-
-	private static boolean isArrayType(DataType dataType) {
-		return dataType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.ARRAY);
-	}
-
-	// This is copied from PlannerTypeUtils in flink-table-runtime-blink that we shouldn't depend on
-	// TODO: remove this and use the original code when it's moved to accessible, dependable module
-	private static boolean isPrimitive(LogicalType type) {
-		switch (type.getTypeRoot()) {
-			case BOOLEAN:
-			case TINYINT:
-			case SMALLINT:
-			case INTEGER:
-			case BIGINT:
-			case FLOAT:
-			case DOUBLE:
-				return true;
-			default:
-				return false;
-		}
+		isArgsSingleArray = HiveFunctionUtil.isSingleBoxedArray(argTypes);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
@@ -24,9 +24,6 @@ import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.hive.util.HiveFunctionUtil;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
 
 import org.apache.hadoop.hive.ql.exec.UDF;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
@@ -24,8 +24,8 @@ import org.apache.flink.table.functions.hive.FlinkHiveUDFException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.VarCharType;
-
 import org.apache.flink.types.Row;
+
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveVarchar;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.VarCharType;
 
+import org.apache.flink.types.Row;
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -38,6 +39,8 @@ import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspector;
@@ -93,6 +96,7 @@ import org.apache.hadoop.io.Text;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.List;
 
 
 /**
@@ -364,7 +368,25 @@ public class HiveInspectors {
 			// TODO: handle decimal type
 		}
 
-		// TODO: handle complex types like struct, list, and map
+		// TODO: handle complex types like list and map
+
+		if (inspector instanceof StandardStructObjectInspector) {
+			StandardStructObjectInspector structInspector = (StandardStructObjectInspector) inspector;
+
+			List<? extends StructField> fields = structInspector.getAllStructFieldRefs();
+
+			Row row = new Row(fields.size());
+			for (int i = 0; i < row.getArity(); i++) {
+				row.setField(
+					i,
+					toFlinkObject(
+						fields.get(i).getFieldObjectInspector(),
+						structInspector.getStructFieldData(data, fields.get(i)))
+				);
+			}
+
+			return row;
+		}
 
 		throw new FlinkHiveUDFException(
 			String.format("Unwrap does not support ObjectInspector '%s' yet", inspector));

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/util/HiveFunctionUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/util/HiveFunctionUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.hive.FlinkHiveUDFException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+/**
+ * Util for Hive functions.
+ */
+@Internal
+public class HiveFunctionUtil {
+	public static boolean isSingleBoxedArray(DataType[] argTypes) {
+		for (DataType dataType : argTypes) {
+			if (HiveFunctionUtil.isPrimitiveArray(dataType)) {
+				throw new FlinkHiveUDFException("Flink doesn't support primitive array for Hive functions yet.");
+			}
+		}
+
+		return argTypes.length == 1 && HiveFunctionUtil.isArrayType(argTypes[0]);
+	}
+
+	private static boolean isPrimitiveArray(DataType dataType) {
+		if (isArrayType(dataType)) {
+			ArrayType arrayType = (ArrayType) dataType.getLogicalType();
+
+			LogicalType elementType = arrayType.getElementType();
+			return !(elementType.isNullable() || !isPrimitive(elementType));
+		} else {
+			return false;
+		}
+	}
+
+	// This is copied from PlannerTypeUtils in flink-table-runtime-blink that we shouldn't depend on
+	// TODO: remove this and use the original code when it's moved to accessible, dependable module
+	private static boolean isPrimitive(LogicalType type) {
+		switch (type.getTypeRoot()) {
+			case BOOLEAN:
+			case TINYINT:
+			case SMALLINT:
+			case INTEGER:
+			case BIGINT:
+			case FLOAT:
+			case DOUBLE:
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private static boolean isArrayType(DataType dataType) {
+		return dataType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.ARRAY);
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.Collector;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTFReplicateRows;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTFStack;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link HiveGenericUDTF}.
+ */
+public class HiveGenericUDTFTest {
+
+	private static TestCollector collector;
+
+	@Test
+	public void testOverSumInt() throws Exception {
+		Object[] constantArgs = new Object[] {
+			null,
+			4
+		};
+
+		DataType[] dataTypes = new DataType[] {
+			DataTypes.INT(),
+			DataTypes.INT()
+		};
+
+		HiveGenericUDTF udf = init(
+			TestOverSumIntUDTF.class,
+			constantArgs,
+			dataTypes
+		);
+
+		udf.eval(5, 4);
+
+		assertEquals(Arrays.asList(Row.of(9), Row.of(9)), collector.result);
+
+		// Test empty input and empty output
+		constantArgs = new Object[] {};
+
+		dataTypes = new DataType[] {};
+
+		udf = init(
+			TestOverSumIntUDTF.class,
+			constantArgs,
+			dataTypes
+		);
+
+		udf.eval();
+
+		assertEquals(Arrays.asList(), collector.result);
+	}
+
+	@Test
+	public void testSplit() throws Exception {
+		Object[] constantArgs = new Object[] {
+			null
+		};
+
+		DataType[] dataTypes = new DataType[] {
+			DataTypes.STRING()
+		};
+
+		HiveGenericUDTF udf = init(
+			TestSplitUDTF.class,
+			constantArgs,
+			dataTypes
+		);
+
+		udf.eval("1,2,3,5");
+
+		assertEquals(Arrays.asList(Row.of("1"), Row.of("2"), Row.of("3"), Row.of("5")), collector.result);
+	}
+
+	@Test
+	public void testReplicateRows() throws Exception {
+		Object[] constantArgs = new Object[] {
+			2L,
+			null
+		};
+
+		DataType[] dataTypes = new DataType[] {
+			DataTypes.BIGINT(),
+			DataTypes.INT()
+		};
+
+		HiveGenericUDTF udf = init(
+			GenericUDTFReplicateRows.class,
+			constantArgs,
+			dataTypes
+		);
+
+		udf.eval(2L, 5);
+
+		assertEquals(Arrays.asList(Row.of(2L, 5), Row.of(2L, 5)), collector.result);
+	}
+
+	@Test
+	public void testStack() throws Exception {
+		Object[] constantArgs = new Object[] {
+			2,
+			null,
+			null,
+			null,
+			null
+		};
+
+		DataType[] dataTypes = new DataType[] {
+			DataTypes.INT(),
+			DataTypes.STRING(),
+			DataTypes.STRING(),
+			DataTypes.STRING(),
+			DataTypes.STRING()
+		};
+
+		HiveGenericUDTF udf = init(
+			GenericUDTFStack.class,
+			constantArgs,
+			dataTypes
+		);
+
+		udf.eval(2, "a", "b", "c", "d");
+
+		assertEquals(Arrays.asList(Row.of("a", "b"), Row.of("c", "d")), collector.result);
+	}
+
+	private static HiveGenericUDTF init(Class hiveUdfClass, Object[] constantArgs, DataType[] argTypes) throws Exception {
+		HiveFunctionWrapper<GenericUDTF> wrapper = new HiveFunctionWrapper(hiveUdfClass.getName());
+
+		HiveGenericUDTF udf = new HiveGenericUDTF(wrapper);
+
+		udf.setArgumentTypesAndConstants(constantArgs, argTypes);
+		udf.getHiveResultType(constantArgs, argTypes);
+
+		ObjectInspector[] argumentInspectors = HiveInspectors.toInspectors(constantArgs, argTypes);
+		ObjectInspector returnInspector = wrapper.createFunction().initialize(argumentInspectors);
+
+		udf.open(null);
+
+		collector = new TestCollector(returnInspector);
+		udf.setCollector(collector);
+
+		return udf;
+	}
+
+	private static class TestCollector implements Collector {
+		List<Row> result = new ArrayList<>();
+		ObjectInspector returnInspector;
+
+		public TestCollector(ObjectInspector returnInspector) {
+			this.returnInspector = returnInspector;
+		}
+
+		@Override
+		public void collect(Object o) throws HiveException {
+			Row row = (Row) HiveInspectors.toFlinkObject(returnInspector, o);
+
+			result.add(row);
+		}
+	}
+
+	/**
+	 * Test over sum int udtf.
+	 */
+	public static class TestOverSumIntUDTF extends GenericUDTF {
+		@Override
+		public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+			return ObjectInspectorFactory.getStandardStructObjectInspector(
+				Collections.singletonList("col1"),
+				Collections.singletonList(PrimitiveObjectInspectorFactory.javaIntObjectInspector));
+		}
+
+		@Override
+		public void process(Object[] args) throws HiveException {
+			int total = 0;
+			for (Object arg : args) {
+				total += (int) arg;
+			}
+			for (Object ignored : args) {
+				forward(total);
+			}
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+
+	/**
+	 * Test split udtf.
+	 */
+	public static class TestSplitUDTF extends GenericUDTF {
+
+		@Override
+		public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+			return ObjectInspectorFactory.getStandardStructObjectInspector(
+				Collections.singletonList("col1"),
+				Collections.singletonList(PrimitiveObjectInspectorFactory.javaStringObjectInspector));
+		}
+
+		@Override
+		public void process(Object[] args) throws HiveException {
+			String str = (String) args[0];
+			for (String s : str.split(",")) {
+				forward(s);
+			}
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates Flink with Hive GenericUDTF.

## Brief change log

- added `HiveGenericUDTF` to delegate function calls to Hive's GenericUDTF
- extracted a few util methods to `HiveFunctionUtil`
- added unit tests for `HiveGenericUDTF`

## Verifying this change

This change added tests and can be verified as `HiveGenericUDTFTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

Documentation will be added later
