### PR TITLE
[FLINK-10868][flink-runtime] Add failure rater for resource manager

### DIFF
--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -27,6 +27,18 @@
             <td>Time in milliseconds of the start-up period of a standalone cluster. During this time, resource manager of the standalone cluster expects new task executors to be registered, and will not fail slot requests that can not be satisfied by any current registered slots. After this time, it will fail pending and new coming requests immediately that can not be satisfied by registered slots. If not set, 'slotmanager.request-timeout' will be used by default.</td>
         </tr>
         <tr>
+            <td><h5>resourcemanager.start-worker.max-failure-rate</h5></td>
+            <td style="word-wrap: break-word;">10.0</td>
+            <td>Double</td>
+            <td>Defines the maximum number of worker (YARN / Mesos) failures per minute before rejecting subsequent worker requests until the failure rate falls below the maximum. It is to quickly catch external dependency caused workers failure and terminate job accordingly. By default, the value is set to 10/min.</td>
+        </tr>
+        <tr>
+            <td><h5>resourcemanager.start-worker.retry-interval</h5></td>
+            <td style="word-wrap: break-word;">3 s</td>
+            <td>Duration</td>
+            <td>Defines the worker creation interval in milliseconds. In case of worker creation failures, we should wait for an interval before trying to create new workers when the failure rate exceeds. Otherwise, ActiveResourceManager will always re-requesting the worker, which keeps the main thread busy.</td>
+        </tr>
+        <tr>
             <td><h5>resourcemanager.taskmanager-timeout</h5></td>
             <td style="word-wrap: break-word;">30000</td>
             <td>Long</td>

--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -30,13 +30,13 @@
             <td><h5>resourcemanager.start-worker.max-failure-rate</h5></td>
             <td style="word-wrap: break-word;">10.0</td>
             <td>Double</td>
-            <td>Defines the maximum number of worker (YARN / Mesos) failures per minute before rejecting subsequent worker requests until the failure rate falls below the maximum. It is to quickly catch external dependency caused workers failure and terminate job accordingly. By default, the value is set to 10/min.</td>
+            <td>The maximum number of start worker failures (Native Kubernetes / Yarn / Mesos) per minute before pausing requesting new workers. Once the threshold is reached, subsequent worker requests will be postponed to after a configured retry interval ('resourcemanager.start-worker.retry-interval').</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.start-worker.retry-interval</h5></td>
             <td style="word-wrap: break-word;">3 s</td>
             <td>Duration</td>
