### PR TITLE
[FLINK-13062] Set ScheduleMode based on boundedness of streaming Pipeline

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
@@ -206,7 +206,7 @@ public class Elasticsearch6UpsertTableSinkFactoryTest extends ElasticsearchUpser
 	private static class TransformationMock extends Transformation<Tuple2<Boolean, Row>> {
 
 		public TransformationMock(String name, TypeInformation<Tuple2<Boolean, Row>> outputType, int parallelism) {
-			super(name, outputType, parallelism);
+			super(name, outputType, parallelism, false);
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -260,7 +260,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 	private static class TransformationMock extends Transformation<Row> {
 
 		public TransformationMock(String name, TypeInformation<Row> outputType, int parallelism) {
-			super(name, outputType, parallelism);
+			super(name, outputType, parallelism, false);
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
@@ -202,7 +202,7 @@ public class DataGenerators {
 
 		private static class MockTransformation extends Transformation<String> {
 			public MockTransformation() {
-				super("MockTransform", BasicTypeInfo.STRING_TYPE_INFO, 1);
+				super("MockTransform", BasicTypeInfo.STRING_TYPE_INFO, 1, false);
 			}
 
 			@Override

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -153,6 +153,8 @@ public abstract class Transformation<T> {
 	@Nullable
 	private String coLocationGroupKey;
 
+	private final boolean isBounded;
+
 	/**
 	 * Creates a new {@code Transformation} with the given name, output type and parallelism.
 	 *
@@ -160,12 +162,17 @@ public abstract class Transformation<T> {
 	 * @param outputType The output type of this {@code Transformation}
 	 * @param parallelism The parallelism of this {@code Transformation}
 	 */
-	public Transformation(String name, TypeInformation<T> outputType, int parallelism) {
+	public Transformation(
+			String name,
+			TypeInformation<T> outputType,
+			int parallelism,
+			boolean isBounded) {
 		this.id = getNewNodeId();
 		this.name = Preconditions.checkNotNull(name);
 		this.outputType = outputType;
 		this.parallelism = parallelism;
 		this.slotSharingGroup = null;
+		this.isBounded = isBounded;
 	}
 
 	/**
@@ -194,6 +201,14 @@ public abstract class Transformation<T> {
 	 */
 	public int getParallelism() {
 		return parallelism;
+	}
+
+	/**
+	 * Returns {@code true} if this transformation is bounded, if this is {@code false} the
+	 * transformation is unbounded.
+	 */
+	public boolean isBounded() {
+		return isBounded;
 	}
 
 	/**

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -89,6 +89,12 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
+
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -17,10 +17,9 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
 
 /**
@@ -31,12 +30,14 @@ import org.apache.flink.streaming.api.transformations.SourceTransformation;
 @Public
 public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 
-	boolean isParallel;
+	private boolean isParallel;
 
-	public DataStreamSource(StreamExecutionEnvironment environment,
-			TypeInformation<T> outTypeInfo, StreamSource<T, ?> operator,
-			boolean isParallel, String sourceName) {
-		super(environment, new SourceTransformation<>(sourceName, operator, outTypeInfo, environment.getParallelism()));
+	@Internal
+	public DataStreamSource(
+			StreamExecutionEnvironment environment,
+			SourceTransformation<T> sourceTransformation,
+			boolean isParallel) {
+		super(environment, sourceTransformation);
 
 		this.isParallel = isParallel;
 		if (!isParallel) {
@@ -44,6 +45,7 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 		}
 	}
 
+	@Internal
 	public DataStreamSource(SingleOutputStreamOperator<T> operator) {
 		super(operator.environment, operator.getTransformation());
 		this.isParallel = true;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -74,6 +74,7 @@ import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SplittableIterator;
 import org.apache.flink.util.StringUtils;
@@ -1472,7 +1473,14 @@ public abstract class StreamExecutionEnvironment {
 		clean(function);
 
 		final StreamSource<OUT, ?> sourceOperator = new StreamSource<>(function);
-		return new DataStreamSource<>(this, typeInfo, sourceOperator, isParallel, sourceName);
+
+		SourceTransformation<OUT> sourceTransformation = new SourceTransformation<>(
+				sourceName,
+				sourceOperator,
+				typeInfo,
+				this.getParallelism());
+
+		return new DataStreamSource<>(this, sourceTransformation, isParallel);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -193,8 +193,18 @@ public class StreamGraphGenerator {
 
 		alreadyTransformed = new HashMap<>();
 
+		boolean allTransformsBounded = true;
 		for (Transformation<?> transformation: transformations) {
 			transform(transformation);
+			if (!transformation.isBounded()) {
+				allTransformsBounded = false;
+			}
+		}
+
+		if (allTransformsBounded) {
+			streamGraph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES);
+		} else {
+			streamGraph.setScheduleMode(ScheduleMode.EAGER);
 		}
 
 		final StreamGraph builtStreamGraph = streamGraph;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformation.java
@@ -70,7 +70,11 @@ public class CoFeedbackTransformation<F> extends Transformation<F> {
 	public CoFeedbackTransformation(int parallelism,
 			TypeInformation<F> feedbackType,
 			Long waitTime) {
-		super("CoFeedback", feedbackType, parallelism);
+		super(
+				"CoFeedback",
+				feedbackType,
+				parallelism,
+				false /* this is not used because we override isBounded()*/);
 		this.waitTime = waitTime;
 		this.feedbackEdges = Lists.newArrayList();
 	}
@@ -113,6 +117,11 @@ public class CoFeedbackTransformation<F> extends Transformation<F> {
 	@Override
 	public Collection<Transformation<?>> getTransitivePredecessors() {
 		return Collections.<Transformation<?>>singleton(this);
+	}
+
+	@Override
+	public boolean isBounded() {
+		return feedbackEdges.stream().allMatch(Transformation::isBounded);
 	}
 }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/FeedbackTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/FeedbackTransformation.java
@@ -61,7 +61,11 @@ public class FeedbackTransformation<T> extends Transformation<T> {
 	 *                          the operation will close and not receive any more feedback elements.
 	 */
 	public FeedbackTransformation(Transformation<T> input, Long waitTime) {
-		super("Feedback", input.getOutputType(), input.getParallelism());
+		super(
+				"Feedback",
+				input.getOutputType(),
+				input.getParallelism(),
+				false /* this is ignored because we override isBounded() */);
 		this.input = input;
 		this.waitTime = waitTime;
 		this.feedbackEdges = Lists.newArrayList();
@@ -116,6 +120,11 @@ public class FeedbackTransformation<T> extends Transformation<T> {
 		result.add(this);
 		result.addAll(input.getTransitivePredecessors());
 		return result;
+	}
+
+	@Override
+	public boolean isBounded() {
+		return input.isBounded() && feedbackEdges.stream().allMatch(Transformation::isBounded);
 	}
 }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -76,7 +76,7 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
 			StreamOperatorFactory<OUT> operatorFactory,
 			TypeInformation<OUT> outputType,
 			int parallelism) {
-		super(name, outputType, parallelism);
+		super(name, outputType, parallelism, input.isBounded());
 		this.input = input;
 		this.operatorFactory = operatorFactory;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
@@ -69,7 +69,7 @@ public class PartitionTransformation<T> extends Transformation<T> {
 			Transformation<T> input,
 			StreamPartitioner<T> partitioner,
 			ShuffleMode shuffleMode) {
-		super("Partition", input.getOutputType(), input.getParallelism());
+		super("Partition", input.getOutputType(), input.getParallelism(), input.isBounded());
 		this.input = input;
 		this.partitioner = partitioner;
 		this.shuffleMode = checkNotNull(shuffleMode);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PhysicalTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PhysicalTransformation.java
@@ -40,10 +40,11 @@ public abstract class PhysicalTransformation<T> extends Transformation<T> {
 	 * @param parallelism The parallelism of this {@code Transformation}
 	 */
 	PhysicalTransformation(
-		String name,
-		TypeInformation<T> outputType,
-		int parallelism) {
-		super(name, outputType, parallelism);
+			String name,
+			TypeInformation<T> outputType,
+			int parallelism,
+			boolean isBounded) {
+		super(name, outputType, parallelism, isBounded);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SelectTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SelectTransformation.java
@@ -51,9 +51,9 @@ public class SelectTransformation<T> extends Transformation<T> {
 	 *                      {@code SelectTransformation} selects.
 	 */
 	public SelectTransformation(
-		Transformation<T> input,
+			Transformation<T> input,
 			List<String> selectedNames) {
-		super("Select", input.getOutputType(), input.getParallelism());
+		super("Select", input.getOutputType(), input.getParallelism(), input.isBounded());
 		this.input = input;
 		this.selectedNames = selectedNames;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SideOutputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SideOutputTransformation.java
@@ -44,7 +44,11 @@ public class SideOutputTransformation<T> extends Transformation<T> {
 	private final OutputTag<T> tag;
 
 	public SideOutputTransformation(Transformation<?> input, final OutputTag<T> tag) {
-		super("SideOutput", tag.getTypeInfo(), requireNonNull(input).getParallelism());
+		super(
+				"SideOutput",
+				tag.getTypeInfo(),
+				requireNonNull(input).getParallelism(),
+				input.isBounded());
 		this.input = input;
 		this.tag = requireNonNull(tag);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
@@ -72,7 +72,7 @@ public class SinkTransformation<T> extends PhysicalTransformation<Object> {
 			String name,
 			StreamOperatorFactory<Object> operatorFactory,
 			int parallelism) {
-		super(name, TypeExtractor.getForClass(Object.class), parallelism);
+		super(name, TypeExtractor.getForClass(Object.class), parallelism, input.isBounded());
 		this.input = input;
 		this.operatorFactory = operatorFactory;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
@@ -53,16 +53,18 @@ public class SourceTransformation<T> extends PhysicalTransformation<T> {
 			String name,
 			StreamSource<T, ?> operator,
 			TypeInformation<T> outputType,
-			int parallelism) {
-		this(name, SimpleOperatorFactory.of(operator), outputType, parallelism);
+			int parallelism,
+			boolean isBounded) {
+		this(name, SimpleOperatorFactory.of(operator), outputType, parallelism, isBounded);
 	}
 
 	public SourceTransformation(
 			String name,
 			StreamOperatorFactory<T> operatorFactory,
 			TypeInformation<T> outputType,
-			int parallelism) {
-		super(name, outputType, parallelism);
+			int parallelism,
+			boolean isBounded) {
+		super(name, outputType, parallelism, isBounded);
 		this.operatorFactory = operatorFactory;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SplitTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SplitTransformation.java
@@ -51,9 +51,9 @@ public class SplitTransformation<T> extends Transformation<T> {
 	 * @param outputSelector The output selector
 	 */
 	public SplitTransformation(
-		Transformation<T> input,
+			Transformation<T> input,
 			OutputSelector<T> outputSelector) {
-		super("Split", input.getOutputType(), input.getParallelism());
+		super("Split", input.getOutputType(), input.getParallelism(), input.isBounded());
 		this.input = input;
 		this.outputSelector = outputSelector;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -83,7 +83,7 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends PhysicalTransformatio
 			StreamOperatorFactory<OUT> operatorFactory,
 			TypeInformation<OUT> outputType,
 			int parallelism) {
-		super(name, outputType, parallelism);
+		super(name, outputType, parallelism, input1.isBounded() && input2.isBounded());
 		this.input1 = input1;
 		this.input2 = input2;
 		this.operatorFactory = operatorFactory;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/UnionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/UnionTransformation.java
@@ -47,7 +47,11 @@ public class UnionTransformation<T> extends Transformation<T> {
 	 * @param inputs The list of input {@code Transformations}
 	 */
 	public UnionTransformation(List<Transformation<T>> inputs) {
-		super("Union", inputs.get(0).getOutputType(), inputs.get(0).getParallelism());
+		super(
+				"Union",
+				inputs.get(0).getOutputType(),
+				inputs.get(0).getParallelism(),
+				areAllBounded(inputs));
 
 		for (Transformation<T> input: inputs) {
 			if (!input.getOutputType().equals(getOutputType())) {
@@ -73,5 +77,9 @@ public class UnionTransformation<T> extends Transformation<T> {
 			result.addAll(input.getTransitivePredecessors());
 		}
 		return result;
+	}
+
+	private static <T> boolean areAllBounded(List<Transformation<T>> inputs) {
+		return inputs.stream().allMatch(Transformation::isBounded);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.streaming.api.operators.StreamSource;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link CoFeedbackTransformation}.
+ */
+public class CoFeedbackTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedAllTrue() {
+		CoFeedbackTransformation<String> coFeedbackTransformation = createCoFeedbackTransform();
+
+		coFeedbackTransformation.addFeedbackEdge(createTestSourceTransform(true));
+		coFeedbackTransformation.addFeedbackEdge(createTestSourceTransform(true));
+
+		assertTrue(coFeedbackTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedAllFalse() {
+		CoFeedbackTransformation<String> coFeedbackTransformation = createCoFeedbackTransform();
+
+		coFeedbackTransformation.addFeedbackEdge(createTestSourceTransform(false));
+		coFeedbackTransformation.addFeedbackEdge(createTestSourceTransform(false));
+
+		assertFalse(coFeedbackTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedMixed() {
+		CoFeedbackTransformation<String> coFeedbackTransformation = createCoFeedbackTransform();
+
+		coFeedbackTransformation.addFeedbackEdge(createTestSourceTransform(true));
+		coFeedbackTransformation.addFeedbackEdge(createTestSourceTransform(false));
+
+		assertFalse(coFeedbackTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createTestSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	private static CoFeedbackTransformation<String> createCoFeedbackTransform() {
+		return new CoFeedbackTransformation<>(1, BasicTypeInfo.STRING_TYPE_INFO, 0L);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/FeedbackTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/FeedbackTransformationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.StreamSource;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link FeedbackTransformation}.
+ */
+public class FeedbackTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedTrue() {
+		FeedbackTransformation<String> feedbackTransformation = createFeedbackTransform(
+				createSourceTransform(true));
+
+		assertTrue(feedbackTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedFalse() {
+		FeedbackTransformation<String> feedbackTransformation = createFeedbackTransform(
+				createSourceTransform(false));
+
+		assertFalse(feedbackTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedTrueFeedbackFalse() {
+		FeedbackTransformation<String> feedbackTransformation = createFeedbackTransform(
+				createSourceTransform(true));
+
+		feedbackTransformation.addFeedbackEdge(createSourceTransform(false));
+
+		assertFalse(feedbackTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedFalseFeedbackTrue() {
+		FeedbackTransformation<String> feedbackTransformation = createFeedbackTransform(
+				createSourceTransform(false));
+
+		feedbackTransformation.addFeedbackEdge(createSourceTransform(true));
+
+		assertFalse(feedbackTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedTrueFeedbackMixed() {
+		FeedbackTransformation<String> feedbackTransformation = createFeedbackTransform(
+				createSourceTransform(true));
+
+		feedbackTransformation.addFeedbackEdge(createSourceTransform(true));
+		feedbackTransformation.addFeedbackEdge(createSourceTransform(false));
+
+		assertFalse(feedbackTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	private static FeedbackTransformation<String> createFeedbackTransform(
+			Transformation<String> input) {
+		return new FeedbackTransformation<>(input, 0L);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/OneInputTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/OneInputTransformationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamSource;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link OneInputTransformation}.
+ */
+public class OneInputTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedTrue() {
+		OneInputTransformation<String, String> oneInputTransformation = createOneInputTransform(
+				createSourceTransform(true));
+
+		assertTrue(oneInputTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedFalse() {
+		OneInputTransformation<String, String> oneInputTransformation = createOneInputTransform(
+				createSourceTransform(false));
+
+		assertFalse(oneInputTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static OneInputTransformation<String, String> createOneInputTransform(
+			Transformation<String> input1) {
+		return new OneInputTransformation<String, String>(
+				input1,
+				"test",
+				mock(OneInputStreamOperator.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/PartitionTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/PartitionTransformationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link PartitionTransformation}.
+ */
+public class PartitionTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedTrue() {
+		PartitionTransformation<String> partitionTransformation = createPartitionTransform(
+				createSourceTransform(true));
+
+		assertTrue(partitionTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedFalse() {
+		PartitionTransformation<String> partitionTransformation = createPartitionTransform(
+				createSourceTransform(false));
+
+		assertFalse(partitionTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	private static PartitionTransformation<String> createPartitionTransform(
+			Transformation<String> input1) {
+		return new PartitionTransformation<>(
+				input1,
+				new StreamPartitioner<String>() {
+					@Override
+					public StreamPartitioner<String> copy() {
+						return null;
+					}
+
+					@Override
+					public int selectChannel(SerializationDelegate<StreamRecord<String>> record) {
+						return 0;
+					}
+				});
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/SelectTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/SelectTransformationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.StreamSource;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link SelectTransformation}.
+ */
+public class SelectTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedTrue() {
+		SelectTransformation<String> selectTransformation = createSelectTransform(
+				createSourceTransform(true));
+
+		assertTrue(selectTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedFalse() {
+		SelectTransformation<String> selectTransformation = createSelectTransform(
+				createSourceTransform(false));
+
+		assertFalse(selectTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	private static SelectTransformation<String> createSelectTransform(
+			Transformation<String> input1) {
+		return new SelectTransformation<>(
+				input1,
+				Collections.emptyList());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/SideOutputTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/SideOutputTransformationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.util.OutputTag;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link SideOutputTransformation}.
+ */
+public class SideOutputTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedTrue() {
+		SideOutputTransformation<String> sideOutputTransformation = createSideOutputTransform(
+				createSourceTransform(true));
+
+		assertTrue(sideOutputTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedFalse() {
+		SideOutputTransformation<String> sideOutputTransformation = createSideOutputTransform(
+				createSourceTransform(false));
+
+		assertFalse(sideOutputTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	private static SideOutputTransformation<String> createSideOutputTransform(
+			Transformation<String> input1) {
+		return new SideOutputTransformation<>(
+				input1,
+				new OutputTag<String>("ciao") {});
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/SinkTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/SinkTransformationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.api.operators.StreamSource;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link SinkTransformation}.
+ */
+public class SinkTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedTrue() {
+		SinkTransformation<String> sinkTransformation = createSinkTransform(
+				createSourceTransform(true));
+
+		assertTrue(sinkTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedFalse() {
+		SinkTransformation<String> sinkTransformation = createSinkTransform(
+				createSourceTransform(false));
+
+		assertFalse(sinkTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SinkTransformation<String> createSinkTransform(
+			Transformation<String> input1) {
+		return new SinkTransformation<String>(
+				input1,
+				"test",
+				mock(StreamSink.class),
+				1);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/SplitTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/SplitTransformationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.StreamSource;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link SplitTransformation}.
+ */
+public class SplitTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedTrue() {
+		SplitTransformation<String> splitTransformation = createSplitTransform(
+				createSourceTransform(true));
+
+		assertTrue(splitTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedFalse() {
+		SplitTransformation<String> splitTransformation = createSplitTransform(
+				createSourceTransform(false));
+
+		assertFalse(splitTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	private static SplitTransformation<String> createSplitTransform(
+			Transformation<String> input1) {
+		return new SplitTransformation<>(
+				input1,
+				(in) -> null);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/TwoInputTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/TwoInputTransformationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link TwoInputTransformation}.
+ */
+public class TwoInputTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedBothInputsTrue() {
+		TwoInputTransformation<String, String, String> twoInputTransformation =
+				createTwoInputTransform(
+						createSourceTransform(true),
+						createSourceTransform(true));
+
+		assertTrue(twoInputTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedBothInputsFalse() {
+		TwoInputTransformation<String, String, String> twoInputTransformation =
+				createTwoInputTransform(
+						createSourceTransform(false),
+						createSourceTransform(false));
+
+		assertFalse(twoInputTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedMixed() {
+		TwoInputTransformation<String, String, String> twoInputTransformation1 =
+				createTwoInputTransform(
+						createSourceTransform(false),
+						createSourceTransform(true));
+		TwoInputTransformation<String, String, String> twoInputTransformation2 =
+				createTwoInputTransform(
+						createSourceTransform(true),
+						createSourceTransform(false));
+
+		assertFalse(twoInputTransformation1.isBounded());
+		assertFalse(twoInputTransformation2.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedMixed2() {
+		TwoInputTransformation<String, String, String> twoInputTransformation =
+				createTwoInputTransform(
+						createSourceTransform(true),
+						createSourceTransform(false));
+
+		assertFalse(twoInputTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static TwoInputTransformation<String, String, String> createTwoInputTransform(
+			Transformation<String> input1,
+			Transformation<String> input2) {
+		return new TwoInputTransformation<String, String, String>(
+				input1,
+				input2,
+				"test",
+				mock(TwoInputStreamOperator.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/UnionTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/UnionTransformationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.StreamSource;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link UnionTransformation}.
+ */
+public class UnionTransformationTest {
+
+	@Test
+	public void forwardsIsBoundedAllTrue() {
+		UnionTransformation<String> unionTransformation = createUnionTransform(
+				createSourceTransform(true),
+				createSourceTransform(true),
+				createSourceTransform(true));
+
+		assertTrue(unionTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedAllFalse() {
+		UnionTransformation<String> unionTransformation = createUnionTransform(
+				createSourceTransform(false),
+				createSourceTransform(false),
+				createSourceTransform(false));
+
+		assertFalse(unionTransformation.isBounded());
+	}
+
+	@Test
+	public void forwardsIsBoundedMixed() {
+		UnionTransformation<String> unionTransformation = createUnionTransform(
+				createSourceTransform(false),
+				createSourceTransform(true),
+				createSourceTransform(false));
+
+		assertFalse(unionTransformation.isBounded());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SourceTransformation<String> createSourceTransform(boolean isBounded) {
+		return new SourceTransformation<String>(
+				"TestSource",
+				mock(StreamSource.class),
+				BasicTypeInfo.STRING_TYPE_INFO,
+				1,
+				isBounded);
+	}
+
+	@SafeVarargs
+	private static UnionTransformation<String> createUnionTransform(
+			Transformation<String>... inputs) {
+		return new UnionTransformation<>(Arrays.asList(inputs));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1797,6 +1797,9 @@ under the License.
 								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
 								<exclude>org.apache.flink.streaming.api.datastream.DataStream#DataStream(org.apache.flink.streaming.api.environment.StreamExecutionEnvironment,org.apache.flink.streaming.api.transformations.StreamTransformation)</exclude>
+								<!-- These constructors should have been internal, there is no need for users to use them -->
+								<exclude>org.apache.flink.streaming.api.datastream.DataStreamSource#DataStreamSource(org.apache.flink.streaming.api.environment.StreamExecutionEnvironment,org.apache.flink.api.common.typeinfo.TypeInformation,org.apache.flink.streaming.api.operators.StreamSource,boolean,java.lang.String)</exclude>
+								<exclude>org.apache.flink.streaming.api.datastream.DataStreamSource#DataStreamSource(org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator)</exclude>
 								<exclude>org.apache.flink.streaming.api.environment.LegacyLocalStreamEnvironment</exclude>
 								<exclude>org.apache.flink.streaming.api.functions.sink.RichSinkFunction#invoke(java.lang.Object)</exclude>
 								<exclude>org.apache.flink.streaming.api.functions.sink.SinkFunction</exclude>


### PR DESCRIPTION
## What is the purpose of the change

The new Blink-based Table Runner needs "streaming pipelines" to be executed with `ScheduleMode.LAZY_FROM_SOURCES` if all sources are bounded. The current Blink code base uses a global flag for this and configures the `StreamGraphGenerator` accordingly.

We propose to add an `isBounded()` property to `Transformation` (formerly known as `StreamTransformation`). The property would only be explicitly settable on sources, other transformations inherit the property from their inputs. The `StreamGraphGenerator` must use `ScheduleMode.LAZY_FROM_SOURCES` if all sources are bounded, otherwise, it should use ScheduleMode.EAGER, as is the currently existing behaviour.

## Brief change log

* ccf6f96 refactors `DataStreamSource` as preparation
* 03aa30b adds the `isBounded()` property to `Transformation`, along with tests for the inheritance logic
* 277c947 adds a new *public* method on `StreamExecutionEnvironment` for adding bounded sources
* c37ffb9 changes `StreamGraphGenerator` to set the `ScheduleMode` based on the newly added boundedness property, along with tests

## Verifying this change

This change added tests and can be verified as follows:

* new tests in 03aa30b for the `isBounded()` property on `Transformation`
* new tests in c37ffb9, i.e in `StreamGraphGeneratorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes, there is a new public API method for adding bounded sources
  - If yes, how is the feature documented? documented in Javadocs, as for now this is more of an under-the-radar featre
