### PR TITLE
[FLINK-12855] [streaming-java][window-assigners] Add functionality that staggers panes on partitions to distribute workload.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowStagger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowStagger.java
@@ -1,0 +1,49 @@
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A {@code WindowStagger} staggers offset in runtime for each window assignment.
+ */
+public enum WindowStagger {
+	/**
+	 * Default mode,  all panes fire at the same time across all partitions.
+	 */
+	ALIGNED {
+		@Override
+		public long getStaggerOffset(
+			final long currentProcessingTime,
+			final long size) {
+			return 0L;
+		}
+	},
+
+	/**
+	 * Stagger offset is sampled from uniform distribution U(0, WindowSize) when first event ingested in the partitioned operator.
+	 */
+	RANDOM {
+		@Override
+		public long getStaggerOffset(
+			final long currentProcessingTime,
+			final long size) {
+			return (long) (ThreadLocalRandom.current().nextDouble() * size);
+		}
+	},
+
+	/**
+	 * Stagger offset is the ingestion delay in processing time, which is the difference between first event ingestion time and its corresponding processing window start time
+	 * in the partitioned operator. In other words, each partitioned window starts when its first pane created.
+	 */
+	NATURAL {
+		@Override
+		public long getStaggerOffset(
+			final long currentProcessingTime,
+			final long size) {
+			final long currentProcessingWindowStart = TimeWindow.getWindowStartWithOffset(currentProcessingTime, 0, size);
+			return Math.max(0, currentProcessingTime - currentProcessingWindowStart);
+		}
+	};
+	public abstract long getStaggerOffset(final long currentProcessingTime, final long size);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowStagger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowStagger.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.api.windowing.assigners;
 
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
@@ -48,7 +48,7 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 	@Test
 	public void testWindowAssignment() {
 		WindowAssigner.WindowAssignerContext mockContext =
-				mock(WindowAssigner.WindowAssignerContext.class);
+			mock(WindowAssigner.WindowAssignerContext.class);
 
 		TumblingProcessingTimeWindows assigner = TumblingProcessingTimeWindows.of(Time.milliseconds(5000));
 
@@ -63,9 +63,9 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 	}
 
 	@Test
-	public void testWindowAssignmentWithOffset() {
+	public void testWindowAssignmentWithGlobalOffset() {
 		WindowAssigner.WindowAssignerContext mockContext =
-				mock(WindowAssigner.WindowAssignerContext.class);
+			mock(WindowAssigner.WindowAssignerContext.class);
 
 		TumblingProcessingTimeWindows assigner = TumblingProcessingTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(100));
 
@@ -80,7 +80,7 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 	}
 
 	@Test
-	public void testWindowAssignmentWithNegativeOffset() {
+	public void testWindowAssignmentWithNegativeGlobalOffset() {
 		WindowAssigner.WindowAssignerContext mockContext =
 			mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -101,7 +101,7 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 		// sanity check with one other time unit
 
 		WindowAssigner.WindowAssignerContext mockContext =
-				mock(WindowAssigner.WindowAssignerContext.class);
+			mock(WindowAssigner.WindowAssignerContext.class);
 
 		TumblingProcessingTimeWindows assigner = TumblingProcessingTimeWindows.of(Time.seconds(5), Time.seconds(1));
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowStaggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowStaggerTest.java
@@ -1,0 +1,23 @@
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link WindowStagger}.
+ */
+public class WindowStaggerTest {
+	private final long sizeInMilliseconds = 5000;
+
+	@Test
+	public void testWindowStagger() {
+		assertEquals(0L, WindowStagger.ALIGNED.getStaggerOffset(500L, sizeInMilliseconds));
+		assertEquals(500L, WindowStagger.NATURAL.getStaggerOffset(5500L, sizeInMilliseconds));
+		assertTrue(0 < WindowStagger.RANDOM.getStaggerOffset(0L, sizeInMilliseconds));
+		assertTrue(sizeInMilliseconds > WindowStagger.RANDOM.getStaggerOffset(0L, sizeInMilliseconds));
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowStaggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowStaggerTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.runtime.operators.windowing;
 
 import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Flink triggers all panes belonging to one window at the same time. In other words, all panes are aligned and their triggers all fire simultaneously, causing the spiking workload effect. This pull request adds WindowStagger to generate staggering offset for each window assignment at runtime, so the workloads are distributed across time. Hence each window assignment is based on window size, window offset and staggering offset (generated in runtime).

This change only modifies TumblingProcessingTimeWindows, will send out other windows change in other PRs. 

## Brief change log

  - *Add WindowStagger for generating staggering offsets*
  - *Enable TumblingProcessingTimeWindows to generate staggering offsets if user enabled*


## Verifying this change

This change is already covered by existing tests, such as *TumblingProcessingTimeWindowsTest*.

This change added tests and can be verified as follows:

  - *Added unit tests for WindowStagger*
  - *Validated the change by running in our clusters with 3500 task managers in total on a stateful streaming program using sliding and tumbling windowing. Some dashboards are shown below*



![](https://issues.apache.org/jira/secure/attachment/12971856/stagger_window_delay.png)
![](https://issues.apache.org/jira/secure/attachment/12971857/stagger_window_throughput.png)
![](https://issues.apache.org/jira/secure/attachment/12971859/stagger_window.png)

*some system metrics*

![buffers_in_queue](https://user-images.githubusercontent.com/10646097/60139232-00f29d80-9762-11e9-84f4-3bfbde28c028.png)
![buffer_usage](https://user-images.githubusercontent.com/10646097/60139234-03ed8e00-9762-11e9-99d1-de845d02a8c6.png)
![output_record_rate](https://user-images.githubusercontent.com/10646097/60139237-064fe800-9762-11e9-959d-2db96c7f7bf6.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, TumblingProcessingTimeWindows(potentially all WindowAssigners)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know, probably no ? 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs