### PR TITLE
[FLINK-12917][hive] support complex type of array, map, struct for Hive functions

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/DeferredObjectAdapter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/DeferredObjectAdapter.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.functions.hive;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
 import org.apache.flink.table.functions.hive.conversion.HiveObjectConversion;
-import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -35,8 +35,8 @@ public class DeferredObjectAdapter implements GenericUDF.DeferredObject {
 	private Object object;
 	private HiveObjectConversion conversion;
 
-	public DeferredObjectAdapter(ObjectInspector inspector, DataType dataType) {
-		conversion = HiveInspectors.getConversion(inspector, dataType);
+	public DeferredObjectAdapter(ObjectInspector inspector, LogicalType logicalType) {
+		conversion = HiveInspectors.getConversion(inspector, logicalType);
 	}
 
 	public void set(Object ob) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDF.java
@@ -67,7 +67,7 @@ public class HiveGenericUDF extends HiveScalarFunction<GenericUDF> {
 			deferredObjects[i] = new DeferredObjectAdapter(
 				TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(
 					HiveTypeUtil.toHiveTypeInfo(argTypes[i])),
-				argTypes[i]
+				argTypes[i].getLogicalType()
 			);
 		}
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
@@ -84,7 +84,7 @@ public class HiveGenericUDTF extends TableFunction<Row> implements HiveFunction 
 
 		conversions = new HiveObjectConversion[argumentInspectors.length];
 		for (int i = 0; i < argumentInspectors.length; i++) {
-			conversions[i] = HiveInspectors.getConversion(argumentInspectors[i], argTypes[i]);
+			conversions[i] = HiveInspectors.getConversion(argumentInspectors[i], argTypes[i].getLogicalType());
 		}
 
 		allIdentityConverter = Arrays.stream(conversions)

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
@@ -87,7 +87,7 @@ public class HiveSimpleUDF extends HiveScalarFunction<UDF> {
 			conversionHelper = new GenericUDFUtils.ConversionHelper(method, argInspectors);
 			conversions = new HiveObjectConversion[argInspectors.length];
 			for (int i = 0; i < argInspectors.length; i++) {
-				conversions[i] = HiveInspectors.getConversion(argInspectors[i], argTypes[i]);
+				conversions[i] = HiveInspectors.getConversion(argInspectors[i], argTypes[i].getLogicalType());
 			}
 
 			allIdentityConverter = Arrays.stream(conversions)

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.functions.hive;
 
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.hive.util.TestHiveUDFArray;
 import org.apache.flink.table.types.DataType;
 
 import org.apache.hadoop.hive.ql.udf.UDFBase64;
@@ -178,6 +179,41 @@ public class HiveSimpleUDFTest {
 			});
 
 		assertEquals("MySQL", new String((byte[]) udf.eval("4D7953514C"), "UTF-8"));
+	}
+
+	@Test
+	public void testUDFArray_singleArray() {
+		Double[] testInputs = new Double[] { 1.1d, 2.2d };
+
+		// input arg is a single array
+		HiveSimpleUDF udf = init(
+			TestHiveUDFArray.class,
+			new DataType[]{
+				DataTypes.ARRAY(DataTypes.DOUBLE())
+			});
+
+		assertEquals(3, udf.eval(1.1d, 2.2d));
+		assertEquals(3, udf.eval(testInputs));
+
+		// input is not a single array
+		udf = init(
+			TestHiveUDFArray.class,
+			new DataType[]{
+				DataTypes.INT(),
+				DataTypes.ARRAY(DataTypes.DOUBLE())
+			});
+
+		assertEquals(8, udf.eval(5, testInputs));
+
+		udf = init(
+			TestHiveUDFArray.class,
+			new DataType[]{
+				DataTypes.INT(),
+				DataTypes.ARRAY(DataTypes.DOUBLE()),
+				DataTypes.ARRAY(DataTypes.DOUBLE())
+			});
+
+		assertEquals(11, udf.eval(5, testInputs, testInputs));
 	}
 
 	protected static HiveSimpleUDF init(Class hiveUdfClass, DataType[] argTypes) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestGenericUDFArray.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestGenericUDFArray.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.util;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Test array in generic UDF.
+ */
+public class TestGenericUDFArray extends GenericUDF {
+
+	@Override
+	public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+		checkArgument(arguments.length == 1);
+		checkArgument(arguments[0].getTypeName().equals("array<int>"));
+		return PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+	}
+
+	@Override
+	public Object evaluate(DeferredObject[] arguments) throws HiveException {
+		List<Integer> list = (List<Integer>) arguments[0].get();
+		return list.stream().reduce((i1, i2) -> i1 + i2).orElse(0);
+	}
+
+	@Override
+	public String getDisplayString(String[] children) {
+		return "TestGenericUDFArray";
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestGenericUDFStructSize.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestGenericUDFStructSize.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.util;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Test Struct in generic UDF.
+ */
+public class TestGenericUDFStructSize extends GenericUDF {
+
+	private StructObjectInspector inspector;
+
+	@Override
+	public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+		checkArgument(arguments.length == 1);
+		inspector = (StructObjectInspector) arguments[0];
+		return PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+	}
+
+	@Override
+	public Object evaluate(DeferredObject[] arguments) throws HiveException {
+		List<Object> data = inspector.getStructFieldsDataAsList(arguments[0].get());
+		return data.size();
+	}
+
+	@Override
+	public String getDisplayString(String[] children) {
+		return "TestGenericUDFStructSize";
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestHiveUDFArray.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestHiveUDFArray.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.util;
+
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+import java.util.List;
+
+/**
+ * Test array in Hive UDF.
+ */
+public class TestHiveUDFArray extends UDF {
+	public TestHiveUDFArray() {
+	}
+
+	public Integer evaluate(List<Double> a) {
+		if (a == null) {
+			return null;
+		} else {
+			Integer total = 0;
+
+			for (Double e : a) {
+				if (e != null) {
+					total += e.intValue();
+				}
+			}
+
+			return total;
+		}
+	}
+
+	public Integer evaluate(int base, List<Double> a) {
+		if (a == null) {
+			return null;
+		} else {
+			Integer total = 0;
+
+			for (Double e : a) {
+				if (e != null) {
+					total += e.intValue();
+				}
+			}
+
+			return total + base;
+		}
+	}
+
+	public Integer evaluate(int base, List<Double> a, List<Double> b) {
+		if (a == null) {
+			return null;
+		} else {
+			Integer total = 0;
+
+			for (Double e : a) {
+				if (e != null) {
+					total += e.intValue();
+				}
+			}
+
+			for (Double e : b) {
+				if (e != null) {
+					total += e.intValue();
+				}
+			}
+
+			return total + base;
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestHiveUDFMap.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestHiveUDFMap.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.util;
+
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Test map in Hive UDF.
+ */
+public class TestHiveUDFMap extends UDF {
+
+	public String evaluate(Map<String, String> a) {
+		if (a == null) {
+			return null;
+		}
+		ArrayList<String> r = new ArrayList<String>(a.size());
+		for (Map.Entry<String, String> entry : a.entrySet()) {
+			r.add("(" + entry.getKey() + ":" + entry.getValue() + ")");
+		}
+		Collections.sort(r);
+
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < r.size(); i++) {
+			sb.append(r.get(i));
+		}
+		return sb.toString();
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support of array, map, and struct for Hive functions, including UDF, GenericUDF, and GenericUDTF.

Note: this depends on https://github.com/apache/flink/pull/8813

## Brief change log

- adds support of array, map, and struct, to convert data of these types between Flink and Hive functions

## Verifying this change

This change added tests and can be verified as follows:

- added more unit tests for UDF, GenericUDF, and GenericUDTF.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
