### PR TITLE
[FLINK-12915][tests] Fix AbstractOperatorRestoreTestBase deadlock of ont test fails

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
@@ -39,7 +39,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,13 +69,6 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 	@Rule
 	public final TemporaryFolder tmpFolder = new TemporaryFolder();
 
-	@ClassRule
-	public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE = new MiniClusterWithClientResource(
-		new MiniClusterResourceConfiguration.Builder()
-			.setNumberTaskManagers(NUM_TMS)
-			.setNumberSlotsPerTaskManager(NUM_SLOTS_PER_TM)
-			.build());
-
 	private final boolean allowNonRestoredState;
 
 	protected AbstractOperatorRestoreTestBase() {
@@ -95,14 +87,27 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 	@Test
 	public void testMigrationAndRestore() throws Throwable {
 		ClassLoader classLoader = this.getClass().getClassLoader();
-		ClusterClient<?> clusterClient = MINI_CLUSTER_RESOURCE.getClusterClient();
+		MiniClusterWithClientResource cluster = getMiniClusterResource();
+		cluster.before();
+		ClusterClient<?> clusterClient = cluster.getClusterClient();
 		clusterClient.setDetached(true);
 		final Deadline deadline = Deadline.now().plus(TEST_TIMEOUT);
 
-		// submit job with old version savepoint and create a migrated savepoint in the new version
-		String savepointPath = migrateJob(classLoader, clusterClient, deadline);
-		// restore from migrated new version savepoint
-		restoreJob(classLoader, clusterClient, deadline, savepointPath);
+		try {
+			// submit job with old version savepoint and create a migrated savepoint in the new version
+			String savepointPath = migrateJob(classLoader, clusterClient, deadline);
+			// restore from migrated new version savepoint
+			restoreJob(classLoader, clusterClient, deadline, savepointPath);
+		} finally {
+			cluster.after();
+		}
+	}
+
+	private static MiniClusterWithClientResource getMiniClusterResource() {
+		return new MiniClusterWithClientResource(new MiniClusterResourceConfiguration.Builder()
+			.setNumberTaskManagers(NUM_TMS)
+			.setNumberSlotsPerTaskManager(NUM_SLOTS_PER_TM)
+			.build());
 	}
 
 	private String migrateJob(ClassLoader classLoader, ClusterClient<?> clusterClient, Deadline deadline) throws Throwable {


### PR DESCRIPTION
## What is the purpose of the change

Fix the deadlock problem when  one of `AbstractOperatorRestoreTestBase` test fails.

## Brief change log
  - Fix the deadlock problem when  one of `AbstractOperatorRestoreTestBase` test fails.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
