### PR TITLE
[FLINK-13106][doc-zh]Translate Parallel Execution page into Chinese

### DIFF
--- a/docs/dev/parallel.md
+++ b/docs/dev/parallel.md
@@ -190,7 +190,7 @@ The maximum parallelism can be set in places where you can also set a parallelis
 `setMaxParallelism()` to set the maximum parallelism.
 
 The default setting for the maximum parallelism is roughly `operatorParallelism + (operatorParallelism / 2)` with
-a lower bound of `127` and an upper bound of `32768`.
+a lower bound of `128` and an upper bound of `32768`.
 
 <span class="label label-danger">Attention</span> Setting the maximum parallelism to a very large
 value can be detrimental to performance because some state backends have to keep internal data

--- a/docs/dev/parallel.zh.md
+++ b/docs/dev/parallel.zh.md
@@ -168,26 +168,7 @@ try {
 
 最大 parallelism 可以在所有设置 parallelism 的地方进行设定（客户端和系统层次除外）。与调用 `setParallelism()` 方法修改并发度相似，你可以通过调用 `setMaxParallelism()` 方法来设定最大 parallelism。
 
-默认的最大 parallelism 等于将 operatorParallelism + (operatorParallelism / 2） 值舍入到其下一个 `2` 的幂次方的值，其计算方式如以下所示。
-
-{% highlight scala %}
-   /**
-	 * Round the given number to the next power of two.
-	 * @param x number is the value  of 'operatorParallelism + (operatorParallelism / 2)'
-	 * @return x rounded up to the next power of two
-	 */
-	public static int roundUpToPowerOfTwo(int x) {
-		x = x - 1;
-		x |= x >> 1;
-		x |= x >> 2;
-		x |= x >> 4;
-		x |= x >> 8;
-		x |= x >> 16;
-		return x + 1;
-	}
-{% endhighlight %}
-
-注意，默认最大 parallelism 下限为 `128`，上限为 `32768`。
+默认的最大 parallelism 等于将 `operatorParallelism + (operatorParallelism / 2）` 值四舍五入到大于等于该值的一个整型值，并且这个整型值是 `2` 的幂次方，注意默认最大 parallelism 下限为 `128`，上限为 `32768`。
 
 <span class="label label-danger">注意</span> 为最大 parallelism 设置一个非常大的值将会降低性能，因为一些 state backends 需要维持内部的数据结构，而这些数据结构将会随着 key-groups 的数目而扩张（key-group 是状态重新分配的最小单元）。
 

--- a/docs/dev/parallel.zh.md
+++ b/docs/dev/parallel.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "并发执行"
+title: "并行执行"
 nav-parent_id: execution
 nav-pos: 30
 ---
@@ -22,20 +22,20 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-本节描述了如何在 Flink 中配置程序的并发执行。一个 Flink 程序由多个任务 task 组成（转换/算子、数据源和数据汇）。一个 task 包括多个并发执行的实例，且每一个实例都处理 task 输入数据的一个子集。一个 task 的并发实例数被称为该 task 的 *parallelism*。
+本节描述了在 Flink 中配置程序的并行执行。一个 Flink 程序由多个任务 task 组成（转换/算子、数据源和数据接收器）。一个 task 包括多个并行执行的实例，且每一个实例都处理 task 输入数据的一个子集。一个 task 的并行实例数被称为该 task 的 *并行度* (parallelism)。
 
-使用 [savepoints]({{ site.baseurl }}/zh/ops/state/savepoints.html) 时，应该考虑设置最大 parallelism。当作业从一个 savepoint 恢复时，你可以改变特定算子或着整个程序的 parallelism，并且此设置会限定整个程序的 parallelism 的上限。由于在 Flink 内部将状态划分为了 key-groups，且性能所限不能无限制地增加 key-groups，因此设定最大 parallelism 是有必要的。
+使用 [savepoints]({{ site.baseurl }}/zh/ops/state/savepoints.html) 时，应该考虑设置最大并行度。当作业从一个 savepoint 恢复时，你可以改变特定算子或着整个程序的并行度，并且此设置会限定整个程序的并行度的上限。由于在 Flink 内部将状态划分为了 key-groups，且性能所限不能无限制地增加 key-groups，因此设定最大并行度是有必要的。
 
 * toc
 {:toc}
 
-## 设置 Parallelism
+## 设置并行度
 
-一个 task 的 parallelism 可以从多个层次指定：
+一个 task 的并行度可以从多个层次指定：
 
 ### 算子层次
 
-单个算子、数据源和数据汇的 parallelism 可以通过调用 `setParallelism()`方法来指定。如下所示：
+单个算子、数据源和数据接收器的并行度可以通过调用 `setParallelism()`方法来指定。如下所示：
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -73,9 +73,9 @@ env.execute("Word Count Example")
 
 ### 执行环境层次
 
-如[此节]({{ site.baseurl }}/zh/dev/api_concepts.html#anatomy-of-a-flink-program)所描述，Flink 程序运行在执行环境的上下文中。执行环境为所有执行的算子、数据源、数据汇定义了一个默认的 parallelism。可以显式配置算子层次的 parallelism 去覆盖执行环境的 parallelism。
+如[此节]({{ site.baseurl }}/zh/dev/api_concepts.html#anatomy-of-a-flink-program)所描述，Flink 程序运行在执行环境的上下文中。执行环境为所有执行的算子、数据源、数据接收器 (data sink) 定义了一个默认的并行度。可以显式配置算子层次的并行度去覆盖执行环境的并行度。
 
-执行环境的默认 parallelism 可以通过调用 `setParallelism()` 方法指定。可以通过如下的方式设置执行环境的 parallelism，以并发度 `3`来执行所有的算子、数据源和数据汇：
+可以通过调用 `setParallelism()` 方法指定执行环境的默认并行度。如果想以并行度`3`来执行所有的算子、数据源和数据接收器。可以在执行环境上设置默认并行度，如下所示：
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -110,14 +110,14 @@ env.execute("Word Count Example")
 
 ### 客户端层次
 
-将作业提交到 Flink 时可在客户端设定其 parallelism。客户端可以是 Java 或 Scala 程序，Flink 的命令行接口（CLI）就是一种典型的客户端。
+将作业提交到 Flink 时可在客户端设定其并行度。客户端可以是 Java 或 Scala 程序，Flink 的命令行接口（CLI）就是一种典型的客户端。
 
-在 CLI 客户端中，可以通过 `-p` 参数指定 parallelism，例如：
+在 CLI 客户端中，可以通过 `-p` 参数指定并行度，例如：
 
     ./bin/flink run -p 10 ../examples/*WordCount-java*.jar
 
 
-在 Java/Scala 程序中，可以通过如下方式指定 parallelism：
+在 Java/Scala 程序中，可以通过如下方式指定并行度：
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -161,16 +161,16 @@ try {
 
 ### 系统层次
 
-可以通过设置 `./conf/flink-conf.yaml` 文件中的 `parallelism.default` 参数，在系统层次来指定所有执行环境的默认 parallelism。你可以通过查阅[配置文档]({{ site.baseurl }}/zh/ops/config.html)获取更多细节。
+可以通过设置 `./conf/flink-conf.yaml` 文件中的 `parallelism.default` 参数，在系统层次来指定所有执行环境的默认并行度。你可以通过查阅[配置文档]({{ site.baseurl }}/zh/ops/config.html)获取更多细节。
 
 
-## 设置最大并发度
+## 设置最大并行度
 
-最大 parallelism 可以在所有设置 parallelism 的地方进行设定（客户端和系统层次除外）。与调用 `setParallelism()` 方法修改并发度相似，你可以通过调用 `setMaxParallelism()` 方法来设定最大 parallelism。
+最大并行度可以在所有设置并行度的地方进行设定（客户端和系统层次除外）。与调用 `setParallelism()` 方法修改并行度相似，你可以通过调用 `setMaxParallelism()` 方法来设定最大并行度。
 
-默认的最大 parallelism 等于将 `operatorParallelism + (operatorParallelism / 2)` 值四舍五入到大于等于该值的一个整型值，并且这个整型值是 `2` 的幂次方，注意默认最大 parallelism 下限为 `128`，上限为 `32768`。
+默认的最大并行度等于将 `operatorParallelism + (operatorParallelism / 2)` 值四舍五入到大于等于该值的一个整型值，并且这个整型值是 `2` 的幂次方，注意默认最大并行度下限为 `128`，上限为 `32768`。
 
-<span class="label label-danger">注意</span> 为最大 parallelism 设置一个非常大的值将会降低性能，因为一些 state backends 需要维持内部的数据结构，而这些数据结构将会随着 key-groups 的数目而扩张（key-group 是状态重新分配的最小单元）。
+<span class="label label-danger">注意</span> 为最大并行度设置一个非常大的值将会降低性能，因为一些 state backends 需要维持内部的数据结构，而这些数据结构将会随着 key-groups 的数目而扩张（key-group 是状态重新分配的最小单元）。
 
 
 {% top %}

--- a/docs/dev/parallel.zh.md
+++ b/docs/dev/parallel.zh.md
@@ -168,7 +168,7 @@ try {
 
 最大 parallelism 可以在所有设置 parallelism 的地方进行设定（客户端和系统层次除外）。与调用 `setParallelism()` 方法修改并发度相似，你可以通过调用 `setMaxParallelism()` 方法来设定最大 parallelism。
 
-默认的最大 parallelism 等于将 `operatorParallelism + (operatorParallelism / 2）` 值四舍五入到大于等于该值的一个整型值，并且这个整型值是 `2` 的幂次方，注意默认最大 parallelism 下限为 `128`，上限为 `32768`。
+默认的最大 parallelism 等于将 `operatorParallelism + (operatorParallelism / 2)` 值四舍五入到大于等于该值的一个整型值，并且这个整型值是 `2` 的幂次方，注意默认最大 parallelism 下限为 `128`，上限为 `32768`。
 
 <span class="label label-danger">注意</span> 为最大 parallelism 设置一个非常大的值将会降低性能，因为一些 state backends 需要维持内部的数据结构，而这些数据结构将会随着 key-groups 的数目而扩张（key-group 是状态重新分配的最小单元）。
 

--- a/docs/dev/parallel.zh.md
+++ b/docs/dev/parallel.zh.md
@@ -22,29 +22,20 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This section describes how the parallel execution of programs can be configured in Flink. A Flink
-program consists of multiple tasks (transformations/operators, data sources, and sinks). A task is split into
-several parallel instances for execution and each parallel instance processes a subset of the task's
-input data. The number of parallel instances of a task is called its *parallelism*.
+本节描述了如何在 Flink 中配置程序的并发执行。一个 Flink 程序由多个任务 task 组成（转换/算子、数据源和数据流出）。一个 task 包括多个并发执行的实例，且每一个实例都处理某个 task 输入数据的一个子集。一个 task 的并发实例数被称为该 task 的 parallelism。
 
-If you want to use [savepoints]({{ site.baseurl }}/ops/state/savepoints.html) you should also consider
-setting a maximum parallelism (or `max parallelism`). When restoring from a savepoint you can
-change the parallelism of specific operators or the whole program and this setting specifies
-an upper bound on the parallelism. This is required because Flink internally partitions state
-into key-groups and we cannot have `+Inf` number of key-groups because this would be detrimental
-to performance.
+使用 [savepoints]({{ site.baseurl }}/zh/ops/state/savepoints.html) 时，应该考虑设置最大 parallelism。当作业从一个 savepoint 恢复时，你可以改变特定算子或着整个程序的 parallelism，并且此设置会限定 parallelism 的上限。由于在 Flink 内部将状态划分为了 key-groups，且性能所限不能无限制地增加 key-groups ，因此设定最大 parallelism 是有必要的。
 
 * toc
 {:toc}
 
-## Setting the Parallelism
+## 设置 Parallelism
 
-The parallelism of a task can be specified in Flink on different levels:
+一个 task 的 parallelism 可以从多个层次指定：
 
-### Operator Level
+### 算子层次
 
-The parallelism of an individual operator, data source, or data sink can be defined by calling its
-`setParallelism()` method.  For example, like this:
+单个算子、数据源和数据流出的 parallelism 可以通过调用 `setParallelism()` 方法来指定。如下所示：
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -80,17 +71,11 @@ env.execute("Word Count Example")
 </div>
 </div>
 
-### Execution Environment Level
+### 执行环境层次
 
-As mentioned [here]({{ site.baseurl }}/dev/api_concepts.html#anatomy-of-a-flink-program) Flink
-programs are executed in the context of an execution environment. An
-execution environment defines a default parallelism for all operators, data sources, and data sinks
-it executes. Execution environment parallelism can be overwritten by explicitly configuring the
-parallelism of an operator.
+如[此节]({{ site.baseurl }}/zh/dev/api_concepts.html#anatomy-of-a-flink-program) 所描述，Flink 程序运行在执行环境的上下文中。执行环境为所有执行的算子、数据源、数据流出定义了一个默认的 parallelism。可以显式配置算子层次的 parallelism 去覆盖执行环境的parallelism。
 
-The default parallelism of an execution environment can be specified by calling the
-`setParallelism()` method. To execute all operators, data sources, and data sinks with a parallelism
-of `3`, set the default parallelism of the execution environment as follows:
+执行环境的默认 parallelism 可以通过调用 `setParallelism()` 方法指定。可以通过如下的方式设置执行环境的 parallelism，以并发度 `3` 来执行所有的算子、数据源和数据流出：
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -123,19 +108,16 @@ env.execute("Word Count Example")
 </div>
 </div>
 
-### Client Level
+### 客户端层次
 
-The parallelism can be set at the Client when submitting jobs to Flink. The
-Client can either be a Java or a Scala program. One example of such a Client is
-Flink's Command-line Interface (CLI).
+将作业提交到 Flink 时可在客户端设定其 parallelism。客户端可以是 Java 或 Scala 程序，Flink 的命令行接口（CLI）就是一种典型的客户端。
 
-For the CLI client, the parallelism parameter can be specified with `-p`. For
-example:
+在 CLI 客户端中，可以通过 `-p` 参数指定 parallelism，例如：
 
     ./bin/flink run -p 10 ../examples/*WordCount-java*.jar
 
 
-In a Java/Scala program, the parallelism is set as follows:
+在 Java/Scala 程序中，可以通过如下方式指定 parallelism：
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -177,25 +159,18 @@ try {
 </div>
 
 
-### System Level
+### 系统层次
 
-A system-wide default parallelism for all execution environments can be defined by setting the
-`parallelism.default` property in `./conf/flink-conf.yaml`. See the
-[Configuration]({{ site.baseurl }}/ops/config.html) documentation for details.
+可以通过设置 ./conf/flink-conf.yaml 文件中的 parallelism.default 参数，在系统层次来指定所有执行环境的默认 parallelism。你可以通过查阅 [配置文档]({{ site.baseurl }}/zh/ops/config.html) 获取更多细节。
+获取更多细节。
 
-## Setting the Maximum Parallelism
+## 设置最大并发度
 
-The maximum parallelism can be set in places where you can also set a parallelism
-(except client level and system level). Instead of calling `setParallelism()` you call
-`setMaxParallelism()` to set the maximum parallelism.
+最大 parallelism 可以在所有设置 parallelism 的地方进行设定（除了客户端和系统层次）。与调用 `setParallelism()` 方法修改并发度相似，你可以通过调用 `setMaxParallelism()` 方法来设定最大 parallelism。
 
-The default setting for the maximum parallelism is roughly `operatorParallelism + (operatorParallelism / 2)` with
-a lower bound of `127` and an upper bound of `32768`.
+默认的最大 parallelism 大致等于算子的 parallelism + 算子的 parallelism/2，其下限为 127，上限为 32768。
 
-<span class="label label-danger">Attention</span> Setting the maximum parallelism to a very large
-value can be detrimental to performance because some state backends have to keep internal data
-structures that scale with the number of key-groups (which are the internal implementation mechanism for
-rescalable state).
+<span class="label label-danger">注意</span> 为最大 parallelism 设置一个非常大的值将会降低性能，因为一些 state backends 需要维持内部的数据结构，而这些数据结构将会随着 key-groups 的数目而扩张（key-groups 是 rescalable state 内部实现机制）
 
 
 {% top %}

--- a/docs/dev/parallel.zh.md
+++ b/docs/dev/parallel.zh.md
@@ -22,9 +22,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-本节描述了如何在 Flink 中配置程序的并发执行。一个 Flink 程序由多个任务 task 组成（转换/算子、数据源和数据流出）。一个 task 包括多个并发执行的实例，且每一个实例都处理某个 task 输入数据的一个子集。一个 task 的并发实例数被称为该 task 的 parallelism。
+本节描述了如何在 Flink 中配置程序的并发执行。一个 Flink 程序由多个任务 task 组成（转换/算子、数据源和数据汇）。一个 task 包括多个并发执行的实例，且每一个实例都处理 task 输入数据的一个子集。一个 task 的并发实例数被称为该 task 的 *parallelism*。
 
-使用 [savepoints]({{ site.baseurl }}/zh/ops/state/savepoints.html) 时，应该考虑设置最大 parallelism。当作业从一个 savepoint 恢复时，你可以改变特定算子或着整个程序的 parallelism，并且此设置会限定 parallelism 的上限。由于在 Flink 内部将状态划分为了 key-groups，且性能所限不能无限制地增加 key-groups ，因此设定最大 parallelism 是有必要的。
+使用 [savepoints]({{ site.baseurl }}/zh/ops/state/savepoints.html) 时，应该考虑设置最大 parallelism。当作业从一个 savepoint 恢复时，你可以改变特定算子或着整个程序的 parallelism，并且此设置会限定整个程序的 parallelism 的上限。由于在 Flink 内部将状态划分为了 key-groups，且性能所限不能无限制地增加 key-groups ，因此设定最大 parallelism 是有必要的。
 
 * toc
 {:toc}
@@ -73,7 +73,7 @@ env.execute("Word Count Example")
 
 ### 执行环境层次
 
-如[此节]({{ site.baseurl }}/zh/dev/api_concepts.html#anatomy-of-a-flink-program) 所描述，Flink 程序运行在执行环境的上下文中。执行环境为所有执行的算子、数据源、数据流出定义了一个默认的 parallelism。可以显式配置算子层次的 parallelism 去覆盖执行环境的parallelism。
+如[此节]({{ site.baseurl }}/zh/dev/api_concepts.html#anatomy-of-a-flink-program)所描述，Flink 程序运行在执行环境的上下文中。执行环境为所有执行的算子、数据源、数据汇定义了一个默认的 parallelism。可以显式配置算子层次的 parallelism 去覆盖执行环境的 parallelism。
 
 执行环境的默认 parallelism 可以通过调用 `setParallelism()` 方法指定。可以通过如下的方式设置执行环境的 parallelism，以并发度 `3` 来执行所有的算子、数据源和数据流出：
 
@@ -161,16 +161,17 @@ try {
 
 ### 系统层次
 
-可以通过设置 ./conf/flink-conf.yaml 文件中的 parallelism.default 参数，在系统层次来指定所有执行环境的默认 parallelism。你可以通过查阅 [配置文档]({{ site.baseurl }}/zh/ops/config.html) 获取更多细节。
-获取更多细节。
+可以通过设置 ./conf/flink-conf.yaml 文件中的 parallelism.default 参数，在系统层次来指定所有执行环境的默认 parallelism。你可以通过查阅[配置文档]({{ site.baseurl }}/zh/ops/config.html)获取更多细节。
+
 
 ## 设置最大并发度
 
 最大 parallelism 可以在所有设置 parallelism 的地方进行设定（除了客户端和系统层次）。与调用 `setParallelism()` 方法修改并发度相似，你可以通过调用 `setMaxParallelism()` 方法来设定最大 parallelism。
 
-默认的最大 parallelism 大致等于算子的 parallelism + 算子的 parallelism/2，其下限为 127，上限为 32768。
+默认的最大 parallelism 大致等于算子的 parallelism + 算子的
+parallelism/2，其下限为 128，上限为 32768。
 
-<span class="label label-danger">注意</span> 为最大 parallelism 设置一个非常大的值将会降低性能，因为一些 state backends 需要维持内部的数据结构，而这些数据结构将会随着 key-groups 的数目而扩张（key-groups 是 rescalable state 内部实现机制）
+<span class="label label-danger">注意</span> 为最大 parallelism 设置一个非常大的值将会降低性能，因为一些 state backends 需要维持内部的数据结构，而这些数据结构将会随着 key-groups 的数目而扩张（key-group 是状态重新分配的最小单元）
 
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

This pull request completes the Chinese translation of parallel executionpage from flink official doucuments "parallel.md"


## Brief change log

This pull request completes the Chinese translation of parallel executionpage from flink official doucuments "parallel.md"

## Verifying this change

This change is to add a new translated document.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
