### PR TITLE
[FLINK-13077][python] Fix the failed test in CatalogPartitionAPICompletenessTests caused by the lack of "getComment" method.

### DIFF
--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -736,6 +736,15 @@ class CatalogPartition(object):
         else:
             return None
 
+    def get_comment(self):
+        """
+        Get comment of the partition.
+
+        :return: Comment of the partition.
+        :rtype: str
+        """
+        return self._j_catalog_partition.getComment()
+
 
 class CatalogFunction(object):
     """


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the failed test in CatalogPartitionAPICompletenessTests caused by the lack of "getComment" method.*


## Brief change log

  - *Add `get_comment` method in python class `CatalogPartition`.*


## Verifying this change


This change is already covered by existing tests `CatalogPartitionAPICompletenessTests`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (python docs)