-            <td>Defines the worker creation interval in milliseconds. In case of worker creation failures, we should wait for an interval before trying to create new workers when the failure rate exceeds. Otherwise, ActiveResourceManager will always re-requesting the worker, which keeps the main thread busy.</td>
+            <td>The time to wait before requesting new workers (Native Kubernetes / Yarn / Mesos) once the max failure rate of starting workers ('resourcemanager.start-worker.max-failure-rate') is reached.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.taskmanager-timeout</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 
+import java.time.Duration;
+
 /** The set of configuration options relating to the ResourceManager. */
 @PublicEvolving
 public class ResourceManagerOptions {
@@ -78,6 +80,37 @@ public class ResourceManagerOptions {
                             "The number of redundant task managers. Redundant task managers are extra task managers "
                                     + "started by Flink, in order to speed up job recovery in case of failures due to task manager lost. "
                                     + "Note that this feature is available only to the active deployments (native K8s, Yarn and Mesos).");
+
+    /**
+     * Defines the maximum number of worker (YARN / Mesos / Kubernetes) failures per minute before
+     * rejecting subsequent worker requests until the failure rate falls below the maximum. It is to
+     * quickly catch external dependency caused workers failure and wait for retry interval before
+     * sending new request. By default, the value is set to 10/min.
+     */
+    public static final ConfigOption<Double> MAXIMUM_WORKERS_FAILURE_RATE =
+            ConfigOptions.key("resourcemanager.start-worker.max-failure-rate")
+                    .doubleType()
+                    .defaultValue(10.0)
+                    .withDescription(
+                            "Defines the maximum number of worker (YARN / Mesos) failures per minute before rejecting"
+                                    + " subsequent worker requests until the failure rate falls below the maximum. It is to quickly catch"
+                                    + " external dependency caused workers failure and terminate job accordingly."
+                                    + " By default, the value is set to 10/min.");
+
+    /**
+     * Defines the worker creation interval in milliseconds. In case of worker creation failures, we
+     * should wait for an interval before trying to create new workers when the failure rate
+     * exceeds. Otherwise, ActiveResourceManager will always re-requesting the worker, which keeps
+     * the main thread busy.
+     */
+    public static final ConfigOption<Duration> WORKER_CREATION_RETRY_INTERVAL =
+            ConfigOptions.key("resourcemanager.start-worker.retry-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(3))
+                    .withDescription(
+                            "Defines the worker creation interval in milliseconds. In case of worker creation failures,"
+                                    + " we should wait for an interval before trying to create new workers when the failure rate exceeds."
+                                    + " Otherwise, ActiveResourceManager will always re-requesting the worker, which keeps the main thread busy.");
 
     /**
      * The timeout for a slot request to be discarded, in milliseconds.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -28,6 +28,9 @@ import java.time.Duration;
 @PublicEvolving
 public class ResourceManagerOptions {
 
+    private static final String START_WORKER_RETRY_INTERVAL_KEY =
+            "resourcemanager.start-worker.retry-interval";
+
     /** Timeout for jobs which don't have a job manager as leader assigned. */
     public static final ConfigOption<String> JOB_TIMEOUT =
             ConfigOptions.key("resourcemanager.job.timeout")
@@ -82,35 +85,35 @@ public class ResourceManagerOptions {
                                     + "Note that this feature is available only to the active deployments (native K8s, Yarn and Mesos).");
 
     /**
-     * Defines the maximum number of worker (YARN / Mesos / Kubernetes) failures per minute before
-     * rejecting subsequent worker requests until the failure rate falls below the maximum. It is to
-     * quickly catch external dependency caused workers failure and wait for retry interval before
-     * sending new request. By default, the value is set to 10/min.
+     * The maximum number of start worker failures (Native Kubernetes / Yarn / Mesos) per minute
+     * before pausing requesting new workers. Once the threshold is reached, subsequent worker
+     * requests will be postponed to after a configured retry interval ({@link
+     * #START_WORKER_RETRY_INTERVAL}).
      */
-    public static final ConfigOption<Double> MAXIMUM_WORKERS_FAILURE_RATE =
+    public static final ConfigOption<Double> START_WORKER_MAX_FAILURE_RATE =
             ConfigOptions.key("resourcemanager.start-worker.max-failure-rate")
                     .doubleType()
                     .defaultValue(10.0)
                     .withDescription(
-                            "Defines the maximum number of worker (YARN / Mesos) failures per minute before rejecting"
-                                    + " subsequent worker requests until the failure rate falls below the maximum. It is to quickly catch"
-                                    + " external dependency caused workers failure and terminate job accordingly."
-                                    + " By default, the value is set to 10/min.");
+                            "The maximum number of start worker failures (Native Kubernetes / Yarn / Mesos) per minute "
+                                    + "before pausing requesting new workers. Once the threshold is reached, subsequent "
+                                    + "worker requests will be postponed to after a configured retry interval ('"
+                                    + START_WORKER_RETRY_INTERVAL_KEY
+                                    + "').");
 
     /**
-     * Defines the worker creation interval in milliseconds. In case of worker creation failures, we
-     * should wait for an interval before trying to create new workers when the failure rate
-     * exceeds. Otherwise, ActiveResourceManager will always re-requesting the worker, which keeps
-     * the main thread busy.
+     * The time to wait before requesting new workers (Native Kubernetes / Yarn / Mesos) once the
+     * max failure rate of starting workers ({@link #START_WORKER_MAX_FAILURE_RATE}) is reached.
      */
-    public static final ConfigOption<Duration> WORKER_CREATION_RETRY_INTERVAL =
-            ConfigOptions.key("resourcemanager.start-worker.retry-interval")
+    public static final ConfigOption<Duration> START_WORKER_RETRY_INTERVAL =
+            ConfigOptions.key(START_WORKER_RETRY_INTERVAL_KEY)
                     .durationType()
                     .defaultValue(Duration.ofSeconds(3))
                     .withDescription(
-                            "Defines the worker creation interval in milliseconds. In case of worker creation failures,"
-                                    + " we should wait for an interval before trying to create new workers when the failure rate exceeds."
-                                    + " Otherwise, ActiveResourceManager will always re-requesting the worker, which keeps the main thread busy.");
+                            "The time to wait before requesting new workers (Native Kubernetes / Yarn / Mesos) once the "
+                                    + "max failure rate of starting workers ('"
+                                    + START_WORKER_MAX_FAILURE_RATE.key()
+                                    + "') is reached.");
 
     /**
      * The timeout for a slot request to be discarded, in milliseconds.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesResourceManagerDriverConfiguration.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesResourceManagerDriverConfiguration.java
@@ -18,26 +18,18 @@
 
 package org.apache.flink.kubernetes.configuration;
 
-import org.apache.flink.api.common.time.Time;
-
 /**
  * Configuration specific to {@link org.apache.flink.kubernetes.KubernetesResourceManagerDriver}.
  */
 public class KubernetesResourceManagerDriverConfiguration {
-    private final String clusterId;
-    private final Time podCreationRetryInterval;
 
-    public KubernetesResourceManagerDriverConfiguration(
-            String clusterId, Time podCreationRetryInterval) {
+    private final String clusterId;
+
+    public KubernetesResourceManagerDriverConfiguration(String clusterId) {
         this.clusterId = clusterId;
-        this.podCreationRetryInterval = podCreationRetryInterval;
     }
 
     public String getClusterId() {
         return clusterId;
-    }
-
-    public Time getPodCreationRetryInterval() {
-        return podCreationRetryInterval;
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.kubernetes.entrypoint;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.KubernetesResourceManagerDriver;
 import org.apache.flink.kubernetes.KubernetesWorkerNode;
@@ -43,8 +42,6 @@ public class KubernetesResourceManagerFactory
     private static final KubernetesResourceManagerFactory INSTANCE =
             new KubernetesResourceManagerFactory();
 
-    private static final Time POD_CREATION_RETRY_INTERVAL = Time.seconds(3L);
-
     private KubernetesResourceManagerFactory() {}
 
     public static KubernetesResourceManagerFactory getInstance() {
@@ -57,8 +54,7 @@ public class KubernetesResourceManagerFactory
         final KubernetesResourceManagerDriverConfiguration
                 kubernetesResourceManagerDriverConfiguration =
                         new KubernetesResourceManagerDriverConfiguration(
-                                configuration.getString(KubernetesConfigOptions.CLUSTER_ID),
-                                POD_CREATION_RETRY_INTERVAL);
+                                configuration.getString(KubernetesConfigOptions.CLUSTER_ID));
 
         return new KubernetesResourceManagerDriver(
                 configuration,

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/ThresholdMeter.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/ThresholdMeter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+/** A timestamp queue based threshold meter. */
+public class ThresholdMeter implements Meter {
+    private static final double MILLISECONDS_PER_SECOND = 1000.0;
+    private final double maxEventsPerInterval;
+    private final Duration interval;
+    private final Queue<Long> failureTimestamps;
+    private long eventCounter = 0;
+
+    public ThresholdMeter(double maxEventsPerInterval, Duration interval) {
+        this.maxEventsPerInterval = maxEventsPerInterval;
+        this.interval = interval;
+        this.failureTimestamps = new ArrayDeque<>();
+        if (this.interval.toMillis() == 0) {
+            throw new IllegalArgumentException("The threshold interval should be larger than 0.");
+        }
+    }
+
+    @Override
+    public void markEvent() {
+        failureTimestamps.add(System.currentTimeMillis());
+        eventCounter++;
+    }
+
+    @Override
+    public void markEvent(long n) {
+        long timestamp = System.currentTimeMillis();
+        for (int i = 0; i < n; i++) {
+            failureTimestamps.add(timestamp);
+        }
+        eventCounter = eventCounter + n;
+    }
+
+    @Override
+    public double getRate() {
+        return getEventCountsRecentInterval() / (interval.toMillis() / MILLISECONDS_PER_SECOND);
+    }
+
+    @Override
+    public long getCount() {
+        return eventCounter;
+    }
+
+    public void checkAgainstThreshold() throws ThresholdExceedException {
+        if (getEventCountsRecentInterval() >= maxEventsPerInterval) {
+            throw new ThresholdExceedException(
+                    String.format(
+                            "Maximum number of events %d is detected during the interval of %d seconds",
+                            getEventCountsRecentInterval(), interval.getSeconds()));
+        }
+    }
+
+    private int getEventCountsRecentInterval() {
+        Long currentTimeStamp = System.currentTimeMillis();
+        while (!failureTimestamps.isEmpty()
+                && currentTimeStamp - failureTimestamps.peek() > interval.toMillis()) {
+            failureTimestamps.remove();
+        }
+
+        return failureTimestamps.size();
+    }
+
+    /** Exception thrown when a threshold exceeds. */
+    public static class ThresholdExceedException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public ThresholdExceedException(String message) {
+            super(message);
+        }
+    }
+}

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/ThresholdMeterTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/ThresholdMeterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import org.apache.flink.metrics.ThresholdMeter.ThresholdExceedException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test time stamp based threshold meter. */
+public class ThresholdMeterTest extends TestLogger {
+
+    @Test(expected = ThresholdExceedException.class)
+    public void testMaximumFailureCheck() {
+        ThresholdMeter rater = new ThresholdMeter(5, Duration.ofSeconds(10));
+
+        for (int i = 0; i < 6; i++) {
+            rater.markEvent();
+        }
+
+        assertEquals(6, rater.getCount());
+        rater.checkAgainstThreshold();
+    }
+
+    @Test(expected = ThresholdExceedException.class)
+    public void testRateRecordMultipleEvents() throws InterruptedException {
+        ThresholdMeter rater = new ThresholdMeter(5, Duration.ofMillis(120));
+
+        for (int i = 0; i < 3; i++) {
+            rater.markEvent(2);
+            Thread.sleep(30);
+        }
+
+        assertEquals(6, rater.getCount());
+        rater.checkAgainstThreshold();
+    }
+
+    @Test
+    public void testMovingRate() throws InterruptedException {
+        ThresholdMeter rater = new ThresholdMeter(5, Duration.ofMillis(120));
+
+        for (int i = 0; i < 6; i++) {
+            rater.markEvent();
+            Thread.sleep(30);
+        }
+
+        assertEquals(6, rater.getCount());
+        rater.checkAgainstThreshold();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -62,7 +62,7 @@ public class MetricNames {
     public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";
     public static final String CHECKPOINT_START_DELAY_TIME = "checkpointStartDelayNanos";
 
-    public static final String WORKER_FAILURE_RATE = "startWorkFailure" + SUFFIX_RATE;
+    public static final String START_WORKER_FAILURE_RATE = "startWorkFailure" + SUFFIX_RATE;
 
     public static String currentInputWatermarkName(int index) {
         return String.format(IO_CURRENT_INPUT_WATERMARK_PATERN, index);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -62,6 +62,8 @@ public class MetricNames {
     public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";
     public static final String CHECKPOINT_START_DELAY_TIME = "checkpointStartDelayNanos";
 
+    public static final String WORKER_FAILURE_RATE = "startWorkFailure" + SUFFIX_RATE;
+
     public static String currentInputWatermarkName(int index) {
         return String.format(IO_CURRENT_INPUT_WATERMARK_PATERN, index);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -145,7 +145,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
     private final ClusterInformation clusterInformation;
 
-    private final ResourceManagerMetricGroup resourceManagerMetricGroup;
+    protected final ResourceManagerMetricGroup resourceManagerMetricGroup;
 
     protected final Executor ioExecutor;
 
@@ -247,7 +247,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
             leaderElectionService.start(this);
             jobLeaderIdService.start(new JobLeaderIdActionsImpl());
 
-            registerTaskExecutorMetrics();
+            registerMetrics();
         } catch (Exception e) {
             handleStartResourceManagerServicesException(e);
         }
@@ -980,7 +980,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         }
     }
 
-    private void registerTaskExecutorMetrics() {
+    protected void registerMetrics() {
         resourceManagerMetricGroup.gauge(
                 MetricNames.NUM_REGISTERED_TASK_MANAGERS, () -> (long) taskExecutors.size());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -220,7 +220,8 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
     @Override
     protected void registerMetrics() {
         super.registerMetrics();
-        resourceManagerMetricGroup.meter(MetricNames.WORKER_FAILURE_RATE, startWorkerFailureRater);
+        resourceManagerMetricGroup.meter(
+                MetricNames.START_WORKER_FAILURE_RATE, startWorkerFailureRater);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.resourcemanager.active;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.metrics.ThresholdMeter;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
@@ -260,12 +259,6 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
     @Override
     public void onError(Throwable exception) {
         onFatalError(exception);
-    }
-
-    public static ThresholdMeter createFailureRater(Configuration configuration) {
-        double rate = configuration.getDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE);
-        Preconditions.checkArgument(rate > 0, "Failure rate should be larger than 0");
-        return new ThresholdMeter(rate, Duration.ofMinutes(1));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -283,7 +283,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
     }
 
     public static ThresholdMeter createFailureRater(Configuration configuration) {
-        double rate = configuration.getDouble(ResourceManagerOptions.MAXIMUM_WORKERS_FAILURE_RATE);
+        double rate = configuration.getDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE);
         Preconditions.checkArgument(rate > 0, "Failure rate should be larger than 0");
         return new ThresholdMeter(rate, Duration.ofMinutes(1));
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.metrics.ThresholdMeter;
@@ -101,7 +102,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
             Executor ioExecutor)
             throws Exception {
 
-        final ThresholdMeter failureRater = ActiveResourceManager.createFailureRater(configuration);
+        final ThresholdMeter failureRater = createStartWorkerFailureRater(configuration);
         final Duration retryInterval =
                 configuration.get(ResourceManagerOptions.START_WORKER_RETRY_INTERVAL);
         return new ActiveResourceManager<>(
@@ -126,4 +127,15 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
     protected abstract ResourceManagerDriver<WorkerType> createResourceManagerDriver(
             Configuration configuration, @Nullable String webInterfaceUrl, String rpcAddress)
             throws Exception;
+
+    public static ThresholdMeter createStartWorkerFailureRater(Configuration configuration) {
+        double rate = configuration.getDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE);
+        if (rate <= 0) {
+            throw new IllegalConfigurationException(
+                    String.format(
+                            "Configured max start worker failure rate ('%s') must be larger than 0. Current: %f",
+                            ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE.key(), rate));
+        }
+        return new ThresholdMeter(rate, Duration.ofMinutes(1));
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -103,7 +103,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
 
         final ThresholdMeter failureRater = ActiveResourceManager.createFailureRater(configuration);
         final Duration retryInterval =
-                configuration.get(ResourceManagerOptions.WORKER_CREATION_RETRY_INTERVAL);
+                configuration.get(ResourceManagerOptions.START_WORKER_RETRY_INTERVAL);
         return new ActiveResourceManager<>(
                 createResourceManagerDriver(
                         configuration, webInterfaceUrl, rpcService.getAddress()),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -19,7 +19,9 @@
 package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.metrics.ThresholdMeter;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
@@ -37,6 +39,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
 import java.util.concurrent.Executor;
 
 /**
@@ -98,6 +101,9 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
             Executor ioExecutor)
             throws Exception {
 
+        final ThresholdMeter failureRater = ActiveResourceManager.createFailureRater(configuration);
+        final Duration retryInterval =
+                configuration.get(ResourceManagerOptions.WORKER_CREATION_RETRY_INTERVAL);
         return new ActiveResourceManager<>(
                 createResourceManagerDriver(
                         configuration, webInterfaceUrl, rpcService.getAddress()),
@@ -112,6 +118,8 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
                 clusterInformation,
                 fatalErrorHandler,
                 resourceManagerMetricGroup,
+                failureRater,
+                retryInterval,
                 ioExecutor);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -75,7 +75,7 @@ public class ActiveResourceManagerTest extends TestLogger {
 
     private static final long TIMEOUT_SEC = 5L;
     private static final Time TIMEOUT_TIME = Time.seconds(TIMEOUT_SEC);
-    private static final Time WORKER_CREATION_INTERVAL = Time.milliseconds(50);
+    private static final Time TESTING_START_WORKER_INTERVAL = Time.milliseconds(50);
 
     private static final WorkerResourceSpec WORKER_RESOURCE_SPEC = WorkerResourceSpec.ZERO;
 
@@ -493,13 +493,13 @@ public class ActiveResourceManagerTest extends TestLogger {
     }
 
     @Test
-    public void testWorkerCreationIntervalOnWorkerTerminationExceedFailureRate() throws Exception {
+    public void testStartWorkerIntervalOnWorkerTerminationExceedFailureRate() throws Exception {
         new Context() {
             {
                 flinkConfig.setDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE, 1);
                 flinkConfig.set(
                         ResourceManagerOptions.START_WORKER_RETRY_INTERVAL,
-                        Duration.ofMillis(WORKER_CREATION_INTERVAL.toMilliseconds()));
+                        Duration.ofMillis(TESTING_START_WORKER_INTERVAL.toMilliseconds()));
 
                 final AtomicInteger requestCount = new AtomicInteger(0);
 
@@ -553,13 +553,13 @@ public class ActiveResourceManagerTest extends TestLogger {
                             long t2 =
                                     requestWorkerFromDriverFutures
                                             .get(1)
-                                            .get(TIMEOUT_SEC * 5, TimeUnit.SECONDS);
+                                            .get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
                             // validate trying creating worker twice, with proper interval
                             assertThat(
                                     (t2 - t1),
                                     greaterThanOrEqualTo(
-                                            WORKER_CREATION_INTERVAL.toMilliseconds()));
+                                            TESTING_START_WORKER_INTERVAL.toMilliseconds()));
                             // second worker registered, verify registration succeed
                             CompletableFuture<RegistrationResponse> registerTaskExecutorFuture =
                                     registerTaskExecutor(tmResourceIds.get(1));
@@ -572,13 +572,13 @@ public class ActiveResourceManagerTest extends TestLogger {
     }
 
     @Test
-    public void testWorkerCreationIntervalAfterException() throws Exception {
+    public void testStartWorkerIntervalOnRequestWorkerFailure() throws Exception {
         new Context() {
             {
                 flinkConfig.setDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE, 1);
                 flinkConfig.set(
                         ResourceManagerOptions.START_WORKER_RETRY_INTERVAL,
-                        Duration.ofMillis(WORKER_CREATION_INTERVAL.toMilliseconds()));
+                        Duration.ofMillis(TESTING_START_WORKER_INTERVAL.toMilliseconds()));
 
                 final AtomicInteger requestCount = new AtomicInteger(0);
                 final ResourceID tmResourceId = ResourceID.generate();
@@ -632,13 +632,13 @@ public class ActiveResourceManagerTest extends TestLogger {
                             long t2 =
                                     requestWorkerFromDriverFutures
                                             .get(1)
-                                            .get(TIMEOUT_SEC * 5, TimeUnit.SECONDS);
+                                            .get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
                             // validate trying creating worker twice, with proper interval
                             assertThat(
                                     (t2 - t1),
                                     greaterThanOrEqualTo(
-                                            WORKER_CREATION_INTERVAL.toMilliseconds()));
+                                            TESTING_START_WORKER_INTERVAL.toMilliseconds()));
 
                             // second worker registered, verify registration succeed
                             resourceIdFutures.get(1).complete(tmResourceId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -48,6 +49,7 @@ import org.apache.flink.util.function.RunnableWithException;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,6 +59,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -72,6 +75,7 @@ public class ActiveResourceManagerTest extends TestLogger {
 
     private static final long TIMEOUT_SEC = 5L;
     private static final Time TIMEOUT_TIME = Time.seconds(TIMEOUT_SEC);
+    private static final Time WORKER_CREATION_INTERVAL = Time.milliseconds(50);
 
     private static final WorkerResourceSpec WORKER_RESOURCE_SPEC = WorkerResourceSpec.ZERO;
 
@@ -488,6 +492,166 @@ public class ActiveResourceManagerTest extends TestLogger {
         };
     }
 
+    @Test
+    public void testWorkerCreationIntervalOnWorkerTerminationExceedFailureRate() throws Exception {
+        new Context() {
+            {
+                flinkConfig.setDouble(ResourceManagerOptions.MAXIMUM_WORKERS_FAILURE_RATE, 1);
+                flinkConfig.set(
+                        ResourceManagerOptions.WORKER_CREATION_RETRY_INTERVAL,
+                        Duration.ofMillis(WORKER_CREATION_INTERVAL.toMilliseconds()));
+
+                final AtomicInteger requestCount = new AtomicInteger(0);
+
+                final List<ResourceID> tmResourceIds = new ArrayList<>();
+                tmResourceIds.add(ResourceID.generate());
+                tmResourceIds.add(ResourceID.generate());
+
+                final List<CompletableFuture<Long>> requestWorkerFromDriverFutures =
+                        new ArrayList<>();
+                requestWorkerFromDriverFutures.add(new CompletableFuture<>());
+                requestWorkerFromDriverFutures.add(new CompletableFuture<>());
+
+                driverBuilder.setRequestResourceFunction(
+                        taskExecutorProcessSpec -> {
+                            int idx = requestCount.getAndIncrement();
+                            assertThat(idx, lessThan(2));
+
+                            requestWorkerFromDriverFutures
+                                    .get(idx)
+                                    .complete(System.currentTimeMillis());
+                            return CompletableFuture.completedFuture(tmResourceIds.get(idx));
+                        });
+
+                slotManagerBuilder.setGetRequiredResourcesSupplier(
+                        () -> Collections.singletonMap(WORKER_RESOURCE_SPEC, 1));
+
+                runTest(
+                        () -> {
+                            // received worker request, verify requesting from driver
+                            CompletableFuture<Boolean> startNewWorkerFuture =
+                                    runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
+                            long t1 =
+                                    requestWorkerFromDriverFutures
+                                            .get(0)
+                                            .get(TIMEOUT_SEC, TimeUnit.SECONDS);
+                            assertThat(
+                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    is(true));
+
+                            // first worker failed before register, verify requesting another worker
+                            // from driver
+                            runInMainThread(
+                                    () ->
+                                            getResourceManager()
+                                                    .onWorkerTerminated(
+                                                            tmResourceIds.get(0),
+                                                            "terminate for testing"));
+                            long t2 =
+                                    requestWorkerFromDriverFutures
+                                            .get(1)
+                                            .get(TIMEOUT_SEC * 5, TimeUnit.SECONDS);
+
+                            // validate trying creating worker twice, with proper interval
+                            assertThat(
+                                    (t2 - t1),
+                                    greaterThanOrEqualTo(
+                                            WORKER_CREATION_INTERVAL.toMilliseconds()));
+                            // second worker registered, verify registration succeed
+                            CompletableFuture<RegistrationResponse> registerTaskExecutorFuture =
+                                    registerTaskExecutor(tmResourceIds.get(1));
+                            assertThat(
+                                    registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    instanceOf(RegistrationResponse.Success.class));
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testWorkerCreationIntervalAfterException() throws Exception {
+        new Context() {
+            {
+                flinkConfig.setDouble(ResourceManagerOptions.MAXIMUM_WORKERS_FAILURE_RATE, 1);
+                flinkConfig.set(
+                        ResourceManagerOptions.WORKER_CREATION_RETRY_INTERVAL,
+                        Duration.ofMillis(WORKER_CREATION_INTERVAL.toMilliseconds()));
+
+                final AtomicInteger requestCount = new AtomicInteger(0);
+                final ResourceID tmResourceId = ResourceID.generate();
+
+                final List<CompletableFuture<ResourceID>> resourceIdFutures = new ArrayList<>();
+                resourceIdFutures.add(new CompletableFuture<>());
+                resourceIdFutures.add(new CompletableFuture<>());
+
+                final List<CompletableFuture<Long>> requestWorkerFromDriverFutures =
+                        new ArrayList<>();
+                requestWorkerFromDriverFutures.add(new CompletableFuture<>());
+                requestWorkerFromDriverFutures.add(new CompletableFuture<>());
+
+                driverBuilder.setRequestResourceFunction(
+                        taskExecutorProcessSpec -> {
+                            int idx = requestCount.getAndIncrement();
+                            assertThat(idx, lessThan(2));
+
+                            requestWorkerFromDriverFutures
+                                    .get(idx)
+                                    .complete(System.currentTimeMillis());
+                            return resourceIdFutures.get(idx);
+                        });
+
+                slotManagerBuilder.setGetRequiredResourcesSupplier(
+                        () -> Collections.singletonMap(WORKER_RESOURCE_SPEC, 1));
+
+                runTest(
+                        () -> {
+                            // received worker request, verify requesting from driver
+                            CompletableFuture<Boolean> startNewWorkerFuture =
+                                    runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
+                            assertThat(
+                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    is(true));
+
+                            long t1 =
+                                    requestWorkerFromDriverFutures
+                                            .get(0)
+                                            .get(TIMEOUT_SEC, TimeUnit.SECONDS);
+                            // first request failed, verify requesting another worker from driver
+                            runInMainThread(
+                                    () ->
+                                            resourceIdFutures
+                                                    .get(0)
+                                                    .completeExceptionally(
+                                                            new Throwable("testing error")));
+                            long t2 =
+                                    requestWorkerFromDriverFutures
+                                            .get(1)
+                                            .get(TIMEOUT_SEC * 5, TimeUnit.SECONDS);
+
+                            // validate trying creating worker twice, with proper interval
+                            assertThat(
+                                    (t2 - t1),
+                                    greaterThanOrEqualTo(
+                                            WORKER_CREATION_INTERVAL.toMilliseconds()));
+
+                            // second worker registered, verify registration succeed
+                            resourceIdFutures.get(1).complete(tmResourceId);
+                            CompletableFuture<RegistrationResponse> registerTaskExecutorFuture =
+                                    registerTaskExecutor(tmResourceId);
+                            assertThat(
+                                    registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    instanceOf(RegistrationResponse.Success.class));
+                        });
+            }
+        };
+    }
+
     /** Tests workers from previous attempt successfully recovered and registered. */
     @Test
     public void testRecoverWorkerFromPreviousAttempt() throws Exception {
@@ -588,6 +752,8 @@ public class ActiveResourceManagerTest extends TestLogger {
             final TestingRpcService rpcService = RPC_SERVICE_RESOURCE.getTestingRpcService();
             final MockResourceManagerRuntimeServices rmServices =
                     new MockResourceManagerRuntimeServices(rpcService, TIMEOUT_TIME, slotManager);
+            final Duration retryInterval =
+                    configuration.get(ResourceManagerOptions.WORKER_CREATION_RETRY_INTERVAL);
 
             final ActiveResourceManager<ResourceID> activeResourceManager =
                     new ActiveResourceManager<>(
@@ -603,6 +769,8 @@ public class ActiveResourceManagerTest extends TestLogger {
                             new ClusterInformation("localhost", 1234),
                             fatalErrorHandler,
                             UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
+                            ActiveResourceManager.createFailureRater(configuration),
+                            retryInterval,
                             ForkJoinPool.commonPool());
 
             activeResourceManager.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -769,7 +769,8 @@ public class ActiveResourceManagerTest extends TestLogger {
                             new ClusterInformation("localhost", 1234),
                             fatalErrorHandler,
                             UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
-                            ActiveResourceManager.createFailureRater(configuration),
+                            ActiveResourceManagerFactory.createStartWorkerFailureRater(
+                                    configuration),
                             retryInterval,
                             ForkJoinPool.commonPool());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -496,9 +496,9 @@ public class ActiveResourceManagerTest extends TestLogger {
     public void testWorkerCreationIntervalOnWorkerTerminationExceedFailureRate() throws Exception {
         new Context() {
             {
-                flinkConfig.setDouble(ResourceManagerOptions.MAXIMUM_WORKERS_FAILURE_RATE, 1);
+                flinkConfig.setDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE, 1);
                 flinkConfig.set(
-                        ResourceManagerOptions.WORKER_CREATION_RETRY_INTERVAL,
+                        ResourceManagerOptions.START_WORKER_RETRY_INTERVAL,
                         Duration.ofMillis(WORKER_CREATION_INTERVAL.toMilliseconds()));
 
                 final AtomicInteger requestCount = new AtomicInteger(0);
@@ -575,9 +575,9 @@ public class ActiveResourceManagerTest extends TestLogger {
     public void testWorkerCreationIntervalAfterException() throws Exception {
         new Context() {
             {
-                flinkConfig.setDouble(ResourceManagerOptions.MAXIMUM_WORKERS_FAILURE_RATE, 1);
+                flinkConfig.setDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE, 1);
                 flinkConfig.set(
-                        ResourceManagerOptions.WORKER_CREATION_RETRY_INTERVAL,
+                        ResourceManagerOptions.START_WORKER_RETRY_INTERVAL,
                         Duration.ofMillis(WORKER_CREATION_INTERVAL.toMilliseconds()));
 
                 final AtomicInteger requestCount = new AtomicInteger(0);
@@ -753,7 +753,7 @@ public class ActiveResourceManagerTest extends TestLogger {
             final MockResourceManagerRuntimeServices rmServices =
                     new MockResourceManagerRuntimeServices(rpcService, TIMEOUT_TIME, slotManager);
             final Duration retryInterval =
-                    configuration.get(ResourceManagerOptions.WORKER_CREATION_RETRY_INTERVAL);
+                    configuration.get(ResourceManagerOptions.START_WORKER_RETRY_INTERVAL);
 
             final ActiveResourceManager<ResourceID> activeResourceManager =
                     new ActiveResourceManager<>(


### PR DESCRIPTION
## What is the purpose of the change
Add failure rate for resource manager, so that every type of Resource Managers can handle with maximum failed executers.

## Brief change log
  - Add a failure rater to record failure numbers in last one minute.
  - Update Resource Manager to use maximum failure rate threshold to limit the resource allocation.

## Verifying this change
  - Added unit test in Resource Manager to verify the functionality of maximum failure rate threshold 
   enforcement


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
