### PR TITLE
[FLINK-12933][sql client] support 'use catalog' and 'use database' in SQL CLI

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -183,11 +183,29 @@ class TableEnvironment(object):
         j_table_path = utils.to_jarray(gateway.jvm.String, table_path_continued)
         self._j_tenv.insertInto(table._j_table, table_path, j_table_path)
 
+    def list_catalogs(self):
+        """
+        Gets the names of all catalogs registered in this environment.
+
+        :return: List of catalog names.
+        """
+        j_catalog_name_array = self._j_tenv.listCatalogs()
+        return [item for item in j_catalog_name_array]
+
+    def list_databases(self):
+            """
+            Gets the names of all databases in the current catalog.
+
+            :return: List of database names in the current catalog.
+            """
+            j_database_name_array = self._j_tenv.listDatabases()
+            return [item for item in j_database_name_array]
+
     def list_tables(self):
         """
-        Gets the names of all tables registered in this environment.
+        Gets the names of all tables in the current database of the current catalog.
 
-        :return: List of table names.
+        :return: List of table names in the current database of the current catalog.
         """
         j_table_name_array = self._j_tenv.listTables()
         return [item for item in j_table_name_array]

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -193,13 +193,13 @@ class TableEnvironment(object):
         return [item for item in j_catalog_name_array]
 
     def list_databases(self):
-            """
-            Gets the names of all databases in the current catalog.
+        """
+        Gets the names of all databases in the current catalog.
 
