### PR TITLE
[FLINK-12981][metrics] ignore NaNs in percentile implementation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
@@ -21,6 +21,8 @@ import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.HistogramStatistics;
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+import org.apache.commons.math3.stat.ranking.NaNStrategy;
 
 /**
  * The {@link DescriptiveStatisticsHistogram} use a DescriptiveStatistics {@link DescriptiveStatistics} as a Flink {@link Histogram}.
@@ -33,6 +35,9 @@ public class DescriptiveStatisticsHistogram implements org.apache.flink.metrics.
 
 	public DescriptiveStatisticsHistogram(int windowSize) {
 		this.descriptiveStatistics = new DescriptiveStatistics(windowSize);
+		// since we are storing Long values, we won't have NaN values
+		Percentile percentileImpl = new Percentile().withNaNStrategy(NaNStrategy.FIXED);
+		descriptiveStatistics.setPercentileImpl(percentileImpl);
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Histogram metrics report `long` values and therefore, there is no `Double.NaN` in `DescriptiveStatistics`' data and there is no need to cleanse it while working with it.

Please note that this PR is based on #8877.
-> follow-up PR: #8887

## Brief change log

- set a percentile implementation with ' NaNStrategy.FIXED' 

## Verifying this change

This change is already covered by existing tests, such as derivatives of `AbstractHistogramTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
