### PR TITLE
[hotfix][python][docs] Fix python doc nav bar not showing issue.

### DIFF
--- a/flink-python/docs/_static/pyflink.css
+++ b/flink-python/docs/_static/pyflink.css
@@ -1,0 +1,28 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+div div.sphinxsidebar {
+    width: 274px;
+}
+
+div div.bodywrapper {
+    margin: 0 0 0 274px;
+}
+
+div div.body {
+    max-width: none;
+}

--- a/flink-python/docs/_templates/layout.html
+++ b/flink-python/docs/_templates/layout.html
@@ -18,5 +18,3 @@ under the License.
 -->
 {% extends "!layout.html" %}
 {% set script_files = script_files + ["_static/pyflink.js"] %}
-{% block rootrellink %}
-{% endblock %}

--- a/flink-python/docs/_templates/layout.html
+++ b/flink-python/docs/_templates/layout.html
@@ -17,4 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 {% extends "!layout.html" %}
-{% set script_files = script_files + ["_static/pyflink.js"] %}
+{% block linktags %}
+{{ super() }}
+<script src="_static/pyflink.js" ></script>
+<link rel="stylesheet" href="_static/pyflink.css" type="text/css" />
+{% endblock %}


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes python doc nav bar not showing issue.

## Brief change log

 - *Remove unnecessary template code in the template file `layout.html` of python docs, which erase the default render logic of the nav bar area of python docs. See https://www.sphinx-doc.org/en/master/templating.html#jinja-sphinx-templating-primer*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
