### PR TITLE
[FLINK-12934][hive] add hadoop dependencies as 'flink-shaded-hadoop-2-uber' for flink-connector-hive to connect to remote hive metastore service

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -35,6 +35,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<servlet-api.version>2.5</servlet-api.version>
+		<commons-configuration.version>1.6</commons-configuration.version>
+		<commons-logging.version>1.2</commons-logging.version>
+	</properties>
+
+
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -62,6 +69,13 @@ under the License.
 
 		<!-- Hadoop dependency -->
 		<!-- Hadoop as provided dependencies, so we can depend on them without pulling in Hadoop -->
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-auth</artifactId>
+			<version>${hivemetastore.hadoop.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
@@ -383,6 +397,33 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<!-- Dependencies required to contact remote Hive Metastore Service -->
+		<!-- These dependencies are not required to compile and run tests in flink-connector-hive,
+			 because flink-connector-hive uses embedded Hive Metastore for testing.
+			 Depend on them more as a reminder to users and developers that they need to add them
+			 into their classpath when running in production -->
+
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<version>${servlet-api.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-configuration</groupId>
+			<artifactId>commons-configuration</artifactId>
+			<version>${commons-configuration.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>${commons-logging.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>
@@ -452,29 +493,15 @@ under the License.
 						<configuration>
 							<shadeTestJar>false</shadeTestJar>
 							<artifactSet>
-								<!-- Needs end-to-end tests to ensure the built flink-connector-hive jar contains all required dependencies and can run -->
 								<includes>
-									<include>commons-dbcp:commons-dbcp</include>
-									<include>commons-pool:commons-pool</include>
-									<include>commons-beanutils:commons-beanutils</include>
-									<include>com.fasterxml.jackson.core:*</include>
-									<include>com.jolbox:bonecp</include>
-									<include>org.apache.thrift:libthrift</include>
-									<include>org.datanucleus:*</include>
-									<include>org.antlr:antlr-runtime</include>
+									<include>*:*</include>
 								</includes>
 							</artifactSet>
 							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
 							<!-- DO NOT RELOCATE GUAVA IN THIS PACKAGE -->
 							<filters>
 								<filter>
-									<!-- some dependencies bring their own LICENSE.txt which we don't need -->
 									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>META-INF/LICENSE.txt</exclude>
-										<exclude>META-INF/ASM_LICENSE.txt</exclude>
-										<exclude>META-INF/ASL2.0</exclude>
-									</excludes>
 								</filter>
 							</filters>
 						</configuration>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -35,13 +35,6 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<properties>
-		<servlet-api.version>2.5</servlet-api.version>
-		<commons-configuration.version>1.6</commons-configuration.version>
-		<commons-logging.version>1.2</commons-logging.version>
-	</properties>
-
-
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -71,72 +64,10 @@ under the License.
 		<!-- Hadoop as provided dependencies, so we can depend on them without pulling in Hadoop -->
 
 		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-auth</artifactId>
-			<version>${hivemetastore.hadoop.version}</version>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-hadoop-2-uber</artifactId>
+			<version>${hadoop.version}-${flink.shaded.version}</version>
 			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-common</artifactId>
-			<version>${hivemetastore.hadoop.version}</version>
-			<scope>provided</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.curator</groupId>
-					<artifactId>curator-client</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.curator</groupId>
-					<artifactId>curator-recipes</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.avro</groupId>
-					<artifactId>avro</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-digester</groupId>
-					<artifactId>commons-digester</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-json</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-mapper-asl</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-mapreduce-client-core</artifactId>
-			<version>${hivemetastore.hadoop.version}</version>
-			<scope>provided</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.curator</groupId>
-					<artifactId>curator-test</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.hadoop</groupId>
-					<artifactId>hadoop-yarn-common</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.avro</groupId>
-					<artifactId>avro</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-core-asl</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- Hive dependencies -->
@@ -395,33 +326,6 @@ under the License.
 					<artifactId>guava</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-
-		<!-- Dependencies required to contact remote Hive Metastore Service -->
-		<!-- These dependencies are not required to compile and run tests in flink-connector-hive,
-			 because flink-connector-hive uses embedded Hive Metastore for testing.
-			 Depend on them more as a reminder to users and developers that they need to add them
-			 into their classpath when running in production -->
-
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>${servlet-api.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-configuration</groupId>
-			<artifactId>commons-configuration</artifactId>
-			<version>${commons-configuration.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>${commons-logging.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
## What is the purpose of the change

Now, for all hadoop related dependencies, we just use the single jar of flink-shaded-hadoop-2-uber, instead of depending on individual hadoop jars. It's much more convenient for users to use now.

To summarize all flink-connector-hive's dependencies, which are all of provided scope:

hive-metastore
hive-exec
flink-shaded-hadoop-2-uber

## Brief change log

- adds a few more dependencies for HiveCatalog in flink-connector-hive to connect to a remote hive metastore service

## Verifying this change

We need to add end-to-end test in order to cover such work. cc @lirui-apache @zjuwangg

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
