### PR TITLE
[FLINK-12954] Supports create(drop) view grammar for sql parser

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -25,6 +25,8 @@
     "org.apache.flink.sql.parser.ddl.SqlCreateTable",
     "org.apache.flink.sql.parser.ddl.SqlDropTable"
     "org.apache.flink.sql.parser.ddl.SqlCreateTable.TableCreationContext",
+    "org.apache.flink.sql.parser.ddl.SqlCreateView",
+    "org.apache.flink.sql.parser.ddl.SqlDropView",
     "org.apache.flink.sql.parser.ddl.SqlTableColumn",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
@@ -414,13 +416,15 @@
   # List of methods for parsing extensions to "CREATE [OR REPLACE]" calls.
   # Each must accept arguments "(SqlParserPos pos, boolean replace)".
   createStatementParserMethods: [
-    "SqlCreateTable"
+    "SqlCreateTable",
+    "SqlCreateView"
   ]
 
   # List of methods for parsing extensions to "DROP" calls.
   # Each must accept arguments "(Span s)".
   dropStatementParserMethods: [
-    "SqlDropTable"
+    "SqlDropTable",
+    "SqlDropView"
   ]
 
   # List of files in @includes directory that have parser method

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
@@ -272,6 +272,7 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 				writer.endList(keyFrame);
 			}
 		}
+
 		writer.newlineAndIndent();
 		writer.endList(frame);
 
@@ -281,7 +282,7 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 			comment.unparse(writer, leftPrec, rightPrec);
 		}
 
-		if (this.partitionKeyList != null) {
+		if (this.partitionKeyList != null && this.partitionKeyList.size() > 0) {
 			writer.newlineAndIndent();
 			writer.keyword("PARTITIONED BY");
 			SqlWriter.Frame withFrame = writer.startList("(", ")");

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateView.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+import org.apache.flink.sql.parser.error.SqlParseException;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlCreate;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.List;
+
+/**
+ * CREATE VIEW DDL sql call.
+ */
+public class SqlCreateView extends SqlCreate implements ExtendedSqlNode {
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE_VIEW", SqlKind.CREATE_VIEW);
+
+	private final SqlIdentifier viewName;
+	private final SqlNodeList fieldList;
+	private final SqlNode query;
+	private final SqlCharStringLiteral comment;
+
+	public SqlCreateView(
+			SqlParserPos pos,
+			SqlIdentifier viewName,
+			SqlNodeList fieldList,
+			SqlNode query,
+			boolean replace,
+			SqlCharStringLiteral comment) {
+		super(OPERATOR, pos, replace, false);
+		this.viewName = viewName;
+		this.fieldList = fieldList;
+		this.query = query;
+		this.comment = comment;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		List<SqlNode> ops = Lists.newArrayList();
+		ops.add(viewName);
+		ops.add(fieldList);
+		ops.add(query);
+		ops.add(SqlLiteral.createBoolean(getReplace(), SqlParserPos.ZERO));
+		return ops;
+	}
+
+	public SqlIdentifier getViewName() {
+		return viewName;
+	}
+
+	public SqlNodeList getFieldList() {
+		return fieldList;
+	}
+
+	public SqlNode getQuery() {
+		return query;
+	}
+
+	public SqlCharStringLiteral getComment() {
+		return comment;
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("CREATE");
+		if (getReplace()) {
+			writer.keyword("OR REPLACE");
+		}
+		writer.keyword("VIEW");
+		viewName.unparse(writer, leftPrec, rightPrec);
+		if (fieldList.size() > 0) {
+			fieldList.unparse(writer, 1, rightPrec);
+		}
+		if (comment != null) {
+			writer.newlineAndIndent();
+			writer.keyword("COMMENT");
+			comment.unparse(writer, leftPrec, rightPrec);
+		}
+		writer.newlineAndIndent();
+		writer.keyword("AS");
+		writer.newlineAndIndent();
+		query.unparse(writer, leftPrec, rightPrec);
+	}
+
+	private void printIndent(SqlWriter writer) {
+		writer.sep(",", false);
+		writer.newlineAndIndent();
+		writer.print("  ");
+	}
+
+	@Override
+	public void validate() throws SqlParseException {
+		// no-op
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropView.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+
+import org.apache.calcite.sql.SqlDrop;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * DROP VIEW DDL sql call.
+ */
+public class SqlDropView extends SqlDrop implements ExtendedSqlNode {
+	private static final SqlOperator OPERATOR =
+		new SqlSpecialOperator("DROP VIEW", SqlKind.DROP_VIEW);
+
+	private final SqlIdentifier viewName;
+
+	public SqlDropView(SqlParserPos pos, SqlIdentifier viewName, boolean ifExists) {
+		super(OPERATOR, pos, ifExists);
+		this.viewName = viewName;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(viewName);
+	}
+
+	public SqlIdentifier getViewName() {
+		return viewName;
+	}
+
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("DROP");
+		writer.keyword("VIEW");
+		if (ifExists) {
+			writer.keyword("IF EXISTS");
+		}
+		viewName.unparse(writer, leftPrec, rightPrec);
+	}
+
+	public void validate() {
+		// no-op
+	}
+
+	public String[] fullViewName() {
+		return viewName.names.toArray(new String[0]);
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -583,6 +583,51 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"OVERWRITE expression is only used with INSERT mode");
 	}
 
+	@Test
+	public void testCreateView() {
+		final String sql = "create view v as select col1 from tbl";
+		final String expected = "CREATE VIEW `V`\n" +
+			"AS\n" +
+			"SELECT `COL1`\n" +
+			"FROM `TBL`";
+		check(sql, expected);
+	}
+
+	@Test
+	public void testCreateViewWithComment() {
+		final String sql = "create view v COMMENT 'this is a view' as select col1 from tbl";
+		final String expected = "CREATE VIEW `V`\n" +
+			"COMMENT 'this is a view'\n" +
+			"AS\n" +
+			"SELECT `COL1`\n" +
+			"FROM `TBL`";
+		check(sql, expected);
+	}
+
+	@Test
+	public void testCreateViewWithFieldNames() {
+		final String sql = "create view v(col1, col2) as select col3, col4 from tbl";
+		final String expected = "CREATE VIEW `V` (`COL1`, `COL2`)\n" +
+			"AS\n" +
+			"SELECT `COL3`, `COL4`\n" +
+			"FROM `TBL`";
+		check(sql, expected);
+	}
+
+	@Test
+	public void testCreateViewWithInvalidName() {
+		final String sql = "create view v^(^*) COMMENT 'this is a view' as select col1 from tbl";
+		final String expected = "(?s).*Encountered \"\\( \\*\" at line 1, column 14.*";
+
+		checkFails(sql, expected);
+	}
+
+	@Test
+	public void testDropView() {
+		final String sql = "DROP VIEW IF EXISTS view_name";
+		check(sql, "DROP VIEW IF EXISTS `VIEW_NAME`");
+	}
+
 	/** Matcher that invokes the #validate() of the produced SqlNode. **/
 	private static class ValidationMatcher extends BaseMatcher<SqlNode> {
 		private String expectedColumnSql;


### PR DESCRIPTION
## What is the purpose of the change

- Add create view grammar like `CREATE VIEW view_name(col1, col2) AS select col3, col4 from tbl`

## Brief change log

  - Add create/drop view


## Verifying this change
See tests in FlinkSqlParserimplTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  not documented
