### PR TITLE
[FLINK-12984][metrics] only call Histogram#getStatistics() once where possible

### DIFF
--- a/flink-metrics/flink-metrics-core/pom.xml
+++ b/flink-metrics/flink-metrics-core/pom.xml
@@ -34,6 +34,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<dependencies>
+		<!-- ================== test dependencies ================== -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<!-- activate API compatibility checks -->

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/AbstractHistogramTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/AbstractHistogramTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import org.apache.flink.util.TestLogger;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Abstract base class for testing {@link Histogram} and {@link HistogramStatistics} implementations.
+ */
+public class AbstractHistogramTest extends TestLogger {
+	protected void testHistogram(int size, Histogram histogram) {
+		HistogramStatistics statistics;
+
+		for (int i = 0; i < size; i++) {
+			histogram.update(i);
+
+			statistics = histogram.getStatistics();
+			assertEquals(i + 1, histogram.getCount());
+			assertEquals(histogram.getCount(), statistics.size());
+			assertEquals(i, statistics.getMax());
+			assertEquals(0, statistics.getMin());
+		}
+
+		statistics = histogram.getStatistics();
+		assertEquals(size, statistics.size());
+		assertEquals((size - 1) / 2.0, statistics.getQuantile(0.5), 0.001);
+
+		for (int i = size; i < 2 * size; i++) {
+			histogram.update(i);
+
+			statistics = histogram.getStatistics();
+			assertEquals(i + 1, histogram.getCount());
+			assertEquals(size, statistics.size());
+			assertEquals(i, statistics.getMax());
+			assertEquals(i + 1 - size, statistics.getMin());
+		}
+
+		statistics = histogram.getStatistics();
+		assertEquals(size, statistics.size());
+		assertEquals(size + (size - 1) / 2.0, statistics.getQuantile(0.5), 0.001);
+	}
+}

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.metrics;
 
+import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
 import static org.apache.flink.metrics.View.UPDATE_INTERVAL_SECONDS;
@@ -26,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for the MeterView.
  */
