### PR TITLE
[FLINK-13006][hive] remove GenericUDTFReplicateRows from GenericUDTFTest because Hive 1.2.1 doesn't have it

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hive.ql.udf.generic.Collector;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTFInline;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTFPosExplode;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDTFReplicateRows;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTFStack;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -108,29 +107,6 @@ public class HiveGenericUDTFTest {
 		udf.eval("1,2,3,5");
 
 		assertEquals(Arrays.asList(Row.of("1"), Row.of("2"), Row.of("3"), Row.of("5")), collector.result);
-	}
-
-	@Test
-	public void testReplicateRows() throws Exception {
-		Object[] constantArgs = new Object[] {
-			2L,
-			null
-		};
-
-		DataType[] dataTypes = new DataType[] {
-			DataTypes.BIGINT(),
-			DataTypes.INT()
-		};
-
-		HiveGenericUDTF udf = init(
-			GenericUDTFReplicateRows.class,
-			constantArgs,
-			dataTypes
-		);
-
-		udf.eval(2L, 5);
-
-		assertEquals(Arrays.asList(Row.of(2L, 5), Row.of(2L, 5)), collector.result);
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

This PR removes GenericUDTFReplicateRows from HiveGenericUDTFTest because Hive 1.2.1 doesn't have it and thus the build profile for Hive 1.2.1 would fail.

I've added pretty a lot test coverage for HiveGenericUDTF, so removing just this one test should be fine.

## Brief change log

- remove GenericUDTFReplicateRows from GenericUDTFTest

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
