### PR TITLE
[FLINK-12889] Set FatalExitExceptionHandler for StreamTask#asyncOperationsThreadPool

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/TestingUncaughtExceptionHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/TestingUncaughtExceptionHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Testing implementation of the {@link java.lang.Thread.UncaughtExceptionHandler} which simply records
+ * the uncaught exception.
+ */
+public class TestingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+	private final CompletableFuture<Throwable> uncaughtExceptionFuture = new CompletableFuture<>();
+
+	@Override
+	public void uncaughtException(Thread t, Throwable e) {
+		uncaughtExceptionFuture.complete(e);
+	}
+
+	public Throwable waitForUncaughtException() {
+		return uncaughtExceptionFuture.join();
+	}
+}

--- a/flink-runtime/src/test/scala/akka/actor/RobustActorSystemTest.scala
+++ b/flink-runtime/src/test/scala/akka/actor/RobustActorSystemTest.scala
@@ -18,16 +18,13 @@
 
 package akka.actor
 
-import java.lang.Thread.UncaughtExceptionHandler
-
 import org.apache.flink.runtime.akka.AkkaUtils
+import org.apache.flink.runtime.concurrent.TestingUncaughtExceptionHandler
 import org.junit.{After, Before, Test}
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitSuite
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future, Promise}
-import scala.util.Success
+import scala.concurrent.Future
 
 class RobustActorSystemTest extends JUnitSuite with Matchers {
 
@@ -57,9 +54,7 @@ class RobustActorSystemTest extends JUnitSuite with Matchers {
       throw error
     }(robustActorSystem.dispatcher)
 
-    val caughtException = Await.result(
-      testingUncaughtExceptionHandler.exceptionPromise.future,
-      Duration.Inf)
+    val caughtException = testingUncaughtExceptionHandler.waitForUncaughtException()
 
     caughtException should equal (error)
   }
@@ -71,19 +66,9 @@ class RobustActorSystemTest extends JUnitSuite with Matchers {
 
     actor ! Failure
 
-    val caughtException = Await.result(
-      testingUncaughtExceptionHandler.exceptionPromise.future,
-      Duration.Inf)
+    val caughtException = testingUncaughtExceptionHandler.waitForUncaughtException()
 
     caughtException should equal (error)
-  }
-}
-
-class TestingUncaughtExceptionHandler extends UncaughtExceptionHandler {
-  val exceptionPromise: Promise[Throwable] = Promise()
-
-  override def uncaughtException(t: Thread, e: Throwable): Unit = {
-    exceptionPromise.complete(Success(e))
   }
 }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/ExceptionallyDoneFuture.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/ExceptionallyDoneFuture.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of a {@link RunnableFuture} which can only complete exceptionally.
