### PR TITLE
[FLINK-13087][table] Add group window Aggregate operator to Table API

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2643,6 +2643,26 @@ Table table = input
     
     <tr>
       <td>
+        <strong>Group Window Aggregate</strong><br>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+      </td>
+      <td>
+        <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys. You have to close the "aggregate" with a select statement. And the select statement does not support "*" or aggregate functions.</p>
+{% highlight java %}
+AggregateFunction myAggFunc = new MyMinMax();
+tableEnv.registerFunction("myAggFunc", myAggFunc);
+
+Table table = input
+    .window(Tumble.over("5.minutes").on("rowtime").as("w")) // define window
+    .groupBy("key, w") // group by key and window
+    .aggregate("myAggFunc(a) as (x, y)")
+    .select("key, x, y, w.start, w.end"); // access window properties and aggregate results
+{% endhighlight %}
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         <strong>FlatAggregate</strong><br>
         <span class="label label-primary">Streaming</span><br>
         <span class="label label-info">Result Updating</span>
@@ -2837,7 +2857,7 @@ class MyMinMax extends AggregateFunction[Row, MyMinMaxAcc] {
   }
 }
 
-val myAggFunc: AggregateFunction = new MyMinMax
+val myAggFunc = new MyMinMax
 val table = input
   .groupBy('key)
   .aggregate(myAggFunc('a) as ('x, 'y))
@@ -2846,6 +2866,25 @@ val table = input
       </td>
     </tr>
     
+    <tr>
+      <td>
+        <strong>Group Window Aggregate</strong><br>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+      </td>
+      <td>
+        <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys. You have to close the "aggregate" with a select statement. And the select statement does not support "*" or aggregate functions.</p>
+{% highlight scala %}
+val myAggFunc = new MyMinMax
+val table = input
+    .window(Tumble over 5.minutes on 'rowtime as 'w) // define window
+    .groupBy('key, 'w) // group by key and window
+    .aggregate(myAggFunc('a) as ('x, 'y))
+    .select('key, 'x, 'y, 'w.start, 'w.end) // access window properties and aggregate results
+
+{% endhighlight %}
+      </td>
+    </tr>
+
     <tr>
       <td>
         <strong>FlatAggregate</strong><br>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
@@ -56,6 +56,43 @@ public interface WindowGroupedTable {
 	Table select(Expression... fields);
 
 	/**
+	 * Performs an aggregate operation on a window grouped table. You have to close the
+	 * {@link #aggregate(String)} with a select statement. The output will be flattened if the
+	 * output type is a composite type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   AggregateFunction aggFunc = new MyAggregateFunction();
+	 *   tableEnv.registerFunction("aggFunc", aggFunc);
+	 *   windowGroupedTable
+	 *     .aggregate("aggFunc(a, b) as (x, y, z)")
+	 *     .select("key, window.start, x, y, z")
+	 * }
+	 * </pre>
+	 */
+	AggregatedTable aggregate(String aggregateFunction);
+
+	/**
+	 * Performs an aggregate operation on a window grouped table. You have to close the
+	 * {@link #aggregate(Expression)} with a select statement. The output will be flattened if the
+	 * output type is a composite type.
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   val aggFunc = new MyAggregateFunction
+	 *   windowGroupedTable
+	 *     .aggregate(aggFunc('a, 'b) as ('x, 'y, 'z))
+	 *     .select('key, 'window.start, 'x, 'y, 'z)
+	 * }
+	 * </pre>
+	 */
+	AggregatedTable aggregate(Expression aggregateFunction);
+
+	/**
 	 * Performs a flatAggregate operation on a window grouped table. FlatAggregate takes a
 	 * TableAggregateFunction which returns multiple rows. Use a selection after flatAggregate.
 	 *
@@ -63,7 +100,7 @@ public interface WindowGroupedTable {
 	 *
 	 * <pre>
 	 * {@code
-	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction
+	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction();
 	 *   tableEnv.registerFunction("tableAggFunc", tableAggFunc);
 	 *   windowGroupedTable
 	 *     .flatAggregate("tableAggFunc(a, b) as (x, y, z)")

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -809,6 +809,12 @@ public class TableImpl implements Table {
 					"after the flatAggregate.");
 			}
 
+			if (extracted.getProjections().stream()
+				.anyMatch(p -> (p instanceof UnresolvedReferenceExpression)
+					&& "*".equals(((UnresolvedReferenceExpression) p).getName()))) {
+				throw new ValidationException("Can not use * for window aggregate!");
+			}
+
 			return table.createTable(
 				table.operationTreeBuilder.project(
 					extracted.getProjections(),

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -804,24 +804,24 @@ public class TableImpl implements Table {
 				expressionsWithResolvedCalls
 			);
 
-		if (!extracted.getAggregations().isEmpty()) {
-			throw new ValidationException("Aggregate functions cannot be used in the select right " +
-				"after the flatAggregate.");
-		}
+			if (!extracted.getAggregations().isEmpty()) {
+				throw new ValidationException("Aggregate functions cannot be used in the select right " +
+					"after the flatAggregate.");
+			}
 
-		return table.createTable(
-			table.operationTreeBuilder.project(
-				extracted.getProjections(),
-				table.operationTreeBuilder.windowTableAggregate(
-					groupKeys,
-					window,
-					extracted.getWindowProperties(),
-					tableAggFunction,
-					table.operationTree
-				),
-				// required for proper resolution of the time attribute in multi-windows
-				true
-			));
+			return table.createTable(
+				table.operationTreeBuilder.project(
+					extracted.getProjections(),
+					table.operationTreeBuilder.windowTableAggregate(
+						groupKeys,
+						window,
+						extracted.getWindowProperties(),
+						tableAggFunction,
+						table.operationTree
+					),
+					// required for proper resolution of the time attribute in multi-windows
+					true
+				));
 		}
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.api.WindowGroupedTable;
 import org.apache.flink.table.catalog.FunctionLookup;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionParser;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.expressions.resolver.LookupCallResolver;
 import org.apache.flink.table.functions.TemporalTableFunction;
 import org.apache.flink.table.functions.TemporalTableFunctionImpl;
@@ -762,6 +763,16 @@ public class TableImpl implements Table {
 		}
 
 		@Override
+		public AggregatedTable aggregate(String aggregateFunction) {
+			return aggregate(ExpressionParser.parseExpression(aggregateFunction));
+		}
+
+		@Override
+		public AggregatedTable aggregate(Expression aggregateFunction) {
+			return new WindowAggregatedTableImpl(table, groupKeys, aggregateFunction, window);
+		}
+
+		@Override
 		public FlatAggregateTable flatAggregate(String tableAggregateFunction) {
 			return flatAggregate(ExpressionParser.parseExpression(tableAggregateFunction));
 		}
@@ -769,6 +780,62 @@ public class TableImpl implements Table {
 		@Override
 		public FlatAggregateTable flatAggregate(Expression tableAggregateFunction) {
 			return new WindowFlatAggregateTableImpl(table, groupKeys, tableAggregateFunction, window);
+		}
+	}
+
+	private static final class WindowAggregatedTableImpl implements AggregatedTable {
+		private final TableImpl table;
+		private final List<Expression> groupKeys;
+		private final Expression aggregateFunction;
+		private final GroupWindow window;
+
+		private WindowAggregatedTableImpl(
+			TableImpl table,
+			List<Expression> groupKeys,
+			Expression aggregateFunction,
+			GroupWindow window) {
+			this.table = table;
+			this.groupKeys = groupKeys;
+			this.aggregateFunction = aggregateFunction;
+			this.window = window;
+		}
+
+		@Override
+		public Table select(String fields) {
+			return select(ExpressionParser.parseExpressionList(fields).toArray(new Expression[0]));
+		}
+
+		@Override
+		public Table select(Expression... fields) {
+			List<Expression> expressionsWithResolvedCalls = Arrays.stream(fields)
+				.map(f -> f.accept(table.lookupResolver))
+				.collect(Collectors.toList());
+			CategorizedExpressions extracted = OperationExpressionsUtils.extractAggregationsAndProperties(
+				expressionsWithResolvedCalls
+			);
+
+			if (!extracted.getAggregations().isEmpty()) {
+				throw new ValidationException("Aggregate functions cannot be used in the select right " +
+					"after the aggregate.");
+			}
+
+			if (extracted.getProjections().stream()
+				.anyMatch(p -> (p instanceof UnresolvedReferenceExpression)
+					&& "*".equals(((UnresolvedReferenceExpression) p).getName()))) {
+				throw new ValidationException("Can not use * for window aggregate!");
+			}
+
+			return table.createTable(
+				table.operationTreeBuilder.project(
+					extracted.getProjections(),
+					table.operationTreeBuilder.windowAggregate(
+						groupKeys,
+						window,
+						extracted.getWindowProperties(),
+						aggregateFunction,
+						table.operationTree
+					)
+				));
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/AggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/AggregateTest.scala
@@ -345,14 +345,14 @@ class AggregateTest extends TableTestBase {
   }
 
   @Test
-  def testSelectStar(): Unit = {
+  def testSelectStarAndGroupByCall(): Unit = {
     val util = streamTestUtil()
     val table = util.addTable[(Int, Long, String)](
       "MyTable", 'a, 'b, 'c)
 
     val testAgg = new CountMinMax
     val resultTable = table
-      .groupBy('b)
+      .groupBy('b % 5)
       .aggregate(testAgg('a))
       .select('*)
 
@@ -364,12 +364,12 @@ class AggregateTest extends TableTestBase {
           unaryNode(
             "DataStreamCalc",
             streamTableNode(table),
-            term("select", "a", "b")
+            term("select", "a", "MOD(b, 5) AS TMP_0")
           ),
-          term("groupBy", "b"),
-          term("select", "b", "CountMinMax(a) AS TMP_0")
+          term("groupBy", "TMP_0"),
+          term("select", "TMP_0", "CountMinMax(a) AS TMP_1")
         ),
-        term("select", "b", "TMP_0.f0 AS f0", "TMP_0.f1 AS f1", "TMP_0.f2 AS f2")
+        term("select", "TMP_0", "TMP_1.f0 AS f0", "TMP_1.f1 AS f1", "TMP_1.f2 AS f2")
       )
     util.verifyTable(resultTable, expected)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/AggregateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/AggregateValidationTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.stream.table.validation
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.{ExpressionParserException, ValidationException}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.utils.{TableFunc0, TableTestBase}
+import org.apache.flink.table.utils.{CountMinMax, TableFunc0, TableTestBase}
 import org.junit.Test
 
 class AggregateValidationTest extends TableTestBase {
@@ -122,5 +122,24 @@ class AggregateValidationTest extends TableTestBase {
       .groupBy('a)
       // must fail. Only one AggregateFunction can be used in aggregate
       .aggregate("sum(c), count(b)")
+  }
+
+  @Test
+  def testInvalidAlias(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("List of column aliases must have same degree as " +
+      "table; the returned table of function 'minMax(b)' has 3 columns, " +
+      "whereas alias list has 2 columns")
+
+    val util = streamTestUtil()
+    val table = util.addTable[(Long, Int, String)]('a, 'b, 'c)
+    val minMax = new CountMinMax
+
+    util.tableEnv.registerFunction("minMax", minMax)
+    table
+      .groupBy('a)
+      // must fail. Invalid alias length
+      .aggregate("minMax(b) as (x, y)")
+      .select("x, y")
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/GroupWindowTableAggregateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/GroupWindowTableAggregateValidationTest.scala
@@ -254,4 +254,19 @@ class GroupWindowTableAggregateValidationTest extends TableTestBase {
       .flatAggregate(top3('int))
       .select('string, 'f0.count)
   }
+
+  @Test
+  def testInvalidStarInSelection(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Can not use * for window aggregate!")
+
+    val util = streamTestUtil()
+    val table = util.addTable[(Long, Int, String)]('long, 'int, 'string, 'proctime.proctime)
+
+    table
+      .window(Tumble over 2.rows on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('*)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
@@ -32,6 +32,7 @@ import org.apache.flink.table.functions.aggfunctions.CountAggFunction
 import org.apache.flink.table.runtime.stream.table.GroupWindowITCase._
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, CountDistinctWithMerge, WeightedAvg, WeightedAvgWithMerge}
 import org.apache.flink.table.runtime.utils.StreamITCase
+import org.apache.flink.table.utils.CountMinMax
 import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.types.Row
 import org.junit.Assert._
@@ -440,6 +441,37 @@ class GroupWindowITCase extends AbstractTestBase {
       "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
       "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
       "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.033")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testRowbasedAggregateWithEventTimeTumblingWindow(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = StreamTableEnvironment.create(env)
+    StreamITCase.testResults = mutable.MutableList()
+
+    val stream = env
+      .fromCollection(data)
+      .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Long, Int, String)](0L))
+    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'rowtime.rowtime)
+    val minMax = new CountMinMax
+
+    val windowedTable = table
+      .window(Tumble over 5.milli on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .aggregate(minMax('int) as ('x, 'y, 'z))
+      .select('string, 'x, 'y, 'z, 'w.start, 'w.end)
+
+    val results = windowedTable.toAppendStream[Row]
+    results.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = Seq(
+      "Hello world,1,3,3,1970-01-01 00:00:00.005,1970-01-01 00:00:00.01",
+      "Hello world,1,3,3,1970-01-01 00:00:00.015,1970-01-01 00:00:00.02",
+      "Hello,2,2,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "Hi,1,1,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds row-based group window Aggregate operator to Table API. 
Also, there are some hotfixes in separate commits. The implementation window aggregate operator depends on some hotfixes, so I didn't create other jiras.


## Brief change log

There are totally 5 commits:
  - [#f5e8d1f](https://github.com/apache/flink/commit/f5e8d1f60a1de4ff69e5e713c4382327c149f33c) Resolve indent problem for `WindowFlatAggregateTableImpl`.
  - [#9395878](https://github.com/apache/flink/commit/939587853716a64c787af17be4610216f9c3b225) Add call support in the group by for row based aggregate. For example, support groupBy('a % b) expressions.
  - [#ee2b065](https://github.com/apache/flink/commit/ee2b06567ef11569dc29fd3c9622fd8afbc49bcc) Throw exceptions if there is a start in the select after window (table)aggregate. Because we don't know which window properties should be selected.
  - [#365f31d](https://github.com/apache/flink/commit/365f31da14376b74dd4a3286dbe0ae17be22d4a6) Validate alias length for aggregate. The alias length should equal to the length of result type.
  - [#0b6348d](https://github.com/apache/flink/pull/8979/commits/0b6348de96fcd1d9a78e4ab2bc91a19b3e677fc6) Add group window Aggregate operator to Table API

For the last commit: Add group window Aggregate operator to Table API, it mainly contains the following changes
  - Add `aggregate` method to the `WindowGroupedTable`
  - Build `windowAggregate` QueryOperation in `OperationTreeBuilder`
  - Add tests and docs


## Verifying this change

This change added tests and can be verified as follows:

  - Added plan tests in `AggregateStringExpressionTest`, `AggregateTest`
  - Add validation tests in `GroupWindowValidationTest`
  - Add IT tests in `GroupWindowITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
