### PR TITLE
[FLINK-12991][python] Correct the implementation of Catalog.get_table_factory

### DIFF
--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -54,15 +54,6 @@ class Catalog(object):
         """
         return self._j_catalog.getDefaultDatabase()
 
-    def get_table_factory(self):
-        """
-        Get an optional TableFactory instance that's responsible for generating source/sink for
-        tables stored in this catalog.
-
-        :return: An optional TableFactory instance.
-        """
-        return self._j_catalog.getTableFactory()
-
     def list_databases(self):
         """
         Get the names of all databases in this catalog.

--- a/flink-python/pyflink/table/tests/test_catalog_completeness.py
+++ b/flink-python/pyflink/table/tests/test_catalog_completeness.py
@@ -40,7 +40,7 @@ class CatalogAPICompletenessTests(PythonAPICompletenessTestCase, unittest.TestCa
     @classmethod
     def excluded_methods(cls):
         # open/close are not needed in Python API as they are used internally
-        return {'open', 'close'}
+        return {'open', 'close', 'getTableFactory'}
 
 
 class CatalogDatabaseAPICompletenessTests(PythonAPICompletenessTestCase, unittest.TestCase):


### PR DESCRIPTION
## What is the purpose of the change

*Currently the implementation of Catalog.get_table_factory returns a Java TableFactory and this is not friendly for Python users.  After taking a look at the implementation and it seems that this method will only be used internally at Java side. So I think it's not necessary to add it to the Python API. This PR fixes this issue by removing this method from the Python Catalog.*

## Brief change log

  - *Removes Catalog.get_table_factory*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
