### PR TITLE
[FLINK-13043][Library / CEP] Fix the bug of parsing Dewey number from string

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/DeweyNumber.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/DeweyNumber.java
@@ -175,9 +175,9 @@ public class DeweyNumber implements Serializable {
 	public static DeweyNumber fromString(final String deweyNumberString) {
 		String[] splits = deweyNumberString.split("\\.");
 
-		if (splits.length == 0) {
+		if (splits.length == 1) {
 			return new DeweyNumber(Integer.parseInt(deweyNumberString));
-		} else {
+		} else if (splits.length > 0) {
 			int[] deweyNumber = new int[splits.length];
 
 			for (int i = 0; i < splits.length; i++) {
@@ -185,6 +185,8 @@ public class DeweyNumber implements Serializable {
 			}
 
 			return new DeweyNumber(deweyNumber);
+		} else {
+			throw new IllegalArgumentException("Failed to parse " + deweyNumberString + " as a Dewey number");
 		}
 	}
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/DeweyNumberTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/DeweyNumberTest.java
@@ -55,4 +55,9 @@ public class DeweyNumberTest extends TestLogger {
 		assertFalse(startAddStage.isCompatibleWith(increaseAddStage));
 		assertFalse(startAddStageIncreased.isCompatibleWith(startAddStageIncreasedAddStage));
 	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testZeroSplitsDeweyNumber() {
+		DeweyNumber.fromString(".");
+	}
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

There is a bug in the current implementation for parsing the Dewey number:

 

String[] splits = deweyNumberString.split("\\.");

if (splits.length == 0){
 return new DeweyNumber(Integer.parseInt(deweyNumberString)); 
}
 

The length in the if condition should be 1 instead of 0.


## Brief change log

  - Fix the problem by modifying the implementation of DeweyNumber#fromString
  

## Verifying this change

This change is already covered by existing tests, such as DeweyNumberTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
