### PR TITLE
[FLINK-12852][network] Fix the deadlock occured when requesting exclusive buffers

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.ConfigGroup;
 import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.annotation.docs.Documentation;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -139,6 +140,18 @@ public class NettyShuffleEnvironmentOptions {
 				" The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can" +
 				" help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be" +
 				" increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.");
+
+	/**
+	 * The timeout for requesting exclusive buffers for each channel.
+	 */
+	@Documentation.ExcludeFromDocumentation("This option is purely implementation related, and may be removed as the implementation changes.")
+	public static final ConfigOption<Long> NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS =
+		key("taskmanager.network.memory.exclusive-buffers-request-timeout-ms")
+			.defaultValue(30000L)
+			.withDescription("The timeout for requesting exclusive buffers for each channel. Since the number of maximum buffers and " +
+					"the number of required buffers is not the same for local buffer pools, there may be deadlock cases that the upstream" +
+					"tasks have occupied all the buffers and the downstream tasks are waiting for the exclusive buffers. The timeout breaks" +
+					"the tie by failing the request of exclusive buffers and ask users to increase the number of total buffers.");
 
 	// ------------------------------------------------------------------------
 	//  Netty Options

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -92,7 +92,8 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
 			config.numNetworkBuffers(),
 			config.networkBufferSize(),
-			config.networkBuffersPerChannel());
+			config.networkBuffersPerChannel(),
+			config.getRequestSegmentsTimeout());
 
 		registerShuffleMetrics(metricGroup, networkBufferPool);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.core.memory.MemorySegment;
@@ -78,6 +79,7 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 
 	private final Duration requestSegmentsTimeout;
 
