### PR TITLE
[FLINK-12609][python] Align the Python data types with Java

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -494,9 +494,11 @@ class TableEnvironment(object):
             raise TypeError(
                 "schema should be RowType, list, tuple or None, but got: %s" % schema)
 
+        # verifies the elements against the specified schema
+        elements = map(verify_obj, elements)
         # converts python data to sql data
         elements = [schema.to_sql_type(element) for element in elements]
-        return self._from_elements(map(verify_obj, elements), schema)
+        return self._from_elements(elements, schema)
 
     def _from_elements(self, elements, schema):
         """

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -67,16 +67,18 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         a.fromstring('ABCD')
         t = t_env.from_elements(
             [(1, 1.0, "hi", "hello", datetime.date(1970, 1, 2), datetime.time(1, 0, 0),
-             datetime.datetime(1970, 1, 2, 0, 0), [1.0, None], array.array("d", [1.0, 2.0]),
+             datetime.datetime(1970, 1, 2, 0, 0), datetime.datetime(1970, 1, 2, 0, 0),
+             [1.0, None], array.array("d", [1.0, 2.0]),
              ["abc"], [datetime.date(1970, 1, 2)], Decimal(1), Row("a", "b")(1, 2.0),
              {"key": 1.0}, a, ExamplePoint(1.0, 2.0),
              PythonOnlyPoint(3.0, 4.0))])
         field_names = ["a", "b", "c", "d", "e", "f", "g", "h",
-                       "i", "j", "k", "l", "m", "n", "o", "p", "q"]
+                       "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
         field_types = [DataTypes.BIGINT(), DataTypes.DOUBLE(), DataTypes.STRING(),
                        DataTypes.STRING(), DataTypes.DATE(),
                        DataTypes.TIME(),
                        DataTypes.TIMESTAMP(),
+                       DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
                        DataTypes.ARRAY(DataTypes.DOUBLE()),
                        DataTypes.ARRAY(DataTypes.DOUBLE(False)),
                        DataTypes.ARRAY(DataTypes.STRING()),
@@ -94,9 +96,9 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
-        expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,[1.0, null],'
-                    '[1.0, 2.0],[abc],[1970-01-02],1,1,2.0,{key=1.0},[65, 66, 67, 68],[1.0, 2.0],'
-                    '[3.0, 4.0]']
+        expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,'
+                    '1970-01-02 00:00:00.0,[1.0, null],[1.0, 2.0],[abc],[1970-01-02],1,1,2.0,'
+                    '{key=1.0},[65, 66, 67, 68],[1.0, 2.0],[3.0, 4.0]']
         self.assert_equals(actual, expected)
 
 

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -63,22 +63,14 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
 
     def test_from_element(self):
         t_env = self.t_env
-        a = array.array('b')
-        a.fromstring('ABCD')
-        t = t_env.from_elements(
-            [(1, 1.0, "hi", "hello", datetime.date(1970, 1, 2), datetime.time(1, 0, 0),
-             datetime.datetime(1970, 1, 2, 0, 0), datetime.datetime(1970, 1, 2, 0, 0),
-             [1.0, None], array.array("d", [1.0, 2.0]),
-             ["abc"], [datetime.date(1970, 1, 2)], Decimal(1), Row("a", "b")(1, 2.0),
-             {"key": 1.0}, a, ExamplePoint(1.0, 2.0),
-             PythonOnlyPoint(3.0, 4.0))])
         field_names = ["a", "b", "c", "d", "e", "f", "g", "h",
-                       "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
+                       "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s"]
         field_types = [DataTypes.BIGINT(), DataTypes.DOUBLE(), DataTypes.STRING(),
                        DataTypes.STRING(), DataTypes.DATE(),
                        DataTypes.TIME(),
                        DataTypes.TIMESTAMP(),
                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
+                       DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND()),
                        DataTypes.ARRAY(DataTypes.DOUBLE()),
                        DataTypes.ARRAY(DataTypes.DOUBLE(False)),
                        DataTypes.ARRAY(DataTypes.STRING()),
@@ -89,16 +81,28 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
                        DataTypes.MAP(DataTypes.STRING(), DataTypes.DOUBLE()),
                        DataTypes.BYTES(), ExamplePointUDT(),
                        PythonOnlyUDT()]
+        schema = DataTypes.ROW(
+            list(map(lambda field_name, field_type: DataTypes.FIELD(field_name, field_type),
+                 field_names,
+                 field_types)))
         table_sink = source_sink_utils.TestAppendSink(field_names, field_types)
         t_env.register_table_sink("Results", table_sink)
-
+        t = t_env.from_elements(
+            [(1, 1.0, "hi", "hello", datetime.date(1970, 1, 2), datetime.time(1, 0, 0),
+              datetime.datetime(1970, 1, 2, 0, 0), datetime.datetime(1970, 1, 2, 0, 0),
+              datetime.timedelta(days=1, microseconds=10),
+              [1.0, None], array.array("d", [1.0, 2.0]),
+              ["abc"], [datetime.date(1970, 1, 2)], Decimal(1), Row("a", "b")(1, 2.0),
+              {"key": 1.0}, bytearray(b'ABCD'), ExamplePoint(1.0, 2.0),
+              PythonOnlyPoint(3.0, 4.0))],
+            schema)
         t.insert_into("Results")
         t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,'
-                    '1970-01-02 00:00:00.0,[1.0, null],[1.0, 2.0],[abc],[1970-01-02],1,1,2.0,'
-                    '{key=1.0},[65, 66, 67, 68],[1.0, 2.0],[3.0, 4.0]']
+                    '1970-01-02 00:00:00.0,86400000010,[1.0, null],[1.0, 2.0],[abc],[1970-01-02],'
+                    '1,1,2.0,{key=1.0},[65, 66, 67, 68],[1.0, 2.0],[3.0, 4.0]']
         self.assert_equals(actual, expected)
 
 

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -30,7 +30,7 @@ from pyflink.table.types import (_infer_schema_from_data, _infer_type,
                                  _array_type_mappings, _merge_type,
                                  _create_type_verifier, UserDefinedType, DataTypes, Row, RowField,
                                  RowType, ArrayType, BigIntType, VarCharType, MapType, DataType,
-                                 _to_java_type, _from_java_type)
+                                 _to_java_type, _from_java_type, ZonedTimestampType)
 
 
 class ExamplePointUDT(UserDefinedType):
@@ -105,6 +105,21 @@ class PythonOnlyPoint(ExamplePoint):
     __UDT__ = PythonOnlyUDT()
 
 
+class UTCOffsetTimezone(datetime.tzinfo):
+    """
+    Specifies timezone in UTC offset
+    """
+
+    def __init__(self, offset=0):
+        self.OFFSET = datetime.timedelta(hours=offset)
+
+    def utcoffset(self, dt):
+        return self.OFFSET
+
+    def dst(self, dt):
+        return self.OFFSET
+
+
 class TypesTests(unittest.TestCase):
 
     def test_infer_schema(self):
@@ -145,7 +160,7 @@ class TypesTests(unittest.TestCase):
             'VarCharType(2147483647, true)',
             'DateType(true)',
             'TimeType(0, true)',
-            'TimestampType(6, true)',
+            'LocalZonedTimestampType(6, true)',
             'DoubleType(true)',
             "ArrayType(DoubleType(false), true)",
             "ArrayType(BigIntType(true), true)",
@@ -522,6 +537,23 @@ class TypesTests(unittest.TestCase):
     def test_timestamp_microsecond(self):
         tst = DataTypes.TIMESTAMP()
         self.assertEqual(tst.to_sql_type(datetime.datetime.max) % 1000000, 999999)
+
+    def test_local_zoned_timestamp_type(self):
+        lztst = DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE()
+        ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000, tzinfo=UTCOffsetTimezone(1))
+        self.assertEqual(-3600000000, lztst.to_sql_type(ts))
+
+        if sys.version_info >= (3, 6):
+            ts2 = lztst.from_sql_type(-3600000000)
+            self.assertEqual(ts.astimezone(), ts2.astimezone())
+
+    def test_zoned_timestamp_type(self):
+        ztst = ZonedTimestampType()
+        ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000, tzinfo=UTCOffsetTimezone(1))
+        self.assertEqual((0, 3600), ztst.to_sql_type(ts))
+
+        ts2 = ztst.from_sql_type((0, 3600))
+        self.assertEqual(ts, ts2)
 
     def test_empty_row(self):
         row = Row()

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -555,6 +555,14 @@ class TypesTests(unittest.TestCase):
         ts2 = ztst.from_sql_type((0, 3600))
         self.assertEqual(ts, ts2)
 
+    def test_day_time_inteval_type(self):
+        ymt = DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND())
+        td = datetime.timedelta(days=1, seconds=10)
+        self.assertEqual(86410000000, ymt.to_sql_type(td))
+
+        td2 = ymt.from_sql_type(86410000000)
+        self.assertEqual(td, td2)
+
     def test_empty_row(self):
         row = Row()
         self.assertEqual(len(row), 0)

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -55,7 +55,7 @@ setup(
     license='http://www.apache.org/licenses/LICENSE-2.0',
     author='Flink Developers',
     author_email='dev@flink.apache.org',
-    install_requires=['py4j==0.10.8.1'],
+    install_requires=['py4j==0.10.8.1', 'python-dateutil'],
     tests_require=['pytest==4.4.1'],
     description='Apache Flink Python API',
     long_description=long_description,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
@@ -144,6 +144,11 @@ object PythonTableUtils {
       case c: Int => new Timestamp(c.toLong / 1000)
     }
 
+    case _ if dataType == Types.INTERVAL_MILLIS() => (obj: Any) => nullSafeConvert(obj) {
+      case c: Long => c / 1000
+      case c: Int => c.toLong / 1000
+    }
+
     case _ if dataType == Types.STRING => (obj: Any) => nullSafeConvert(obj) {
       case _ => obj.toString
     }


### PR DESCRIPTION
## What is the purpose of the change

*Currently, there are some data types defined in Java not supported in Python such as TIMESTAMP_WITH_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE, etc. This pull request adds support of these types and align the Python data types with Java*


## Brief change log
  - *[0111fbf](https://github.com/dianfu/flink/commit/0111fbf1cdf488f5ee9a587390dbe94e175d3ae5) Add LocalZonedTimestampType and ZonedTimestampType*
  - *[92f77f3](https://github.com/dianfu/flink/commit/92f77f345d649b8e33fa31925668fad3de445425) Add DayTimeIntervalType and YearMonthIntervalType*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_types.test_local_zoned_timestamp_type, test_types. test_zoned_timestamp_type, test_types.test_day_time_inteval_type and test_calc.test_from_element*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
