### PR TITLE
[FLINK-13081][table-planner][table-api-java] Supports explain DAG plan

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -290,6 +290,25 @@ public interface TableEnvironment {
 	String explain(Table table);
 
 	/**
+	 * Returns the AST of the specified Table API and SQL queries and the execution plan to compute
+	 * the result of the given {@link Table}.
+	 *
+	 * @param table The table for which the AST and execution plan will be returned.
+	 * @param extended if the plan should contain additional properties such as
+	 * e.g. estimated cost, traits
+	 */
+	String explain(Table table, boolean extended);
+
+	/**
+	 * Returns the AST of the specified Table API and SQL queries and the execution plan to compute
+	 * the result of multiple-sinks plan.
+	 *
+	 * @param extended if the plan should contain additional properties such as
+	 * e.g. estimated cost, traits
+	 */
+	String explain(boolean extended);
+
+	/**
 	 * Returns completion hints for the given statement at the given cursor position.
 	 * The completion happens case insensitively.
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -68,6 +68,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of {@link TableEnvironment} that works exclusively with Table API interfaces.
@@ -269,7 +270,19 @@ public class TableEnvironmentImpl implements TableEnvironment {
 
 	@Override
 	public String explain(Table table) {
-		return planner.explain(Collections.singletonList(table.getQueryOperation()), false);
+		return explain(table, false);
+	}
+
+	@Override
+	public String explain(Table table, boolean extended) {
+		return planner.explain(Collections.singletonList(table.getQueryOperation()), extended);
+	}
+
+	@Override
+	public String explain(boolean extended) {
+		List<Operation> operations = bufferedModifyOperations.stream()
+			.map(o -> (Operation) o).collect(Collectors.toList());
+		return planner.explain(operations, extended);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -84,12 +84,12 @@ public interface Planner {
 	 * Returns the AST of the specified Table API and SQL queries and the execution plan
 	 * to compute the result of the given collection of {@link QueryOperation}s.
 	 *
-	 * @param queryOperations The collection of relational queries for which the AST
+	 * @param operations The collection of relational queries for which the AST
 	 * and execution plan will be returned.
 	 * @param extended if the plan should contain additional properties such as
 	 * e.g. estimated cost, traits
 	 */
-	String explain(List<QueryOperation> queryOperations, boolean extended);
+	String explain(List<Operation> operations, boolean extended);
 
 	/**
 	 * Returns completion hints for the given statement at the given cursor position.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
@@ -200,7 +200,9 @@ abstract class BatchTableEnvImpl(
 
   def explain(table: Table): String = explain(table: Table, extended = false)
 
-  override def execute(jobName: String): JobExecutionResult = execEnv.execute(jobName)
+  override def explain(extended: Boolean): String = {
+    throw new TableException("This method is unsupported in old planner.")
+  }
 
   protected def asQueryOperation[T](dataSet: DataSet[T], fields: Option[Array[Expression]])
     : DataSetQueryOperation[T] = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -124,12 +124,13 @@ class StreamPlanner(
     tableOperations.asScala.map(translate).filter(Objects.nonNull).asJava
   }
 
-  override def explain(
-      tableOperations: util.List[QueryOperation],
-      extended: Boolean)
-    : String = {
-    tableOperations.asScala.map(explain(_, unwrapQueryConfig))
-      .mkString(s"${System.lineSeparator}${System.lineSeparator}")
+  override def explain(operations: util.List[Operation], extended: Boolean): String = {
+    operations.asScala.map {
+      case queryOperation: QueryOperation =>
+        explain(queryOperation, unwrapQueryConfig)
+      case operation =>
+        throw new TableException(s"${operation.getClass.getCanonicalName} is not supported")
+    }.mkString(s"${System.lineSeparator}${System.lineSeparator}")
   }
 
   override def getCompletionHints(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -64,6 +64,10 @@ class MockTableEnvironment extends TableEnvironment {
 
   override def explain(table: Table): String = ???
 
+  override def explain(table: Table, extended: Boolean): String = ???
+
+  override def explain(extended: Boolean): String = ???
+
   override def getCompletionHints(statement: String, position: Int): Array[String] = ???
 
   override def sqlQuery(query: String): Table = ???


### PR DESCRIPTION
## What is the purpose of the change

*Supports explain DAG plan*


## Brief change log

  - *add explain(Boolean) into TableEnvironment*
  - *add isLazyOptMode field into EnvironmentSettings, which tells whether the table environment should optimize a query in sqlUpdate&insertInto method or before executing*


## Verifying this change

the existing test cases should be passed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
