### PR TITLE
[FLINK-13057][state] Correct comments in ListState class

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
@@ -28,11 +28,13 @@ import java.util.List;
  * by the system as part of the distributed snapshots.
  *
  * <p>The state can be a keyed list state or an operator list state.
- * When it is a keyed list state, it is accessed by functions applied on a {@code KeyedStream}.
+ *
+ * <p>When it is a keyed list state, it is accessed by functions applied on a {@code KeyedStream}.
  * The key is automatically supplied by the system, so the function always sees the value mapped
  * to the key of the current element. That way, the system can handle stream and state
  * partitioning consistently together.
- * When it is an operator list state, the list is a collection of state items that are
+ *
+ * <p>When it is an operator list state, the list is a collection of state items that are
  * independent from each other and eligible for redistribution across operator instances in case
  * of changed operator parallelism.
  *

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
@@ -27,10 +27,14 @@ import java.util.List;
  * The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  *
- * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
- * automatically supplied by the system, so the function always sees the value mapped to the
- * key of the current element. That way, the system can handle stream and state partitioning
- * consistently together.
+ * <p>The state can be a keyed list state or an operator list state.
+ * When it is a keyed list state, it is accessed by functions applied on a {@code KeyedStream}.
+ * The key is automatically supplied by the system, so the function always sees the value mapped
+ * to the key of the current element. That way, the system can handle stream and state
+ * partitioning consistently together.
+ * When it is an operator list state, the list is a collection of state items that are
+ * independent from each other and eligible for redistribution across operator instances in case
+ * of changed operator parallelism.
  *
  * @param <T> Type of values that this list state keeps.
  */


### PR DESCRIPTION


## What is the purpose of the change

This pull request fixes the comments in `ListState`. 

`ListState` can be a keyed state or an operator state, but the comment in `ListState` said it can only be a keyed state


## Brief change log

  - Correct comments in `ListState` class, i.e. `ListState` can be a keyed state or an operator state.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