+ *
+ * @param <V> type of the RunnableFuture
+ */
+class ExceptionallyDoneFuture<V> implements RunnableFuture<V> {
+
+	private final Throwable throwable;
+
+	private ExceptionallyDoneFuture(Throwable throwable) {
+		this.throwable = throwable;
+	}
+
+	@Override
+	public void run() {}
+
+	@Override
+	public boolean cancel(boolean mayInterruptIfRunning) {
+		return false;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return false;
+	}
+
+	@Override
+	public boolean isDone() {
+		return true;
+	}
+
+	@Override
+	public V get() throws ExecutionException {
+		throw new ExecutionException(throwable);
+	}
+
+	@Override
+	public V get(long timeout, TimeUnit unit) throws ExecutionException {
+		return get();
+	}
+
+	public static <T> ExceptionallyDoneFuture<T> of(Throwable throwable) {
+		return new ExceptionallyDoneFuture<>(throwable);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
@@ -36,6 +37,7 @@ import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -57,6 +59,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
@@ -66,15 +69,18 @@ import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.DoneFuture;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackendFactory;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StatePartitionStreamProvider;
+import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
@@ -94,7 +100,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
-import org.apache.flink.streaming.api.operators.OperatorSnapshotFinalizer;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -104,6 +109,7 @@ import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.util.CloseableIterable;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.SupplierWithException;
@@ -124,15 +130,19 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.streaming.util.StreamTaskUtil.waitTaskIsRunning;
 import static org.hamcrest.Matchers.everyItem;
@@ -156,7 +166,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 /**
  * Tests for {@link StreamTask}.
@@ -516,71 +525,56 @@ public class StreamTaskTest extends TestLogger {
 	@Test
 	public void testAsyncCheckpointingConcurrentCloseBeforeAcknowledge() throws Exception {
 
-		final OneShotLatch createSubtask = new OneShotLatch();
-		final OneShotLatch completeSubtask = new OneShotLatch();
+		final TestingKeyedStateHandle managedKeyedStateHandle = new TestingKeyedStateHandle();
+		final TestingKeyedStateHandle rawKeyedStateHandle = new TestingKeyedStateHandle();
+		final TestingOperatorStateHandle managedOperatorStateHandle = new TestingOperatorStateHandle();
+		final TestingOperatorStateHandle rawOperatorStateHandle = new TestingOperatorStateHandle();
 
-		whenNew(OperatorSnapshotFinalizer.class).
-			withAnyArguments().
-			thenAnswer((Answer<OperatorSnapshotFinalizer>) invocation -> {
-					createSubtask.trigger();
-					completeSubtask.await();
-					Object[] arguments = invocation.getArguments();
-					return new OperatorSnapshotFinalizer((OperatorSnapshotFutures) arguments[0]);
-				}
-			);
-
-		KeyedStateHandle managedKeyedStateHandle = mock(KeyedStateHandle.class);
-		KeyedStateHandle rawKeyedStateHandle = mock(KeyedStateHandle.class);
-		OperatorStateHandle managedOperatorStateHandle = mock(OperatorStreamStateHandle.class);
-		OperatorStateHandle rawOperatorStateHandle = mock(OperatorStreamStateHandle.class);
-
+		final BlockingRunnableFuture<SnapshotResult<KeyedStateHandle>> rawKeyedStateHandleFuture = new BlockingRunnableFuture<>(2, SnapshotResult.of(rawKeyedStateHandle));
 		OperatorSnapshotFutures operatorSnapshotResult = new OperatorSnapshotFutures(
 			DoneFuture.of(SnapshotResult.of(managedKeyedStateHandle)),
-			DoneFuture.of(SnapshotResult.of(rawKeyedStateHandle)),
+			rawKeyedStateHandleFuture,
 			DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)));
 
 		final StreamOperator<?> streamOperator = streamOperatorWithSnapshot(operatorSnapshotResult);
 
-		try (MockEnvironment mockEnvironment = spy(new MockEnvironmentBuilder().build())) {
+		final AcknowledgeDummyEnvironment mockEnvironment = new AcknowledgeDummyEnvironment();
 
-			RunningTask<MockStreamTask> task = runTask(() -> new MockStreamTask(
-				mockEnvironment,
-				operatorChain(streamOperator)));
+		RunningTask<MockStreamTask> task = runTask(() -> new MockStreamTask(
+			mockEnvironment,
+			operatorChain(streamOperator)));
 
-			waitTaskIsRunning(task.streamTask, task.invocationFuture);
+		waitTaskIsRunning(task.streamTask, task.invocationFuture);
 
-			final long checkpointId = 42L;
-			task.streamTask.triggerCheckpoint(
-				new CheckpointMetaData(checkpointId, 1L),
-				CheckpointOptions.forCheckpointWithDefaultLocation(),
-				false);
+		final long checkpointId = 42L;
+		task.streamTask.triggerCheckpoint(
+			new CheckpointMetaData(checkpointId, 1L),
+			CheckpointOptions.forCheckpointWithDefaultLocation(),
+			false);
 
-			createSubtask.await();
+		rawKeyedStateHandleFuture.awaitRun();
 
-			task.streamTask.cancel();
+		task.streamTask.cancel();
 
-			completeSubtask.trigger();
+		final FutureUtils.ConjunctFuture<Void> discardFuture = FutureUtils.waitForAll(
+			Arrays.asList(
+				managedKeyedStateHandle.getDiscardFuture(),
+				rawKeyedStateHandle.getDiscardFuture(),
+				managedOperatorStateHandle.getDiscardFuture(),
+				rawOperatorStateHandle.getDiscardFuture()));
 
-			// wait for the completion of the async task
-			ExecutorService executor = task.streamTask.getAsyncOperationsThreadPool();
-			executor.shutdown();
-			if (!executor.awaitTermination(10000L, TimeUnit.MILLISECONDS)) {
-				fail("Executor did not shut down within the given timeout. This indicates that the " +
-					"checkpointing did not resume.");
-			}
+		// make sure that all state handles have been discarded
+		discardFuture.get();
 
-			// check that the checkpoint has not been acknowledged
-			verify(mockEnvironment, never()).acknowledgeCheckpoint(eq(checkpointId), any(CheckpointMetrics.class), any(TaskStateSnapshot.class));
-
-			// check that the state handles have been discarded
-			verify(managedKeyedStateHandle).discardState();
-			verify(rawKeyedStateHandle).discardState();
-			verify(managedOperatorStateHandle).discardState();
-			verify(rawOperatorStateHandle).discardState();
-
-			task.waitForTaskCompletion(true);
+		try {
+			mockEnvironment.getAcknowledgeCheckpointFuture().get(10L, TimeUnit.MILLISECONDS);
+			fail("The checkpoint should not get acknowledged.");
+		} catch (TimeoutException expected) {
+			// future should not be completed
 		}
+
+		task.waitForTaskCompletion(true);
 	}
 
 	/**
@@ -1325,6 +1319,159 @@ public class StreamTaskTest extends TestLogger {
 			rawKeyedStateInputs =
 				(CloseableIterable<KeyGroupStatePartitionStreamProvider>) context.getRawKeyedStateInputs();
 			super.initializeState(context);
+		}
+	}
+
+	private static class TestingKeyedStateHandle implements KeyedStateHandle {
+
+		private static final long serialVersionUID = -2473861305282291582L;
+
+		private final transient CompletableFuture<Void> discardFuture = new CompletableFuture<>();
+
+		public CompletableFuture<Void> getDiscardFuture() {
+			return discardFuture;
+		}
+
+		@Override
+		public KeyGroupRange getKeyGroupRange() {
+			return KeyGroupRange.EMPTY_KEY_GROUP_RANGE;
+		}
+
+		@Override
+		public TestingKeyedStateHandle getIntersection(KeyGroupRange keyGroupRange) {
+			return this;
+		}
+
+		@Override
+		public void registerSharedStates(SharedStateRegistry stateRegistry) {
+
+		}
+
+		@Override
+		public void discardState() {
+			discardFuture.complete(null);
+		}
+
+		@Override
+		public long getStateSize() {
+			return 0L;
+		}
+	}
+
+	private static class TestingOperatorStateHandle implements OperatorStateHandle {
+
+		private static final long serialVersionUID = 923794934187614088L;
+
+		private final transient CompletableFuture<Void> discardFuture = new CompletableFuture<>();
+
+		public CompletableFuture<Void> getDiscardFuture() {
+			return discardFuture;
+		}
+
+		@Override
+		public Map<String, StateMetaInfo> getStateNameToPartitionOffsets() {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public FSDataInputStream openInputStream() throws IOException {
+			throw new IOException("Cannot open input streams in testing implementation.");
+		}
+
+		@Override
+		public StreamStateHandle getDelegateStateHandle() {
+			throw new UnsupportedOperationException("Not implemented.");
+		}
+
+		@Override
+		public void discardState() throws Exception {
+			discardFuture.complete(null);
+		}
+
+		@Override
+		public long getStateSize() {
+			return 0L;
+		}
+	}
+
+	private static class AcknowledgeDummyEnvironment extends DummyEnvironment {
+
+		private final CompletableFuture<Long> acknowledgeCheckpointFuture = new CompletableFuture<>();
+
+		public CompletableFuture<Long> getAcknowledgeCheckpointFuture() {
+			return acknowledgeCheckpointFuture;
+		}
+
+		@Override
+		public void acknowledgeCheckpoint(long checkpointId, CheckpointMetrics checkpointMetrics) {
+			acknowledgeCheckpointFuture.complete(checkpointId);
+		}
+
+		@Override
+		public void acknowledgeCheckpoint(long checkpointId, CheckpointMetrics checkpointMetrics, TaskStateSnapshot subtaskState) {
+			acknowledgeCheckpointFuture.complete(checkpointId);
+		}
+	}
+
+	private static final class BlockingRunnableFuture<V> implements RunnableFuture<V> {
+
+		private final CompletableFuture<V> future = new CompletableFuture<>();
+
+		private final OneShotLatch signalRunLatch = new OneShotLatch();
+
+		private final CountDownLatch continueRunLatch;
+
+		private final V value;
+
+		private BlockingRunnableFuture(int parties, V value) {
+			this.continueRunLatch = new CountDownLatch(parties);
+			this.value = value;
+		}
+
+		@Override
+		public void run() {
+			signalRunLatch.trigger();
+			continueRunLatch.countDown();
+
+			try {
+				// poor man's barrier because it can happen that the async operations thread gets
+				// interrupted by the mail box thread. The CyclicBarrier would in this case fail
+				// all participants of the barrier, leaving the future uncompleted
+				continueRunLatch.await();
+			} catch (InterruptedException e) {
+				ExceptionUtils.rethrow(e);
+			}
+
+			future.complete(value);
+		}
+
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			return false;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return future.isCancelled();
+		}
+
+		@Override
+		public boolean isDone() {
+			return future.isDone();
+		}
+
+		@Override
+		public V get() throws InterruptedException, ExecutionException {
+			return future.get();
+		}
+
+		@Override
+		public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+			return future.get(timeout, unit);
+		}
+
+		void awaitRun() throws InterruptedException {
+			signalRunLatch.await();
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

In order to avoid the swallowing of uncaught exceptions in asynchronous checkpoint operations,
this commit sets the FatalExitExceptionHandler for the StreamTask#asyncOperationsThreadPool.

For testing purposes the uncaught exception handler was made configurable in the StreamTask.

## Verifying this change

Added `StreamTaskTest#testUncaughtExceptionInAsynchronousCheckpointingOperation`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
