### PR TITLE
[hotfix][table] rename defaultCatalog and defaultDatabase to currentCatalog and currentDatabase, to be consistent with namings

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -74,8 +74,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 
 	private final CatalogManager catalogManager;
 
-	private final String defaultCatalogName;
-	private final String defaultDatabaseName;
+	private final String currentCatalogName;
+	private final String currentDatabaseName;
 	private final TableConfig tableConfig;
 	private final OperationTreeBuilder operationTreeBuilder;
 
@@ -96,8 +96,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 
 		this.tableConfig = tableConfig;
 		this.tableConfig.addPlannerConfig(queryConfigProvider);
-		this.defaultCatalogName = catalogManager.getCurrentCatalog();
-		this.defaultDatabaseName = catalogManager.getCurrentDatabase();
+		this.currentCatalogName = catalogManager.getCurrentCatalog();
+		this.currentDatabaseName = catalogManager.getCurrentDatabase();
 
 		this.functionCatalog = functionCatalog;
 		this.planner = planner;
@@ -340,8 +340,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	protected void registerTableInternal(String name, CatalogBaseTable table) {
 		try {
 			checkValidTableName(name);
-			ObjectPath path = new ObjectPath(defaultDatabaseName, name);
-			Optional<Catalog> catalog = catalogManager.getCatalog(defaultCatalogName);
+			ObjectPath path = new ObjectPath(currentDatabaseName, name);
+			Optional<Catalog> catalog = catalogManager.getCatalog(currentCatalogName);
 			if (catalog.isPresent()) {
 				catalog.get().createTable(
 					path,
@@ -355,8 +355,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 
 	private void replaceTableInternal(String name, CatalogBaseTable table) {
 		try {
-			ObjectPath path = new ObjectPath(defaultDatabaseName, name);
-			Optional<Catalog> catalog = catalogManager.getCatalog(defaultCatalogName);
+			ObjectPath path = new ObjectPath(currentDatabaseName, name);
+			Optional<Catalog> catalog = catalogManager.getCatalog(currentCatalogName);
 			if (catalog.isPresent()) {
 				catalog.get().alterTable(
 					path,
@@ -385,7 +385,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 
 	private void registerTableSourceInternal(String name, TableSource<?> tableSource) {
 		validateTableSource(tableSource);
-		Optional<CatalogBaseTable> table = getCatalogTable(defaultCatalogName, defaultDatabaseName, name);
+		Optional<CatalogBaseTable> table = getCatalogTable(currentCatalogName, currentDatabaseName, name);
 
 		if (table.isPresent()) {
 			if (table.get() instanceof ConnectorCatalogTable<?, ?>) {
@@ -410,7 +410,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	}
 
 	private void registerTableSinkInternal(String name, TableSink<?> tableSink) {
-		Optional<CatalogBaseTable> table = getCatalogTable(defaultCatalogName, defaultDatabaseName, name);
+		Optional<CatalogBaseTable> table = getCatalogTable(currentCatalogName, currentDatabaseName, name);
 
 		if (table.isPresent()) {
 			if (table.get() instanceof ConnectorCatalogTable<?, ?>) {


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a naming inconsistency issue in `TableEnvironmentImpl`.

## Brief change log

- rename `defaultCatalog` and `defaultDatabase` to `currentCatalog` and `currentDatabase`, to be consistent with namings

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:(no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
