### PR TITLE
[FLINK-12935][hive] package flink-connector-hive into flink distribution for HiveCatalog

### DIFF
--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -192,6 +192,14 @@
 			<destName>flink-python-${project.version}-java-binding.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
+
+		<!-- HiveCatalog and Hive connector -->
+		<file>
+			<source>../flink-connectors/flink-connector-hive/target/flink-connector-hive_${scala.binary.version}-${project.version}.jar</source>
+			<outputDirectory>opt</outputDirectory>
+			<destName>flink-connector-hive_${scala.binary.version}-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
 	</files>
 	<fileSets>
 		<fileSet>


### PR DESCRIPTION
## What is the purpose of the change

This PR adds `flink-connector-hive` jar into Flink distribution to `/opt` dir. This is mainly to include `HiveCatalog` rather than the hive data connector.

## Brief change log

adds `flink-connector-hive` jar into Flink distribution to`/opt` dir.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
