### PR TITLE
[FLINK-12990][python] Date type doesn't consider the local TimeZone

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
@@ -20,6 +20,8 @@ package org.apache.flink.table.util.python
 
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
+import java.time.{LocalDate, LocalDateTime, LocalTime}
+import java.util.TimeZone
 import java.util.function.BiConsumer
 
 import org.apache.flink.api.common.functions.MapFunction
@@ -131,7 +133,10 @@ object PythonTableUtils {
     }
 
     case _ if dataType == Types.SQL_DATE => (obj: Any) => nullSafeConvert(obj) {
-      case c: Int => new Date(c * 86400000)
+      case c: Int =>
+        val millisLocal = c.toLong * 86400000
+        val millisGmt = millisLocal - getOffsetFromLocalMillis(millisLocal)
+        new Date(millisGmt)
     }
 
     case _ if dataType == Types.SQL_TIME => (obj: Any) => nullSafeConvert(obj) {
@@ -388,5 +393,27 @@ object PythonTableUtils {
         }
         array
     }
+  }
+
+  private def getOffsetFromLocalMillis(millisLocal: Long): Int = {
+    val localZone = TimeZone.getDefault
+    var result = localZone.getRawOffset
+    // the actual offset should be calculated based on milliseconds in UTC
+    val offset = localZone.getOffset(millisLocal - result)
+    if (offset != result) {
+      // consider DayLight Saving Time
+      result = localZone.getOffset(millisLocal - offset)
+      if (result != offset) {
+        // fallback to do the reverse lookup using java.time.LocalDateTime
+        // this should only happen near the start or end of DST
+        val localDate = LocalDate.ofEpochDay(millisLocal / 86400000)
+        val localTime = LocalTime.ofNanoOfDay(
+          Math.floorMod(millisLocal, 86400000) * 1000 * 1000)
+        val localDateTime = LocalDateTime.of(localDate, localTime)
+        val millisEpoch = localDateTime.atZone(localZone.toZoneId).toInstant.toEpochMilli
+        result = (millisLocal - millisEpoch).toInt
+      }
+    }
+    result
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
@@ -135,8 +135,8 @@ object PythonTableUtils {
     case _ if dataType == Types.SQL_DATE => (obj: Any) => nullSafeConvert(obj) {
       case c: Int =>
         val millisLocal = c.toLong * 86400000
-        val millisGmt = millisLocal - getOffsetFromLocalMillis(millisLocal)
-        new Date(millisGmt)
+        val millisUtc = millisLocal - getOffsetFromLocalMillis(millisLocal)
+        new Date(millisUtc)
     }
 
     case _ if dataType == Types.SQL_TIME => (obj: Any) => nullSafeConvert(obj) {
@@ -395,13 +395,13 @@ object PythonTableUtils {
     }
   }
 
-  private def getOffsetFromLocalMillis(millisLocal: Long): Int = {
+  def getOffsetFromLocalMillis(millisLocal: Long): Int = {
     val localZone = TimeZone.getDefault
     var result = localZone.getRawOffset
     // the actual offset should be calculated based on milliseconds in UTC
     val offset = localZone.getOffset(millisLocal - result)
     if (offset != result) {
-      // consider DayLight Saving Time
+      // DayLight Saving Time
       result = localZone.getOffset(millisLocal - offset)
       if (result != offset) {
         // fallback to do the reverse lookup using java.time.LocalDateTime

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/util/python/PythonTableUtilsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/util/python/PythonTableUtilsTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.util.python
+
+import java.time.ZoneId
+import java.util.TimeZone
+
+import org.apache.calcite.avatica.util.DateTimeUtils
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class PythonTableUtilsTest {
+
+  @Test
+  def testGetOffsetFromLocalMillis(): Unit = {
+    def testOffset(localMillis: Long, expected: Long): Unit = {
+      assertEquals(expected, PythonTableUtils.getOffsetFromLocalMillis(localMillis))
+    }
+
+    val originalZone = TimeZone.getDefault
+    try {
+      // Daylight Saving Time Test
+      TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("PST", ZoneId.SHORT_IDS)))
+
+      // 2018-03-11 01:59:59.0 PST
+      testOffset(DateTimeUtils.timestampStringToUnixDate("2018-03-11 01:59:59.0"), -28800000)
+
+      // 2018-03-11 03:00:00.0 PST
+      testOffset(DateTimeUtils.timestampStringToUnixDate("2018-03-11 03:00:00.0"), -25200000)
+
+      // 2018-11-04 00:59:59.0 PST
+      testOffset(DateTimeUtils.timestampStringToUnixDate("2018-11-04 00:59:59.0"), -25200000)
+
+      // 2018-11-04 02:00:00.0 PST
+      testOffset(DateTimeUtils.timestampStringToUnixDate("2018-11-04 02:00:00.0"), -28800000)
+    } finally {
+      TimeZone.setDefault(originalZone)
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Currently, the python DateType is converted by an `int` which indicates the days passed since 1970-1-1 and then the Java side will create a Java Date by call `new Date(days * 86400)`. As we know that the Date constructor expected milliseconds since 1970-1-1 00:00:00 GMT and so we should convert `days * 86400` to GMT milliseconds. This PR will fix this issue.*

## Brief change log

  - *Add method getOffsetFromLocalMillis to deal with the offset calculation of the local timezone and use the calculated offset when creating the Date object.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
