### PR TITLE
[FLINK-12962][python] Allows pyflink to be pip installed.

### DIFF
--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -60,14 +60,14 @@ The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink w
 
 ## Build PyFlink
 
-If you wish to build a pip installable PyFlink package, you need to build Flink jars first as described in [Build Flink](##Build Flink).
-Then enter the root directory of flink source code and run this command to build a sdist package:
+If you want to build a PyFlink package that can be used for pip installation, you need to build Flink jars first, as described in [Build Flink](##Build Flink).
+Then go to the root directory of flink source code and run this command to build a sdist package:
 
 {% highlight bash %}
 cd flink-python; python setup.py sdist
 {% endhighlight %}
 
-The sdist package will be found under `./flink-python/dist/` and can be used for pip installation.
+The sdist package will be found under `./flink-python/dist/`.
 
 ## Dependency Shading
 

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -61,13 +61,18 @@ The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink w
 ## Build PyFlink
 
 If you want to build a PyFlink package that can be used for pip installation, you need to build Flink jars first, as described in [Build Flink](##Build Flink).
-Then go to the root directory of flink source code and run this command to build a sdist package:
+Then go to the root directory of flink source code and run this command to build the sdist package and wheel package:
 
 {% highlight bash %}
-cd flink-python; python setup.py sdist
+cd flink-python; python setup.py sdist bdist_wheel
 {% endhighlight %}
 
-The sdist package will be found under `./flink-python/dist/`.
+The sdist and wheel package will be found under `./flink-python/dist/`. Either of them could be used for pip installation:
+
+{% highlight bash %}
+pip install dist/*.tar.gz
+pip install dist/*.whl
+{% endhighlight %}
 
 ## Dependency Shading
 

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -58,6 +58,17 @@ mvn clean install -DskipTests -Dfast
 
 The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink with HDFS and YARN.
 
+## Build PyFlink
+
+If you wish to build a pip installable PyFlink package, you need to build Flink jars first as described in [Build Flink](##Build Flink).
+Then enter the root directory of flink source code and run this command to build a sdist package:
+
+{% highlight bash %}
+cd flink-python; python setup.py sdist
+{% endhighlight %}
+
+The sdist package will be found under `./flink-python/dist/` and can be used for pip installation.
+
 ## Dependency Shading
 
 Flink [shades away](https://maven.apache.org/plugins/maven-shade-plugin/) some of the libraries it uses, in order to avoid version clashes with user programs that use different versions of these libraries. Among the shaded libraries are *Google Guava*, *Asm*, *Apache Curator*, *Apache HTTP Components*, *Netty*, and others.

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -58,6 +58,17 @@ mvn clean install -DskipTests -Dfast
 
 The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink with HDFS and YARN.
 
+## 构建PyFlink
+
+如果您想构建一个可用于pip安装的PyFlink包，您需要先构建Flink的Jar包，如[构建Flink](##Build Flink)中所述。
+之后，进入Flink源码根目录，并执行以下命令，构建PyFlink的源码发布包：
+
+{% highlight bash %}
+cd flink-python; python setup.py sdist
+{% endhighlight %}
+
+构建好的源码发布包在`./flink-python/dist/`目录下，可以通过pip安装使用。
+
 ## Dependency Shading
 
 Flink [shades away](https://maven.apache.org/plugins/maven-shade-plugin/) some of the libraries it uses, in order to avoid version clashes with user programs that use different versions of these libraries. Among the shaded libraries are *Google Guava*, *Asm*, *Apache Curator*, *Apache HTTP Components*, *Netty*, and others.

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -61,13 +61,18 @@ The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink w
 ## 构建PyFlink
 
 如果您想构建一个可用于pip安装的PyFlink包，您需要先构建Flink的Jar包，如[构建Flink](##Build Flink)中所述。
-之后，进入Flink源码根目录，并执行以下命令，构建PyFlink的源码发布包：
+之后，进入Flink源码根目录，并执行以下命令，构建PyFlink的源码发布包和wheel包：
 
 {% highlight bash %}
-cd flink-python; python setup.py sdist
+cd flink-python; python setup.py sdist bdist_wheel
 {% endhighlight %}
 
-构建好的源码发布包位于`./flink-python/dist/`目录下。
+构建好的源码发布包和wheel包位于`./flink-python/dist/`目录下。它们均可使用pip安装：
+
+{% highlight bash %}
+pip install dist/*.tar.gz
+pip install dist/*.whl
+{% endhighlight %}
 
 ## Dependency Shading
 

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -67,7 +67,7 @@ The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink w
 cd flink-python; python setup.py sdist
 {% endhighlight %}
 
-构建好的源码发布包在`./flink-python/dist/`目录下，可以通过pip安装使用。
+构建好的源码发布包位于`./flink-python/dist/`目录下。
 
 ## Dependency Shading
 

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -296,7 +296,7 @@ bin=`dirname "$target"`
 SYMLINK_RESOLVED_BIN=`cd "$bin"; pwd -P`
 
 # Define the main directory of the flink installation
-# If config.sh is called by pyflink-shell.sh in python bin directory(pip installed), use the _PYFLINK_HOME
+# If config.sh is called by pyflink-shell.sh in python bin directory(pip installed), then do not need to set the FLINK_HOME here.
 if [ -z "$_FLINK_HOME_DETERMINED" ]; then
     FLINK_HOME=`dirname "$SYMLINK_RESOLVED_BIN"`
 fi

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -296,7 +296,12 @@ bin=`dirname "$target"`
 SYMLINK_RESOLVED_BIN=`cd "$bin"; pwd -P`
 
 # Define the main directory of the flink installation
-FLINK_HOME=`dirname "$SYMLINK_RESOLVED_BIN"`
+# If config.sh is called by pyflink-shell.sh in python bin directory(pip installed), use the _PYFLINK_HOME
+if [ -z "$_PYFLINK_HOME" ]; then
+    FLINK_HOME=`dirname "$SYMLINK_RESOLVED_BIN"`
+else
+    FLINK_HOME="$_PYFLINK_HOME"
+fi
 FLINK_LIB_DIR=$FLINK_HOME/lib
 FLINK_PLUGINS_DIR=$FLINK_HOME/plugins
 FLINK_OPT_DIR=$FLINK_HOME/opt

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -297,10 +297,8 @@ SYMLINK_RESOLVED_BIN=`cd "$bin"; pwd -P`
 
 # Define the main directory of the flink installation
 # If config.sh is called by pyflink-shell.sh in python bin directory(pip installed), use the _PYFLINK_HOME
-if [ -z "$_PYFLINK_HOME" ]; then
+if [ -z "$_FLINK_HOME_DETERMINED" ]; then
     FLINK_HOME=`dirname "$SYMLINK_RESOLVED_BIN"`
-else
-    FLINK_HOME="$_PYFLINK_HOME"
 fi
 FLINK_LIB_DIR=$FLINK_HOME/lib
 FLINK_PLUGINS_DIR=$FLINK_HOME/plugins

--- a/flink-dist/src/main/flink-bin/bin/find-flink-home.sh
+++ b/flink-dist/src/main/flink-bin/bin/find-flink-home.sh
@@ -22,9 +22,7 @@ FIND_FLINK_HOME_PYTHON_SCRIPT="$CURRENT_DIR/find_flink_home.py"
 
 if [ ! -f "$FIND_FLINK_HOME_PYTHON_SCRIPT" ]; then
     export FLINK_HOME="$( cd "$CURRENT_DIR"/.. ; pwd -P )"
-    echo $FLINK_HOME
 else
     PYFLINK_PYTHON="${PYFLINK_PYTHON:-"python"}"
     export FLINK_HOME=$($PYFLINK_PYTHON "$FIND_FLINK_HOME_PYTHON_SCRIPT")
-    echo $FLINK_HOME
 fi

--- a/flink-dist/src/main/flink-bin/bin/find-flink-home.sh
+++ b/flink-dist/src/main/flink-bin/bin/find-flink-home.sh
@@ -24,5 +24,5 @@ if [ ! -f "$FIND_FLINK_HOME_PYTHON_SCRIPT" ]; then
     export FLINK_HOME="$( cd "$CURRENT_DIR"/.. ; pwd -P )"
 else
     PYFLINK_PYTHON="${PYFLINK_PYTHON:-"python"}"
-    export FLINK_HOME=$($PYFLINK_PYTHON "$FIND_FLINK_HOME_PYTHON_SCRIPT")
+    export FLINK_HOME=$("$FIND_FLINK_HOME_PYTHON_SCRIPT")
 fi

--- a/flink-dist/src/main/flink-bin/bin/find-flink-home.sh
+++ b/flink-dist/src/main/flink-bin/bin/find-flink-home.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -16,4 +17,14 @@
 # limitations under the License.
 ################################################################################
 
-__version__ = "1.9.dev0"
+CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+FIND_FLINK_HOME_PYTHON_SCRIPT="$CURRENT_DIR/find_flink_home.py"
+
+if [ ! -f "$FIND_FLINK_HOME_PYTHON_SCRIPT" ]; then
+    export FLINK_HOME="$( cd "$CURRENT_DIR"/.. ; pwd -P )"
+    echo $FLINK_HOME
+else
+    PYFLINK_PYTHON="${PYFLINK_PYTHON:-"python"}"
+    export FLINK_HOME=$($PYFLINK_PYTHON "$FIND_FLINK_HOME_PYTHON_SCRIPT")
+    echo $FLINK_HOME
+fi

--- a/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
@@ -22,8 +22,6 @@ bin=`cd "$bin"; pwd`
 
 _FLINK_HOME_DETERMINED=1
 
-cd "$FLINK_HOME"/bin
-
 . "$FLINK_HOME"/bin/config.sh
 
 FLINK_CLASSPATH=`constructFlinkClassPath`

--- a/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
@@ -18,8 +18,13 @@
 ################################################################################
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
+. "$bin"/find-flink-home.sh
 
-. "$bin"/config.sh
+_PYFLINK_HOME=$FLINK_HOME
+
+cd "$FLINK_HOME"/bin
+
+. "$FLINK_HOME"/bin/config.sh
 
 FLINK_CLASSPATH=`constructFlinkClassPath`
 PYTHON_JAR_PATH=`echo "$FLINK_OPT_DIR"/flink-python*java-binding.jar`

--- a/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
@@ -20,7 +20,7 @@ bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
 . "$bin"/find-flink-home.sh
 
-_PYFLINK_HOME=$FLINK_HOME
+_FLINK_HOME_DETERMINED=1
 
 cd "$FLINK_HOME"/bin
 

--- a/flink-python/MANIFEST.in
+++ b/flink-python/MANIFEST.in
@@ -17,10 +17,12 @@
 ################################################################################
 
 global-exclude *.py[cod] __pycache__ .DS_Store
-recursive-include deps/lib *.jar
-recursive-include deps/opt *.jar *.txt *.zip
+graft deps/lib
+recursive-include deps/opt *
+recursive-include deps/plugins *
 graft deps/bin
 graft deps/conf
+graft deps/log
 recursive-include deps/examples *.py
 graft deps/licenses
 include README.md

--- a/flink-python/MANIFEST.in
+++ b/flink-python/MANIFEST.in
@@ -16,4 +16,14 @@
 # limitations under the License.
 ################################################################################
 
-__version__ = "1.9.dev0"
+global-exclude *.py[cod] __pycache__ .DS_Store
+recursive-include deps/lib *.jar
+recursive-include deps/opt *.jar *.txt *.zip
+graft deps/bin
+graft deps/conf
+recursive-include deps/examples *.py
+graft deps/licenses
+include README.md
+include pyflink/LICENSE
+include pyflink/NOTICE
+include pyflink/README.txt

--- a/flink-python/dev/pip_test_code.py
+++ b/flink-python/dev/pip_test_code.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+# test pyflink shell environment
 from pyflink.shell import bt_env, FileSystem, OldCsv, DataTypes, Schema
 
 import tempfile

--- a/flink-python/dev/pip_test_code.py
+++ b/flink-python/dev/pip_test_code.py
@@ -1,0 +1,52 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.shell import bt_env, FileSystem, OldCsv, DataTypes, Schema
+
+import tempfile
+import os
+import shutil
+
+sink_path = tempfile.gettempdir() + '/batch.csv'
+if os.path.exists(sink_path):
+    if os.path.isfile(sink_path):
+        os.remove(sink_path)
+    else:
+        shutil.rmtree(sink_path)
+bt_env.exec_env().set_parallelism(1)
+t = bt_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
+bt_env.connect(FileSystem().path(sink_path)) \
+    .with_format(OldCsv()
+                 .field_delimiter(',')
+                 .field("a", DataTypes.BIGINT())
+                 .field("b", DataTypes.STRING())
+                 .field("c", DataTypes.STRING())) \
+    .with_schema(Schema()
+                 .field("a", DataTypes.BIGINT())
+                 .field("b", DataTypes.STRING())
+                 .field("c", DataTypes.STRING())) \
+    .register_table_sink("batch_sink")
+
+t.select("a + 1, b, c").insert_into("batch_sink")
+
+bt_env.exec_env().execute()
+
+with open(sink_path, 'r') as f:
+    lines = f.read()
+    assert lines == '2,hi,hello\n' + '3,hi,hello\n'
+
+print('pip_test_code.py success!')

--- a/flink-python/dev/run_pip_test.sh
+++ b/flink-python/dev/run_pip_test.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -16,4 +17,6 @@
 # limitations under the License.
 ################################################################################
 
-__version__ = "1.9.dev0"
+cd "$( dirname "$0" )"
+
+python pip_test_code.py

--- a/flink-python/pyflink/find_flink_home.py
+++ b/flink-python/pyflink/find_flink_home.py
@@ -40,9 +40,7 @@ def _find_flink_home():
         return os.environ['FLINK_HOME']
     else:
         try:
-            # in python site-packages dir
             current_dir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
-            # in source code dir
             flink_root_dir = os.path.abspath(current_dir + "/../../")
             build_target = flink_root_dir + "/build-target"
             if is_flink_home(build_target):

--- a/flink-python/pyflink/find_flink_home.py
+++ b/flink-python/pyflink/find_flink_home.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# ################################################################################
+#################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -22,7 +22,7 @@ import os
 import sys
 
 
-def is_flink_home(path):
+def _is_flink_home(path):
     pyflink_file = path + "/bin/pyflink-gateway-server.sh"
     flink_dist_jar_file = path + "/lib/flink-dist*.jar"
     if os.path.isfile(pyflink_file) and len(glob.glob(flink_dist_jar_file)) > 0:
@@ -43,28 +43,20 @@ def _find_flink_home():
             current_dir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
             flink_root_dir = os.path.abspath(current_dir + "/../../")
             build_target = flink_root_dir + "/build-target"
-            if is_flink_home(build_target):
+            if _is_flink_home(build_target):
                 os.environ['FLINK_HOME'] = build_target
                 return build_target
 
             if sys.version < "3":
                 import imp
-                try:
-                    module_home = imp.find_module("pyflink")[1]
-                    if is_flink_home(module_home):
-                        os.environ['FLINK_HOME'] = module_home
-                        return module_home
-                except ImportError:
-                    pass
+                module_home = imp.find_module("pyflink")[1]
             else:
                 from importlib.util import find_spec
-                try:
-                    module_home = os.path.dirname(find_spec("pyflink").origin)
-                    if is_flink_home(module_home):
-                        os.environ['FLINK_HOME'] = module_home
-                        return module_home
-                except ImportError:
-                    pass
+                module_home = os.path.dirname(find_spec("pyflink").origin)
+
+            if _is_flink_home(module_home):
+                os.environ['FLINK_HOME'] = module_home
+                return module_home
         except Exception:
             pass
         logging.error("Could not find valid FLINK_HOME(Flink distribution directory) "

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -139,7 +139,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     * t.select("a + 1, b, c").insert_into("stream_sink")
     *
     * st_env.exec_env().execute()
-      '''
+'''
 utf8_out.write(welcome_msg)
 
 bt_env = BatchTableEnvironment.create(ExecutionEnvironment.get_execution_environment())

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -15,7 +15,10 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import codecs
+import io
 import platform
+import sys
 
 from pyflink.dataset import ExecutionEnvironment
 from pyflink.datastream import StreamExecutionEnvironment
@@ -23,6 +26,11 @@ from pyflink.table import *
 from pyflink.table.catalog import *
 from pyflink.table.descriptors import *
 from pyflink.table.window import *
+
+if sys.version > '3':
+    utf8_out = open(sys.stdout.fileno(), mode='w', encoding='utf8', buffering=1)
+else:
+    utf8_out = codecs.getwriter("utf-8")(sys.stdout)
 
 print("Using Python version %s (%s, %s)" % (
     platform.python_version(),
@@ -132,7 +140,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *
     * st_env.exec_env().execute()
       '''
-print(welcome_msg)
+utf8_out.write(welcome_msg)
 
 bt_env = BatchTableEnvironment.create(ExecutionEnvironment.get_execution_environment())
 

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 ################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
 # limitations under the License.
 ################################################################################
 import codecs
-import io
 import platform
 import sys
 

--- a/flink-python/pyflink/version.py
+++ b/flink-python/pyflink/version.py
@@ -16,4 +16,8 @@
 # limitations under the License.
 ################################################################################
 
+"""
+The pyflink version will be consistent with the flink version and follow the PEP440.
+.. seealso:: https://www.python.org/dev/peps/pep-0440
+"""
 __version__ = "1.9.dev0"

--- a/flink-python/setup.cfg
+++ b/flink-python/setup.cfg
@@ -16,4 +16,8 @@
 # limitations under the License.
 ################################################################################
 
-__version__ = "1.9.dev0"
+[bdist_wheel]
+universal = 1
+
+[metadata]
+description-file = README.md

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 import io
 import os
 import sys
+from shutil import copytree, copy, rmtree
+
 from setuptools import setup
 
 if sys.version_info < (2, 7):
@@ -42,31 +44,165 @@ VERSION = __version__  # noqa
 with io.open(os.path.join(this_directory, 'README.md'), 'r', encoding='utf-8') as f:
     long_description = f.read()
 
-setup(
-    name='pyflink',
-    version=VERSION,
-    packages=['pyflink',
-              'pyflink.table',
-              'pyflink.util',
-              'pyflink.datastream',
-              'pyflink.dataset',
-              'pyflink.common'],
-    url='http://flink.apache.org',
-    license='http://www.apache.org/licenses/LICENSE-2.0',
-    author='Flink Developers',
-    author_email='dev@flink.apache.org',
-    install_requires=['py4j==0.10.8.1', 'python-dateutil'],
-    tests_require=['pytest==4.4.1'],
-    description='Apache Flink Python API',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    classifiers=[
-        'Development Status :: 1 - Planning',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7']
-)
+TEMP_PATH = "deps"
+
+LIB_TEMP_PATH = os.path.join(TEMP_PATH, "lib")
+OPT_TEMP_PATH = os.path.join(TEMP_PATH, "opt")
+CONF_TEMP_PATH = os.path.join(TEMP_PATH, "conf")
+EXAMPLES_TEMP_PATH = os.path.join(TEMP_PATH, "examples")
+LICENSES_TEMP_PATH = os.path.join(TEMP_PATH, "licenses")
+SCRIPTS_TEMP_PATH = os.path.join(TEMP_PATH, "bin")
+
+LICENSE_FILE_TEMP_PATH = os.path.join("pyflink", "LICENSE")
+NOTICE_FILE_TEMP_PATH = os.path.join("pyflink", "NOTICE")
+README_FILE_TEMP_PATH = os.path.join("pyflink", "README.txt")
+
+in_flink_source = os.path.isfile("../flink-java/src/main/java/org/apache/flink/api/java/"
+                                 "ExecutionEnvironment.java")
+
+try:
+    if in_flink_source:
+
+        try:
+            os.mkdir(TEMP_PATH)
+        except:
+            print("Temp path for symlink to parent already exists {0}".format(TEMP_PATH),
+                  file=sys.stderr)
+            sys.exit(-1)
+
+        FLINK_HOME = os.path.abspath("../build-target")
+
+        incorrect_invocation_message = """
+If you are installing pyflink from flink source, you must first build Flink and
+run sdist.
+
+    To build Flink with maven you can run:
+      mvn -DskipTests clean package
+    Building the source dist is done in the flink-python directory:
+      cd flink-python
+      python setup.py sdist
+      pip install dist/*.tar.gz"""
+
+        LIB_PATH = os.path.join(FLINK_HOME, "lib")
+        OPT_PATH = os.path.join(FLINK_HOME, "opt")
+        CONF_PATH = os.path.join(FLINK_HOME, "conf")
+        EXAMPLES_PATH = os.path.join(FLINK_HOME, "examples")
+        LICENSES_PATH = os.path.join(FLINK_HOME, "licenses")
+        SCRIPTS_PATH = os.path.join(FLINK_HOME, "bin")
+
+        LICENSE_FILE_PATH = os.path.join(FLINK_HOME, "LICENSE")
+        NOTICE_FILE_PATH = os.path.join(FLINK_HOME, "NOTICE")
+        README_FILE_PATH = os.path.join(FLINK_HOME, "README.txt")
+
+        if not os.path.isdir(LIB_PATH):
+            print(incorrect_invocation_message, file=sys.stderr)
+            sys.exit(-1)
+
+        if getattr(os, "symlink", None) is not None:
+            os.symlink(LIB_PATH, LIB_TEMP_PATH)
+            os.symlink(OPT_PATH, OPT_TEMP_PATH)
+            os.symlink(CONF_PATH, CONF_TEMP_PATH)
+            os.symlink(EXAMPLES_PATH, EXAMPLES_TEMP_PATH)
+            os.symlink(LICENSES_PATH, LICENSES_TEMP_PATH)
+            os.symlink(SCRIPTS_PATH, SCRIPTS_TEMP_PATH)
+            os.symlink(LICENSE_FILE_PATH, LICENSE_FILE_TEMP_PATH)
+            os.symlink(NOTICE_FILE_PATH, NOTICE_FILE_TEMP_PATH)
+            os.symlink(README_FILE_PATH, README_FILE_TEMP_PATH)
+        else:
+            copytree(LIB_PATH, LIB_TEMP_PATH)
+            copytree(OPT_PATH, OPT_TEMP_PATH)
+            copytree(CONF_PATH, CONF_TEMP_PATH)
+            copytree(EXAMPLES_PATH, EXAMPLES_TEMP_PATH)
+            copytree(LICENSES_PATH, LICENSES_TEMP_PATH)
+            copytree(SCRIPTS_PATH, SCRIPTS_TEMP_PATH)
+            copy(LICENSE_FILE_PATH, LICENSE_FILE_TEMP_PATH)
+            copy(NOTICE_FILE_PATH, NOTICE_FILE_TEMP_PATH)
+            copy(README_FILE_PATH, README_FILE_TEMP_PATH)
+    else:
+        if not os.path.isdir(LIB_TEMP_PATH) or not os.path.isdir(OPT_TEMP_PATH) \
+                or not os.path.isdir(SCRIPTS_TEMP_PATH):
+            print("The flink core files are not found. Please make sure your installation package "
+                  "is complete, or do this in the flink-python directory of the flink source "
+                  "directory.")
+            sys.exit(-1)
+
+    script_names = ["pyflink-shell.sh", "find-flink-home.sh"]
+    scripts = [os.path.join(SCRIPTS_TEMP_PATH, script) for script in script_names]
+    scripts.append("pyflink/find_flink_home.py")
+
+    setup(
+        name='pyflink',
+        version=VERSION,
+        packages=['pyflink',
+                  'pyflink.table',
+                  'pyflink.util',
+                  'pyflink.datastream',
+                  'pyflink.dataset',
+                  'pyflink.common',
+                  'pyflink.lib',
+                  'pyflink.opt',
+                  'pyflink.conf',
+                  'pyflink.examples',
+                  'pyflink.licenses',
+                  'pyflink.bin'],
+        include_package_data=True,
+        package_dir={
+            'pyflink.lib': TEMP_PATH + '/lib',
+            'pyflink.opt': TEMP_PATH + '/opt',
+            'pyflink.conf': TEMP_PATH + '/conf',
+            'pyflink.examples': TEMP_PATH + '/examples',
+            'pyflink.licenses': TEMP_PATH + '/licenses',
+            'pyflink.bin': TEMP_PATH + '/bin'
+        },
+        package_data={
+            'pyflink': ['LICENSE', 'NOTICE', 'README.txt'],
+            'pyflink.lib': ['*.jar'],
+            'pyflink.opt': ['*.jar', '*.txt', '*/*.zip', '*/*.txt'],
+            'pyflink.conf': ['*'],
+            'pyflink.examples': ['*.py', '*/*.py'],
+            'pyflink.licenses': ['*'],
+            'pyflink.bin': ['*']
+        },
+        scripts=scripts,
+        url='http://flink.apache.org',
+        license='http://www.apache.org/licenses/LICENSE-2.0',
+        author='Flink Developers',
+        author_email='dev@flink.apache.org',
+        install_requires=['py4j==0.10.8.1', 'python-dateutil'],
+        tests_require=['pytest==4.4.1'],
+        description='Apache Flink Python API',
+        long_description=long_description,
+        long_description_content_type='text/markdown',
+        classifiers=[
+            'Development Status :: 1 - Planning',
+            'License :: OSI Approved :: Apache Software License',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7']
+    )
+finally:
+    if in_flink_source:
+        if getattr(os, "symlink", None) is not None:
+            os.remove(LIB_TEMP_PATH)
+            os.remove(OPT_TEMP_PATH)
+            os.remove(CONF_TEMP_PATH)
+            os.remove(EXAMPLES_TEMP_PATH)
+            os.remove(LICENSES_TEMP_PATH)
+            os.remove(SCRIPTS_TEMP_PATH)
+            os.remove(LICENSE_FILE_TEMP_PATH)
+            os.remove(NOTICE_FILE_TEMP_PATH)
+            os.remove(README_FILE_TEMP_PATH)
+        else:
+            rmtree(LIB_TEMP_PATH)
+            rmtree(OPT_TEMP_PATH)
+            rmtree(CONF_TEMP_PATH)
+            rmtree(EXAMPLES_TEMP_PATH)
+            rmtree(LICENSES_TEMP_PATH)
+            rmtree(SCRIPTS_TEMP_PATH)
+            os.remove(LICENSE_FILE_TEMP_PATH)
+            os.remove(NOTICE_FILE_TEMP_PATH)
+            os.remove(README_FILE_TEMP_PATH)
+        os.rmdir(TEMP_PATH)

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -49,8 +49,10 @@ TEMP_PATH = "deps"
 LIB_TEMP_PATH = os.path.join(TEMP_PATH, "lib")
 OPT_TEMP_PATH = os.path.join(TEMP_PATH, "opt")
 CONF_TEMP_PATH = os.path.join(TEMP_PATH, "conf")
+LOG_TEMP_PATH = os.path.join(TEMP_PATH, "log")
 EXAMPLES_TEMP_PATH = os.path.join(TEMP_PATH, "examples")
 LICENSES_TEMP_PATH = os.path.join(TEMP_PATH, "licenses")
+PLUGINS_TEMP_PATH = os.path.join(TEMP_PATH, "plugins")
 SCRIPTS_TEMP_PATH = os.path.join(TEMP_PATH, "bin")
 
 LICENSE_FILE_TEMP_PATH = os.path.join("pyflink", "LICENSE")
@@ -88,6 +90,7 @@ run sdist.
         CONF_PATH = os.path.join(FLINK_HOME, "conf")
         EXAMPLES_PATH = os.path.join(FLINK_HOME, "examples")
         LICENSES_PATH = os.path.join(FLINK_HOME, "licenses")
+        PLUGINS_PATH = os.path.join(FLINK_HOME, "plugins")
         SCRIPTS_PATH = os.path.join(FLINK_HOME, "bin")
 
         LICENSE_FILE_PATH = os.path.join(FLINK_HOME, "LICENSE")
@@ -104,6 +107,7 @@ run sdist.
             os.symlink(CONF_PATH, CONF_TEMP_PATH)
             os.symlink(EXAMPLES_PATH, EXAMPLES_TEMP_PATH)
             os.symlink(LICENSES_PATH, LICENSES_TEMP_PATH)
+            os.symlink(PLUGINS_PATH, PLUGINS_TEMP_PATH)
             os.symlink(SCRIPTS_PATH, SCRIPTS_TEMP_PATH)
             os.symlink(LICENSE_FILE_PATH, LICENSE_FILE_TEMP_PATH)
             os.symlink(NOTICE_FILE_PATH, NOTICE_FILE_TEMP_PATH)
@@ -114,10 +118,15 @@ run sdist.
             copytree(CONF_PATH, CONF_TEMP_PATH)
             copytree(EXAMPLES_PATH, EXAMPLES_TEMP_PATH)
             copytree(LICENSES_PATH, LICENSES_TEMP_PATH)
+            copytree(PLUGINS_PATH, PLUGINS_TEMP_PATH)
             copytree(SCRIPTS_PATH, SCRIPTS_TEMP_PATH)
             copy(LICENSE_FILE_PATH, LICENSE_FILE_TEMP_PATH)
             copy(NOTICE_FILE_PATH, NOTICE_FILE_TEMP_PATH)
             copy(README_FILE_PATH, README_FILE_TEMP_PATH)
+        os.mkdir(LOG_TEMP_PATH)
+        with open(os.path.join(LOG_TEMP_PATH, "empty.txt"), 'w') as f:
+            f.write("This file is used to force setuptools to include the log directory. "
+                    "You can delete it at any time after installation.")
     else:
         if not os.path.isdir(LIB_TEMP_PATH) or not os.path.isdir(OPT_TEMP_PATH) \
                 or not os.path.isdir(SCRIPTS_TEMP_PATH):
@@ -142,25 +151,31 @@ run sdist.
                   'pyflink.lib',
                   'pyflink.opt',
                   'pyflink.conf',
+                  'pyflink.log',
                   'pyflink.examples',
                   'pyflink.licenses',
+                  'pyflink.plugins',
                   'pyflink.bin'],
         include_package_data=True,
         package_dir={
             'pyflink.lib': TEMP_PATH + '/lib',
             'pyflink.opt': TEMP_PATH + '/opt',
             'pyflink.conf': TEMP_PATH + '/conf',
+            'pyflink.log': TEMP_PATH + '/log',
             'pyflink.examples': TEMP_PATH + '/examples',
             'pyflink.licenses': TEMP_PATH + '/licenses',
+            'pyflink.plugins': TEMP_PATH + '/plugins',
             'pyflink.bin': TEMP_PATH + '/bin'
         },
         package_data={
             'pyflink': ['LICENSE', 'NOTICE', 'README.txt'],
             'pyflink.lib': ['*.jar'],
-            'pyflink.opt': ['*.jar', '*.txt', '*/*.zip', '*/*.txt'],
+            'pyflink.opt': ['*', '*/*'],
             'pyflink.conf': ['*'],
+            'pyflink.log': ['*'],
             'pyflink.examples': ['*.py', '*/*.py'],
             'pyflink.licenses': ['*'],
+            'pyflink.plugins': ['*', '*/*'],
             'pyflink.bin': ['*']
         },
         scripts=scripts,
@@ -191,6 +206,7 @@ finally:
             os.remove(CONF_TEMP_PATH)
             os.remove(EXAMPLES_TEMP_PATH)
             os.remove(LICENSES_TEMP_PATH)
+            os.remove(PLUGINS_TEMP_PATH)
             os.remove(SCRIPTS_TEMP_PATH)
             os.remove(LICENSE_FILE_TEMP_PATH)
             os.remove(NOTICE_FILE_TEMP_PATH)
@@ -201,8 +217,10 @@ finally:
             rmtree(CONF_TEMP_PATH)
             rmtree(EXAMPLES_TEMP_PATH)
             rmtree(LICENSES_TEMP_PATH)
+            rmtree(PLUGINS_TEMP_PATH)
             rmtree(SCRIPTS_TEMP_PATH)
             os.remove(LICENSE_FILE_TEMP_PATH)
             os.remove(NOTICE_FILE_TEMP_PATH)
             os.remove(README_FILE_TEMP_PATH)
+        rmtree(LOG_TEMP_PATH)
         os.rmdir(TEMP_PATH)

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -24,12 +24,15 @@
 envlist = py27, py33, py34, py35, py36, py37
 
 [testenv]
+whitelist_externals=
+    /bin/bash
 deps =
     pytest
 commands =
     python --version
     python setup.py install --force
     pytest
+    bash ./dev/run_pip_test.sh
 
 [flake8]
 # We follow PEP 8 (https://www.python.org/dev/peps/pep-0008/) with one exception: lines can be

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -57,6 +57,12 @@ perl -pi -e "s#^version: .*#version: \"${NEW_VERSION}\"#" _config.yml
 perl -pi -e "s#^version_title: .*#version_title: \"${NEW_VERSION}\"#" _config.yml
 cd ..
 
+#change version of pyflink
+cd flink-python/pyflink
+perl -pi -e "s#^__version__ = \".*\"#__version__ = \"${NEW_VERSION}\"#" version.py
+perl -pi -e "s#-SNAPSHOT#\\.dev0#" version.py
+cd ../..
+
 git commit -am "Update version to $NEW_VERSION"
 
 echo "Don't forget to push the change."


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds pip support for pyflink. Execute `python setup.py sdist` in `flink-python` directory will generate the pyflink package in the `dist` directory. The package is pip-installable and contains all python code of pyflink and all files in `build-target` directory. Users can install it through `pip install package_file_name.tar.gz`. If installation is success, users can import pyflink to their projects, open a pyflink shell by enter `pyflink-shell.sh [mode]` and no need to manually install a java version of flink before using pyflink.*


## Brief change log

  - *Allows pyflink to be pip installed.*
  - *Upgrade `find_flink_home.py`, `config.sh` and add `find-flink-home.sh`, make sure `pyflink-shell.sh` could run on pip installed pyflink.*
  - *Add tests and documentation for pip installation.*


## Verifying this change
This change added tests and can be verified as follows:
running `flink-python/dev/lint-python.sh`, if the exit code is 0 then the change is OK.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
