### PR TITLE
[hotfix][python] Remove the redundant 'python setup.py install' from tox.ini

### DIFF
--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -30,7 +30,6 @@ deps =
     pytest
 commands =
     python --version
-    python setup.py install --force
     pytest
     bash ./dev/run_pip_test.sh
 


### PR DESCRIPTION
## What is the purpose of the change

*Currently the command `python setup.py install` is executed twice for each Python environment during test: one is triggered by tox by default and the other one is triggered by the script defined in tox.ini. This is unnecessary and this pull request fixes this by removing the command from tox.ini.*

## Brief change log

  - *Removes the command `python setup.py install` from tox.ini*

## Verifying this change

This change is a trivial rework without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
