### PR TITLE
[FLINK-13104][metrics] Updated request callback to log warning on failure

### DIFF
--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -119,8 +119,18 @@ public class DatadogHttpClient {
 		client.connectionPool().evictAll();
 	}
 
-	private static class EmptyCallback implements Callback {
+	/**
+	 * A handler for OkHttpClient callback.  In case of error or failure it logs the error at warning level.
+	 */
+	protected static class EmptyCallback implements Callback {
+
+		protected static final String FAILED_SENDING_REQUEST_TO_DATADOG = "Failed to send request to Datadog (response code was {})";
+
 		private static final EmptyCallback singleton = new EmptyCallback();
+
+		public Logger getLogger() {
+			return LOGGER;
+		}
 
 		public static Callback getEmptyCallback() {
 			return singleton;
@@ -133,6 +143,11 @@ public class DatadogHttpClient {
 
 		@Override
 		public void onResponse(Call call, Response response) throws IOException {
+
+			if (!response.isSuccessful()) {
+				getLogger().warn(FAILED_SENDING_REQUEST_TO_DATADOG, response.code());
+			}
+
 			response.close();
 		}
 	}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -124,13 +124,7 @@ public class DatadogHttpClient {
 	 */
 	protected static class EmptyCallback implements Callback {
 
-		protected static final String FAILED_SENDING_REQUEST_TO_DATADOG = "Failed to send request to Datadog (response code was {})";
-
 		private static final EmptyCallback singleton = new EmptyCallback();
-
-		public Logger getLogger() {
-			return LOGGER;
-		}
 
 		public static Callback getEmptyCallback() {
 			return singleton;
@@ -138,14 +132,13 @@ public class DatadogHttpClient {
 
 		@Override
 		public void onFailure(Call call, IOException e) {
-			LOGGER.debug("Failed sending request to Datadog" , e);
+			LOGGER.warn("Failed sending request to Datadog", e);
 		}
 
 		@Override
 		public void onResponse(Call call, Response response) throws IOException {
-
 			if (!response.isSuccessful()) {
-				getLogger().warn(FAILED_SENDING_REQUEST_TO_DATADOG, response.code());
+				LOGGER.warn("Failed to send request to Datadog (response code was {} and response body was {})", response.code(), response.body());
 			}
 
 			response.close();

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -138,7 +138,7 @@ public class DatadogHttpClient {
 		@Override
 		public void onResponse(Call call, Response response) throws IOException {
 			if (!response.isSuccessful()) {
-				LOGGER.warn("Failed to send request to Datadog (response code was {} and response body was {})", response.code(), response.body());
+				LOGGER.warn("Failed to send request to Datadog (response was {})", response);
 			}
 
 			response.close();

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -110,6 +110,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeGauge() throws JsonProcessingException {
+
 		DGauge g = new DGauge(new Gauge<Number>() {
 			@Override
 			public Number getValue() {

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -94,6 +94,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeGauge() throws JsonProcessingException {
+
 		DGauge g = new DGauge(new Gauge<Number>() {
 			@Override
 			public Number getValue() {
@@ -108,6 +109,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeGaugeWithoutHost() throws JsonProcessingException {
+
 		DGauge g = new DGauge(new Gauge<Number>() {
 			@Override
 			public Number getValue() {

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -24,21 +24,14 @@ import org.apache.flink.metrics.Meter;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.api.support.membermodification.MemberMatcher;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -52,22 +45,13 @@ import static org.junit.Assert.assertTrue;
  * Tests for the DatadogHttpClient.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({DMetric.class, DatadogHttpClient.class, DatadogHttpClient.EmptyCallback.class, Request.class})
+@PrepareForTest({DMetric.class, DatadogHttpClient.class})
 @PowerMockIgnore("javax.net.ssl.*")
 public class DatadogHttpClientTest {
 
 	private static List<String> tags = Arrays.asList("tag1", "tag2");
 
 	private static final long MOCKED_SYSTEM_MILLIS = 123L;
-
-	@Mock
-	private Logger mockLogger;
-
-	@Mock
-	private Request mockRequest;
-
-	@Mock
-	private ResponseBody mockResponseBody;
 
 	@Before
 	public void mockSystemMillis() {
@@ -110,7 +94,6 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeGauge() throws JsonProcessingException {
-
 		DGauge g = new DGauge(new Gauge<Number>() {
 			@Override
 			public Number getValue() {
@@ -135,52 +118,6 @@ public class DatadogHttpClientTest {
 		assertEquals(
 			"{\"metric\":\"testCounter\",\"type\":\"gauge\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
 			DatadogHttpClient.serialize(g));
-	}
-
-	@Test
-	public void testRequestNotSuccessful() throws Exception {
-		Protocol protocol = Protocol.get("http/1.1");
-
-		int httpClientError = 400;
-		Response response =	new Response.Builder().
-			code(httpClientError).
-			request(mockRequest).
-			protocol(protocol).
-			body(mockResponseBody).
-			build();
-
-		DatadogHttpClient.EmptyCallback emptyCallBack = (DatadogHttpClient.EmptyCallback) DatadogHttpClient.EmptyCallback.getEmptyCallback();
-
-		DatadogHttpClient.EmptyCallback emptyCallbackPartialMock = PowerMockito.spy(emptyCallBack);
-		PowerMockito.when(emptyCallbackPartialMock.getLogger()).thenReturn(mockLogger);
-
-		emptyCallbackPartialMock.onResponse(null, response);
-
-		Mockito.verify(mockLogger).warn(DatadogHttpClient.EmptyCallback.FAILED_SENDING_REQUEST_TO_DATADOG, httpClientError);
-		Mockito.verify(mockResponseBody).close();
-	}
-
-	@Test
-	public void testRequestSuccessful() throws Exception {
-		Protocol protocol = Protocol.get("http/1.1");
-
-		int httpSuccess = 200;
-		Response response =	new Response.Builder().
-			code(httpSuccess).
-			request(mockRequest).
-			protocol(protocol).
-			body(mockResponseBody).
-			build();
-
-		DatadogHttpClient.EmptyCallback emptyCallBack = (DatadogHttpClient.EmptyCallback) DatadogHttpClient.EmptyCallback.getEmptyCallback();
-		DatadogHttpClient.EmptyCallback emptyCallbackPartialMock = PowerMockito.spy(emptyCallBack);
-
-		PowerMockito.when(emptyCallbackPartialMock.getLogger()).thenReturn(mockLogger);
-
-		emptyCallbackPartialMock.onResponse(null, response);
-
-		PowerMockito.verifyZeroInteractions(mockLogger);
-		Mockito.verify(mockResponseBody).close();
 	}
 
 	@Test


### PR DESCRIPTION
## Contribution Checklist


## What is the purpose of the change

* Check for success status on posting metrics to Datadog and log warning in case request is not successful


## Brief change log

* Added check in request callback to check for successful status and if not log a warning

## Verifying this change
  - Added unit tests for successful and un-successful posting scenarios

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
