### PR TITLE
[FLINK-12972][table-planner-blink] Ensure calling open/close in join condition of generated functions for blink

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/FunctionCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/FunctionCodeGenerator.scala
@@ -179,11 +179,10 @@ object FunctionCodeGenerator {
       input2Term: String = CodeGenUtils.DEFAULT_INPUT2_TERM): GeneratedJoinCondition = {
     val funcName = newName(name)
 
-    val baseClass = classOf[JoinCondition]
-
     val funcCode =
       j"""
-      public class $funcName implements ${baseClass.getCanonicalName} {
+      public class $funcName extends ${className[AbstractRichFunction]}
+          implements ${className[JoinCondition]} {
 
         ${ctx.reuseMemberCode()}
 
@@ -194,11 +193,22 @@ object FunctionCodeGenerator {
         ${ctx.reuseConstructorCode(funcName)}
 
         @Override
+        public void open(${className[Configuration]} parameters) throws Exception {
+          ${ctx.reuseOpenCode()}
+        }
+
+        @Override
         public boolean apply($BASE_ROW $input1Term, $BASE_ROW $input2Term) throws Exception {
           ${ctx.reusePerRecordCode()}
           ${ctx.reuseLocalVariableCode()}
           ${ctx.reuseInputUnboxingCode()}
           $bodyCode
+        }
+
+        @Override
+        public void close() throws Exception {
+          super.close();
+          ${ctx.reuseCloseCode()}
         }
       }
      """.stripMargin

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/LongHashJoinGenerator.scala
@@ -18,9 +18,10 @@
 
 package org.apache.flink.table.codegen
 
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Gauge
 import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.codegen.CodeGenUtils.{BASE_ROW, BINARY_ROW, baseRowFieldReadAccess, newName}
+import org.apache.flink.table.codegen.CodeGenUtils.{BASE_ROW, BINARY_ROW, baseRowFieldReadAccess, className, newName}
 import org.apache.flink.table.codegen.OperatorCodeGenerator.generateCollect
 import org.apache.flink.table.dataformat.{BaseRow, JoinedRow}
 import org.apache.flink.table.generated.{GeneratedJoinCondition, GeneratedProjection}
@@ -136,6 +137,9 @@ object LongHashJoinGenerator {
     ctx.addReusableMember(s"${condFunc.getClassName} condFunc;")
     val condRefs = ctx.addReusableObject(condFunc.getReferences, "condRefs")
     ctx.addReusableInitStatement(s"condFunc = new ${condFunc.getClassName}($condRefs);")
+    ctx.addReusableOpenStatement(s"condFunc.setRuntimeContext(getRuntimeContext());")
+    ctx.addReusableOpenStatement(s"condFunc.open(new ${className[Configuration]}());")
+    ctx.addReusableCloseStatement(s"condFunc.close();")
 
     val gauge = classOf[Gauge[_]].getCanonicalName
     ctx.addReusableOpenStatement(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/codegen/LongHashJoinGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/codegen/LongHashJoinGeneratorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.codegen;
 
+import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.generated.GeneratedJoinCondition;
@@ -79,7 +80,7 @@ public class LongHashJoinGeneratorTest extends Int2HashJoinOperatorTest {
 	/**
 	 * Test cond.
 	 */
-	public static class MyJoinCondition implements JoinCondition {
+	public static class MyJoinCondition extends AbstractRichFunction implements JoinCondition {
 
 		public MyJoinCondition(Object[] reference) {}
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
@@ -313,6 +313,22 @@ object Func20 extends ScalarFunction {
   }
 }
 
+class FuncWithOpen extends ScalarFunction {
+  private var permitted: Boolean = false
+
+  override def open(context: FunctionContext): Unit = {
+    permitted = true
+  }
+
+  def eval(x: Int): Boolean = {
+    permitted
+  }
+
+  override def close(): Unit = {
+    permitted = false
+  }
+}
+
 class SplitUDF(deterministic: Boolean) extends ScalarFunction {
   def eval(x: String, sep: String, index: Int): String = {
     val splits = StringUtils.splitByWholeSeparator(x, sep)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/JoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/JoinITCase.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_T
 import org.apache.flink.api.common.typeutils.TypeComparator
 import org.apache.flink.api.java.typeutils.{GenericTypeInfo, RowTypeInfo}
 import org.apache.flink.table.api.{TableConfigOptions, Types}
+import org.apache.flink.table.expressions.utils.FuncWithOpen
 import org.apache.flink.table.runtime.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.batch.sql.join.JoinType.{BroadcastHashJoin, HashJoin, JoinType, NestedLoopJoin, SortMergeJoin}
 import org.apache.flink.table.runtime.utils.BatchTestBase
@@ -783,6 +784,18 @@ class JoinITCase() extends BatchTestBase {
         row(2, 2L, 4L, 4L),
         row(2, 2L, 4L, 4L)
       )
+    )
+  }
+
+  @Test
+  def testJoinWithUDFFilter(): Unit = {
+    tEnv.registerFunction("funcWithOpen", new FuncWithOpen)
+    checkResult(
+      "SELECT c, g FROM SmallTable3 join Table5 on funcWithOpen(a + d) where b = e",
+      Seq(
+        row("Hi", "Hallo"),
+        row("Hello", "Hallo Welt"),
+        row("Hello world", "Hallo Welt"))
     )
   }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/JoinCondition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/generated/JoinCondition.java
@@ -18,12 +18,13 @@
 
 package org.apache.flink.table.generated;
 
+import org.apache.flink.api.common.functions.RichFunction;
 import org.apache.flink.table.dataformat.BaseRow;
 
 /**
  * Interface for code generated condition function for [[org.apache.calcite.rel.core.Join]].
  */
-public interface JoinCondition {
+public interface JoinCondition extends RichFunction {
 
 	/**
 	 * @return true if the join condition stays true for the joined row (in1, in2)

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/HashJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/HashJoinOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.join;
 
 import org.apache.flink.configuration.AlgorithmOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.dataformat.BaseRow;
@@ -27,6 +28,7 @@ import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.dataformat.JoinedRow;
 import org.apache.flink.table.generated.GeneratedJoinCondition;
 import org.apache.flink.table.generated.GeneratedProjection;
+import org.apache.flink.table.generated.JoinCondition;
 import org.apache.flink.table.runtime.TableStreamOperator;
 import org.apache.flink.table.runtime.hashtable.BinaryHashTable;
 import org.apache.flink.table.runtime.util.RowIterator;
@@ -66,6 +68,7 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	private transient BaseRow probeSideNullRow;
 	private transient JoinedRow joinedRow;
 	private transient boolean buildEnd;
+	private transient JoinCondition condition;
 
 	HashJoinOperator(HashJoinParameter parameter) {
 		this.parameter = parameter;
@@ -89,6 +92,10 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 
 		int parallel = getRuntimeContext().getNumberOfParallelSubtasks();
 
+		this.condition = parameter.condFuncCode.newInstance(cl);
+		condition.setRuntimeContext(getRuntimeContext());
+		condition.open(new Configuration());
+
 		this.table = new BinaryHashTable(
 				getContainingTask().getJobConfiguration(),
 				getContainingTask(),
@@ -104,7 +111,7 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 				parameter.buildRowCount / parallel,
 				hashJoinUseBitMaps,
 				type,
-				parameter.condFuncCode.newInstance(cl),
+				condition,
 				reverseJoinFunction,
 				parameter.filterNullKeys,
 				parameter.tryDistinctBuildRow);
@@ -192,6 +199,7 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 			this.table.free();
 			this.table = null;
 		}
+		condition.close();
 	}
 
 	public static HashJoinOperator newHashJoinOperator(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/SortMergeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/SortMergeJoinOperator.java
@@ -172,6 +172,8 @@ public class SortMergeJoinOperator extends TableStreamOperator<BaseRow>
 
 		keyComparator = genKeyComparator.newInstance(cl);
 		this.condFunc = condFuncCode.newInstance(cl);
+		condFunc.setRuntimeContext(getRuntimeContext());
+		condFunc.open(new Configuration());
 
 		projection1 = projectionCode1.newInstance(cl);
 		projection2 = projectionCode2.newInstance(cl);
@@ -456,6 +458,7 @@ public class SortMergeJoinOperator extends TableStreamOperator<BaseRow>
 		if (this.sorter2 != null) {
 			this.sorter2.close();
 		}
+		condFunc.close();
 	}
 
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/Int2HashJoinOperatorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.join;
 
+import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -409,7 +410,7 @@ public class Int2HashJoinOperatorTest implements Serializable {
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {
-						return (in1, in2) -> true;
+						return new TrueCondition();
 					}
 				},
 				reverseJoinFunction, new boolean[]{true},
@@ -427,5 +428,16 @@ public class Int2HashJoinOperatorTest implements Serializable {
 				},
 				false, 20, 10000,
 				10000, RowType.of(new IntType()));
+	}
+
+	/**
+	 * Test util.
+	 */
+	public static class TrueCondition extends AbstractRichFunction implements JoinCondition {
+
+		@Override
+		public boolean apply(BaseRow in1, BaseRow in2) {
+			return true;
+		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/Int2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/Int2SortMergeJoinOperatorTest.java
@@ -190,7 +190,7 @@ public class Int2SortMergeJoinOperatorTest {
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {
-						return (in1, in2) -> true;
+						return new Int2HashJoinOperatorTest.TrueCondition();
 					}
 				},
 				new GeneratedProjection("", "", new Object[0]) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/String2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/String2HashJoinOperatorTest.java
@@ -313,7 +313,7 @@ public class String2HashJoinOperatorTest implements Serializable {
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {
-						return (in1, in2) -> true;
+						return new Int2HashJoinOperatorTest.TrueCondition();
 					}
 				},
 				reverseJoinFunction, new boolean[]{true},

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/join/String2SortMergeJoinOperatorTest.java
@@ -170,7 +170,7 @@ public class String2SortMergeJoinOperatorTest {
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {
-						return (in1, in2) -> true;
+						return new Int2HashJoinOperatorTest.TrueCondition();
 					}
 				},
 				new GeneratedProjection("", "", new Object[0]) {


### PR DESCRIPTION

## What is the purpose of the change

Generated functions' open method are not called in join operator. e.g. AbstractStreamingJoinOperator, SortMergeJoinOperator, HashJoinOperator, LongHashJoinGenerator.

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no