### PR TITLE
[FLINK-12974][checkstyle] Bump checkstyle to 8.14

### DIFF
--- a/docs/flinkDev/ide_setup.md
+++ b/docs/flinkDev/ide_setup.md
@@ -87,7 +87,7 @@ IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
 1. Install the "Checkstyle-IDEA" plugin from the IntelliJ plugin repository.
 2. Configure the plugin by going to Settings -> Other Settings -> Checkstyle.
 3. Set the "Scan Scope" to "Only Java sources (including tests)".
-4. Select _8.12_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
+4. Select _8.14_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
    don't skip it!**
 5. In the "Configuration File" pane, add a new configuration using the plus icon:
     1. Set the "Description" to "Flink".

--- a/pom.xml
+++ b/pom.xml
@@ -1608,7 +1608,7 @@ under the License.
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
 							<!-- Note: match version with docs/flinkDev/ide_setup.md -->
-							<version>8.12</version>
+							<version>8.14</version>
 						</dependency>
 					</dependencies>
 					<executions>


### PR DESCRIPTION
## What is the purpose of the change

* Bump checkstyle to 8.14 since 8.12 is no longer supported

* The description below is copied from JIRA issue
>The descriptions of checkstyle of IDE setup document [1] is out of date. In the current checkstyle plugin (v5.28.0), there is no option of 8.12 in checkstyle setting dialog box. The version 8.12 is no longer supported, checkstyle suggests to upgrade to 8.14 "due to lack of breaking changes" [2].
It would confuse the user that document says "This step is important, don’t skip it!", but user can not find the 8.12 option.
Since there are still some modules do not support checkstyle plugin, I have just manually checked some modules under 8.14 version. It shows OK.
cc Chesnay Schepler, is there a better way to check the bumping?

>1. https://ci.apache.org/projects/flink/flink-docs-master/flinkDev/ide_setup.html#checkstyle-for-java
>2. https://github.com/jshiell/checkstyle-idea/commit/8504b286e9e443223db0b0f3b2d82e5bc183918f#diff-1698afbd7d9abfdb701fc6e471529013
## Brief change log

* Update description of ide_setup.md about the checkstyle version
* Update pom.xml about the checkstyle version

## Verifying this change

* This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
