### PR TITLE
[FLINK-12983][metrics] replace descriptive histogram's storage back-end

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
@@ -27,27 +27,63 @@ import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
  */
 public class DescriptiveStatisticsHistogram implements org.apache.flink.metrics.Histogram {
 
-	private final DescriptiveStatistics descriptiveStatistics;
-
-	private long elementsSeen = 0L;
+	private final CircularDoubleArray descriptiveStatistics;
 
 	public DescriptiveStatisticsHistogram(int windowSize) {
-		this.descriptiveStatistics = new DescriptiveStatistics(windowSize);
+		this.descriptiveStatistics = new CircularDoubleArray(windowSize);
 	}
 
 	@Override
 	public void update(long value) {
-		elementsSeen += 1L;
 		this.descriptiveStatistics.addValue(value);
 	}
 
 	@Override
 	public long getCount() {
-		return this.elementsSeen;
+		return this.descriptiveStatistics.getElementsSeen();
 	}
 
 	@Override
 	public HistogramStatistics getStatistics() {
 		return new DescriptiveStatisticsHistogramStatistics(this.descriptiveStatistics);
+	}
+
+	/**
+	 * Fixed-size array that wraps around at the end and has a dynamic start position.
+	 */
+	static class CircularDoubleArray {
+		private final double[] backingArray;
+		private int nextPos = 0;
+		private boolean fullSize = false;
+		private long elementsSeen = 0;
+
+		CircularDoubleArray(int windowSize) {
+			this.backingArray = new double[windowSize];
+		}
+
+		synchronized void addValue(double value) {
+			backingArray[nextPos] = value;
+			++elementsSeen;
+			++nextPos;
+			if (nextPos == backingArray.length) {
+				nextPos = 0;
+				fullSize = true;
+			}
+		}
+
+		synchronized double[] toUnsortedArray() {
+			final int size = getSize();
+			double[] result = new double[size];
+			System.arraycopy(backingArray, 0, result, 0, result.length);
+			return result;
+		}
+
+		private synchronized int getSize() {
+			return fullSize ? backingArray.length : nextPos;
+		}
+
+		private synchronized long getElementsSeen() {
+			return elementsSeen;
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
@@ -38,8 +38,9 @@ import java.util.Arrays;
 public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistics {
 	private final CommonMetricsSnapshot statisticsSummary = new CommonMetricsSnapshot();
 
-	public DescriptiveStatisticsHistogramStatistics(DescriptiveStatistics latencyHistogram) {
-		latencyHistogram.apply(statisticsSummary);
+	public DescriptiveStatisticsHistogramStatistics(
+			DescriptiveStatisticsHistogram.CircularDoubleArray histogramValues) {
+		statisticsSummary.evaluate(histogramValues.toUnsortedArray());
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Instead of using `DescriptiveStatistics` and its `ResizableDoubleArray` storage back-end, implement an own circular array based on a fixed-size double array that wraps around. This significantly improves the time needed to add new values. It also ensures that access is synchronized which `ResizableDoubleArray` does not guarantee.

Performance results:
1. only adding values to the histogram
```
    Benchmark                                       Mode  Cnt      Score        Error   Units
    HistogramBenchmarks.dropwizardHistogramAdd     thrpt   30   47985.359 ±    25.847  ops/ms
    HistogramBenchmarks.descriptiveHistogramAdd    thrpt   30   70158.792 ±   276.858  ops/ms
-> #8887:
    HistogramBenchmarks.descriptiveHistogramAdd    thrpt   30   75303.040 ±   475.355  ops/ms
-> this PR:
    HistogramBenchmarks.descrHistogramCircularAdd  thrpt   30  200906.902 ±   384.483  ops/ms
-> using a linear array of twice the histogram size (and moving values back to the start once the window reaches the end), for reference:
    HistogramBenchmarks.descrHistogramLinearAdd    thrpt   30  189788.728 ±   233.283  ops/ms
```
2. after adding each value, also retrieving a common set of metrics:
```
    Benchmark                                       Mode  Cnt      Score        Error   Units
    HistogramBenchmarks.dropwizardHistogram        thrpt   30     400.274 ±     4.930  ops/ms
    HistogramBenchmarks.descriptiveHistogram       thrpt   30     124.533 ±     1.060  ops/ms
-> #8887:
    HistogramBenchmarks.descriptiveHistogram       thrpt   30     251.895 ±     1.809  ops/ms
-> this PR:
    HistogramBenchmarks.descrHistogramCircular     thrpt   30     301.068 ±     2.077  ops/ms
-> using a linear array as above:
    HistogramBenchmarks.descrHistogramLinear       thrpt   30     234.050 ±     5.485  ops/ms
```

Please note that this PR is based on #8887.

## Brief change log

- add `CircularDoubleArray` to `DescriptiveStatisticsHistogram`
- remove extra `AtomicLong elementsSeen` (can be done more efficiently in `CircularDoubleArray`)

## Verifying this change

This change is already covered by existing tests, such as derivatives of `AbstractHistogramTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **maybe** (histograms are used by latency markers only but may be used by users)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
