### PR TITLE
[FLINK-12920][python] Drop support of register_table_sink with parameters field_names and field_types

### DIFF
--- a/flink-python/pyflink/dataset/tests/test_execution_environment.py
+++ b/flink-python/pyflink/dataset/tests/test_execution_environment.py
@@ -107,7 +107,7 @@ class ExecutionEnvironmentTests(PyFlinkTestCase):
         t_env.register_table_source("Orders", csv_source)
         t_env.register_table_sink(
             "Results",
-            field_names, field_types, CsvTableSink(tmp_csv))
+            CsvTableSink(field_names, field_types, tmp_csv))
         t_env.scan("Orders").insert_into("Results")
 
         plan = t_env.exec_env().get_execution_plan()

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -184,7 +184,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         t_env.register_table_source("Orders", csv_source)
         t_env.register_table_sink(
             "Results",
-            field_names, field_types, CsvTableSink(tmp_csv))
+            CsvTableSink(field_names, field_types, tmp_csv))
         t_env.scan("Orders").insert_into("Results")
 
         plan = t_env.exec_env().get_execution_plan()

--- a/flink-python/pyflink/table/examples/batch/word_count.py
+++ b/flink-python/pyflink/table/examples/batch/word_count.py
@@ -21,7 +21,8 @@ import shutil
 import sys
 import tempfile
 
-from pyflink.table import TableEnvironment, TableConfig, FileSystem, OldCsv, Schema
+from pyflink.table import TableConfig, TableEnvironment
+from pyflink.table.descriptors import FileSystem, OldCsv, Schema
 from pyflink.table.types import DataTypes
 
 

--- a/flink-python/pyflink/table/sinks.py
+++ b/flink-python/pyflink/table/sinks.py
@@ -17,7 +17,7 @@
 ################################################################################
 
 from pyflink.java_gateway import get_gateway
-from pyflink.table.types import _to_java_type
+from pyflink.table.types import _to_java_type, DataType
 from pyflink.util import utils
 
 __all__ = ['TableSink', 'CsvTableSink']
@@ -41,6 +41,8 @@ class CsvTableSink(TableSink):
     """
     A simple :class:`TableSink` to emit data as CSV files.
 
+    :param field_names: The list of field names.
+    :param field_types: The list of field data types.
     :param path: The output path to write the Table to.
     :param field_delimiter: The field delimiter.
     :param num_files: The number of files to write to.
@@ -49,7 +51,7 @@ class CsvTableSink(TableSink):
 
     def __init__(self, field_names, field_types, path, field_delimiter=',', num_files=1,
                  write_mode=None):
-        # type: (str, str, int, int) -> None
+        # type: (list[str], list[DataType], str, str, int, int) -> None
         gateway = get_gateway()
         if write_mode == WriteMode.NO_OVERWRITE:
             j_write_mode = gateway.jvm.scala.Option.apply(

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -112,23 +112,16 @@ class TableEnvironment(object):
         """
         self._j_tenv.registerTableSource(name, table_source._j_table_source)
 
-    def register_table_sink(self, name, field_names, field_types, table_sink):
+    def register_table_sink(self, name, table_sink):
         """
         Registers an external :class:`TableSink` with given field names and types in this
         :class:`TableEnvironment`'s catalog.
         Registered sink tables can be referenced in SQL DML statements.
 
         :param name: The name under which the :class:`TableSink` is registered.
-        :param field_names: The field names to register with the :class:`TableSink`.
-        :param field_types: The field types to register with the :class:`TableSink`.
         :param table_sink: The :class:`TableSink` to register.
         """
