### PR TITLE
[FLINK-13098][datastream] Add a new type UNDEFINED of shuffle mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -83,7 +83,7 @@ public class StreamEdge implements Serializable {
 				selectedNames,
 				outputPartitioner,
 				outputTag,
-				ShuffleMode.PIPELINED);
+				ShuffleMode.UNDEFINED);
 	}
 
 	public StreamEdge(StreamNode sourceVertex, StreamNode targetVertex, int typeNumber,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -470,7 +470,7 @@ public class StreamGraph extends StreamingPlan {
 			}
 
 			if (shuffleMode == null) {
-				shuffleMode = ShuffleMode.PIPELINED;
+				shuffleMode = ShuffleMode.UNDEFINED;
 			}
 
 			StreamEdge edge = new StreamEdge(upstreamNode, downstreamNode, typeNumber, outputNames, partitioner, outputTag, shuffleMode);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -509,6 +509,7 @@ public class StreamingJobGraphGenerator {
 		ResultPartitionType resultPartitionType;
 		switch (edge.getShuffleMode()) {
 			case PIPELINED:
+			case UNDEFINED:
 				resultPartitionType = ResultPartitionType.PIPELINED_BOUNDED;
 				break;
 			case BATCH:

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
@@ -54,7 +54,7 @@ public class PartitionTransformation<T> extends Transformation<T> {
 	 * @param partitioner The {@code StreamPartitioner}
 	 */
 	public PartitionTransformation(Transformation<T> input, StreamPartitioner<T> partitioner) {
-		this(input, partitioner, ShuffleMode.PIPELINED);
+		this(input, partitioner, ShuffleMode.UNDEFINED);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ShuffleMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ShuffleMode.java
@@ -35,5 +35,12 @@ public enum ShuffleMode {
 	 * The producer first produces its entire result and finishes.
 	 * After that, the consumer is started and may consume the data.
 	 */
-	BATCH
+	BATCH,
+
+	/**
+	 * The shuffle mode is undefined.
+	 * It leaves it up to the framework to decide the shuffle mode.
+	 * The framework will pick one of {@link ShuffleMode#BATCH} or {@link ShuffleMode#PIPELINED} in the end.
+	 */
+	UNDEFINED
 }


### PR DESCRIPTION
## What is the purpose of the change

* This new shuffle type leaves some space for optimization later. The optimization might be based on resources or some global settings.

## Brief change log

* The `UNDEFINED` type is the default value of shuffle mode. If there is no specific `PartitionTransformation`, the shuffle mode would be `UNDEFINED`.
* The `UNDEFINED` shuffle mode can be chained

## Verifying this change

* Modify the existing case to cover this

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable