### PR TITLE
[FLINK-12958] Integrate AsyncWaitOperator with mailbox

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -28,9 +28,12 @@ import org.apache.flink.util.function.SupplierWithException;
 
 import akka.dispatch.OnComplete;
 
+import javax.annotation.Nonnull;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -994,5 +997,28 @@ public class FutureUtils {
 				uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), throwable);
 			}
 		});
+	}
+
+	/**
+	 * Cancels all instances of {@link java.util.concurrent.Future} in the given list of runnables without interrupting.
+	 * This method will suppress unexpected exceptions until the whole list is processed and then rethrow.
+	 *
+	 * @param runnables list of {@link Runnable} candidates to cancel.
+	 */
+	public static void cancelRunnableFutures(@Nonnull List<Runnable> runnables) {
+		RuntimeException suppressedExceptions = null;
+		for (Runnable runnable : runnables) {
+			if (runnable instanceof java.util.concurrent.Future) {
+				try {
+					((java.util.concurrent.Future<?>) runnable).cancel(false);
+				} catch (RuntimeException ex) {
+					// safety net to ensure all candidates get cancelled before we let the exception bubble up.
+					suppressedExceptions = ExceptionUtils.firstOrSuppressed(ex, suppressedExceptions);
+				}
+			}
+		}
+		if (suppressedExceptions != null) {
+			throw suppressedExceptions;
+		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1339,7 +1339,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 */
 	public final class ActionContext {
 
-		private final Runnable actionUnavailableLetter = ThrowingRunnable.unchecked(mailbox::waitUntilHasMail);
+		private final Runnable actionUnavailableLetter = ThrowingRunnable.unchecked(() -> mailbox.takeMail().run());
 
 		/**
 		 * This method must be called to end the stream task when all actions for the tasks have been performed.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
@@ -57,6 +58,9 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.mailbox.Mailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxImpl;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxStateException;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxExecutor;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxExecutorServiceImpl;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.ThrowingRunnable;
@@ -126,10 +130,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	public static final ThreadGroup TRIGGER_THREAD_GROUP = new ThreadGroup("Triggers");
 
 	/** The logger used by the StreamTask and its subclasses. */
-	private static final Logger LOG = LoggerFactory.getLogger(StreamTask.class);
-
-	/** Special value, letter that terminates the mailbox loop. */
-	private static final Runnable POISON_LETTER = () -> {};
+	protected static final Logger LOG = LoggerFactory.getLogger(StreamTask.class);
 
 	/** Special value, letter that "wakes up" a waiting mailbox loop. */
 	private static final Runnable DEFAULT_ACTION_AVAILABLE = () -> {};
@@ -192,7 +193,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	private final SynchronousSavepointLatch syncSavepointLatch;
 
-	protected final Mailbox mailbox;
+	protected final TaskMailboxExecutorServiceImpl taskMailboxExecutor;
+
+	protected final Runnable mailboxPoisonLetter;
+
+	private boolean mailboxLoopRunning;
 
 	// ------------------------------------------------------------------------
 
@@ -226,7 +231,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		this.accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();
 		this.recordWriters = createRecordWriters(configuration, environment);
 		this.syncSavepointLatch = new SynchronousSavepointLatch();
-		this.mailbox = new MailboxImpl();
+		this.taskMailboxExecutor = new TaskMailboxExecutorServiceImpl(new MailboxImpl());
+		this.mailboxLoopRunning = false;
+		this.mailboxPoisonLetter = () -> {
+			mailboxLoopRunning = false;
+		};
 	}
 
 	// ------------------------------------------------------------------------
@@ -252,21 +261,32 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 * Runs the stream-tasks main processing loop.
 	 */
 	private void run() throws Exception {
-		final ActionContext actionContext = new ActionContext();
+
+		assert taskMailboxExecutor.isMailboxThread() : "StreamTask::run must be executed by declared mailbox thread!";
+
+		final Mailbox mailbox = taskMailboxExecutor.getMailbox();
+		final ActionContext actionContext = new ActionContext(taskMailboxExecutor, mailboxPoisonLetter);
+
+		mailboxLoopRunning = true;
+
 		while (true) {
+
 			if (mailbox.hasMail()) {
 				Optional<Runnable> maybeLetter;
-				while ((maybeLetter = mailbox.tryTakeMail()).isPresent()) {
-					Runnable letter = maybeLetter.get();
-					if (letter == POISON_LETTER) {
-						return;
-					}
-					letter.run();
+				while (mailboxLoopRunning && (maybeLetter = mailbox.tryTakeMail()).isPresent()) {
+					maybeLetter.get().run();
+				}
+				if (!mailboxLoopRunning) {
+					return;
 				}
 			}
 
 			performDefaultAction(actionContext);
 		}
+	}
+
+	protected boolean isMailboxLoopRunning() {
+		return mailboxLoopRunning;
 	}
 
 	/**
@@ -354,6 +374,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// -------- Invoke --------
 			LOG.debug("Invoking {}", getName());
 
+			// open mailbox
+			taskMailboxExecutor.getMailbox().open();
+
 			// we need to make sure that any triggers scheduled in open() cannot be
 			// executed before all operators are opened
 			synchronized (lock) {
@@ -394,6 +417,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 				// make sure no new timers can come
 				timerService.quiesce();
+
+				// let mailbox execution reject all new letters from this point
+				taskMailboxExecutor.shutdown();
 
 				// only set the StreamTask to not running after all operators have been closed!
 				// See FLINK-7430
@@ -462,12 +488,20 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 					operatorChain.releaseOutputs();
 				}
 			}
+
+			// close mailbox
+			FutureUtils.cancelRunnableFutures(taskMailboxExecutor.shutdownNow());
 		}
 	}
 
 	@Override
 	public final void cancel() throws Exception {
-		mailbox.clearAndPut(POISON_LETTER);
+		try {
+			List<Runnable> droppedRunnables = taskMailboxExecutor.getMailbox().clearAndPut(mailboxPoisonLetter);
+			FutureUtils.cancelRunnableFutures(droppedRunnables);
+		} catch (MailboxStateException msex) {
+			LOG.debug("Mailbox already closed in cancel().", msex);
+		}
 		isRunning = false;
 		canceled = true;
 
@@ -480,6 +514,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		finally {
 			cancelables.close();
 		}
+	}
+
+	public TaskMailboxExecutor getTaskMailboxExecutor() {
+		return taskMailboxExecutor;
 	}
 
 	public final boolean isRunning() {
@@ -1339,33 +1377,68 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 */
 	public final class ActionContext {
 
-		private final Runnable actionUnavailableLetter = ThrowingRunnable.unchecked(() -> mailbox.takeMail().run());
+		private final Runnable mailboxPoisonLetter;
+		private final Runnable actionUnavailableLetter;
+		private final TaskMailboxExecutorServiceImpl mailboxExecutorService;
+
+		public ActionContext(TaskMailboxExecutorServiceImpl mailboxExecutorService, Runnable mailboxPoisonLetter) {
+			final Mailbox mailbox = taskMailboxExecutor.getMailbox();
+			this.actionUnavailableLetter = ThrowingRunnable.unchecked(() -> mailbox.takeMail().run());
+			this.mailboxPoisonLetter = mailboxPoisonLetter;
+			this.mailboxExecutorService = mailboxExecutorService;
+		}
 
 		/**
 		 * This method must be called to end the stream task when all actions for the tasks have been performed.
 		 */
 		public void allActionsCompleted() {
-			mailbox.clearAndPut(POISON_LETTER);
+			try {
+				if (mailboxExecutorService.isMailboxThread()) {
+					if (!taskMailboxExecutor.getMailbox().tryPutFirst(mailboxPoisonLetter)) {
+						// mailbox is full - in this particular case we know for sure that we will still run through the
+						// break condition check inside the mailbox loop and so we can just run directly.
+						mailboxPoisonLetter.run();
+					}
+				} else {
+					mailboxExecutorService.getMailbox().putFirst(mailboxPoisonLetter);
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			} catch (MailboxStateException me) {
+				LOG.debug("Action context could not submit poison letter to mailbox.", me);
+			}
 		}
 
 		/**
 		 * Calling this method signals that the mailbox-thread should continue invoking the default action, e.g. because
 		 * new input became available for processing.
-		 *
-		 * @throws InterruptedException on interruption.
 		 */
-		public void actionsAvailable() throws InterruptedException {
-			mailbox.putMail(DEFAULT_ACTION_AVAILABLE);
+		public void actionsAvailable() {
+			putOrExecuteDirectly(DEFAULT_ACTION_AVAILABLE);
 		}
 
 		/**
 		 * Calling this method signals that the mailbox-thread should (temporarily) stop invoking the default action,
 		 * e.g. because there is currently no input available.
-		 *
-		 * @throws InterruptedException on interruption.
 		 */
-		public void actionsUnavailable() throws InterruptedException {
-			mailbox.putMail(actionUnavailableLetter);
+		public void actionsUnavailable() {
+			putOrExecuteDirectly(actionUnavailableLetter);
+		}
+
+		private void putOrExecuteDirectly(Runnable letter) {
+			try {
+				if (mailboxExecutorService.isMailboxThread()) {
+					if (!mailboxExecutorService.getMailbox().tryPutMail(letter)) {
+						letter.run();
+					}
+				} else {
+					mailboxExecutorService.getMailbox().putMail(letter);
+				}
+			} catch (InterruptedException ie) {
+				Thread.currentThread().interrupt();
+			} catch (MailboxStateException me) {
+				LOG.debug("Action context could not submit letter {} to mailbox.", letter, me);
+			}
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
@@ -56,14 +55,11 @@ import org.apache.flink.streaming.runtime.partitioner.ConfigurableStreamPartitio
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
-import org.apache.flink.streaming.runtime.tasks.mailbox.Mailbox;
-import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxImpl;
-import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxStateException;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxExecutor;
-import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxExecutorServiceImpl;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +71,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -124,16 +119,13 @@ import java.util.concurrent.atomic.AtomicReference;
 @Internal
 public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		extends AbstractInvokable
-		implements AsyncExceptionHandler {
+		implements AsyncExceptionHandler, MailboxDefaultAction {
 
 	/** The thread group that holds all trigger timer threads. */
 	public static final ThreadGroup TRIGGER_THREAD_GROUP = new ThreadGroup("Triggers");
 
 	/** The logger used by the StreamTask and its subclasses. */
 	protected static final Logger LOG = LoggerFactory.getLogger(StreamTask.class);
-
-	/** Special value, letter that "wakes up" a waiting mailbox loop. */
-	private static final Runnable DEFAULT_ACTION_AVAILABLE = () -> {};
 
 	// ------------------------------------------------------------------------
 
@@ -193,11 +185,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	private final SynchronousSavepointLatch syncSavepointLatch;
 
-	protected final TaskMailboxExecutorServiceImpl taskMailboxExecutor;
-
-	protected final Runnable mailboxPoisonLetter;
-
-	private boolean mailboxLoopRunning;
+	protected final MailboxProcessor mailboxProcessor;
 
 	// ------------------------------------------------------------------------
 
@@ -231,16 +219,17 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		this.accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();
 		this.recordWriters = createRecordWriters(configuration, environment);
 		this.syncSavepointLatch = new SynchronousSavepointLatch();
-		this.taskMailboxExecutor = new TaskMailboxExecutorServiceImpl(new MailboxImpl());
-		this.mailboxLoopRunning = false;
-		this.mailboxPoisonLetter = () -> {
-			mailboxLoopRunning = false;
-		};
+		this.mailboxProcessor = new MailboxProcessor(this);
 	}
 
 	// ------------------------------------------------------------------------
 	//  Life cycle methods for specific implementations
 	// ------------------------------------------------------------------------
+
+	@Override
+	public final void runDefaultAction(ActionContext context) throws Exception {
+		performDefaultAction(context);
+	}
 
 	protected abstract void init() throws Exception;
 
@@ -256,38 +245,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 * @throws Exception on any problems in the action.
 	 */
 	protected abstract void performDefaultAction(ActionContext context) throws Exception;
-
-	/**
-	 * Runs the stream-tasks main processing loop.
-	 */
-	private void run() throws Exception {
-
-		assert taskMailboxExecutor.isMailboxThread() : "StreamTask::run must be executed by declared mailbox thread!";
-
-		final Mailbox mailbox = taskMailboxExecutor.getMailbox();
-		final ActionContext actionContext = new ActionContext(taskMailboxExecutor, mailboxPoisonLetter);
-
-		mailboxLoopRunning = true;
-
-		while (true) {
-
-			if (mailbox.hasMail()) {
-				Optional<Runnable> maybeLetter;
-				while (mailboxLoopRunning && (maybeLetter = mailbox.tryTakeMail()).isPresent()) {
-					maybeLetter.get().run();
-				}
-				if (!mailboxLoopRunning) {
-					return;
-				}
-			}
-
-			performDefaultAction(actionContext);
-		}
-	}
-
-	protected boolean isMailboxLoopRunning() {
-		return mailboxLoopRunning;
-	}
 
 	/**
 	 * Emits the {@link org.apache.flink.streaming.api.watermark.Watermark#MAX_WATERMARK MAX_WATERMARK}
@@ -375,7 +332,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			LOG.debug("Invoking {}", getName());
 
 			// open mailbox
-			taskMailboxExecutor.getMailbox().open();
+			mailboxProcessor.openMailbox();
 
 			// we need to make sure that any triggers scheduled in open() cannot be
 			// executed before all operators are opened
@@ -396,7 +353,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 			// let the task do its work
 			isRunning = true;
-			run();
+			mailboxProcessor.runMailboxLoop();
 
 			// if this left the run() method cleanly despite the fact that this was canceled,
 			// make sure the "clean shutdown" is not attempted
@@ -419,7 +376,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				timerService.quiesce();
 
 				// let mailbox execution reject all new letters from this point
-				taskMailboxExecutor.shutdown();
+				mailboxProcessor.prepareShutDown();
 
 				// only set the StreamTask to not running after all operators have been closed!
 				// See FLINK-7430
@@ -489,19 +446,13 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				}
 			}
 
-			// close mailbox
-			FutureUtils.cancelRunnableFutures(taskMailboxExecutor.shutdownNow());
+			mailboxProcessor.shutDown();
 		}
 	}
 
 	@Override
 	public final void cancel() throws Exception {
-		try {
-			List<Runnable> droppedRunnables = taskMailboxExecutor.getMailbox().clearAndPut(mailboxPoisonLetter);
-			FutureUtils.cancelRunnableFutures(droppedRunnables);
-		} catch (MailboxStateException msex) {
-			LOG.debug("Mailbox already closed in cancel().", msex);
-		}
+		mailboxProcessor.cancelMailboxExecution();
 		isRunning = false;
 		canceled = true;
 
@@ -517,7 +468,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	public TaskMailboxExecutor getTaskMailboxExecutor() {
-		return taskMailboxExecutor;
+		return mailboxProcessor.getTaskMailboxExecutor();
 	}
 
 	public final boolean isRunning() {
@@ -1369,76 +1320,5 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			.build(bufferWriter);
 		output.setMetricGroup(environment.getMetricGroup().getIOMetricGroup());
 		return output;
-	}
-
-	/**
-	 * The action context is passed as parameter into the default action method and holds control methods for feedback
-	 * of from the default action to the mailbox.
-	 */
-	public final class ActionContext {
-
-		private final Runnable mailboxPoisonLetter;
-		private final Runnable actionUnavailableLetter;
-		private final TaskMailboxExecutorServiceImpl mailboxExecutorService;
-
-		public ActionContext(TaskMailboxExecutorServiceImpl mailboxExecutorService, Runnable mailboxPoisonLetter) {
-			final Mailbox mailbox = taskMailboxExecutor.getMailbox();
-			this.actionUnavailableLetter = ThrowingRunnable.unchecked(() -> mailbox.takeMail().run());
-			this.mailboxPoisonLetter = mailboxPoisonLetter;
-			this.mailboxExecutorService = mailboxExecutorService;
-		}
-
-		/**
-		 * This method must be called to end the stream task when all actions for the tasks have been performed.
-		 */
-		public void allActionsCompleted() {
-			try {
-				if (mailboxExecutorService.isMailboxThread()) {
-					if (!taskMailboxExecutor.getMailbox().tryPutFirst(mailboxPoisonLetter)) {
-						// mailbox is full - in this particular case we know for sure that we will still run through the
-						// break condition check inside the mailbox loop and so we can just run directly.
-						mailboxPoisonLetter.run();
-					}
-				} else {
-					mailboxExecutorService.getMailbox().putFirst(mailboxPoisonLetter);
-				}
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-			} catch (MailboxStateException me) {
-				LOG.debug("Action context could not submit poison letter to mailbox.", me);
-			}
-		}
-
-		/**
-		 * Calling this method signals that the mailbox-thread should continue invoking the default action, e.g. because
-		 * new input became available for processing.
-		 */
-		public void actionsAvailable() {
-			putOrExecuteDirectly(DEFAULT_ACTION_AVAILABLE);
-		}
-
-		/**
-		 * Calling this method signals that the mailbox-thread should (temporarily) stop invoking the default action,
-		 * e.g. because there is currently no input available.
-		 */
-		public void actionsUnavailable() {
-			putOrExecuteDirectly(actionUnavailableLetter);
-		}
-
-		private void putOrExecuteDirectly(Runnable letter) {
-			try {
-				if (mailboxExecutorService.isMailboxThread()) {
-					if (!mailboxExecutorService.getMailbox().tryPutMail(letter)) {
-						letter.run();
-					}
-				} else {
-					mailboxExecutorService.getMailbox().putMail(letter);
-				}
-			} catch (InterruptedException ie) {
-				Thread.currentThread().interrupt();
-			} catch (MailboxStateException me) {
-				LOG.debug("Action context could not submit letter {} to mailbox.", letter, me);
-			}
-		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxDefaultAction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxDefaultAction.java
@@ -38,6 +38,7 @@ public interface MailboxDefaultAction {
 	 */
 	interface ActionContext {
 
+
 		/**
 		 * This method must be called to end the stream task when all actions for the tasks have been performed. This
 		 * method can be invoked from any thread.
@@ -45,15 +46,20 @@ public interface MailboxDefaultAction {
 		void allActionsCompleted();
 
 		/**
-		 * Calling this method signals that the mailbox-thread should continue invoking the default action, e.g. because
-		 * new input became available for processing.
+		 * Calling this method signals that the mailbox-thread should (temporarily) stop invoking the default action,
+		 * e.g. because there is currently no input available. This method must be invoked from the mailbox-thread only!
 		 */
-		void actionsAvailable();
+		SuspendedDefaultAction suspendDefaultAction();
+	}
+
+	/**
+	 * Represents the suspended state of the default action, ready to resume.
+	 */
+	interface SuspendedDefaultAction {
 
 		/**
-		 * Calling this method signals that the mailbox-thread should (temporarily) stop invoking the default action,
-		 * e.g. because there is currently no input available.
+		 * Resume execution of the default action. Can be called from any thread.
 		 */
-		void actionsUnavailable();
+		void resume();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxDefaultAction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxDefaultAction.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+/**
+ * Interface for the default action that is repeatedly invoked in the mailbox-loop.
+ */
+public interface MailboxDefaultAction {
+
+	/**
+	 * This method implements the default action of the mailbox loop (e.g. processing one event from the input).
+	 * Implementations should (in general) be non-blocking.
+	 *
+	 * @param context context object for collaborative interaction between the default action and the mailbox loop.
+	 * @throws Exception on any problems in the action.
+	 */
+	void runDefaultAction(ActionContext context) throws Exception;
+
+	/**
+	 * This context is a feedback interface for the default action to interact with the mailbox execution. In particular
+	 * it offers ways to signal that the execution of the default action should be finished or temporarily suspended.
+	 */
+	interface ActionContext {
+
+		/**
+		 * This method must be called to end the stream task when all actions for the tasks have been performed. This
+		 * method can be invoked from any thread.
+		 */
+		void allActionsCompleted();
+
+		/**
+		 * Calling this method signals that the mailbox-thread should continue invoking the default action, e.g. because
+		 * new input became available for processing.
+		 */
+		void actionsAvailable();
+
+		/**
+		 * Calling this method signals that the mailbox-thread should (temporarily) stop invoking the default action,
+		 * e.g. because there is currently no input available.
+		 */
+		void actionsUnavailable();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImpl.java
@@ -126,19 +126,6 @@ public class MailboxImpl implements Mailbox {
 		}
 	}
 
-	@Override
-	public void waitUntilHasMail() throws InterruptedException {
-		final ReentrantLock lock = this.lock;
-		lock.lockInterruptibly();
-		try {
-			while (isEmpty()) {
-				notEmpty.await();
-			}
-		} finally {
-			lock.unlock();
-		}
-	}
-
 	//------------------------------------------------------------------------------------------------------------------
 
 	@Override
@@ -166,19 +153,6 @@ public class MailboxImpl implements Mailbox {
 				notFull.await();
 			}
 			putInternal(letter);
-		} finally {
-			lock.unlock();
-		}
-	}
-
-	@Override
-	public void waitUntilHasCapacity() throws InterruptedException {
-		final ReentrantLock lock = this.lock;
-		lock.lockInterruptibly();
-		try {
-			while (isFull()) {
-				notFull.await();
-			}
 		} finally {
 			lock.unlock();
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This class encapsulates the logic of the mailbox-based execution model.
+ */
+public class MailboxProcessor {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MailboxProcessor.class);
+
+	private final Runnable DEFAULT_ACTION_AVAILABLE = () -> {};
+
+	private final Mailbox mailbox;
+	private final TaskMailboxExecutorService taskMailboxExecutor;
+	private final MailboxDefaultAction mailboxDefaultAction;
+
+	private boolean mailboxLoopRunning;
+	private final Runnable mailboxPoisonLetter;
+
+	public MailboxProcessor(MailboxDefaultAction mailboxDefaultAction) {
+		this.mailboxDefaultAction = mailboxDefaultAction;
+		this.mailbox = new MailboxImpl();
+		this.taskMailboxExecutor = new TaskMailboxExecutorServiceImpl(mailbox);
+
+		this.mailboxPoisonLetter = () -> mailboxLoopRunning = false;
+		this.mailboxLoopRunning = true;
+	}
+
+	public TaskMailboxExecutorService getTaskMailboxExecutor() {
+		return taskMailboxExecutor;
+	}
+
+	public void openMailbox() {
+		mailbox.open();
+	}
+
+	public void prepareShutDown() {
+		taskMailboxExecutor.shutdown();
+	}
+
+	public void shutDown() {
+		FutureUtils.cancelRunnableFutures(taskMailboxExecutor.shutdownNow());
+	}
+
+	public void runMailboxLoop() throws Exception {
+
+		assert taskMailboxExecutor.isMailboxThread() :
+			"StreamTask::run must be executed by declared mailbox thread!";
+
+		final Mailbox localMailbox = mailbox;
+
+		assert localMailbox.getState() == Mailbox.State.OPEN : "Mailbox must be opened!";
+
+		final MailboxDefaultActionContext defaultActionContext = new MailboxDefaultActionContext();
+
+		while (processMail(localMailbox)) {
+			mailboxDefaultAction.runDefaultAction(defaultActionContext);
+		}
+	}
+
+	public void switchToLegacySourceCompatibilityMailboxLoop(
+		final Object checkpointLock) throws MailboxStateException, InterruptedException {
+
+		assert taskMailboxExecutor.isMailboxThread() :
+			"Legacy source compatibility mailbox loop must run in mailbox thread!";
+
+		while (isMailboxLoopRunning()) {
+
+			Runnable letter = mailbox.takeMail();
+
+			synchronized (checkpointLock) {
+				letter.run();
+			}
+		}
+	}
+
+	public void cancelMailboxExecution() {
+		try {
+			List<Runnable> droppedRunnables = mailbox.clearAndPut(mailboxPoisonLetter);
+			FutureUtils.cancelRunnableFutures(droppedRunnables);
+		} catch (MailboxStateException msex) {
+			LOG.debug("Mailbox already closed in cancel().", msex);
+		}
+	}
+
+	/**
+	 * This method must be called to end the stream task when all actions for the tasks have been performed.
+	 */
+	public void allActionsCompleted() {
+		try {
+			if (taskMailboxExecutor.isMailboxThread()) {
+				if (!mailbox.tryPutFirst(mailboxPoisonLetter)) {
+					// mailbox is full - in this particular case we know for sure that we will still run through the
+					// break condition check inside the mailbox loop and so we can just run directly.
+					mailboxPoisonLetter.run();
+				}
+			} else {
+				mailbox.putFirst(mailboxPoisonLetter);
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (MailboxStateException me) {
+			LOG.debug("Action context could not submit poison letter to mailbox.", me);
+		}
+	}
+
+	private boolean processMail(Mailbox mailbox) throws MailboxStateException {
+
+		if (!mailbox.hasMail()) {
+			return true;
+		}
+
+		// TODO consider batched draining into list and/or limit number of executed letters
+		Optional<Runnable> maybeLetter;
+		while (isMailboxLoopRunning() && (maybeLetter = mailbox.tryTakeMail()).isPresent()) {
+			maybeLetter.get().run();
+		}
+
+		return isMailboxLoopRunning();
+	}
+
+	private boolean isMailboxLoopRunning() {
+		return mailboxLoopRunning;
+	}
+
+	private final class MailboxDefaultActionContext implements MailboxDefaultAction.ActionContext {
+
+		/** Special value, letter that "wakes up" a waiting mailbox loop. */
+		private final Runnable actionUnavailableLetter;
+
+		MailboxDefaultActionContext() {
+			this.actionUnavailableLetter = ThrowingRunnable.unchecked(() -> mailbox.takeMail().run());
+		}
+
+		@Override
+		public void allActionsCompleted() {
+			MailboxProcessor.this.allActionsCompleted();
+		}
+
+		/**
+		 * Calling this method signals that the mailbox-thread should continue invoking the default action, e.g. because
+		 * new input became available for processing.
+		 */
+		public void actionsAvailable() {
+			putOrExecuteDirectly(DEFAULT_ACTION_AVAILABLE);
+		}
+
+		/**
+		 * Calling this method signals that the mailbox-thread should (temporarily) stop invoking the default action,
+		 * e.g. because there is currently no input available.
+		 */
+		public void actionsUnavailable() {
+			putOrExecuteDirectly(actionUnavailableLetter);
+		}
+
+		private void putOrExecuteDirectly(Runnable letter) {
+			try {
+				if (taskMailboxExecutor.isMailboxThread()) {
+					if (!mailbox.tryPutMail(letter)) {
+						letter.run();
+					}
+				} else {
+					mailbox.putMail(letter);
+				}
+			} catch (InterruptedException ie) {
+				Thread.currentThread().interrupt();
+			} catch (MailboxStateException me) {
+				LOG.debug("Action context could not submit letter {} to mailbox.", letter, me);
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxReceiver.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxReceiver.java
@@ -39,15 +39,17 @@ public interface MailboxReceiver {
 	 *
 	 * @return an optional with either the oldest letter from the mailbox (head of queue) if the mailbox is not empty or
 	 * an empty optional otherwise.
+	 * @throws  MailboxStateException if mailbox is already closed.
 	 */
-	Optional<Runnable> tryTakeMail();
+	Optional<Runnable> tryTakeMail() throws MailboxStateException;
 
 	/**
 	 * This method returns the oldest letter from the mailbox (head of queue) or blocks until a letter is available.
 	 *
 	 * @return the oldest letter from the mailbox (head of queue).
 	 * @throws InterruptedException on interruption.
+	 * @throws  MailboxStateException if mailbox is already closed.
 	 */
 	@Nonnull
-	Runnable takeMail() throws InterruptedException;
+	Runnable takeMail() throws InterruptedException, MailboxStateException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxReceiver.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxReceiver.java
@@ -50,10 +50,4 @@ public interface MailboxReceiver {
 	 */
 	@Nonnull
 	Runnable takeMail() throws InterruptedException;
-
-	/**
-	 * This method blocks if the mailbox is empty until mail becomes available.
-	 * @throws InterruptedException on interruption.
-	 */
-	void waitUntilHasMail() throws InterruptedException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxSender.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxSender.java
@@ -42,11 +42,4 @@ public interface MailboxSender {
 	 * @throws InterruptedException on interruption.
 	 */
 	void putMail(@Nonnull Runnable letter) throws InterruptedException;
-
-	/**
-	 * This method blocks until the mailbox has again capacity to enqueue new letters.
-	 *
-	 * @throws InterruptedException on interruption.
-	 */
-	void waitUntilHasCapacity() throws InterruptedException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxSender.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxSender.java
@@ -32,14 +32,16 @@ public interface MailboxSender {
 	 *
 	 * @param letter the letter to enqueue.
 	 * @return <code>true</code> iff successful.
+	 * @throws MailboxStateException if the mailbox is quiesced or closed.
 	 */
-	boolean tryPutMail(@Nonnull Runnable letter);
+	boolean tryPutMail(@Nonnull Runnable letter) throws MailboxStateException;
 
 	/**
 	 * Enqueues the given letter to the mailbox and blocks until there is capacity for a successful put.
 	 *
 	 * @param letter the letter to enqueue.
 	 * @throws InterruptedException on interruption.
+	 * @throws MailboxStateException if the mailbox is quiesced or closed.
 	 */
-	void putMail(@Nonnull Runnable letter) throws InterruptedException;
+	void putMail(@Nonnull Runnable letter) throws InterruptedException,  MailboxStateException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxStateException.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxStateException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+/**
+ * This exception signals that a method of the mailbox was invoked in a state that does not support the invocation,
+ * e.g. on the attempt to put a letter into a closed mailbox.
+ */
+public class MailboxStateException extends Exception {
+
+	MailboxStateException() {
+	}
+
+	MailboxStateException(String message) {
+		super(message);
+	}
+
+	MailboxStateException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	MailboxStateException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutor.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Interface for an {@link Executor} build around a {@link Mailbox}-based execution model.
+ */
+public interface TaskMailboxExecutor extends Executor {
+
+	/**
+	 * Executes the given command at some time in the future in the mailbox thread. This call can block when the
+	 * mailbox is currently full. Therefore, this method must not be called from the mailbox thread itself as this
+	 * can cause a deadlock. Instead, if the caller is already in the mailbox thread, the command should just be
+	 * executed directly or use the non-blocking {@link #tryExecute(Runnable)}.
+	 *
+	 * @param command the runnable task to add to the mailbox for execution.
+	 * @throws RejectedExecutionException if this task cannot be accepted for execution, e.g. because the mailbox is
+	 *                                    quiesced or closed.
+	 */
+	@Override
+	void execute(@Nonnull Runnable command) throws RejectedExecutionException;
+
+	/**
+	 * Attempts to enqueue the given command in the mailbox for execution. On success, the method returns true. If
+	 * the mailbox is full, this method returns immediately without adding the command and returns false.
+	 *
+	 * @param command the runnable task to add to the mailbox for execution.
+	 * @return true if the command was added to the mailbox. False if the command could not be added because the mailbox
+	 * was full.
+	 * @throws RejectedExecutionException if this task cannot be accepted for execution, e.g. because the mailbox is
+	 *                                    quiesced or closed.
+	 */
+	boolean tryExecute(Runnable command) throws RejectedExecutionException;
+
+	/**
+	 * This methods starts running the command at the head of the mailbox and is intended to be used by the mailbox
+	 * thread to yield from a currently ongoing action to another command. The method blocks until another command to
+	 * run is available in the mailbox and must only be called from the mailbox thread. Must only be called from the
+	 * mailbox thread to not violate the single-threaded execution model.
+	 *
+	 * @throws InterruptedException on interruption.
+	 * @throws IllegalStateException if the mailbox is closed and can no longer supply runnables for yielding.
+	 */
+	void yield() throws InterruptedException, IllegalStateException;
+
+	/**
+	 * This methods attempts to run the command at the head of the mailbox. This is intended to be used by the mailbox
+	 * thread to yield from a currently ongoing action to another command. The method returns true if a command was
+	 * found and executed or false if the mailbox was empty. Must only be called from the
+	 * mailbox thread to not violate the single-threaded execution model.
+	 *
+	 * @return true on successful yielding to another command, false if there was no command to yield to.
+	 * @throws IllegalStateException if the mailbox is closed and can no longer supply runnables for yielding.
+	 */
+	boolean tryYield() throws IllegalStateException;
+
+	/**
+	 * Check if the current thread is the mailbox thread.
+	 *
+	 * @return only true if called from the mailbox thread.
+	 */
+	boolean isMailboxThread();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorService.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Interface for an {@link ExecutorService} build around a {@link Mailbox}-based execution model.
+ */
+public interface TaskMailboxExecutorService extends TaskMailboxExecutor, ExecutorService {
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorServiceImpl.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of an executor service build around a mailbox-based execution model.
+ */
+public class TaskMailboxExecutorServiceImpl extends AbstractExecutorService implements TaskMailboxExecutorService {
+
+	/** Reference to the thread that executes the mailbox letters.  */
+	@Nonnull
+	private final Thread taskMailboxThread;
+
+	/** The mailbox that manages the submitted runnable objects. */
+	@Nonnull
+	private final Mailbox mailbox;
+
+	public TaskMailboxExecutorServiceImpl(@Nonnull Mailbox mailbox) {
+		this(mailbox, Thread.currentThread());
+	}
+
+	public TaskMailboxExecutorServiceImpl(@Nonnull Mailbox mailbox, @Nonnull Thread taskMailboxThread) {
+		this.mailbox = mailbox;
+		this.taskMailboxThread = taskMailboxThread;
+	}
+
+	@Override
+	public void execute(@Nonnull Runnable command) {
+		checkIsNotMailboxThread();
+		try {
+			mailbox.putMail(command);
+		} catch (InterruptedException irex) {
+			Thread.currentThread().interrupt();
+			throw new RejectedExecutionException("Sender thread was interrupted while blocking on mailbox.", irex);
+		} catch (MailboxStateException mbex) {
+			throw new RejectedExecutionException(mbex);
+		}
+	}
+
+	@Override
+	public boolean tryExecute(Runnable command) {
+		try {
+			return mailbox.tryPutMail(command);
+		} catch (MailboxStateException e) {
+			throw new RejectedExecutionException(e);
+		}
+	}
+
+	@Override
+	public void yield() throws InterruptedException, IllegalStateException {
+		checkIsMailboxThread();
+		try {
+			Runnable runnable = mailbox.takeMail();
+			runnable.run();
+		} catch (MailboxStateException e) {
+			throw new IllegalStateException("Mailbox can no longer supply runnables for yielding.", e);
+		}
+	}
+
+	@Override
+	public boolean tryYield() throws IllegalStateException {
+		checkIsMailboxThread();
+		try {
+			Optional<Runnable> runnableOptional = mailbox.tryTakeMail();
+			if (runnableOptional.isPresent()) {
+				runnableOptional.get().run();
+				return true;
+			} else {
+				return false;
+			}
+		} catch (MailboxStateException e) {
+			throw new IllegalStateException("Mailbox can no longer supply runnables for yielding.", e);
+		}
+	}
+
+	@Override
+	public boolean isMailboxThread() {
+		return Thread.currentThread() == taskMailboxThread;
+	}
+
+	@Override
+	public void shutdown() {
+		mailbox.quiesce();
+	}
+
+	@Nonnull
+	@Override
+	public List<Runnable> shutdownNow() {
+		return mailbox.close();
+	}
+
+	@Override
+	public boolean isShutdown() {
+		return mailbox.getState() != Mailbox.State.OPEN;
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return mailbox.getState() == Mailbox.State.CLOSED;
+	}
+
+	@Override
+	public boolean awaitTermination(long timeout, @Nonnull TimeUnit unit) {
+		return isTerminated();
+	}
+
+	/**
+	 * Returns the mailbox that manages the execution order.
+	 *
+	 * @return the mailbox.
+	 */
+	@Nonnull
+	public Mailbox getMailbox() {
+		return mailbox;
+	}
+
+	private void checkIsMailboxThread() {
+		if (!isMailboxThread()) {
+			throw new IllegalStateException(
+				"Illegal thread detected. This method must be called from inside the mailbox thread!");
+		}
+	}
+
+	private void checkIsNotMailboxThread() {
+		if (isMailboxThread()) {
+			throw new IllegalStateException(
+				"Illegal thread detected. This method must NOT be called from inside the mailbox thread!");
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/EmitterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/EmitterTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.operators.async.queue.WatermarkQueueEntry;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TestTaskMailboxExecutor;
 import org.apache.flink.streaming.util.CollectorOutput;
 import org.apache.flink.util.TestLogger;
 
@@ -99,7 +100,7 @@ public class EmitterTest extends TestLogger {
 
 		StreamElementQueue queue = new OrderedStreamElementQueue(capacity, executor, operatorActions);
 
-		final Emitter<Integer> emitter = new Emitter<>(lock, output, queue, operatorActions);
+		final Emitter<Integer> emitter = new Emitter<>(new TestTaskMailboxExecutor(), lock, output, queue, operatorActions);
 
 		final Thread emitterThread = new Thread(emitter);
 		emitterThread.start();
@@ -151,7 +152,7 @@ public class EmitterTest extends TestLogger {
 
 		StreamElementQueue queue = new OrderedStreamElementQueue(capacity, executor, operatorActions);
 
-		final Emitter<Integer> emitter = new Emitter<>(lock, output, queue, operatorActions);
+		final Emitter<Integer> emitter = new Emitter<>(new TestTaskMailboxExecutor(), lock, output, queue, operatorActions);
 
 		final Thread emitterThread = new Thread(emitter);
 		emitterThread.start();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -20,13 +20,10 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.mock.Whitebox;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -41,6 +38,7 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
@@ -67,7 +65,6 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.DoneFuture;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
@@ -83,7 +80,6 @@ import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
 import org.apache.flink.runtime.state.TestTaskStateManager;
-import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
@@ -93,7 +89,6 @@ import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -110,11 +105,15 @@ import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.util.CloseableIterable;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.SupplierWithException;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
@@ -130,20 +129,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.flink.runtime.concurrent.Executors.newDirectExecutorService;
+import static org.apache.flink.streaming.util.StreamTaskUtil.waitTaskIsRunning;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -152,7 +150,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -173,6 +170,9 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 public class StreamTaskTest extends TestLogger {
 
 	private static OneShotLatch syncLatch;
+
+	@Rule
+	public final Timeout timeoutPerTest = Timeout.seconds(30);
 
 	/**
 	 * This test checks that cancel calls that are issued before the operator is
@@ -311,21 +311,6 @@ public class StreamTaskTest extends TestLogger {
 
 	@Test
 	public void testFailingCheckpointStreamOperator() throws Exception {
-		final long checkpointId = 42L;
-		final long timestamp = 1L;
-
-		TaskInfo mockTaskInfo = mock(TaskInfo.class);
-		when(mockTaskInfo.getTaskNameWithSubtasks()).thenReturn("foobar");
-		when(mockTaskInfo.getIndexOfThisSubtask()).thenReturn(0);
-		Environment mockEnvironment = new MockEnvironmentBuilder().build();
-
-		StreamTask<?, ?> streamTask = new EmptyStreamTask(mockEnvironment);
-		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, timestamp);
-
-		// mock the operators
-		StreamOperator<?> streamOperator1 = mock(StreamOperator.class);
-		StreamOperator<?> streamOperator2 = mock(StreamOperator.class);
-		StreamOperator<?> streamOperator3 = mock(StreamOperator.class);
 
 		// mock the returned snapshots
 		OperatorSnapshotFutures operatorSnapshotResult1 = mock(OperatorSnapshotFutures.class);
@@ -333,49 +318,34 @@ public class StreamTaskTest extends TestLogger {
 
 		final Exception testException = new Exception("Test exception");
 
-		when(streamOperator1.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class))).thenReturn(operatorSnapshotResult1);
-		when(streamOperator2.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class))).thenReturn(operatorSnapshotResult2);
-		when(streamOperator3.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class))).thenThrow(testException);
+		try (MockEnvironment mockEnvironment = new MockEnvironmentBuilder().build()) {
+			RunningTask<MockStreamTask> task = runTask(() -> new MockStreamTask(
+				mockEnvironment,
+				operatorChain(
+					streamOperatorWithSnapshot(operatorSnapshotResult1),
+					streamOperatorWithSnapshot(operatorSnapshotResult2),
+					streamOperatorWithSnapshotException(testException))));
+			MockStreamTask streamTask = task.streamTask;
 
-		OperatorID operatorID1 = new OperatorID();
-		OperatorID operatorID2 = new OperatorID();
-		OperatorID operatorID3 = new OperatorID();
-		when(streamOperator1.getOperatorID()).thenReturn(operatorID1);
-		when(streamOperator2.getOperatorID()).thenReturn(operatorID2);
-		when(streamOperator3.getOperatorID()).thenReturn(operatorID3);
+			waitTaskIsRunning(streamTask, task.invocationFuture);
 
-		// set up the task
+			try {
+				streamTask.triggerCheckpoint(
+					new CheckpointMetaData(42L, 1L),
+					CheckpointOptions.forCheckpointWithDefaultLocation(),
+					false);
 
-		StreamOperator<?>[] streamOperators = {streamOperator1, streamOperator2, streamOperator3};
+				fail("Expected test exception here.");
+			} catch (Exception e) {
+				assertTrue(ExceptionUtils.findThrowable(e, testException::equals).isPresent());
+			}
 
-		OperatorChain<Void, AbstractStreamOperator<Void>> operatorChain = mock(OperatorChain.class);
-		when(operatorChain.getAllOperators()).thenReturn(streamOperators);
+			verify(operatorSnapshotResult1).cancel();
+			verify(operatorSnapshotResult2).cancel();
 
-		Whitebox.setInternalState(streamTask, "isRunning", true);
-		Whitebox.setInternalState(streamTask, "lock", new Object());
-		Whitebox.setInternalState(streamTask, "operatorChain", operatorChain);
-		Whitebox.setInternalState(streamTask, "cancelables", new CloseableRegistry());
-		Whitebox.setInternalState(streamTask, "configuration", new StreamConfig(new Configuration()));
-		Whitebox.setInternalState(streamTask, "checkpointStorage", new MemoryBackendCheckpointStorage(new JobID(), null, null, Integer.MAX_VALUE));
-
-		CheckpointExceptionHandlerFactory checkpointExceptionHandlerFactory = new CheckpointExceptionHandlerFactory();
-		CheckpointExceptionHandler checkpointExceptionHandler =
-			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(true, mockEnvironment);
-		Whitebox.setInternalState(streamTask, "synchronousCheckpointExceptionHandler", checkpointExceptionHandler);
-
-		StreamTask.AsyncCheckpointExceptionHandler asyncCheckpointExceptionHandler =
-			new StreamTask.AsyncCheckpointExceptionHandler(streamTask);
-		Whitebox.setInternalState(streamTask, "asynchronousCheckpointExceptionHandler", asyncCheckpointExceptionHandler);
-
-		try {
-			streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false);
-			fail("Expected test exception here.");
-		} catch (Exception e) {
-			assertEquals(testException, e.getCause());
+			task.streamTask.finishInput();
+			task.waitForTaskCompletion(false);
 		}
-
-		verify(operatorSnapshotResult1).cancel();
-		verify(operatorSnapshotResult2).cancel();
 	}
 
 	/**
@@ -384,17 +354,6 @@ public class StreamTaskTest extends TestLogger {
 	 */
 	@Test
 	public void testFailingAsyncCheckpointRunnable() throws Exception {
-		final long checkpointId = 42L;
-		final long timestamp = 1L;
-
-		MockEnvironment mockEnvironment = new MockEnvironmentBuilder().build();
-		StreamTask<?, ?> streamTask = spy(new EmptyStreamTask(mockEnvironment));
-		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, timestamp);
-
-		// mock the operators
-		StreamOperator<?> streamOperator1 = mock(StreamOperator.class);
-		StreamOperator<?> streamOperator2 = mock(StreamOperator.class);
-		StreamOperator<?> streamOperator3 = mock(StreamOperator.class);
 
 		// mock the new state operator snapshots
 		OperatorSnapshotFutures operatorSnapshotResult1 = mock(OperatorSnapshotFutures.class);
@@ -406,47 +365,41 @@ public class StreamTaskTest extends TestLogger {
 
 		when(operatorSnapshotResult3.getOperatorStateRawFuture()).thenReturn(failingFuture);
 
-		when(streamOperator1.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class))).thenReturn(operatorSnapshotResult1);
-		when(streamOperator2.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class))).thenReturn(operatorSnapshotResult2);
-		when(streamOperator3.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class))).thenReturn(operatorSnapshotResult3);
+		try (MockEnvironment mockEnvironment = new MockEnvironmentBuilder().build()) {
+			RunningTask<MockStreamTask> task = runTask(() -> new MockStreamTask(
+				mockEnvironment,
+				operatorChain(
+					streamOperatorWithSnapshot(operatorSnapshotResult1),
+					streamOperatorWithSnapshot(operatorSnapshotResult2),
+					streamOperatorWithSnapshot(operatorSnapshotResult3))));
 
-		OperatorID operatorID1 = new OperatorID();
-		OperatorID operatorID2 = new OperatorID();
-		OperatorID operatorID3 = new OperatorID();
-		when(streamOperator1.getOperatorID()).thenReturn(operatorID1);
-		when(streamOperator2.getOperatorID()).thenReturn(operatorID2);
-		when(streamOperator3.getOperatorID()).thenReturn(operatorID3);
+			MockStreamTask streamTask = task.streamTask;
 
-		StreamOperator<?>[] streamOperators = {streamOperator1, streamOperator2, streamOperator3};
+			waitTaskIsRunning(streamTask, task.invocationFuture);
 
-		OperatorChain<Void, AbstractStreamOperator<Void>> operatorChain = mock(OperatorChain.class);
-		when(operatorChain.getAllOperators()).thenReturn(streamOperators);
+			mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
+			streamTask.triggerCheckpoint(
+				new CheckpointMetaData(42L, 1L),
+				CheckpointOptions.forCheckpointWithDefaultLocation(),
+				false);
 
-		Whitebox.setInternalState(streamTask, "isRunning", true);
-		Whitebox.setInternalState(streamTask, "lock", new Object());
-		Whitebox.setInternalState(streamTask, "operatorChain", operatorChain);
-		Whitebox.setInternalState(streamTask, "cancelables", new CloseableRegistry());
-		Whitebox.setInternalState(streamTask, "asyncOperationsThreadPool", newDirectExecutorService());
-		Whitebox.setInternalState(streamTask, "configuration", new StreamConfig(new Configuration()));
-		Whitebox.setInternalState(streamTask, "checkpointStorage", new MemoryBackendCheckpointStorage(new JobID(), null, null, Integer.MAX_VALUE));
+			// wait for the completion of the async task
+			ExecutorService executor = streamTask.getAsyncOperationsThreadPool();
+			executor.shutdown();
+			if (!executor.awaitTermination(10000L, TimeUnit.MILLISECONDS)) {
+				fail("Executor did not shut down within the given timeout. This indicates that the " +
+					"checkpointing did not resume.");
+			}
 
-		CheckpointExceptionHandlerFactory checkpointExceptionHandlerFactory = new CheckpointExceptionHandlerFactory();
-		CheckpointExceptionHandler checkpointExceptionHandler =
-			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(true, mockEnvironment);
-		Whitebox.setInternalState(streamTask, "synchronousCheckpointExceptionHandler", checkpointExceptionHandler);
+			assertTrue(mockEnvironment.getActualExternalFailureCause().isPresent());
 
-		StreamTask.AsyncCheckpointExceptionHandler asyncCheckpointExceptionHandler =
-			new StreamTask.AsyncCheckpointExceptionHandler(streamTask);
-		Whitebox.setInternalState(streamTask, "asynchronousCheckpointExceptionHandler", asyncCheckpointExceptionHandler);
+			verify(operatorSnapshotResult1).cancel();
+			verify(operatorSnapshotResult2).cancel();
+			verify(operatorSnapshotResult3).cancel();
 
-		mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
-		streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false);
-
-		verify(streamTask).handleAsyncException(anyString(), any(Throwable.class));
-
-		verify(operatorSnapshotResult1).cancel();
-		verify(operatorSnapshotResult2).cancel();
-		verify(operatorSnapshotResult3).cancel();
+			streamTask.finishInput();
+			task.waitForTaskCompletion(false);
+		}
 	}
 
 	/**
@@ -459,8 +412,6 @@ public class StreamTaskTest extends TestLogger {
 	 */
 	@Test
 	public void testAsyncCheckpointingConcurrentCloseAfterAcknowledge() throws Exception {
-		final long checkpointId = 42L;
-		final long timestamp = 1L;
 
 		final OneShotLatch acknowledgeCheckpointLatch = new OneShotLatch();
 		final OneShotLatch completeAcknowledge = new OneShotLatch();
@@ -490,17 +441,6 @@ public class StreamTaskTest extends TestLogger {
 			null,
 			checkpointResponder);
 
-		MockEnvironment mockEnvironment = new MockEnvironmentBuilder()
-			.setTaskName("mock-task")
-			.setTaskStateManager(taskStateManager)
-			.build();
-
-		StreamTask<?, ?> streamTask = new EmptyStreamTask(mockEnvironment);
-		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, timestamp);
-
-		StreamOperator<?> streamOperator = mock(StreamOperator.class);
-		when(streamOperator.getOperatorID()).thenReturn(new OperatorID(42, 42));
-
 		KeyedStateHandle managedKeyedStateHandle = mock(KeyedStateHandle.class);
 		KeyedStateHandle rawKeyedStateHandle = mock(KeyedStateHandle.class);
 		OperatorStateHandle managedOperatorStateHandle = mock(OperatorStreamStateHandle.class);
@@ -512,62 +452,64 @@ public class StreamTaskTest extends TestLogger {
 			DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)));
 
-		when(streamOperator.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class))).thenReturn(operatorSnapshotResult);
+		try (MockEnvironment mockEnvironment = new MockEnvironmentBuilder()
+			.setTaskName("mock-task")
+			.setTaskStateManager(taskStateManager)
+			.build()) {
 
-		StreamOperator<?>[] streamOperators = {streamOperator};
+			RunningTask<MockStreamTask> task = runTask(() -> new MockStreamTask(
+				mockEnvironment,
+				operatorChain(streamOperatorWithSnapshot(operatorSnapshotResult))));
 
-		OperatorChain<Void, AbstractStreamOperator<Void>> operatorChain = mock(OperatorChain.class);
-		when(operatorChain.getAllOperators()).thenReturn(streamOperators);
+			MockStreamTask streamTask = task.streamTask;
+			waitTaskIsRunning(streamTask, task.invocationFuture);
 
-		CheckpointStorage checkpointStorage = new MemoryBackendCheckpointStorage(new JobID(), null, null, Integer.MAX_VALUE);
+			final long checkpointId = 42L;
+			streamTask.triggerCheckpoint(
+				new CheckpointMetaData(checkpointId, 1L),
+				CheckpointOptions.forCheckpointWithDefaultLocation(),
+				false);
 
-		Whitebox.setInternalState(streamTask, "isRunning", true);
-		Whitebox.setInternalState(streamTask, "lock", new Object());
-		Whitebox.setInternalState(streamTask, "operatorChain", operatorChain);
-		Whitebox.setInternalState(streamTask, "cancelables", new CloseableRegistry());
-		Whitebox.setInternalState(streamTask, "asyncOperationsThreadPool", Executors.newFixedThreadPool(1));
-		Whitebox.setInternalState(streamTask, "configuration", new StreamConfig(new Configuration()));
-		Whitebox.setInternalState(streamTask, "checkpointStorage", checkpointStorage);
+			acknowledgeCheckpointLatch.await();
 
-		streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false);
+			ArgumentCaptor<TaskStateSnapshot> subtaskStateCaptor = ArgumentCaptor.forClass(TaskStateSnapshot.class);
 
-		acknowledgeCheckpointLatch.await();
+			// check that the checkpoint has been completed
+			verify(checkpointResponder).acknowledgeCheckpoint(
+				any(JobID.class),
+				any(ExecutionAttemptID.class),
+				eq(checkpointId),
+				any(CheckpointMetrics.class),
+				subtaskStateCaptor.capture());
 
-		ArgumentCaptor<TaskStateSnapshot> subtaskStateCaptor = ArgumentCaptor.forClass(TaskStateSnapshot.class);
+			TaskStateSnapshot subtaskStates = subtaskStateCaptor.getValue();
+			OperatorSubtaskState subtaskState = subtaskStates.getSubtaskStateMappings().iterator().next().getValue();
 
-		// check that the checkpoint has been completed
-		verify(checkpointResponder).acknowledgeCheckpoint(
-			any(JobID.class),
-			any(ExecutionAttemptID.class),
-			eq(checkpointId),
-			any(CheckpointMetrics.class),
-			subtaskStateCaptor.capture());
+			// check that the subtask state contains the expected state handles
+			assertEquals(StateObjectCollection.singleton(managedKeyedStateHandle), subtaskState.getManagedKeyedState());
+			assertEquals(StateObjectCollection.singleton(rawKeyedStateHandle), subtaskState.getRawKeyedState());
+			assertEquals(StateObjectCollection.singleton(managedOperatorStateHandle), subtaskState.getManagedOperatorState());
+			assertEquals(StateObjectCollection.singleton(rawOperatorStateHandle), subtaskState.getRawOperatorState());
 
-		TaskStateSnapshot subtaskStates = subtaskStateCaptor.getValue();
-		OperatorSubtaskState subtaskState = subtaskStates.getSubtaskStateMappings().iterator().next().getValue();
+			// check that the state handles have not been discarded
+			verify(managedKeyedStateHandle, never()).discardState();
+			verify(rawKeyedStateHandle, never()).discardState();
+			verify(managedOperatorStateHandle, never()).discardState();
+			verify(rawOperatorStateHandle, never()).discardState();
 
-		// check that the subtask state contains the expected state handles
-		assertEquals(StateObjectCollection.singleton(managedKeyedStateHandle), subtaskState.getManagedKeyedState());
-		assertEquals(StateObjectCollection.singleton(rawKeyedStateHandle), subtaskState.getRawKeyedState());
-		assertEquals(StateObjectCollection.singleton(managedOperatorStateHandle), subtaskState.getManagedOperatorState());
-		assertEquals(StateObjectCollection.singleton(rawOperatorStateHandle), subtaskState.getRawOperatorState());
+			streamTask.cancel();
 
-		// check that the state handles have not been discarded
-		verify(managedKeyedStateHandle, never()).discardState();
-		verify(rawKeyedStateHandle, never()).discardState();
-		verify(managedOperatorStateHandle, never()).discardState();
-		verify(rawOperatorStateHandle, never()).discardState();
+			completeAcknowledge.trigger();
 
-		streamTask.cancel();
+			// canceling the stream task after it has acknowledged the checkpoint should not discard
+			// the state handles
+			verify(managedKeyedStateHandle, never()).discardState();
+			verify(rawKeyedStateHandle, never()).discardState();
+			verify(managedOperatorStateHandle, never()).discardState();
+			verify(rawOperatorStateHandle, never()).discardState();
 
-		completeAcknowledge.trigger();
-
-		// canceling the stream task after it has acknowledged the checkpoint should not discard
-		// the state handles
-		verify(managedKeyedStateHandle, never()).discardState();
-		verify(rawKeyedStateHandle, never()).discardState();
-		verify(managedOperatorStateHandle, never()).discardState();
-		verify(rawOperatorStateHandle, never()).discardState();
+			task.waitForTaskCompletion(true);
+		}
 	}
 
 	/**
@@ -580,13 +522,9 @@ public class StreamTaskTest extends TestLogger {
 	 */
 	@Test
 	public void testAsyncCheckpointingConcurrentCloseBeforeAcknowledge() throws Exception {
-		final long checkpointId = 42L;
-		final long timestamp = 1L;
 
 		final OneShotLatch createSubtask = new OneShotLatch();
 		final OneShotLatch completeSubtask = new OneShotLatch();
-
-		Environment mockEnvironment = spy(new MockEnvironmentBuilder().build());
 
 		whenNew(OperatorSnapshotFinalizer.class).
 			withAnyArguments().
@@ -597,13 +535,6 @@ public class StreamTaskTest extends TestLogger {
 					return new OperatorSnapshotFinalizer((OperatorSnapshotFutures) arguments[0]);
 				}
 			);
-
-		StreamTask<?, ?> streamTask = new EmptyStreamTask(mockEnvironment);
-		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, timestamp);
-
-		final StreamOperator<?> streamOperator = mock(StreamOperator.class);
-		final OperatorID operatorID = new OperatorID();
-		when(streamOperator.getOperatorID()).thenReturn(operatorID);
 
 		KeyedStateHandle managedKeyedStateHandle = mock(KeyedStateHandle.class);
 		KeyedStateHandle rawKeyedStateHandle = mock(KeyedStateHandle.class);
@@ -616,49 +547,47 @@ public class StreamTaskTest extends TestLogger {
 			DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)));
 
-		when(streamOperator.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class))).thenReturn(operatorSnapshotResult);
+		final StreamOperator<?> streamOperator = streamOperatorWithSnapshot(operatorSnapshotResult);
 
-		StreamOperator<?>[] streamOperators = {streamOperator};
+		try (MockEnvironment mockEnvironment = spy(new MockEnvironmentBuilder().build())) {
 
-		OperatorChain<Void, AbstractStreamOperator<Void>> operatorChain = mock(OperatorChain.class);
-		when(operatorChain.getAllOperators()).thenReturn(streamOperators);
+			RunningTask<MockStreamTask> task = runTask(() -> new MockStreamTask(
+				mockEnvironment,
+				operatorChain(streamOperator)));
 
-		CheckpointStorage checkpointStorage = new MemoryBackendCheckpointStorage(new JobID(), null, null, Integer.MAX_VALUE);
+			waitTaskIsRunning(task.streamTask, task.invocationFuture);
 
-		ExecutorService executor = Executors.newFixedThreadPool(1);
+			final long checkpointId = 42L;
+			task.streamTask.triggerCheckpoint(
+				new CheckpointMetaData(checkpointId, 1L),
+				CheckpointOptions.forCheckpointWithDefaultLocation(),
+				false);
 
-		Whitebox.setInternalState(streamTask, "isRunning", true);
-		Whitebox.setInternalState(streamTask, "lock", new Object());
-		Whitebox.setInternalState(streamTask, "operatorChain", operatorChain);
-		Whitebox.setInternalState(streamTask, "cancelables", new CloseableRegistry());
-		Whitebox.setInternalState(streamTask, "asyncOperationsThreadPool", executor);
-		Whitebox.setInternalState(streamTask, "configuration", new StreamConfig(new Configuration()));
-		Whitebox.setInternalState(streamTask, "checkpointStorage", checkpointStorage);
+			createSubtask.await();
 
-		streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false);
+			task.streamTask.cancel();
 
-		createSubtask.await();
+			completeSubtask.trigger();
 
-		streamTask.cancel();
+			// wait for the completion of the async task
+			ExecutorService executor = task.streamTask.getAsyncOperationsThreadPool();
+			executor.shutdown();
+			if (!executor.awaitTermination(10000L, TimeUnit.MILLISECONDS)) {
+				fail("Executor did not shut down within the given timeout. This indicates that the " +
+					"checkpointing did not resume.");
+			}
 
-		completeSubtask.trigger();
+			// check that the checkpoint has not been acknowledged
+			verify(mockEnvironment, never()).acknowledgeCheckpoint(eq(checkpointId), any(CheckpointMetrics.class), any(TaskStateSnapshot.class));
 
-		// wait for the completion of the async task
-		executor.shutdown();
+			// check that the state handles have been discarded
+			verify(managedKeyedStateHandle).discardState();
+			verify(rawKeyedStateHandle).discardState();
+			verify(managedOperatorStateHandle).discardState();
+			verify(rawOperatorStateHandle).discardState();
 
-		if (!executor.awaitTermination(10000L, TimeUnit.MILLISECONDS)) {
-			fail("Executor did not shut down within the given timeout. This indicates that the " +
-				"checkpointing did not resume.");
+			task.waitForTaskCompletion(true);
 		}
-
-		// check that the checkpoint has not been acknowledged
-		verify(mockEnvironment, never()).acknowledgeCheckpoint(eq(checkpointId), any(CheckpointMetrics.class), any(TaskStateSnapshot.class));
-
-		// check that the state handles have been discarded
-		verify(managedKeyedStateHandle).discardState();
-		verify(rawKeyedStateHandle).discardState();
-		verify(managedOperatorStateHandle).discardState();
-		verify(rawOperatorStateHandle).discardState();
 	}
 
 	/**
@@ -669,10 +598,6 @@ public class StreamTaskTest extends TestLogger {
 	 */
 	@Test
 	public void testEmptySubtaskStateLeadsToStatelessAcknowledgment() throws Exception {
-		final long checkpointId = 42L;
-		final long timestamp = 1L;
-
-		Environment mockEnvironment = spy(new MockEnvironmentBuilder().build());
 
 		// latch blocks until the async checkpoint thread acknowledges
 		final OneShotLatch checkpointCompletedLatch = new OneShotLatch();
@@ -701,42 +626,32 @@ public class StreamTaskTest extends TestLogger {
 			null,
 			checkpointResponder);
 
-		when(mockEnvironment.getTaskStateManager()).thenReturn(taskStateManager);
+		// mock the operator with empty snapshot result (all state handles are null)
+		StreamOperator<?> statelessOperator = streamOperatorWithSnapshot(new OperatorSnapshotFutures());
 
-		StreamTask<?, ?> streamTask = new EmptyStreamTask(mockEnvironment);
-		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, timestamp);
+		try (MockEnvironment mockEnvironment = new MockEnvironmentBuilder()
+			.setTaskStateManager(taskStateManager)
+			.build()) {
 
-		// mock the operators
-		StreamOperator<?> statelessOperator =
-				mock(StreamOperator.class);
+			RunningTask<MockStreamTask> task = runTask(() -> new MockStreamTask(
+				mockEnvironment,
+				operatorChain(statelessOperator)));
 
-		final OperatorID operatorID = new OperatorID();
-		when(statelessOperator.getOperatorID()).thenReturn(operatorID);
+			waitTaskIsRunning(task.streamTask, task.invocationFuture);
 
-		// mock the returned empty snapshot result (all state handles are null)
-		OperatorSnapshotFutures statelessOperatorSnapshotResult = new OperatorSnapshotFutures();
-		when(statelessOperator.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class)))
-				.thenReturn(statelessOperatorSnapshotResult);
+			task.streamTask.triggerCheckpoint(
+				new CheckpointMetaData(42L, 1L),
+				CheckpointOptions.forCheckpointWithDefaultLocation(),
+				false);
 
-		// set up the task
-		StreamOperator<?>[] streamOperators = {statelessOperator};
-		OperatorChain<Void, AbstractStreamOperator<Void>> operatorChain = mock(OperatorChain.class);
-		when(operatorChain.getAllOperators()).thenReturn(streamOperators);
+			checkpointCompletedLatch.await(30, TimeUnit.SECONDS);
 
-		Whitebox.setInternalState(streamTask, "isRunning", true);
-		Whitebox.setInternalState(streamTask, "lock", new Object());
-		Whitebox.setInternalState(streamTask, "operatorChain", operatorChain);
-		Whitebox.setInternalState(streamTask, "cancelables", new CloseableRegistry());
-		Whitebox.setInternalState(streamTask, "configuration", new StreamConfig(new Configuration()));
-		Whitebox.setInternalState(streamTask, "asyncOperationsThreadPool", Executors.newCachedThreadPool());
-		Whitebox.setInternalState(streamTask, "checkpointStorage", new MemoryBackendCheckpointStorage(new JobID(), null, null, Integer.MAX_VALUE));
+			// ensure that 'null' was acknowledged as subtask state
+			Assert.assertNull(checkpointResult.get(0));
 
-		streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false);
-		checkpointCompletedLatch.await(30, TimeUnit.SECONDS);
-		streamTask.cancel();
-
-		// ensure that 'null' was acknowledged as subtask state
-		Assert.assertNull(checkpointResult.get(0));
+			task.streamTask.cancel();
+			task.waitForTaskCompletion(true);
+		}
 	}
 
 	/**
@@ -760,37 +675,21 @@ public class StreamTaskTest extends TestLogger {
 					.setBufferSize(1)
 					.setTaskConfiguration(taskConfiguration)
 					.build()) {
-			StreamTask<Void, BlockingCloseStreamOperator> streamTask = new NoOpStreamTask<>(mockEnvironment);
-			final AtomicReference<Throwable> atomicThrowable = new AtomicReference<>(null);
 
-			CompletableFuture<Void> invokeFuture = CompletableFuture.runAsync(
-				() -> {
-					try {
-						streamTask.invoke();
-					} catch (Exception e) {
-						atomicThrowable.set(e);
-					}
-				},
-				TestingUtils.defaultExecutor());
+			RunningTask<StreamTask<Void, BlockingCloseStreamOperator>> task = runTask(() -> new NoOpStreamTask<>(mockEnvironment));
 
 			BlockingCloseStreamOperator.IN_CLOSE.await();
 
 			// check that the StreamTask is not yet in isRunning == false
-			assertTrue(streamTask.isRunning());
+			assertTrue(task.streamTask.isRunning());
 
 			// let the operator finish its close operation
 			BlockingCloseStreamOperator.FINISH_CLOSE.trigger();
 
-			// wait until the invoke is complete
-			invokeFuture.get();
+			task.waitForTaskCompletion(false);
 
 			// now the StreamTask should no longer be running
-			assertFalse(streamTask.isRunning());
-
-			// check if an exception occurred
-			if (atomicThrowable.get() != null) {
-				throw atomicThrowable.get();
-			}
+			assertFalse(task.streamTask.isRunning());
 		}
 	}
 
@@ -805,28 +704,91 @@ public class StreamTaskTest extends TestLogger {
 			new MockEnvironmentBuilder()
 				.setUserCodeClassLoader(new TestUserCodeClassLoader())
 				.build()) {
-			TimeServiceTask timerServiceTask = new TimeServiceTask(mockEnvironment);
+			RunningTask<TimeServiceTask> task = runTask(() -> new TimeServiceTask(mockEnvironment));
+			task.waitForTaskCompletion(false);
 
-			CompletableFuture<Void> invokeFuture = CompletableFuture.runAsync(
-				() -> {
-					try {
-						timerServiceTask.invoke();
-					} catch (Exception e) {
-						throw new CompletionException(e);
-					}
-				},
-				TestingUtils.defaultExecutor());
-
-			invokeFuture.get();
-
-			assertThat(timerServiceTask.getClassLoaders(), hasSize(greaterThanOrEqualTo(1)));
-			assertThat(timerServiceTask.getClassLoaders(), everyItem(instanceOf(TestUserCodeClassLoader.class)));
+			assertThat(task.streamTask.getClassLoaders(), hasSize(greaterThanOrEqualTo(1)));
+			assertThat(task.streamTask.getClassLoaders(), everyItem(instanceOf(TestUserCodeClassLoader.class)));
 		}
 	}
 
 	// ------------------------------------------------------------------------
 	//  Test Utilities
 	// ------------------------------------------------------------------------
+
+	private static StreamOperator<?> streamOperatorWithSnapshot(OperatorSnapshotFutures operatorSnapshotResult) throws Exception {
+		StreamOperator<?> operator = mock(StreamOperator.class);
+		when(operator.getOperatorID()).thenReturn(new OperatorID());
+
+		when(operator.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class)))
+			.thenReturn(operatorSnapshotResult);
+
+		return operator;
+	}
+
+	private static StreamOperator<?> streamOperatorWithSnapshotException(Exception exception) throws Exception {
+		StreamOperator<?> operator = mock(StreamOperator.class);
+		when(operator.getOperatorID()).thenReturn(new OperatorID());
+
+		when(operator.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class)))
+			.thenThrow(exception);
+
+		return operator;
+	}
+
+	private static <T> OperatorChain<T, AbstractStreamOperator<T>> operatorChain(StreamOperator<?>... streamOperators) {
+		OperatorChain<T, AbstractStreamOperator<T>> operatorChain = mock(OperatorChain.class);
+		when(operatorChain.getAllOperators()).thenReturn(streamOperators);
+		return operatorChain;
+	}
+
+	private static class RunningTask<T extends StreamTask<?, ?>> {
+		final T streamTask;
+		final CompletableFuture<Void> invocationFuture;
+
+		RunningTask(T streamTask, CompletableFuture<Void> invocationFuture) {
+			this.streamTask = streamTask;
+			this.invocationFuture = invocationFuture;
+		}
+
+		void waitForTaskCompletion(boolean cancelled) throws Exception {
+			try {
+				invocationFuture.get();
+			} catch (Exception e) {
+				if (cancelled) {
+					assertThat(e.getCause(), is(instanceOf(CancelTaskException.class)));
+				} else {
+					throw e;
+				}
+			}
+			assertThat(streamTask.isCanceled(), is(cancelled));
+		}
+	}
+
+	private static <T extends StreamTask<?, ?>> RunningTask<T> runTask(SupplierWithException<T, Exception> taskFactory) throws Exception {
+		CompletableFuture<T> taskCreationFuture = new CompletableFuture<>();
+		CompletableFuture<Void> invocationFuture = CompletableFuture.runAsync(
+			() -> {
+				T task;
+				try {
+					task = taskFactory.get();
+					taskCreationFuture.complete(task);
+				} catch (Exception e) {
+					taskCreationFuture.completeExceptionally(e);
+					return;
+				}
+				try {
+					task.invoke();
+				} catch (RuntimeException e) {
+					throw e;
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+			}, Executors.newSingleThreadExecutor());
+
+		// Wait until task is created.
+		return new RunningTask<>(taskCreationFuture.get(), invocationFuture);
+	}
 
 	/**
 	 * Operator that does nothing.
@@ -1024,18 +986,30 @@ public class StreamTaskTest extends TestLogger {
 	// ------------------------------------------------------------------------
 	// ------------------------------------------------------------------------
 
-	private static class EmptyStreamTask extends StreamTask<String, AbstractStreamOperator<String>> {
+	private static class MockStreamTask extends StreamTask<String, AbstractStreamOperator<String>> {
 
-		public EmptyStreamTask(Environment env) {
+		private final OperatorChain<String, AbstractStreamOperator<String>> overrideOperatorChain;
+		private volatile boolean inputFinished;
+
+		MockStreamTask(Environment env, OperatorChain<String, AbstractStreamOperator<String>> operatorChain) {
 			super(env, null);
+			this.overrideOperatorChain = operatorChain;
 		}
 
 		@Override
-		protected void init() throws Exception {}
+		protected void init() {
+			// The StreamTask initializes operatorChain first on it's own in `invoke()` method.
+			// Later it calls the `init()` method before actual `run()`, so we are overriding the operatorChain
+			// here for test purposes.
+			super.operatorChain = this.overrideOperatorChain;
+			super.headOperator = super.operatorChain.getHeadOperator();
+		}
 
 		@Override
-		protected void performDefaultAction(ActionContext context) throws Exception {
-			context.allActionsCompleted();
+		protected void performDefaultAction(ActionContext context) {
+			if (isCanceled() || inputFinished) {
+				context.allActionsCompleted();
+			}
 		}
 
 		@Override
@@ -1043,6 +1017,10 @@ public class StreamTaskTest extends TestLogger {
 
 		@Override
 		protected void cancelTask() throws Exception {}
+
+		void finishInput() {
+			this.inputFinished = true;
+		}
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -264,9 +264,7 @@ public class StreamTaskTestHarness<OUT> {
 	 * @throws Exception
 	 */
 	public void waitForTaskCompletion(long timeout) throws Exception {
-		if (taskThread == null) {
-			throw new IllegalStateException("Task thread was not started.");
-		}
+		Preconditions.checkState(taskThread != null, "Task thread was not started.");
 
 		taskThread.join(timeout);
 		if (taskThread.getError() != null) {
@@ -291,9 +289,7 @@ public class StreamTaskTestHarness<OUT> {
 	 * @throws Exception
 	 */
 	public void waitForTaskRunning(long timeout) throws Exception {
-		if (taskThread == null || taskThread.task == null) {
-			throw new IllegalStateException("Task thread was not started.");
-		}
+		Preconditions.checkState(taskThread != null, "Task thread was not started.");
 		StreamTask<?, ?> streamTask = taskThread.task;
 		while (!streamTask.isRunning()) {
 			Thread.sleep(10);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -111,8 +111,8 @@ public class StreamTaskTestHarness<OUT> {
 	protected StreamTestSingleInputGate[] inputGates;
 
 	public StreamTaskTestHarness(
-			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
-			TypeInformation<OUT> outputType) {
+		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		TypeInformation<OUT> outputType) {
 		this(taskFactory, outputType, TestLocalRecoveryConfig.disabled());
 	}
 
@@ -398,7 +398,7 @@ public class StreamTaskTestHarness<OUT> {
 		while (true) {
 			Thread.State state = taskThread.getState();
 			if (state == Thread.State.BLOCKED || state == Thread.State.TERMINATED ||
-					state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
+				state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
 				break;
 			}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -159,7 +159,7 @@ public class SynchronousCheckpointITCase {
 			if (isCanceled()) {
 				context.allActionsCompleted();
 			} else {
-				context.actionsUnavailable();
+				context.suspendDefaultAction();
 			}
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
@@ -57,9 +57,8 @@ public class SynchronousCheckpointTest {
 		execLatch = new OneShotLatch();
 		error = new AtomicReference<>();
 
-		streamTaskUnderTest = createTask(runningLatch, execLatch);
-
 		mainThreadExecutingTaskUnderTest = launchOnSeparateThread(() -> {
+			streamTaskUnderTest = createTask(runningLatch, execLatch);
 			try {
 				streamTaskUnderTest.invoke();
 			} catch (Exception e) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessorTest.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import org.apache.flink.core.testutils.OneShotLatch;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Unit tests for {@link MailboxProcessor}.
+ */
+public class MailboxProcessorTest {
+
+	@Test
+	public void testRejectIfNotOpen() {
+		MailboxProcessor mailboxProcessor = new MailboxProcessor((ctx) -> {});
+		try {
+			mailboxProcessor.getTaskMailboxExecutor().tryExecute(() -> {});
+			Assert.fail("Should not be able to accept runnables if not opened.");
+		} catch (RejectedExecutionException expected) {
+		}
+	}
+
+	@Test
+	public void testShutdown() {
+		MailboxProcessor mailboxProcessor = new MailboxProcessor((ctx) -> {});
+		FutureTask<Void> testRunnableFuture = new FutureTask<>(() -> {}, null);
+		mailboxProcessor.openMailbox();
+		mailboxProcessor.getTaskMailboxExecutor().tryExecute(testRunnableFuture);
+		mailboxProcessor.prepareShutDown();
+
+		try {
+			mailboxProcessor.getTaskMailboxExecutor().tryExecute(() -> {});
+			Assert.fail("Should not be able to accept runnables if not opened.");
+		} catch (RejectedExecutionException expected) {
+		}
+
+		Assert.assertFalse(testRunnableFuture.isDone());
+
+		mailboxProcessor.shutDown();
+		Assert.assertTrue(testRunnableFuture.isCancelled());
+	}
+
+	@Test
+	public void testLegacySourceLoop() throws Exception {
+		final Object lock = new Object();
+		final MailboxProcessor mailboxProcessor = new MailboxProcessor((ctx) -> {});
+		mailboxProcessor.openMailbox();
+		mailboxProcessor.getTaskMailboxExecutor().tryExecute(() -> {
+			Assert.assertTrue(Thread.holdsLock(lock));
+			mailboxProcessor.allActionsCompleted();
+		});
+		mailboxProcessor.switchToLegacySourceCompatibilityMailboxLoop(lock);
+	}
+
+	@Test
+	public void testRunDefaultActionAndLetters() throws Exception {
+		AtomicBoolean stop = new AtomicBoolean(false);
+		MailboxThread mailboxThread = new MailboxThread() {
+			@Override
+			public void runDefaultAction(ActionContext context) throws Exception {
+				if (stop.get()) {
+					context.allActionsCompleted();
+				} else {
+					Thread.sleep(10L);
+				}
+			}
+		};
+
+		MailboxProcessor mailboxProcessor = start(mailboxThread);
+		mailboxProcessor.getTaskMailboxExecutor().execute(() -> {
+			stop.set(true);
+		});
+		stop(mailboxThread);
+	}
+
+	@Test
+	public void testRunDefaultAction() throws Exception {
+
+		final int expectedInvocations = 3;
+		final AtomicInteger counter = new AtomicInteger(0);
+		MailboxThread mailboxThread = new MailboxThread() {
+			@Override
+			public void runDefaultAction(ActionContext context) {
+				if (counter.incrementAndGet() == expectedInvocations) {
+					context.allActionsCompleted();
+				}
+			}
+		};
+
+		start(mailboxThread);
+		stop(mailboxThread);
+		Assert.assertEquals(expectedInvocations, counter.get());
+	}
+
+	@Test
+	public void testSignalUnAvailable() throws Exception {
+
+		final AtomicInteger counter = new AtomicInteger(0);
+		final AtomicReference<MailboxDefaultAction.SuspendedDefaultAction> suspendedActionRef = new AtomicReference<>();
+		final OneShotLatch actionSuspendedLatch = new OneShotLatch();
+		final int blockAfterInvocations = 3;
+		final int totalInvocations = blockAfterInvocations * 2;
+
+		MailboxThread mailboxThread = new MailboxThread() {
+			@Override
+			public void runDefaultAction(ActionContext context) {
+				if (counter.incrementAndGet() == blockAfterInvocations) {
+					suspendedActionRef.set(context.suspendDefaultAction());
+					actionSuspendedLatch.trigger();
+				} else if (counter.get() == totalInvocations) {
+					context.allActionsCompleted();
+				}
+			}
+		};
+
+		start(mailboxThread);
+		actionSuspendedLatch.await();
+		Assert.assertEquals(blockAfterInvocations, counter.get());
+
+		suspendedActionRef.get().resume();
+		stop(mailboxThread);
+		Assert.assertEquals(totalInvocations, counter.get());
+	}
+
+	@Test
+	public void testSignalUnAvailablePingPong() throws Exception {
+		final AtomicReference<MailboxDefaultAction.SuspendedDefaultAction> suspendedActionRef = new AtomicReference<>();
+		final int totalSwitches = 10000;
+		final MailboxThread mailboxThread = new MailboxThread() {
+			int count = 0;
+
+			@Override
+			public void runDefaultAction(ActionContext context) {
+
+				// If this is violated, it means that the default action was invoked while we assumed suspension
+				Assert.assertTrue(suspendedActionRef.compareAndSet(null, context.suspendDefaultAction()));
+
+				++count;
+
+				if (count == totalSwitches) {
+					context.allActionsCompleted();
+				} else if (count % 1000 == 0) {
+					try {
+						Thread.sleep(1L);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}
+			}
+		};
+
+		mailboxThread.start();
+		final MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();
+		mailboxProcessor.openMailbox();
+
+		final Thread asyncUnblocker = new Thread(() -> {
+			int count = 0;
+			while (!Thread.currentThread().isInterrupted()) {
+
+				final MailboxDefaultAction.SuspendedDefaultAction resume =
+					suspendedActionRef.getAndSet(null);
+				if (resume != null) {
+					resume.resume();
+				} else {
+					try {
+						mailboxProcessor.getTaskMailboxExecutor().execute(() -> { });
+					} catch (RejectedExecutionException ignore) {
+					}
+				}
+
+				++count;
+				if (count % 5000 == 0) {
+					try {
+						Thread.sleep(1L);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}
+			}
+		});
+
+		asyncUnblocker.start();
+		mailboxThread.signalStart();
+		mailboxThread.join();
+		asyncUnblocker.interrupt();
+		asyncUnblocker.join();
+		mailboxProcessor.prepareShutDown();
+		mailboxProcessor.shutDown();
+		mailboxThread.checkException();
+	}
+
+	private static MailboxProcessor start(MailboxThread mailboxThread) {
+		mailboxThread.start();
+		final MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();
+		mailboxProcessor.openMailbox();
+		mailboxThread.signalStart();
+		return mailboxProcessor;
+	}
+
+	private static void stop(MailboxThread mailboxThread) throws Exception {
+		mailboxThread.join();
+		MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();
+		mailboxProcessor.prepareShutDown();
+		mailboxProcessor.shutDown();
+		mailboxThread.checkException();
+	}
+
+	static class MailboxThread extends Thread implements MailboxDefaultAction {
+
+		MailboxProcessor mailboxProcessor;
+		OneShotLatch mailboxCreatedLatch = new OneShotLatch();
+		OneShotLatch canRun = new OneShotLatch();
+		private Throwable caughtException;
+
+		@Override
+		public final void run() {
+			mailboxProcessor = new MailboxProcessor(this);
+			mailboxCreatedLatch.trigger();
+			try {
+				canRun.await();
+				mailboxProcessor.runMailboxLoop();
+			} catch (Throwable t) {
+				this.caughtException = t;
+			}
+		}
+
+		@Override
+		public void runDefaultAction(ActionContext context) throws Exception {
+			context.allActionsCompleted();
+		}
+
+		final MailboxProcessor getMailboxProcessor() {
+			try {
+				mailboxCreatedLatch.await();
+				return mailboxProcessor;
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new RuntimeException(e);
+			}
+		}
+
+		final void signalStart() {
+			if (mailboxCreatedLatch.isTriggered()) {
+				canRun.trigger();
+			}
+		}
+
+		void checkException() throws Exception {
+			if (caughtException != null) {
+				throw new Exception(caughtException);
+			}
+		}
+	}
+
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorServiceImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorServiceImplTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tests for {@link TaskMailboxExecutorServiceImpl}.
+ */
+public class TaskMailboxExecutorServiceImplTest {
+
+	private TaskMailboxExecutorServiceImpl mailboxExecutorService;
+	private ExecutorService otherThreadExecuter;
+	private MailboxImpl mailbox;
+
+	@Before
+	public void setUp() throws Exception {
+		this.mailbox = new MailboxImpl();
+		this.mailbox.open();
+		this.mailboxExecutorService = new TaskMailboxExecutorServiceImpl(mailbox);
+		this.otherThreadExecuter = Executors.newSingleThreadScheduledExecutor();
+	}
+
+	@After
+	public void tearDown() {
+		otherThreadExecuter.shutdown();
+		try {
+			if (!otherThreadExecuter.awaitTermination(60, TimeUnit.SECONDS)) {
+				otherThreadExecuter.shutdownNow();
+				if (!otherThreadExecuter.awaitTermination(60, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("Thread pool did not terminate on time!");
+				}
+			}
+		} catch (InterruptedException ie) {
+			otherThreadExecuter.shutdownNow();
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	@Test
+	public void testOpsAndLifecycle() throws Exception {
+		Assert.assertFalse(mailboxExecutorService.isShutdown());
+		Assert.assertFalse(mailboxExecutorService.isTerminated());
+		final TestRunnable testRunnable = new TestRunnable();
+		Assert.assertTrue(mailboxExecutorService.tryExecute(testRunnable));
+		Assert.assertEquals(testRunnable, mailbox.tryTakeMail().get());
+		CompletableFuture.runAsync(() -> mailboxExecutorService.execute(testRunnable), otherThreadExecuter).get();
+		Assert.assertEquals(testRunnable, mailbox.takeMail());
+		final TestRunnable yieldRun = new TestRunnable();
+		final TestRunnable leftoverRun = new TestRunnable();
+		Assert.assertTrue(mailboxExecutorService.tryExecute(yieldRun));
+		Future<?> leftoverFuture = CompletableFuture.supplyAsync(
+			() -> mailboxExecutorService.submit(leftoverRun), otherThreadExecuter).get();
+		mailboxExecutorService.shutdown();
+		Assert.assertTrue(mailboxExecutorService.isShutdown());
+		Assert.assertFalse(mailboxExecutorService.isTerminated());
+
+		try {
+			CompletableFuture.runAsync(() -> mailboxExecutorService.execute(testRunnable), otherThreadExecuter).get();
+			Assert.fail("execution should not work after shutdown().");
+		} catch (ExecutionException expected) {
+			Assert.assertTrue(expected.getCause() instanceof RejectedExecutionException);
+		}
+
+		try {
+			CompletableFuture.runAsync(() -> mailboxExecutorService.tryExecute(testRunnable), otherThreadExecuter).get();
+			Assert.fail("execution should not work after shutdown().");
+		} catch (ExecutionException expected) {
+			Assert.assertTrue(expected.getCause() instanceof RejectedExecutionException);
+		}
+
+		Assert.assertTrue(mailboxExecutorService.tryYield());
+		Assert.assertEquals(Thread.currentThread(), yieldRun.wasExecutedBy());
+
+		Assert.assertFalse(mailboxExecutorService.awaitTermination(1L, TimeUnit.SECONDS));
+		Assert.assertFalse(leftoverFuture.isDone());
+
+		List<Runnable> leftoverTasks = mailboxExecutorService.shutdownNow();
+		Assert.assertEquals(1, leftoverTasks.size());
+		Assert.assertFalse(leftoverFuture.isCancelled());
+		FutureUtils.cancelRunnableFutures(leftoverTasks);
+		Assert.assertTrue(leftoverFuture.isCancelled());
+
+		try {
+			mailboxExecutorService.tryYield();
+			Assert.fail("yielding should not work after shutdown().");
+		} catch (IllegalStateException expected) {
+		}
+
+		try {
+			mailboxExecutorService.yield();
+			Assert.fail("yielding should not work after shutdown().");
+		} catch (IllegalStateException expected) {
+		}
+	}
+
+	@Test
+	public void testTryYield() throws Exception {
+		final TestRunnable testRunnable = new TestRunnable();
+		CompletableFuture.runAsync(() -> mailboxExecutorService.execute(testRunnable), otherThreadExecuter).get();
+		Assert.assertTrue(mailboxExecutorService.tryYield());
+		Assert.assertFalse(mailbox.tryTakeMail().isPresent());
+		Assert.assertEquals(Thread.currentThread(), testRunnable.wasExecutedBy());
+	}
+
+	@Test
+	public void testYield() throws Exception {
+		final AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+		final TestRunnable testRunnable = new TestRunnable();
+		final Thread submitThread = new Thread(() -> {
+			try {
+				mailboxExecutorService.execute(testRunnable);
+			} catch (Exception e) {
+				exceptionReference.set(e);
+			}
+		});
+
+		submitThread.start();
+		mailboxExecutorService.yield();
+		submitThread.join();
+
+		Assert.assertNull(exceptionReference.get());
+		Assert.assertEquals(Thread.currentThread(), testRunnable.wasExecutedBy());
+	}
+
+	/**
+	 * Test {@link Runnable} that tracks execution.
+	 */
+	static class TestRunnable implements Runnable {
+
+		private Thread executedByThread = null;
+
+		@Override
+		public void run() {
+			Preconditions.checkState(!isExecuted(), "Runnable was already executed before by " + executedByThread);
+			executedByThread = Thread.currentThread();
+		}
+
+		boolean isExecuted() {
+			return executedByThread != null;
+		}
+
+		Thread wasExecutedBy() {
+			return executedByThread;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TestTaskMailboxExecutor.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TestTaskMailboxExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Dummy implementation of {@link TaskMailboxExecutor} for testing.
+ */
+public class TestTaskMailboxExecutor implements TaskMailboxExecutor {
+
+	private final Object lock;
+
+	public TestTaskMailboxExecutor(Object lock) {
+		this.lock = lock;
+	}
+
+	public TestTaskMailboxExecutor() {
+		this(new Object());
+	}
+
+	@Override
+	public void execute(@Nonnull Runnable command) throws RejectedExecutionException {
+		synchronized (lock) {
+			command.run();
+			lock.notifyAll();
+		}
+	}
+
+	@Override
+	public boolean tryExecute(Runnable command) {
+		execute(command);
+		return true;
+	}
+
+	@Override
+	public void yield() throws InterruptedException {
+		synchronized (lock) {
+			lock.wait(1);
+		}
+	}
+
+	@Override
+	public boolean tryYield() {
+		return false;
+	}
+
+	@Override
+	public boolean isMailboxThread() {
+		return true;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -181,7 +181,6 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		this.config.setOperatorID(operatorID);
 		this.executionConfig = env.getExecutionConfig();
 		this.closableRegistry = new CloseableRegistry();
-		this.checkpointLock = new Object();
 
 		this.environment = Preconditions.checkNotNull(env);
 
@@ -198,7 +197,6 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		};
 
 		mockTask = new MockStreamTaskBuilder(env)
-			.setCheckpointLock(checkpointLock)
 			.setConfig(config)
 			.setExecutionConfig(executionConfig)
 			.setStreamTaskStateInitializer(streamTaskStateInitializer)
@@ -207,6 +205,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			.setProcessingTimeService(processingTimeService)
 			.setHandleAsyncException(handleAsyncException)
 			.build();
+
+		this.checkpointLock = mockTask.getCheckpointLock();
 	}
 
 	protected StreamTaskStateInitializer createStreamTaskStateManager(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxExecutor;
 
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -39,6 +40,7 @@ public class MockStreamTask extends StreamTask {
 
 	private final String name;
 	private final Object checkpointLock;
+	private final TaskMailboxExecutor taskMailboxExecutor;
 	private final StreamConfig config;
 	private final ExecutionConfig executionConfig;
 	private StreamTaskStateInitializer streamTaskStateInitializer;
@@ -53,6 +55,7 @@ public class MockStreamTask extends StreamTask {
 		Environment environment,
 		String name,
 		Object checkpointLock,
+		TaskMailboxExecutor mailboxExecutor,
 		StreamConfig config,
 		ExecutionConfig executionConfig,
 		StreamTaskStateInitializer streamTaskStateInitializer,
@@ -66,6 +69,7 @@ public class MockStreamTask extends StreamTask {
 		super(environment);
 		this.name = name;
 		this.checkpointLock = checkpointLock;
+		this.taskMailboxExecutor = mailboxExecutor;
 		this.config = config;
 		this.executionConfig = executionConfig;
 		this.streamTaskStateInitializer = streamTaskStateInitializer;
@@ -153,5 +157,10 @@ public class MockStreamTask extends StreamTask {
 	@Override
 	public Map<String, Accumulator<?, ?>> getAccumulatorMap() {
 		return accumulatorMap;
+	}
+
+	@Override
+	public TaskMailboxExecutor getTaskMailboxExecutor() {
+		return taskMailboxExecutor;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -35,6 +35,8 @@ import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxExecutor;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TestTaskMailboxExecutor;
 
 import java.util.Collections;
 import java.util.Map;
@@ -47,6 +49,7 @@ public class MockStreamTaskBuilder {
 	private final Environment environment;
 	private String name = "Mock Task";
 	private Object checkpointLock = new Object();
+	private TaskMailboxExecutor mailboxExecutor = new TestTaskMailboxExecutor(checkpointLock);
 	private StreamConfig config = new StreamConfig(new Configuration());
 	private ExecutionConfig executionConfig = new ExecutionConfig();
 	private CloseableRegistry closableRegistry = new CloseableRegistry();
@@ -115,11 +118,17 @@ public class MockStreamTaskBuilder {
 		return this;
 	}
 
+	public MockStreamTaskBuilder setMailboxExecutor(TaskMailboxExecutor mailboxExecutor) {
+		this.mailboxExecutor = mailboxExecutor;
+		return this;
+	}
+
 	public MockStreamTask build() {
 		return new MockStreamTask(
 			environment,
 			name,
 			checkpointLock,
+			mailboxExecutor,
 			config,
 			executionConfig,
 			streamTaskStateInitializer,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/StreamTaskUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/StreamTaskUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Utils for working with StreamTask.
+ */
+public class StreamTaskUtil {
+
+	public static void waitTaskIsRunning(StreamTask<?, ?> task, CompletableFuture<Void> taskInvocation) throws InterruptedException {
+		while (!task.isRunning()) {
+			if (taskInvocation.isDone()) {
+				fail("Task has stopped");
+			}
+			Thread.sleep(10L);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR sits on top of #8692 and integrates the ``AsyncWaitOperator`` with the mailbox model. This PR keeps backwards compatibility with the legacy sources and also honors that timers and checkpoints are not yet using the mailbox. This means, there is some followup cleanup that can be done once the mailbox effort is further progressed and I left some `TODO` comments as markers. 


## Brief change log

- Integrate `AsyncWaitOperator` and the companion `Emitter` with the mailbox model.


## Verifying this change

This change is already covered by existing unit tests and IT cases for the `AsyncWaitOperator`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