+	@VisibleForTesting
 	public NetworkBufferPool(int numberOfSegmentsToAllocate, int segmentSize, int numberOfSegmentsToRequest) {
 		this(numberOfSegmentsToAllocate, segmentSize, numberOfSegmentsToRequest, Duration.ofMillis(Integer.MAX_VALUE));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -192,7 +192,7 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 		final List<MemorySegment> segments = new ArrayList<>(numberOfSegmentsToRequest);
 		try {
 			long startTimeInNanos = System.nanoTime();
-			while (segments.size() < numberOfSegmentsToRequest) {
+			while (true) {
 				if (isDestroyed) {
 					throw new IllegalStateException("Buffer pool is destroyed.");
 				}
@@ -202,8 +202,11 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 					segments.add(segment);
 				}
 
-				if ((System.nanoTime() - startTimeInNanos) / 1_000_000 >= requestSegmentsTimeoutInMillis &&
-						segments.size() < numberOfSegmentsToRequest) {
+				if (segments.size() >= numberOfSegmentsToRequest) {
+					break;
+				}
+
+				if ((System.nanoTime() - startTimeInNanos) / 1_000_000 >= requestSegmentsTimeoutInMillis) {
 					throw new IOException(String.format("Insufficient number of network buffers: " +
 									"requesting exclusive buffers timeout. The total number of network " +
 									"buffers is currently set to %d of %d bytes each. You can increase this " +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Arrays;
 
 /**
@@ -59,7 +60,7 @@ public class NettyShuffleEnvironmentConfiguration {
 	/** Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). */
 	private final int floatingNetworkBuffersPerGate;
 
-	private final long requestSegmentsTimeoutInMillis;
+	private final Duration requestSegmentsTimeout;
 
 	private final boolean isCreditBased;
 
@@ -76,7 +77,7 @@ public class NettyShuffleEnvironmentConfiguration {
 			int partitionRequestMaxBackoff,
 			int networkBuffersPerChannel,
 			int floatingNetworkBuffersPerGate,
-			long requestSegmentsTimeoutInMillis,
+			Duration requestSegmentsTimeout,
 			boolean isCreditBased,
 			boolean isNetworkDetailedMetrics,
 			@Nullable NettyConfig nettyConfig,
@@ -88,7 +89,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		this.partitionRequestMaxBackoff = partitionRequestMaxBackoff;
 		this.networkBuffersPerChannel = networkBuffersPerChannel;
 		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
-		this.requestSegmentsTimeoutInMillis = requestSegmentsTimeoutInMillis;
+		this.requestSegmentsTimeout = Preconditions.checkNotNull(requestSegmentsTimeout);
 		this.isCreditBased = isCreditBased;
 		this.isNetworkDetailedMetrics = isNetworkDetailedMetrics;
 		this.nettyConfig = nettyConfig;
@@ -121,8 +122,8 @@ public class NettyShuffleEnvironmentConfiguration {
 		return floatingNetworkBuffersPerGate;
 	}
 
-	public long getRequestSegmentsTimeoutInMillis() {
-		return requestSegmentsTimeoutInMillis;
+	public Duration getRequestSegmentsTimeout() {
+		return requestSegmentsTimeout;
 	}
 
 	public NettyConfig nettyConfig() {
@@ -179,8 +180,8 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		String[] tempDirs = ConfigurationUtils.parseTempDirectories(configuration);
 
-		long requestSegmentsTimeoutInMillis = configuration.getLong(
-				NettyShuffleEnvironmentOptions.NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS);
+		Duration requestSegmentsTimeout = Duration.ofMillis(configuration.getLong(
+				NettyShuffleEnvironmentOptions.NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS));
 
 		return new NettyShuffleEnvironmentConfiguration(
 			numberOfNetworkBuffers,
@@ -189,7 +190,7 @@ public class NettyShuffleEnvironmentConfiguration {
 			maxRequestBackoff,
 			buffersPerChannel,
 			extraBuffersPerGate,
-			requestSegmentsTimeoutInMillis,
+			requestSegmentsTimeout,
 			isCreditBased,
 			isNetworkDetailedMetrics,
 			nettyConfig,
@@ -491,7 +492,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		result = 31 * result + partitionRequestMaxBackoff;
 		result = 31 * result + networkBuffersPerChannel;
 		result = 31 * result + floatingNetworkBuffersPerGate;
-		result = 31 * result + (int) requestSegmentsTimeoutInMillis;
+		result = 31 * result + requestSegmentsTimeout.hashCode();
 		result = 31 * result + (isCreditBased ? 1 : 0);
 		result = 31 * result + (nettyConfig != null ? nettyConfig.hashCode() : 0);
 		result = 31 * result + Arrays.hashCode(tempDirs);
@@ -515,7 +516,7 @@ public class NettyShuffleEnvironmentConfiguration {
 					this.partitionRequestMaxBackoff == that.partitionRequestMaxBackoff &&
 					this.networkBuffersPerChannel == that.networkBuffersPerChannel &&
 					this.floatingNetworkBuffersPerGate == that.floatingNetworkBuffersPerGate &&
-					this.requestSegmentsTimeoutInMillis == that.requestSegmentsTimeoutInMillis &&
+					this.requestSegmentsTimeout.equals(that.requestSegmentsTimeout) &&
 					this.isCreditBased == that.isCreditBased &&
 					(nettyConfig != null ? nettyConfig.equals(that.nettyConfig) : that.nettyConfig == null) &&
 					Arrays.equals(this.tempDirs, that.tempDirs);
@@ -531,7 +532,7 @@ public class NettyShuffleEnvironmentConfiguration {
 				", partitionRequestMaxBackoff=" + partitionRequestMaxBackoff +
 				", networkBuffersPerChannel=" + networkBuffersPerChannel +
 				", floatingNetworkBuffersPerGate=" + floatingNetworkBuffersPerGate +
-				", requestSegmentsTimeoutInMillis=" + requestSegmentsTimeoutInMillis +
+				", requestSegmentsTimeout=" + requestSegmentsTimeout +
 				", isCreditBased=" + isCreditBased +
 				", nettyConfig=" + nettyConfig +
 				", tempDirs=" + Arrays.toString(tempDirs) +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -59,6 +59,8 @@ public class NettyShuffleEnvironmentConfiguration {
 	/** Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). */
 	private final int floatingNetworkBuffersPerGate;
 
+	private final long requestSegmentsTimeoutInMillis;
+
 	private final boolean isCreditBased;
 
 	private final boolean isNetworkDetailedMetrics;
@@ -74,6 +76,7 @@ public class NettyShuffleEnvironmentConfiguration {
 			int partitionRequestMaxBackoff,
 			int networkBuffersPerChannel,
 			int floatingNetworkBuffersPerGate,
+			long requestSegmentsTimeoutInMillis,
 			boolean isCreditBased,
 			boolean isNetworkDetailedMetrics,
 			@Nullable NettyConfig nettyConfig,
@@ -85,6 +88,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		this.partitionRequestMaxBackoff = partitionRequestMaxBackoff;
 		this.networkBuffersPerChannel = networkBuffersPerChannel;
 		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
+		this.requestSegmentsTimeoutInMillis = requestSegmentsTimeoutInMillis;
 		this.isCreditBased = isCreditBased;
 		this.isNetworkDetailedMetrics = isNetworkDetailedMetrics;
 		this.nettyConfig = nettyConfig;
@@ -115,6 +119,10 @@ public class NettyShuffleEnvironmentConfiguration {
 
 	public int floatingNetworkBuffersPerGate() {
 		return floatingNetworkBuffersPerGate;
+	}
+
+	public long getRequestSegmentsTimeoutInMillis() {
+		return requestSegmentsTimeoutInMillis;
 	}
 
 	public NettyConfig nettyConfig() {
@@ -171,6 +179,9 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		String[] tempDirs = ConfigurationUtils.parseTempDirectories(configuration);
 
+		long requestSegmentsTimeoutInMillis = configuration.getLong(
+				NettyShuffleEnvironmentOptions.NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS);
+
 		return new NettyShuffleEnvironmentConfiguration(
 			numberOfNetworkBuffers,
 			pageSize,
@@ -178,6 +189,7 @@ public class NettyShuffleEnvironmentConfiguration {
 			maxRequestBackoff,
 			buffersPerChannel,
 			extraBuffersPerGate,
+			requestSegmentsTimeoutInMillis,
 			isCreditBased,
 			isNetworkDetailedMetrics,
 			nettyConfig,
@@ -479,6 +491,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		result = 31 * result + partitionRequestMaxBackoff;
 		result = 31 * result + networkBuffersPerChannel;
 		result = 31 * result + floatingNetworkBuffersPerGate;
+		result = 31 * result + (int) requestSegmentsTimeoutInMillis;
 		result = 31 * result + (isCreditBased ? 1 : 0);
 		result = 31 * result + (nettyConfig != null ? nettyConfig.hashCode() : 0);
 		result = 31 * result + Arrays.hashCode(tempDirs);
@@ -502,6 +515,7 @@ public class NettyShuffleEnvironmentConfiguration {
 					this.partitionRequestMaxBackoff == that.partitionRequestMaxBackoff &&
 					this.networkBuffersPerChannel == that.networkBuffersPerChannel &&
 					this.floatingNetworkBuffersPerGate == that.floatingNetworkBuffersPerGate &&
+					this.requestSegmentsTimeoutInMillis == that.requestSegmentsTimeoutInMillis &&
 					this.isCreditBased == that.isCreditBased &&
 					(nettyConfig != null ? nettyConfig.equals(that.nettyConfig) : that.nettyConfig == null) &&
 					Arrays.equals(this.tempDirs, that.tempDirs);
@@ -517,6 +531,7 @@ public class NettyShuffleEnvironmentConfiguration {
 				", partitionRequestMaxBackoff=" + partitionRequestMaxBackoff +
 				", networkBuffersPerChannel=" + networkBuffersPerChannel +
 				", floatingNetworkBuffersPerGate=" + floatingNetworkBuffersPerGate +
+				", requestSegmentsTimeoutInMillis=" + requestSegmentsTimeoutInMillis +
 				", isCreditBased=" + isCreditBased +
 				", nettyConfig=" + nettyConfig +
 				", tempDirs=" + Arrays.toString(tempDirs) +

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -46,6 +46,8 @@ public class NettyShuffleEnvironmentBuilder {
 
 	private int floatingNetworkBuffersPerGate = 8;
 
+	private long requestSegmentsTimeoutInMillis = 30000L;
+
 	private boolean isCreditBased = true;
 
 	private boolean isNetworkDetailedMetrics = false;
@@ -95,6 +97,10 @@ public class NettyShuffleEnvironmentBuilder {
 		return this;
 	}
 
+	public void setRequestSegmentsTimeoutInMillis(long requestSegmentsTimeoutInMillis) {
+		this.requestSegmentsTimeoutInMillis = requestSegmentsTimeoutInMillis;
+	}
+
 	public NettyShuffleEnvironmentBuilder setIsCreditBased(boolean isCreditBased) {
 		this.isCreditBased = isCreditBased;
 		return this;
@@ -129,6 +135,7 @@ public class NettyShuffleEnvironmentBuilder {
 				partitionRequestMaxBackoff,
 				networkBuffersPerChannel,
 				floatingNetworkBuffersPerGate,
+				requestSegmentsTimeoutInMillis,
 				isCreditBased,
 				isNetworkDetailedMetrics,
 				nettyConfig,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import java.time.Duration;
+
 /**
  * Builder for the {@link NettyShuffleEnvironment}.
  */
@@ -46,7 +48,7 @@ public class NettyShuffleEnvironmentBuilder {
 
 	private int floatingNetworkBuffersPerGate = 8;
 
-	private long requestSegmentsTimeoutInMillis = 30000L;
+	private Duration requestSegmentsTimeout = Duration.ofMillis(30000L);
 
 	private boolean isCreditBased = true;
 
@@ -97,8 +99,8 @@ public class NettyShuffleEnvironmentBuilder {
 		return this;
 	}
 
-	public void setRequestSegmentsTimeoutInMillis(long requestSegmentsTimeoutInMillis) {
-		this.requestSegmentsTimeoutInMillis = requestSegmentsTimeoutInMillis;
+	public void setRequestSegmentsTimeout(Duration requestSegmentsTimeout) {
+		this.requestSegmentsTimeout = requestSegmentsTimeout;
 	}
 
 	public NettyShuffleEnvironmentBuilder setIsCreditBased(boolean isCreditBased) {
@@ -135,7 +137,7 @@ public class NettyShuffleEnvironmentBuilder {
 				partitionRequestMaxBackoff,
 				networkBuffersPerChannel,
 				floatingNetworkBuffersPerGate,
-				requestSegmentsTimeoutInMillis,
+				requestSegmentsTimeout,
 				isCreditBased,
 				isNetworkDetailedMetrics,
 				nettyConfig,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -510,7 +510,7 @@ public class NetworkBufferPoolTest extends TestLogger {
 		asyncRequest.start();
 
 		expectedException.expect(IOException.class);
-		expectedException.expectMessage("Insufficient");
+		expectedException.expectMessage("Timeout");
 
 		try {
 			asyncRequest.sync();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -485,7 +485,7 @@ public class NetworkBufferPoolTest extends TestLogger {
 	public void testRequestMemorySegmentsTimeout() throws Exception {
 		final int numBuffers = 10;
 		final int numberOfSegmentsToRequest = 2;
-		final long requestSegmentsTimeoutInMillis = 1000L;
+		final long requestSegmentsTimeoutInMillis = 50L;
 
 		NetworkBufferPool globalPool = new NetworkBufferPool(
 				numBuffers,
@@ -509,12 +509,12 @@ public class NetworkBufferPoolTest extends TestLogger {
 
 		asyncRequest.start();
 
+		expectedException.expect(IOException.class);
+		expectedException.expectMessage("Insufficient");
+
 		try {
-			asyncRequest.trySync(requestSegmentsTimeoutInMillis * 10);
-			fail("Requesting exclusive buffer does not timeout and throw exception as expected.");
-		} catch (IOException ignored) {
-			// Expected exception
-		}  finally {
+			asyncRequest.sync();
+		} finally {
 			globalPool.destroy();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -485,13 +486,13 @@ public class NetworkBufferPoolTest extends TestLogger {
 	public void testRequestMemorySegmentsTimeout() throws Exception {
 		final int numBuffers = 10;
 		final int numberOfSegmentsToRequest = 2;
-		final long requestSegmentsTimeoutInMillis = 50L;
+		final Duration requestSegmentsTimeout = Duration.ofMillis(50L);
 
 		NetworkBufferPool globalPool = new NetworkBufferPool(
 				numBuffers,
 				128,
 				numberOfSegmentsToRequest,
-				requestSegmentsTimeoutInMillis);
+				requestSegmentsTimeout);
 
 		BufferPool localBufferPool = globalPool.createBufferPool(0, numBuffers);
 		for (int i = 0; i < numBuffers; ++i) {


### PR DESCRIPTION
## What is the purpose of the change

This pull request tries to fix the deadlock problem during requesting exclusive buffers. Since currently the number of maximum buffers and the number of required buffers are not the same for local buffer pools, there may be cases that the local buffer pools of the upstream tasks occupy all the buffers while the downstream tasks fail to acquire exclusive buffers to make progress. Although this problem can be fixed by increasing the number of total buffers, the deadlock may not be acceptable. Therefore, this PR tries to failover the current execution when the deadlock occurs and tips users to increase the number of buffers in the exceptional message.

## Brief change log

The main changes include

1. Add an option for the timeout of `requestMemorySegment` for each channel. The default timeout is 30s. This option is marked as undocumented since it may be removed within the future implementation.
2. Transfer the timeout to `NetworkBufferPool`.
3. `requestMemorySegments` will throw `IOException("Insufficient buffer")`  if not all segments acquired after timeout.

## Verifying this change

1. Added test that validates `requestMemorySegments` end exceptionally if not all segments acquired after timeout.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
