### PR TITLE
[FLINK-13067][docs] Fix broken links to contributing docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,6 +6,6 @@ To make the process smooth for the project *committers* (those who review and ac
 
 ## Contribution Guidelines
 
-Please check out the [How to Contribute guide](http://flink.apache.org/how-to-contribute.html) to understand how contributions are made. 
-A detailed explanation can be found in our [Contribute Code Guide](http://flink.apache.org/contribute-code.html) which also contains a list of coding guidelines that you should follow.
+Please check out the [How to Contribute guide](http://flink.apache.org/contributing/how-to-contribute.html) to understand how contributions are made. 
+A detailed explanation can be found in our [Contribute Code Guide](http://flink.apache.org/contributing/contribute-code.html) which also contains a list of coding guidelines that you should follow.
 For pull requests, there is a [check list](PULL_REQUEST_TEMPLATE.md) with criteria taken from the How to Contribute Guide and the Coding Guidelines.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
   - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
   
-  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contributing/contribute-code.html#best-practices).
+  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).
 
   - Each pull request should address only one issue, not mix up code from multiple issues.
   

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
   - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
   
-  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).
+  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contributing/contribute-code.html#best-practices).
 
   - Each pull request should address only one issue, not mix up code from multiple issues.
   

--- a/docs/dev/libs/gelly/index.md
+++ b/docs/dev/libs/gelly/index.md
@@ -135,6 +135,6 @@ wget -O - http://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.g
 
 Please submit feature requests and report issues on the user [mailing list](https://flink.apache.org/community.html#mailing-lists)
 or [Flink Jira](https://issues.apache.org/jira/browse/FLINK). We welcome suggestions for new algorithms and features as
-well as [code contributions](https://flink.apache.org/contribute-code.html).
+well as [code contributions](https://flink.apache.org/contributing/contribute-code.html).
 
 {% top %}

--- a/docs/dev/libs/gelly/index.zh.md
+++ b/docs/dev/libs/gelly/index.zh.md
@@ -135,6 +135,6 @@ wget -O - http://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.g
 
 Please submit feature requests and report issues on the user [mailing list](https://flink.apache.org/community.html#mailing-lists)
 or [Flink Jira](https://issues.apache.org/jira/browse/FLINK). We welcome suggestions for new algorithms and features as
-well as [code contributions](https://flink.apache.org/contribute-code.html).
+well as [code contributions](https://flink.apache.org/contributing/contribute-code.html).
 
 {% top %}

--- a/docs/dev/libs/ml/contribution_guide.md
+++ b/docs/dev/libs/ml/contribution_guide.md
@@ -31,7 +31,7 @@ The following document describes how to contribute to FlinkML.
 
 ## Getting Started
 
-In order to get started first read Flink's [contribution guide](http://flink.apache.org/how-to-contribute.html).
+In order to get started first read Flink's [contribution guide](http://flink.apache.org/contributing/how-to-contribute.html).
 Everything from this guide also applies to FlinkML.
 
 ## Pick a Topic
@@ -103,6 +103,6 @@ See `docs/_include/latex_commands.html` for the complete list of predefined late
 ## Contributing
 
 Once you have implemented the algorithm with adequate test coverage and added documentation, you are ready to open a pull request.
-Details of how to open a pull request can be found [here](http://flink.apache.org/how-to-contribute.html#contributing-code--documentation).
+Details of how to open a pull request can be found [here](http://flink.apache.org/contributing/how-to-contribute.html).
 
 {% top %}

--- a/docs/dev/libs/ml/contribution_guide.zh.md
+++ b/docs/dev/libs/ml/contribution_guide.zh.md
@@ -31,7 +31,7 @@ The following document describes how to contribute to FlinkML.
 
 ## Getting Started
 
-In order to get started first read Flink's [contribution guide](http://flink.apache.org/how-to-contribute.html).
+In order to get started first read Flink's [contribution guide](http://flink.apache.org/contributing/how-to-contribute.html).
 Everything from this guide also applies to FlinkML.
 
 ## Pick a Topic
@@ -103,6 +103,6 @@ See `docs/_include/latex_commands.html` for the complete list of predefined late
 ## Contributing
 
 Once you have implemented the algorithm with adequate test coverage and added documentation, you are ready to open a pull request.
-Details of how to open a pull request can be found [here](http://flink.apache.org/how-to-contribute.html#contributing-code--documentation).
+Details of how to open a pull request can be found [here](http://flink.apache.org/contributing/how-to-contribute.html).
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

Fix broken links to contributing docs


## Brief change log

Fix broken links to contributing websites in all docs

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
