### PR TITLE
[FLINK-13097] Make the cause for EOFException explicit (buffer depletion)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/SimpleCollectingOutputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/SimpleCollectingOutputView.java
@@ -76,7 +76,7 @@ public class SimpleCollectingOutputView extends AbstractPagedOutputView {
 			this.segmentNum++;
 			return next;
 		} else {
-			throw new EOFException();
+			throw new EOFException("Can't collect further: memorySource depleted");
 		}
 	}
 	


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request makes explicit that the cause of EOFException is the inability to further allocate buffers.
The JDK documentation hints but does not specify that EOFException is "mainly" made for input channels, making the choice of EOFException valid to the letter of the specification. 
However, not providing an explanatory text makes it difficult as a newcomer to understand that Flink isn't failing to read (as would be expected of an EOFException) but to allocate a buffer

Alternates solutions considered:
* throw OutOfMemoryError: errors are not made to be thrown by application-level code; furthermore, and contrary to OOME, the depletion of a pre-allocated MemorySegmentSource does **not** mean that the JVM is in an unpredictable state
* throw ClosedChannelException: the definition of this exception may make it more appropriate, however it is also vague enough that explanatory text would still be important to facilitate diagnosis. Furthermore, while the AbstractPagedOutputView contract would allow it ("throws IOException"), this may be a surprising change to existing consumers.

## Brief change log

- throw new EOFException now uses the ctor with an explanatory message.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
