### PR TITLE
[FLINK-13046][hive] rename hive-site-path to hive-conf-dir to be cons…

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -228,12 +228,12 @@ catalogs:
    - name: catalog_1
      type: hive
      property-version: 1
-     hive-site-path: file://...
+     hive-conf-dir: ...
    - name: catalog_2
      type: hive
      property-version: 1
      default-database: mydb2        # optional: name of default database of this catalog
-     hive-site-path: file://...     # optional: path of the hive-site.xml file. (Default value is created by HiveConf)
+     hive-conf-dir: ...             # optional: path of Hive conf directory. (Default value is created by HiveConf)
      hive-version: 1.2.1            # optional: version of Hive (2.3.4 by default)
 {% endhighlight %}
 
@@ -245,7 +245,7 @@ This configuration:
 - specifies a parallelism of 1 for queries executed in this streaming environment,
 - specifies an event-time characteristic, and
 - runs queries in the `table` result mode.
-- creates two `HiveCatalog` (type: hive) named with their own default databases and specified hive site path. Hive version of the first `HiveCatalog` is `2.3.4` by default and that of the second one is specified as `1.2.1`.
+- creates two `HiveCatalog` (type: hive) named with their own default databases and specified Hive conf directory. Hive version of the first `HiveCatalog` is `2.3.4` by default and that of the second one is specified as `1.2.1`.
 - use `catalog_1` as the current catalog of the environment upon start, and `mydb1` as the current database of the catalog.
 
 Depending on the use case, a configuration can be split into multiple files. Therefore, environment files can be created for general purposes (*defaults environment file* using `--defaults`) as well as on a per-session basis (*session environment file* using `--environment`). Every CLI session is initialized with the default properties followed by the session properties. For example, the defaults environment file could specify all table sources that should be available for querying in every session whereas the session environment file only declares a specific state retention time and parallelism. Both default and session environment files can be passed when starting the CLI application. If no default environment file has been specified, the SQL Client searches for `./conf/sql-client-defaults.yaml` in Flink's configuration directory.
@@ -447,11 +447,11 @@ catalogs:
      property-version: 1
      default-database: mydb2
      hive-version: 1.2.1
-     hive-site-path: <path of hive-site.xml>
+     hive-conf-dir: <path of Hive conf directory>
    - name: catalog_2
      type: hive
      property-version: 1
