### PR TITLE
[FLINK-12960] Introduce ShuffleDescriptor#ReleaseType and ShuffleDescriptor#getSupportedReleaseTypes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleDescriptor.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
 import java.io.Serializable;
 import java.net.InetSocketAddress;
+import java.util.EnumSet;
 import java.util.Optional;
 
 /**
@@ -34,19 +35,29 @@ public class NettyShuffleDescriptor implements ShuffleDescriptor {
 
 	private static final long serialVersionUID = 852181945034989215L;
 
+	private static final EnumSet<ReleaseType> SUPPORTED_RELEASE_TYPES_FOR_BLOCKING_PARTITIONS =
+		EnumSet.of(ReleaseType.AUTO, ReleaseType.MANUAL);
+
+	private static final EnumSet<ReleaseType> SUPPORTED_RELEASE_TYPES_FOR_NON_BLOCKING_PARTITIONS =
+		EnumSet.of(ReleaseType.AUTO);
+
 	private final ResourceID producerLocation;
 
 	private final PartitionConnectionInfo partitionConnectionInfo;
 
 	private final ResultPartitionID resultPartitionID;
 
+	private final boolean isBlocking;
+
 	public NettyShuffleDescriptor(
 			ResourceID producerLocation,
 			PartitionConnectionInfo partitionConnectionInfo,
-			ResultPartitionID resultPartitionID) {
+			ResultPartitionID resultPartitionID,
+			boolean isBlocking) {
 		this.producerLocation = producerLocation;
 		this.partitionConnectionInfo = partitionConnectionInfo;
 		this.resultPartitionID = resultPartitionID;
+		this.isBlocking = isBlocking;
 	}
 
 	public ConnectionID getConnectionId() {
@@ -61,6 +72,12 @@ public class NettyShuffleDescriptor implements ShuffleDescriptor {
 	@Override
 	public Optional<ResourceID> storesLocalResourcesOn() {
 		return Optional.of(producerLocation);
+	}
+
+	@Override
+	public EnumSet<ReleaseType> getSupportedReleaseTypes() {
+		return isBlocking ?
+			SUPPORTED_RELEASE_TYPES_FOR_BLOCKING_PARTITIONS : SUPPORTED_RELEASE_TYPES_FOR_NON_BLOCKING_PARTITIONS;
 	}
 
 	public boolean isLocalTo(ResourceID consumerLocation) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -42,7 +42,8 @@ public enum NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor> 
 		NettyShuffleDescriptor shuffleDeploymentDescriptor = new NettyShuffleDescriptor(
 			producerDescriptor.getProducerLocation(),
 			createConnectionInfo(producerDescriptor, partitionDescriptor.getConnectionIndex()),
-			resultPartitionID);
+			resultPartitionID,
+			partitionDescriptor.getPartitionType().isBlocking());
 
 		return CompletableFuture.completedFuture(shuffleDeploymentDescriptor);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleDescriptor.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Optional;
 
 /**
@@ -67,4 +68,32 @@ public interface ShuffleDescriptor extends Serializable {
 	 * @return the resource id of the producing task executor if the partition occupies local resources there
 	 */
 	Optional<ResourceID> storesLocalResourcesOn();
