### PR TITLE
[FLINK-12765][coordinator] Bookkeeping of available resources of allocated slots in SlotPool

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
@@ -79,6 +79,26 @@ public abstract class Resource implements Serializable {
 		return create(aggregatedValue, resourceAggregateType);
 	}
 
+	public Resource minus(Resource other) {
+		Preconditions.checkArgument(getClass() == other.getClass(), "Minus with different resource resourceAggregateType");
+		Preconditions.checkArgument(this.name.equals(other.name), "Minus with different resource name");
+		Preconditions.checkArgument(this.resourceAggregateType == other.resourceAggregateType, "Minus with different aggregate resourceAggregateType");
+
+		final double aggregatedValue;
+		switch (resourceAggregateType) {
+			case AGGREGATE_TYPE_MAX :
+				// TODO: For max, should check if the latest max item is removed and change accordingly.
+				aggregatedValue = this.value;
+				break;
+
+			case AGGREGATE_TYPE_SUM:
+			default:
+				aggregatedValue = this.value - other.value;
+		}
+
+		return create(aggregatedValue, resourceAggregateType);
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
@@ -61,42 +61,43 @@ public abstract class Resource implements Serializable {
 	}
 
 	public Resource merge(Resource other) {
-		Preconditions.checkArgument(getClass() == other.getClass(), "Merge with different resource resourceAggregateType");
-		Preconditions.checkArgument(this.name.equals(other.name), "Merge with different resource name");
-		Preconditions.checkArgument(this.resourceAggregateType == other.resourceAggregateType, "Merge with different aggregate resourceAggregateType");
+		Preconditions.checkArgument(getClass() == other.getClass(), "Merge with different resource type");
+		Preconditions.checkArgument(name.equals(other.name), "Merge with different resource name");
+		Preconditions.checkArgument(resourceAggregateType == other.resourceAggregateType, "Merge with different aggregate resourceAggregateType");
 
 		final double aggregatedValue;
 		switch (resourceAggregateType) {
 			case AGGREGATE_TYPE_MAX :
-				aggregatedValue = Math.max(other.value, this.value);
+				aggregatedValue = Math.max(value, other.value);
 				break;
 
 			case AGGREGATE_TYPE_SUM:
 			default:
-				aggregatedValue = this.value + other.value;
+				aggregatedValue = value + other.value;
 		}
 
 		return create(aggregatedValue, resourceAggregateType);
 	}
 
-	public Resource minus(Resource other) {
-		Preconditions.checkArgument(getClass() == other.getClass(), "Minus with different resource resourceAggregateType");
-		Preconditions.checkArgument(this.name.equals(other.name), "Minus with different resource name");
-		Preconditions.checkArgument(this.resourceAggregateType == other.resourceAggregateType, "Minus with different aggregate resourceAggregateType");
+	public Resource subtract(Resource other) {
+		Preconditions.checkArgument(getClass() == other.getClass(), "Minus with different resource type");
+		Preconditions.checkArgument(name.equals(other.name), "Minus with different resource name");
+		Preconditions.checkArgument(resourceAggregateType == other.resourceAggregateType, "Minus with different aggregate resourceAggregateType");
+		Preconditions.checkArgument(value >= other.value, "Try to subtract a larger resource from this one.");
 
-		final double aggregatedValue;
+		final double subtractedValue;
 		switch (resourceAggregateType) {
 			case AGGREGATE_TYPE_MAX :
 				// TODO: For max, should check if the latest max item is removed and change accordingly.
-				aggregatedValue = this.value;
+				subtractedValue = value;
 				break;
 
 			case AGGREGATE_TYPE_SUM:
 			default:
-				aggregatedValue = this.value - other.value;
+				subtractedValue = value - other.value;
 		}
 
-		return create(aggregatedValue, resourceAggregateType);
+		return create(subtractedValue, resourceAggregateType);
 	}
 
 	@Override
@@ -125,11 +126,11 @@ public abstract class Resource implements Serializable {
 	}
 
 	public ResourceAggregateType getResourceAggregateType() {
-		return this.resourceAggregateType;
+		return resourceAggregateType;
 	}
 
 	public double getValue() {
-		return this.value;
+		return value;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.clusterframework.types;
 
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.resources.Resource;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +30,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Describe the immutable resource profile of the slot, either when requiring or offering it. The profile can be
@@ -48,7 +51,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 
 	private static final long serialVersionUID = 1L;
 
-	public static final ResourceProfile UNKNOWN = new ResourceProfile(-1.0, -1);
+	public static final ResourceProfile UNKNOWN = new ResourceProfile();
 
 	/** ResourceProfile which matches any other ResourceProfile. */
 	public static final ResourceProfile ANY = new ResourceProfile(Double.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyMap());
@@ -97,6 +100,12 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 			int networkMemoryInMB,
 			int managedMemoryInMB,
 			Map<String, Resource> extendedResources) {
+		Preconditions.checkArgument(cpuCores >= 0);
+		Preconditions.checkArgument(heapMemoryInMB >= 0);
+		Preconditions.checkArgument(directMemoryInMB >= 0);
+		Preconditions.checkArgument(nativeMemoryInMB >= 0);
+		Preconditions.checkArgument(networkMemoryInMB >= 0);
+		Preconditions.checkArgument(managedMemoryInMB >= 0);
 		this.cpuCores = cpuCores;
 		this.heapMemoryInMB = heapMemoryInMB;
 		this.directMemoryInMB = directMemoryInMB;
@@ -116,6 +125,18 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 */
 	public ResourceProfile(double cpuCores, int heapMemoryInMB) {
 		this(cpuCores, heapMemoryInMB, 0, 0, 0, 0, Collections.emptyMap());
+	}
+
+	/**
+	 * Creates a special ResourceProfile with negative values, indicating resources are unspecified.
+	 */
+	private ResourceProfile() {
+		this.cpuCores = -1.0;
+		this.heapMemoryInMB = -1;
+		this.directMemoryInMB = -1;
+		this.nativeMemoryInMB = -1;
+		this.networkMemoryInMB = -1;
+		this.managedMemoryInMB = -1;
 	}
 
 	/**
@@ -307,6 +328,104 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 					Objects.equals(extendedResources, that.extendedResources);
 		}
 		return false;
+	}
+
+	/**
+	 * Calculates the sum of two resource profiles.
+	 *
+	 * @param other The other resource profile to add.
+	 * @return The merged resource profile.
+	 */
+	@Nonnull
+	public ResourceProfile merge(@Nonnull ResourceProfile other) {
+		if (equals(ANY) || other.equals(ANY)) {
+			return ANY;
+		}
+
+		if (this.equals(UNKNOWN) || other.equals(UNKNOWN)) {
+			return UNKNOWN;
+		}
+
+		Map<String, Resource> resultExtendedResource = new HashMap<>(extendedResources);
+
+		other.extendedResources.forEach((String name, Resource resource) -> {
+			resultExtendedResource.compute(name, (ignored, oldResource) ->
+				oldResource == null ? resource : oldResource.merge(resource));
+		});
+
+		return new ResourceProfile(
+			addNonNegativeDoublesConsideringOverflow(cpuCores, other.cpuCores),
+			addNonNegativeIntegersConsideringOverflow(heapMemoryInMB, other.heapMemoryInMB),
+			addNonNegativeIntegersConsideringOverflow(directMemoryInMB, other.directMemoryInMB),
+			addNonNegativeIntegersConsideringOverflow(nativeMemoryInMB, other.nativeMemoryInMB),
+			addNonNegativeIntegersConsideringOverflow(networkMemoryInMB, other.networkMemoryInMB),
+			addNonNegativeIntegersConsideringOverflow(managedMemoryInMB, other.managedMemoryInMB),
+			resultExtendedResource);
+	}
+
+	/**
+	 * Subtracts another piece of resource profile from this one.
+	 *
+	 * @param other The other resource profile to subtract.
+	 * @return The subtracted resource profile.
+	 */
+	public ResourceProfile subtract(ResourceProfile other) {
+		if (equals(ANY) || other.equals(ANY)) {
+			return ANY;
+		}
+
+		if (this.equals(UNKNOWN) || other.equals(UNKNOWN)) {
+			return UNKNOWN;
+		}
+
+		checkArgument(isMatching(other), "Try to subtract an unmatched resource profile from this one.");
+
+		Map<String, Resource> resultExtendedResource = new HashMap<>(extendedResources);
+
+		other.extendedResources.forEach((String name, Resource resource) -> {
+			resultExtendedResource.compute(name, (ignored, oldResource) -> {
+				Resource resultResource = oldResource.minus(resource);
+				return resultResource.getValue() == 0 ? null : resultResource;
+			});
+		});
+
+		return new ResourceProfile(
+			subtractDoublesConsideringInf(cpuCores, other.cpuCores),
+			subtractIntegersConsideringInf(heapMemoryInMB, other.heapMemoryInMB),
+			subtractIntegersConsideringInf(directMemoryInMB, other.directMemoryInMB),
+			subtractIntegersConsideringInf(nativeMemoryInMB, other.nativeMemoryInMB),
+			subtractIntegersConsideringInf(networkMemoryInMB, other.networkMemoryInMB),
+			subtractIntegersConsideringInf(managedMemoryInMB, other.managedMemoryInMB),
+			resultExtendedResource
+		);
+	}
+
+	private double addNonNegativeDoublesConsideringOverflow(double first, double second) {
+		double result = first + second;
+
+		if (result == Double.POSITIVE_INFINITY) {
+			return Double.MAX_VALUE;
+		}
+
+		return result;
+	}
+
+	private int addNonNegativeIntegersConsideringOverflow(int first, int second) {
+		int result = first + second;
+
+		if (result < 0) {
+			return Integer.MAX_VALUE;
+		}
+
+		return result;
+	}
+
+	private double subtractDoublesConsideringInf(double first, double second) {
+		return first == Double.MAX_VALUE ? Double.MAX_VALUE : first - second;
+	}
+
+	private int subtractIntegersConsideringInf(int first, int second) {
+		return first == Integer.MAX_VALUE ? Integer.MAX_VALUE : first - second;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -56,6 +56,8 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	/** ResourceProfile which matches any other ResourceProfile. */
 	public static final ResourceProfile ANY = new ResourceProfile(Double.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyMap());
 
+	public static final ResourceProfile EMPTY = new ResourceProfile(0, 0);
+
 	// ------------------------------------------------------------------------
 
 	/** How many cpu cores are needed, use double so we can specify cpu like 0.1. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -445,6 +445,10 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	}
 
 	public static ResourceProfile fromResourceSpec(ResourceSpec resourceSpec, int networkMemory) {
+		if (resourceSpec == ResourceSpec.UNKNOWN) {
+			return UNKNOWN;
+		}
+
 		Map<String, Resource> copiedExtendedResources = new HashMap<>(resourceSpec.getExtendedResources());
 
 		return new ResourceProfile(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -384,7 +384,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 
 		other.extendedResources.forEach((String name, Resource resource) -> {
 			resultExtendedResource.compute(name, (ignored, oldResource) -> {
-				Resource resultResource = oldResource.minus(resource);
+				Resource resultResource = oldResource.subtract(resource);
 				return resultResource.getValue() == 0 ? null : resultResource;
 			});
 		});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
@@ -22,7 +22,6 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
-import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import javax.annotation.Nonnull;
@@ -48,7 +47,7 @@ public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStra
 
 	@Override
 	public Optional<SlotInfoAndLocality> selectBestSlotForProfile(
-		@Nonnull Collection<? extends SlotInfo> availableSlots,
+		@Nonnull Collection<SlotInfoAndRemainingResource> availableSlots,
 		@Nonnull SlotProfile slotProfile) {
 
 		Collection<TaskManagerLocation> locationPreferences = slotProfile.getPreferredLocations();
@@ -67,12 +66,12 @@ public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStra
 
 	@Nonnull
 	private Optional<SlotInfoAndLocality> selectWithoutLocationPreference(
-		@Nonnull Collection<? extends SlotInfo> availableSlots,
+		@Nonnull Collection<SlotInfoAndRemainingResource> availableSlots,
 		@Nonnull ResourceProfile resourceProfile) {
 
-		for (SlotInfo candidate : availableSlots) {
-			if (candidate.getResourceProfile().isMatching(resourceProfile)) {
-				return Optional.of(SlotInfoAndLocality.of(candidate, Locality.UNCONSTRAINED));
+		for (SlotInfoAndRemainingResource candidate : availableSlots) {
+			if (candidate.getRemainingResources().isMatching(resourceProfile)) {
+				return Optional.of(SlotInfoAndLocality.of(candidate.getSlotInfo(), Locality.UNCONSTRAINED));
 			}
 		}
 		return Optional.empty();
@@ -80,7 +79,7 @@ public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStra
 
 	@Nonnull
 	private Optional<SlotInfoAndLocality> selectWitLocationPreference(
-		@Nonnull Collection<? extends SlotInfo> availableSlots,
+		@Nonnull Collection<SlotInfoAndRemainingResource> availableSlots,
 		@Nonnull Collection<TaskManagerLocation> locationPreferences,
 		@Nonnull ResourceProfile resourceProfile) {
 
@@ -93,21 +92,21 @@ public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStra
 			preferredFQHostNames.merge(locationPreference.getFQDNHostname(), 1, Integer::sum);
 		}
 
-		SlotInfo bestCandidate = null;
+		SlotInfoAndRemainingResource bestCandidate = null;
 		Locality bestCandidateLocality = Locality.UNKNOWN;
 		int bestCandidateScore = Integer.MIN_VALUE;
 
-		for (SlotInfo candidate : availableSlots) {
+		for (SlotInfoAndRemainingResource candidate : availableSlots) {
 
-			if (candidate.getResourceProfile().isMatching(resourceProfile)) {
+			if (candidate.getRemainingResources().isMatching(resourceProfile)) {
 
 				// this gets candidate is local-weigh
 				Integer localWeigh = preferredResourceIDs.getOrDefault(
-					candidate.getTaskManagerLocation().getResourceID(), 0);
+					candidate.getSlotInfo().getTaskManagerLocation().getResourceID(), 0);
 
 				// this gets candidate is host-local-weigh
 				Integer hostLocalWeigh = preferredFQHostNames.getOrDefault(
-					candidate.getTaskManagerLocation().getFQDNHostname(), 0);
+					candidate.getSlotInfo().getTaskManagerLocation().getFQDNHostname(), 0);
 
 				int candidateScore = LOCALITY_EVALUATION_FUNCTION.apply(localWeigh, hostLocalWeigh);
 				if (candidateScore > bestCandidateScore) {
@@ -122,7 +121,7 @@ public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStra
 
 		// at the end of the iteration, we return the candidate with best possible locality or null.
 		return bestCandidate != null ?
-			Optional.of(SlotInfoAndLocality.of(bestCandidate, bestCandidateLocality)) :
+			Optional.of(SlotInfoAndLocality.of(bestCandidate.getSlotInfo(), bestCandidateLocality)) :
 			Optional.empty();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
-import org.apache.flink.runtime.jobmaster.SlotInfo;
 
 import javax.annotation.Nonnull;
 
@@ -41,39 +40,39 @@ public enum PreviousAllocationSlotSelectionStrategy implements SlotSelectionStra
 
 	@Override
 	public Optional<SlotInfoAndLocality> selectBestSlotForProfile(
-		@Nonnull Collection<? extends SlotInfo> availableSlots,
+		@Nonnull Collection<SlotInfoAndRemainingResource> availableSlots,
 		@Nonnull SlotProfile slotProfile) {
 
 		Collection<AllocationID> priorAllocations = slotProfile.getPreferredAllocations();
 
 		// First, if there was a prior allocation try to schedule to the same/old slot
 		if (!priorAllocations.isEmpty()) {
-			for (SlotInfo availableSlot : availableSlots) {
-				if (priorAllocations.contains(availableSlot.getAllocationId())) {
+			for (SlotInfoAndRemainingResource availableSlot : availableSlots) {
+				if (priorAllocations.contains(availableSlot.getSlotInfo().getAllocationId())) {
 					return Optional.of(
-						SlotInfoAndLocality.of(availableSlot, Locality.LOCAL));
+						SlotInfoAndLocality.of(availableSlot.getSlotInfo(), Locality.LOCAL));
 				}
 			}
 		}
 
 		// Second, select based on location preference, excluding blacklisted allocations
 		Set<AllocationID> blackListedAllocations = slotProfile.getPreviousExecutionGraphAllocations();
-		Collection<? extends SlotInfo> availableAndAllowedSlots = computeWithoutBlacklistedSlots(availableSlots, blackListedAllocations);
+		Collection<SlotInfoAndRemainingResource> availableAndAllowedSlots = computeWithoutBlacklistedSlots(availableSlots, blackListedAllocations);
 		return LocationPreferenceSlotSelectionStrategy.INSTANCE.selectBestSlotForProfile(availableAndAllowedSlots, slotProfile);
 	}
 
 	@Nonnull
-	private Collection<SlotInfo> computeWithoutBlacklistedSlots(
-		@Nonnull Collection<? extends SlotInfo> availableSlots,
+	private Collection<SlotInfoAndRemainingResource> computeWithoutBlacklistedSlots(
+		@Nonnull Collection<SlotInfoAndRemainingResource> availableSlots,
 		@Nonnull Set<AllocationID> blacklistedAllocations) {
 
 		if (blacklistedAllocations.isEmpty()) {
 			return Collections.unmodifiableCollection(availableSlots);
 		}
 
-		ArrayList<SlotInfo> availableAndAllowedSlots = new ArrayList<>(availableSlots.size());
-		for (SlotInfo availableSlot : availableSlots) {
-			if (!blacklistedAllocations.contains(availableSlot.getAllocationId())) {
+		ArrayList<SlotInfoAndRemainingResource> availableAndAllowedSlots = new ArrayList<>(availableSlots.size());
+		for (SlotInfoAndRemainingResource availableSlot : availableSlots) {
+			if (!blacklistedAllocations.contains(availableSlot.getSlotInfo().getAllocationId())) {
 				availableAndAllowedSlots.add(availableSlot);
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -280,6 +280,7 @@ public class SchedulerImpl implements Scheduler {
 
 		final SlotSharingManager.SingleTaskSlot leaf = multiTaskSlotLocality.getMultiTaskSlot().allocateSingleTaskSlot(
 			slotRequestId,
+			slotProfile.getResourceProfile(),
 			scheduledUnit.getJobVertexId(),
 			multiTaskSlotLocality.getLocality());
 		return leaf.getLogicalSlotFuture();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
@@ -116,24 +117,53 @@ public class SchedulerImpl implements Scheduler {
 		componentMainThreadExecutor.assertRunningInMainThread();
 
 		final CompletableFuture<LogicalSlot> allocationResultFuture = new CompletableFuture<>();
+		internalAllocateSlot(
+				allocationResultFuture,
+				slotRequestId,
+				scheduledUnit,
+				slotProfile,
+				allowQueuedScheduling,
+				allocationTimeout);
+		return allocationResultFuture;
+	}
 
+	private void internalAllocateSlot(
+			CompletableFuture<LogicalSlot> allocationResultFuture,
+			SlotRequestId slotRequestId,
+			ScheduledUnit scheduledUnit,
+			SlotProfile slotProfile,
+			boolean allowQueuedScheduling,
+			Time allocationTimeout) {
 		CompletableFuture<LogicalSlot> allocationFuture = scheduledUnit.getSlotSharingGroupId() == null ?
 			allocateSingleSlot(slotRequestId, slotProfile, allowQueuedScheduling, allocationTimeout) :
 			allocateSharedSlot(slotRequestId, scheduledUnit, slotProfile, allowQueuedScheduling, allocationTimeout);
 
 		allocationFuture.whenComplete((LogicalSlot slot, Throwable failure) -> {
 			if (failure != null) {
-				cancelSlotRequest(
-					slotRequestId,
-					scheduledUnit.getSlotSharingGroupId(),
-					failure);
-				allocationResultFuture.completeExceptionally(failure);
+				Optional<SharedSlotOverAllocatedException> sharedSlotOverAllocatedException =
+						ExceptionUtils.findThrowable(failure, SharedSlotOverAllocatedException.class);
+				if (sharedSlotOverAllocatedException.isPresent() &&
+						sharedSlotOverAllocatedException.get().isCouldRetry()) {
+
+					// Retry the allocation
+					internalAllocateSlot(
+							allocationResultFuture,
+							slotRequestId,
+							scheduledUnit,
+							slotProfile,
+							allowQueuedScheduling,
+							allocationTimeout);
+				} else {
+					cancelSlotRequest(
+							slotRequestId,
+							scheduledUnit.getSlotSharingGroupId(),
+							failure);
+					allocationResultFuture.completeExceptionally(failure);
+				}
 			} else {
 				allocationResultFuture.complete(slot);
 			}
 		});
-
-		return allocationResultFuture;
 	}
 
 	@Override
@@ -314,7 +344,14 @@ public class SchedulerImpl implements Scheduler {
 
 			if (taskSlot != null) {
 				Preconditions.checkState(taskSlot instanceof SlotSharingManager.MultiTaskSlot);
-				return SlotSharingManager.MultiTaskSlotLocality.of(((SlotSharingManager.MultiTaskSlot) taskSlot), Locality.LOCAL);
+
+				SlotSharingManager.MultiTaskSlot multiTaskSlot = (SlotSharingManager.MultiTaskSlot) taskSlot;
+
+				if (multiTaskSlot.mayHaveEnoughToFulfill(slotProfile.getResourceProfile())) {
+					return SlotSharingManager.MultiTaskSlotLocality.of(multiTaskSlot, Locality.LOCAL);
+				}
+
+				throw new NoResourceAvailableException("Not enough resource in the co-located slot.");
 			} else {
 				// the slot may have been cancelled in the mean time
 				coLocationConstraint.setSlotRequestId(null);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableExceptio
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotContext;
-import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.ExceptionUtils;
@@ -51,6 +50,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 
 /**
  * Scheduler that assigns tasks to slots. This class is currently work in progress, comments will be updated as we
@@ -253,7 +253,11 @@ public class SchedulerImpl implements Scheduler {
 		@Nonnull SlotRequestId slotRequestId,
 		@Nonnull SlotProfile slotProfile) {
 
-		Collection<SlotInfo> slotInfoList = slotPool.getAvailableSlotsInformation();
+		Collection<SlotSelectionStrategy.SlotInfoAndRemainingResource> slotInfoList =
+				slotPool.getAvailableSlotsInformation()
+						.stream()
+						.map(SlotSelectionStrategy.SlotInfoAndRemainingResource::new)
+						.collect(Collectors.toList());
 
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> selectedAvailableSlot =
 			slotSelectionStrategy.selectBestSlotForProfile(slotInfoList, slotProfile);
@@ -439,7 +443,8 @@ public class SchedulerImpl implements Scheduler {
 		boolean allowQueuedScheduling,
 		Time allocationTimeout) throws NoResourceAvailableException {
 
-		Collection<SlotInfo> resolvedRootSlotsInfo = slotSharingManager.listResolvedRootSlotInfo(groupId);
+		Collection<SlotSelectionStrategy.SlotInfoAndRemainingResource> resolvedRootSlotsInfo =
+				slotSharingManager.listResolvedRootSlotInfo(groupId);
 
 		SlotSelectionStrategy.SlotInfoAndLocality bestResolvedRootSlotWithLocality =
 			slotSelectionStrategy.selectBestSlotForProfile(resolvedRootSlotsInfo, slotProfile).orElse(null);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SharedSlotOverAllocatedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SharedSlotOverAllocatedException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+/**
+ * If a shared slot is over-allocated before it has been resolved,
+ * some requests will be rejected with this exception to ensure the
+ * total resource requested do not exceed the total resources. The
+ * released requests can be retried if couldRetry is marked.
+ */
+class SharedSlotOverAllocatedException extends Exception {
+
+	/** Whether the requester should retry. */
+	private final boolean couldRetry;
+
+	SharedSlotOverAllocatedException(String message, boolean couldRetry) {
+		super(message);
+		this.couldRetry = couldRetry;
+	}
+
+	boolean isCouldRetry() {
+		return couldRetry;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSelectionStrategy.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
@@ -36,14 +38,46 @@ public interface SlotSelectionStrategy {
 	 * Selects the best {@link SlotInfo} w.r.t. a certain selection criterion from the provided list of available slots
 	 * and considering the given {@link SlotProfile} that describes the requirements.
 	 *
-	 * @param availableSlots a list of the available slots to select from.
+	 * @param availableSlots a list of the available slots together with their remaining resources to select from.
 	 * @param slotProfile a slot profile, describing requirements for the slot selection.
 	 * @return the selected slot info with the corresponding locality hint.
 	 */
 	Optional<SlotInfoAndLocality> selectBestSlotForProfile(
-		@Nonnull Collection<? extends SlotInfo> availableSlots,
+		@Nonnull Collection<SlotInfoAndRemainingResource> availableSlots,
 		@Nonnull SlotProfile slotProfile);
 
+	/**
+	 * This class is a value type that combines a {@link SlotInfo} with its remaining {@link ResourceProfile}.
+	 */
+	final class SlotInfoAndRemainingResource {
+
+		@Nonnull
+		private final SlotInfo slotInfo;
+
+		@Nonnull
+		private final ResourceProfile remainingResources;
+
+		@VisibleForTesting
+		public SlotInfoAndRemainingResource(@Nonnull SlotInfo slotInfo) {
+			this(slotInfo, slotInfo.getResourceProfile());
+		}
+
+		SlotInfoAndRemainingResource(@Nonnull SlotInfo slotInfo, @Nonnull ResourceProfile remainingResources) {
+			this.slotInfo = slotInfo;
+			this.remainingResources = remainingResources;
+		}
+
+		@VisibleForTesting
+		@Nonnull
+		public SlotInfo getSlotInfo() {
+			return slotInfo;
+		}
+
+		@Nonnull
+		ResourceProfile getRemainingResources() {
+			return remainingResources;
+		}
+	}
 
 	/**
 	 * This class is a value type that combines a {@link SlotInfo} with a {@link Locality} hint.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -181,14 +181,18 @@ public class SlotSharingManager {
 	}
 
 	@Nonnull
-	public Collection<SlotInfo> listResolvedRootSlotInfo(@Nullable AbstractID groupId) {
+	public Collection<SlotSelectionStrategy.SlotInfoAndRemainingResource> listResolvedRootSlotInfo(@Nullable AbstractID groupId) {
 		return resolvedRootSlots
 			.values()
 			.stream()
-			.flatMap((Map<AllocationID, MultiTaskSlot> map) -> map.values().stream())
-			.filter((MultiTaskSlot multiTaskSlot) -> !multiTaskSlot.contains(groupId))
-			.map((MultiTaskSlot multiTaskSlot) -> (SlotInfo) multiTaskSlot.getSlotContextFuture().join())
-			.collect(Collectors.toList());
+				.flatMap((Map<AllocationID, MultiTaskSlot> map) -> map.values().stream())
+				.filter((MultiTaskSlot multiTaskSlot) -> !multiTaskSlot.contains(groupId))
+				.map((MultiTaskSlot multiTaskSlot) -> {
+					SlotInfo slotInfo = multiTaskSlot.getSlotContextFuture().join();
+					return new SlotSelectionStrategy.SlotInfoAndRemainingResource(
+							slotInfo,
+							slotInfo.getResourceProfile().subtract(multiTaskSlot.getReservedResources()));
+				}).collect(Collectors.toList());
 	}
 
 	@Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -293,6 +294,13 @@ public class SlotSharingManager {
 		 * @param cause for the release
 		 */
 		public abstract void release(Throwable cause);
+
+		/**
+		 * Gets the total requested resources of the slot and its descendants.
+		 *
+		 * @return The total requested resources of the slot and its descendants.
+		 */
+		public abstract ResourceProfile getRequestedResources();
 	}
 
 	/**
@@ -315,6 +323,9 @@ public class SlotSharingManager {
 
 		// true if we are currently releasing our children
 		private boolean releasingChildren;
+
+		// the total requested by all the descendants.
+		private ResourceProfile requestedResources;
 
 		private MultiTaskSlot(
 				SlotRequestId slotRequestId,
@@ -354,6 +365,8 @@ public class SlotSharingManager {
 
 			this.children = new HashMap<>(16);
 			this.releasingChildren = false;
+
+			this.requestedResources = ResourceProfile.EMPTY;
 
 			slotContextFuture.whenComplete(
 				(SlotContext ignored, Throwable throwable) -> {
@@ -404,6 +417,7 @@ public class SlotSharingManager {
 		 */
 		SingleTaskSlot allocateSingleTaskSlot(
 				SlotRequestId slotRequestId,
+				ResourceProfile resourceProfile,
 				AbstractID groupId,
 				Locality locality) {
 			Preconditions.checkState(!super.contains(groupId));
@@ -412,6 +426,7 @@ public class SlotSharingManager {
 
 			final SingleTaskSlot leaf = new SingleTaskSlot(
 				slotRequestId,
+				resourceProfile,
 				groupId,
 				this,
 				locality);
@@ -420,6 +435,8 @@ public class SlotSharingManager {
 
 			// register the newly allocated slot also at the SlotSharingManager
 			allTaskSlots.put(slotRequestId, leaf);
+
+			onResourceRequested(resourceProfile);
 
 			return leaf;
 		}
@@ -490,6 +507,11 @@ public class SlotSharingManager {
 			}
 		}
 
+		@Override
+		public ResourceProfile getRequestedResources() {
+			return requestedResources;
+		}
+
 		/**
 		 * Releases the child with the given childGroupId.
 		 *
@@ -501,11 +523,30 @@ public class SlotSharingManager {
 
 				if (child != null) {
 					allTaskSlots.remove(child.getSlotRequestId());
+
+					// Update the resources of this slot and the parents
+					onResourceReleased(child.getRequestedResources());
 				}
 
 				if (children.isEmpty()) {
 					release(new FlinkException("Release multi task slot because all children have been released."));
 				}
+			}
+		}
+
+		private void onResourceRequested(ResourceProfile resourceProfile) {
+			requestedResources = requestedResources.merge(resourceProfile);
+
+			if (parent != null) {
+				parent.onResourceRequested(resourceProfile);
+			}
+		}
+
+		private void onResourceReleased(ResourceProfile resourceProfile) {
+			requestedResources = requestedResources.subtract(resourceProfile);
+
+			if (parent != null) {
+				parent.onResourceReleased(resourceProfile);
 			}
 		}
 
@@ -539,13 +580,18 @@ public class SlotSharingManager {
 		// future containing a LogicalSlot which is completed once the underlying SlotContext future is completed
 		private final CompletableFuture<SingleLogicalSlot> singleLogicalSlotFuture;
 
+		// the resource requested of this slot.
+		private final ResourceProfile resourceProfile;
+
 		private SingleTaskSlot(
 				SlotRequestId slotRequestId,
+				ResourceProfile resourceProfile,
 				AbstractID groupId,
 				MultiTaskSlot parent,
 				Locality locality) {
 			super(slotRequestId, groupId);
 
+			this.resourceProfile = Preconditions.checkNotNull(resourceProfile);
 			this.parent = Preconditions.checkNotNull(parent);
 
 			Preconditions.checkNotNull(locality);
@@ -578,6 +624,11 @@ public class SlotSharingManager {
 			}
 
 			parent.releaseChild(getGroupId());
+		}
+
+		@Override
+		public ResourceProfile getRequestedResources() {
+			return resourceProfile;
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionStrategyTestBase {
 
@@ -61,7 +62,11 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		SlotProfile slotProfile = new SlotProfile(ResourceProfile.UNKNOWN, Collections.emptyList(), Collections.emptySet());
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
-		Assert.assertTrue(candidates.contains(match.get().getSlotInfo()));
+		Assert.assertTrue(
+				candidates.stream()
+						.map(SlotSelectionStrategy.SlotInfoAndRemainingResource::getSlotInfo)
+						.collect(Collectors.toList())
+						.contains(match.get().getSlotInfo()));
 	}
 
 	@Test
@@ -70,7 +75,11 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tmlX), Collections.emptySet());
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
-		Assert.assertTrue(candidates.contains(match.get().getSlotInfo()));
+		Assert.assertTrue(
+				candidates.stream()
+						.map(SlotSelectionStrategy.SlotInfoAndRemainingResource::getSlotInfo)
+						.collect(Collectors.toList())
+						.contains(match.get().getSlotInfo()));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -162,4 +162,43 @@ public class ResourceProfileTest {
 		assertEquals(100, rp.getOperatorsMemoryInMB());
 		assertEquals(1.6, rp.getExtendedResources().get(ResourceSpec.GPU_NAME).getValue(), 0.000001);
 	}
+
+	@Test
+	public void testMerge() throws Exception {
+		final double LARGE_DOUBLE = Double.MAX_VALUE - 1.0;
+		final int LARGE_INTEGER = Integer.MAX_VALUE - 100;
+
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.emptyMap());
+		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
+		ResourceProfile rp4 = new ResourceProfile(LARGE_DOUBLE, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, Collections.emptyMap());
+
+		assertEquals(rp2, rp1.merge(rp1));
+		assertEquals(rp3, rp1.merge(rp2));
+
+		assertEquals(ResourceProfile.ANY, rp4.merge(rp1));
+		assertEquals(ResourceProfile.ANY, rp4.merge(rp2));
+
+		assertEquals(ResourceProfile.UNKNOWN, rp4.merge(ResourceProfile.UNKNOWN));
+		assertEquals(ResourceProfile.ANY, rp4.merge(ResourceProfile.ANY));
+	}
+
+	@Test
+	public void testSubtract() throws Exception {
+
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.emptyMap());
+		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
+
+		assertEquals(rp1, rp3.subtract(rp2));
+		assertEquals(rp1, rp2.subtract(rp1));
+
+		ResourceProfile rp4 = new ResourceProfile(Double.MAX_VALUE, 100, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyMap());
+		ResourceProfile rp5 = new ResourceProfile(Double.MAX_VALUE, 0, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyMap());
+
+		assertEquals(rp5, rp4.subtract(rp1));
+
+		assertEquals(ResourceProfile.ANY, ResourceProfile.ANY.subtract(rp3));
+		assertEquals(ResourceProfile.UNKNOWN, ResourceProfile.UNKNOWN.subtract(rp3));
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.clusterframework.types;
 
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.resources.GPUResource;
+
 import org.junit.Test;
 
 import java.util.Collections;
@@ -26,6 +28,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ResourceProfileTest {
 
@@ -165,27 +168,45 @@ public class ResourceProfileTest {
 
 	@Test
 	public void testMerge() throws Exception {
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200,
+				Collections.singletonMap("gpu", new GPUResource(2.0)));
+
+		ResourceProfile rp1MergeRp1 = new ResourceProfile(2.0, 200, 200, 200, 200, 200,
+				Collections.emptyMap());
+		ResourceProfile rp1MergeRp2 = new ResourceProfile(3.0, 300, 300, 300, 300, 300,
+				Collections.singletonMap("gpu", new GPUResource(2.0)));
+		ResourceProfile rp2MergeRp2 = new ResourceProfile(4.0, 400, 400, 400, 400, 400,
+				Collections.singletonMap("gpu", new GPUResource(4.0)));
+
+		assertEquals(rp1MergeRp1, rp1.merge(rp1));
+		assertEquals(rp1MergeRp2, rp1.merge(rp2));
+		assertEquals(rp1MergeRp2, rp2.merge(rp1));
+		assertEquals(rp2MergeRp2, rp2.merge(rp2));
+
+		assertEquals(ResourceProfile.UNKNOWN, rp1.merge(ResourceProfile.UNKNOWN));
+		assertEquals(ResourceProfile.UNKNOWN, ResourceProfile.UNKNOWN.merge(rp1));
+		assertEquals(ResourceProfile.UNKNOWN, ResourceProfile.UNKNOWN.merge(ResourceProfile.UNKNOWN));
+		assertEquals(ResourceProfile.ANY, rp1.merge(ResourceProfile.ANY));
+		assertEquals(ResourceProfile.ANY, ResourceProfile.ANY.merge(rp1));
+		assertEquals(ResourceProfile.ANY, ResourceProfile.ANY.merge(ResourceProfile.ANY));
+	}
+
+	@Test
+	public void testMergeWithOverflow() throws Exception {
 		final double LARGE_DOUBLE = Double.MAX_VALUE - 1.0;
 		final int LARGE_INTEGER = Integer.MAX_VALUE - 100;
 
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
-		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.emptyMap());
-		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
-		ResourceProfile rp4 = new ResourceProfile(LARGE_DOUBLE, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, Collections.emptyMap());
+		ResourceProfile rp1 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
+		ResourceProfile rp2 = new ResourceProfile(LARGE_DOUBLE, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, Collections.emptyMap());
 
-		assertEquals(rp2, rp1.merge(rp1));
-		assertEquals(rp3, rp1.merge(rp2));
-
-		assertEquals(ResourceProfile.ANY, rp4.merge(rp1));
-		assertEquals(ResourceProfile.ANY, rp4.merge(rp2));
-
-		assertEquals(ResourceProfile.UNKNOWN, rp4.merge(ResourceProfile.UNKNOWN));
-		assertEquals(ResourceProfile.ANY, rp4.merge(ResourceProfile.ANY));
+		assertEquals(ResourceProfile.ANY, rp2.merge(rp2));
+		assertEquals(ResourceProfile.ANY, rp2.merge(rp1));
+		assertEquals(ResourceProfile.ANY, rp1.merge(rp2));
 	}
 
 	@Test
 	public void testSubtract() throws Exception {
-
 		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
 		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.emptyMap());
 		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
@@ -198,7 +219,30 @@ public class ResourceProfileTest {
 
 		assertEquals(rp5, rp4.subtract(rp1));
 
+		try {
+			ResourceProfile ignored = rp1.subtract(rp2);
+			fail("The subtract should failed due to trying to subtract a larger resource");
+		} catch (IllegalArgumentException ex) {
+			// Ignore ex.
+		}
+
 		assertEquals(ResourceProfile.ANY, ResourceProfile.ANY.subtract(rp3));
+		assertEquals(ResourceProfile.ANY, ResourceProfile.ANY.subtract(ResourceProfile.ANY));
+		assertEquals(ResourceProfile.ANY, rp3.subtract(ResourceProfile.ANY));
+
 		assertEquals(ResourceProfile.UNKNOWN, ResourceProfile.UNKNOWN.subtract(rp3));
+		assertEquals(ResourceProfile.UNKNOWN, rp3.subtract(ResourceProfile.UNKNOWN));
+		assertEquals(ResourceProfile.UNKNOWN, ResourceProfile.UNKNOWN.subtract(ResourceProfile.UNKNOWN));
+	}
+
+	@Test
+	public void testSubtractWithInfValues() {
+		// Does not equals to ANY since it has extended resources.
+		ResourceProfile rp1 = new ResourceProfile(Double.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
+				Integer.MAX_VALUE, Collections.singletonMap("gpu", new GPUResource(4.0)));
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200,
+				Collections.emptyMap());
+
+		assertEquals(rp1, rp1.subtract(rp2));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.clusterframework.types;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
-import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.TestLogger;
@@ -56,7 +55,7 @@ public abstract class SlotSelectionStrategyTestBase extends TestLogger {
 	protected final SimpleSlotContext ssc3 = new SimpleSlotContext(aid3, tml3, 3, taskManagerGateway, resourceProfile);
 	protected final SimpleSlotContext ssc4 = new SimpleSlotContext(aid4, tml4, 4, taskManagerGateway, resourceProfile);
 
-	protected final Set<SlotContext> candidates = Collections.unmodifiableSet(createCandidates());
+	protected final Set<SlotSelectionStrategy.SlotInfoAndRemainingResource> candidates = Collections.unmodifiableSet(createCandidates());
 
 	protected final SlotSelectionStrategy selectionStrategy;
 
@@ -64,12 +63,12 @@ public abstract class SlotSelectionStrategyTestBase extends TestLogger {
 		this.selectionStrategy = slotSelectionStrategy;
 	}
 
-	private Set<SlotContext> createCandidates() {
-		Set<SlotContext> candidates = new HashSet<>(4);
-		candidates.add(ssc1);
-		candidates.add(ssc2);
-		candidates.add(ssc3);
-		candidates.add(ssc4);
+	private Set<SlotSelectionStrategy.SlotInfoAndRemainingResource> createCandidates() {
+		Set<SlotSelectionStrategy.SlotInfoAndRemainingResource> candidates = new HashSet<>(4);
+		candidates.add(new SlotSelectionStrategy.SlotInfoAndRemainingResource(ssc1));
+		candidates.add(new SlotSelectionStrategy.SlotInfoAndRemainingResource(ssc2));
+		candidates.add(new SlotSelectionStrategy.SlotInfoAndRemainingResource(ssc3));
+		candidates.add(new SlotSelectionStrategy.SlotInfoAndRemainingResource(ssc4));
 		return candidates;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolCoLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolCoLocationTest.java
@@ -41,6 +41,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -51,6 +52,7 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test cases for {@link CoLocationConstraint} with the {@link SlotPoolImpl}.
@@ -157,5 +159,165 @@ public class SlotPoolCoLocationTest extends TestLogger {
 		assertEquals(logicalSlot11.getAllocationId(), logicalSlot12.getAllocationId());
 		assertEquals(logicalSlot21.getAllocationId(), logicalSlot22.getAllocationId());
 		assertNotEquals(logicalSlot11.getAllocationId(), logicalSlot21.getAllocationId());
+	}
+
+	@Test
+	public void testCoLocatedSlotRequestsFailBeforeResolved() throws ExecutionException, InterruptedException {
+		final ResourceProfile rp1 = new ResourceProfile(1.0, 100);
+		final ResourceProfile rp2 = new ResourceProfile(2.0, 200);
+		final ResourceProfile rp3 = new ResourceProfile(5.0, 500);
+
+		final ResourceProfile allocatedSlotRp = new ResourceProfile(3.0, 300);
+
+		final BlockingQueue<AllocationID> allocationIds = new ArrayBlockingQueue<>(1);
+
+		final TestingResourceManagerGateway testingResourceManagerGateway = slotPoolResource.getTestingResourceManagerGateway();
+
+		testingResourceManagerGateway.setRequestSlotConsumer(
+				(SlotRequest slotRequest) -> allocationIds.offer(slotRequest.getAllocationId()));
+
+		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
+		final SlotPool slotPoolGateway = slotPoolResource.getSlotPool();
+		slotPoolGateway.registerTaskManager(taskManagerLocation.getResourceID());
+
+		CoLocationGroup group = new CoLocationGroup();
+		CoLocationConstraint coLocationConstraint1 = group.getLocationConstraint(0);
+
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+
+		JobVertexID jobVertexId1 = new JobVertexID();
+		JobVertexID jobVertexId2 = new JobVertexID();
+		JobVertexID jobVertexId3 = new JobVertexID();
+
+		final SlotProvider slotProvider = slotPoolResource.getSlotProvider();
+		CompletableFuture<LogicalSlot> logicalSlotFuture1 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId1,
+						slotSharingGroupId,
+						coLocationConstraint1),
+				true,
+				SlotProfile.noLocality(rp1),
+				TestingUtils.infiniteTime());
+
+		CompletableFuture<LogicalSlot> logicalSlotFuture2 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId2,
+						slotSharingGroupId,
+						coLocationConstraint1),
+				true,
+				SlotProfile.noLocality(rp2),
+				TestingUtils.infiniteTime());
+
+		CompletableFuture<LogicalSlot> logicalSlotFuture3 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId3,
+						slotSharingGroupId,
+						coLocationConstraint1),
+				true,
+				SlotProfile.noLocality(rp3),
+				TestingUtils.infiniteTime());
+
+		final AllocationID allocationId1 = allocationIds.take();
+
+		Collection<SlotOffer> slotOfferFuture1 = slotPoolGateway.offerSlots(
+				taskManagerLocation,
+				new SimpleAckingTaskManagerGateway(),
+				Collections.singletonList(new SlotOffer(
+						allocationId1,
+						0,
+						allocatedSlotRp)));
+
+		assertFalse(slotOfferFuture1.isEmpty());
+
+		for (CompletableFuture<LogicalSlot> logicalSlotFuture : Arrays.asList(logicalSlotFuture1, logicalSlotFuture2, logicalSlotFuture3)) {
+			assertTrue(logicalSlotFuture.isDone() && logicalSlotFuture.isCompletedExceptionally());
+			logicalSlotFuture.whenComplete((LogicalSlot ignored, Throwable throwable) -> {
+				assertTrue(throwable instanceof SharedSlotOverAllocatedException);
+				assertTrue(((SharedSlotOverAllocatedException) throwable).isCouldRetry());
+			});
+		}
+	}
+
+	@Test
+	public void testCoLocatedSlotRequestsFailAfterResolved() throws ExecutionException, InterruptedException {
+		final ResourceProfile rp1 = new ResourceProfile(1.0, 100);
+		final ResourceProfile rp2 = new ResourceProfile(2.0, 200);
+		final ResourceProfile rp3 = new ResourceProfile(5.0, 500);
+
+		final ResourceProfile allocatedSlotRp = new ResourceProfile(3.0, 300);
+
+		final BlockingQueue<AllocationID> allocationIds = new ArrayBlockingQueue<>(1);
+
+		final TestingResourceManagerGateway testingResourceManagerGateway = slotPoolResource.getTestingResourceManagerGateway();
+
+		testingResourceManagerGateway.setRequestSlotConsumer(
+				(SlotRequest slotRequest) -> allocationIds.offer(slotRequest.getAllocationId()));
+
+		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
+		final SlotPool slotPoolGateway = slotPoolResource.getSlotPool();
+		slotPoolGateway.registerTaskManager(taskManagerLocation.getResourceID());
+
+		CoLocationGroup group = new CoLocationGroup();
+		CoLocationConstraint coLocationConstraint1 = group.getLocationConstraint(0);
+
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+
+		JobVertexID jobVertexId1 = new JobVertexID();
+		JobVertexID jobVertexId2 = new JobVertexID();
+		JobVertexID jobVertexId3 = new JobVertexID();
+
+		final SlotProvider slotProvider = slotPoolResource.getSlotProvider();
+		CompletableFuture<LogicalSlot> logicalSlotFuture1 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId1,
+						slotSharingGroupId,
+						coLocationConstraint1),
+				true,
+				SlotProfile.noLocality(rp1),
+				TestingUtils.infiniteTime());
+
+		CompletableFuture<LogicalSlot> logicalSlotFuture2 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId2,
+						slotSharingGroupId,
+						coLocationConstraint1),
+				true,
+				SlotProfile.noLocality(rp2),
+				TestingUtils.infiniteTime());
+
+		final AllocationID allocationId1 = allocationIds.take();
+
+		Collection<SlotOffer> slotOfferFuture1 = slotPoolGateway.offerSlots(
+				taskManagerLocation,
+				new SimpleAckingTaskManagerGateway(),
+				Collections.singletonList(new SlotOffer(
+						allocationId1,
+						0,
+						allocatedSlotRp)));
+
+		assertFalse(slotOfferFuture1.isEmpty());
+
+		CompletableFuture<LogicalSlot> logicalSlotFuture3 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId3,
+						slotSharingGroupId,
+						coLocationConstraint1),
+				true,
+				SlotProfile.noLocality(rp3),
+				TestingUtils.infiniteTime());
+
+		LogicalSlot logicalSlot1 = logicalSlotFuture1.get();
+		LogicalSlot logicalSlot2 = logicalSlotFuture2.get();
+
+		assertEquals(allocationId1, logicalSlot1.getAllocationId());
+		assertEquals(allocationId1, logicalSlot2.getAllocationId());
+
+		assertTrue(logicalSlotFuture3.isDone() && logicalSlotFuture3.isCompletedExceptionally());
+		logicalSlotFuture3.whenComplete((LogicalSlot ignored, Throwable throwable) -> {
+			assertTrue(throwable instanceof SharedSlotOverAllocatedException);
+			assertTrue(((SharedSlotOverAllocatedException) throwable).isCouldRetry());
+		});
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSharingTest.java
@@ -331,6 +331,95 @@ public class SlotPoolSlotSharingTest extends TestLogger {
 		assertEquals(allocationId2, logicalSlot3.getAllocationId());
 	}
 
+	/**
+	 * Tests that when matching from the allocated slot, the remaining resources of the slot
+	 * will be used instead of the total resource.
+	 */
+	@Test
+	public void testSlotSharingRespectsRemainingResource() throws Exception {
+		final ResourceProfile allocatedSlotRp = new ResourceProfile(3.0, 300);
+		final ResourceProfile largeRequestResource = new ResourceProfile(2.0, 200);
+		final ResourceProfile smallRequestResource = new ResourceProfile(1.0, 100);
+
+		final BlockingQueue<AllocationID> allocationIds = new ArrayBlockingQueue<>(2);
+		final TestingResourceManagerGateway testingResourceManagerGateway = slotPoolResource.getTestingResourceManagerGateway();
+		testingResourceManagerGateway.setRequestSlotConsumer(
+				(SlotRequest slotRequest) -> allocationIds.offer(slotRequest.getAllocationId()));
+
+		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
+		final SlotPoolImpl slotPool = slotPoolResource.getSlotPool();
+		slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+		final JobVertexID jobVertexId1 = new JobVertexID();
+		final JobVertexID jobVertexId2 = new JobVertexID();
+		final JobVertexID jobVertexId3 = new JobVertexID();
+
+		final SlotProvider slotProvider = slotPoolResource.getSlotProvider();
+		CompletableFuture<LogicalSlot> logicalSlotFuture1 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId1,
+						slotSharingGroupId,
+						null),
+				true,
+				SlotProfile.noLocality(largeRequestResource),
+				TestingUtils.infiniteTime());
+
+		final AllocationID allocationId1 = allocationIds.take();
+
+		// This should fulfill the first request.
+		boolean offerFuture = slotPool.offerSlot(
+				taskManagerLocation,
+				new SimpleAckingTaskManagerGateway(),
+				new SlotOffer(
+						allocationId1,
+						0,
+						allocatedSlotRp));
+
+		assertTrue(offerFuture);
+		assertTrue(logicalSlotFuture1.isDone());
+		assertEquals(allocationId1, logicalSlotFuture1.get().getAllocationId());
+
+		// The second request should not share the same slot with the first request since it is large.
+		CompletableFuture<LogicalSlot> logicalSlotFuture2 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId2,
+						slotSharingGroupId,
+						null),
+				true,
+				SlotProfile.noLocality(largeRequestResource),
+				TestingUtils.infiniteTime());
+		assertFalse(logicalSlotFuture2.isDone());
+
+		// The third request should be able to share the same slot with the first request since it is small.
+		CompletableFuture<LogicalSlot> logicalSlotFuture3 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId3,
+						slotSharingGroupId,
+						null),
+				true,
+				SlotProfile.noLocality(smallRequestResource),
+				TestingUtils.infiniteTime());
+		assertTrue(logicalSlotFuture3.isDone());
+		assertEquals(allocationId1, logicalSlotFuture1.get().getAllocationId());
+
+		// The second request should be finally fulfilled by a new slot.
+		final AllocationID allocationId2 = allocationIds.take();
+		// This should fulfill the first two requests.
+		offerFuture = slotPool.offerSlot(
+				taskManagerLocation,
+				new SimpleAckingTaskManagerGateway(),
+				new SlotOffer(
+						allocationId2,
+						0,
+						allocatedSlotRp));
+
+		assertTrue(offerFuture);
+		assertTrue(logicalSlotFuture2.isDone());
+		assertEquals(allocationId2, logicalSlotFuture2.get().getAllocationId());
+	}
+
 	@Test
 	public void testRetryOnSharedSlotOverAllocated() throws InterruptedException, ExecutionException {
 		final ResourceProfile rp1 = new ResourceProfile(1.0, 100);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSharingTest.java
@@ -331,4 +331,96 @@ public class SlotPoolSlotSharingTest extends TestLogger {
 		assertEquals(allocationId2, logicalSlot3.getAllocationId());
 	}
 
+	@Test
+	public void testRetryOnSharedSlotOverAllocated() throws InterruptedException, ExecutionException {
+		final ResourceProfile rp1 = new ResourceProfile(1.0, 100);
+		final ResourceProfile rp2 = new ResourceProfile(2.0, 200);
+		final ResourceProfile rp3 = new ResourceProfile(5.0, 500);
+
+		final ResourceProfile firstAllocatedSlotRp = new ResourceProfile(3.0, 300);
+		final ResourceProfile secondAllocatedSlotRp = new ResourceProfile(5.0, 500);
+
+		final BlockingQueue<AllocationID> allocationIds = new ArrayBlockingQueue<>(2);
+		final TestingResourceManagerGateway testingResourceManagerGateway = slotPoolResource.getTestingResourceManagerGateway();
+		testingResourceManagerGateway.setRequestSlotConsumer(
+				(SlotRequest slotRequest) -> allocationIds.offer(slotRequest.getAllocationId()));
+
+		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
+		final SlotPoolImpl slotPool = slotPoolResource.getSlotPool();
+		slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+		final JobVertexID jobVertexId1 = new JobVertexID();
+		final JobVertexID jobVertexId2 = new JobVertexID();
+		final JobVertexID jobVertexId3 = new JobVertexID();
+
+		final SlotProvider slotProvider = slotPoolResource.getSlotProvider();
+		CompletableFuture<LogicalSlot> logicalSlotFuture1 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId1,
+						slotSharingGroupId,
+						null),
+				true,
+				SlotProfile.noLocality(rp1),
+				TestingUtils.infiniteTime());
+
+		CompletableFuture<LogicalSlot> logicalSlotFuture2 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId2,
+						slotSharingGroupId,
+						null),
+				true,
+				SlotProfile.noLocality(rp2),
+				TestingUtils.infiniteTime());
+
+		CompletableFuture<LogicalSlot> logicalSlotFuture3 = slotProvider.allocateSlot(
+				new ScheduledUnit(
+						jobVertexId3,
+						slotSharingGroupId,
+						null),
+				true,
+				SlotProfile.noLocality(rp3),
+				TestingUtils.infiniteTime());
+
+		assertFalse(logicalSlotFuture1.isDone());
+		assertFalse(logicalSlotFuture2.isDone());
+		assertFalse(logicalSlotFuture3.isDone());
+
+		final AllocationID allocationId1 = allocationIds.take();
+
+		// This should fulfill the first two requests.
+		boolean offerFuture = slotPool.offerSlot(
+				taskManagerLocation,
+				new SimpleAckingTaskManagerGateway(),
+				new SlotOffer(
+						allocationId1,
+						0,
+						firstAllocatedSlotRp));
+
+		assertTrue(offerFuture);
+
+		LogicalSlot logicalSlot1 = logicalSlotFuture1.get();
+		LogicalSlot logicalSlot2 = logicalSlotFuture2.get();
+
+		assertEquals(allocationId1, logicalSlot1.getAllocationId());
+		assertEquals(allocationId1, logicalSlot2.getAllocationId());
+
+		// The third request will retry.
+		assertFalse(logicalSlotFuture3.isDone());
+		final AllocationID allocationId2 = allocationIds.take();
+
+		offerFuture = slotPool.offerSlot(
+				taskManagerLocation,
+				new SimpleAckingTaskManagerGateway(),
+				new SlotOffer(
+						allocationId2,
+						1,
+						secondAllocatedSlotRp));
+
+		assertTrue(offerFuture);
+
+		LogicalSlot logicalSlot3 = logicalSlotFuture3.get();
+		assertEquals(allocationId2, logicalSlot3.getAllocationId());
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.jobmanager.slots.DummySlotOwner;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotContext;
-import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -438,12 +437,12 @@ public class SlotSharingManagerTest extends TestLogger {
 
 		AbstractID groupId = new AbstractID();
 
-		Collection<SlotInfo> slotInfos = slotSharingManager.listResolvedRootSlotInfo(groupId);
+		Collection<SlotSelectionStrategy.SlotInfoAndRemainingResource> slotInfos = slotSharingManager.listResolvedRootSlotInfo(groupId);
 		Assert.assertEquals(1, slotInfos.size());
 
-		SlotInfo slotInfo = slotInfos.iterator().next();
+		SlotSelectionStrategy.SlotInfoAndRemainingResource slotInfoAndRemainingResource = slotInfos.iterator().next();
 		SlotSharingManager.MultiTaskSlot resolvedMultiTaskSlot =
-			slotSharingManager.getResolvedRootSlot(slotInfo);
+			slotSharingManager.getResolvedRootSlot(slotInfoAndRemainingResource.getSlotInfo());
 
 		SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality =
 			LocationPreferenceSlotSelectionStrategy.INSTANCE.selectBestSlotForProfile(slotInfos, SlotProfile.noRequirements()).get();
@@ -500,7 +499,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 		SlotProfile slotProfile = SlotProfile.preferredLocality(ResourceProfile.UNKNOWN, Collections.singleton(taskManagerLocation));
 
-		Collection<SlotInfo> slotInfos = slotSharingManager.listResolvedRootSlotInfo(groupId);
+		Collection<SlotSelectionStrategy.SlotInfoAndRemainingResource> slotInfos = slotSharingManager.listResolvedRootSlotInfo(groupId);
 		SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality =
 			LocationPreferenceSlotSelectionStrategy.INSTANCE.selectBestSlotForProfile(slotInfos, slotProfile).get();
 		SlotSharingManager.MultiTaskSlot resolvedRootSlot = slotSharingManager.getResolvedRootSlot(slotInfoAndLocality.getSlotInfo());
@@ -616,6 +615,51 @@ public class SlotSharingManagerTest extends TestLogger {
 		// Releases the first child in the left-side tree.
 		firstChild.release(new Throwable("Release for testing"));
 		assertEquals(ResourceProfile.EMPTY, unresolvedRootSlot.getRequestedResources());
+	}
+
+	@Test
+	public void testGetResolvedSlotWithResourceConfigured() {
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100);
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200);
+		ResourceProfile allocatedSlotRp = new ResourceProfile(5.0, 500);
+
+		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
+
+		SlotSharingManager slotSharingManager = new SlotSharingManager(
+				SLOT_SHARING_GROUP_ID,
+				allocatedSlotActions,
+				SLOT_OWNER);
+
+		SlotSharingManager.MultiTaskSlot rootSlot = slotSharingManager.createRootSlot(
+				new SlotRequestId(),
+				CompletableFuture.completedFuture(
+						new SimpleSlotContext(
+								new AllocationID(),
+								new LocalTaskManagerLocation(),
+								0,
+								new SimpleAckingTaskManagerGateway(),
+								allocatedSlotRp)),
+				new SlotRequestId());
+
+		rootSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				rp1,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+
+		Collection<SlotSelectionStrategy.SlotInfoAndRemainingResource> resolvedRoots =
+			slotSharingManager.listResolvedRootSlotInfo(new AbstractID());
+		assertEquals(1, resolvedRoots.size());
+		assertEquals(allocatedSlotRp.subtract(rp1), resolvedRoots.iterator().next().getRemainingResources());
+
+		rootSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				rp2,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+		resolvedRoots = slotSharingManager.listResolvedRootSlotInfo(new AbstractID());
+		assertEquals(1, resolvedRoots.size());
+		assertEquals(allocatedSlotRp.subtract(rp1).subtract(rp2), resolvedRoots.iterator().next().getRemainingResources());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.common.resources.GPUResource;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
@@ -27,11 +28,13 @@ import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmanager.slots.DummySlotOwner;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
@@ -39,18 +42,27 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
+import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test cases for the {@link SlotSharingManager}.
@@ -604,5 +616,211 @@ public class SlotSharingManagerTest extends TestLogger {
 		// Releases the first child in the left-side tree.
 		firstChild.release(new Throwable("Release for testing"));
 		assertEquals(ResourceProfile.EMPTY, unresolvedRootSlot.getRequestedResources());
+	}
+
+	@Test
+	public void testHashEnoughResourceOfMultiTaskSlot() {
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100);
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200);
+		ResourceProfile allocatedSlotRp = new ResourceProfile(2.0, 200);
+
+		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
+
+		SlotSharingManager slotSharingManager = new SlotSharingManager(
+				SLOT_SHARING_GROUP_ID,
+				allocatedSlotActions,
+				SLOT_OWNER);
+
+		CompletableFuture<SlotContext> slotContextFuture = new CompletableFuture<>();
+
+		SlotSharingManager.MultiTaskSlot unresolvedRootSlot = slotSharingManager.createRootSlot(
+				new SlotRequestId(),
+				slotContextFuture,
+				new SlotRequestId());
+
+		SlotSharingManager.MultiTaskSlot multiTaskSlot =
+				unresolvedRootSlot.allocateMultiTaskSlot(new SlotRequestId(), new SlotSharingGroupId());
+
+		SlotSharingManager.SingleTaskSlot firstChild = multiTaskSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				rp1,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+
+		assertThat(multiTaskSlot.mayHaveEnoughToFulfill(rp1), is(true));
+		assertThat(multiTaskSlot.mayHaveEnoughToFulfill(rp2), is(true));
+		assertThat(multiTaskSlot.mayHaveEnoughToFulfill(ResourceProfile.UNKNOWN), is(true));
+
+		slotContextFuture.complete(new AllocatedSlot(
+				new AllocationID(),
+				new TaskManagerLocation(new ResourceID("tm-X"), InetAddress.getLoopbackAddress(), 46),
+				0,
+				allocatedSlotRp,
+				mock(TaskManagerGateway.class)));
+
+		assertThat(multiTaskSlot.mayHaveEnoughToFulfill(rp1), is(true));
+		assertThat(multiTaskSlot.mayHaveEnoughToFulfill(rp2), is(false));
+		assertThat(multiTaskSlot.mayHaveEnoughToFulfill(ResourceProfile.UNKNOWN), is(true));
+	}
+
+	@Test
+	public void testSlotAllocatedWithEnoughResource() {
+		SlotSharingResourceTestContext context = createResourceTestContext(new ResourceProfile(16.0, 1600));
+
+		// With enough resources, all the requests should be fulfilled.
+		for (SlotSharingManager.SingleTaskSlot singleTaskSlot : context.singleTaskSlotsInOrder) {
+			assertThat(singleTaskSlot.getLogicalSlotFuture().isDone(), is(true));
+			assertThat(singleTaskSlot.getLogicalSlotFuture().isCompletedExceptionally(), is(false));
+		}
+
+		// The multi-task slot for coLocation should be kept.
+		assertThat(context.slotSharingManager.getTaskSlot(context.coLocationTaskSlot.getSlotRequestId()), notNullValue());
+	}
+
+	@Test
+	public void testSlotOverAllocatedAndSingleSlotReleased() {
+		SlotSharingResourceTestContext context = createResourceTestContext(new ResourceProfile(7.0, 700));
+
+		// The two coLocated requests and the third request is successful.
+		for (int i = 0; i < context.singleTaskSlotsInOrder.size(); ++i) {
+			SlotSharingManager.SingleTaskSlot singleTaskSlot = context.singleTaskSlotsInOrder.get(i);
+			assertThat(singleTaskSlot.getLogicalSlotFuture().isDone(), is(true));
+
+			if (i != 3) {
+				assertThat(singleTaskSlot.getLogicalSlotFuture().isCompletedExceptionally(), is(false));
+			} else {
+				assertThat(singleTaskSlot.getLogicalSlotFuture().isCompletedExceptionally(), is(true));
+				singleTaskSlot.getLogicalSlotFuture().whenComplete((LogicalSlot ignored, Throwable throwable) -> {
+					assertThat(throwable instanceof SharedSlotOverAllocatedException, is(true));
+					assertThat(((SharedSlotOverAllocatedException) throwable).isCouldRetry(), is(true));
+				});
+			}
+		}
+
+		// The multi-task slot for coLocation should be kept.
+		assertThat(context.slotSharingManager.getTaskSlot(context.coLocationTaskSlot.getSlotRequestId()), notNullValue());
+	}
+
+	@Test
+	public void testSlotOverAllocatedAndMultiTaskSlotReleased() {
+		SlotSharingResourceTestContext context = createResourceTestContext(new ResourceProfile(3.0, 300));
+
+		// Only the third request is fulfilled.
+		for (int i = 0; i < context.singleTaskSlotsInOrder.size(); ++i) {
+			SlotSharingManager.SingleTaskSlot singleTaskSlot = context.singleTaskSlotsInOrder.get(i);
+			assertThat(singleTaskSlot.getLogicalSlotFuture().isDone(), is(true));
+
+			if (i ==2) {
+				assertThat(singleTaskSlot.getLogicalSlotFuture().isCompletedExceptionally(), is(false));
+			} else {
+				assertThat(singleTaskSlot.getLogicalSlotFuture().isCompletedExceptionally(), is(true));
+				singleTaskSlot.getLogicalSlotFuture().whenComplete((LogicalSlot ignored, Throwable throwable) -> {
+					assertThat(throwable instanceof SharedSlotOverAllocatedException, is(true));
+					assertThat(((SharedSlotOverAllocatedException) throwable).isCouldRetry(), is(true));
+				});
+			}
+		}
+
+		// The multi-task slot for coLocation should not be kept.
+		assertThat(context.slotSharingManager.getTaskSlot(context.coLocationTaskSlot.getSlotRequestId()), nullValue());
+	}
+
+	@Test
+	public void testSlotOverAllocatedAndAllTaskSlotReleased() {
+		SlotSharingResourceTestContext context = createResourceTestContext(new ResourceProfile(2.0, 200));
+
+		// Only the third request is fulfilled.
+		for (int i = 0; i < context.singleTaskSlotsInOrder.size(); ++i) {
+			SlotSharingManager.SingleTaskSlot singleTaskSlot = context.singleTaskSlotsInOrder.get(i);
+			assertThat(singleTaskSlot.getLogicalSlotFuture().isDone(), is(true));
+
+			assertThat(singleTaskSlot.getLogicalSlotFuture().isCompletedExceptionally(), is(true));
+			singleTaskSlot.getLogicalSlotFuture().whenComplete((LogicalSlot ignored, Throwable throwable) -> {
+				assertThat(throwable instanceof SharedSlotOverAllocatedException, is(true));
+
+				// Since no request is fulfilled, these requests will be failed and should not retry.
+				assertThat(((SharedSlotOverAllocatedException) throwable).isCouldRetry(), is(false));
+			});
+		}
+
+		// All the task slots should be removed.
+		assertThat(context.slotSharingManager.isEmpty(), is(true));
+	}
+
+	private SlotSharingResourceTestContext createResourceTestContext(ResourceProfile allocatedResourceProfile) {
+		ResourceProfile coLocationTaskRp = new ResourceProfile(2.0, 200);
+		ResourceProfile thirdChildRp = new ResourceProfile(3.0, 300);
+		ResourceProfile forthChildRp = new ResourceProfile(9.0, 900);
+
+		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
+
+		SlotSharingManager slotSharingManager = new SlotSharingManager(
+				SLOT_SHARING_GROUP_ID,
+				allocatedSlotActions,
+				SLOT_OWNER);
+
+		CompletableFuture<SlotContext> slotContextFuture = new CompletableFuture<>();
+
+		SlotSharingManager.MultiTaskSlot unresolvedRootSlot = slotSharingManager.createRootSlot(
+				new SlotRequestId(),
+				slotContextFuture,
+				new SlotRequestId());
+
+		SlotSharingManager.MultiTaskSlot coLocationTaskSlot = unresolvedRootSlot.allocateMultiTaskSlot(
+				new SlotRequestId(), new SlotSharingGroupId());
+
+		SlotSharingManager.SingleTaskSlot firstCoLocatedChild = coLocationTaskSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				coLocationTaskRp,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+		SlotSharingManager.SingleTaskSlot secondCoLocatedChild = coLocationTaskSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				coLocationTaskRp,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+
+		SlotSharingManager.SingleTaskSlot thirdChild = unresolvedRootSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				thirdChildRp,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+
+		SlotSharingManager.SingleTaskSlot forthChild = unresolvedRootSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				forthChildRp,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+
+		slotContextFuture.complete(new AllocatedSlot(
+				new AllocationID(),
+				new TaskManagerLocation(new ResourceID("tm-X"), InetAddress.getLoopbackAddress(), 46),
+				0,
+				allocatedResourceProfile,
+				mock(TaskManagerGateway.class)));
+
+		return new SlotSharingResourceTestContext(
+				slotSharingManager,
+				coLocationTaskSlot,
+				Arrays.asList(firstCoLocatedChild, secondCoLocatedChild, thirdChild, forthChild));
+	}
+
+	/**
+	 * An utility class maintains the testing sharing slot hierarchy.
+	 */
+	private class SlotSharingResourceTestContext {
+		final SlotSharingManager slotSharingManager;
+		final SlotSharingManager.MultiTaskSlot coLocationTaskSlot;
+		final List<SlotSharingManager.SingleTaskSlot> singleTaskSlotsInOrder;
+
+		SlotSharingResourceTestContext(
+				@Nonnull SlotSharingManager slotSharingManager,
+				@Nonnull SlotSharingManager.MultiTaskSlot coLocationTaskSlot,
+				@Nonnull List<SlotSharingManager.SingleTaskSlot> singleTaskSlotsInOrder) {
+
+			this.slotSharingManager = slotSharingManager;
+			this.coLocationTaskSlot = coLocationTaskSlot;
+			this.singleTaskSlotsInOrder = singleTaskSlotsInOrder;
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.api.common.resources.GPUResource;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
@@ -135,6 +136,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		SlotRequestId singleTaskSlotRequestId = new SlotRequestId();
 		SlotSharingManager.SingleTaskSlot singleTaskSlot = rootSlot.allocateSingleTaskSlot(
 			singleTaskSlotRequestId,
+			ResourceProfile.UNKNOWN,
 			singleTaskSlotGroupId,
 			Locality.LOCAL);
 
@@ -180,6 +182,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		SlotRequestId singleTaskSlotRequestId = new SlotRequestId();
 		SlotSharingManager.SingleTaskSlot singleTaskSlot = rootSlot.allocateSingleTaskSlot(
 			singleTaskSlotRequestId,
+			ResourceProfile.UNKNOWN,
 			new AbstractID(),
 			Locality.LOCAL);
 
@@ -237,6 +240,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 		SlotSharingManager.SingleTaskSlot singleTaskSlot1 = multiTaskSlot.allocateSingleTaskSlot(
 			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
 			new AbstractID(),
 			Locality.LOCAL);
 
@@ -284,12 +288,14 @@ public class SlotSharingManagerTest extends TestLogger {
 		Locality locality1 = Locality.LOCAL;
 		SlotSharingManager.SingleTaskSlot singleTaskSlot1 = rootSlot.allocateSingleTaskSlot(
 			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
 			new AbstractID(),
 			locality1);
 
 		Locality locality2 = Locality.HOST_LOCAL;
 		SlotSharingManager.SingleTaskSlot singleTaskSlot2 = rootSlot.allocateSingleTaskSlot(
 			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
 			new AbstractID(),
 			locality2);
 
@@ -314,6 +320,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		Locality locality3 = Locality.NON_LOCAL;
 		SlotSharingManager.SingleTaskSlot singleTaskSlot3 = rootSlot.allocateSingleTaskSlot(
 			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
 			new AbstractID(),
 			locality3);
 
@@ -349,6 +356,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 		SlotSharingManager.SingleTaskSlot singleTaskSlot = rootSlot.allocateSingleTaskSlot(
 			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
 			new AbstractID(),
 			Locality.LOCAL);
 
@@ -435,6 +443,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		// occupy the resolved root slot
 		resolvedMultiTaskSlot.allocateSingleTaskSlot(
 			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
 			groupId,
 			Locality.UNCONSTRAINED);
 
@@ -491,6 +500,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		// occupy the slot
 		resolvedRootSlot.allocateSingleTaskSlot(
 			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
 			groupId,
 			slotInfoAndLocality.getLocality());
 
@@ -525,6 +535,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		// occupy the unresolved slot
 		unresolvedRootSlot.allocateSingleTaskSlot(
 			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
 			groupId,
 			Locality.UNKNOWN);
 
@@ -532,5 +543,66 @@ public class SlotSharingManagerTest extends TestLogger {
 
 		// we should no longer have a free unresolved root slot
 		assertNull(unresolvedRootSlot1);
+	}
+
+	@Test
+	public void testResourceCalculationOnSlotAllocatingAndReleasing() {
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.singletonMap("gpu", new GPUResource(2.0)));
+		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.singletonMap("gpu", new GPUResource(3.0)));
+
+		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
+
+		SlotSharingManager slotSharingManager = new SlotSharingManager(
+				SLOT_SHARING_GROUP_ID,
+				allocatedSlotActions,
+				SLOT_OWNER);
+
+		SlotSharingManager.MultiTaskSlot unresolvedRootSlot = slotSharingManager.createRootSlot(
+				new SlotRequestId(),
+				new CompletableFuture<>(),
+				new SlotRequestId());
+
+		// Allocates the left subtree.
+		SlotSharingManager.MultiTaskSlot leftMultiTaskSlot =
+				unresolvedRootSlot.allocateMultiTaskSlot(new SlotRequestId(), new SlotSharingGroupId());
+
+		SlotSharingManager.SingleTaskSlot firstChild = leftMultiTaskSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				rp1,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+		SlotSharingManager.SingleTaskSlot secondChild = leftMultiTaskSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				rp2,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+
+		assertEquals(rp1, firstChild.getRequestedResources());
+		assertEquals(rp2, secondChild.getRequestedResources());
+		assertEquals(rp1.merge(rp2), leftMultiTaskSlot.getRequestedResources());
+		assertEquals(rp1.merge(rp2), unresolvedRootSlot.getRequestedResources());
+
+		// Allocates the right subtree.
+		SlotSharingManager.SingleTaskSlot thirdChild = unresolvedRootSlot.allocateSingleTaskSlot(
+				new SlotRequestId(),
+				rp3,
+				new SlotSharingGroupId(),
+				Locality.LOCAL);
+		assertEquals(rp3, thirdChild.getRequestedResources());
+		assertEquals(rp1.merge(rp2).merge(rp3), unresolvedRootSlot.getRequestedResources());
+
+		// Releases the second child in the left-side tree.
+		secondChild.release(new Throwable("Release for testing"));
+		assertEquals(rp1, leftMultiTaskSlot.getRequestedResources());
+		assertEquals(rp1.merge(rp3), unresolvedRootSlot.getRequestedResources());
+
+		// Releases the third child in the right-side tree.
+		thirdChild.release(new Throwable("Release for testing"));
+		assertEquals(rp1, unresolvedRootSlot.getRequestedResources());
+
+		// Releases the first child in the left-side tree.
+		firstChild.release(new Throwable("Release for testing"));
+		assertEquals(ResourceProfile.EMPTY, unresolvedRootSlot.getRequestedResources());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is to introduce the bookkeeping logic for the shared slots and colocated slots. It is a part of introducing the fine-grained resource management for Flink and is based on #8704 #8840 and #8846 . Based on the current design, a task will always request the resource according to its own resource need, and the returned slot may be larger than requested resource. Therefore, it leaves chance for slot sharing and colocation group.

To considering resources during slot sharing and colocation, the resource already requested must be recorded to ensure the resource requests of the assigned tasks do not exceed the total resource of the slot.  

The first step is to bookkeep the resources inside the slot sharing tree structure. A variable is added to each MultiTaskSlot to record the resources already requests by all its descendants. 

For the allocating, there are in general two scenarios:
1. The underlying slot has been allocated. 
2. The underlying slot is requested but not allocated.

For the first type of slots, the allocation is modified to use the remaining resource of the slot instead of the total resource. For slot sharing, if no allocated slots can be fulfilled, it will turn to slots in requesting or request new slot as before. For colocation, if the slot has been allocated but it cannot fulfill the current request, then the request will never be fulfilled and will fail directly.

For the second type of slots, since the total resource of the slots are not known before they get allocated, the requests will be recorded temporarily. When the underlying slot get allocated, the requests will be checked whether they can be fulfilled. Some requests may be failed due to over-allocation. For the failed tests:
1. If only a part of requests are failed, they may succeed if requests without others, therefore these requests can be retry. The colocation requests are considered as a whole instead of the single task requests.
2. If all the requests can not be fulfilled, this case can only happen when we request to RM according to the resource of a task in a colocation group, but the return slot can not fulfill the colocation group and any other requests in the same sharing group. Since for static resource matching this exception cannot be recovered, and to avoid infinite retrying, currently we do not allow the requests to retry. 

3. If the request cannot be fulfilled by RM, RM will return an error directly and the requests will be failed as before.

## Brief change log

1. cfc25388147495a33ba9897a439db44dfc8b8c59 introduces merge/subtract on `ResourceProfile` and 122399a7caa515c1b4390cac7d092e897f0aebe0 enhance the tests.
2. 4f81f937ba1d0900bdfacf9b6d0253cc931535cf changes the default resource in ResourceSpec from DEFAULT to UNKNOWN.
3. 62388dba3fb3e36b5f2fa7bcd473dc998c642639 disables jobs who only have parts of resources configured. This ensure the resources of job vertices are either all UNKNOWN or all configured.
4. 869e800e12ffc33cf6585f94194277076c2009b9 revises the codes of the class of Resource.java.

Based on the above commits,

5. c26aa1763187221961b76a68635a8fc75947eff7 maintains the resource requested in the MutiTaskSlot, which indicates the total resources requested by all its descendant.
6. 2f6add017d250c520265f98ba21b938d699cff9e adds the resource checking logic when the underlying slot is resolved. The over-allocated requests will be marked fail. The over-allocated requests will iff some requests are fulfilled by the underlying slot in `SchedulerImpl`. For the co-located requests, it also adds the checking of whether the remaining resource is possible to fulfill the requests if the underlying slot is already resolved.
7. c9cf151a68344a2aac328983593a7dd07a267ac5 modifies the interface of `SlotSelectionStrategy` to also pass the remaining resource of the underlying slot. The implementation of the strategies should use the remaining resource instead of the total resource.

## Verifying this change

This change added tests and can be verified as follows:

  - Added tests that validate the calculated of requested resource for the hierarchical structure of MultiTaskSlot/SingleTaskSlot. 
  - Added tests that validate the routine to fail the over-allocated requests when the underlying slot is resolved.
  - Added tests that validate the retry logic after failing due to over-allocation.
  - Added tests that validate the failure of the co-located requests if the slot is not enough for all the co-located tasks.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? [Doc](https://docs.google.com/document/d/1UR3vYsLOPXMGVyXHXYg3b5yNZcvSTvot4wela8knVAY/edit?usp=sharing)
