### PR TITLE
[FLINK-12946][docs]Translate Apache NiFi Connector page into Chinese

### DIFF
--- a/docs/dev/connectors/nifi.zh.md
+++ b/docs/dev/connectors/nifi.zh.md
@@ -24,7 +24,7 @@ under the License.
 -->
 
 [Apache NiFi](https://nifi.apache.org/) 连接器提供了可以读取和写入的 Source 和 Sink. 
-使用这个连接器， 需要在工程中添加下面的依赖:
+使用这个连接器，需要在工程中添加下面的依赖:
 
 {% highlight xml %}
 <dependency>
@@ -34,15 +34,15 @@ under the License.
 </dependency>
 {% endhighlight %}
 
-注意这些连接器目前还没有包含在二进制发行版中。添加依赖、打包配置以及集群运行的相关信息请参考 [here]({{site.baseurl}}/zh/dev/projectsetup/dependencies.html)。
+注意这些连接器目前还没有包含在二进制发行版中。添加依赖、打包配置以及集群运行的相关信息请参考 [这里]({{site.baseurl}}/zh/dev/projectsetup/dependencies.html)。
 
 #### 安装 Apache NiFi
 
-安装 Apache NiFi 集群请参考 [here](https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#how-to-install-and-start-nifi).
+安装 Apache NiFi 集群请参考 [这里](https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#how-to-install-and-start-nifi).
 
 #### Apache NiFi Source
 
-连接器提供 Source，可以从 Apache NiFi 读取数据到 Apache Flink。
+该连接器提供了一个 Source 可以用来从 Apache NiFi 读取数据到 Apache Flink。
 
 `NiFiSource(…)` 类有两个构造方法。
 
@@ -85,7 +85,7 @@ val nifiSource = new NiFiSource(clientConfig)
 
 #### Apache NiFi Sink
 
-连接器提供了 Sink，可以把 Apache Flink 数据写入到 Apache NiFi。
+该连接器提供了一个 Sink 可以用来把 Apache Flink 的数据写入到 Apache NiFi。
 
 `NiFiSink(…)` 类只有一个构造方法。
 
@@ -126,6 +126,6 @@ streamExecEnv.addSink(nifiSink)
 </div>
 </div>      
 
-更多关于 [Apache NiFi](https://nifi.apache.org) Site-to-Site Protocol 的信息请参考 [here](https://nifi.apache.org/docs/nifi-docs/html/user-guide.html#site-to-site)
+更多关于 [Apache NiFi](https://nifi.apache.org) Site-to-Site Protocol 的信息请参考 [这里](https://nifi.apache.org/docs/nifi-docs/html/user-guide.html#site-to-site)
 
 {% top %}

--- a/docs/dev/connectors/nifi.zh.md
+++ b/docs/dev/connectors/nifi.zh.md
@@ -23,9 +23,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This connector provides a Source and Sink that can read from and write to
-[Apache NiFi](https://nifi.apache.org/). To use this connector, add the
-following dependency to your project:
+[Apache NiFi](https://nifi.apache.org/) 连接器提供了可以读取和写入的 Source 和 Sink. 
+使用这个连接器， 需要在工程中添加下面的依赖:
 
 {% highlight xml %}
 <dependency>
@@ -35,30 +34,23 @@ following dependency to your project:
 </dependency>
 {% endhighlight %}
 
-Note that the streaming connectors are currently not part of the binary
-distribution. See
-[here]({{site.baseurl}}/dev/projectsetup/dependencies.html)
-for information about how to package the program with the libraries for
-cluster execution.
+注意这些连接器目前还没有包含在二进制发行版中。添加依赖、打包配置以及集群运行的相关信息请参考 [here]({{site.baseurl}}/zh/dev/projectsetup/dependencies.html)。
 
-#### Installing Apache NiFi
+#### 安装 Apache NiFi
 
-Instructions for setting up a Apache NiFi cluster can be found
-[here](https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#how-to-install-and-start-nifi).
+安装 Apache NiFi 集群请参考 [here](https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#how-to-install-and-start-nifi).
 
 #### Apache NiFi Source
 
-The connector provides a Source for reading data from Apache NiFi to Apache Flink.
+连接器提供 Source，可以从 Apache NiFi 读取数据到 Apache Flink。
 
-The class `NiFiSource(…)` provides 2 constructors for reading data from NiFi.
+`NiFiSource(…)` 类有两个构造方法。
 
-- `NiFiSource(SiteToSiteConfig config)` - Constructs a `NiFiSource(…)` given the client's SiteToSiteConfig and a
-     default wait time of 1000 ms.
+- `NiFiSource(SiteToSiteConfig config)` - 构造一个 `NiFiSource(…)` ，需要指定参数 SiteToSiteConfig ，采用默认的等待时间 1000 ms。
 
-- `NiFiSource(SiteToSiteConfig config, long waitTimeMs)` - Constructs a `NiFiSource(…)` given the client's
-     SiteToSiteConfig and the specified wait time (in milliseconds).
+- `NiFiSource(SiteToSiteConfig config, long waitTimeMs)` - 构造一个 `NiFiSource(…)`，需要指定参数 SiteToSiteConfig 和等待时间（单位为毫秒）。
 
-Example:
+示例:
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -89,18 +81,17 @@ val nifiSource = new NiFiSource(clientConfig)
 </div>
 </div>
 
-Here data is read from the Apache NiFi Output Port called "Data for Flink" which is part of Apache NiFi
-Site-to-site protocol configuration.
+数据从 Apache NiFi Output Port 读取，Apache NiFi Output Port 也被称为 "Data for Flink"，是 Apache NiFi Site-to-site 协议配置的一部分。
 
 #### Apache NiFi Sink
 
-The connector provides a Sink for writing data from Apache Flink to Apache NiFi.
+连接器提供了 Sink，可以把 Apache Flink 数据写入到 Apache NiFi。
 
-The class `NiFiSink(…)` provides a constructor for instantiating a `NiFiSink`.
+`NiFiSink(…)` 类只有一个构造方法。
 
-- `NiFiSink(SiteToSiteClientConfig, NiFiDataPacketBuilder<T>)` constructs a `NiFiSink(…)` given the client's `SiteToSiteConfig` and a `NiFiDataPacketBuilder` that converts data from Flink to `NiFiDataPacket` to be ingested by NiFi.
+- `NiFiSink(SiteToSiteClientConfig, NiFiDataPacketBuilder<T>)` 构造一个 `NiFiSink(…)`，需要指定 `SiteToSiteConfig` 和  `NiFiDataPacketBuilder` 参数 ，`NiFiDataPacketBuilder` 可以将Flink数据转化成可以被NiFi识别的 `NiFiDataPacket`.
 
-Example:
+示例:
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -135,6 +126,6 @@ streamExecEnv.addSink(nifiSink)
 </div>
 </div>      
 
-More information about [Apache NiFi](https://nifi.apache.org) Site-to-Site Protocol can be found [here](https://nifi.apache.org/docs/nifi-docs/html/user-guide.html#site-to-site)
+更多关于 [Apache NiFi](https://nifi.apache.org) Site-to-Site Protocol 的信息请参考 [here](https://nifi.apache.org/docs/nifi-docs/html/user-guide.html#site-to-site)
 
 {% top %}


### PR DESCRIPTION

## What is the purpose of the change

Translate Apache NiFi Connector page into Chinese

## Brief change log

Translate Apache NiFi Connector page into Chinese

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)