### PR TITLE
[hotfix] Remove incorrect doc comments from RocksDBMapState

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -50,7 +50,7 @@ import static org.apache.flink.runtime.state.StateSnapshotTransformer.Collection
  * {@link ListState} implementation that stores state in RocksDB.
  *
  * <p>{@link RocksDBStateBackend} must ensure that we set the
- * {@link org.rocksdb.StringAppendOperator} on the column family that we use for our state since
+ * {@link org.rocksdb.MergeOperator} on the column family that we use for our state since
  * we use the {@code merge()} call.
  *
  * @param <K> The type of the key.

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -56,10 +56,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /**
  * {@link MapState} implementation that stores state in RocksDB.
  *
- * <p>{@link RocksDBStateBackend} must ensure that we set the
- * {@link org.rocksdb.StringAppendOperator} on the column family that we use for our state since
- * we use the {@code merge()} call.
- *
  * @param <K> The type of the key.
  * @param <N> The type of the namespace.
  * @param <UK> The type of the keys in the map state.


### PR DESCRIPTION
## What is the purpose of the change

Remove incorrect doc comments from RocksDBMapState. This is inspired from [a developer mail](http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/A-question-about-RocksDBListState-and-RocksDBMapState-td30249.html).


## Brief change log

  - Remove incorrect doc comments from `RocksDBMapState`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
