### PR TITLE
[FLINK-13101][datastream] Introduce blockingConnectionsBetweenChains property of StreamGraph

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -83,7 +83,7 @@ public class StreamEdge implements Serializable {
 				selectedNames,
 				outputPartitioner,
 				outputTag,
-				ShuffleMode.PIPELINED);
+				ShuffleMode.UNDEFINED);
 	}
 
 	public StreamEdge(StreamNode sourceVertex, StreamNode targetVertex, int typeNumber,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -97,6 +97,12 @@ public class StreamGraph extends StreamingPlan {
 
 	private TimeCharacteristic timeCharacteristic;
 
+	/**
+	 * If there are some stream edges that can not be chained and the shuffle mode of edge is not specified,
+	 * translate these edges into `BLOCKING` result partition type.
+	 */
+	private boolean blockingConnectionsBetweenChains;
+
 	private Map<Integer, StreamNode> streamNodes;
 	private Set<Integer> sources;
 	private Set<Integer> sinks;
@@ -182,6 +188,14 @@ public class StreamGraph extends StreamingPlan {
 
 	public void setTimeCharacteristic(TimeCharacteristic timeCharacteristic) {
 		this.timeCharacteristic = timeCharacteristic;
+	}
+
+	public boolean isBlockingConnectionsBetweenChains() {
+		return blockingConnectionsBetweenChains;
+	}
+
+	public void setBlockingConnectionsBetweenChains(boolean blockingConnectionsBetweenChains) {
+		this.blockingConnectionsBetweenChains = blockingConnectionsBetweenChains;
 	}
 
 	// Checkpointing

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -470,7 +470,7 @@ public class StreamGraph extends StreamingPlan {
 			}
 
 			if (shuffleMode == null) {
-				shuffleMode = ShuffleMode.PIPELINED;
+				shuffleMode = ShuffleMode.UNDEFINED;
 			}
 
 			StreamEdge edge = new StreamEdge(upstreamNode, downstreamNode, typeNumber, outputNames, partitioner, outputTag, shuffleMode);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -123,6 +123,12 @@ public class StreamGraphGenerator {
 
 	private String jobName = DEFAULT_JOB_NAME;
 
+	/**
+	 * If there are some stream edges that can not be chained and the shuffle mode of edge is not specified,
+	 * translate these edges into `BLOCKING` result partition type.
+	 */
+	private boolean blockingConnectionsBetweenChains = false;
+
 	// This is used to assign a unique ID to iteration source/sink
 	protected static Integer iterationIdCounter = 0;
 	public static int getNewIterationNodeId() {
@@ -182,6 +188,11 @@ public class StreamGraphGenerator {
 		return this;
 	}
 
+	public StreamGraphGenerator setBlockingConnectionsBetweenChains(boolean blockingConnectionsBetweenChains) {
+		this.blockingConnectionsBetweenChains = blockingConnectionsBetweenChains;
+		return this;
+	}
+
 	public StreamGraph generate() {
 		streamGraph = new StreamGraph(executionConfig, checkpointConfig);
 		streamGraph.setStateBackend(stateBackend);
@@ -190,6 +201,7 @@ public class StreamGraphGenerator {
 		streamGraph.setUserArtifacts(userArtifacts);
 		streamGraph.setTimeCharacteristic(timeCharacteristic);
 		streamGraph.setJobName(jobName);
+		streamGraph.setBlockingConnectionsBetweenChains(blockingConnectionsBetweenChains);
 
 		alreadyTransformed = new HashMap<>();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -509,11 +509,14 @@ public class StreamingJobGraphGenerator {
 		ResultPartitionType resultPartitionType;
 		switch (edge.getShuffleMode()) {
 			case PIPELINED:
-			case UNDEFINED:
 				resultPartitionType = ResultPartitionType.PIPELINED_BOUNDED;
 				break;
 			case BATCH:
 				resultPartitionType = ResultPartitionType.BLOCKING;
+				break;
+			case UNDEFINED:
+				resultPartitionType = streamGraph.isBlockingConnectionsBetweenChains() ?
+						ResultPartitionType.BLOCKING : ResultPartitionType.PIPELINED_BOUNDED;
 				break;
 			default:
 				throw new UnsupportedOperationException("Data exchange mode " +

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -509,6 +509,7 @@ public class StreamingJobGraphGenerator {
 		ResultPartitionType resultPartitionType;
 		switch (edge.getShuffleMode()) {
 			case PIPELINED:
+			case UNDEFINED:
 				resultPartitionType = ResultPartitionType.PIPELINED_BOUNDED;
 				break;
 			case BATCH:

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
@@ -54,7 +54,7 @@ public class PartitionTransformation<T> extends Transformation<T> {
 	 * @param partitioner The {@code StreamPartitioner}
 	 */
 	public PartitionTransformation(Transformation<T> input, StreamPartitioner<T> partitioner) {
-		this(input, partitioner, ShuffleMode.PIPELINED);
+		this(input, partitioner, ShuffleMode.UNDEFINED);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ShuffleMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ShuffleMode.java
@@ -35,5 +35,12 @@ public enum ShuffleMode {
 	 * The producer first produces its entire result and finishes.
 	 * After that, the consumer is started and may consume the data.
 	 */
-	BATCH
+	BATCH,
+
+	/**
+	 * The shuffle mode is undefined.
+	 * It leaves it up to the framework to decide the shuffle mode.
+	 * The framework will pick one of {@link ShuffleMode#BATCH} or {@link ShuffleMode#PIPELINED} in the end.
+	 */
+	UNDEFINED
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -600,4 +600,77 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 		assertEquals(ScheduleMode.LAZY_FROM_SOURCES, jobGraph.getScheduleMode());
 	}
+
+	/**
+	 * Test disabling (by default) the property "blockingAfterChainingOff".
+	 */
+	@Test
+	public void testBlockingAfterChainingOffDisabled() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		// fromElements -> Filter -> Print
+		DataStream<Integer> sourceDataStream = env.fromElements(1, 2, 3);
+
+		// partition transformation with an undefined shuffle mode between source and filter
+		DataStream<Integer> partitionAfterSourceDataStream = new DataStream<>(env, new PartitionTransformation<>(
+			sourceDataStream.getTransformation(), new RescalePartitioner<>(), ShuffleMode.UNDEFINED));
+		DataStream<Integer> filterDataStream = partitionAfterSourceDataStream.filter(value -> true).setParallelism(2);
+
+		DataStream<Integer> partitionAfterFilterDataStream = new DataStream<>(env, new PartitionTransformation<>(
+			filterDataStream.getTransformation(), new ForwardPartitioner<>(), ShuffleMode.UNDEFINED));
+
+		partitionAfterFilterDataStream.print().setParallelism(2);
+
+		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+
+		List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
+		assertEquals(2, verticesSorted.size());
+
+		JobVertex sourceVertex = verticesSorted.get(0);
+		JobVertex filterAndPrintVertex = verticesSorted.get(1);
+
+		assertEquals(ResultPartitionType.PIPELINED_BOUNDED, sourceVertex.getProducedDataSets().get(0).getResultType());
+		assertEquals(ResultPartitionType.PIPELINED_BOUNDED,
+				filterAndPrintVertex.getInputs().get(0).getSource().getResultType());
+	}
+
+	/**
+	 * Test enabling the property "blockingConnectionsBetweenChains".
+	 */
+	@Test
+	public void testBlockingConnectionsBetweenChainsEnabled() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		// fromElements -> Filter -> Map -> Print
+		DataStream<Integer> sourceDataStream = env.fromElements(1, 2, 3);
+
+		// partition transformation with an undefined shuffle mode between source and filter
+		DataStream<Integer> partitionAfterSourceDataStream = new DataStream<>(env, new PartitionTransformation<>(
+			sourceDataStream.getTransformation(), new RescalePartitioner<>(), ShuffleMode.UNDEFINED));
+		DataStream<Integer> filterDataStream = partitionAfterSourceDataStream.filter(value -> true).setParallelism(2);
+
+		DataStream<Integer> partitionAfterFilterDataStream = new DataStream<>(env, new PartitionTransformation<>(
+			filterDataStream.getTransformation(), new ForwardPartitioner<>(), ShuffleMode.UNDEFINED));
+		partitionAfterFilterDataStream.map(value -> value).setParallelism(2);
+
+		DataStream<Integer> partitionAfterMapDataStream = new DataStream<>(env, new PartitionTransformation<>(
+			filterDataStream.getTransformation(), new RescalePartitioner<>(), ShuffleMode.PIPELINED));
+		partitionAfterMapDataStream.print().setParallelism(1);
+
+		StreamGraph streamGraph = env.getStreamGraph();
+		streamGraph.setBlockingConnectionsBetweenChains(true);
+		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+
+		List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
+		assertEquals(3, verticesSorted.size());
+
+		JobVertex sourceVertex = verticesSorted.get(0);
+		// still can be chained
+		JobVertex filterAndMapVertex = verticesSorted.get(1);
+		JobVertex printVertex = verticesSorted.get(2);
+
+		// the edge with undefined shuffle mode is translated into BLOCKING
+		assertEquals(ResultPartitionType.BLOCKING, sourceVertex.getProducedDataSets().get(0).getResultType());
+		// the edge with PIPELINED shuffle mode is translated into PIPELINED_BOUNDED
+		assertEquals(ResultPartitionType.PIPELINED_BOUNDED, filterAndMapVertex.getProducedDataSets().get(0).getResultType());
+		assertEquals(ResultPartitionType.PIPELINED_BOUNDED, printVertex.getInputs().get(0).getSource().getResultType());
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

* **This is based on https://github.com/apache/flink/pull/8982**

* The reason of introducing it is to satisfy the requirement of Blink batch planner.
* Because the current scheduling strategy is a bit simple. It can not support some complex scenarios, like a batch job with resources limited.
* To be honest, it's probably a work-around solution. However it's an internal implementation, we can replace it when we are able to support batch job by scheduling strategy.

## Brief change log

* Add a property `blockingConnectionsBetweenChains` of `StreamGraph`
* The property `blockingConnectionsBetweenChains` means, if there are some stream edges that can not be chained and the shuffle mode of edge is not specified, translate these edges into `BLOCKING` result partition type.

## Verifying this change

* This change added unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **JavaDocs**
