### PR TITLE
[FLINK-12964][sql client] add commented-out defaults to sql client yaml file to make it easier for users to adopt

### DIFF
--- a/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
@@ -119,6 +119,8 @@ deployment:
 # Catalogs
 #==============================================================================
 
+# Define catalogs here.
+
 catalogs: [] # empty list
 #  - name: myhive
 #    type: hive

--- a/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
@@ -93,6 +93,10 @@ execution:
     # strategy type
     # possible values are "fixed-delay", "failure-rate", "none", or "fallback" (default)
     type: fallback
+  # current catalog of SQL Client
+#  current-catalog: ...
+  # current database of the current catalog
+#  current-database: ...
 
 
 #==============================================================================
@@ -111,3 +115,12 @@ deployment:
   gateway-port: 0
 
 
+#==============================================================================
+# Catalogs
+#==============================================================================
+
+catalogs: [] # empty list
+#  - name: myhive
+#    type: hive
+#    hive-site-path: /opt/hive_conf/hive-site.xml
+#    default-database: ...


### PR DESCRIPTION
## What is the purpose of the change

This PR adds commented-out defaults for catalogs to sql client yaml file, to make it easier for users to adopt. This is done similar to how existing defaults of tables and functions is written, e.g.

```
#==============================================================================
# Tables
#==============================================================================

# Define tables here such as sources, sinks, views, or temporal tables.

tables: [] # empty list
# A typical table source definition looks like:
# - name: ...
#   type: source-table
#   connector: ...
#   format: ...
#   schema: ...

...

#==============================================================================
# User-defined functions
#==============================================================================

# Define scalar, aggregate, or table functions here.

functions: [] # empty list
# A typical function definition looks like:
# - name: ...
#   from: class
#   class: ...
#   constructor: ...
```

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. And verified manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
