### PR TITLE
[FLINK-12957][docs] fix thrift and protobuf dependency examples

### DIFF
--- a/docs/dev/custom_serializers.md
+++ b/docs/dev/custom_serializers.md
@@ -67,13 +67,20 @@ for Apache Thrift:
 <dependency>
 	<groupId>com.twitter</groupId>
 	<artifactId>chill-thrift</artifactId>
-	<version>0.5.2</version>
+	<version>0.7.6</version>
+	<!-- exclusions for dependency conversion -->
+	<exclusions>
+		<exclusion>
+			<groupId>com.esotericsoftware.kryo</groupId>
+			<artifactId>kryo</artifactId>
+		</exclusion>
+	</exclusions>
 </dependency>
 <!-- libthrift is required by chill-thrift -->
 <dependency>
 	<groupId>org.apache.thrift</groupId>
 	<artifactId>libthrift</artifactId>
-	<version>0.6.1</version>
+	<version>0.11.0</version>
 	<exclusions>
 		<exclusion>
 			<groupId>javax.servlet</groupId>
@@ -95,13 +102,20 @@ For Google Protobuf you need the following Maven dependency:
 <dependency>
 	<groupId>com.twitter</groupId>
 	<artifactId>chill-protobuf</artifactId>
-	<version>0.5.2</version>
+	<version>0.7.6</version>
+	<!-- exclusions for dependency conversion -->
+	<exclusions>
+		<exclusion>
+			<groupId>com.esotericsoftware.kryo</groupId>
+			<artifactId>kryo</artifactId>
+		</exclusion>
+	</exclusions>
 </dependency>
 <!-- We need protobuf for chill-protobuf -->
 <dependency>
 	<groupId>com.google.protobuf</groupId>
 	<artifactId>protobuf-java</artifactId>
-	<version>2.5.0</version>
+	<version>3.7.0</version>
 </dependency>
 
 {% endhighlight %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,6 @@ Release notes cover important changes between Flink versions. Please carefully r
 
 - **Flink Forward**: Talks from past conferences are available at the [Flink Forward](http://flink-forward.org/) website and on [YouTube](https://www.youtube.com/channel/UCY8_lgiZLZErZPF47a2hXMA). [Robust Stream Processing with Apache Flink](http://2016.flink-forward.org/kb_sessions/robust-stream-processing-with-apache-flink/) is a good place to start.
 
-- **Training**: The [training materials](https://training.ververica.com/) from data Artisans include slides, exercises, and sample solutions.
+- **Training**: The [training materials](https://training.ververica.com/) from Ververica include slides, exercises, and sample solutions.
 
 - **Blogs**: The [Apache Flink](https://flink.apache.org/blog/) and [Ververica](https://www.ververica.com/blog) blogs publish frequent, in-depth technical articles about Flink.

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1229,8 +1229,8 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
   <tbody>
     <tr>
       <th rowspan="1"><strong>Job (only available on TaskManager)</strong></th>
-      <td>&lt;source_id&gt;.&lt;source_subtask_index&gt;.&lt;operator_id&gt;.&lt;operator_subtask_index&gt;.latency</td>
-      <td>The latency distributions from a given source subtask to an operator subtask (in milliseconds).</td>
+      <td>[&lt;source_id&gt;.[&lt;source_subtask_index&gt;.]]&lt;operator_id&gt;.&lt;operator_subtask_index&gt;.latency</td>
+      <td>The latency distributions from a given source (subtask) to an operator subtask (in milliseconds), depending on the [latency granularity]({{ site.baseurl }}/ops/config.html#metrics-latency-granularity).</td>
       <td>Histogram</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1649,7 +1649,7 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
 
 ## Latency tracking
 
-Flink allows to track the latency of records traveling through the system. This feature is disabled by default.
+Flink allows to track the latency of records travelling through the system. This feature is disabled by default.
 To enable the latency tracking you must set the `latencyTrackingInterval` to a positive number in either the
 [Flink configuration]({{ site.baseurl }}/ops/config.html#metrics-latency-interval) or `ExecutionConfig`.
 


### PR DESCRIPTION
## What is the purpose of the change

This PR includes some fixes in the docs.

## Brief change log

- "data Artisans" -> "Ververica"
- update latency metric name to cover for latency granularity
- fix typo in metrics docs
- fix thrift and protobuf dependency examples

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
