### PR TITLE
[FLINK-13096][Deployment/YARN]Typo in Utils

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -333,7 +333,7 @@ public final class Utils {
 	 * Method to extract environment variables from the flinkConfiguration based on the given prefix String.
 	 *
 	 * @param envPrefix Prefix for the environment variables key
-	 * @param flinkConfiguration The Flink config to get the environment variable defintion from
+	 * @param flinkConfiguration The Flink config to get the environment variable definition from
 	 */
 	public static Map<String, String> getEnvironmentVariables(String envPrefix, org.apache.flink.configuration.Configuration flinkConfiguration) {
 		Map<String, String> result  = new HashMap<>();


### PR DESCRIPTION
## What is the purpose of the change

Change Typo in Utils.getEnvironmentVariables() method's comment : "defintion" to "definition".

## Brief change log
Change Typo in Utils.getEnvironmentVariables() method's comment : "defintion” to “definition”.

## Verifying this change

this change just correct a word error.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
