### PR TITLE
[FLINK-12931][python] Fix lint-python.sh cannot find flake8

### DIFF
--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -204,7 +204,7 @@ function install_py_env() {
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_tox() {
     if [ -f "$TOX_PATH" ]; then
-        ${CONDA_PATH} remove tox -y -q 2>&1 >/dev/null
+        ${CONDA_PATH} remove -p ${CONDA_HOME} tox -y -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
             echo "conda remove tox failed \
             please try to exec the script again.\
@@ -213,7 +213,7 @@ function install_tox() {
         fi
     fi
 
-    ${CONDA_PATH} install -c conda-forge tox -y -q 2>&1 >/dev/null
+    ${CONDA_PATH} install -p ${CONDA_HOME} -c conda-forge tox -y -q 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "conda install tox failed \
         please try to exec the script again.\
@@ -226,7 +226,7 @@ function install_tox() {
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_flake8() {
     if [ -f "$FLAKE8_PATH" ]; then
-        ${CONDA_PATH} remove flake8 -y -q 2>&1 >/dev/null
+        ${CONDA_PATH} remove -p ${CONDA_HOME} flake8 -y -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
             echo "conda remove flake8 failed \
             please try to exec the script again.\
@@ -235,7 +235,7 @@ function install_flake8() {
         fi
     fi
 
-    ${CONDA_PATH} install -c anaconda flake8 -y -q 2>&1 >/dev/null
+    ${CONDA_PATH} install -p ${CONDA_HOME} -c anaconda flake8 -y -q 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "conda install flake8 failed \
         please try to exec the script again.\
@@ -248,7 +248,7 @@ function install_flake8() {
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_sphinx() {
     if [ -f "$SPHINX_PATH" ]; then
-        ${CONDA_PATH} remove sphinx -y -q 2>&1 >/dev/null
+        ${CONDA_PATH} remove -p ${CONDA_HOME} sphinx -y -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
             echo "conda remove sphinx failed \
             please try to exec the script again.\
@@ -257,7 +257,7 @@ function install_sphinx() {
         fi
     fi
 
-    ${CONDA_PATH} install -c anaconda sphinx -y -q 2>&1 >/dev/null
+    ${CONDA_PATH} install -p ${CONDA_HOME} -c anaconda sphinx -y -q 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "conda install sphinx failed \
         please try to exec the script again.\
@@ -528,6 +528,9 @@ CURRENT_DIR="$(cd "$( dirname "$0" )" && pwd)"
 # FLINK_PYTHON_DIR is "flink/flink-python"
 FLINK_PYTHON_DIR=$(dirname "$CURRENT_DIR")
 pushd "$FLINK_PYTHON_DIR" &> /dev/null
+
+# conda home path
+CONDA_HOME=$CURRENT_DIR/.conda
 
 # conda path
 CONDA_PATH=$CURRENT_DIR/.conda/bin/conda


### PR DESCRIPTION
## What is the purpose of the change

*The `lint-python.sh` will execute failed during installing `flake8` when there is `anaconda2/anaconda3` installed. We need to solve this issue because `anaconda` is a pretty common package that developers install and use. 
The reason to this issue is that `conda install flake8` will try to install `flake8` into the conda home which may be the conda installed by user, not the `miniconda` installed by lint-python.sh.*


## Brief change log

  - *Updates lint-python.sh to specify the conda home explicitly when executing `conda remove` and `conda install`*

## Verifying this change

This change can be verified as follows:

  - *Executes ./dev/lint-python.sh and it will succeed*
  - *Installs anaconda2/anaconda3, starts a new shell and makes sure the newly installed anaconda2/anaconda3 is used.*
  - *Executes ./dev/lint-python.sh -f and it will fail without the changes of this PR*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
