### PR TITLE
[FLINK-12988][table] restore AbstractCatalogTable as parent for Catal…

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
@@ -19,63 +19,66 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.config.CatalogConfig;
-import org.apache.flink.table.descriptors.DescriptorProperties;
-import org.apache.flink.table.descriptors.Schema;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * A catalog table implementation.
+ * An abstract catalog table.
  */
-public class CatalogTableImpl extends AbstractCatalogTable {
+public abstract class AbstractCatalogTable implements CatalogTable {
+	// Schema of the table (column names and types)
+	private final TableSchema tableSchema;
+	// Partition keys if this is a partitioned table. It's an empty set if the table is not partitioned
+	private final List<String> partitionKeys;
+	// Properties of the table
+	private final Map<String, String> properties;
+	// Comment of the table
+	private final String comment;
 
-	public CatalogTableImpl(
+	public AbstractCatalogTable(
 			TableSchema tableSchema,
 			Map<String, String> properties,
 			String comment) {
 		this(tableSchema, new ArrayList<>(), properties, comment);
 	}
 
-	public CatalogTableImpl(
+	public AbstractCatalogTable(
 			TableSchema tableSchema,
 			List<String> partitionKeys,
 			Map<String, String> properties,
 			String comment) {
-		super(tableSchema, partitionKeys, properties, comment);
+		this.tableSchema = checkNotNull(tableSchema, "tableSchema cannot be null");
+		this.partitionKeys = checkNotNull(partitionKeys, "partitionKeys cannot be null");
+		this.properties = checkNotNull(properties, "properties cannot be null");
+		this.comment = comment;
 	}
 
 	@Override
-	public CatalogBaseTable copy() {
-		return new CatalogTableImpl(
-			getSchema().copy(), new ArrayList<>(getPartitionKeys()), new HashMap<>(getProperties()), getComment());
+	public boolean isPartitioned() {
+		return !partitionKeys.isEmpty();
 	}
 
 	@Override
-	public Optional<String> getDescription() {
-		return Optional.of(getComment());
+	public List<String> getPartitionKeys() {
+		return partitionKeys;
 	}
 
 	@Override
-	public Optional<String> getDetailedDescription() {
-		return Optional.of("This is a catalog table in an im-memory catalog");
+	public Map<String, String> getProperties() {
+		return properties;
 	}
 
 	@Override
-	public Map<String, String> toProperties() {
-		DescriptorProperties descriptor = new DescriptorProperties();
+	public TableSchema getSchema() {
+		return tableSchema;
+	}
 
-		descriptor.putTableSchema(Schema.SCHEMA, getSchema());
-
-		Map<String, String> properties = new HashMap<>(getProperties());
-		properties.remove(CatalogConfig.IS_GENERIC);
-
-		descriptor.putProperties(properties);
-
-		return descriptor.asMap();
+	@Override
+	public String getComment() {
+		return comment;
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  * @param <T2> type of the expected elements by the {@link TableSink}
  */
 @Internal
-public class ConnectorCatalogTable<T1, T2> extends CatalogTableImpl {
+public class ConnectorCatalogTable<T1, T2> extends AbstractCatalogTable {
 	private final TableSource<T1> tableSource;
 	private final TableSink<T2> tableSink;
 	private final boolean isBatch;


### PR DESCRIPTION
…ogTableImpl and ConnectorCatalogTable

## What is the purpose of the change

After doing #8815, Xuefu brought up a concern that it may not reflect the correct inheritance structure of CatalogTableImpl and ConnectorCatalogTable (which inherits from CatalogTableImpl now) anymore.

Thus we propose to add back AbstractCatalogTable from FLINK-12918. But the unification of catalog table implementations remain untouch

## Brief change log

- add back AbstractCatalogTable 

## Verifying this change

This change added tests and can be verified as follows:  GenericInMemoryCatalogTest, HiveCatalogGenericMetadataTest, HiveCatalogHiveMetadataTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:(no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