-            :return: List of database names in the current catalog.
-            """
-            j_database_name_array = self._j_tenv.listDatabases()
-            return [item for item in j_database_name_array]
+        :return: List of database names in the current catalog.
+        """
+        j_database_name_array = self._j_tenv.listDatabases()
+        return [item for item in j_database_name_array]
 
     def list_tables(self):
         """

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -263,6 +263,12 @@ public class CliClient {
 			case HELP:
 				callHelp();
 				break;
+			case SHOW_CATALOGS:
+				callShowCatalogs();
+				break;
+			case SHOW_DATABASES:
+				callShowDatabases();
+				break;
 			case SHOW_TABLES:
 				callShowTables();
 				break;
@@ -340,6 +346,38 @@ public class CliClient {
 
 	private void callHelp() {
 		terminal.writer().println(CliStrings.MESSAGE_HELP);
+		terminal.flush();
+	}
+
+	private void callShowCatalogs() {
+		final List<String> catalogs;
+		try {
+			catalogs = executor.listCatalogs(context);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
+		}
+		if (catalogs.isEmpty()) {
+			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
+		} else {
+			catalogs.forEach((v) -> terminal.writer().println(v));
+		}
+		terminal.flush();
+	}
+
+	private void callShowDatabases() {
+		final List<String> dbs;
+		try {
+			dbs = executor.listDatabases(context);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
+		}
+		if (dbs.isEmpty()) {
+			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
+		} else {
+			dbs.forEach((v) -> terminal.writer().println(v));
+		}
 		terminal.flush();
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -275,6 +275,12 @@ public class CliClient {
 			case SHOW_FUNCTIONS:
 				callShowFunctions();
 				break;
+			case USE_CATALOG:
+				callUseCatalog(cmdCall);
+				break;
+			case USE_DATABASE:
+				callUseDatabase(cmdCall);
+				break;
 			case DESCRIBE:
 				callDescribe(cmdCall);
 				break;
@@ -409,6 +415,26 @@ public class CliClient {
 			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
 		} else {
 			functions.forEach((v) -> terminal.writer().println(v));
+		}
+		terminal.flush();
+	}
+
+	private void callUseCatalog(SqlCommandCall cmdCall) {
+		try {
+			executor.useCatalog(context, cmdCall.operands[0]);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
+		}
+		terminal.flush();
+	}
+
+	private void callUseDatabase(SqlCommandCall cmdCall) {
+		try {
+			executor.useDatabase(context, cmdCall.operands[0]);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
 		}
 		terminal.flush();
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -83,6 +83,14 @@ public final class SqlCommandParser {
 			"HELP",
 			NO_OPERANDS),
 
+		SHOW_CATALOGS(
+			"SHOW\\s+CATALOGS",
+			NO_OPERANDS),
+
+		SHOW_DATABASES(
+			"SHOW\\s+DATABASES",
+			NO_OPERANDS),
+
 		SHOW_TABLES(
 			"SHOW\\s+TABLES",
 			NO_OPERANDS),

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -99,6 +99,14 @@ public final class SqlCommandParser {
 			"SHOW\\s+FUNCTIONS",
 			NO_OPERANDS),
 
+		USE_CATALOG(
+			"USE\\s+CATALOG\\s+(.*)",
+			SINGLE_OPERAND),
+
+		USE_DATABASE(
+			"USE\\s+DATABASE\\s+(.*)",
+			SINGLE_OPERAND),
+
 		DESCRIBE(
 			"DESCRIBE\\s+(.*)",
 			SINGLE_OPERAND),

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -41,7 +41,17 @@ public interface Executor {
 	Map<String, String> getSessionProperties(SessionContext session) throws SqlExecutionException;
 
 	/**
-	 * Lists all tables known to the executor.
+	 * Lists all registered catalogs.
+	 */
+	List<String> listCatalogs(SessionContext session) throws SqlExecutionException;
+
+	/**
+	 * Lists all databases in the current catalog.
+	 */
+	List<String> listDatabases(SessionContext session) throws SqlExecutionException;
+
+	/**
+	 * Lists all tables in the current database of the current catalog.
 	 */
 	List<String> listTables(SessionContext session) throws SqlExecutionException;
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -61,6 +61,16 @@ public interface Executor {
 	List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException;
 
 	/**
+	 * Sets a catalog with given name as the current catalog.
+	 */
+	void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException;
+
+	/**
+	 * Sets a database with given name as the current database of the current catalog.
+	 */
+	void useDatabase(SessionContext session, String databaseName) throws SqlExecutionException;
+
+	/**
 	 * Returns the schema of a table. Throws an exception if the table could not be found. The
 	 * schema might contain time attribute types for helping the user during debugging a query.
 	 */

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -189,6 +189,22 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public List<String> listCatalogs(SessionContext session) throws SqlExecutionException {
+		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+		return Arrays.asList(tableEnv.listCatalogs());
+	}
+
+	@Override
+	public List<String> listDatabases(SessionContext session) throws SqlExecutionException {
+		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+		return Arrays.asList(tableEnv.listDatabases());
+	}
+
+	@Override
 	public List<String> listTables(SessionContext session) throws SqlExecutionException {
 		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
 		final TableEnvironment tableEnv = context

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -223,6 +223,32 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+		final TableEnvironment tableEnv = context
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+
+		context.wrapClassLoader(() -> {
+			tableEnv.useCatalog(catalogName);
+			return null;
+		});
+	}
+
+	@Override
+	public void useDatabase(SessionContext session, String databaseName) throws SqlExecutionException {
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+		final TableEnvironment tableEnv = context
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+
+		context.wrapClassLoader(() -> {
+			tableEnv.useDatabase(databaseName);
+			return null;
+		});
+	}
+
+	@Override
 	public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
 		final TableEnvironment tableEnv = context

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -159,6 +159,16 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public List<String> listCatalogs(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public List<String> listDatabases(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public List<String> listTables(SessionContext session) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -179,6 +179,16 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void useDatabase(SessionContext session, String databaseName) throws SqlExecutionException {
+
+		}
+
+		@Override
 		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -146,6 +146,16 @@ public class CliResultViewTest {
 		}
 
 		@Override
+		public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void useDatabase(SessionContext session, String databaseName) throws SqlExecutionException {
+
+		}
+
+		@Override
 		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -126,6 +126,16 @@ public class CliResultViewTest {
 		}
 
 		@Override
+		public List<String> listCatalogs(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public List<String> listDatabases(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public List<String> listTables(SessionContext session) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -23,7 +23,10 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
@@ -161,6 +164,8 @@ public class DependencyTest {
 	 * to test logic of {@link HiveCatalogFactory}.
 	 */
 	public static class TestHiveCatalogFactory extends HiveCatalogFactory {
+		public static final String ADDITIONAL_TEST_DATABASE = "additional_test_database";
+
 		@Override
 		public Map<String, String> requiredContext() {
 			Map<String, String> context = super.requiredContext();
@@ -179,7 +184,20 @@ public class DependencyTest {
 			// Developers may already have their own production/testing hive-site.xml set in their environment,
 			// and Flink tests should avoid using those hive-site.xml.
 			// Thus, explicitly create a testing HiveConf for unit tests here
-			return HiveTestUtils.createHiveCatalog(name, properties.get(HiveCatalogValidator.CATALOG_HIVE_VERSION));
+			Catalog hiveCatalog = HiveTestUtils.createHiveCatalog(name, properties.get(HiveCatalogValidator.CATALOG_HIVE_VERSION));
+
+			// Creates an additional database to test tableEnv.useDatabase() will switch current database of the catalog
+			hiveCatalog.open();
+			try {
+				hiveCatalog.createDatabase(
+					ADDITIONAL_TEST_DATABASE,
+					new CatalogDatabaseImpl(new HashMap<>(), null),
+					false);
+			} catch (DatabaseAlreadyExistException e) {
+				throw new CatalogException(e);
+			}
+
+			return hiveCatalog;
 		}
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -87,8 +87,8 @@ public class ExecutionContextTest {
 		final ExecutionContext<?> context = createCatalogExecutionContext();
 		final TableEnvironment tableEnv = context.createEnvironmentInstance().getTableEnvironment();
 
-		assertEquals(tableEnv.getCurrentCatalog(), inmemoryCatalog);
-		assertEquals(tableEnv.getCurrentDatabase(), "mydatabase");
+		assertEquals(inmemoryCatalog, tableEnv.getCurrentCatalog());
+		assertEquals("mydatabase", tableEnv.getCurrentDatabase());
 
 		Catalog catalog = tableEnv.getCatalog(hiveCatalog).orElse(null);
 		assertNotNull(catalog);
@@ -100,6 +100,10 @@ public class ExecutionContextTest {
 		assertTrue(catalog instanceof HiveCatalog);
 		// make sure we have assigned a default hive version
 		assertFalse(StringUtils.isNullOrWhitespaceOnly(((HiveCatalog) catalog).getHiveVersion()));
+
+		tableEnv.useCatalog(hiveCatalog);
+
+		assertEquals(hiveCatalog, tableEnv.getCurrentCatalog());
 
 		Set<String> allCatalogs = new HashSet<>(Arrays.asList(tableEnv.listCatalogs()));
 		assertEquals(6, allCatalogs.size());
@@ -129,8 +133,23 @@ public class ExecutionContextTest {
 
 		tableEnv.useCatalog(hiveCatalog);
 
-		assertEquals(1, tableEnv.listDatabases().length);
-		assertEquals(HiveCatalog.DEFAULT_DB, tableEnv.listDatabases()[0]);
+		assertEquals(2, tableEnv.listDatabases().length);
+		assertEquals(
+			new HashSet<>(
+				Arrays.asList(
+					HiveCatalog.DEFAULT_DB,
+					DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE)
+			),
+			new HashSet<>(Arrays.asList(tableEnv.listDatabases()))
+		);
+
+		tableEnv.useCatalog(hiveCatalog);
+
+		assertEquals(HiveCatalog.DEFAULT_DB, tableEnv.getCurrentDatabase());
+
+		tableEnv.useDatabase(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE);
+
+		assertEquals(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE, tableEnv.getCurrentDatabase());
 	}
 
 	@Test

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.ViewEntry;
@@ -147,6 +148,31 @@ public class LocalExecutorITCase extends TestLogger {
 			"TestView1",
 			"TestView2");
 		assertEquals(expectedTables, actualTables);
+	}
+
+	@Test
+	public void testListCatalogs() throws Exception {
+		final Executor executor = createDefaultExecutor(clusterClient);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+
+		final List<String> actualCatalogs = executor.listCatalogs(session);
+
+		final List<String> expectedCatalogs = Arrays.asList(
+			TableConfig.getDefault().getBuiltInCatalogName(),
+			"catalog1");
+		assertEquals(expectedCatalogs, actualCatalogs);
+	}
+
+	@Test
+	public void testListDatabases() throws Exception {
+		final Executor executor = createDefaultExecutor(clusterClient);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+
+		final List<String> actualDatabases = executor.listDatabases(session);
+
+		final List<String> expectedDatabases = Arrays.asList(
+			TableConfig.getDefault().getBuiltInDatabaseName());
+		assertEquals(expectedDatabases, actualDatabases);
 	}
 
 	@Test

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-catalogs.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-catalogs.yaml
@@ -127,7 +127,7 @@ catalogs:
   - name: inmemorycatalog
     type: generic_in_memory
     default-database: mydatabase
-  - name: mycatalog
+  - name: hivecatalog
     type: hive
     test: test
     hive-version: 2.3.4

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -242,9 +242,23 @@ public interface TableEnvironment {
 	TableDescriptor connect(ConnectorDescriptor connectorDescriptor);
 
 	/**
-	 * Gets the names of all tables registered directly in this environment.
+	 * Gets the names of all catalogs registered in this environment.
 	 *
-	 * @return A list of the names of all registered tables.
+	 * @return A list of the names of all registered catalogs.
+	 */
+	String[] listCatalogs();
+
+	/**
+	 * Gets the names of all databases registered in the current catalog.
+	 *
+	 * @return A list of the names of all registered databases in the current catalog.
+	 */
+	String[] listDatabases();
+
+	/**
+	 * Gets the names of all tables registered in the current database of the current catalog.
+	 *
+	 * @return A list of the names of all registered tables in the current database of the current catalog.
 	 */
 	String[] listTables();
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -221,6 +221,19 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	}
 
 	@Override
+	public String[] listCatalogs() {
+		return catalogManager.getCatalogs().toArray(new String[0]);
+	}
+
+	@Override
+	public String[] listDatabases() {
+		return catalogManager.getCatalog(catalogManager.getCurrentCatalog())
+			.get()
+			.listDatabases()
+			.toArray(new String[0]);
+	}
+
+	@Override
 	public String[] listTables() {
 		String currentCatalogName = catalogManager.getCurrentCatalog();
 		Optional<Catalog> currentCatalog = catalogManager.getCatalog(currentCatalogName);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -354,6 +354,17 @@ abstract class TableEnvImpl(
       .map(t => new CatalogQueryOperation(t.getTablePath, t.getTableSchema))
   }
 
+  override def listCatalogs(): Array[String] = {
+    catalogManager.getCatalogs.asScala.toArray
+  }
+
+  override def listDatabases(): Array[String] = {
+    catalogManager.getCatalog(catalogManager.getCurrentCatalog)
+      .get()
+      .listDatabases()
+      .asScala.toArray
+  }
+
   override def listTables(): Array[String] = {
     val currentCatalogName = catalogManager.getCurrentCatalog
     val currentCatalog = catalogManager.getCatalog(currentCatalogName)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -53,6 +53,10 @@ class MockTableEnvironment extends TableEnvironment {
 
   override def connect(connectorDescriptor: ConnectorDescriptor): TableDescriptor = ???
 
+  override def listCatalogs(): Array[String] = ???
+
+  override def listDatabases(): Array[String] = ???
+
   override def listTables(): Array[String] = ???
 
   override def listUserDefinedFunctions(): Array[String] = ???


### PR DESCRIPTION
## What is the purpose of the change

This PR adds `USE CATALOG` and `USE DATABASE` commands to SQL CLI.

This PR depends on https://github.com/apache/flink/pull/8829.

## Brief change log

- added `USE CATALOG` and `USE DATABASE` commands to SQL CLI.
- updated unit tests in `ExecutionContextTest` and `LocalExecutorITCase` to cover these changes

## Verifying this change

This change added tests and can be verified as follows: `ExecutionContextTest` and `LocalExecutorITCase` 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

Documentation will be added later