### PR TITLE
[FLINK-12870][doc] Add missing warnings to schema evolution documentation

### DIFF
--- a/docs/dev/stream/state/schema_evolution.md
+++ b/docs/dev/stream/state/schema_evolution.md
@@ -106,4 +106,12 @@ Flink fully supports evolving schema of Avro type state, as long as the schema c
 One limitation is that Avro generated classes used as the state type cannot be relocated or have different
 namespaces when the job is restored.
 
+{% warn Attention %} Schema evolution of keys is not supported.
+
+Example: RocksDB state backend relies on binary objects identity, rather than `hashCode` method implementation. Any changes to the keys object structure could lead to non deterministic behaviour.  
+
+{% warn Attention %} **Kryo** cannot be used for schema evolution.  
+
+When Kryo is used, there is no possibility for the framework to verify if any incompatible changes have been made.
+
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

Add missing warnings to schema evolution documentation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?: no
  - If yes, how is the feature documented?: not applicable