-public class MeterViewTest {
+public class MeterViewTest extends TestLogger {
 	@Test
 	public void testGetCount() {
 		Counter c = new SimpleCounter();

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
@@ -20,13 +20,13 @@ package org.apache.flink.dropwizard.metrics;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.dropwizard.ScheduledDropwizardReporter;
+import org.apache.flink.metrics.AbstractHistogramTest;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
-import org.apache.flink.util.TestLogger;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for the DropwizardFlinkHistogramWrapper.
  */
-public class DropwizardFlinkHistogramWrapperTest extends TestLogger {
+public class DropwizardFlinkHistogramWrapperTest extends AbstractHistogramTest {
 
 	/**
 	 * Tests the histogram functionality of the DropwizardHistogramWrapper.
@@ -66,28 +66,7 @@ public class DropwizardFlinkHistogramWrapperTest extends TestLogger {
 		int size = 10;
 		DropwizardHistogramWrapper histogramWrapper = new DropwizardHistogramWrapper(
 			new com.codahale.metrics.Histogram(new SlidingWindowReservoir(size)));
-
-		for (int i = 0; i < size; i++) {
-			histogramWrapper.update(i);
-
-			assertEquals(i + 1, histogramWrapper.getCount());
-			assertEquals(i, histogramWrapper.getStatistics().getMax());
-			assertEquals(0, histogramWrapper.getStatistics().getMin());
-		}
-
-		assertEquals(size, histogramWrapper.getStatistics().size());
-		assertEquals((size - 1) / 2.0, histogramWrapper.getStatistics().getQuantile(0.5), 0.001);
-
-		for (int i = size; i < 2 * size; i++) {
-			histogramWrapper.update(i);
-
-			assertEquals(i + 1, histogramWrapper.getCount());
-			assertEquals(i, histogramWrapper.getStatistics().getMax());
-			assertEquals(i + 1 - size, histogramWrapper.getStatistics().getMin());
-		}
-
-		assertEquals(size, histogramWrapper.getStatistics().size());
-		assertEquals(size + (size - 1) / 2.0, histogramWrapper.getStatistics().getQuantile(0.5), 0.001);
+		testHistogram(size, histogramWrapper);
 	}
 
 	/**

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.metrics.jmx;
 
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
@@ -245,16 +246,17 @@ public class JMXReporterTest extends TestLogger {
 			assertEquals(11, attributeInfos.length);
 
 			assertEquals(histogram.getCount(), mBeanServer.getAttribute(objectName, "Count"));
-			assertEquals(histogram.getStatistics().getMean(), mBeanServer.getAttribute(objectName, "Mean"));
-			assertEquals(histogram.getStatistics().getStdDev(), mBeanServer.getAttribute(objectName, "StdDev"));
-			assertEquals(histogram.getStatistics().getMax(), mBeanServer.getAttribute(objectName, "Max"));
-			assertEquals(histogram.getStatistics().getMin(), mBeanServer.getAttribute(objectName, "Min"));
-			assertEquals(histogram.getStatistics().getQuantile(0.5), mBeanServer.getAttribute(objectName, "Median"));
-			assertEquals(histogram.getStatistics().getQuantile(0.75), mBeanServer.getAttribute(objectName, "75thPercentile"));
-			assertEquals(histogram.getStatistics().getQuantile(0.95), mBeanServer.getAttribute(objectName, "95thPercentile"));
-			assertEquals(histogram.getStatistics().getQuantile(0.98), mBeanServer.getAttribute(objectName, "98thPercentile"));
-			assertEquals(histogram.getStatistics().getQuantile(0.99), mBeanServer.getAttribute(objectName, "99thPercentile"));
-			assertEquals(histogram.getStatistics().getQuantile(0.999), mBeanServer.getAttribute(objectName, "999thPercentile"));
+			HistogramStatistics statistics = histogram.getStatistics();
+			assertEquals(statistics.getMean(), mBeanServer.getAttribute(objectName, "Mean"));
+			assertEquals(statistics.getStdDev(), mBeanServer.getAttribute(objectName, "StdDev"));
+			assertEquals(statistics.getMax(), mBeanServer.getAttribute(objectName, "Max"));
+			assertEquals(statistics.getMin(), mBeanServer.getAttribute(objectName, "Min"));
+			assertEquals(statistics.getQuantile(0.5), mBeanServer.getAttribute(objectName, "Median"));
+			assertEquals(statistics.getQuantile(0.75), mBeanServer.getAttribute(objectName, "75thPercentile"));
+			assertEquals(statistics.getQuantile(0.95), mBeanServer.getAttribute(objectName, "95thPercentile"));
+			assertEquals(statistics.getQuantile(0.98), mBeanServer.getAttribute(objectName, "98thPercentile"));
+			assertEquals(statistics.getQuantile(0.99), mBeanServer.getAttribute(objectName, "99thPercentile"));
+			assertEquals(statistics.getQuantile(0.999), mBeanServer.getAttribute(objectName, "999thPercentile"));
 
 		} finally {
 			if (registry != null) {

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -24,6 +24,7 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
@@ -300,10 +301,11 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 		private void addSamples(final List<String> labelValues, final Histogram histogram, final List<MetricFamilySamples.Sample> samples) {
 			samples.add(new MetricFamilySamples.Sample(metricName + "_count",
 				labelNamesWithQuantile.subList(0, labelNamesWithQuantile.size() - 1), labelValues, histogram.getCount()));
+			final HistogramStatistics statistics = histogram.getStatistics();
 			for (final Double quantile : QUANTILES) {
 				samples.add(new MetricFamilySamples.Sample(metricName, labelNamesWithQuantile,
 					addToList(labelValues, quantile.toString()),
-					histogram.getStatistics().getQuantile(quantile)));
+					statistics.getQuantile(quantile)));
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
@@ -29,18 +29,21 @@ public class DescriptiveStatisticsHistogram implements org.apache.flink.metrics.
 
 	private final DescriptiveStatistics descriptiveStatistics;
 
+	private long elementsSeen = 0L;
+
 	public DescriptiveStatisticsHistogram(int windowSize) {
 		this.descriptiveStatistics = new DescriptiveStatistics(windowSize);
 	}
 
 	@Override
 	public void update(long value) {
+		elementsSeen += 1L;
 		this.descriptiveStatistics.addValue(value);
 	}
 
 	@Override
 	public long getCount() {
-		return this.descriptiveStatistics.getN();
+		return this.elementsSeen;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.metrics.AbstractHistogramTest;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link DescriptiveStatisticsHistogram} and
+ * {@link DescriptiveStatisticsHistogramStatistics}.
+ */
+public class DescriptiveStatisticsHistogramTest extends AbstractHistogramTest {
+
+	/**
+	 * Tests the histogram functionality of the DropwizardHistogramWrapper.
+	 */
+	@Test
+	public void testDescriptiveHistogram() {
+		int size = 10;
+		testHistogram(size, new DescriptiveStatisticsHistogram(size));
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

In some occasions, `Histogram#getStatistics()` was called multiple times to retrieve different statistics. However, at least the Dropwizard implementation has some constant overhead per call and we should maybe rather interpret this method as returning a point-in-time snapshot of the histogram in order to get consistent values when querying them.

Please note that this PR is based on #8886.
-> follow-up PR: #8884

## Brief change log

- adapt prometheus reporter
- adapt JMX and dropwizward unit tests

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