-        gateway = get_gateway()
-        j_field_names = utils.to_jarray(gateway.jvm.String, field_names)
-        j_field_types = utils.to_jarray(
-            gateway.jvm.TypeInformation,
-            [_to_java_type(field_type) for field_type in field_types])
-        self._j_tenv.registerTableSink(name, j_field_names, j_field_types, table_sink._j_table_sink)
+        self._j_tenv.registerTableSink(name, table_sink._j_table_sink)
 
     def scan(self, *table_path):
         """
@@ -239,7 +232,7 @@ class TableEnvironment(object):
         ::
 
             # register the table sink into which the result is inserted.
-            >>> t_env.register_table_sink("sink_table", field_names, fields_types, table_sink)
+            >>> t_env.register_table_sink("sink_table", table_sink)
             >>> source_table = ...
             # source_table is not registered to the table environment
             >>> tEnv.sql_update(s"INSERT INTO sink_table SELECT * FROM %s" % source_table)

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -87,9 +87,8 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
                        DataTypes.MAP(DataTypes.VARCHAR(), DataTypes.DOUBLE()),
                        DataTypes.VARBINARY(), ExamplePointUDT(),
                        PythonOnlyUDT()]
-        t_env.register_table_sink(
-            "Results",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+        table_sink = source_sink_utils.TestAppendSink(field_names, field_types)
+        t_env.register_table_sink("Results", table_sink)
 
         t.insert_into("Results")
         t_env.exec_env().execute()

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -50,7 +50,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
         t_env.register_table_sink(
             "Sinks",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+            source_sink_utils.TestAppendSink(field_names, field_types))
 
         t_env.from_elements([(1, "Hi", "Hello")], ["a", "b", "c"]).insert_into("Sinks")
         t_env.exec_env().execute()
@@ -80,10 +80,10 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         t_env.register_table_source("Orders", csv_source)
         t_env.register_table_sink(
             "Sinks",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+            source_sink_utils.TestAppendSink(field_names, field_types))
         t_env.register_table_sink(
             "Results",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+            source_sink_utils.TestAppendSink(field_names, field_types))
 
         actual = t_env.list_tables()
 
@@ -110,7 +110,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
         t_env.register_table_sink(
             "sinks",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+            source_sink_utils.TestAppendSink(field_names, field_types))
 
         result = t_env.sql_query("select a + 1, b, c from %s" % source)
         result.insert_into("sinks")
@@ -127,7 +127,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
         t_env.register_table_sink(
             "sinks",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+            source_sink_utils.TestAppendSink(field_names, field_types))
 
         t_env.sql_update("insert into sinks select * from %s" % source)
         t_env.exec_env().execute("test_sql_job")
@@ -143,7 +143,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
         t_env.register_table_sink(
             "sinks",
-            field_names, field_types, source_sink_utils.TestAppendSink())
+            source_sink_utils.TestAppendSink(field_names, field_types))
         query_config = t_env.query_config()
         query_config.with_idle_state_retention_time(
             datetime.timedelta(days=1), datetime.timedelta(days=2))

--- a/flink-python/pyflink/testing/source_sink_utils.py
+++ b/flink-python/pyflink/testing/source_sink_utils.py
@@ -25,6 +25,8 @@ from py4j.java_gateway import java_import
 from pyflink.find_flink_home import _find_flink_source_root
 from pyflink.java_gateway import get_gateway
 from pyflink.table import TableSink
+from pyflink.table.types import _to_java_type
+from pyflink.util import utils
 
 if sys.version_info[0] >= 3:
     xrange = range
@@ -37,7 +39,13 @@ class TestTableSink(TableSink):
 
     _inited = False
 
-    def __init__(self, j_table_sink):
+    def __init__(self, j_table_sink, field_names, field_types):
+        gateway = get_gateway()
+        j_field_names = utils.to_jarray(gateway.jvm.String, field_names)
+        j_field_types = utils.to_jarray(
+            gateway.jvm.TypeInformation,
+            [_to_java_type(field_type) for field_type in field_types])
+        j_table_sink = j_table_sink.configure(j_field_names, j_field_types)
         super(TestTableSink, self).__init__(j_table_sink)
 
     @classmethod
@@ -67,11 +75,12 @@ class TestAppendSink(TestTableSink):
     A test append table sink.
     """
 
-    def __init__(self):
+    def __init__(self, field_names, field_types):
         TestTableSink._ensure_initialized()
 
         gateway = get_gateway()
-        super(TestAppendSink, self).__init__(gateway.jvm.TestAppendSink())
+        super(TestAppendSink, self).__init__(
+            gateway.jvm.TestAppendSink(), field_names, field_types)
 
 
 class TestRetractSink(TestTableSink):
@@ -79,11 +88,12 @@ class TestRetractSink(TestTableSink):
     A test retract table sink.
     """
 
-    def __init__(self):
+    def __init__(self, field_names, field_types):
         TestTableSink._ensure_initialized()
 
         gateway = get_gateway()
-        super(TestRetractSink, self).__init__(gateway.jvm.TestRetractSink())
+        super(TestRetractSink, self).__init__(
+            gateway.jvm.TestRetractSink(), field_names, field_types)
 
 
 class TestUpsertSink(TestTableSink):
@@ -91,7 +101,7 @@ class TestUpsertSink(TestTableSink):
     A test upsert table sink.
     """
 
-    def __init__(self, keys, is_append_only):
+    def __init__(self, field_names, field_types, keys, is_append_only):
         TestTableSink._ensure_initialized()
 
         gateway = get_gateway()
@@ -99,7 +109,8 @@ class TestUpsertSink(TestTableSink):
         for i in xrange(0, len(keys)):
             j_keys[i] = keys[i]
 
-        super(TestUpsertSink, self).__init__(gateway.jvm.TestUpsertSink(j_keys, is_append_only))
+        super(TestUpsertSink, self).__init__(
+            gateway.jvm.TestUpsertSink(j_keys, is_append_only), field_names, field_types)
 
 
 def results():


### PR DESCRIPTION
## What is the purpose of the change

*The following API registerTableSink in TableEnvironment has been deprecated at Java side:*
`@Deprecated
void registerTableSink(String name, String[] fieldNames, TypeInformation<?>[] fieldTypes, TableSink<?> tableSink);`
*We should drop support of it in Python Table API.*

## Brief change log

  - *Remove the parameters field_names and field_types in register_table_sink*
  - *Update TestTableSink to make it accept field_names and field_types as parameters and configure the Java TableSink during constructing the Java TableSink*

## Verifying this change

This change is already covered by existing tests, such as *StreamTableEnvironmentTests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
