### PR TITLE
[FLINK-13036] [elasticsearch] ActionRequestFailureHandler can access RuntimeContext

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.RuntimeContext;
 
 import org.elasticsearch.action.ActionRequest;
 
@@ -74,4 +75,21 @@ public interface ActionRequestFailureHandler extends Serializable {
 	 */
 	void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable;
 
+	/**
+	 * Handle a failed {@link ActionRequest}.
+	 * We could access accumulator via runtimeContext to count the exceptions in order to throw or ignore them.
+	 * Avoid new interface method or different parameters method break previous users' implements.
+	 *
+	 * @param action the {@link ActionRequest} that failed due to the failure
+	 * @param failure the cause of failure
+	 * @param restStatusCode the REST status code of the failure (-1 if none can be retrieved)
+	 * @param indexer request indexer to re-add the failed action, if intended to do so
+	 * @param runtimeContext the task's runtime context
+	 *
+	 * @throws Throwable if the sink should fail on this failure, the implementation should rethrow
+	 *                   the exception or a custom one
+	 */
+	default void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer, RuntimeContext runtimeContext) throws Throwable{
+		onFailure(action, failure, restStatusCode, indexer);
+	}
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -407,9 +407,9 @@ public abstract class ElasticsearchSinkBase<T, C extends AutoCloseable> extends 
 
 							restStatus = itemResponse.getFailure().getStatus();
 							if (restStatus == null) {
-								failureHandler.onFailure(request.requests().get(i), failure, -1, failureRequestIndexer);
+								failureHandler.onFailure(request.requests().get(i), failure, -1, failureRequestIndexer, getRuntimeContext());
 							} else {
-								failureHandler.onFailure(request.requests().get(i), failure, restStatus.getStatus(), failureRequestIndexer);
+								failureHandler.onFailure(request.requests().get(i), failure, restStatus.getStatus(), failureRequestIndexer, getRuntimeContext());
 							}
 						}
 					}
@@ -431,7 +431,7 @@ public abstract class ElasticsearchSinkBase<T, C extends AutoCloseable> extends 
 
 			try {
 				for (ActionRequest action : request.requests()) {
-					failureHandler.onFailure(action, failure, -1, failureRequestIndexer);
+					failureHandler.onFailure(action, failure, -1, failureRequestIndexer, getRuntimeContext());
 				}
 			} catch (Throwable t) {
 				// fail the sink and skip the rest of the items


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes RuntimeContext is accessable for ActionRequestFailureHandler.
We can count exceptions via accumulator in ActionRequestFailureHandler instead of log, ignore them only.
By the way we can check message count end-to-end consistency.


## Brief change log



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)