-     hive-site-path: <path of hive-site.xml>
+     hive-conf-dir: <path of Hive conf directory>
 {% endhighlight %}
 
 Currently Flink supports two types of catalog - `FlinkInMemoryCatalog` and `HiveCatalog`.

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -119,10 +119,10 @@ public class HiveCatalog extends AbstractCatalog {
 
 	private HiveMetastoreClientWrapper client;
 
-	public HiveCatalog(String catalogName, @Nullable String defaultDatabase, @Nullable URL hiveSiteUrl, String hiveVersion) {
+	public HiveCatalog(String catalogName, @Nullable String defaultDatabase, @Nullable URL hiveConfDir, String hiveVersion) {
 		this(catalogName,
 			defaultDatabase == null ? DEFAULT_DB : defaultDatabase,
-			createHiveConf(hiveSiteUrl),
+			createHiveConf(hiveConfDir),
 			hiveVersion);
 	}
 
@@ -137,10 +137,10 @@ public class HiveCatalog extends AbstractCatalog {
 		LOG.info("Created HiveCatalog '{}'", catalogName);
 	}
 
-	private static HiveConf createHiveConf(URL hiveSiteUrl) {
-		LOG.info("Setting hive-site location as {}", hiveSiteUrl);
+	private static HiveConf createHiveConf(URL hiveConfDir) {
+		LOG.info("Setting hive-site location as {}", hiveConfDir);
 
-		HiveConf.setHiveSiteLocation(hiveSiteUrl);
+		HiveConf.setHiveSiteLocation(hiveConfDir);
 
 		return new HiveConf();
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/descriptors/HiveCatalogDescriptor.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/descriptors/HiveCatalogDescriptor.java
@@ -26,7 +26,7 @@ import org.apache.flink.util.StringUtils;
 
 import java.util.Map;
 
-import static org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator.CATALOG_HIVE_SITE_PATH;
+import static org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator.CATALOG_HIVE_CONF_DIR;
 import static org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator.CATALOG_HIVE_VERSION;
 import static org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator.CATALOG_TYPE_VALUE_HIVE;
 
@@ -61,7 +61,7 @@ public class HiveCatalogDescriptor extends CatalogDescriptor {
 		final DescriptorProperties properties = new DescriptorProperties();
 
 		if (hiveSitePath != null) {
-			properties.putString(CATALOG_HIVE_SITE_PATH, hiveSitePath);
+			properties.putString(CATALOG_HIVE_CONF_DIR, hiveSitePath);
 		}
 
 		if (hiveVersion != null) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/descriptors/HiveCatalogValidator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/descriptors/HiveCatalogValidator.java
@@ -26,14 +26,14 @@ import org.apache.flink.table.descriptors.DescriptorProperties;
  */
 public class HiveCatalogValidator extends CatalogDescriptorValidator {
 	public static final String CATALOG_TYPE_VALUE_HIVE = "hive";
-	public static final String CATALOG_HIVE_SITE_PATH = "hive-site-path";
+	public static final String CATALOG_HIVE_CONF_DIR = "hive-conf-dir";
 	public static final String CATALOG_HIVE_VERSION = "hive-version";
 
 	@Override
 	public void validate(DescriptorProperties properties) {
 		super.validate(properties);
 		properties.validateValue(CATALOG_TYPE, CATALOG_TYPE_VALUE_HIVE, false);
-		properties.validateString(CATALOG_HIVE_SITE_PATH, true, 1);
+		properties.validateString(CATALOG_HIVE_CONF_DIR, true, 1);
 		properties.validateString(CATALOG_HIVE_VERSION, true, 1);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveCatalogFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveCatalogFactory.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator.CATALOG_HIVE_SITE_PATH;
+import static org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator.CATALOG_HIVE_CONF_DIR;
 import static org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator.CATALOG_HIVE_VERSION;
 import static org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator.CATALOG_TYPE_VALUE_HIVE;
 import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_DEFAULT_DATABASE;
@@ -67,7 +67,7 @@ public class HiveCatalogFactory implements CatalogFactory {
 		// default database
 		properties.add(CATALOG_DEFAULT_DATABASE);
 
-		properties.add(CATALOG_HIVE_SITE_PATH);
+		properties.add(CATALOG_HIVE_CONF_DIR);
 
 		properties.add(CATALOG_HIVE_VERSION);
 
@@ -82,26 +82,26 @@ public class HiveCatalogFactory implements CatalogFactory {
 			descriptorProperties.getOptionalString(CATALOG_DEFAULT_DATABASE)
 				.orElse(HiveCatalog.DEFAULT_DB);
 
-		final Optional<String> hiveSitePath = descriptorProperties.getOptionalString(CATALOG_HIVE_SITE_PATH);
+		final Optional<String> hiveSitePath = descriptorProperties.getOptionalString(CATALOG_HIVE_CONF_DIR);
 
 		final String version = descriptorProperties.getOptionalString(CATALOG_HIVE_VERSION).orElse(HiveShimLoader.getHiveVersion());
 
-		return new HiveCatalog(name, defaultDatabase, loadHiveSiteUrl(hiveSitePath.orElse(null)), version);
+		return new HiveCatalog(name, defaultDatabase, loadHiveConfDir(hiveSitePath.orElse(null)), version);
 	}
 
-	private static URL loadHiveSiteUrl(String filePath) {
+	private static URL loadHiveConfDir(String hiveConfDir) {
 
 		URL url = null;
 
-		if (!StringUtils.isNullOrWhitespaceOnly(filePath)) {
+		if (!StringUtils.isNullOrWhitespaceOnly(hiveConfDir)) {
 			try {
-				url = new File(filePath).toURI().toURL();
+				url = new File(hiveConfDir).toURI().toURL();
 
-				LOG.info("Successfully loaded '{}'", filePath);
+				LOG.info("Successfully loaded '{}'", hiveConfDir);
 
 			} catch (MalformedURLException e) {
 				throw new CatalogException(
-					String.format("Failed to get hive-site.xml from the given path '%s'", filePath), e);
+					String.format("Failed to get hive conf dir from the given path '%s'", hiveConfDir), e);
 			}
 		}
 

--- a/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
@@ -124,5 +124,5 @@ deployment:
 catalogs: [] # empty list
 #  - name: myhive
 #    type: hive
-#    hive-site-path: /opt/hive_conf/hive-site.xml
+#    hive-conf-dir: /opt/hive_conf/
 #    default-database: ...


### PR DESCRIPTION
…istent with standard name in Hive

## What is the purpose of the change

This PR renames the SQL CLI config key for HiveCatalog from `hive-site-path` to `hive-conf-dir` which is consistent with standard Hive conf key name.

## Brief change log

- renamed the config from `hive-site-path` to `hive-conf-dir`
- updated a few method names and yaml files of unit tests 
- updated documentation

## Verifying this change

This change is already covered by existing tests, such as *ExecutionContextTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
