### PR TITLE
[FLINK-12968][table-common] Add a utility for logical type casts

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
 
 import javax.annotation.Nullable;
 
@@ -206,7 +207,9 @@ public final class TypeInferenceUtil {
 	}
 
 	private static boolean canCast(DataType sourceDataType, DataType targetDataType) {
-		return false; // TODO unsupported for now
+		return LogicalTypeCasts.supportsImplicitCast(
+			sourceDataType.getLogicalType(),
+			targetDataType.getLogicalType());
 	}
 
 	private static Result inferTypes(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalType.java
@@ -37,7 +37,8 @@ import java.util.Set;
  * also contains information about the nullability of a value for efficient handling of scalar
  * expressions.
  *
- * <p>Subclasses of this class define characteristics of built-in or user-defined types.
+ * <p>Subclasses of this class define characteristics of built-in or user-defined types. Every logical
+ * type must support nullability.
  *
  * <p>Instances of this class describe the fully parameterized, immutable type with additional
  * information such as numeric precision or expected length.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.BINARY_STRING;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.CHARACTER_STRING;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.CONSTRUCTED;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.DATETIME;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.EXACT_NUMERIC;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.INTERVAL;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.NUMERIC;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.PREDEFINED;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.TIME;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.TIMESTAMP;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ANY;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BINARY;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BOOLEAN;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.CHAR;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DATE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DISTINCT_TYPE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DOUBLE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.FLOAT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTEGER;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTERVAL_DAY_TIME;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTERVAL_YEAR_MONTH;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.NULL;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.SMALLINT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.STRUCTURED_TYPE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.SYMBOL;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TINYINT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARBINARY;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isSingleFieldInterval;
+
+/**
+ * Utilities for casting {@link LogicalType}.
+ *
+ * <p>This class aims to be compatible with the SQL standard cast specification.
+ *
+ * <p>Conversions that are defined by the {@link LogicalType} (e.g. interpreting a {@link DateType}
+ * as integer value) are not considered here. They are an internal bridging feature that is not
+ * standard compliant. If at all, {@code CONVERT} methods should make such conversions available.
+ */
+@Internal
+public final class LogicalTypeCasts {
+
+	private static final Map<LogicalTypeRoot, Set<LogicalTypeRoot>> implicitCastingRules;
+
+	private static final Map<LogicalTypeRoot, Set<LogicalTypeRoot>> explicitCastingRules;
+
+	static {
+		implicitCastingRules = new HashMap<>();
+		explicitCastingRules = new HashMap<>();
+
+		// identity casts
+
+		for (LogicalTypeRoot typeRoot : allTypes()) {
+			castTo(typeRoot)
+				.implicitFrom(typeRoot)
+				.build();
+		}
+
+		// cast specification
+
+		castTo(CHAR)
+			.implicitFrom(CHAR)
+			.explicitFromFamily(PREDEFINED)
+			.explicitNotFromFamily(BINARY_STRING)
+			.build();
+
+		castTo(VARCHAR)
+			.implicitFromFamily(CHARACTER_STRING)
+			.explicitFromFamily(PREDEFINED)
+			.explicitNotFromFamily(BINARY_STRING)
+			.build();
+
+		castTo(BOOLEAN)
+			.implicitFrom(BOOLEAN)
+			.explicitFromFamily(CHARACTER_STRING)
+			.build();
+
+		castTo(BINARY)
+			.implicitFromFamily(BINARY_STRING)
+			.build();
+
+		castTo(VARBINARY)
+			.implicitFromFamily(BINARY_STRING)
+			.build();
+
+		castTo(DECIMAL)
+			.implicitFromFamily(NUMERIC)
+			.explicitFromFamily(CHARACTER_STRING)
+			.build();
+
+		castTo(TINYINT)
+			.implicitFrom(TINYINT)
+			.explicitFromFamily(NUMERIC, CHARACTER_STRING)
+			.build();
+
+		castTo(SMALLINT)
+			.implicitFrom(TINYINT, SMALLINT)
+			.explicitFromFamily(NUMERIC, CHARACTER_STRING)
+			.build();
+
+		castTo(INTEGER)
+			.implicitFrom(TINYINT, SMALLINT, INTEGER)
+			.explicitFromFamily(NUMERIC, CHARACTER_STRING)
+			.build();
+
+		castTo(BIGINT)
+			.implicitFrom(TINYINT, SMALLINT, INTEGER, BIGINT)
+			.explicitFromFamily(NUMERIC, CHARACTER_STRING)
+			.build();
+
+		castTo(FLOAT)
+			.implicitFrom(TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, DECIMAL)
+			.explicitFromFamily(NUMERIC, CHARACTER_STRING)
+			.build();
+
+		castTo(DOUBLE)
+			.implicitFrom(TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, DOUBLE, DECIMAL)
+			.explicitFromFamily(CHARACTER_STRING)
+			.build();
+
+		castTo(DATE)
+			.implicitFrom(DATE, TIMESTAMP_WITHOUT_TIME_ZONE)
+			.explicitFromFamily(TIMESTAMP, CHARACTER_STRING)
+			.build();
+
+		castTo(TIME_WITHOUT_TIME_ZONE)
+			.implicitFrom(TIME_WITHOUT_TIME_ZONE, TIMESTAMP_WITHOUT_TIME_ZONE)
+			.explicitFromFamily(TIME, TIMESTAMP, CHARACTER_STRING)
+			.build();
+
+		castTo(TIMESTAMP_WITHOUT_TIME_ZONE)
+			.implicitFrom(TIMESTAMP_WITHOUT_TIME_ZONE)
+			.explicitFromFamily(DATETIME, CHARACTER_STRING)
+			.build();
+
+		castTo(TIMESTAMP_WITH_TIME_ZONE)
+			.implicitFrom(TIMESTAMP_WITH_TIME_ZONE)
+			.explicitFromFamily(DATETIME, CHARACTER_STRING)
+			.build();
+
+		castTo(TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+			.implicitFrom(TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+			.explicitFromFamily(DATETIME, CHARACTER_STRING)
+			.build();
+
+		castTo(INTERVAL_YEAR_MONTH)
+			.implicitFrom(INTERVAL_YEAR_MONTH)
+			.explicitFromFamily(EXACT_NUMERIC, CHARACTER_STRING)
+			.build();
+
+		castTo(INTERVAL_DAY_TIME)
+			.implicitFrom(INTERVAL_DAY_TIME)
+			.explicitFromFamily(EXACT_NUMERIC, CHARACTER_STRING)
+			.build();
+	}
+
+	public static boolean supportsImplicitCast(LogicalType sourceType, LogicalType targetType) {
+		return supportsCasting(sourceType, targetType, false);
+	}
+
+	public static boolean supportsExplicitCast(LogicalType sourceType, LogicalType targetType) {
+		return supportsCasting(sourceType, targetType, true);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static boolean supportsCasting(
+			LogicalType sourceType,
+			LogicalType targetType,
+			boolean allowExplicit) {
+		if (sourceType.isNullable() && !targetType.isNullable()) {
+			return false;
+		}
+		// ignore nullability during compare
+		if (sourceType.copy(true).equals(targetType.copy(true))) {
+			return true;
+		}
+
+		final LogicalTypeRoot sourceRoot = sourceType.getTypeRoot();
+		final LogicalTypeRoot targetRoot = targetType.getTypeRoot();
+
+		if (hasFamily(sourceType, INTERVAL) && hasFamily(targetType, EXACT_NUMERIC)) {
+			// cast between interval and exact numeric is only supported if interval has a single field
+			return isSingleFieldInterval(sourceType);
+		} else if (hasFamily(sourceType, EXACT_NUMERIC) && hasFamily(targetType, INTERVAL)) {
+			// cast between interval and exact numeric is only supported if interval has a single field
+			return isSingleFieldInterval(targetType);
+		} else if (hasFamily(sourceType, CONSTRUCTED) || hasFamily(targetType, CONSTRUCTED)) {
+			return supportsConstructedCasting(sourceType, targetType, allowExplicit);
+		} else if (sourceRoot == DISTINCT_TYPE && targetRoot == DISTINCT_TYPE) {
+			// the two distinct types are not equal (from initial invariant), casting is not possible
+			return false;
+		} else if (sourceRoot == DISTINCT_TYPE) {
+			return supportsCasting(((DistinctType) sourceType).getSourceType(), targetType, allowExplicit);
+		} else if (targetRoot == DISTINCT_TYPE) {
+			return supportsCasting(sourceType, ((DistinctType) targetType).getSourceType(), allowExplicit);
+		} else if (sourceRoot == STRUCTURED_TYPE || targetRoot == STRUCTURED_TYPE) {
+			// TODO structured types are not supported yet
+			return false;
+		} else if (sourceRoot == NULL) {
+			// null can be cast to an arbitrary type
+			return true;
+		} else if (sourceRoot == ANY || targetRoot == ANY) {
+			// the two any types are not equal (from initial invariant), casting is not possible
+			return false;
+		} else if (sourceRoot == SYMBOL || targetRoot == SYMBOL) {
+			// the two symbol types are not equal (from initial invariant), casting is not possible
+			return false;
+		}
+
+		if (implicitCastingRules.get(targetRoot).contains(sourceRoot)) {
+			return true;
+		}
+		if (allowExplicit) {
+			return explicitCastingRules.get(targetRoot).contains(sourceRoot);
+		}
+		return false;
+	}
+
+	private static boolean supportsConstructedCasting(
+			LogicalType sourceType,
+			LogicalType targetType,
+			boolean allowExplicit) {
+		final LogicalTypeRoot sourceRoot = sourceType.getTypeRoot();
+		final LogicalTypeRoot targetRoot = targetType.getTypeRoot();
+		// all constructed types can only be casted within the same type root
+		if (sourceRoot == targetRoot) {
+			final List<LogicalType> sourceChildren = sourceType.getChildren();
+			final List<LogicalType> targetChildren = targetType.getChildren();
+			if (sourceChildren.size() != targetChildren.size()) {
+				return false;
+			}
+			for (int i = 0; i < sourceChildren.size(); i++) {
+				if (!supportsCasting(sourceChildren.get(i), targetChildren.get(i), allowExplicit)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	private static CastingRuleBuilder castTo(LogicalTypeRoot sourceType) {
+		return new CastingRuleBuilder(sourceType);
+	}
+
+	private static LogicalTypeRoot[] allTypes() {
+		return LogicalTypeRoot.values();
+	}
+
+	private static class CastingRuleBuilder {
+
+		private final LogicalTypeRoot sourceType;
+		private Set<LogicalTypeRoot> implicitTargetTypes = new HashSet<>();
+		private Set<LogicalTypeRoot> explicitTargetTypes = new HashSet<>();
+
+		CastingRuleBuilder(LogicalTypeRoot sourceType) {
+			this.sourceType = sourceType;
+		}
+
+		CastingRuleBuilder implicitFrom(LogicalTypeRoot... targetTypes) {
+			this.implicitTargetTypes.addAll(Arrays.asList(targetTypes));
+			return this;
+		}
+
+		CastingRuleBuilder implicitFromFamily(LogicalTypeFamily... targetFamilies) {
+			for (LogicalTypeFamily family : targetFamilies) {
+				for (LogicalTypeRoot root : LogicalTypeRoot.values()) {
+					if (root.getFamilies().contains(family)) {
+						this.implicitTargetTypes.add(root);
+					}
+				}
+			}
+			return this;
+		}
+
+		CastingRuleBuilder explicitFrom(LogicalTypeRoot... targetTypes) {
+			this.explicitTargetTypes.addAll(Arrays.asList(targetTypes));
+			return this;
+		}
+
+		CastingRuleBuilder explicitFromFamily(LogicalTypeFamily... targetFamilies) {
+			for (LogicalTypeFamily family : targetFamilies) {
+				for (LogicalTypeRoot root : LogicalTypeRoot.values()) {
+					if (root.getFamilies().contains(family)) {
+						this.explicitTargetTypes.add(root);
+					}
+				}
+			}
+			return this;
+		}
+
+		CastingRuleBuilder explicitNotFromFamily(LogicalTypeFamily... targetFamilies) {
+			for (LogicalTypeFamily family : targetFamilies) {
+				for (LogicalTypeRoot root : LogicalTypeRoot.values()) {
+					if (root.getFamilies().contains(family)) {
+						this.explicitTargetTypes.remove(root);
+					}
+				}
+			}
+			return this;
+		}
+
+		void build() {
+			implicitCastingRules.put(sourceType, implicitTargetTypes);
+			explicitCastingRules.put(sourceType, explicitTargetTypes);
+		}
+	}
+
+	private LogicalTypeCasts() {
+		// no instantiation
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
@@ -59,6 +59,8 @@ public final class LogicalTypeChecks {
 
 	private static final FractionalPrecisionExtractor FRACTIONAL_PRECISION_EXTRACTOR = new FractionalPrecisionExtractor();
 
+	private static final SingleFieldIntervalExtractor SINGLE_FIELD_INTERVAL_EXTRACTOR = new SingleFieldIntervalExtractor();
+
 	public static boolean hasRoot(LogicalType logicalType, LogicalTypeRoot typeRoot) {
 		return logicalType.getTypeRoot() == typeRoot;
 	}
@@ -137,6 +139,10 @@ public final class LogicalTypeChecks {
 
 	public static boolean hasFractionalPrecision(LogicalType logicalType, int fractionalPrecision) {
 		return getFractionalPrecision(logicalType) == fractionalPrecision;
+	}
+
+	public static boolean isSingleFieldInterval(LogicalType logicalType) {
+		return logicalType.accept(SINGLE_FIELD_INTERVAL_EXTRACTOR);
 	}
 
 	private LogicalTypeChecks() {
@@ -297,6 +303,33 @@ public final class LogicalTypeChecks {
 		@Override
 		public TimestampKind visit(LocalZonedTimestampType localZonedTimestampType) {
 			return localZonedTimestampType.getKind();
+		}
+	}
+
+	private static class SingleFieldIntervalExtractor extends Extractor<Boolean> {
+
+		@Override
+		public Boolean visit(YearMonthIntervalType yearMonthIntervalType) {
+			switch (yearMonthIntervalType.getResolution()) {
+				case YEAR:
+				case MONTH:
+					return true;
+				default:
+					return false;
+			}
+		}
+
+		@Override
+		public Boolean visit(DayTimeIntervalType dayTimeIntervalType) {
+			switch (dayTimeIntervalType.getResolution()) {
+				case DAY:
+				case HOUR:
+				case MINUTE:
+				case SECOND:
+					return true;
+				default:
+					return false;
+			}
 		}
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link LogicalTypeCasts}.
+ */
+@RunWith(Parameterized.class)
+public class LogicalTypeCastsTest {
+
+	@Parameters(name = "{index}: [From: {0}, To: {1}, Implicit: {2}, Explicit: {3}]")
+	public static List<Object[]> testData() {
+		return Arrays.asList(
+			new Object[][]{
+				{DataTypes.SMALLINT(), DataTypes.BIGINT(), true, true},
+
+				// nullability does not match
+				{DataTypes.SMALLINT().notNull(), DataTypes.SMALLINT(), true, true},
+
+				{DataTypes.SMALLINT(), DataTypes.SMALLINT().notNull(), false, false},
+
+				{DataTypes.INTERVAL(DataTypes.YEAR()), DataTypes.SMALLINT(), true, true},
+
+				// not an interval with single field
+				{DataTypes.INTERVAL(DataTypes.YEAR(), DataTypes.MONTH()), DataTypes.SMALLINT(), false, false},
+
+				{DataTypes.INT(), DataTypes.DECIMAL(5, 5), true, true},
+
+				// loss of precision
+				{DataTypes.FLOAT(), DataTypes.INT(), false, true},
+
+				{DataTypes.STRING(), DataTypes.FLOAT(), false, true},
+
+				{DataTypes.FLOAT(), DataTypes.STRING(), false, true},
+
+				{DataTypes.DECIMAL(3, 2), DataTypes.STRING(), false, true},
+
+				{
+					DataTypes.ANY(Types.GENERIC(LogicalTypesTest.class)),
+					DataTypes.ANY(Types.GENERIC(LogicalTypesTest.class)),
+					true,
+					true
+				},
+
+				{
+					DataTypes.ANY(Types.GENERIC(LogicalTypesTest.class)),
+					DataTypes.ANY(Types.GENERIC(Object.class)),
+					false,
+					false
+				},
+
+				{DataTypes.NULL(), DataTypes.INT(), true, true},
+
+				{DataTypes.ARRAY(DataTypes.INT()), DataTypes.ARRAY(DataTypes.BIGINT()), true, true},
+
+				{DataTypes.ARRAY(DataTypes.INT()), DataTypes.ARRAY(DataTypes.STRING()), false, true},
+
+				{
+					DataTypes.ROW(
+						DataTypes.FIELD("f1", DataTypes.INT()),
+						DataTypes.FIELD("f2", DataTypes.INT())),
+					DataTypes.ROW(
+						DataTypes.FIELD("f1", DataTypes.INT()),
+						DataTypes.FIELD("f2", DataTypes.BIGINT())),
+					true,
+					true
+				},
+
+				{
+					DataTypes.ROW(
+						DataTypes.FIELD("f1", DataTypes.INT(), "description"),
+						DataTypes.FIELD("f2", DataTypes.INT())),
+					DataTypes.ROW(
+						DataTypes.FIELD("f1", DataTypes.INT()),
+						DataTypes.FIELD("f2", DataTypes.BIGINT())),
+					true,
+					true
+				},
+
+				{
+					DataTypes.ROW(
+						DataTypes.FIELD("f1", DataTypes.INT()),
+						DataTypes.FIELD("f2", DataTypes.INT())),
+					DataTypes.ROW(
+						DataTypes.FIELD("f1", DataTypes.INT()),
+						DataTypes.FIELD("f2", DataTypes.BOOLEAN())),
+					false,
+					false
+				},
+
+				{
+					DataTypes.ROW(
+						DataTypes.FIELD("f1", DataTypes.INT()),
+						DataTypes.FIELD("f2", DataTypes.INT())),
+					DataTypes.STRING(),
+					false,
+					false
+				}
+			}
+		);
+	}
+
+	@Parameter
+	public DataType sourceType;
+
+	@Parameter(1)
+	public DataType targetType;
+
+	@Parameter(2)
+	public boolean supportsImplicit;
+
+	@Parameter(3)
+	public boolean supportsExplicit;
+
+	@Test
+	public void testImplicitCasting() {
+		assertThat(
+			LogicalTypeCasts.supportsImplicitCast(sourceType.getLogicalType(), targetType.getLogicalType()),
+			equalTo(supportsImplicit));
+	}
+
+	@Test
+	public void testExplicitCasting() {
+		assertThat(
+			LogicalTypeCasts.supportsExplicitCast(sourceType.getLogicalType(), targetType.getLogicalType()),
+			equalTo(supportsExplicit));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This introduces a utility for checking logical types for casting. The goal is to be SQL standard compliant. The standard cast specification is quite large, it might be that the code misses some functionality which we can still fix in the future. This code was also inspired by Calcite's `org.apache.calcite.sql.type.SqlTypeAssignmentRules`.

## Brief change log

- Utility for casting added

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
