### PR TITLE
[FLINK-12536][Runtime/Network]Make BufferOrEventSequence#getNext non blocking

### DIFF
--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -8,6 +8,11 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>taskmanager.memory.async-load.buffer-count</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Number of memory buffer will be used to fetch data from spilled file asynchronous.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.fraction</h5></td>
             <td style="word-wrap: break-word;">0.7</td>
             <td>The relative amount of memory (after subtracting the amount of memory used by network buffers) that the task manager reserves for sorting, hash tables, and caching of intermediate results. For example, a value of <span markdown="span">`0.8`</span> means that a task manager reserves 80% of its memory (on-heap or off-heap depending on taskmanager.memory.off-heap) for internal data buffers, leaving 20% of free memory for the task manager's heap for objects created by user-defined functions. This parameter is only evaluated, if taskmanager.memory.size is not set.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -188,6 +188,14 @@ public class TaskManagerOptions {
 			.withDescription("Size of memory buffers used by the network stack and the memory manager.");
 
 	/**
+	 * Number of memory buffer will be used to fetch data from spilled file asynchronous.
+	 */
+	public static final ConfigOption<Integer> MEMORY_BUFFER_ASYNC_LOAD_COUNT =
+			key("taskmanager.memory.async-load.buffer-count")
+			.defaultValue(2)
+			.withDescription("Number of memory buffer will be used to fetch data from spilled file asynchronous.");
+
+	/**
 	 * Amount of memory to be allocated by the task manager's memory manager. If not
 	 * set, a relative fraction will be allocated, as defined by {@link #MANAGED_MEMORY_FRACTION}.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 
 /**
  * An utility class for I/O related functionality.
@@ -136,6 +138,24 @@ public final class IOUtils {
 			}
 			toRead -= ret;
 			off += ret;
+		}
+	}
+
+	/**
+	 * Reads bytes into ByteBuffer, blocking until all ByteBuffer is full.
+	 *
+	 * @param fileChannel The source where we read from
+	 * @param buffer The target we'll write the bytes to.
+	 * @throws IOException If we could not read requested number of bytes for any reason (including EOF)
+	 */
+	public static void readFully(FileChannel fileChannel, ByteBuffer buffer) throws IOException {
+		int toRead = buffer.limit() - buffer.position();
+		while (toRead > 0) {
+			final int ret = fileChannel.read(buffer);
+			if (ret < 0) {
+				throw new IOException("Premeture EOF from FileChannel");
+			}
+			toRead -= ret;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousBufferOrEventFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousBufferOrEventFileReader.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.disk.iomanager;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * AsynchronousBufferOrEventFileReader used to read spilled data asynchronous.
+ */
+public class AsynchronousBufferOrEventFileReader extends AsynchronousFileIOChannel<Buffer, ReadRequest> implements BufferFileReader  {
+	private final AtomicBoolean hasReachedEndOfFile = new AtomicBoolean();
+
+	protected AsynchronousBufferOrEventFileReader(ID channelID, RequestQueue<ReadRequest> requestQueue, RequestDoneCallback<Buffer> callback) throws IOException {
+		super(channelID, requestQueue, callback, false);
+	}
+
+	@Override
+	public void readInto(Buffer buffer) throws IOException {
+		addRequest(new BufferOrEventReadRequest(this, buffer, hasReachedEndOfFile));
+	}
+
+	@Override
+	public void seekToPosition(long position) {
+		requestQueue.add(new SeekRequest(this, position));
+	}
+
+	@Override
+	public boolean hasReachedEndOfFile() {
+		return hasReachedEndOfFile.get();
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/BufferOrEventFileChannelReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/BufferOrEventFileChannelReader.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.disk.iomanager;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.util.IOUtils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Used for read data from fileChannel asynchronous, will be used in {@link AsynchronousBufferOrEventFileReader}.
+ */
+public class BufferOrEventFileChannelReader {
+	/** Header is "channel index" (4 bytes) + length (4 bytes) + buffer/event (1 byte). */
+	private static final int HEAD_LENGTH = 9;
+	private final FileChannel fileChannel;
+	private int size;
+	private boolean isBuffer;
+
+	BufferOrEventFileChannelReader(FileChannel fileChannel) {
+		this.fileChannel = fileChannel;
+	}
+
+	/**
+	 * Reads data from the object's file channel into the given buffer.
+	 *
+	 * @param buffer the buffer to read into
+	 *
+	 * @return whether the end of the file has been reached (<tt>true</tt>) or not (<tt>false</tt>)
+	 */
+	public boolean readBufferFromFileChannel(Buffer buffer) throws IOException {
+		checkArgument(fileChannel.size() - fileChannel.position() > 0);
+
+		// Read header
+		ByteBuffer header = buffer.getNioBuffer(0, HEAD_LENGTH);
+		header.clear();
+		IOUtils.readFully(fileChannel, header);
+		header.flip();
+		readBufferOrEventMeta(header);
+
+		if (size > buffer.getMaxCapacity()) {
+			throw new IllegalStateException("Buffer is too small for data: " + buffer.getMaxCapacity() + " bytes available, but " + size + " needed. This is most likely due to an serialized event, which is larger than the buffer size.");
+		}
+		checkArgument(buffer.getSize() == 0, "Buffer not empty");
+
+		IOUtils.readFully(fileChannel, (buffer.getNioBuffer(HEAD_LENGTH, size)));
+		buffer.setSize(HEAD_LENGTH + size);
+
+		if (!isBuffer) {
+			buffer.tagAsEvent();
+		}
+
+		return fileChannel.size() - fileChannel.position() == 0;
+	}
+
+	public static void writeBufferOrEventMeta(ByteBuffer buffer, int channel, int size, byte isBuffer) {
+		buffer.putInt(channel);
+		buffer.putInt(size);
+		buffer.put(isBuffer);
+	}
+
+	private void readBufferOrEventMeta(ByteBuffer buffer) {
+		// ignore channel.
+		buffer.order(ByteOrder.LITTLE_ENDIAN);
+		buffer.getInt();
+		size = buffer.getInt();
+		isBuffer = buffer.get() == 0;
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/BufferOrEventReadRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/BufferOrEventReadRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.disk.iomanager;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * An implementation of {@link ReadRequest} will used in {@link AsynchronousBufferOrEventFileReader}.
+ */
+public final class BufferOrEventReadRequest implements ReadRequest {
+	private final AsynchronousFileIOChannel<Buffer, ReadRequest> channel;
+
+	private final Buffer buffer;
+
+	private final AtomicBoolean hasReachedEndOfFile;
+
+	public BufferOrEventReadRequest(
+		AsynchronousFileIOChannel<Buffer, ReadRequest> targetChannel,
+		Buffer buffer,
+		AtomicBoolean hasReachedEndOfFile) {
+		this.channel = targetChannel;
+		this.buffer = buffer;
+		this.hasReachedEndOfFile = hasReachedEndOfFile;
+	}
+
+	@Override
+	public void requestDone(IOException ioex) {
+		channel.handleProcessedBuffer(buffer, ioex);
+	}
+
+	@Override
+	public void read() throws IOException {
+		final FileChannel fileChannel = channel.fileChannel;
+
+		if (fileChannel.size() - fileChannel.position() > 0) {
+			BufferOrEventFileChannelReader reader = new BufferOrEventFileChannelReader(fileChannel);
+			hasReachedEndOfFile.set(reader.readBufferFromFileChannel(buffer));
+		}
+		else {
+			hasReachedEndOfFile.set(true);
+		}
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * The facade for the provided I/O manager services.
@@ -131,6 +132,19 @@ public abstract class IOManager {
 	}
 
 	/**
+	 * Creates a new {@link FileIOChannel.ID} out of all the tmp directories to avoid get cleared
+	 * unexpected.
+	 *
+	 * @param path The file to read
+	 * @return A channel in an directory out of all the tmp directories.
+	 */
+	public FileIOChannel.ID createChannel(File path) {
+		// we choose a thread num randomly.
+		final int threadNum = ThreadLocalRandom.current().nextInt(this.paths.length);
+		return new FileIOChannel.ID(path, threadNum);
+	}
+
+	/**
 	 * Creates a new {@link FileIOChannel.Enumerator}, spreading the channels in a round-robin fashion
 	 * across the temporary file directories.
 	 *
@@ -223,6 +237,8 @@ public abstract class IOManager {
 	public abstract BufferFileWriter createBufferFileWriter(FileIOChannel.ID channelID) throws IOException;
 
 	public abstract BufferFileReader createBufferFileReader(FileIOChannel.ID channelID, RequestDoneCallback<Buffer> callback) throws IOException;
+
+	public abstract BufferFileReader createBufferOrEventFileReader(FileIOChannel.ID channelID, RequestDoneCallback<Buffer> callback) throws IOException;
 
 	public abstract BufferFileSegmentReader createBufferFileSegmentReader(FileIOChannel.ID channelID, RequestDoneCallback<FileSegment> callback) throws IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsync.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsync.java
@@ -240,6 +240,14 @@ public class IOManagerAsync extends IOManager implements UncaughtExceptionHandle
 	}
 
 	@Override
+	public BufferFileReader createBufferOrEventFileReader(
+		FileIOChannel.ID channelID, RequestDoneCallback<Buffer> callback) throws IOException {
+		checkState(!isShutdown.get(), "I/O-Manager is shut down.");
+
+		return new AsynchronousBufferOrEventFileReader(channelID, readers[channelID.getThreadNum()].requestQueue, callback);
+	}
+
+	@Override
 	public BufferFileSegmentReader createBufferFileSegmentReader(FileIOChannel.ID channelID, RequestDoneCallback<FileSegment> callback) throws IOException {
 		checkState(!isShutdown.get(), "I/O-Manager is shut down.");
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerTest.java
@@ -130,5 +130,11 @@ public class IOManagerTest {
 		public BulkBlockChannelReader createBulkBlockChannelReader(ID channelID, List<MemorySegment> targetSegments, int numBlocks) {
 			throw new UnsupportedOperationException();
 		}
+
+		@Override
+		public BufferFileReader createBufferOrEventFileReader(
+			ID channelID, RequestDoneCallback<Buffer> callback) throws IOException {
+			throw new UnsupportedOperationException();
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/NoOpIOManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/NoOpIOManager.java
@@ -70,4 +70,10 @@ public class NoOpIOManager extends IOManager {
 	public BulkBlockChannelReader createBulkBlockChannelReader(ID channelID, List<MemorySegment> targetSegments, int numBlocks) throws IOException {
 		throw new UnsupportedOperationException();
 	}
+
+	@Override
+	public BufferFileReader createBufferOrEventFileReader(
+		ID channelID, RequestDoneCallback<Buffer> callback) throws IOException {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferOrException.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferOrException.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+/**
+ * Either type for {@link org.apache.flink.runtime.io.network.buffer.Buffer} or an Exception or EoF.
+ * - Represents as a buffer if #buffer is not null
+ * - Represents as an Exception if #exception is not null
+ * - Represents as an EoF if #buffer and #exception are both null
+ */
+public class BufferOrException<T extends Exception> {
+
+	private final Buffer buffer;
+	private final T exception;
+
+	public BufferOrException() {
+		this.buffer = null;
+		this.exception = null;
+	}
+
+	public BufferOrException(Buffer buffer) {
+		this.buffer = buffer;
+		this.exception = null;
+	}
+
+	public BufferOrException(T e) {
+		this.buffer = null;
+		this.exception = e;
+	}
+
+	public boolean isBuffer() {
+		return buffer != null;
+	}
+
+	public boolean isException() {
+		return exception != null;
+	}
+
+	public Buffer getBuffer() {
+		return buffer;
+	}
+
+	public T getException() {
+		return exception;
+	}
+
+	public boolean isEof() {
+		return buffer == null && exception == null;
+	}
+}
+

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferSpiller.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferSpiller.java
@@ -21,7 +21,9 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.disk.iomanager.AsynchronousBufferOrEventFileReader;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.RequestDoneCallback;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
@@ -36,8 +38,12 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.runtime.io.disk.iomanager.BufferOrEventFileChannelReader.writeBufferOrEventMeta;
 
 /**
  * The buffer spiller takes the buffers and events from a data stream and adds them to a spill file.
@@ -55,7 +61,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Deprecated
 public class BufferSpiller implements BufferBlocker {
 
-	/** Size of header in bytes (see add method). */
+	/** Size of header in bytes. Header is "channel index" (4 bytes) + length (4 bytes) + buffer/event (1 byte). */
 	static final int HEADER_SIZE = 9;
 
 	/** The counter that selects the next directory to spill into. */
@@ -70,8 +76,8 @@ public class BufferSpiller implements BufferBlocker {
 	/** The name prefix for spill files. */
 	private final String spillFilePrefix;
 
-	/** The buffer used for bulk reading data (used in the SpilledBufferOrEventSequence). */
-	private final ByteBuffer readBuffer;
+	/** The buffer pool used for bulk reading data (used in the SpilledBufferOrEventSequence). */
+	private final ByteBuffer[] readBufferPool;
 
 	/** The buffer that encodes the spilled header. */
 	private final ByteBuffer headBuffer;
@@ -85,11 +91,17 @@ public class BufferSpiller implements BufferBlocker {
 	/** The page size, to let this reader instantiate properly sized memory segments. */
 	private final int pageSize;
 
+	/** The segment count will be used to fetch data from spilled file asynchrouns. */
+	private final int asyncLoadBufferCount;
+
 	/** A counter, to created numbered spill files. */
 	private int fileCounter;
 
 	/** The number of bytes written since the last roll over. */
 	private long bytesWritten;
+
+	/** The IO Manager associated to current BufferSpiller. */
+	private final IOManager ioManager;
 
 	/**
 	 * Creates a new buffer spiller, spilling to one of the I/O manager's temp directories.
@@ -98,15 +110,20 @@ public class BufferSpiller implements BufferBlocker {
 	 * @param pageSize The page size used to re-create spilled buffers.
 	 * @throws IOException Thrown if the temp files for spilling cannot be initialized.
 	 */
-	public BufferSpiller(IOManager ioManager, int pageSize) throws IOException {
+	public BufferSpiller(IOManager ioManager, int pageSize, int asyncLoadBufferCount) throws IOException {
 		this.pageSize = pageSize;
+		this.asyncLoadBufferCount = asyncLoadBufferCount;
 
-		this.readBuffer = ByteBuffer.allocateDirect(READ_BUFFER_SIZE);
-		this.readBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		this.readBufferPool = new ByteBuffer[asyncLoadBufferCount];
+		for (int i = 0; i < asyncLoadBufferCount; ++i) {
+			this.readBufferPool[i] = ByteBuffer.allocateDirect(READ_BUFFER_SIZE);
+			this.readBufferPool[i].order(ByteOrder.LITTLE_ENDIAN);
+		}
 
 		this.headBuffer = ByteBuffer.allocateDirect(16);
 		this.headBuffer.order(ByteOrder.LITTLE_ENDIAN);
 
+		this.ioManager = ioManager;
 		File[] tempDirs = ioManager.getSpillingDirectories();
 		this.tempDir = tempDirs[DIRECTORY_INDEX.getAndIncrement() % tempDirs.length];
 
@@ -137,9 +154,7 @@ public class BufferSpiller implements BufferBlocker {
 			}
 
 			headBuffer.clear();
-			headBuffer.putInt(boe.getChannelIndex());
-			headBuffer.putInt(contents.remaining());
-			headBuffer.put((byte) (boe.isBuffer() ? 0 : 1));
+			writeBufferOrEventMeta(headBuffer, boe.getChannelIndex(), contents.remaining(), (byte) (boe.isBuffer() ? 0 : 1));
 			headBuffer.flip();
 
 			bytesWritten += (headBuffer.remaining() + contents.remaining());
@@ -188,18 +203,21 @@ public class BufferSpiller implements BufferBlocker {
 			return null;
 		}
 
-		ByteBuffer buf;
+		ByteBuffer[] bufPool;
 		if (newBuffer) {
-			buf = ByteBuffer.allocateDirect(READ_BUFFER_SIZE);
-			buf.order(ByteOrder.LITTLE_ENDIAN);
+			bufPool = new ByteBuffer[asyncLoadBufferCount];
+			for (int i = 0; i < asyncLoadBufferCount; ++i) {
+				bufPool[i] = ByteBuffer.allocateDirect(READ_BUFFER_SIZE);
+				bufPool[i].order(ByteOrder.LITTLE_ENDIAN);
+			}
 		} else {
-			buf = readBuffer;
+			bufPool = readBufferPool;
 		}
 
 		// create a reader for the spilled data
 		currentChannel.position(0L);
 		SpilledBufferOrEventSequence seq =
-				new SpilledBufferOrEventSequence(currentSpillFile, currentChannel, buf, pageSize);
+				new SpilledBufferOrEventSequence(ioManager, currentSpillFile, currentChannel, bufPool, pageSize);
 
 		// create ourselves a new spill file
 		createSpillingChannel();
@@ -265,9 +283,6 @@ public class BufferSpiller implements BufferBlocker {
 	@Deprecated
 	public static class SpilledBufferOrEventSequence implements BufferOrEventSequence {
 
-		/** Header is "channel index" (4 bytes) + length (4 bytes) + buffer/event (1 byte). */
-		private static final int HEADER_LENGTH = 9;
-
 		/** The file containing the data. */
 		private final File file;
 
@@ -275,7 +290,7 @@ public class BufferSpiller implements BufferBlocker {
 		private final FileChannel fileChannel;
 
 		/** The byte buffer for bulk reading. */
-		private final ByteBuffer buffer;
+		private ByteBuffer buffer;
 
 		/** We store this size as a constant because it is crucial it never changes. */
 		private final long size;
@@ -286,21 +301,57 @@ public class BufferSpiller implements BufferBlocker {
 		/** Flag to track whether the sequence has been opened already. */
 		private boolean opened = false;
 
+		/** Buffer filer reader used to load the spilled data from file asynchronous. */
+		private AsynchronousBufferOrEventFileReader fileReader;
+
+		/** Buffers reused to asynchronous load the spilled data. */
+		private ByteBuffer[] bufferPool;
+
+		/** Queue used to contain buffers/Exception/EOF reading from the spilled file. */
+		private BlockingQueue<BufferOrException<IOException>> queue;
+
+		/** The index of bufferPool used to retrieve next BufferOrEvent. */
+		private int nextIndex;
+
+		/** The Exception when loading data from file. */
+		private volatile IOException lastException = null;
+
 		/**
 		 * Create a reader that reads a sequence of spilled buffers and events.
 		 *
 		 * @param file The file with the data.
 		 * @param fileChannel The file channel to read the data from.
-		 * @param buffer The buffer used for bulk reading.
+		 * @param bufferPool The buffer pool used for bulk reading.
 		 * @param pageSize The page size to use for the created memory segments.
 		 */
-		SpilledBufferOrEventSequence(File file, FileChannel fileChannel, ByteBuffer buffer, int pageSize)
+		SpilledBufferOrEventSequence(IOManager ioManager, File file, FileChannel fileChannel, ByteBuffer[] bufferPool, int pageSize)
 				throws IOException {
 			this.file = file;
 			this.fileChannel = fileChannel;
-			this.buffer = buffer;
+			this.bufferPool = bufferPool;
 			this.pageSize = pageSize;
+			// +1 for EOF.
+			this.queue = new LinkedBlockingQueue<>(bufferPool.length + 1);
 			this.size = fileChannel.size();
+			this.nextIndex = 0;
+			fileReader = (AsynchronousBufferOrEventFileReader) ioManager.createBufferOrEventFileReader(ioManager.createChannel(file), new RequestDoneCallback<Buffer>() {
+				@Override
+				public void requestSuccessful(Buffer request) {
+					if (request.getSize() > 0) {
+						queue.offer(new BufferOrException<>(request));
+					}
+					if (fileReader.hasReachedEndOfFile()) {
+						// add an eof into the queue.
+						queue.offer(new BufferOrException<>());
+					}
+				}
+
+				@Override
+				public void requestFailed(Buffer buffer, IOException e) {
+					queue.offer(new BufferOrException<>(e));
+					lastException = e;
+				}
+			});
 		}
 
 		/**
@@ -311,33 +362,37 @@ public class BufferSpiller implements BufferBlocker {
 		public void open() {
 			if (!opened) {
 				opened = true;
-				buffer.position(0);
-				buffer.limit(0);
+				for (int i = 0; i < bufferPool.length; ++i) {
+					if (!readOneBuffer(i)) {
+						break;
+					}
+				}
 			}
 		}
 
 		@Override
 		public BufferOrEvent getNext() throws IOException {
-			if (buffer.remaining() < HEADER_LENGTH) {
-				buffer.compact();
-
-				while (buffer.position() < HEADER_LENGTH) {
-					if (fileChannel.read(buffer) == -1) {
-						if (buffer.position() == 0) {
-							// no trailing data
-							return null;
-						} else {
-							throw new IOException("Found trailing incomplete buffer or event");
-						}
-					}
+			BufferOrException<IOException> bufferOrException;
+			try {
+				bufferOrException = queue.take();
+				if (bufferOrException.isEof()) {
+					return null;
 				}
 
-				buffer.flip();
+				if (bufferOrException.isException()) {
+					throw bufferOrException.getException();
+				}
+
+				buffer = bufferOrException.getBuffer().getNioBufferReadable();
+				buffer.order(ByteOrder.LITTLE_ENDIAN);
+			} catch (InterruptedException e) {
+				throw new IOException("Can not read the next buffer or event.");
 			}
 
 			final int channel = buffer.getInt();
 			final int length = buffer.getInt();
 			final boolean isBuffer = buffer.get() == 0;
+			buffer.limit(HEADER_SIZE + length);
 
 			if (isBuffer) {
 				// deserialize buffer
@@ -351,54 +406,26 @@ public class BufferSpiller implements BufferBlocker {
 				int segPos = 0;
 				int bytesRemaining = length;
 
-				while (true) {
+				//we know we always have enough content
+				while (bytesRemaining > 0) {
 					int toCopy = Math.min(buffer.remaining(), bytesRemaining);
-					if (toCopy > 0) {
-						seg.put(segPos, buffer, toCopy);
-						segPos += toCopy;
-						bytesRemaining -= toCopy;
-					}
-
-					if (bytesRemaining == 0) {
-						break;
-					}
-					else {
-						buffer.clear();
-						if (fileChannel.read(buffer) == -1) {
-							throw new IOException("Found trailing incomplete buffer");
-						}
-						buffer.flip();
-					}
+					seg.put(segPos, buffer, toCopy);
+					segPos += toCopy;
+					bytesRemaining -= toCopy;
 				}
 
 				Buffer buf = new NetworkBuffer(seg, FreeingBufferRecycler.INSTANCE);
 				buf.setSize(length);
 
+				readOneBuffer(nextIndex);
+				nextIndex = (nextIndex + 1) % bufferPool.length;
 				return new BufferOrEvent(buf, channel, true);
 			}
 			else {
 				// deserialize event
-				if (length > buffer.capacity() - HEADER_LENGTH) {
-					throw new IOException("Event is too large");
-				}
-
-				if (buffer.remaining() < length) {
-					buffer.compact();
-
-					while (buffer.position() < length) {
-						if (fileChannel.read(buffer) == -1) {
-							throw new IOException("Found trailing incomplete event");
-						}
-					}
-
-					buffer.flip();
-				}
-
-				int oldLimit = buffer.limit();
-				buffer.limit(buffer.position() + length);
 				AbstractEvent evt = EventSerializer.fromSerializedEvent(buffer, getClass().getClassLoader());
-				buffer.limit(oldLimit);
-
+				readOneBuffer(nextIndex);
+				nextIndex = (nextIndex + 1) % bufferPool.length;
 				return new BufferOrEvent(evt, channel, true, length);
 			}
 		}
@@ -414,6 +441,27 @@ public class BufferSpiller implements BufferBlocker {
 		@Override
 		public long size() {
 			return size;
+		}
+
+		private boolean readOneBuffer(int index) {
+			// reach the end of file, no need to add request.
+			if (fileReader.hasReachedEndOfFile()) {
+				return false;
+			}
+
+			// catch an exception previously, no need to add request.
+			if (lastException != null) {
+				return false;
+			}
+
+			try {
+				Buffer buffer = new NetworkBuffer(MemorySegmentFactory.wrapOffHeapMemory(bufferPool[index]), FreeingBufferRecycler.INSTANCE);
+				fileReader.readInto(buffer);
+			} catch (IOException e) {
+				lastException = e;
+				return false;
+			}
+			return true;
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -62,7 +62,7 @@ public class InputProcessorUtil {
 			} else {
 				barrierHandler = new BarrierBuffer(
 					inputGate,
-					new BufferSpiller(ioManager, inputGate.getPageSize()),
+					new BufferSpiller(ioManager, inputGate.getPageSize(), taskManagerConfig.getInteger(TaskManagerOptions.MEMORY_BUFFER_ASYNC_LOAD_COUNT)),
 					maxAlign,
 					taskName);
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
@@ -115,7 +115,7 @@ public class BarrierBufferAlignmentLimitTest {
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
 		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 1000, "Testing");
+		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize(), 2), 1000, "Testing");
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);
@@ -210,7 +210,7 @@ public class BarrierBufferAlignmentLimitTest {
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
 		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 500, "Testing");
+		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize(), 2), 500, "Testing");
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -62,7 +62,7 @@ public class BarrierBufferMassiveRandomTest {
 					new BufferPool[] { pool1, pool2 },
 					new BarrierGenerator[] { new CountBarrier(100000), new RandomBarrier(100000) });
 
-			BarrierBuffer barrierBuffer = new BarrierBuffer(myIG, new BufferSpiller(ioMan, myIG.getPageSize()));
+			BarrierBuffer barrierBuffer = new BarrierBuffer(myIG, new BufferSpiller(ioMan, myIG.getPageSize(), 2));
 
 			for (int i = 0; i < 2000000; i++) {
 				BufferOrEvent boe = barrierBuffer.pollNext().get();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BufferSpillerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BufferSpillerTest.java
@@ -60,7 +60,7 @@ public class BufferSpillerTest extends BufferBlockerTestBase {
 
 	@Before
 	public void createSpiller() throws IOException {
-		spiller = new BufferSpiller(ioManager, PAGE_SIZE);
+		spiller = new BufferSpiller(ioManager, PAGE_SIZE, 2);
 	}
 
 	@After

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/SpillingBarrierBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/SpillingBarrierBufferTest.java
@@ -65,7 +65,7 @@ public class SpillingBarrierBufferTest extends BarrierBufferTestBase {
 
 	@Override
 	public BarrierBuffer createBarrierBuffer(InputGate gate) throws IOException{
-		return new BarrierBuffer(gate, new BufferSpiller(ioManager, PAGE_SIZE));
+		return new BarrierBuffer(gate, new BufferSpiller(ioManager, PAGE_SIZE, 2));
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Currently it is non-blocking in case of credit-based flow control (default), however for SpilledBufferOrEventSequence it is blocking on reading from file. We might want to consider reimplementing it to be non blocking with CompletableFuture<?> isAvailable() method.

Otherwise we will block mailbox processing for the duration of reading from file - for example we will block processing time timers and potentially in the future network flushes.

## Brief change log

Use a ByteBuffer pool to read the BufferOrEvent asynchronous.
- the pool size if default 2, can be configurated by key `taskmanager.memory.async-load.buffer-count`
- will reuse the read thread in `IOManager`


## Verifying this change

This change is already covered by existing tests, such as:
- `SpilledBufferOrEventSequenceTest.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
