### PR TITLE
 [FLINK-13029][table-planner] Removed usages of ExpressionBridge in QueryOperation's factories

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -200,7 +201,7 @@ public final class LegacyTypeInfoDataTypeConverter {
 			return Types.STRING;
 		}
 
-		else if (canConvertToTimestampLenient(logicalType)) {
+		else if (canConvertToTimestampTypeInfoLenient(dataType)) {
 			return Types.SQL_TIMESTAMP;
 		}
 
@@ -238,8 +239,11 @@ public final class LegacyTypeInfoDataTypeConverter {
 				dataType.getConversionClass().getName()));
 	}
 
-	private static boolean canConvertToTimestampLenient(LogicalType logicalType) {
-		return hasRoot(logicalType, LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) && LogicalTypeChecks.getPrecision(logicalType) <= 3;
+	private static boolean canConvertToTimestampTypeInfoLenient(DataType dataType) {
+		LogicalType logicalType = dataType.getLogicalType();
+		return hasRoot(logicalType, LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) &&
+			dataType.getConversionClass() != LocalDateTime.class &&
+			LogicalTypeChecks.getPrecision(logicalType) <= 3;
 	}
 
 	private static DataType createLegacyType(LogicalTypeRoot typeRoot, TypeInformation<?> typeInfo) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
@@ -503,10 +503,6 @@ public final class AggregateOperationFactory {
 			} else if (logicalType.getTypeRoot() == LogicalTypeRoot.ANY) {
 				// we don't know anything about the ANY type, we don't know if it is comparable and hashable.
 				return false;
-			} else if (logicalType instanceof StructuredType) {
-				StructuredType.StructuredComparision comparision = ((StructuredType) logicalType).getComparision();
-				return comparision == StructuredType.StructuredComparision.FULL ||
-					comparision == StructuredType.StructuredComparision.EQUALS;
 			}
 
 			return true;
@@ -519,6 +515,12 @@ public final class AggregateOperationFactory {
 
 		@Override
 		public Boolean visit(FieldsDataType fieldsDataType) {
+			LogicalType logicalType = fieldsDataType.getLogicalType();
+			if (logicalType instanceof StructuredType) {
+				StructuredType.StructuredComparision comparision = ((StructuredType) logicalType).getComparision();
+				return comparision == StructuredType.StructuredComparision.FULL ||
+					comparision == StructuredType.StructuredComparision.EQUALS;
+			}
 			return fieldsDataType.getFieldDataTypes().values().stream().allMatch(t -> t.accept(this));
 		}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
@@ -31,14 +31,12 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.TumbleWithSizeOnTimeWithAlias;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.expressions.AggFunctionCall;
+import org.apache.flink.table.expressions.ApiExpressionUtils;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
-import org.apache.flink.table.expressions.ExpressionBridge;
 import org.apache.flink.table.expressions.ExpressionResolver;
 import org.apache.flink.table.expressions.ExpressionUtils;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
-import org.apache.flink.table.expressions.PlannerExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.ResolvedExpressionDefaultVisitor;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
@@ -46,11 +44,11 @@ import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionRequirement;
-import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableAggregateFunctionDefinition;
 import org.apache.flink.table.operations.WindowAggregateQueryOperation.ResolvedGroupWindow;
 import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.DataTypeVisitor;
 import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.table.types.KeyValueDataType;
@@ -58,6 +56,8 @@ import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.typeutils.FieldInfoUtils;
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo;
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
@@ -65,13 +65,11 @@ import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
-import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.LONG_TYPE_INFO;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.isFunctionOfKind;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AS;
 import static org.apache.flink.table.functions.FunctionKind.AGGREGATE;
@@ -93,14 +91,12 @@ import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isTim
 public final class AggregateOperationFactory {
 
 	private final boolean isStreaming;
-	private final ExpressionBridge<PlannerExpression> expressionBridge;
 	private final NoNestedAggregates noNestedAggregates = new NoNestedAggregates();
 	private final ValidateDistinct validateDistinct = new ValidateDistinct();
 	private final AggregationExpressionValidator aggregationsValidator = new AggregationExpressionValidator();
 	private final IsKeyTypeChecker isKeyTypeChecker = new IsKeyTypeChecker();
 
-	public AggregateOperationFactory(ExpressionBridge<PlannerExpression> expressionBridge, boolean isStreaming) {
-		this.expressionBridge = expressionBridge;
+	public AggregateOperationFactory(boolean isStreaming) {
 		this.isStreaming = isStreaming;
 	}
 
@@ -119,13 +115,10 @@ public final class AggregateOperationFactory {
 		validateGroupings(groupings);
 		validateAggregates(aggregates);
 
-		List<PlannerExpression> convertedGroupings = bridge(groupings);
-		List<PlannerExpression> convertedAggregates = bridge(aggregates);
-
-		TypeInformation[] fieldTypes = Stream.concat(
-			convertedGroupings.stream().map(PlannerExpression::resultType),
-			convertedAggregates.stream().flatMap(this::extractAggregateResultTypes)
-		).toArray(TypeInformation[]::new);
+		DataType[] fieldTypes = Stream.concat(
+			groupings.stream().map(ResolvedExpression::getOutputDataType),
+			aggregates.stream().flatMap(this::extractAggregateResultTypes)
+		).toArray(DataType[]::new);
 
 		String[] groupNames = groupings.stream()
 			.map(expr -> extractName(expr).orElseGet(expr::toString)).toArray(String[]::new);
@@ -134,7 +127,7 @@ public final class AggregateOperationFactory {
 			aggregates.stream().flatMap(p -> extractAggregateNames(p, Arrays.asList(groupNames)))
 		).toArray(String[]::new);
 
-		TableSchema tableSchema = new TableSchema(fieldNames, fieldTypes);
+		TableSchema tableSchema = TableSchema.builder().fields(fieldNames, fieldTypes).build();
 
 		return new AggregateQueryOperation(groupings, aggregates, child, tableSchema);
 	}
@@ -159,15 +152,11 @@ public final class AggregateOperationFactory {
 		validateAggregates(aggregates);
 		validateWindowProperties(windowProperties, window);
 
-		List<PlannerExpression> convertedGroupings = bridge(groupings);
-		List<PlannerExpression> convertedAggregates = bridge(aggregates);
-		List<PlannerExpression> convertedWindowProperties = bridge(windowProperties);
-
-		TypeInformation[] fieldTypes = concat(
-			convertedGroupings.stream().map(PlannerExpression::resultType),
-			convertedAggregates.stream().flatMap(this::extractAggregateResultTypes),
-			convertedWindowProperties.stream().map(PlannerExpression::resultType)
-		).toArray(TypeInformation[]::new);
+		DataType[] fieldTypes = concat(
+			groupings.stream().map(ResolvedExpression::getOutputDataType),
+			aggregates.stream().flatMap(this::extractAggregateResultTypes),
+			windowProperties.stream().map(ResolvedExpression::getOutputDataType)
+		).toArray(DataType[]::new);
 
 		String[] groupNames = groupings.stream()
 			.map(expr -> extractName(expr).orElseGet(expr::toString)).toArray(String[]::new);
@@ -177,7 +166,7 @@ public final class AggregateOperationFactory {
 			windowProperties.stream().map(expr -> extractName(expr).orElseGet(expr::toString))
 		).toArray(String[]::new);
 
-		TableSchema tableSchema = new TableSchema(fieldNames, fieldTypes);
+		TableSchema tableSchema = TableSchema.builder().fields(fieldNames, fieldTypes).build();
 
 		return new WindowAggregateQueryOperation(
 			groupings,
@@ -192,12 +181,13 @@ public final class AggregateOperationFactory {
 	 * Extract result types for the aggregate or the table aggregate expression. For a table aggregate,
 	 * it may return multi result types when the composite return type is flattened.
 	 */
-	private Stream<TypeInformation<?>> extractAggregateResultTypes(PlannerExpression plannerExpression) {
-		if ((plannerExpression instanceof AggFunctionCall) &&
-			(((AggFunctionCall) plannerExpression).aggregateFunction() instanceof TableAggregateFunction)) {
-			return Stream.of(FieldInfoUtils.getFieldTypes(plannerExpression.resultType()));
+	private Stream<DataType> extractAggregateResultTypes(ResolvedExpression expression) {
+		if (ApiExpressionUtils.isFunctionOfKind(expression, TABLE_AGGREGATE)) {
+			TypeInformation<?> legacyInfo = TypeConversions.fromDataTypeToLegacyInfo(expression.getOutputDataType());
+			return Stream.of(FieldInfoUtils.getFieldTypes(legacyInfo))
+				.map(TypeConversions::fromLegacyInfoToDataType);
 		} else {
-			return Stream.of(plannerExpression.resultType());
+			return Stream.of(expression.getOutputDataType());
 		}
 	}
 
@@ -400,8 +390,8 @@ public final class AggregateOperationFactory {
 	private void validateWindowProperties(List<ResolvedExpression> windowProperties, ResolvedGroupWindow window) {
 		if (!windowProperties.isEmpty()) {
 			if (window.getType() == TUMBLE || window.getType() == SLIDE) {
-				TypeInformation<?> resultType = window.getSize().map(expressionBridge::bridge).get().resultType();
-				if (resultType == LONG_TYPE_INFO) {
+				DataType windowType = window.getSize().get().getOutputDataType();
+				if (LogicalTypeChecks.hasRoot(windowType.getLogicalType(), BIGINT)) {
 					throw new ValidationException(String.format("Window start and Window end cannot be selected " +
 						"for a row-count %s window.", window.getType().toString().toLowerCase()));
 				}
@@ -412,12 +402,6 @@ public final class AggregateOperationFactory {
 	private static <T> Stream<T> concat(Stream<T> first, Stream<T> second, Stream<T> third) {
 		Stream<T> firstConcat = Stream.concat(first, second);
 		return Stream.concat(firstConcat, third);
-	}
-
-	private List<PlannerExpression> bridge(List<ResolvedExpression> aggregates) {
-		return aggregates.stream()
-			.map(expressionBridge::bridge)
-			.collect(Collectors.toList());
 	}
 
 	private void validateGroupings(List<ResolvedExpression> groupings) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/JoinOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/JoinOperationFactory.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.expressions.ResolvedExpressionDefaultVisitor;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.operations.JoinQueryOperation.JoinType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
@@ -94,7 +95,8 @@ public class JoinOperationFactory {
 
 	private void verifyConditionType(ResolvedExpression condition) {
 		DataType conditionType = condition.getOutputDataType();
-		if (!LogicalTypeChecks.hasRoot(conditionType.getLogicalType(), LogicalTypeRoot.BOOLEAN)) {
+		LogicalType logicalType = conditionType.getLogicalType();
+		if (!LogicalTypeChecks.hasRoot(logicalType, LogicalTypeRoot.BOOLEAN)) {
 			throw new ValidationException(String.format("Filter operator requires a boolean expression as input, " +
 				"but %s is of type %s", condition, conditionType));
 		}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/OperationTreeBuilderFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/OperationTreeBuilderFactory.java
@@ -20,9 +20,6 @@ package org.apache.flink.table.operations;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.FunctionLookup;
-import org.apache.flink.table.expressions.ExpressionBridge;
-import org.apache.flink.table.expressions.PlannerExpression;
-import org.apache.flink.table.expressions.PlannerExpressionConverter$;
 import org.apache.flink.table.expressions.lookups.TableReferenceLookup;
 
 /**
@@ -35,12 +32,8 @@ public final class OperationTreeBuilderFactory {
 	public static OperationTreeBuilder create(
 			TableReferenceLookup tableReferenceLookup,
 			FunctionLookup functionLookup) {
-		ExpressionBridge<PlannerExpression> expressionBridge = new ExpressionBridge<>(
-			functionLookup,
-			PlannerExpressionConverter$.MODULE$.INSTANCE());
 		return new OperationTreeBuilderImpl(
 			tableReferenceLookup,
-			expressionBridge,
 			functionLookup,
 			true
 		);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/ProjectionOperationFactory.java
@@ -19,23 +19,21 @@
 package org.apache.flink.table.operations;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
-import org.apache.flink.table.expressions.ExpressionBridge;
 import org.apache.flink.table.expressions.ExpressionResolver;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.LocalReferenceExpression;
-import org.apache.flink.table.expressions.PlannerExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.ResolvedExpressionDefaultVisitor;
 import org.apache.flink.table.expressions.TableReferenceExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.LinkedHashSet;
@@ -63,12 +61,6 @@ public final class ProjectionOperationFactory {
 	private final StripAliases stripAliases = new StripAliases();
 	private int currentFieldIndex = 0;
 
-	private final ExpressionBridge<PlannerExpression> expressionBridge;
-
-	public ProjectionOperationFactory(ExpressionBridge<PlannerExpression> expressionBridge) {
-		this.expressionBridge = expressionBridge;
-	}
-
 	public QueryOperation create(
 			List<ResolvedExpression> projectList,
 			QueryOperation child,
@@ -89,12 +81,11 @@ public final class ProjectionOperationFactory {
 				.collect(Collectors.toList());
 		}
 
-		TypeInformation[] fieldTypes = namedExpressions.stream()
-			.map(expressionBridge::bridge)
-			.map(PlannerExpression::resultType)
-			.toArray(TypeInformation[]::new);
+		DataType[] fieldTypes = namedExpressions.stream()
+			.map(ResolvedExpression::getOutputDataType)
+			.toArray(DataType[]::new);
 
-		TableSchema tableSchema = new TableSchema(fieldNames, fieldTypes);
+		TableSchema tableSchema = TableSchema.builder().fields(fieldNames, fieldTypes).build();
 
 		return new ProjectQueryOperation(finalExpression, child, tableSchema);
 	}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -75,7 +75,6 @@ abstract class TableEnvImpl(
 
   private[flink] val operationTreeBuilder = new OperationTreeBuilderImpl(
     tableLookup,
-    expressionBridge,
     functionCatalog,
     !isBatch)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions._
 import org.apache.flink.table.expressions.{E => PlannerE, UUID => PlannerUUID}
 import org.apache.flink.table.functions._
+import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot.{CHAR, DECIMAL, SYMBOL, TIMESTAMP_WITHOUT_TIME_ZONE}
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks._
 import org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo
@@ -695,7 +696,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
       return SymbolPlannerExpression(plannerSymbol)
     }
 
-    val typeInfo = getLiteralTypeInfo(literal)
+    val typeInfo = fromDataTypeToLegacyInfo(literal.getOutputDataType)
     if (literal.isNull) {
       Null(typeInfo)
     } else {
@@ -703,41 +704,6 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
         literal.getValueAs(typeInfo.getTypeClass).get(),
         typeInfo)
     }
-  }
-
-  /**
-    * This method makes the planner more lenient for new data types defined for literals.
-    */
-  private def getLiteralTypeInfo(literal: ValueLiteralExpression): TypeInformation[_] = {
-    val logicalType = literal.getOutputDataType.getLogicalType
-
-    if (hasRoot(logicalType, DECIMAL)) {
-      if (literal.isNull) {
-        return Types.BIG_DEC
-      }
-      val value = literal.getValueAs(classOf[java.math.BigDecimal]).get()
-      if (hasPrecision(logicalType, value.precision()) && hasScale(logicalType, value.scale())) {
-        return Types.BIG_DEC
-      }
-    }
-
-    else if (hasRoot(logicalType, CHAR)) {
-      if (literal.isNull) {
-        return Types.STRING
-      }
-      val value = literal.getValueAs(classOf[java.lang.String]).get()
-      if (hasLength(logicalType, value.length)) {
-        return Types.STRING
-      }
-    }
-
-    else if (hasRoot(logicalType, TIMESTAMP_WITHOUT_TIME_ZONE)) {
-      if (getPrecision(logicalType) <= 3) {
-        return Types.SQL_TIMESTAMP
-      }
-    }
-
-    fromDataTypeToLegacyInfo(literal.getOutputDataType)
   }
 
   private def getSymbol(symbol: TableSymbol): PlannerSymbol = symbol match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -18,13 +18,11 @@
 
 package org.apache.flink.table.expressions
 
-import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
 import org.apache.flink.table.api.{TableException, ValidationException}
-import org.apache.flink.table.functions.BuiltInFunctionDefinitions._
 import org.apache.flink.table.expressions.{E => PlannerE, UUID => PlannerUUID}
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions._
 import org.apache.flink.table.functions._
-import org.apache.flink.table.types.DataType
-import org.apache.flink.table.types.logical.LogicalTypeRoot.{CHAR, DECIMAL, SYMBOL, TIMESTAMP_WITHOUT_TIME_ZONE}
+import org.apache.flink.table.types.logical.LogicalTypeRoot.SYMBOL
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks._
 import org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilderImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilderImpl.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.operations
 
 import java.util.{Collections, Optional, List => JList}
-
 import org.apache.flink.table.api._
 import org.apache.flink.table.catalog.FunctionLookup
 import org.apache.flink.table.expressions.ApiExpressionUtils.{isFunctionOfKind, unresolvedCall, unresolvedRef, valueLiteral}
@@ -33,6 +32,8 @@ import org.apache.flink.table.operations.AliasOperationUtils.createAliasList
 import org.apache.flink.table.operations.JoinQueryOperation.JoinType
 import org.apache.flink.table.operations.OperationExpressionsUtils.extractAggregationsAndProperties
 import org.apache.flink.table.operations.SetQueryOperation.SetQueryOperationType._
+import org.apache.flink.table.types.logical.LogicalTypeRoot
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
 import org.apache.flink.table.util.JavaScalaConversionUtil.toScala
 import org.apache.flink.util.Preconditions
 
@@ -47,19 +48,17 @@ import _root_.scala.collection.JavaConverters._
   */
 class OperationTreeBuilderImpl(
     tableCatalog: TableReferenceLookup,
-    expressionBridge: ExpressionBridge[PlannerExpression],
     functionCatalog: FunctionLookup,
     isStreaming: Boolean)
   extends OperationTreeBuilder{
 
   private val lookupResolver = new LookupCallResolver(functionCatalog)
-  private val projectionOperationFactory = new ProjectionOperationFactory(expressionBridge)
+  private val projectionOperationFactory = new ProjectionOperationFactory()
   private val sortOperationFactory = new SortOperationFactory(isStreaming)
   private val calculatedTableFactory = new CalculatedTableFactory()
   private val setOperationFactory = new SetOperationFactory(isStreaming)
-  private val aggregateOperationFactory = new AggregateOperationFactory(expressionBridge,
-    isStreaming)
-  private val joinOperationFactory = new JoinOperationFactory(expressionBridge)
+  private val aggregateOperationFactory = new AggregateOperationFactory(isStreaming)
+  private val joinOperationFactory = new JoinOperationFactory()
 
   private val noWindowPropertyChecker = new NoWindowPropertyChecker(
     "Window start and end properties are not available for Over windows.")
@@ -441,10 +440,10 @@ class OperationTreeBuilderImpl(
 
     val resolver = resolverFor(tableCatalog, functionCatalog, child).build()
     val resolvedExpression = resolveSingleExpression(condition, resolver)
-    val convertedCondition = expressionBridge.bridge(resolvedExpression)
-    if (convertedCondition.resultType != Types.BOOLEAN) {
+    val conditionType = resolvedExpression.getOutputDataType
+    if (!LogicalTypeChecks.hasRoot(conditionType.getLogicalType, LogicalTypeRoot.BOOLEAN)) {
       throw new ValidationException(s"Filter operator requires a boolean expression as input," +
-        s" but $condition is of type ${convertedCondition.resultType}")
+        s" but $condition is of type ${conditionType}")
     }
 
     new FilterQueryOperation(resolvedExpression, child)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/CalcTest.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.utils.TableTestUtil._
 
 import org.junit.Test
 
+import java.sql.Timestamp
 import java.time.LocalDateTime
 
 class CalcTest extends TableTestBase {
@@ -124,7 +125,8 @@ class CalcTest extends TableTestBase {
   def testSelectLiterals(): Unit = {
     val util = batchTestUtil()
     val sourceTable = util.addTable[Int]("MyTable", 'a)
-    val resultTable = sourceTable.select("ABC", BigDecimal(1234), LocalDateTime.of(1, 1, 1, 1, 1))
+    val resultTable = sourceTable
+      .select("ABC", BigDecimal(1234), Timestamp.valueOf(LocalDateTime.of(1, 1, 1, 1, 1)))
       .select('*)
 
     val expected = unaryNode(
@@ -141,7 +143,7 @@ class CalcTest extends TableTestBase {
     val util = batchTestUtil()
     val sourceTable = util.addTable[Int]("MyTable", 'a)
     val resultTable = sourceTable
-      .select("ABC", BigDecimal(1234), LocalDateTime.of(1, 1, 1, 1, 1))
+      .select("ABC", BigDecimal(1234), Timestamp.valueOf(LocalDateTime.of(1, 1, 1, 1, 1)))
       .groupBy('_c0)
       .select('*)
 


### PR DESCRIPTION
## What is the purpose of the change

The QueryOperation's factories are part of the API, therefore they should not use the `PlannerExpression`s and `ExpressionBridge`.


## Brief change log

  - Ported few type checks to the new type system (window size type, group by key type)
  - Loosen the restrictions for `DataType` -> `TypeInformation` conversion to support value literal types.
  - Removed all usages of `ExpressionBridge` in QueryOperation's


## Verifying this change

* This change is already covered by existing tests.
* Added tests to check value literal types support:
** org.apache.flink.table.api.batch.table.CalcTest#testSelectLiterals
** org.apache.flink.table.api.batch.table.CalcTest#testGroupByLiteral

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
