### PR TITLE
[FLINK-12967][runtime] Change the processing that the input reaches the end to comply with the InputSelectable contract

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputSelectableProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputSelectableProcessor.java
@@ -337,10 +337,9 @@ public class StreamTwoInputSelectableProcessor<IN1, IN2> {
 
 	private boolean checkFinished() throws Exception {
 		if (getInput(lastReadInputIndex).isFinished()) {
-			inputSelection = (lastReadInputIndex == 0) ? InputSelection.SECOND : InputSelection.FIRST;
-
 			synchronized (lock) {
 				operatorChain.endInput(getInputId(lastReadInputIndex));
+				inputSelection = inputSelector.nextSelection();
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request changes the processing that the input reaches the end to comply with the following `InputSelectable` contract.

- When the input being read reaches the end, the runtime must call `nextSelection()` to determine the next input to be read.


## Brief change log

  -  Uses invoking `InputSelectable#nextSelection()` to replace the assignment on the input selection in `StreamTwoInputSelectableProcessor#checkFinished()` . The input selection should been switched in `endInput()` by the operator.


## Verifying this change

This change is already covered by existing tests, such as `StreamTaskSelectiveReadingTest`, `StreamTaskSelectiveReadingITCase`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
