### PR TITLE
[FLINK-13066][hive] append hive-site.xml to path of Hive conf dir

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -86,7 +86,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -120,7 +119,7 @@ public class HiveCatalog extends AbstractCatalog {
 
 	private HiveMetastoreClientWrapper client;
 
-	public HiveCatalog(String catalogName, @Nullable String defaultDatabase, @Nullable URL hiveConfDir, String hiveVersion) {
+	public HiveCatalog(String catalogName, @Nullable String defaultDatabase, @Nullable String hiveConfDir, String hiveVersion) {
 		this(catalogName,
 			defaultDatabase == null ? DEFAULT_DB : defaultDatabase,
 			createHiveConf(hiveConfDir),
@@ -138,15 +137,16 @@ public class HiveCatalog extends AbstractCatalog {
 		LOG.info("Created HiveCatalog '{}'", catalogName);
 	}
 
-	private static HiveConf createHiveConf(@Nullable URL hiveConfDir) {
+	private static HiveConf createHiveConf(@Nullable String hiveConfDir) {
 		LOG.info("Setting hive conf dir as {}", hiveConfDir);
 
 		try {
 			HiveConf.setHiveSiteLocation(
 				hiveConfDir == null ?
-					null : Paths.get(hiveConfDir.getPath(), "hive-site.xml").toUri().toURL());
+					null : Paths.get(hiveConfDir, "hive-site.xml").toUri().toURL());
 		} catch (MalformedURLException e) {
-			throw new CatalogException(e);
+			throw new CatalogException(
+				String.format("Failed to get hive-site.xml from %s", hiveConfDir), e);
 		}
 
 		return new HiveConf();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveCatalogFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveCatalogFactory.java
@@ -19,20 +19,15 @@
 package org.apache.flink.table.catalog.hive.factories;
 
 import org.apache.flink.table.catalog.Catalog;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.CatalogFactory;
-import org.apache.flink.util.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -82,30 +77,11 @@ public class HiveCatalogFactory implements CatalogFactory {
 			descriptorProperties.getOptionalString(CATALOG_DEFAULT_DATABASE)
 				.orElse(HiveCatalog.DEFAULT_DB);
 
-		final Optional<String> hiveSitePath = descriptorProperties.getOptionalString(CATALOG_HIVE_CONF_DIR);
+		final Optional<String> hiveConfDir = descriptorProperties.getOptionalString(CATALOG_HIVE_CONF_DIR);
 
 		final String version = descriptorProperties.getOptionalString(CATALOG_HIVE_VERSION).orElse(HiveShimLoader.getHiveVersion());
 
-		return new HiveCatalog(name, defaultDatabase, loadHiveConfDir(hiveSitePath.orElse(null)), version);
-	}
-
-	private static URL loadHiveConfDir(String hiveConfDir) {
-
-		URL url = null;
-
-		if (!StringUtils.isNullOrWhitespaceOnly(hiveConfDir)) {
-			try {
-				url = new File(hiveConfDir).toURI().toURL();
-
-				LOG.info("Successfully loaded '{}'", hiveConfDir);
-
-			} catch (MalformedURLException e) {
-				throw new CatalogException(
-					String.format("Failed to get hive conf dir from the given path '%s'", hiveConfDir), e);
-			}
-		}
-
-		return url;
+		return new HiveCatalog(name, defaultDatabase, hiveConfDir.orElse(null), version);
 	}
 
 	private static DescriptorProperties getValidatedProperties(Map<String, String> properties) {

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -966,14 +966,11 @@ class HiveCatalog(Catalog):
     A catalog implementation for Hive.
     """
 
-    def __init__(self, catalog_name=None, default_database="default", hive_site_path=None,
+    def __init__(self, catalog_name=None, default_database="default", hive_conf_dir=None,
                  j_hive_catalog=None):
         gateway = get_gateway()
 
         if j_hive_catalog is None:
-            hive_site_url = gateway.jvm.java.io.File(hive_site_path).toURI().toURL() \
-                if hive_site_path is not None else None
-
             j_hive_catalog = gateway.jvm.org.apache.flink.table.catalog.hive.HiveCatalog(
-                catalog_name, default_database, hive_site_url)
+                catalog_name, default_database, hive_conf_dir)
         super(HiveCatalog, self).__init__(j_hive_catalog)


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a bug that we previously only pass Hive conf dir to `HiveConf` but we really should pass path of hive-site.xml. Thus, the change is to append `hive-site.xml` to the Hive conf dir and pass into `HiveConf` if Hive conf dir is not null.

## Brief change log

- make `hiveConfDir` String rather than URL to simplify logic
-  append `hive-site.xml` to the Hive conf dir and pass into `HiveConf` if Hive conf dir is not null

## Verifying this change

- covered by existing test such as `DependencyTest` and `ExecutionContextTest` in sql cli
- manual testing and verificaiton

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
