### PR TITLE
[FLINK-12900][Table SQL / Runtime] Refactor the class hierarchy for BinaryFormat

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/sort/SortCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/sort/SortCodeGenerator.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.codegen.sort
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.codegen.CodeGenUtils.{BASE_ROW, SEGMENT, newName}
 import org.apache.flink.table.codegen.Indenter.toISC
-import org.apache.flink.table.dataformat.{BinaryRow, Decimal}
+import org.apache.flink.table.dataformat.{BinaryRow, BipartiteBinaryFormat, Decimal}
 import org.apache.flink.table.generated.{GeneratedNormalizedKeyComputer, GeneratedRecordComparator, NormalizedKeyComputer, RecordComparator}
 import org.apache.flink.table.runtime.sort.SortUtil
 import org.apache.flink.table.types.PlannerTypeUtils
@@ -281,7 +281,7 @@ class SortCodeGenerator(
      */
     val reverseKeys = new mutable.ArrayBuffer[String]
     // If it is big endian, it would be better, no reverse.
-    if (BinaryRow.LITTLE_ENDIAN) {
+    if (BipartiteBinaryFormat.LITTLE_ENDIAN) {
       var reverseOffset = 0
       for (chunk <- chunks) {
         val operator = BYTE_OPERATOR_MAPPING(chunk)

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArray.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArray.java
@@ -33,7 +33,14 @@ import static org.apache.flink.core.memory.MemoryUtils.UNSAFE;
  *
  * <p>{@code BinaryArray} are influenced by Apache Spark UnsafeArrayData.
  */
-public final class BinaryArray extends BinaryFormat implements TypeGetterSetters {
+public final class BinaryArray extends BipartiteBinaryFormat {
+
+	/**
+	 * 4 bytes for the array length and 4 bytes for the fixed data length.
+	 */
+	public static final int HEADER_SIZE_IN_BYTES = 8;
+
+	public static final int NULL_BITS_UNIT_IN_BYTES = 4;
 
 	/**
 	 * Offset for Arrays.
@@ -46,8 +53,13 @@ public final class BinaryArray extends BinaryFormat implements TypeGetterSetters
 	private static final int FLOAT_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(float[].class);
 	private static final int DOUBLE_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(double[].class);
 
-	public static int calculateHeaderInBytes(int numFields) {
-		return 4 + ((numFields + 31) / 32) * 4;
+	/**
+	 * Index for array elements in the segment.
+	 */
+	private int elementOffset;
+
+	public BinaryArray() {
+		super(HEADER_SIZE_IN_BYTES, NULL_BITS_UNIT_IN_BYTES);
 	}
 
 	/**
@@ -74,289 +86,21 @@ public final class BinaryArray extends BinaryFormat implements TypeGetterSetters
 		}
 	}
 
-	// The number of elements in this array
-	private int numElements;
-
-	/** The position to start storing array elements. */
-	private int elementOffset;
-
-	public BinaryArray() {}
-
-	private void assertIndexIsValid(int ordinal) {
-		assert ordinal >= 0 : "ordinal (" + ordinal + ") should >= 0";
-		assert ordinal < numElements : "ordinal (" + ordinal + ") should < " + numElements;
-	}
-
-	private int getElementOffset(int ordinal, int elementSize) {
-		return elementOffset + ordinal * elementSize;
-	}
-
-	public int numElements() {
-		return numElements;
-	}
-
 	@Override
 	public void pointTo(MemorySegment[] segments, int offset, int sizeInBytes) {
+		super.pointTo(segments, offset, sizeInBytes);
+
 		// Read the number of elements from the first 4 bytes.
 		final int numElements = SegmentsUtil.getInt(segments, offset);
 		assert numElements >= 0 : "numElements (" + numElements + ") should >= 0";
 
+		final int fixedElementSizeInBytes = SegmentsUtil.getInt(segments, offset + 4);
+		assert numElements >= 0 : "fixedElementSizeInBytes (" + fixedElementSizeInBytes + ") should >= 0";
+
 		this.numElements = numElements;
-		this.segments = segments;
-		this.offset = offset;
-		this.sizeInBytes = sizeInBytes;
-		this.elementOffset = offset + calculateHeaderInBytes(this.numElements);
-	}
-
-	@Override
-	public boolean isNullAt(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.bitGet(segments, offset + 4, pos);
-	}
-
-	@Override
-	public void setNullAt(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitSet(segments, offset + 4, pos);
-	}
-
-	public void setNotNullAt(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitUnSet(segments, offset + 4, pos);
-	}
-
-	@Override
-	public long getLong(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getLong(segments, getElementOffset(pos, 8));
-	}
-
-	@Override
-	public void setLong(int pos, long value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setLong(segments, getElementOffset(pos, 8), value);
-	}
-
-	public void setNullLong(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitSet(segments, offset + 4, pos);
-		SegmentsUtil.setLong(segments, getElementOffset(pos, 8), 0L);
-	}
-
-	@Override
-	public int getInt(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getInt(segments, getElementOffset(pos, 4));
-	}
-
-	@Override
-	public void setInt(int pos, int value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setInt(segments, getElementOffset(pos, 4), value);
-	}
-
-	public void setNullInt(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitSet(segments, offset + 4, pos);
-		SegmentsUtil.setInt(segments, getElementOffset(pos, 4), 0);
-	}
-
-	@Override
-	public BinaryString getString(int pos) {
-		assertIndexIsValid(pos);
-		int fieldOffset = getElementOffset(pos, 8);
-		final long offsetAndSize = SegmentsUtil.getLong(segments, fieldOffset);
-		return BinaryString.readBinaryStringFieldFromSegments(
-				segments, offset, fieldOffset, offsetAndSize);
-	}
-
-	@Override
-	public Decimal getDecimal(int pos, int precision, int scale) {
-		assertIndexIsValid(pos);
-		if (Decimal.isCompact(precision)) {
-			return Decimal.fromUnscaledLong(precision, scale,
-					SegmentsUtil.getLong(segments, getElementOffset(pos, 8)));
-		}
-
-		int fieldOffset = getElementOffset(pos, 8);
-		final long offsetAndSize = SegmentsUtil.getLong(segments, fieldOffset);
-		return Decimal.readDecimalFieldFromSegments(segments, offset, offsetAndSize, precision, scale);
-	}
-
-	@Override
-	public <T> BinaryGeneric<T> getGeneric(int pos) {
-		assertIndexIsValid(pos);
-		int fieldOffset = getElementOffset(pos, 8);
-		final long offsetAndSize = SegmentsUtil.getLong(segments, fieldOffset);
-		return BinaryGeneric.readBinaryGenericFieldFromSegments(
-				segments, offset, offsetAndSize);
-	}
-
-	@Override
-	public byte[] getBinary(int pos) {
-		assertIndexIsValid(pos);
-		int fieldOffset = getElementOffset(pos, 8);
-		final long offsetAndSize = SegmentsUtil.getLong(segments, fieldOffset);
-		return readBinaryFieldFromSegments(
-				segments, offset, fieldOffset, offsetAndSize);
-	}
-
-	@Override
-	public BinaryArray getArray(int pos) {
-		assertIndexIsValid(pos);
-		return BinaryArray.readBinaryArrayFieldFromSegments(segments, offset, getLong(pos));
-	}
-
-	@Override
-	public BinaryMap getMap(int pos) {
-		assertIndexIsValid(pos);
-		return BinaryMap.readBinaryMapFieldFromSegments(segments, offset, getLong(pos));
-	}
-
-	@Override
-	public BaseRow getRow(int pos, int numFields) {
-		assertIndexIsValid(pos);
-		int fieldOffset = getElementOffset(pos, 8);
-		final long offsetAndSize = SegmentsUtil.getLong(segments, fieldOffset);
-		return NestedRow.readNestedRowFieldFromSegments(
-				segments, numFields, offset, offsetAndSize);
-	}
-
-	@Override
-	public boolean getBoolean(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getBoolean(segments, getElementOffset(pos, 1));
-	}
-
-	@Override
-	public void setBoolean(int pos, boolean value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setBoolean(segments, getElementOffset(pos, 1), value);
-	}
-
-	public void setNullBoolean(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitSet(segments, offset + 4, pos);
-		SegmentsUtil.setBoolean(segments, getElementOffset(pos, 1), false);
-	}
-
-	@Override
-	public byte getByte(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getByte(segments, getElementOffset(pos, 1));
-	}
-
-	@Override
-	public void setByte(int pos, byte value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setByte(segments, getElementOffset(pos, 1), value);
-	}
-
-	public void setNullByte(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitSet(segments, offset + 4, pos);
-		SegmentsUtil.setByte(segments, getElementOffset(pos, 1), (byte) 0);
-	}
-
-	@Override
-	public short getShort(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getShort(segments, getElementOffset(pos, 2));
-	}
-
-	@Override
-	public void setShort(int pos, short value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setShort(segments, getElementOffset(pos, 2), value);
-	}
-
-	public void setNullShort(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitSet(segments, offset + 4, pos);
-		SegmentsUtil.setShort(segments, getElementOffset(pos, 2), (short) 0);
-	}
-
-	@Override
-	public float getFloat(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getFloat(segments, getElementOffset(pos, 4));
-	}
-
-	@Override
-	public void setFloat(int pos, float value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setFloat(segments, getElementOffset(pos, 4), value);
-	}
-
-	public void setNullFloat(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitSet(segments, offset + 4, pos);
-		SegmentsUtil.setFloat(segments, getElementOffset(pos, 4), 0F);
-	}
-
-	@Override
-	public double getDouble(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getDouble(segments, getElementOffset(pos, 8));
-	}
-
-	@Override
-	public void setDouble(int pos, double value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setDouble(segments, getElementOffset(pos, 8), value);
-	}
-
-	public void setNullDouble(int pos) {
-		assertIndexIsValid(pos);
-		SegmentsUtil.bitSet(segments, offset + 4, pos);
-		SegmentsUtil.setDouble(segments, getElementOffset(pos, 8), 0.0);
-	}
-
-	@Override
-	public void setDecimal(int pos, Decimal value, int precision) {
-		assertIndexIsValid(pos);
-
-		if (Decimal.isCompact(precision)) {
-			// compact format
-			setLong(pos, value.toUnscaledLong());
-		} else {
-			int fieldOffset = getElementOffset(pos, 8);
-			int cursor = (int) (SegmentsUtil.getLong(segments, fieldOffset) >>> 32);
-			assert cursor > 0 : "invalid cursor " + cursor;
-			// zero-out the bytes
-			SegmentsUtil.setLong(segments, offset + cursor, 0L);
-			SegmentsUtil.setLong(segments, offset + cursor + 8, 0L);
-
-			if (value == null) {
-				setNullAt(pos);
-				// keep the offset for future update
-				SegmentsUtil.setLong(segments, fieldOffset, ((long) cursor) << 32);
-			} else {
-
-				byte[] bytes = value.toUnscaledBytes();
-				assert (bytes.length <= 16);
-
-				// Write the bytes to the variable length portion.
-				SegmentsUtil.copyFromBytes(segments, offset + cursor, bytes, 0, bytes.length);
-				setLong(pos, ((long) cursor << 32) | ((long) bytes.length));
-			}
-		}
-	}
-
-	public boolean anyNull() {
-		for (int i = offset + 4; i < elementOffset; i += 4) {
-			if (SegmentsUtil.getInt(segments, i) != 0) {
-				return true;
-			}
-		}
-		return false;
+		this.fixedElementSizeInBytes = fixedElementSizeInBytes;
+		this.nullBitsSizeInBytes = calculateBitSetWidthInBytes(this.numElements, NULL_BITS_UNIT_IN_BYTES, HEADER_SIZE_IN_BYTES);
+		this.elementOffset = offset + nullBitsSizeInBytes;
 	}
 
 	private void checkNoNull() {
@@ -431,14 +175,9 @@ public final class BinaryArray extends BinaryFormat implements TypeGetterSetters
 		return reuse;
 	}
 
-	@Override
-	public int hashCode() {
-		return SegmentsUtil.hashByWords(segments, offset, sizeInBytes);
-	}
-
 	private static BinaryArray fromPrimitiveArray(
 			Object arr, int offset, int length, int elementSize) {
-		final long headerInBytes = calculateHeaderInBytes(length);
+		final long headerInBytes = calculateBitSetWidthInBytes(length, NULL_BITS_UNIT_IN_BYTES, HEADER_SIZE_IN_BYTES);
 		final long valueRegionInBytes = elementSize * length;
 
 		// must align by 8 bytes
@@ -452,6 +191,7 @@ public final class BinaryArray extends BinaryFormat implements TypeGetterSetters
 		final byte[] data = new byte[(int) totalSize];
 
 		UNSAFE.putInt(data, (long) BYTE_ARRAY_BASE_OFFSET, length);
+		UNSAFE.putInt(data, (long) BYTE_ARRAY_BASE_OFFSET + 4, elementSize);
 		UNSAFE.copyMemory(
 				arr, offset, data, BYTE_ARRAY_BASE_OFFSET + headerInBytes, valueRegionInBytes);
 
@@ -496,4 +236,38 @@ public final class BinaryArray extends BinaryFormat implements TypeGetterSetters
 		array.pointTo(segments, offset + baseOffset, size);
 		return array;
 	}
+
+	public void setNullBoolean(int pos) {
+		super.setNullAt(pos);
+		SegmentsUtil.setBoolean(segments, getFieldOffset(pos), false);
+	}
+
+	public void setNullByte(int pos) {
+		super.setNullAt(pos);
+		SegmentsUtil.setByte(segments, getFieldOffset(pos), (byte) 0);
+	}
+
+	public void setNullShort(int pos) {
+		super.setNullAt(pos);
+		SegmentsUtil.setShort(segments, getFieldOffset(pos), (short) 0);
+	}
+
+	public void setNullInt(int pos) {
+		super.setNullAt(pos);
+		SegmentsUtil.setInt(segments, getFieldOffset(pos), 0);
+	}
+
+	public void setNullLong(int pos) {
+		super.setNullAt(pos);
+		SegmentsUtil.setLong(segments, getFieldOffset(pos), 0L);
+	}
+
+	public void setNullFloat(int pos) {
+		setNullInt(pos);
+	}
+
+	public void setNullDouble(int pos) {
+		setNullLong(pos);
+	}
 }
+

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArrayWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArrayWriter.java
@@ -32,14 +32,17 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 	private int fixedSize;
 
 	public BinaryArrayWriter(BinaryArray array, int numElements, int elementSize) {
-		this.nullBitsSizeInBytes = BinaryArray.calculateHeaderInBytes(numElements);
+		this.nullBitsSizeInBytes = BinaryArray.calculateBitSetWidthInBytes(numElements,
+			BinaryArray.NULL_BITS_UNIT_IN_BYTES, BinaryArray.HEADER_SIZE_IN_BYTES);
 		this.fixedSize = roundNumberOfBytesToNearestWord(
 				nullBitsSizeInBytes + elementSize * numElements);
+		array.fixedElementSizeInBytes = elementSize;
 		this.cursor = fixedSize;
 		this.numElements = numElements;
 
 		this.segment = MemorySegmentFactory.wrap(new byte[fixedSize]);
 		this.segment.putInt(0, numElements);
+		this.segment.putInt(4, elementSize);
 		this.array = array;
 	}
 
@@ -57,7 +60,7 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 
 	@Override
 	public void setNullBit(int ordinal) {
-		SegmentsUtil.bitSet(segment, 4, ordinal);
+		SegmentsUtil.bitSet(segment, BinaryArray.HEADER_SIZE_IN_BYTES, ordinal);
 	}
 
 	public void setNullBoolean(int ordinal) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArrayWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArrayWriter.java
@@ -29,6 +29,7 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 	private final int nullBitsSizeInBytes;
 	private final BinaryArray array;
 	private final int numElements;
+	private final int elementSize;
 	private int fixedSize;
 
 	public BinaryArrayWriter(BinaryArray array, int numElements, int elementSize) {
@@ -39,6 +40,7 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 		array.fixedElementSizeInBytes = elementSize;
 		this.cursor = fixedSize;
 		this.numElements = numElements;
+		this.elementSize = elementSize;
 
 		this.segment = MemorySegmentFactory.wrap(new byte[fixedSize]);
 		this.segment.putInt(0, numElements);
@@ -56,6 +58,7 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 			segment.putLong(i, 0L);
 		}
 		this.segment.putInt(0, numElements);
+		this.segment.putInt(4, elementSize);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRowWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRowWriter.java
@@ -65,7 +65,7 @@ public final class BinaryRowWriter extends AbstractBinaryWriter {
 
 	@Override
 	public void setNullBit(int pos) {
-		SegmentsUtil.bitSet(segment, 0, pos + BinaryRow.HEADER_SIZE_IN_BITS);
+		SegmentsUtil.bitSet(segment, BinaryRow.HEADER_SIZE_IN_BYTES, pos);
 	}
 
 	public void writeHeader(byte header) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BipartiteBinaryFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BipartiteBinaryFormat.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.	See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.table.util.SegmentsUtil;
+
+import java.nio.ByteOrder;
+
+/**
+ * Binary format that is based on a two part memory layout:
+ * 1. The fixed length part contains the memory head, the null bits, and the fixed size data.
+ * 2. The variable length part contains data without a fixed length, e.g. strings, byte arrays, etc.
+ */
+public class BipartiteBinaryFormat extends BinaryFormat implements TypeGetterSetters {
+	public static final boolean LITTLE_ENDIAN = (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
+
+	/**
+	 * The number of elements.
+	 */
+	protected int numElements;
+
+	/**
+	 * The size of the header in bytes.
+	 */
+	protected final int headerSizeInBytes;
+
+	/**
+	 * The size (in bytes) of the null bits plus the header.
+	 */
+	protected int nullBitsSizeInBytes;
+
+	/**
+	 * The unit for the null bits and header.
+	 * That is, the total size (in bytes) of the null bits plus the header must be rounded up to this value.
+	 */
+	protected final int nullBitsUnitInBytes;
+
+	/**
+	 * The size of fixed length element.
+	 */
+	protected int fixedElementSizeInBytes;
+
+	public BipartiteBinaryFormat(int headerSizeInBytes, int nullBitsUnitInBytes) {
+		this.headerSizeInBytes = headerSizeInBytes;
+		this.nullBitsUnitInBytes = nullBitsUnitInBytes;
+	}
+
+	public BipartiteBinaryFormat(
+		MemorySegment[] segments,
+		int offset, int sizeInBytes,
+		int headerSizeInBytes,
+		int nullBitsUnitInBytes) {
+		super(segments, offset, sizeInBytes);
+		this.headerSizeInBytes = headerSizeInBytes;
+		this.nullBitsUnitInBytes = nullBitsUnitInBytes;
+	}
+
+	/**
+	 * Calculate the number bytes to store the nullable bits plus the header, rounded up to 8 bytes.
+	 * @return the required size.
+	 */
+	public static int calculateBitSetWidthInBytes(int numElements, int nullBitsUnitInBytes, int headerSizeInBytes) {
+		int nullBitsUnitInBits = nullBitsUnitInBytes * 8;
+		int headerSizeInBits = headerSizeInBytes * 8;
+		return ((numElements + headerSizeInBits + nullBitsUnitInBits - 1) / nullBitsUnitInBits) * nullBitsUnitInBytes;
+	}
+
+	public static int calculateFixPartSizeInBytes(
+		int numElements, int nullBitsUnitInBytes, int headerSizeInBytes, int fixedElementSizeInBytes) {
+		return calculateBitSetWidthInBytes(
+			numElements, nullBitsUnitInBytes, headerSizeInBytes) + fixedElementSizeInBytes * numElements;
+	}
+
+	protected int getFieldOffset(int pos) {
+		return offset + nullBitsSizeInBytes + pos * fixedElementSizeInBytes;
+	}
+
+	private void assertIndexIsValid(int index) {
+		assert index >= 0 : "index (" + index + ") should >= 0";
+		assert index < numElements : "index (" + index + ") should < " + numElements;
+	}
+
+	public int getFixedLengthPartSize() {
+		return nullBitsSizeInBytes + fixedElementSizeInBytes * numElements;
+	}
+
+	@Override
+	public boolean isNullAt(int pos) {
+		assertIndexIsValid(pos);
+		return SegmentsUtil.bitGet(segments, offset + headerSizeInBytes, pos);
+	}
+
+	protected void setNotNullAt(int i) {
+		assertIndexIsValid(i);
+		SegmentsUtil.bitUnSet(segments, offset + headerSizeInBytes, i);
+	}
+
+	@Override
+	public void setNullAt(int i) {
+		assertIndexIsValid(i);
+		SegmentsUtil.bitSet(segments, offset  + headerSizeInBytes, i);
+	}
+
+	@Override
+	public void setInt(int pos, int value) {
+		assertIndexIsValid(pos);
+		setNotNullAt(pos);
+		SegmentsUtil.setInt(segments, getFieldOffset(pos), value);
+	}
+
+	@Override
+	public void setLong(int pos, long value) {
+		assertIndexIsValid(pos);
+		setNotNullAt(pos);
+		SegmentsUtil.setLong(segments, getFieldOffset(pos), value);
+	}
+
+	@Override
+	public void setDouble(int pos, double value) {
+		assertIndexIsValid(pos);
+		setNotNullAt(pos);
+		SegmentsUtil.setDouble(segments, getFieldOffset(pos), value);
+	}
+
+	@Override
+	public void setDecimal(int pos, Decimal value, int precision) {
+		assertIndexIsValid(pos);
+
+		if (Decimal.isCompact(precision)) {
+			// compact format
+			setLong(pos, value.toUnscaledLong());
+		} else {
+			int fieldOffset = getFieldOffset(pos);
+			int cursor = (int) (SegmentsUtil.getLong(segments, fieldOffset) >>> 32);
+			assert cursor > 0 : "invalid cursor " + cursor;
+			// zero-out the bytes
+			SegmentsUtil.setLong(segments, offset + cursor, 0L);
+			SegmentsUtil.setLong(segments, offset + cursor + 8, 0L);
+
+			if (value == null) {
+				setNullAt(pos);
+				// keep the offset for future update
+				SegmentsUtil.setLong(segments, fieldOffset, ((long) cursor) << 32);
+			} else {
+
+				byte[] bytes = value.toUnscaledBytes();
+				assert bytes.length <= 16;
+
+				// Write the bytes to the variable length portion.
+				SegmentsUtil.copyFromBytes(segments, offset + cursor, bytes, 0, bytes.length);
+				setLong(pos, ((long) cursor << 32) | ((long) bytes.length));
+			}
+		}
+	}
+
+	@Override
+	public void setBoolean(int pos, boolean value) {
+		assertIndexIsValid(pos);
+		setNotNullAt(pos);
+		SegmentsUtil.setBoolean(segments, getFieldOffset(pos), value);
+	}
+
+	@Override
+	public void setShort(int pos, short value) {
+		assertIndexIsValid(pos);
+		setNotNullAt(pos);
+		SegmentsUtil.setShort(segments, getFieldOffset(pos), value);
+	}
+
+	@Override
+	public void setByte(int pos, byte value) {
+		assertIndexIsValid(pos);
+		setNotNullAt(pos);
+		SegmentsUtil.setByte(segments, getFieldOffset(pos), value);
+	}
+
+	@Override
+	public void setFloat(int pos, float value) {
+		assertIndexIsValid(pos);
+		setNotNullAt(pos);
+		SegmentsUtil.setFloat(segments, getFieldOffset(pos), value);
+	}
+
+	@Override
+	public boolean getBoolean(int pos) {
+		assertIndexIsValid(pos);
+		return SegmentsUtil.getBoolean(segments, getFieldOffset(pos));
+	}
+
+	@Override
+	public byte getByte(int pos) {
+		assertIndexIsValid(pos);
+		return SegmentsUtil.getByte(segments, getFieldOffset(pos));
+	}
+
+	@Override
+	public short getShort(int pos) {
+		assertIndexIsValid(pos);
+		return SegmentsUtil.getShort(segments, getFieldOffset(pos));
+	}
+
+	@Override
+	public int getInt(int pos) {
+		assertIndexIsValid(pos);
+		return SegmentsUtil.getInt(segments, getFieldOffset(pos));
+	}
+
+	@Override
+	public long getLong(int pos) {
+		assertIndexIsValid(pos);
+		return SegmentsUtil.getLong(segments, getFieldOffset(pos));
+	}
+
+	@Override
+	public float getFloat(int pos) {
+		assertIndexIsValid(pos);
+		return SegmentsUtil.getFloat(segments, getFieldOffset(pos));
+	}
+
+	@Override
+	public double getDouble(int pos) {
+		assertIndexIsValid(pos);
+		return SegmentsUtil.getDouble(segments, getFieldOffset(pos));
+	}
+
+	@Override
+	public BinaryString getString(int pos) {
+		assertIndexIsValid(pos);
+		int fieldOffset = getFieldOffset(pos);
+		final long offsetAndLen = SegmentsUtil.getLong(segments, fieldOffset);
+		return BinaryString.readBinaryStringFieldFromSegments(segments, offset, fieldOffset, offsetAndLen);
+	}
+
+	@Override
+	public Decimal getDecimal(int pos, int precision, int scale) {
+		assertIndexIsValid(pos);
+
+		if (Decimal.isCompact(precision)) {
+			return Decimal.fromUnscaledLong(precision, scale,
+				SegmentsUtil.getLong(segments, getFieldOffset(pos)));
+		}
+
+		int fieldOffset = getFieldOffset(pos);
+		final long offsetAndSize = SegmentsUtil.getLong(segments, fieldOffset);
+		return Decimal.readDecimalFieldFromSegments(segments, offset, offsetAndSize, precision, scale);
+	}
+
+	@Override
+	public <T> BinaryGeneric<T> getGeneric(int pos) {
+		assertIndexIsValid(pos);
+		return BinaryGeneric.readBinaryGenericFieldFromSegments(segments, offset, getLong(pos));
+	}
+
+	@Override
+	public byte[] getBinary(int pos) {
+		assertIndexIsValid(pos);
+		int fieldOffset = getFieldOffset(pos);
+		final long offsetAndLen = SegmentsUtil.getLong(segments, fieldOffset);
+		return readBinaryFieldFromSegments(segments, offset, fieldOffset, offsetAndLen);
+	}
+
+	@Override
+	public BinaryArray getArray(int pos) {
+		assertIndexIsValid(pos);
+		return BinaryArray.readBinaryArrayFieldFromSegments(segments, offset, getLong(pos));
+	}
+
+	@Override
+	public BinaryMap getMap(int pos) {
+		assertIndexIsValid(pos);
+		return BinaryMap.readBinaryMapFieldFromSegments(segments, offset, getLong(pos));
+	}
+
+	@Override
+	public BaseRow getRow(int pos, int numFields) {
+		assertIndexIsValid(pos);
+		return NestedRow.readNestedRowFieldFromSegments(segments, numFields, offset, getLong(pos));
+	}
+
+	/**
+	 * The bit is 1 when the field is null. Default is 0.
+	 */
+	public boolean anyNull() {
+		int index = headerSizeInBytes;
+		while (index + 8 <= nullBitsSizeInBytes) {
+			if (SegmentsUtil.getLong(segments, index) != 0) {
+				return true;
+			}
+			index += 8;
+		}
+
+		while (index < nullBitsSizeInBytes) {
+			if (SegmentsUtil.getByte(segments, index) != 0) {
+				return true;
+			}
+			index += 1;
+		}
+
+		return false;
+	}
+
+	public boolean anyNull(int[] fields) {
+		for (int field : fields) {
+			if (isNullAt(field)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public void clear() {
+		segments = null;
+		offset = 0;
+		sizeInBytes = 0;
+	}
+
+	@Override
+	public int hashCode() {
+		return SegmentsUtil.hashByWords(segments, offset, sizeInBytes);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return equalsFrom(o, 0);
+	}
+
+	protected boolean equalsFrom(Object o, int startIndex) {
+		if (o == null) {
+			return false;
+		}
+
+		if (!o.getClass().equals(this.getClass())) {
+			return false;
+		}
+
+		BipartiteBinaryFormat other = (BipartiteBinaryFormat) o;
+		return sizeInBytes == other.sizeInBytes &&
+			SegmentsUtil.equals(
+				segments, offset + startIndex,
+				other.segments, other.offset + startIndex, sizeInBytes - startIndex);
+	}
+
+	public int numElements() {
+		return numElements;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
@@ -21,22 +21,26 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.util.SegmentsUtil;
 
-import static org.apache.flink.table.dataformat.BinaryRow.calculateBitSetWidthInBytes;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Its memory storage structure and {@link BinaryRow} exactly the same, the only different is it supports
  * all bytes in variable MemorySegments.
  */
-public final class NestedRow extends BinaryFormat implements BaseRow {
+public final class NestedRow extends BipartiteBinaryFormat implements BaseRow {
 
 	private final int arity;
-	private final int nullBitsSizeInBytes;
 
 	public NestedRow(int arity) {
+		super(BinaryRow.HEADER_SIZE_IN_BYTES, BinaryRow.NULL_BITS_UNIT_IN_BYTES);
+
 		checkArgument(arity >= 0);
 		this.arity = arity;
-		this.nullBitsSizeInBytes = calculateBitSetWidthInBytes(arity);
+		this.numElements = arity;
+		this.fixedElementSizeInBytes = BinaryRow.FIXED_ELEMENT_SIZE_IN_BYTES;
+
+		this.nullBitsSizeInBytes = calculateBitSetWidthInBytes(arity,
+			BinaryRow.NULL_BITS_UNIT_IN_BYTES, BinaryRow.HEADER_SIZE_IN_BYTES);
 	}
 
 	static NestedRow readNestedRowFieldFromSegments(
@@ -46,15 +50,6 @@ public final class NestedRow extends BinaryFormat implements BaseRow {
 		NestedRow row = new NestedRow(numFields);
 		row.pointTo(segments, offset + baseOffset, size);
 		return row;
-	}
-
-	private int getFieldOffset(int pos) {
-		return offset + nullBitsSizeInBytes + pos * 8;
-	}
-
-	private void assertIndexIsValid(int index) {
-		assert index >= 0 : "index (" + index + ") should >= 0";
-		assert index < arity : "index (" + index + ") should < " + arity;
 	}
 
 	@Override
@@ -72,201 +67,13 @@ public final class NestedRow extends BinaryFormat implements BaseRow {
 		SegmentsUtil.setByte(segments, offset, header);
 	}
 
-	private void setNotNullAt(int i) {
-		assertIndexIsValid(i);
-		SegmentsUtil.bitUnSet(segments, offset, i + 8);
-	}
-
 	/**
 	 * See {@link BinaryRow#setNullAt(int)}.
 	 */
 	@Override
 	public void setNullAt(int i) {
-		assertIndexIsValid(i);
-		SegmentsUtil.bitSet(segments, offset, i + 8);
+		super.setNullAt(i);
 		SegmentsUtil.setLong(segments, getFieldOffset(i), 0);
-	}
-
-	@Override
-	public void setInt(int pos, int value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setInt(segments, getFieldOffset(pos), value);
-	}
-
-	@Override
-	public void setLong(int pos, long value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setLong(segments, getFieldOffset(pos), value);
-	}
-
-	@Override
-	public void setDouble(int pos, double value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setDouble(segments, getFieldOffset(pos), value);
-	}
-
-	@Override
-	public void setDecimal(int pos, Decimal value, int precision) {
-		assertIndexIsValid(pos);
-
-		if (Decimal.isCompact(precision)) {
-			// compact format
-			setLong(pos, value.toUnscaledLong());
-		} else {
-			int fieldOffset = getFieldOffset(pos);
-			int cursor = (int) (SegmentsUtil.getLong(segments, fieldOffset) >>> 32);
-			assert cursor > 0 : "invalid cursor " + cursor;
-			// zero-out the bytes
-			SegmentsUtil.setLong(segments, offset + cursor, 0L);
-			SegmentsUtil.setLong(segments, offset + cursor + 8, 0L);
-
-			if (value == null) {
-				setNullAt(pos);
-				// keep the offset for future update
-				SegmentsUtil.setLong(segments, fieldOffset, ((long) cursor) << 32);
-			} else {
-
-				byte[] bytes = value.toUnscaledBytes();
-				assert (bytes.length <= 16);
-
-				// Write the bytes to the variable length portion.
-				SegmentsUtil.copyFromBytes(segments, offset + cursor, bytes, 0, bytes.length);
-				setLong(pos, ((long) cursor << 32) | ((long) bytes.length));
-			}
-		}
-	}
-
-	@Override
-	public void setBoolean(int pos, boolean value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setBoolean(segments, getFieldOffset(pos), value);
-	}
-
-	@Override
-	public void setShort(int pos, short value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setShort(segments, getFieldOffset(pos), value);
-	}
-
-	@Override
-	public void setByte(int pos, byte value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setByte(segments, getFieldOffset(pos), value);
-	}
-
-	@Override
-	public void setFloat(int pos, float value) {
-		assertIndexIsValid(pos);
-		setNotNullAt(pos);
-		SegmentsUtil.setFloat(segments, getFieldOffset(pos), value);
-	}
-
-	@Override
-	public boolean isNullAt(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.bitGet(segments, offset, pos + 8);
-	}
-
-	@Override
-	public boolean getBoolean(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getBoolean(segments, getFieldOffset(pos));
-	}
-
-	@Override
-	public byte getByte(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getByte(segments, getFieldOffset(pos));
-	}
-
-	@Override
-	public short getShort(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getShort(segments, getFieldOffset(pos));
-	}
-
-	@Override
-	public int getInt(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getInt(segments, getFieldOffset(pos));
-	}
-
-	@Override
-	public long getLong(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getLong(segments, getFieldOffset(pos));
-	}
-
-	@Override
-	public float getFloat(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getFloat(segments, getFieldOffset(pos));
-	}
-
-	@Override
-	public double getDouble(int pos) {
-		assertIndexIsValid(pos);
-		return SegmentsUtil.getDouble(segments, getFieldOffset(pos));
-	}
-
-	@Override
-	public BinaryString getString(int pos) {
-		assertIndexIsValid(pos);
-		int fieldOffset = getFieldOffset(pos);
-		final long offsetAndLen = segments[0].getLong(fieldOffset);
-		return BinaryString.readBinaryStringFieldFromSegments(segments, offset, fieldOffset, offsetAndLen);
-	}
-
-	@Override
-	public Decimal getDecimal(int pos, int precision, int scale) {
-		assertIndexIsValid(pos);
-
-		if (Decimal.isCompact(precision)) {
-			return Decimal.fromUnscaledLong(precision, scale,
-					SegmentsUtil.getLong(segments, getFieldOffset(pos)));
-		}
-
-		int fieldOffset = getFieldOffset(pos);
-		final long offsetAndSize = SegmentsUtil.getLong(segments, fieldOffset);
-		return Decimal.readDecimalFieldFromSegments(segments, offset, offsetAndSize, precision, scale);
-	}
-
-	@Override
-	public <T> BinaryGeneric<T> getGeneric(int pos) {
-		assertIndexIsValid(pos);
-		return BinaryGeneric.readBinaryGenericFieldFromSegments(segments, offset, getLong(pos));
-	}
-
-	@Override
-	public byte[] getBinary(int pos) {
-		assertIndexIsValid(pos);
-		int fieldOffset = getFieldOffset(pos);
-		final long offsetAndLen = segments[0].getLong(fieldOffset);
-		return readBinaryFieldFromSegments(segments, offset, fieldOffset, offsetAndLen);
-	}
-
-	@Override
-	public BaseRow getRow(int pos, int numFields) {
-		assertIndexIsValid(pos);
-		return NestedRow.readNestedRowFieldFromSegments(segments, numFields, offset, getLong(pos));
-	}
-
-	@Override
-	public BinaryArray getArray(int pos) {
-		assertIndexIsValid(pos);
-		return BinaryArray.readBinaryArrayFieldFromSegments(segments, offset, getLong(pos));
-	}
-
-	@Override
-	public BinaryMap getMap(int pos) {
-		assertIndexIsValid(pos);
-		return BinaryMap.readBinaryMapFieldFromSegments(segments, offset, getLong(pos));
 	}
 
 	public NestedRow copy() {
@@ -281,10 +88,5 @@ public final class NestedRow extends BinaryFormat implements BaseRow {
 		byte[] bytes = SegmentsUtil.copyToBytes(segments, offset, sizeInBytes);
 		reuse.pointTo(MemorySegmentFactory.wrap(bytes), 0, sizeInBytes);
 		return reuse;
-	}
-
-	@Override
-	public int hashCode() {
-		return SegmentsUtil.hashByWords(segments, offset, sizeInBytes);
 	}
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The there are many classes in the class hierarchy of BinaryFormat. They share the same memory format:

header + nullable bits + fixed length part + variable length part

So many operations can be applied to a number of sub-classes. Currently, many such operations are implemented in each sub-class, although they implement identical functionality. 

This makes the code hard to understand and maintain.

In this proposal, we refactor the class hierarchy, and move common operations into the base class, leaving only one implementation for each common operation. 


## Brief change log

  - Create a class named BipartiteBinaryFormat the represents all binary format with two parts (fixed length part and variable length part)
  - Make BinaryRow, BinaryArray and NestedRow classes inherit from BipartiteBinaryFormat
  - Move common methods from sub-classes into BipartiteBinaryFormat and remove duplicated implementations


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