+
+	/**
+	 * Return release types supported by Shuffle Service for this partition.
+	 */
+	EnumSet<ReleaseType> getSupportedReleaseTypes();
+
+	/**
+	 * Partition release type.
+	 */
+	enum ReleaseType {
+		/**
+		 * Auto-release the partition after having been fully consumed once.
+		 *
+		 * <p>No additional actions required, like {@link ShuffleMaster#releasePartitionExternally(ShuffleDescriptor)}
+		 * or {@link ShuffleEnvironment#releasePartitionsLocally(Collection)}
+		 */
+		AUTO,
+
+		/**
+		 * Manually release the partition, the partition has to support consumption multiple times.
+		 *
+		 * <p>The partition requires manual release once all consumption is done:
+		 * {@link ShuffleMaster#releasePartitionExternally(ShuffleDescriptor)} and
+		 * if the partition occupies producer local resources ({@link #storesLocalResourcesOn()}) then also
+		 * {@link ShuffleEnvironment#releasePartitionsLocally(Collection)}.
+		 */
+		MANUAL
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironment.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor.ReleaseType;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -63,12 +64,14 @@ import java.util.Collection;
  *     <li>if {@link ResultPartitionDeploymentDescriptor#isReleasedOnConsumption()} is {@code true} and
  *     {@link ResultPartitionWriter#finish()} and {@link ResultPartitionWriter#close()} are called when the production is done.
  *     The actual release can take some time depending on implementation details,
- *     e.g. if the `end of consumption' confirmation from the consumer is being awaited implicitly.</li>
+ *     e.g. if the `end of consumption' confirmation from the consumer is being awaited implicitly.
+ *     The partition has to support the {@link ReleaseType#AUTO} in {@link ShuffleDescriptor#getSupportedReleaseTypes()}.</li>
  *     <li>if {@link ResultPartitionDeploymentDescriptor#isReleasedOnConsumption()} is {@code false} and
  *     {@link ShuffleMaster#releasePartitionExternally(ShuffleDescriptor)} and {@link ShuffleEnvironment#releasePartitionsLocally(Collection)},
  *     if it occupies any producer local resources ({@link ShuffleDescriptor#storesLocalResourcesOn()}),
  *     are called outside of the producer thread, e.g. to manage the lifecycle of BLOCKING result partitions
- *     which can outlive their producers.</li>
+ *     which can outlive their producers. The partition has to support the {@link ReleaseType#MANUAL} in
+ *     {@link ShuffleDescriptor#getSupportedReleaseTypes()}.</li>
  * </ol>
  * The partitions, which currently still occupy local resources, can be queried with
  * {@link ShuffleEnvironment#getPartitionsOccupyingLocalResources}.
@@ -130,6 +133,7 @@ public interface ShuffleEnvironment<P extends ResultPartitionWriter, G extends I
 	 * <p>This is called for partitions which occupy resources locally
 	 * (can be checked by {@link ShuffleDescriptor#storesLocalResourcesOn()}).
 	 * This method is not called if {@link ResultPartitionDeploymentDescriptor#isReleasedOnConsumption()} is {@code true}.
+	 * The partition has to support the {@link ReleaseType#MANUAL} in {@link ShuffleDescriptor#getSupportedReleaseTypes()}.
 	 *
 	 * @param partitionIds identifying the partitions to be released
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.shuffle;
 
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor.ReleaseType;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -51,6 +52,7 @@ public interface ShuffleMaster<T extends ShuffleDescriptor> {
 	 * <p>This call triggers release of any resources which are occupied by the given partition in the external systems
 	 * outside of the producer executor. This is mostly relevant for the batch jobs and blocking result partitions.
 	 * This method is not called if {@link ResultPartitionDeploymentDescriptor#isReleasedOnConsumption()} is {@code true}.
+	 * The partition has to support the {@link ReleaseType#MANUAL} in {@link ShuffleDescriptor#getSupportedReleaseTypes()}.
 	 * The producer local resources are managed by {@link ShuffleDescriptor#storesLocalResourcesOn()} and
 	 * {@link ShuffleEnvironment#releasePartitionsLocally(Collection)}.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/UnknownShuffleDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/UnknownShuffleDescriptor.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.shuffle;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
+import java.util.EnumSet;
 import java.util.Optional;
 
 /**
@@ -55,5 +56,10 @@ public final class UnknownShuffleDescriptor implements ShuffleDescriptor {
 	@Override
 	public Optional<ResourceID> storesLocalResourcesOn() {
 		return Optional.empty();
+	}
+
+	@Override
+	public EnumSet<ReleaseType> getSupportedReleaseTypes() {
+		return EnumSet.noneOf(ReleaseType.class);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.NetworkPartitionConnectionInfo;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
@@ -72,13 +73,9 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 	 * Tests simple de/serialization with {@link UnknownShuffleDescriptor}.
 	 */
 	@Test
-	public void testSerializationWithUnknownShuffleDescriptor() throws Exception {
+	public void testSerializationOfUnknownShuffleDescriptor() throws IOException {
 		ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(resultPartitionID);
-
-		ResultPartitionDeploymentDescriptor copy =
-			createCopyAndVerifyResultPartitionDeploymentDescriptor(shuffleDescriptor);
-
-		ShuffleDescriptor shuffleDescriptorCopy = copy.getShuffleDescriptor();
+		ShuffleDescriptor shuffleDescriptorCopy = CommonTestUtils.createCopySerializable(shuffleDescriptor);
 		assertThat(shuffleDescriptorCopy, instanceOf(UnknownShuffleDescriptor.class));
 		assertThat(shuffleDescriptorCopy.getResultPartitionID(), is(resultPartitionID));
 		assertThat(shuffleDescriptorCopy.isUnknown(), is(true));
@@ -88,10 +85,10 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 	 * Tests simple de/serialization with {@link NettyShuffleDescriptor}.
 	 */
 	@Test
-	public void testSerializationWithNettyShuffleDescriptor() throws Exception {
+	public void testSerializationWithNettyShuffleDescriptor() throws IOException {
 		ShuffleDescriptor shuffleDescriptor = new NettyShuffleDescriptor(
 			producerLocation,
-			new NettyShuffleDescriptor.NetworkPartitionConnectionInfo(connectionID),
+			new NetworkPartitionConnectionInfo(connectionID),
 			resultPartitionID);
 
 		ResultPartitionDeploymentDescriptor copy =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -71,7 +71,7 @@ public class PartitionTestUtils {
 	}
 
 	public static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(ResultPartitionType partitionType) {
-		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().buildLocal();
+		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().setBlocking(partitionType.isBlocking()).buildLocal();
 		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
 			new IntermediateDataSetID(),
 			shuffleDescriptor.getResultPartitionID().getPartitionId(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -58,14 +58,15 @@ public class ResultPartitionFactoryTest extends TestLogger {
 			forceConsumptionOnRelease
 		);
 
+		ResultPartitionType partitionType = ResultPartitionType.BLOCKING;
 		final ResultPartitionDeploymentDescriptor descriptor = new ResultPartitionDeploymentDescriptor(
 			new PartitionDescriptor(
 				new IntermediateDataSetID(),
 				new IntermediateResultPartitionID(),
-				ResultPartitionType.BLOCKING,
+				partitionType,
 				1,
 				0),
-			NettyShuffleDescriptorBuilder.newBuilder().buildLocal(),
+			NettyShuffleDescriptorBuilder.newBuilder().setBlocking(partitionType.isBlocking()).buildLocal(),
 			1,
 			true
 		);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
@@ -40,6 +40,7 @@ public class NettyShuffleDescriptorBuilder {
 	private InetAddress address = InetAddress.getLoopbackAddress();
 	private int dataPort = 0;
 	private int connectionIndex = 0;
+	private boolean isBlocking;
 
 	public NettyShuffleDescriptorBuilder setProducerLocation(ResourceID producerLocation) {
 		this.producerLocation = producerLocation;
@@ -73,19 +74,26 @@ public class NettyShuffleDescriptorBuilder {
 		return this;
 	}
 
+	public NettyShuffleDescriptorBuilder setBlocking(boolean isBlocking) {
+		this.isBlocking = isBlocking;
+		return this;
+	}
+
 	public NettyShuffleDescriptor buildRemote() {
 		ConnectionID connectionID = new ConnectionID(new InetSocketAddress(address, dataPort), connectionIndex);
 		return new NettyShuffleDescriptor(
 			producerLocation,
 			new NetworkPartitionConnectionInfo(connectionID),
-			id);
+			id,
+			isBlocking);
 	}
 
 	public NettyShuffleDescriptor buildLocal() {
 		return new NettyShuffleDescriptor(
 			producerLocation,
 			LocalExecutionPartitionConnectionInfo.INSTANCE,
-			id);
+			id,
+			isBlocking);
 	}
 
 	public static NettyShuffleDescriptorBuilder newBuilder() {


### PR DESCRIPTION
## What is the purpose of the change

`ResultPartitionDeploymentDescriptor#releasedOnConsumption` shows the intention how the partition is going to be used by the shuffle user and released. The `ShuffleDescriptor` should provide a way to query which release type is supported by shuffle service for this partition. If the requested release type is not supported by the shuffle service for a certain type of partition, the job should fail fast.

## Brief change log

  - Introduce `ShuffleDescriptor#ReleaseType.AUTO and MANUAL`
  - Introduce `ShuffleDescriptor#getSupportedReleaseTypes`
  - Add assertion whether the auto-release on consumption or manual are supported for the requested `ResultPartitionDeploymentDescriptor#releaseType`
  - adjust tests add test for the assertion

## Verifying this change

Simple refactoring covered by existing tests, plus `ResultPartitionDeploymentDescriptorTest#testIncompatibleReleaseTypeManual`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
