### PR TITLE
[FLINK-13048][hive] support decimal in Flink's integration with Hive …

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDAFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDAFTest.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFResolver2;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFSum;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
@@ -80,6 +81,26 @@ public class HiveGenericUDAFTest {
 		udf.merge(acc, Arrays.asList());
 
 		assertEquals(6.1d, udf.getValue(acc));
+
+		constantArgs = new Object[] {
+			null
+		};
+
+		argTypes = new DataType[] {
+			DataTypes.DECIMAL(5, 3)
+		};
+
+		udf = init(GenericUDAFSum.class, constantArgs, argTypes);
+
+		acc = udf.createAccumulator();
+
+		udf.accumulate(acc, BigDecimal.valueOf(10.111));
+		udf.accumulate(acc, BigDecimal.valueOf(3.222));
+		udf.accumulate(acc, BigDecimal.valueOf(5.333));
+
+		udf.merge(acc, Arrays.asList());
+
+		assertEquals(BigDecimal.valueOf(18.666), udf.getValue(acc));
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
@@ -34,10 +34,12 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateDiff;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateFormat;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDecode;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMapKeys;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFRound;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFStringToMap;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFStruct;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.HashMap;
@@ -201,18 +203,17 @@ public class HiveGenericUDFTest {
 
 		assertEquals(0L, udf.eval(-0.1d));
 
-		// TODO: reenable the test when we support decimal for Hive functions
-//		udf = init(
-//			GenericUDFCeil.class,
-//			new Object[] {
-//				null
-//			},
-//			new DataType[] {
-//				DataTypes.DECIMAL(1, 1)
-//			}
-//		);
-//
-//		assertEquals(0L, udf.eval(BigDecimal.valueOf(-0.1)));
+		udf = init(
+			GenericUDFCeil.class,
+			new Object[] {
+				null
+			},
+			new DataType[] {
+				DataTypes.DECIMAL(2, 1)
+			}
+		);
+
+		assertEquals(BigDecimal.valueOf(4), udf.eval(BigDecimal.valueOf(3.1d)));
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
@@ -29,11 +29,14 @@ import org.apache.hadoop.hive.ql.udf.UDFJson;
 import org.apache.hadoop.hive.ql.udf.UDFMinute;
 import org.apache.hadoop.hive.ql.udf.UDFRand;
 import org.apache.hadoop.hive.ql.udf.UDFRegExpExtract;
+import org.apache.hadoop.hive.ql.udf.UDFToInteger;
+import org.apache.hadoop.hive.ql.udf.UDFToShort;
 import org.apache.hadoop.hive.ql.udf.UDFUnhex;
 import org.apache.hadoop.hive.ql.udf.UDFWeekOfYear;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 
@@ -179,6 +182,17 @@ public class HiveSimpleUDFTest {
 			});
 
 		assertEquals("MySQL", new String((byte[]) udf.eval("4D7953514C"), "UTF-8"));
+	}
+
+	@Test
+	public void testUDFToInteger() {
+		HiveSimpleUDF udf = init(
+			UDFToInteger.class,
+			new DataType[]{
+				DataTypes.DECIMAL(5, 3)
+			});
+
+		assertEquals(1, udf.eval(BigDecimal.valueOf(1.1d)));
 	}
 
 	@Test


### PR DESCRIPTION
…user defined functions

## What is the purpose of the change

This PR adds support for decimal in Flink's integration with Hive user defined functions.

## Brief change log

- added decimal conversions in util methods of `HiveInspectors`
- added unit tests

## Verifying this change

This change added tests and can be verified as follows:

See newly added unit tests in `HiveSimpleUDFTest`, `HiveGenericUDFTest` and `HiveGenericUDAFTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
