### PR TITLE
[FLINK-12916][tests] Retry cancelWithSavepoint on cancellation barrier in AbstractOperatorRestoreTestBase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointSerializers;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -49,6 +50,8 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -67,11 +70,13 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 	private static final int NUM_SLOTS_PER_TM = 4;
 	private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10000L);
 	private static final Pattern PATTERN_CANCEL_WITH_SAVEPOINT_TOLERATED_EXCEPTIONS = Pattern
-		.compile(
-			"(was not running)" +
-				"|(Not all required tasks are currently running)" +
-				"|(Checkpoint was declined \\(tasks not ready\\))" +
-				"|(Task received cancellation from one of its inputs)"
+		.compile(Stream
+			.of("was not running",
+				CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING.message(),
+				CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_NOT_READY.message(),
+				CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER.message())
+			.map(AbstractOperatorRestoreTestBase::escapeRegexCharacters)
+			.collect(Collectors.joining(")|(", "(", ")"))
 		);
 
 	@Rule
@@ -226,4 +231,10 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 	 * @return savepoint directory to use
 	 */
 	protected abstract String getMigrationSavepointName();
+
+	private static String escapeRegexCharacters(String string) {
+		return string
+			.replaceAll("\\(", "\\\\(")
+			.replaceAll("\\)", "\\\\)");
+	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
@@ -70,7 +70,8 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 		.compile(
 			"(was not running)" +
 				"|(Not all required tasks are currently running)" +
-				"|(Checkpoint was declined \\(tasks not ready\\))"
+				"|(Checkpoint was declined \\(tasks not ready\\))" +
+				"|(Task received cancellation from one of its inputs)"
 		);
 
 	@Rule


### PR DESCRIPTION
## What is the purpose of the change

Add retry logical for checkpoint failure reason on cancellation barrier. 

## Brief change log

  - Add retry logical for checkpoint failure reason on cancellation barrier in `AbstractOperatorRestoreTestBase`.

## Verifying this change

This change is already covered by existing tests, such as `AbstractOperatorRestoreTestBase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
