### PR TITLE
[FLIN-12663]Implement HiveTableSource to read Hive tables

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -53,6 +53,13 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge_2.11</artifactId>
+			<version>1.9-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- Hadoop dependency -->
 		<!-- Hadoop as provided dependencies, so we can depend on them without pulling in Hadoop -->
 
@@ -415,7 +422,12 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -415,6 +415,7 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -53,13 +53,6 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-api-java-bridge_2.11</artifactId>
-			<version>1.9-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-
 		<!-- Hadoop dependency -->
 		<!-- Hadoop as provided dependencies, so we can depend on them without pulling in Hadoop -->
 
@@ -419,12 +412,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-clients_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/batch/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/batch/connectors/hive/HiveTableSource.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.hive;
+
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
+import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
+import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
+import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
+import org.apache.flink.table.sources.InputFormatTableSource;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.types.Row;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.JobConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * HiveTableSource used in tableApi/Sql environment to read data from hive table.
+ */
+public class HiveTableSource extends InputFormatTableSource<Row> {
+
+	private static Logger logger = LoggerFactory.getLogger(HiveTableSource.class);
+
+	private final TableSchema tableSchema;
+	private final JobConf jobConf;
+	private final String dbName;
+	private final String tableName;
+	private final Boolean isPartitionTable;
+	private final String[] partitionColNames;
+	private List<HiveTablePartition> allPartitions;
+	private String hiveVersion;
+
+	public HiveTableSource(TableSchema tableSchema,
+						JobConf jobConf,
+						String dbName,
+						String tableName,
+						String[] partitionColNames) {
+		this.tableSchema = tableSchema;
+		this.jobConf = jobConf;
+		this.dbName = dbName;
+		this.tableName = tableName;
+		this.isPartitionTable = (null != partitionColNames && partitionColNames.length != 0);
+		this.partitionColNames = partitionColNames;
+		this.hiveVersion = jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION, HiveShimLoader.getHiveVersion());
+	}
+
+	@Override
+	public InputFormat getInputFormat() {
+		initAllPartitions();
+		return new HiveTableInputFormat(jobConf, isPartitionTable, partitionColNames, allPartitions, new RowTypeInfo(tableSchema.getFieldTypes(), tableSchema.getFieldNames()));
+	}
+
+	@Override
+	public TableSchema getTableSchema() {
+		return tableSchema;
+	}
+
+	@Override
+	public DataType getProducedDataType() {
+		DataTypes.Field[] fields = new DataTypes.Field[tableSchema.getFieldCount()];
+		for (int i = 0; i < fields.length; i++) {
+			fields[i] = DataTypes.FIELD(tableSchema.getFieldName(i).get(), tableSchema.getFieldDataType(i).get());
+		}
+		return DataTypes.ROW(fields);
+	}
+
+	private void initAllPartitions() {
+		allPartitions = new ArrayList<>();
+		// Please note that the following directly accesses Hive metastore, which is only a temporary workaround.
+		// Ideally, we need to go thru Catalog API to get all info we need here, which requires some major
+		// refactoring. We will postpone this until we merge Blink to Flink.
+		HiveMetastoreClientWrapper client = HiveMetastoreClientFactory.create(new HiveConf(jobConf, HiveConf.class), hiveVersion);
+		try {
+			if (isPartitionTable) {
+				List<org.apache.hadoop.hive.metastore.api.Partition> partitions =
+						client.listPartitions(dbName, tableName, (short) -1);
+				for (org.apache.hadoop.hive.metastore.api.Partition partition : partitions) {
+					StorageDescriptor sd = partition.getSd();
+					Map<String, Object> partitionColValues = new HashMap<>();
+					for (int i = 0; i < partitionColNames.length; i++) {
+						String partitionValue = partition.getValues().get(i);
+						DataType type = tableSchema.getFieldDataType(partitionColNames[i]).get();
+						Object partitionObject = restoreObjectInfoFromType(partitionValue, type);
+						partitionColValues.put(partitionColNames[i], partitionObject);
+					}
+					allPartitions.add(new HiveTablePartition(sd, partitionColValues));
+				}
+			} else {
+				allPartitions.add(new HiveTablePartition(client.getTable(dbName, tableName).getSd(), null));
+			}
+		} catch (Exception e) {
+			logger.error("Failed to collect all partitions from hive metaStore", e);
+			throw new FlinkHiveException("Failed to collect all partitions from hive metaStore", e);
+		}
+	}
+
+	private Object restoreObjectInfoFromType(String valStr, DataType type) {
+		LogicalTypeRoot typeRoot = type.getLogicalType().getTypeRoot();
+		switch (typeRoot) {
+			case CHAR:
+			case VARCHAR:
+				return valStr;
+			case BOOLEAN:
+				return Boolean.parseBoolean(valStr);
+			case TINYINT:
+				return Integer.valueOf(valStr).byteValue();
+			case SMALLINT:
+				return Short.valueOf(valStr);
+			case INTEGER:
+				return Integer.valueOf(valStr);
+			case BIGINT:
+				return Long.valueOf(valStr);
+			case FLOAT:
+				return Float.valueOf(valStr);
+			case DOUBLE:
+				return Double.valueOf(valStr);
+			case DATE:
+				return Date.valueOf(valStr);
+			default:
+				logger.warn(String.format("Can not convert %s to type %s for partition value", valStr, type));
+		}
+		throw new FlinkHiveException(
+				new IllegalArgumentException(String.format("Can not convert %s to type %s for partition value", valStr, type)));
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/batch/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/batch/connectors/hive/HiveTableSourceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.hive;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.table.catalog.hive.HiveCatalog;
+import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
+import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
+import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
+import org.apache.flink.types.Row;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Tests {@link HiveTableSource}
+ */
+public class HiveTableSourceTest {
+	public static final String DEFAULT_SERDE_CLASS = org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.class.getName();
+	public static final String DEFAULT_INPUT_FORMAT_CLASS = org.apache.hadoop.mapred.TextInputFormat.class.getName();
+	public static final String DEFAULT_OUTPUT_FORMAT_CLASS = org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat.class.getName();
+
+	private static HiveCatalog hiveCatalog;
+	private static HiveConf hiveConf;
+
+	@BeforeClass
+	public static void createCatalog() throws IOException {
+		hiveConf = HiveTestUtils.createHiveConf();
+		hiveCatalog = HiveTestUtils.createHiveCatalog(hiveConf);
+		hiveCatalog.open();
+	}
+
+	@AfterClass
+	public static void closeCatalog() {
+		if (null != hiveCatalog) {
+			hiveCatalog.close();
+		}
+	}
+
+	@Test
+	public void testReadNonPartitionedTable() throws Exception {
+		final String dbName = "default";
+		final String tblName = "test";
+		TableSchema tableSchema = new TableSchema(
+				new String[]{"a", "b", "c", "d", "e"},
+				new TypeInformation[]{
+						BasicTypeInfo.INT_TYPE_INFO,
+						BasicTypeInfo.INT_TYPE_INFO,
+						BasicTypeInfo.STRING_TYPE_INFO,
+						BasicTypeInfo.LONG_TYPE_INFO,
+						BasicTypeInfo.DOUBLE_TYPE_INFO}
+		);
+		//Now we used metaStore client to create hive table instead of using hiveCatalog for it doesn't support set
+		//serDe temporarily.
+		HiveMetastoreClientWrapper client = HiveMetastoreClientFactory.create(hiveConf, null);
+		org.apache.hadoop.hive.metastore.api.Table tbl = new org.apache.hadoop.hive.metastore.api.Table();
+		tbl.setDbName(dbName);
+		tbl.setTableName(tblName);
+		tbl.setCreateTime((int) (System.currentTimeMillis() / 1000));
+		tbl.setParameters(new HashMap<>());
+		StorageDescriptor sd = new StorageDescriptor();
+		String location = HiveTableSourceTest.class.getResource("/test").getPath();
+		sd.setLocation(location);
+		sd.setInputFormat(DEFAULT_INPUT_FORMAT_CLASS);
+		sd.setOutputFormat(DEFAULT_OUTPUT_FORMAT_CLASS);
+		sd.setSerdeInfo(new SerDeInfo());
+		sd.getSerdeInfo().setSerializationLib(DEFAULT_SERDE_CLASS);
+		sd.getSerdeInfo().setParameters(new HashMap<>());
+		sd.getSerdeInfo().getParameters().put("serialization.format", "1");
+		sd.getSerdeInfo().getParameters().put("field.delim", ",");
+		sd.setCols(HiveTableUtil.createHiveColumns(tableSchema));
+		tbl.setSd(sd);
+		tbl.setPartitionKeys(new ArrayList<>());
+
+		client.createTable(tbl);
+		ExecutionEnvironment execEnv = ExecutionEnvironment.createLocalEnvironment(1);
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(execEnv);
+		HiveTableSource hiveTableSource = new HiveTableSource(tableSchema, new JobConf(hiveConf), dbName, tblName, null);
+		Table src = tEnv.fromTableSource(hiveTableSource);
+		DataSet<Row> rowDataSet = tEnv.toDataSet(src, new RowTypeInfo(tableSchema.getFieldTypes(),
+																	tableSchema.getFieldNames()));
+		List<Row> rows = rowDataSet.collect();
+		Assert.assertEquals(4, rows.size());
+		Assert.assertEquals(1, rows.get(0).getField(0));
+		Assert.assertEquals(2, rows.get(1).getField(0));
+		Assert.assertEquals(3, rows.get(2).getField(0));
+		Assert.assertEquals(4, rows.get(3).getField(0));
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/batch/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/batch/connectors/hive/HiveTableSourceTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
 import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
 import org.apache.flink.types.Row;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
@@ -47,7 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 
 /**
- * Tests {@link HiveTableSource}
+ * Tests {@link HiveTableSource}.
  */
 public class HiveTableSourceTest {
 	public static final String DEFAULT_SERDE_CLASS = org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.class.getName();


### PR DESCRIPTION
## What is the purpose of the change

*Implement HiveTableSource to read Hive tables*


## Brief change log
  - *add hive table source to read hive tables*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added HiveTableSourceTest that verify read normally*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (JavaDocs)
