### PR TITLE
[hotfix][table] remove @PublicEvolving annotation from AbstractCatalog

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/AbstractCatalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/AbstractCatalog.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.catalog;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.util.StringUtils;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -26,7 +25,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /**
  * Abstract class for catalogs.
  */
-@PublicEvolving
 public abstract class AbstractCatalog implements Catalog {
 	private final String catalogName;
 	private final String defaultDatabase;


### PR DESCRIPTION
## What is the purpose of the change

This PR removes `@PublicEvolving` annotation from `AbstractCatalog`. `@PublicEvolving` should be on the `Catalog` interface (which it already is), and marking `AbstractCatalog` as `@PublicEvolving` brings us extra burden on maintaining its compatibility.

## Brief change log

- removes `@PublicEvolving` annotation from `AbstractCatalog`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
