### PR TITLE
[hotfix][docs] fix invalid link in migration docs

### DIFF
--- a/docs/dev/migration.md
+++ b/docs/dev/migration.md
@@ -33,8 +33,7 @@ This would be relevant mostly for users implementing custom `TypeSerializer`s fo
 
 The old `TypeSerializerConfigSnapshot` abstraction is now deprecated, and will be fully removed in the future
 in favor of the new `TypeSerializerSnapshot`. For details and guides on how to migrate, please see
-[Migrating from deprecated serializer snapshot APIs before Flink 1.7]
-({{ site.baseurl }}/dev/stream/state/custom_serialization.html#migration-from-deprecated-serializer-snapshot-apis-before-Flink-1.7).
+[Migrating from deprecated serializer snapshot APIs before Flink 1.7]({{ site.baseurl }}/dev/stream/state/custom_serialization.html#migrating-from-deprecated-serializer-snapshot-apis-before-flink-17).
 
 ## Migrating from Flink 1.2 to Flink 1.3
 

--- a/docs/dev/migration.zh.md
+++ b/docs/dev/migration.zh.md
@@ -33,8 +33,7 @@ This would be relevant mostly for users implementing custom `TypeSerializer`s fo
 
 The old `TypeSerializerConfigSnapshot` abstraction is now deprecated, and will be fully removed in the future
 in favor of the new `TypeSerializerSnapshot`. For details and guides on how to migrate, please see
-[Migrating from deprecated serializer snapshot APIs before Flink 1.7]
-({{ site.baseurl }}/dev/stream/state/custom_serialization.html#migration-from-deprecated-serializer-snapshot-apis-before-Flink-1.7).
+[Migrating from deprecated serializer snapshot APIs before Flink 1.7]({{ site.baseurl }}/dev/stream/state/custom_serialization.html#migrating-from-deprecated-serializer-snapshot-apis-before-flink-17).
 
 ## Migrating from Flink 1.2 to Flink 1.3
 


### PR DESCRIPTION
## What is the purpose of the change

* Remove space in between link name and url which causes it to be rendered literally instead of being recognized as a hyperlink

* Fix had url path which was not caught by the `check-links` script due to above issue. 


## Brief change log

See above


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

