### PR TITLE
[FLINK-12627][doc][sql client][hive] Document how to configure and use catalogs in SQL CLI

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -157,7 +157,7 @@ Mode "embedded" submits Flink jobs from the local machine.
 
 ### Environment Files
 
-A SQL query needs a configuration environment in which it is executed. The so-called *environment files* define available table sources and sinks, external catalogs, user-defined functions, and other properties required for execution and deployment.
+A SQL query needs a configuration environment in which it is executed. The so-called *environment files* define available catalogs, table sources and sinks, user-defined functions, and other properties required for execution and deployment.
 
 Every environment file is a regular [YAML file](http://yaml.org/). An example of such a file is presented below.
 
@@ -214,11 +214,27 @@ execution:
   max-idle-state-retention: 0       # optional: table program's maximum idle state time
   restart-strategy:                 # optional: restart strategy
     type: fallback                  #   "fallback" to global restart strategy by default
+  current-catalog: catalog_1
+  current-database: mydb1
 
 # Deployment properties allow for describing the cluster to which table programs are submitted to.
 
 deployment:
   response-timeout: 5000
+
+# Catalogs
+
+catalogs:
+   - name: catalog_1
+     type: hive
+     property-version: 1
+     hive-site-path: file://...
+   - name: catalog_2
+     type: hive
+     property-version: 1
+     default-database: mydb2
+     hive-site-path: file://...
+     hive-version: 1.2.1
 {% endhighlight %}
 
 This configuration:
@@ -229,6 +245,8 @@ This configuration:
 - specifies a parallelism of 1 for queries executed in this streaming environment,
 - specifies an event-time characteristic, and
 - runs queries in the `table` result mode.
+- creates two `HiveCatalog` (type: hive) named with their own default databases and specified hive site path. Hive version of the first `HiveCatalog` is `2.3.4` by default and that of the second one is specified as `1.2.1`.
+- use `catalog_1` as the current catalog of the environment upon start, and `mydb1` as the current database of the catalog.
 
 Depending on the use case, a configuration can be split into multiple files. Therefore, environment files can be created for general purposes (*defaults environment file* using `--defaults`) as well as on a per-session basis (*session environment file* using `--environment`). Every CLI session is initialized with the default properties followed by the session properties. For example, the defaults environment file could specify all table sources that should be available for querying in every session whereas the session environment file only declares a specific state retention time and parallelism. Both default and session environment files can be passed when starting the CLI application. If no default environment file has been specified, the SQL Client searches for `./conf/sql-client-defaults.yaml` in Flink's configuration directory.
 
@@ -409,6 +427,34 @@ This process can be recursively performed until all the constructor parameters a
 {% endhighlight %}
 
 {% top %}
+
+Catalogs
+--------
+
+Catalogs can be defined as a set of yaml properties and are automatically registered to the environment upon starting SQL Cli. Users can specify in section `execution` that which catalog they want to use as the current catalog in SQL CLI, and which database of the catalog they want to use as the current database.
+
+{% highlight yaml %}
+execution:
+   ...
+   current-catalog: catalog_1
+   current-database: mydb1
+
+catalogs:
+   - name: catalog_1
+     type: hive
+     property-version: 1
+     hive-version:
+     hive-site-path: file://...
+   - name: catalog_2
+     type: hive
+     property-version: 1
+     default-database: mydb2
+     hive-site-path: file://...
+{% endhighlight %}
+
+Currently Flink supports two types of catalog - `FlinkInMemoryCatalog` and `HiveCatalog`.
+
+For more information about catalog, see [Catalogs]({{ site.baseurl }}/dev/table/catalog.html).
 
 Detached SQL Queries
 --------------------

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -436,20 +436,20 @@ Catalogs can be defined as a set of yaml properties and are automatically regist
 {% highlight yaml %}
 execution:
    ...
-   current-catalog: catalog_1
-   current-database: mydb1
+   current-catalog: catalog_1 # Optional, default value is "default_catalog"
+   current-database: mydb1 # Optional, default value is the default database of the current-catalog
 
 catalogs:
    - name: catalog_1
      type: hive
      property-version: 1
-     hive-version:
-     hive-site-path: file://...
+     default-database: mydb2 # Optional, default value is the default database of this catalog
+     hive-version: 1.2.1 # Optional, default value is 2.3.4
+     hive-site-path: <path of hive-site.xml>
    - name: catalog_2
      type: hive
      property-version: 1
-     default-database: mydb2
-     hive-site-path: file://...
+     hive-site-path: <path of hive-site.xml>
 {% endhighlight %}
 
 Currently Flink supports two types of catalog - `FlinkInMemoryCatalog` and `HiveCatalog`.

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -431,7 +431,7 @@ This process can be recursively performed until all the constructor parameters a
 Catalogs
 --------
 
-Catalogs can be defined as a set of yaml properties and are automatically registered to the environment upon starting SQL Cli.
+Catalogs can be defined as a set of yaml properties and are automatically registered to the environment upon starting SQL Client.
 
 Users can specify in section `execution` that which catalog they want to use as the current catalog in SQL CLI, and which database of the catalog they want to use as the current database. 
 

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -214,8 +214,8 @@ execution:
   max-idle-state-retention: 0       # optional: table program's maximum idle state time
   restart-strategy:                 # optional: restart strategy
     type: fallback                  #   "fallback" to global restart strategy by default
-  current-catalog: catalog_1
-  current-database: mydb1
+  current-catalog: catalog_1        # optional: name of the current catalog of the session ("default_catalog" by default)
+  current-database: mydb1           # optional: name of the current database of the current catalog (default value is the default database name of the current catalog)
 
 # Deployment properties allow for describing the cluster to which table programs are submitted to.
 
@@ -232,9 +232,9 @@ catalogs:
    - name: catalog_2
      type: hive
      property-version: 1
-     default-database: mydb2
-     hive-site-path: file://...
-     hive-version: 1.2.1
+     default-database: mydb2        # optional: name of default database of this catalog
+     hive-site-path: file://...     # optional: path of the hive-site.xml file. (Default value is created by HiveConf)
+     hive-version: 1.2.1            # optional: version of Hive (2.3.4 by default)
 {% endhighlight %}
 
 This configuration:
@@ -431,20 +431,22 @@ This process can be recursively performed until all the constructor parameters a
 Catalogs
 --------
 
-Catalogs can be defined as a set of yaml properties and are automatically registered to the environment upon starting SQL Cli. Users can specify in section `execution` that which catalog they want to use as the current catalog in SQL CLI, and which database of the catalog they want to use as the current database.
+Catalogs can be defined as a set of yaml properties and are automatically registered to the environment upon starting SQL Cli.
+
+Users can specify in section `execution` that which catalog they want to use as the current catalog in SQL CLI, and which database of the catalog they want to use as the current database. 
 
 {% highlight yaml %}
 execution:
    ...
-   current-catalog: catalog_1 # Optional, default value is "default_catalog"
-   current-database: mydb1 # Optional, default value is the default database of the current-catalog
+   current-catalog: catalog_1
+   current-database: mydb1
 
 catalogs:
    - name: catalog_1
      type: hive
      property-version: 1
-     default-database: mydb2 # Optional, default value is the default database of this catalog
-     hive-version: 1.2.1 # Optional, default value is 2.3.4
+     default-database: mydb2
+     hive-version: 1.2.1
      hive-site-path: <path of hive-site.xml>
    - name: catalog_2
      type: hive


### PR DESCRIPTION
## What is the purpose of the change

This PR adds English doc for configuring catalogs in SQL CLI.

Ticket for Chinese doc is [FLINK-12894](https://issues.apache.org/jira/browse/FLINK-12894). I'll leave that as a newbie ticket to engage more contributors to Flink community.

## Brief change log

- adds document for configuring catalogs in SQL CLI.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
