### PR TITLE
[FLINK-12952][docs] Minor doc correction to incremental window functions

### DIFF
--- a/docs/dev/stream/operators/windows.md
+++ b/docs/dev/stream/operators/windows.md
@@ -420,7 +420,7 @@ elements of each (possibly keyed) window once the system determines that a windo
 (see [triggers](#triggers) for how Flink determines when a window is ready).
 
 The window function can be one of `ReduceFunction`, `AggregateFunction`, `FoldFunction` or `ProcessWindowFunction`. The first
-two can be executed more efficiently (see [State Size](#state size) section) because Flink can incrementally aggregate
+three can be executed more efficiently (see [State Size](#state size) section) because Flink can incrementally aggregate
 the elements for each window as they arrive. A `ProcessWindowFunction` gets an `Iterable` for all the elements contained in a
 window and additional meta information about the window to which the elements belong.
 

--- a/docs/dev/stream/operators/windows.zh.md
+++ b/docs/dev/stream/operators/windows.zh.md
@@ -420,7 +420,7 @@ elements of each (possibly keyed) window once the system determines that a windo
 (see [triggers](#triggers) for how Flink determines when a window is ready).
 
 The window function can be one of `ReduceFunction`, `AggregateFunction`, `FoldFunction` or `ProcessWindowFunction`. The first
-two can be executed more efficiently (see [State Size](#state size) section) because Flink can incrementally aggregate
+three can be executed more efficiently (see [State Size](#state size) section) because Flink can incrementally aggregate
 the elements for each window as they arrive. A `ProcessWindowFunction` gets an `Iterable` for all the elements contained in a
 window and additional meta information about the window to which the elements belong.
 


### PR DESCRIPTION

## What is the purpose of the change

Minor correction to documentation regarding incremental windows functions

## Brief change log

The Flink documentation [Window Functions](https://ci.apache.org/projects/flink/flink-docs-release-1.8/dev/stream/operators/windows.html#window-functions) mentions that

> The window function can be one of ReduceFunction, AggregateFunction, FoldFunction or ProcessWindowFunction. The first two can be executed more efficiently


It should perhaps state (since FoldFunction, though deprecated, is also incremental):

> The first three can be executed more efficiently