### PR TITLE
[FLINK-12766][runtime] Dynamically allocate TaskExecutor's managed memory to slots.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
@@ -79,6 +79,26 @@ public abstract class Resource implements Serializable {
 		return create(aggregatedValue, resourceAggregateType);
 	}
 
+	public Resource minus(Resource other) {
+		Preconditions.checkArgument(getClass() == other.getClass(), "Minus with different resource resourceAggregateType");
+		Preconditions.checkArgument(this.name.equals(other.name), "Minus with different resource name");
+		Preconditions.checkArgument(this.resourceAggregateType == other.resourceAggregateType, "Minus with different aggregate resourceAggregateType");
+
+		final double aggregatedValue;
+		switch (resourceAggregateType) {
+			case AGGREGATE_TYPE_MAX :
+				// TODO: For max, should check if the latest max item is removed and change accordingly.
+				aggregatedValue = this.value;
+				break;
+
+			case AGGREGATE_TYPE_SUM:
+			default:
+				aggregatedValue = this.value - other.value;
+		}
+
+		return create(aggregatedValue, resourceAggregateType);
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -438,9 +438,15 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 
 	@Override
 	public Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile) {
-		if (!slotsPerWorker.iterator().next().isMatching(resourceProfile)) {
+		ResourceProfile totalResourceProfile = new ResourceProfile(0.0, 0);
+		for (ResourceProfile slotResourceProfile : slotsPerWorker) {
+			totalResourceProfile = totalResourceProfile.merge(slotResourceProfile);
+		}
+
+		if (!totalResourceProfile.isMatching(resourceProfile)) {
 			return Collections.emptyList();
 		}
+
 		LOG.info("Starting a new worker.");
 		try {
 			// generate new workers into persistent state and launch associated actors

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.clusterframework.types;
 
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.resources.Resource;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +30,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Describe the immutable resource profile of the slot, either when requiring or offering it. The profile can be
@@ -48,7 +51,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 
 	private static final long serialVersionUID = 1L;
 
-	public static final ResourceProfile UNKNOWN = new ResourceProfile(-1.0, -1);
+	public static final ResourceProfile UNKNOWN = new ResourceProfile();
 
 	/** ResourceProfile which matches any other ResourceProfile. */
 	public static final ResourceProfile ANY = new ResourceProfile(Double.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyMap());
@@ -97,6 +100,12 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 			int networkMemoryInMB,
 			int managedMemoryInMB,
 			Map<String, Resource> extendedResources) {
+		Preconditions.checkArgument(cpuCores >= 0);
+		Preconditions.checkArgument(heapMemoryInMB >= 0);
+		Preconditions.checkArgument(directMemoryInMB >= 0);
+		Preconditions.checkArgument(nativeMemoryInMB >= 0);
+		Preconditions.checkArgument(networkMemoryInMB >= 0);
+		Preconditions.checkArgument(managedMemoryInMB >= 0);
 		this.cpuCores = cpuCores;
 		this.heapMemoryInMB = heapMemoryInMB;
 		this.directMemoryInMB = directMemoryInMB;
@@ -116,6 +125,18 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 */
 	public ResourceProfile(double cpuCores, int heapMemoryInMB) {
 		this(cpuCores, heapMemoryInMB, 0, 0, 0, 0, Collections.emptyMap());
+	}
+
+	/**
+	 * Creates a special ResourceProfile with negative values, indicating resources are unspecified.
+	 */
+	private ResourceProfile() {
+		this.cpuCores = -1.0;
+		this.heapMemoryInMB = -1;
+		this.directMemoryInMB = -1;
+		this.nativeMemoryInMB = -1;
+		this.networkMemoryInMB = -1;
+		this.managedMemoryInMB = -1;
 	}
 
 	/**
@@ -307,6 +328,104 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 					Objects.equals(extendedResources, that.extendedResources);
 		}
 		return false;
+	}
+
+	/**
+	 * Calculates the sum of two resource profiles.
+	 *
+	 * @param other The other resource profile to add.
+	 * @return The merged resource profile.
+	 */
+	@Nonnull
+	public ResourceProfile merge(@Nonnull ResourceProfile other) {
+		if (equals(ANY) || other.equals(ANY)) {
+			return ANY;
+		}
+
+		if (this.equals(UNKNOWN) || other.equals(UNKNOWN)) {
+			return UNKNOWN;
+		}
+
+		Map<String, Resource> resultExtendedResource = new HashMap<>(extendedResources);
+
+		other.extendedResources.forEach((String name, Resource resource) -> {
+			resultExtendedResource.compute(name, (ignored, oldResource) ->
+				oldResource == null ? resource : oldResource.merge(resource));
+		});
+
+		return new ResourceProfile(
+			addNonNegativeDoublesConsideringOverflow(cpuCores, other.cpuCores),
+			addNonNegativeIntegersConsideringOverflow(heapMemoryInMB, other.heapMemoryInMB),
+			addNonNegativeIntegersConsideringOverflow(directMemoryInMB, other.directMemoryInMB),
+			addNonNegativeIntegersConsideringOverflow(nativeMemoryInMB, other.nativeMemoryInMB),
+			addNonNegativeIntegersConsideringOverflow(networkMemoryInMB, other.networkMemoryInMB),
+			addNonNegativeIntegersConsideringOverflow(managedMemoryInMB, other.managedMemoryInMB),
+			resultExtendedResource);
+	}
+
+	/**
+	 * Subtracts another piece of resource profile from this one.
+	 *
+	 * @param other The other resource profile to subtract.
+	 * @return The subtracted resource profile.
+	 */
+	public ResourceProfile subtract(ResourceProfile other) {
+		if (equals(ANY) || other.equals(ANY)) {
+			return ANY;
+		}
+
+		if (this.equals(UNKNOWN) || other.equals(UNKNOWN)) {
+			return UNKNOWN;
+		}
+
+		checkArgument(isMatching(other), "Try to subtract an unmatched resource profile from this one.");
+
+		Map<String, Resource> resultExtendedResource = new HashMap<>(extendedResources);
+
+		other.extendedResources.forEach((String name, Resource resource) -> {
+			resultExtendedResource.compute(name, (ignored, oldResource) -> {
+				Resource resultResource = oldResource.minus(resource);
+				return resultResource.getValue() == 0 ? null : resultResource;
+			});
+		});
+
+		return new ResourceProfile(
+			subtractDoublesConsideringInf(cpuCores, other.cpuCores),
+			subtractIntegersConsideringInf(heapMemoryInMB, other.heapMemoryInMB),
+			subtractIntegersConsideringInf(directMemoryInMB, other.directMemoryInMB),
+			subtractIntegersConsideringInf(nativeMemoryInMB, other.nativeMemoryInMB),
+			subtractIntegersConsideringInf(networkMemoryInMB, other.networkMemoryInMB),
+			subtractIntegersConsideringInf(managedMemoryInMB, other.managedMemoryInMB),
+			resultExtendedResource
+		);
+	}
+
+	private double addNonNegativeDoublesConsideringOverflow(double first, double second) {
+		double result = first + second;
+
+		if (result == Double.POSITIVE_INFINITY) {
+			return Double.MAX_VALUE;
+		}
+
+		return result;
+	}
+
+	private int addNonNegativeIntegersConsideringOverflow(int first, int second) {
+		int result = first + second;
+
+		if (result < 0) {
+			return Integer.MAX_VALUE;
+		}
+
+		return result;
+	}
+
+	private double subtractDoublesConsideringInf(double first, double second) {
+		return first == Double.MAX_VALUE ? Double.MAX_VALUE : first - second;
+	}
+
+	private int subtractIntegersConsideringInf(int first, int second) {
+		return first == Integer.MAX_VALUE ? Integer.MAX_VALUE : first - second;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManagerId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManagerId.java
@@ -18,34 +18,16 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-import org.apache.flink.runtime.clusterframework.types.TaskManagerSlot;
 import org.apache.flink.util.AbstractID;
 
 /**
- * Id of {@link TaskManagerSlot} and {@link PendingTaskManagerSlot}.
+ * Id of pending task managers.
  */
-public class TaskManagerSlotId extends AbstractID {
+public class PendingTaskManagerId extends AbstractID {
 
-	private static final long serialVersionUID = -4024240625523472071L;
+	private PendingTaskManagerId() {}
 
-	/**
-	 * Id of pending task manager for {@link PendingTaskManagerSlot}, or null for {@link TaskManagerSlot}.
-	 */
-	private final PendingTaskManagerId pendingTaskManagerId;
-
-	private TaskManagerSlotId(PendingTaskManagerId pendingTaskManagerId) {
-		this.pendingTaskManagerId = pendingTaskManagerId;
-	}
-
-	public static TaskManagerSlotId generate(PendingTaskManagerId pendingTaskManagerId) {
-		return new TaskManagerSlotId(pendingTaskManagerId);
-	}
-
-	public static TaskManagerSlotId generate() {
-		return new TaskManagerSlotId(null);
-	}
-
-	public PendingTaskManagerId getPendingTaskManagerId() {
-		return pendingTaskManagerId;
+	public static PendingTaskManagerId generate() {
+		return new PendingTaskManagerId();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManagerSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManagerSlot.java
@@ -29,14 +29,15 @@ import javax.annotation.Nullable;
  */
 public class PendingTaskManagerSlot {
 
-	private final TaskManagerSlotId taskManagerSlotId = TaskManagerSlotId.generate();
+	private final TaskManagerSlotId taskManagerSlotId;
 
 	private final ResourceProfile resourceProfile;
 
 	@Nullable
 	private PendingSlotRequest pendingSlotRequest;
 
-	public PendingTaskManagerSlot(ResourceProfile resourceProfile) {
+	public PendingTaskManagerSlot(PendingTaskManagerId pendingTaskManagerId, ResourceProfile resourceProfile) {
+		taskManagerSlotId = TaskManagerSlotId.generate(pendingTaskManagerId);
 		this.resourceProfile = resourceProfile;
 	}
 
@@ -46,6 +47,10 @@ public class PendingTaskManagerSlot {
 
 	public ResourceProfile getResourceProfile() {
 		return resourceProfile;
+	}
+
+	public PendingTaskManagerId getPendingTaskManagerId() {
+		return taskManagerSlotId.getPendingTaskManagerId();
 	}
 
 	public void assignPendingSlotRequest(@Nonnull PendingSlotRequest pendingSlotRequestToAssign) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -852,6 +852,7 @@ public class SlotManager implements AutoCloseable {
 			slotId,
 			pendingSlotRequest.getJobId(),
 			allocationId,
+			pendingSlotRequest.getResourceProfile(),
 			pendingSlotRequest.getTargetAddress(),
 			resourceManagerId,
 			taskManagerRequestTimeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorResource.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Bookkeeping of total/allocated/available resources of a TaskExecutor.
+ */
+public class TaskExecutorResource<SlotIdType> {
+
+	/** Total resource of the TaskExecutor. */
+	private final ResourceProfile totalResource;
+
+	/** Resources of allocated slots. */
+	private final Map<SlotIdType, ResourceProfile> allocatedSlotsResources;
+
+	/** Remaining available resource. */
+	private ResourceProfile availableResource;
+
+	public TaskExecutorResource(ResourceProfile totalResource) {
+		this.totalResource = totalResource;
+		this.allocatedSlotsResources = new HashMap<>();
+		this.availableResource = totalResource;
+	}
+
+	public ResourceProfile getTotalResource() {
+		return totalResource;
+	}
+
+	public Map<SlotIdType, ResourceProfile> getAllocatedSlotsResources() {
+		return Collections.unmodifiableMap(allocatedSlotsResources);
+	}
+
+	public ResourceProfile getAvailableResource() {
+		return new ResourceProfile(availableResource);
+	}
+
+	public void addSlot(SlotIdType slotID, ResourceProfile slotResource) {
+		allocatedSlotsResources.put(slotID, slotResource);
+		availableResource = availableResource.subtract(slotResource);
+	}
+
+	public void removeSlot(SlotIdType slotID) {
+		ResourceProfile slotResource = allocatedSlotsResources.remove(slotID);
+		if (slotResource != null) {
+			availableResource = availableResource.merge(slotResource);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorResourceBookkeeper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorResourceBookkeeper.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.clusterframework.types.TaskManagerSlot;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+
+/**
+ * Bookkeeps total/allocated/available resources TaskExecutors and pending TaskExecutors.
+ */
+public class TaskExecutorResourceBookkeeper {
+
+	private final HashMap<ResourceID, TaskExecutorResource<SlotID>> taskExecutorResources;
+	private final HashMap<PendingTaskManagerId, TaskExecutorResource<TaskManagerSlotId>> pendingTaskExecutorResources;
+
+	public TaskExecutorResourceBookkeeper() {
+		taskExecutorResources = new HashMap<>();
+		pendingTaskExecutorResources = new HashMap<>();
+	}
+
+	public void addResource(ResourceID resourceID, ResourceProfile totalResourceProfile) {
+		taskExecutorResources.put(resourceID, new TaskExecutorResource<>(totalResourceProfile));
+	}
+
+	public void addResource(PendingTaskManagerId pendingTaskManagerId, ResourceProfile totalResourceProfile) {
+		pendingTaskExecutorResources.put(pendingTaskManagerId, new TaskExecutorResource<>(totalResourceProfile));
+	}
+
+	public void removeResource(ResourceID resourceID) {
+		taskExecutorResources.remove(resourceID);
+	}
+
+	public void removeResource(PendingTaskManagerId pendingTaskManagerId) {
+		pendingTaskExecutorResources.remove(pendingTaskManagerId);
+	}
+
+	public boolean hasEnoughResource(TaskManagerSlot slot, ResourceProfile resourceProfile) {
+		ResourceID resourceID = slot.getSlotId().getResourceID();
+		TaskExecutorResource taskExecutorResource = Preconditions.checkNotNull(taskExecutorResources.get(resourceID));
+
+		ResourceProfile requestedResourceProfile = resourceProfile.equals(ResourceProfile.UNKNOWN) ?
+			slot.getResourceProfile() : resourceProfile;
+		ResourceProfile availableResourceProfile = taskExecutorResource.getAvailableResource();
+		return availableResourceProfile.isMatching(requestedResourceProfile);
+	}
+
+	public boolean hasEnoughResource(PendingTaskManagerSlot pendingSlot, ResourceProfile resourceProfile) {
+		PendingTaskManagerId pendingTaskManagerId = pendingSlot.getPendingTaskManagerId();
+		TaskExecutorResource taskExecutorResource = Preconditions.checkNotNull(pendingTaskExecutorResources.get(pendingTaskManagerId));
+
+		ResourceProfile requestedResourceProfile = resourceProfile.equals(ResourceProfile.UNKNOWN) ?
+			pendingSlot.getResourceProfile() : resourceProfile;
+		ResourceProfile availableResourceProfile = taskExecutorResource.getAvailableResource();
+		return availableResourceProfile.isMatching(requestedResourceProfile);
+	}
+
+	public void recordAllocatedResource(TaskManagerSlot slot, ResourceProfile resourceProfile) {
+		ResourceID resourceID = slot.getSlotId().getResourceID();
+		TaskExecutorResource taskExecutorResource = Preconditions.checkNotNull(taskExecutorResources.get(resourceID));
+
+		ResourceProfile allocatedResourceProfile = resourceProfile.equals(ResourceProfile.UNKNOWN) ?
+			slot.getResourceProfile() : resourceProfile;
+		taskExecutorResource.addSlot(slot.getSlotId(), allocatedResourceProfile);
+	}
+
+	public void recordAllocatedResource(PendingTaskManagerSlot pendingSlot, ResourceProfile resourceProfile) {
+		PendingTaskManagerId pendingTaskManagerId = pendingSlot.getPendingTaskManagerId();
+		TaskExecutorResource taskExecutorResource = Preconditions.checkNotNull(pendingTaskExecutorResources.get(pendingTaskManagerId));
+
+		ResourceProfile allocatedResourceProfile = resourceProfile.equals(ResourceProfile.UNKNOWN) ?
+			pendingSlot.getResourceProfile() : resourceProfile;
+		taskExecutorResource.addSlot(pendingTaskManagerId, allocatedResourceProfile);
+	}
+
+	public void removeAllocatedResource(TaskManagerSlot slot) {
+		ResourceID resourceID = slot.getSlotId().getResourceID();
+		TaskExecutorResource taskExecutorResource = Preconditions.checkNotNull(taskExecutorResources.get(resourceID));
+
+		taskExecutorResource.removeSlot(slot.getSlotId());
+	}
+
+	public void removeAllocatedResource(PendingTaskManagerSlot pendingSlot) {
+		PendingTaskManagerId pendingTaskManagerId = pendingSlot.getPendingTaskManagerId();
+		TaskExecutorResource taskExecutorResource = Preconditions.checkNotNull(pendingTaskExecutorResources.get(pendingTaskManagerId));
+
+		taskExecutorResource.removeSlot(pendingTaskManagerId);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
@@ -54,6 +54,10 @@ public class SlotReport implements Serializable, Iterable<SlotStatus> {
 		return slotsStatus.iterator();
 	}
 
+	public int getSlotNumber() {
+		return slotsStatus.size();
+	}
+
 	@Override
 	public String toString() {
 		return "SlotReport{" +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotStatus.java
@@ -43,21 +43,26 @@ public class SlotStatus implements Serializable {
 	/** If the slot is allocated, allocationId identify its allocation; else, allocationId is null. */
 	private final AllocationID allocationID;
 
+	/** Allocated resource in this slot; null if not allocated. */
+	private final ResourceProfile allocationResourceProfile;
+
 	/** If the slot is allocated, jobId identify which job this slot is allocated to; else, jobId is null. */
 	private final JobID jobID;
 
 	public SlotStatus(SlotID slotID, ResourceProfile resourceProfile) {
-		this(slotID, resourceProfile, null, null);
+		this(slotID, resourceProfile, null, null, null);
 	}
 
 	public SlotStatus(
 		SlotID slotID,
 		ResourceProfile resourceProfile,
 		JobID jobID,
-		AllocationID allocationID) {
+		AllocationID allocationID,
+		ResourceProfile allocationResourceProfile) {
 		this.slotID = checkNotNull(slotID, "slotID cannot be null");
 		this.resourceProfile = checkNotNull(resourceProfile, "profile cannot be null");
 		this.allocationID = allocationID;
+		this.allocationResourceProfile = allocationResourceProfile;
 		this.jobID = jobID;
 	}
 
@@ -89,6 +94,15 @@ public class SlotStatus implements Serializable {
 	}
 
 	/**
+	 * Gets allocated resource in this slot.
+	 *
+	 * @return Allocated resource in this slot; null if not allocated.
+	 */
+	public ResourceProfile getAllocationResourceProfile() {
+		return allocationResourceProfile;
+	}
+
+	/**
 	 * Get the job id of the slot allocated for.
 	 *
 	 * @return The job id if this slot is allocated, otherwise null
@@ -117,6 +131,9 @@ public class SlotStatus implements Serializable {
 		if (allocationID != null ? !allocationID.equals(that.allocationID) : that.allocationID != null) {
 			return false;
 		}
+		if (allocationResourceProfile != null ? !allocationResourceProfile.equals(that.allocationResourceProfile) : that.allocationResourceProfile != null) {
+			return false;
+		}
 		return jobID != null ? jobID.equals(that.jobID) : that.jobID == null;
 
 	}
@@ -126,6 +143,7 @@ public class SlotStatus implements Serializable {
 		int result = slotID.hashCode();
 		result = 31 * result + resourceProfile.hashCode();
 		result = 31 * result + (allocationID != null ? allocationID.hashCode() : 0);
+		result = 31 * result + (allocationResourceProfile != null ? allocationResourceProfile.hashCode() : 0);
 		result = 31 * result + (jobID != null ? jobID.hashCode() : 0);
 		return result;
 	}
@@ -136,6 +154,7 @@ public class SlotStatus implements Serializable {
 			"slotID=" + slotID +
 			", resourceProfile=" + resourceProfile +
 			", allocationID=" + allocationID +
+			", allocationResourceProfile=" + allocationResourceProfile +
 			", jobID=" + jobID +
 			'}';
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -816,7 +816,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			}
 
 			if (taskSlotTable.isSlotFree(slotId.getSlotNumber())) {
-				if (taskSlotTable.allocateSlot(slotId.getSlotNumber(), jobId, allocationId, taskManagerConfiguration.getTimeout())) {
+				if (taskSlotTable.allocateSlot(slotId.getSlotNumber(), jobId, allocationId, allocationResourceProfile, taskManagerConfiguration.getTimeout())) {
 					log.info("Allocated slot for {}.", allocationId);
 				} else {
 					log.info("Could not allocate slot for {}.", allocationId);
@@ -828,7 +828,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				log.info(message);
 
 				final AllocationID allocationID = taskSlotTable.getCurrentAllocation(slotId.getSlotNumber());
-				throw new SlotOccupiedException(message, allocationID, taskSlotTable.getOwningJob(allocationID));
+				final ResourceProfile currentAllocationResourceProfile = taskSlotTable.getCurrentAllocationResourceProfile(slotId.getSlotNumber());
+				throw new SlotOccupiedException(message, allocationID, taskSlotTable.getOwningJob(allocationID), currentAllocationResourceProfile);
 			}
 
 			if (jobManagerTable.contains(jobId)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1624,6 +1624,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		return resourceManagerHeartbeatManager;
 	}
 
+	@VisibleForTesting
+	SlotReport getSlotReport() {
+		return taskSlotTable.createSlotReport(getResourceID());
+	}
+
 	// ------------------------------------------------------------------------
 	//  Utility classes
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -798,6 +799,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		final SlotID slotId,
 		final JobID jobId,
 		final AllocationID allocationId,
+		final ResourceProfile allocationResourceProfile,
 		final String targetAddress,
 		final ResourceManagerId resourceManagerId,
 		final Time timeout) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -54,6 +55,7 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * @param slotId slot id for the request
 	 * @param jobId for which to request a slot
 	 * @param allocationId id for the request
+	 * @param allocationResourceProfile to describe the resource of the allocation
 	 * @param targetAddress to which to offer the requested slots
 	 * @param resourceManagerId current leader id of the ResourceManager
 	 * @param timeout for the operation
@@ -63,6 +65,7 @@ public interface TaskExecutorGateway extends RpcGateway {
 		SlotID slotId,
 		JobID jobId,
 		AllocationID allocationId,
+		ResourceProfile allocationResourceProfile,
 		String targetAddress,
 		ResourceManagerId resourceManagerId,
 		@RpcTimeout Time timeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/exceptions/SlotOccupiedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/exceptions/SlotOccupiedException.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskexecutor.exceptions;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -33,10 +34,13 @@ public class SlotOccupiedException extends SlotAllocationException {
 
 	private final JobID jobId;
 
-	public SlotOccupiedException(String message, AllocationID allocationId, JobID jobId) {
+	private final ResourceProfile allocationResourceProfile;
+
+	public SlotOccupiedException(String message, AllocationID allocationId, JobID jobId, ResourceProfile allocationResourceProfile) {
 		super(message);
 		this.allocationId = Preconditions.checkNotNull(allocationId);
 		this.jobId = Preconditions.checkNotNull(jobId);
+		this.allocationResourceProfile = Preconditions.checkNotNull(allocationResourceProfile);
 	}
 
 	public AllocationID getAllocationId() {
@@ -45,5 +49,9 @@ public class SlotOccupiedException extends SlotAllocationException {
 
 	public JobID getJobId() {
 		return jobId;
+	}
+
+	public ResourceProfile getAllocationResourceProfile() {
+		return allocationResourceProfile;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -311,6 +311,9 @@ public class TaskSlot {
 			"The task slot is not in state active or allocated.");
 		Preconditions.checkState(allocationId != null, "The task slot are not allocated");
 
+		if (!allocationResourceProfile.equals(ResourceProfile.UNKNOWN)) {
+			return new SlotOffer(allocationId, index, allocationResourceProfile);
+		}
 		return new SlotOffer(allocationId, index, resourceProfile);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -68,6 +68,9 @@ public class TaskSlot {
 	/** Allocation id of this slot; null if not allocated. */
 	private AllocationID allocationId;
 
+	/** Allocated resource in this slot; null if not allocated. */
+	private ResourceProfile allocationResourceProfile;
+
 	TaskSlot(final int index, final ResourceProfile resourceProfile) {
 		Preconditions.checkArgument(0 <= index, "The index must be greater than 0.");
 		this.index = index;
@@ -78,6 +81,7 @@ public class TaskSlot {
 
 		this.jobId = null;
 		this.allocationId = null;
+		this.allocationResourceProfile = null;
 	}
 
 	// ----------------------------------------------------------------------------------
@@ -98,6 +102,10 @@ public class TaskSlot {
 
 	public AllocationID getAllocationId() {
 		return allocationId;
+	}
+
+	public ResourceProfile getAllocationResourceProfile() {
+		return allocationResourceProfile;
 	}
 
 	TaskSlotState getState() {
@@ -203,9 +211,10 @@ public class TaskSlot {
 	 *
 	 * @param newJobId to allocate the slot for
 	 * @param newAllocationId to identify the slot allocation
+	 * @param newAllocationResourceProfile to describe the resource of the allocation
 	 * @return True if the slot was allocated for the given job and allocation id; otherwise false
 	 */
-	public boolean allocate(JobID newJobId, AllocationID newAllocationId) {
+	public boolean allocate(JobID newJobId, AllocationID newAllocationId, ResourceProfile newAllocationResourceProfile) {
 		if (TaskSlotState.FREE == state) {
 			// sanity checks
 			Preconditions.checkState(allocationId == null);
@@ -213,6 +222,7 @@ public class TaskSlot {
 
 			this.jobId = Preconditions.checkNotNull(newJobId);
 			this.allocationId = Preconditions.checkNotNull(newAllocationId);
+			this.allocationResourceProfile = Preconditions.checkNotNull(newAllocationResourceProfile);
 
 			state = TaskSlotState.ALLOCATED;
 
@@ -220,8 +230,11 @@ public class TaskSlot {
 		} else if (TaskSlotState.ALLOCATED == state || TaskSlotState.ACTIVE == state) {
 			Preconditions.checkNotNull(newJobId);
 			Preconditions.checkNotNull(newAllocationId);
+			Preconditions.checkNotNull(newAllocationResourceProfile);
 
-			return newJobId.equals(jobId) && newAllocationId.equals(allocationId);
+			return newJobId.equals(jobId) &&
+				newAllocationId.equals(allocationId) &&
+				newAllocationResourceProfile.equals(allocationResourceProfile);
 		} else {
 			return false;
 		}
@@ -270,6 +283,7 @@ public class TaskSlot {
 			state = TaskSlotState.FREE;
 			this.jobId = null;
 			this.allocationId = null;
+			this.allocationResourceProfile = null;
 
 			return true;
 		} else {
@@ -303,6 +317,8 @@ public class TaskSlot {
 	@Override
 	public String toString() {
 		return "TaskSlot(index:" + index + ", state:" + state + ", resource profile: " + resourceProfile +
-			", allocationId: " + (allocationId != null ? allocationId.toString() : "none") + ", jobId: " + (jobId != null ? jobId.toString() : "none") + ')';
+			", allocationId: " + (allocationId != null ? allocationId.toString() : "none") +
+			", allocationResourceProfile: " +  (allocationResourceProfile != null ? allocationResourceProfile.toString() : "none") +
+			", jobId: " + (jobId != null ? jobId.toString() : "none") + ')';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -166,7 +166,8 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 				slotId,
 				taskSlot.getResourceProfile(),
 				taskSlot.getJobId(),
-				taskSlot.getAllocationId());
+				taskSlot.getAllocationId(),
+				taskSlot.getAllocationResourceProfile());
 
 			slotStatuses.set(i, slotStatus);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -162,4 +162,43 @@ public class ResourceProfileTest {
 		assertEquals(100, rp.getOperatorsMemoryInMB());
 		assertEquals(1.6, rp.getExtendedResources().get(ResourceSpec.GPU_NAME).getValue(), 0.000001);
 	}
+
+	@Test
+	public void testMerge() throws Exception {
+		final double LARGE_DOUBLE = Double.MAX_VALUE - 1.0;
+		final int LARGE_INTEGER = Integer.MAX_VALUE - 100;
+
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.emptyMap());
+		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
+		ResourceProfile rp4 = new ResourceProfile(LARGE_DOUBLE, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, LARGE_INTEGER, Collections.emptyMap());
+
+		assertEquals(rp2, rp1.merge(rp1));
+		assertEquals(rp3, rp1.merge(rp2));
+
+		assertEquals(ResourceProfile.ANY, rp4.merge(rp1));
+		assertEquals(ResourceProfile.ANY, rp4.merge(rp2));
+
+		assertEquals(ResourceProfile.UNKNOWN, rp4.merge(ResourceProfile.UNKNOWN));
+		assertEquals(ResourceProfile.ANY, rp4.merge(ResourceProfile.ANY));
+	}
+
+	@Test
+	public void testSubtract() throws Exception {
+
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
+		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.emptyMap());
+		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
+
+		assertEquals(rp1, rp3.subtract(rp2));
+		assertEquals(rp1, rp2.subtract(rp1));
+
+		ResourceProfile rp4 = new ResourceProfile(Double.MAX_VALUE, 100, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyMap());
+		ResourceProfile rp5 = new ResourceProfile(Double.MAX_VALUE, 0, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyMap());
+
+		assertEquals(rp5, rp4.subtract(rp1));
+
+		assertEquals(ResourceProfile.ANY, ResourceProfile.ANY.subtract(rp3));
+		assertEquals(ResourceProfile.UNKNOWN, ResourceProfile.UNKNOWN.subtract(rp3));
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -1200,7 +1200,7 @@ public class SlotManagerTest extends TestLogger {
 			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> secondRequest = requestSlotQueue.take();
 
 			// fail second request
-			secondManualSlotRequestResponse.completeExceptionally(new SlotOccupiedException("Test exception", slotRequest1.getAllocationId(), jobID));
+			secondManualSlotRequestResponse.completeExceptionally(new SlotOccupiedException("Test exception", slotRequest1.getAllocationId(), jobID, ResourceProfile.UNKNOWN));
 
 			assertThat(firstRequest.f2, equalTo(slotRequest1.getAllocationId()));
 			assertThat(secondRequest.f2, equalTo(slotRequest2.getAllocationId()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -1419,12 +1419,12 @@ public class SlotManagerTest extends TestLogger {
 			assertThat(slotManager.getNumberRegisteredSlots(), is(0));
 
 			final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
-			final SlotReport slotReport = createSlotReport(taskExecutorConnection.getResourceID(), numberSlots - 1);
+			final SlotReport slotReport = createSlotReport(taskExecutorConnection.getResourceID(), numberSlots);
 
 			slotManager.registerTaskManager(taskExecutorConnection, slotReport);
 
-			assertThat(slotManager.getNumberRegisteredSlots(), is(numberSlots - 1));
-			assertThat(slotManager.getNumberPendingTaskManagerSlots(), is(1));
+			assertThat(slotManager.getNumberRegisteredSlots(), is(3));
+			assertThat(slotManager.getNumberPendingTaskManagerSlots(), is(0));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -152,7 +152,7 @@ public class SlotManagerTest extends TestLogger {
 		final AllocationID allocationId1 = new AllocationID();
 		final AllocationID allocationId2 = new AllocationID();
 		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
-		final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile, jobId, allocationId1);
+		final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile, jobId, allocationId1, resourceProfile);
 		final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
 		final SlotReport slotReport = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
 
@@ -412,7 +412,7 @@ public class SlotManagerTest extends TestLogger {
 
 		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
 
-		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId);
+		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId, ResourceProfile.UNKNOWN);
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
 		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
@@ -482,7 +482,7 @@ public class SlotManagerTest extends TestLogger {
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
 
-		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId);
+		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId, ResourceProfile.UNKNOWN);
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
 		final SlotRequest slotRequest = new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
@@ -633,7 +633,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile);
 		final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
 
-		final SlotStatus newSlotStatus2 = new SlotStatus(slotId2, resourceProfile, jobId, allocationId);
+		final SlotStatus newSlotStatus2 = new SlotStatus(slotId2, resourceProfile, jobId, allocationId, ResourceProfile.UNKNOWN);
 
 		final SlotReport slotReport1 = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
 		final SlotReport slotReport2 = new SlotReport(Arrays.asList(newSlotStatus2, slotStatus1));
@@ -874,7 +874,7 @@ public class SlotManagerTest extends TestLogger {
 
 			assertTrue(freeSlotFuture.get());
 
-			final SlotStatus newSlotStatus1 = new SlotStatus(slotIdCaptor.getValue(), resourceProfile, new JobID(), new AllocationID());
+			final SlotStatus newSlotStatus1 = new SlotStatus(slotIdCaptor.getValue(), resourceProfile, new JobID(), new AllocationID(), ResourceProfile.UNKNOWN);
 			final SlotStatus newSlotStatus2 = new SlotStatus(freeSlotId, resourceProfile);
 			final SlotReport newSlotReport = new SlotReport(Arrays.asList(newSlotStatus1, newSlotStatus2));
 
@@ -1072,7 +1072,8 @@ public class SlotManagerTest extends TestLogger {
 				slotId,
 				ResourceProfile.UNKNOWN,
 				new JobID(),
-				new AllocationID());
+				new AllocationID(),
+				ResourceProfile.UNKNOWN);
 			final SlotReport slotReport = new SlotReport(
 				slotStatus);
 
@@ -1481,7 +1482,7 @@ public class SlotManagerTest extends TestLogger {
 
 			final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
 			final SlotID slotId = new SlotID(taskExecutorConnection.getResourceID(), 0);
-			final SlotStatus slotStatus = new SlotStatus(slotId, ResourceProfile.UNKNOWN, jobId, new AllocationID());
+			final SlotStatus slotStatus = new SlotStatus(slotId, ResourceProfile.UNKNOWN, jobId, new AllocationID(), ResourceProfile.UNKNOWN);
 			final SlotReport slotReport = new SlotReport(slotStatus);
 
 			slotManager.registerTaskManager(taskExecutorConnection, slotReport);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -312,6 +312,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 						slotStatus.getSlotID(),
 						jobId,
 						taskDeploymentDescriptor.getAllocationId(),
+						ResourceProfile.UNKNOWN,
 						jobMasterAddress,
 						testingResourceManagerGateway.getFencingToken(),
 						timeout

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -118,7 +119,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd, env.getJobMasterId(), timeout).get();
 
 			taskRunningFuture.get();
@@ -145,7 +146,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd, env.getJobMasterId(), timeout).get();
 		} catch (Exception e) {
 			assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
@@ -177,11 +178,11 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd1.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd1.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd1, env.getJobMasterId(), timeout).get();
 			task1RunningFuture.get();
 
-			taskSlotTable.allocateSlot(1, jobId, tdd2.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(1, jobId, tdd2.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd2, env.getJobMasterId(), timeout).get();
 			task2RunningFuture.get();
 
@@ -226,11 +227,11 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd1.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd1.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd1, env.getJobMasterId(), timeout).get();
 			task1RunningFuture.get();
 
-			taskSlotTable.allocateSlot(1, jobId, tdd2.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(1, jobId, tdd2.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd2, env.getJobMasterId(), timeout).get();
 			task2RunningFuture.get();
 
@@ -281,11 +282,11 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd1.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd1.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd1, jobMasterId, timeout).get();
 			task1RunningFuture.get();
 
-			taskSlotTable.allocateSlot(1, jobId, tdd2.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(1, jobId, tdd2.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd2, jobMasterId, timeout).get();
 			task2RunningFuture.get();
 
@@ -347,11 +348,11 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd1.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd1.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd1, jobMasterId, timeout).get();
 			task1RunningFuture.get();
 
-			taskSlotTable.allocateSlot(1, jobId, tdd2.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(1, jobId, tdd2.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd2, jobMasterId, timeout).get();
 			task2RunningFuture.get();
 
@@ -397,7 +398,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd, env.getJobMasterId(), timeout).get();
 			taskRunningFuture.get();
 
@@ -429,7 +430,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd, env.getJobMasterId(), timeout).get();
 			taskRunningFuture.get();
 
@@ -482,7 +483,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd, env.getJobMasterId(), timeout).get();
 			taskRunningFuture.get();
 
@@ -543,7 +544,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 
 			TestingAbstractInvokables.TestInvokableRecordCancel.resetGotCanceledFuture();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd, jobMasterId, timeout).get();
 			taskRunningFuture.get();
 
@@ -584,7 +585,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
 			TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
-			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), Time.seconds(60));
+			taskSlotTable.allocateSlot(0, jobId, tdd.getAllocationId(), ResourceProfile.UNKNOWN, Time.seconds(60));
 			tmGateway.submitTask(tdd, env.getJobMasterId(), timeout).get();
 			taskRunningFuture.get();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -498,7 +498,8 @@ public class TaskExecutorTest extends TestLogger {
 				slotId,
 				resourceProfile,
 				new JobID(),
-				new AllocationID()));
+				new AllocationID(),
+				ResourceProfile.UNKNOWN));
 
 		final TestingTaskSlotTable taskSlotTable = new TestingTaskSlotTable(new ArrayDeque<>(Arrays.asList(slotReport1, slotReport2)));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -844,7 +844,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotAcceptance() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(mock(ResourceProfile.class), mock(ResourceProfile.class)), timerService);
+		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(ResourceProfile.ANY, ResourceProfile.ANY), timerService);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
@@ -911,8 +911,8 @@ public class TaskExecutorTest extends TestLogger {
 
 			assertThat(registrationFuture.get(), equalTo(taskManagerLocation.getResourceID()));
 
-			taskSlotTable.allocateSlot(0, jobId, allocationId1, Time.milliseconds(10000L));
-			taskSlotTable.allocateSlot(1, jobId, allocationId2, Time.milliseconds(10000L));
+			taskSlotTable.allocateSlot(0, jobId, allocationId1, ResourceProfile.UNKNOWN, Time.milliseconds(10000L));
+			taskSlotTable.allocateSlot(1, jobId, allocationId2, ResourceProfile.UNKNOWN, Time.milliseconds(10000L));
 
 			// we have to add the job after the TaskExecutor, because otherwise the service has not
 			// been properly started.
@@ -937,7 +937,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testSubmitTaskBeforeAcceptSlot() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(mock(ResourceProfile.class), mock(ResourceProfile.class)), timerService);
+		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(ResourceProfile.ANY, ResourceProfile.ANY), timerService);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
@@ -992,8 +992,8 @@ public class TaskExecutorTest extends TestLogger {
 
 			final TaskExecutorGateway tmGateway = taskManager.getSelfGateway(TaskExecutorGateway.class);
 
-			taskSlotTable.allocateSlot(0, jobId, allocationId1, Time.milliseconds(10000L));
-			taskSlotTable.allocateSlot(1, jobId, allocationId2, Time.milliseconds(10000L));
+			taskSlotTable.allocateSlot(0, jobId, allocationId1, ResourceProfile.UNKNOWN, Time.milliseconds(10000L));
+			taskSlotTable.allocateSlot(1, jobId, allocationId2, ResourceProfile.UNKNOWN, Time.milliseconds(10000L));
 
 			final JobVertexID jobVertexId = new JobVertexID();
 
@@ -2018,8 +2018,8 @@ public class TaskExecutorTest extends TestLogger {
 		}
 
 		@Override
-		public boolean allocateSlot(int index, JobID jobId, AllocationID allocationId, Time slotTimeout) {
-			final boolean result = super.allocateSlot(index, jobId, allocationId, slotTimeout);
+		public boolean allocateSlot(int index, JobID jobId, AllocationID allocationId, ResourceProfile allocationResourceProfile, Time slotTimeout) {
+			final boolean result = super.allocateSlot(index, jobId, allocationId, allocationResourceProfile, slotTimeout);
 			allocateSlotLatch.trigger();
 
 			return result;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -820,6 +820,7 @@ public class TaskExecutorTest extends TestLogger {
 				slotId,
 				jobId,
 				allocationId,
+				ResourceProfile.UNKNOWN,
 				jobMasterGateway.getAddress(),
 				resourceManagerGateway.getFencingToken(),
 				timeout);
@@ -1224,6 +1225,7 @@ public class TaskExecutorTest extends TestLogger {
 				slotId,
 				jobId,
 				allocationId,
+				ResourceProfile.UNKNOWN,
 				"foobar",
 				resourceManagerId,
 				timeout).get();
@@ -1340,7 +1342,8 @@ public class TaskExecutorTest extends TestLogger {
 			final ResourceID resourceId = taskExecutorResourceIdFuture.get();
 
 			final SlotID slotId = new SlotID(resourceId, 0);
-			final CompletableFuture<Acknowledge> slotRequestResponse = taskExecutorGateway.requestSlot(slotId, jobId, new AllocationID(), "foobar", testingResourceManagerGateway.getFencingToken(), timeout);
+			final CompletableFuture<Acknowledge> slotRequestResponse = taskExecutorGateway.requestSlot(slotId, jobId,
+				new AllocationID(), ResourceProfile.UNKNOWN, "foobar", testingResourceManagerGateway.getFencingToken(), timeout);
 
 			try {
 				slotRequestResponse.get();
@@ -1551,6 +1554,7 @@ public class TaskExecutorTest extends TestLogger {
 				new SlotID(taskExecutor.getResourceID(), 0),
 				jobId,
 				allocationId,
+				ResourceProfile.UNKNOWN,
 				jobManagerAddress,
 				testingResourceManagerGateway.getFencingToken(),
 				timeout).get();
@@ -1615,6 +1619,7 @@ public class TaskExecutorTest extends TestLogger {
 				new SlotID(resourceID, 0),
 				jobId,
 				new AllocationID(),
+				ResourceProfile.UNKNOWN,
 				"foobar",
 				resourceManagerGateway.getFencingToken(),
 				timeout).get();
@@ -1728,8 +1733,10 @@ public class TaskExecutorTest extends TestLogger {
 			final AllocationID allocationIdOnlyInJM = new AllocationID();
 			final AllocationID allocationIdOnlyInTM = new AllocationID();
 
-			taskExecutorGateway.requestSlot(slotId1, jobId, allocationIdInBoth, "foobar", testingResourceManagerGateway.getFencingToken(), timeout);
-			taskExecutorGateway.requestSlot(slotId2, jobId, allocationIdOnlyInTM, "foobar", testingResourceManagerGateway.getFencingToken(), timeout);
+			taskExecutorGateway.requestSlot(slotId1, jobId, allocationIdInBoth, ResourceProfile.UNKNOWN, "foobar",
+				testingResourceManagerGateway.getFencingToken(), timeout);
+			taskExecutorGateway.requestSlot(slotId2, jobId, allocationIdOnlyInTM, ResourceProfile.UNKNOWN, "foobar",
+				testingResourceManagerGateway.getFencingToken(), timeout);
 
 			activeSlots.await();
 
@@ -1829,6 +1836,7 @@ public class TaskExecutorTest extends TestLogger {
 				slotId,
 				jobId,
 				new AllocationID(),
+				ResourceProfile.UNKNOWN,
 				"foobar",
 				testingResourceManagerGateway.getFencingToken(),
 				timeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -20,11 +20,12 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -62,7 +63,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	private final BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer;
 
-	private final Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction;
+	private final Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction;
 
 	private final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction;
 
@@ -82,7 +83,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 			BiConsumer<ResourceID, AllocatedSlotReport> heartbeatJobManagerConsumer,
 			BiConsumer<JobID, Throwable> disconnectJobManagerConsumer,
 			BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer,
-			Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction,
+			Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction,
 			BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction,
 			Consumer<ResourceID> heartbeatResourceManagerConsumer,
 			Consumer<Exception> disconnectResourceManagerConsumer,
@@ -104,8 +105,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	}
 
 	@Override
-	public CompletableFuture<Acknowledge> requestSlot(SlotID slotId, JobID jobId, AllocationID allocationId, String targetAddress, ResourceManagerId resourceManagerId, Time timeout) {
-		return requestSlotFunction.apply(Tuple5.of(slotId, jobId, allocationId, targetAddress, resourceManagerId));
+	public CompletableFuture<Acknowledge> requestSlot(SlotID slotId, JobID jobId, AllocationID allocationId, ResourceProfile allocationResourceProfile, String targetAddress, ResourceManagerId resourceManagerId, Time timeout) {
+		return requestSlotFunction.apply(Tuple6.of(slotId, jobId, allocationId, allocationResourceProfile, targetAddress, resourceManagerId));
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -19,9 +19,10 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -47,7 +48,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private static final BiConsumer<ResourceID, AllocatedSlotReport> NOOP_HEARTBEAT_JOBMANAGER_CONSUMER = (ignoredA, ignoredB) -> {};
 	private static final BiConsumer<JobID, Throwable> NOOP_DISCONNECT_JOBMANAGER_CONSUMER = (ignoredA, ignoredB) -> {};
 	private static final BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> NOOP_SUBMIT_TASK_CONSUMER = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
-	private static final Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> NOOP_REQUEST_SLOT_FUNCTION = ignored -> CompletableFuture.completedFuture(Acknowledge.get());
+	private static final Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> NOOP_REQUEST_SLOT_FUNCTION = ignored -> CompletableFuture.completedFuture(Acknowledge.get());
 	private static final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> NOOP_FREE_SLOT_FUNCTION = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
 	private static final Consumer<ResourceID> NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
 	private static final Consumer<Exception> NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
@@ -59,7 +60,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private BiConsumer<ResourceID, AllocatedSlotReport> heartbeatJobManagerConsumer = NOOP_HEARTBEAT_JOBMANAGER_CONSUMER;
 	private BiConsumer<JobID, Throwable> disconnectJobManagerConsumer = NOOP_DISCONNECT_JOBMANAGER_CONSUMER;
 	private BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer = NOOP_SUBMIT_TASK_CONSUMER;
-	private Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction = NOOP_REQUEST_SLOT_FUNCTION;
+	private Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction = NOOP_REQUEST_SLOT_FUNCTION;
 	private BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction = NOOP_FREE_SLOT_FUNCTION;
 	private Consumer<ResourceID> heartbeatResourceManagerConsumer = NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER;
 	private Consumer<Exception> disconnectResourceManagerConsumer = NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER;
@@ -92,7 +93,7 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
-	public TestingTaskExecutorGatewayBuilder setRequestSlotFunction(Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction) {
+	public TestingTaskExecutorGatewayBuilder setRequestSlotFunction(Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction) {
 		this.requestSlotFunction = requestSlotFunction;
 		return this;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
@@ -60,12 +60,12 @@ public class TaskSlotTableTest extends TestLogger {
 
 			final JobID jobId1 = new JobID();
 			final AllocationID allocationId1 = new AllocationID();
-			taskSlotTable.allocateSlot(0, jobId1, allocationId1, SLOT_TIMEOUT);
+			taskSlotTable.allocateSlot(0, jobId1, allocationId1, ResourceProfile.UNKNOWN, SLOT_TIMEOUT);
 			final AllocationID allocationId2 = new AllocationID();
-			taskSlotTable.allocateSlot(1, jobId1, allocationId2, SLOT_TIMEOUT);
+			taskSlotTable.allocateSlot(1, jobId1, allocationId2, ResourceProfile.UNKNOWN, SLOT_TIMEOUT);
 			final AllocationID allocationId3 = new AllocationID();
 			final JobID jobId2 = new JobID();
-			taskSlotTable.allocateSlot(2, jobId2, allocationId3, SLOT_TIMEOUT);
+			taskSlotTable.allocateSlot(2, jobId2, allocationId3, ResourceProfile.UNKNOWN, SLOT_TIMEOUT);
 
 			taskSlotTable.markSlotActive(allocationId1);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -311,7 +311,12 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	@Override
 	public Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile) {
-		if (!slotsPerWorker.iterator().next().isMatching(resourceProfile)) {
+		ResourceProfile totalResourceProfile = new ResourceProfile(0.0, 0);
+		for (ResourceProfile slotResourceProfile : slotsPerWorker) {
+			totalResourceProfile = totalResourceProfile.merge(slotResourceProfile);
+		}
+
+		if (!totalResourceProfile.isMatching(resourceProfile)) {
 			return Collections.emptyList();
 		}
 		requestYarnContainer();


### PR DESCRIPTION
## What is the purpose of the change

This pull request is base on #8704 and #8740. It dynamically allocates the TaskExecutor's resources to the slots on it. FTM, managed memory in slot resource profiles is set to the actual size, the rest are set to `ANY` that matches any request (see #8704).

## Brief change log

- 0d3245b7462d157895257750988c46416feb4bb0: Introduce `merge` and `subtract` calculations in `ResourceProfile`, and corresponding tests. These calculations are needed for bookkeeping task executors' resources.
- 4b822d6f68eae559c07220949da894c7811762c7 - 11262902755a455ca7ff0926ca7e8afd323ee69d: Changes on the task executor side.
  - 4b822d6f68eae559c07220949da894c7811762c7: Add argument `allocationResourceProfile` in `TaskExecutorGateway#requestSlot` which describes the dynamically allocated slot resources. Task executors need to record the allocation resource profiles so they can:
    1. offer slots with requested resources to job masters, and
    2. report allocated resources to the resource manager so it can recover the task executor resource bookkeepings after a failover.
  - 1b09722d03d64025e4e184845cfc0d43218fa285: `TaskExecutor` checks the requested allocation resource profiles and rejects those that exceed its current available resources. This could happen due to asynchronous information on RM/TM. 
    - E.g., RM requests slot1 from the TE, then receives an outdated slot report from the TE showing that slot1 is free. After that RM requests slot2 from the TE. At this moment, RM1 believes that the TE has enough available for slot2 because it thinks slot1 is free, but the TE may not have enough resources because slot1 is actually allocated.
  - e90d462c530814bee19efe0203a895d78ad1d2f9: `TaskExecutor` offers slot with allocation resource profile.
  - 231d5691bddbcf5c207d3edcf6d86fc00d52b5ac: `TaskExecutor` report slot status with allocation resource profile.
  - 11262902755a455ca7ff0926ca7e8afd323ee69d: Add `TaskExecutorTest#testAllocationResourceProfile` that validates `TaskExecutor` maintains allocation resource profiles of slots properly.
- 29d44b40f5c245ad606e06cddcd71ea3e8ff3b7b - e2ee9de9847b219a3ad1f07d7a023f4dc1746e1b: Changes on the resource manager side.
  - 29d44b40f5c245ad606e06cddcd71ea3e8ff3b7b: `SlotManager` groups `PendingTaskManagerSlots` according to whether they should be on the same `TaskExecutor`, and matches registered slots accordingly. We need this change to bookkeep available resources for pending task executors in subsequent commit.
  - 4e05a878f37ceba81e65a3ae6c3d9e28f5251dfa: Update `SlotManagerTest#testPendingTaskManagerSlotCompletion`. The original assumption that pending task slots are completed independently from each other no longer holds.
  - 85d58f2641fdbae4d1d349010552fe11b8d723bf: Introduce the data structure `TaskExecutorResourceBookkeeper` for bookkeeping total/available/allocated resources of registered and pending task executors.
  - 35591c5efe5f52c1cfa111a959a744a06c4ce9e9: `SlotManager` bookkeeps task executors' resources.
  - 9b6cac6d719e04d07a169930635e36f8661a8674: With dynamic slot resource allocation, resource managers on Yarn/Mesos should be able to start new worker for resource requests that is larger than the default resources of one slot but not larger than the total resources of slots per task executor.
  - e2ee9de9847b219a3ad1f07d7a023f4dc1746e1b: Add `SlotManagerTest#testBookkeepingTaskExecutorResources` that validates `SlotManager` bookkeeps resources of task executors properly.

## Verifying this change
This change added tests and can be verified as follows:
  - Add `TaskExecutorTest#testAllocationResourceProfile` that validates `TaskExecutor` maintains allocation resource profiles of slots properly.
  - Add `SlotManagerTest#testBookkeepingTaskExecutorResources` that validates `SlotManager` bookkeeps resources of task executors properly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
