### PR TITLE
[FLINK-12736][coordination] Release TaskExecutor in SlotManager if no slot allocations after partition check

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -1023,20 +1023,30 @@ public class SlotManager implements AutoCloseable {
 
 			// second we trigger the release resource callback which can decide upon the resource release
 			for (TaskManagerRegistration taskManagerRegistration : timedOutTaskManagers) {
-				InstanceID timedOutTaskManagerId = taskManagerRegistration.getInstanceId();
 				if (waitResultConsumedBeforeRelease) {
-					// checking whether TaskManagers can be safely removed
-					taskManagerRegistration.getTaskManagerConnection().getTaskExecutorGateway().canBeReleased()
-						.thenAcceptAsync(canBeReleased -> {
-							if (canBeReleased) {
-								releaseTaskExecutor(timedOutTaskManagerId);
-							}},
-							mainThreadExecutor);
+					releaseTaskExecutorIfPossible(taskManagerRegistration);
 				} else {
-					releaseTaskExecutor(timedOutTaskManagerId);
+					releaseTaskExecutor(taskManagerRegistration.getInstanceId());
 				}
 			}
 		}
+	}
+
+	private void releaseTaskExecutorIfPossible(TaskManagerRegistration taskManagerRegistration) {
+		long idleSince = taskManagerRegistration.getIdleSince();
+		taskManagerRegistration
+			.getTaskManagerConnection()
+			.getTaskExecutorGateway()
+			.canBeReleased()
+			.thenAcceptAsync(
+				canBeReleased -> {
+					InstanceID timedOutTaskManagerId = taskManagerRegistration.getInstanceId();
+					boolean stillIdle = idleSince == taskManagerRegistration.getIdleSince();
+					if (stillIdle && canBeReleased) {
+						releaseTaskExecutor(timedOutTaskManagerId);
+					}
+				},
+				mainThreadExecutor);
 	}
 
 	private void releaseTaskExecutor(InstanceID timedOutTaskManagerId) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.clusterframework.types.TaskManagerSlot;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -665,109 +664,6 @@ public class SlotManagerTest extends TestLogger {
 
 			// slotId2 should have been allocated for allocationId
 			assertEquals(allocationId, slotManager.getSlot(slotId2).getAllocationId());
-		}
-	}
-
-	/**
-	 * Tests that idle task managers time out after the configured timeout. A timed out task manager
-	 * will be removed from the slot manager and the resource manager will be notified about the
-	 * timeout, if it can be released.
-	 */
-	@Test
-	public void testTaskManagerTimeout() throws Exception {
-		final long tmTimeout = 10L;
-
-		final CompletableFuture<InstanceID> releaseFuture = new CompletableFuture<>();
-		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
-			.setReleaseResourceConsumer((instanceID, e) -> releaseFuture.complete(instanceID))
-			.build();
-		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceID resourceID = ResourceID.generate();
-
-		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
-		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
-
-		final SlotID slotId = new SlotID(resourceID, 0);
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
-		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
-		final SlotReport slotReport = new SlotReport(slotStatus);
-
-		final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
-
-		try (SlotManager slotManager = SlotManagerBuilder.newBuilder()
-			.setTaskManagerTimeout(Time.milliseconds(tmTimeout))
-			.build()) {
-
-			slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
-
-			mainThreadExecutor.execute(() -> slotManager.registerTaskManager(taskManagerConnection, slotReport));
-
-			assertThat(releaseFuture.get(), is(equalTo(taskManagerConnection.getInstanceID())));
-		}
-	}
-
-	/**
-	 * Tests that idle but not releasable task managers will not be released even if timed out before it can be.
-	 */
-	@Test
-	public void testTaskManagerNotReleasedBeforeItCanBe() throws Exception {
-		final CompletableFuture<InstanceID> releaseFuture = new CompletableFuture<>();
-		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
-			.setReleaseResourceConsumer((instanceID, e) -> releaseFuture.complete(instanceID))
-			.build();
-		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceID resourceID = ResourceID.generate();
-
-		final AtomicReference<CompletableFuture<Boolean>> canBeReleased = new AtomicReference<>();
-		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-			.setCanBeReleasedSupplier(canBeReleased::get)
-			.createTestingTaskExecutorGateway();
-		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
-
-		final SlotID slotId = new SlotID(resourceID, 0);
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
-		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
-		final SlotReport slotReport = new SlotReport(slotStatus);
-
-		final ManuallyTriggeredScheduledExecutor mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
-
-		try (SlotManager slotManager = SlotManagerBuilder.newBuilder()
-			.setScheduledExecutor(mainThreadExecutor)
-			.setTaskManagerTimeout(Time.milliseconds(0L))
-			.build()) {
-
-			slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
-
-			mainThreadExecutor.execute(() -> slotManager.registerTaskManager(taskManagerConnection, slotReport));
-
-			// now it can not be released yet
-			canBeReleased.set(new CompletableFuture<>());
-			mainThreadExecutor.execute(slotManager::checkTaskManagerTimeouts); // trigger TM.canBeReleased request
-			mainThreadExecutor.triggerAll();
-			canBeReleased.get().complete(false);
-			mainThreadExecutor.triggerAll();
-			assertThat(releaseFuture.isDone(), is(false));
-
-			// Allocate and free slot between triggering TM.canBeReleased request and receiving response.
-			// There can be potentially newly unreleased partitions, therefore TM can not be released yet.
-			canBeReleased.set(new CompletableFuture<>());
-			mainThreadExecutor.execute(slotManager::checkTaskManagerTimeouts); // trigger TM.canBeReleased request
-			mainThreadExecutor.triggerAll();
-			AllocationID allocationID = new AllocationID();
-			slotManager.registerSlotRequest(new SlotRequest(new JobID(), allocationID, resourceProfile, "foobar"));
-			mainThreadExecutor.triggerAll();
-			slotManager.freeSlot(slotId, allocationID);
-			canBeReleased.get().complete(true);
-			mainThreadExecutor.triggerAll();
-			assertThat(releaseFuture.isDone(), is(false));
-
-			// now it can and should be released
-			canBeReleased.set(new CompletableFuture<>());
-			mainThreadExecutor.execute(slotManager::checkTaskManagerTimeouts); // trigger TM.canBeReleased request
-			mainThreadExecutor.triggerAll();
-			canBeReleased.get().complete(true);
-			mainThreadExecutor.triggerAll();
-			assertThat(releaseFuture.get(), is(equalTo(taskManagerConnection.getInstanceID())));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerReleaseInSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerReleaseInSlotManagerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.RunnableWithException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test suite for idle task managers release in slot manager.
+ */
+public class TaskManagerReleaseInSlotManagerTest extends TestLogger {
+	private static final ResourceID resourceID = ResourceID.generate();
+	private static final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
+	private static final SlotID slotId = new SlotID(resourceID, 0);
+	private static final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
+	private static final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
+	private static final SlotReport slotReport = new SlotReport(slotStatus);
+
+	private final AtomicReference<CompletableFuture<Boolean>> canBeReleasedFuture = new AtomicReference<>();
+	private final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+		.setCanBeReleasedSupplier(canBeReleasedFuture::get)
+		.createTestingTaskExecutorGateway();
+	private final TaskExecutorConnection taskManagerConnection =
+		new TaskExecutorConnection(resourceID, taskExecutorGateway);
+
+	private CompletableFuture<InstanceID> releaseFuture;
+	private ResourceActions resourceManagerActions;
+	private ManuallyTriggeredScheduledExecutor mainThreadExecutor;
+
+	@Before
+	public void setup() {
+		canBeReleasedFuture.set(new CompletableFuture<>());
+		releaseFuture = new CompletableFuture<>();
+		resourceManagerActions = new TestingResourceActionsBuilder()
+			.setReleaseResourceConsumer((instanceID, e) -> releaseFuture.complete(instanceID))
+			.build();
+		mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
+	}
+
+	/**
+	 * Tests that idle task managers time out after the configured timeout. A timed out task manager
+	 * will be removed from the slot manager and the resource manager will be notified about the
+	 * timeout, if it can be released.
+	 */
+	@Test
+	public void testTaskManagerTimeout() throws Exception {
+		Executor executor = TestingUtils.defaultExecutor();
+		canBeReleasedFuture.set(CompletableFuture.completedFuture(true));
+		try (SlotManager slotManager = SlotManagerBuilder
+			.newBuilder()
+			.setTaskManagerTimeout(Time.milliseconds(10L))
+			.build()) {
+
+			slotManager.start(resourceManagerId, executor, resourceManagerActions);
+			executor.execute(() -> slotManager.registerTaskManager(taskManagerConnection, slotReport));
+			assertThat(releaseFuture.get(), is(equalTo(taskManagerConnection.getInstanceID())));
+		}
+	}
+
+	/**
+	 * Tests that idle but not releasable task managers will not be released even if timed out before it can be.
+	 */
+	@Test
+	public void testTaskManagerIsNotReleasedBeforeItCanBe() throws Exception {
+		try (SlotManager slotManager = createAndStartSlotManagerWithTM()) {
+			checkTaskManagerTimeoutWithCustomCanBeReleasedResponse(slotManager, false);
+			verifyTmReleased(false);
+
+			checkTaskManagerTimeoutWithCustomCanBeReleasedResponse(slotManager, true);
+			verifyTmReleased(true);
+		}
+	}
+
+	/**
+	 * Tests that idle task managers will not be released after "can be" check in case of concurrent resource allocations.
+	 */
+	@Test
+	public void testTaskManagerIsNotReleasedInCaseOfConcurrentAllocation() throws Exception {
+		try (SlotManager slotManager = createAndStartSlotManagerWithTM()) {
+			checkTaskManagerTimeoutWithCustomCanBeReleasedResponse(slotManager, true, () -> {
+				// Allocate and free slot between triggering TM.canBeReleased request and receiving response.
+				// There can be potentially newly unreleased partitions, therefore TM can not be released yet.
+				AllocationID allocationID = new AllocationID();
+				slotManager.registerSlotRequest(new SlotRequest(new JobID(), allocationID, resourceProfile, "foobar"));
+				mainThreadExecutor.triggerAll();
+				slotManager.freeSlot(slotId, allocationID);
+			});
+			verifyTmReleased(false);
+
+			checkTaskManagerTimeoutWithCustomCanBeReleasedResponse(slotManager, true);
+			verifyTmReleased(true);
+		}
+	}
+
+	private SlotManager createAndStartSlotManagerWithTM() {
+		SlotManager slotManager = SlotManagerBuilder
+			.newBuilder()
+			.setScheduledExecutor(mainThreadExecutor)
+			.setTaskManagerTimeout(Time.milliseconds(0L))
+			.build();
+		slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
+		mainThreadExecutor.execute(() -> slotManager.registerTaskManager(taskManagerConnection, slotReport));
+		return slotManager;
+	}
+
+	private void checkTaskManagerTimeoutWithCustomCanBeReleasedResponse(
+			SlotManager slotManager,
+			boolean canBeReleased) throws Exception {
+		checkTaskManagerTimeoutWithCustomCanBeReleasedResponse(slotManager, canBeReleased, () -> {});
+	}
+
+	private void checkTaskManagerTimeoutWithCustomCanBeReleasedResponse(
+			SlotManager slotManager,
+			boolean canBeReleased,
+			RunnableWithException doAfterCheckTriggerBeforeCanBeReleasedResponse) throws Exception {
+		canBeReleasedFuture.set(new CompletableFuture<>());
+		mainThreadExecutor.execute(slotManager::checkTaskManagerTimeouts); // trigger TM.canBeReleased request
+		mainThreadExecutor.triggerAll();
+		doAfterCheckTriggerBeforeCanBeReleasedResponse.run();
+		canBeReleasedFuture.get().complete(canBeReleased); // finish TM.canBeReleased request
+		mainThreadExecutor.triggerAll();
+	}
+
+	private void verifyTmReleased(boolean isTmReleased) {
+		assertThat(releaseFuture.isDone(), is(isTmReleased));
+		if (isTmReleased) {
+			assertThat(releaseFuture.join(), is(equalTo(taskManagerConnection.getInstanceID())));
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -72,7 +72,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	private final Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction;
 
-	private final Supplier<Boolean> canBeReleasedSupplier;
+	private final Supplier<CompletableFuture<Boolean>> canBeReleasedSupplier;
 
 	private final BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer;
 
@@ -87,7 +87,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 			Consumer<ResourceID> heartbeatResourceManagerConsumer,
 			Consumer<Exception> disconnectResourceManagerConsumer,
 			Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction,
-			Supplier<Boolean> canBeReleasedSupplier,
+			Supplier<CompletableFuture<Boolean>> canBeReleasedSupplier,
 			BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer) {
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
@@ -186,7 +186,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	@Override
 	public CompletableFuture<Boolean> canBeReleased() {
-		return CompletableFuture.completedFuture(canBeReleasedSupplier.get());
+		return canBeReleasedSupplier.get();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -64,7 +64,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private Consumer<ResourceID> heartbeatResourceManagerConsumer = NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER;
 	private Consumer<Exception> disconnectResourceManagerConsumer = NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER;
 	private Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction = NOOP_CANCEL_TASK_FUNCTION;
-	private Supplier<Boolean> canBeReleasedSupplier = () -> true;
+	private Supplier<CompletableFuture<Boolean>> canBeReleasedSupplier = () -> CompletableFuture.completedFuture(true);
 	private BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer = NOOP_RELEASE_PARTITIONS_CONSUMER;
 
 	public TestingTaskExecutorGatewayBuilder setAddress(String address) {
@@ -117,7 +117,7 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
-	public TestingTaskExecutorGatewayBuilder setCanBeReleasedSupplier(Supplier<Boolean> canBeReleasedSupplier) {
+	public TestingTaskExecutorGatewayBuilder setCanBeReleasedSupplier(Supplier<CompletableFuture<Boolean>> canBeReleasedSupplier) {
 		this.canBeReleasedSupplier = canBeReleasedSupplier;
 		return this;
 	}


### PR DESCRIPTION
## What is the purpose of the change

The ResourceManager looks out for TaskManagers that have not had any slots allocated on them for a while, as these could be released to safe resources. If such a TM is found, the RM checks via an RPC call whether the TM still holds any partitions. If no partition is held then the TM is released. However, in the RPC callback no check is made whether the TM is actually still idle. In the meantime a slot could have been allocated on the TM. Even if the slot has been freed, there can be newly allocated partitions not included in check result.

To make sure there was no resource allocation in between, we can mark the `taskManagerRegistration.getIdleSince()` time before starting the async 'no partition' check. The TM can be released only if the idle time after the check matches the previously marked one. Otherwise we discard the release and start over after the next timeout.

## Brief change log

  - mark the TM idle time before `canBeReleased` check in `SlotManager.checkTaskManagerTimeouts`
  - check it after the `canBeReleased` check and release only if it coincides
  - modify `SlotManagerTest.testTaskManagerNotReleasedBeforeItCanBe` to check that TM is not released if there was allocation between triggering of `canBeReleased` check and completing it

## Verifying this change

run `SlotManagerTest.testTaskManagerNotReleasedBeforeItCanBe`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
