### PR TITLE
[FLINK-13059][Cassandra Connector] Release Semaphore correctly on Exception in send()

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -129,7 +129,13 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 	public void invoke(IN value) throws Exception {
 		checkAsyncErrors();
 		tryAcquire();
-		final ListenableFuture<V> result = send(value);
+		final ListenableFuture<V> result;
+		try {
+			result = send(value);
+		} catch (Exception e) {
+			semaphore.release();
+			throw e;
+		}
 		Futures.addCallback(result, callback);
 	}
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -128,7 +128,7 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 	@Override
 	public void invoke(IN value) throws Exception {
 		checkAsyncErrors();
-		tryAcquire();
+		tryAcquire(1);
 		final ListenableFuture<V> result;
 		try {
 			result = send(value);
@@ -144,10 +144,6 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 	}
 
 	public abstract ListenableFuture<V> send(IN value);
-
-	private void tryAcquire() throws InterruptedException, TimeoutException {
-		tryAcquire(1);
-	}
 
 	private void tryAcquire(int permits) throws InterruptedException, TimeoutException {
 		if (!semaphore.tryAcquire(permits, config.getMaxConcurrentRequestsTimeout().toMillis(), TimeUnit.MILLISECONDS)) {

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -181,7 +181,7 @@ public class CassandraSinkBaseTest {
 				}
 			};
 			t.start();
-			while (t.getState() != Thread.State.WAITING) {
+			while (t.getState() != Thread.State.TIMED_WAITING) {
 				Thread.sleep(5);
 			}
 
@@ -213,7 +213,7 @@ public class CassandraSinkBaseTest {
 				}
 			};
 			t.start();
-			while (t.getState() != Thread.State.WAITING) {
+			while (t.getState() != Thread.State.TIMED_WAITING) {
 				Thread.sleep(5);
 			}
 

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.Preconditions;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.Assert;
@@ -273,6 +274,26 @@ public class CassandraSinkBaseTest {
 	}
 
 	@Test(timeout = DEFAULT_TEST_TIMEOUT)
+	public void testReleaseOnSendException() throws Exception {
+		final CassandraSinkBaseConfig config = CassandraSinkBaseConfig.newBuilder()
+			.setMaxConcurrentRequests(1)
+			.build();
+
+		try (TestCassandraSink testCassandraSink = createOpenedSendExceptionTestCassandraSink(config)) {
+			Assert.assertEquals(1, testCassandraSink.getAvailablePermits());
+			Assert.assertEquals(0, testCassandraSink.getAcquiredPermits());
+
+			try {
+				testCassandraSink.invoke("N/A");
+			} catch (Exception e) {
+				Assert.assertTrue(e instanceof InvalidQueryException);
+				Assert.assertEquals(1, testCassandraSink.getAvailablePermits());
+				Assert.assertEquals(0, testCassandraSink.getAcquiredPermits());
+			}
+		}
+	}
+
+	@Test(timeout = DEFAULT_TEST_TIMEOUT)
 	public void testTimeoutExceptionOnInvoke() throws Exception {
 		final CassandraSinkBaseConfig config = CassandraSinkBaseConfig.newBuilder()
 			.setMaxConcurrentRequests(1)
@@ -331,6 +352,12 @@ public class CassandraSinkBaseTest {
 		return testHarness;
 	}
 
+	private TestCassandraSink createOpenedSendExceptionTestCassandraSink(CassandraSinkBaseConfig config) {
+		final TestCassandraSink testCassandraSink = new SendExceptionTestCassandraSink(config);
+		testCassandraSink.open(new Configuration());
+		return testCassandraSink;
+	}
+
 	private static class TestCassandraSink extends CassandraSinkBase<String, ResultSet> implements AutoCloseable {
 
 		private static final ClusterBuilder builder;
@@ -377,6 +404,17 @@ public class CassandraSinkBaseTest {
 		void enqueueCompletableFuture(CompletableFuture<ResultSet> completableFuture) {
 			Preconditions.checkNotNull(completableFuture);
 			resultSetFutures.offer(ResultSetFutures.fromCompletableFuture(completableFuture));
+		}
+	}
+
+	private static class SendExceptionTestCassandraSink extends TestCassandraSink {
+		SendExceptionTestCassandraSink(CassandraSinkBaseConfig config) {
+			super(config, new NoOpCassandraFailureHandler());
+		}
+
+		@Override
+		public ListenableFuture<ResultSet> send(String value) {
+			throw new InvalidQueryException("For test purposes");
 		}
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Release the MaxConcurrentRequests Semaphore correctly, if an exception happens in send(). This should make flush() not deadlock, but just in case: make flush timeout controllable by MaxConcurrentRequestsTimeout.

## Brief change log

  - Release Semaphore correctly on Exception in send()
  - Use getMaxConcurrentRequestsTimeout() also for flush



## Verifying this change

This change added tests and can be verified as follows:
  - Added unit test that validates semaphore released if Exception in send(); test fails before change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
