### PR TITLE
[FLINK-13101][datastream] Add slotSharingAfterChainingDisabled proper…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -97,6 +97,11 @@ public class StreamGraph extends StreamingPlan {
 
 	private TimeCharacteristic timeCharacteristic;
 
+	/**
+	 * Disable slot sharing between non-chained operators.
+	 */
+	private boolean slotSharingAfterChainingDisabled = false;
+
 	private Map<Integer, StreamNode> streamNodes;
 	private Set<Integer> sources;
 	private Set<Integer> sinks;
@@ -182,6 +187,14 @@ public class StreamGraph extends StreamingPlan {
 
 	public void setTimeCharacteristic(TimeCharacteristic timeCharacteristic) {
 		this.timeCharacteristic = timeCharacteristic;
+	}
+
+	public boolean isSlotSharingAfterChainingDisabled() {
+		return slotSharingAfterChainingDisabled;
+	}
+
+	public void setSlotSharingAfterChainingDisabled(boolean slotSharingAfterChainingDisabled) {
+		this.slotSharingAfterChainingDisabled = slotSharingAfterChainingDisabled;
 	}
 
 	// Checkpointing

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -158,7 +158,9 @@ public class StreamingJobGraphGenerator {
 
 		setPhysicalEdges();
 
-		setSlotSharingAndCoLocation();
+		if (!streamGraph.isSlotSharingAfterChainingDisabled()) {
+			setSlotSharingAndCoLocation();
+		}
 
 		configureCheckpointing();
 
@@ -517,6 +519,11 @@ public class StreamingJobGraphGenerator {
 			default:
 				throw new UnsupportedOperationException("Data exchange mode " +
 					edge.getShuffleMode() + " is not supported yet.");
+		}
+
+		// at the moment scheduler can not handle pipelined without slot sharing
+		if (streamGraph.isSlotSharingAfterChainingDisabled()) {
+			resultPartitionType = ResultPartitionType.BLOCKING;
 		}
 
 		JobEdge jobEdge;


### PR DESCRIPTION
…ty of StreamGraph

## What is the purpose of the change

* The reason of introducing it is to satisfy the requirement of Blink batch planner.
* Because the current scheduling strategy is a bit simple. It can not support some complex scenarios, like a batch job with resources limited.
* To be honest, it's probably a work-around solution. However it's an internal implementation, we can replace it when we are able to support batch job by scheduling strategy.
* **This is alternative solution of FLINK-13101**

## Brief change log

* Add a property `slotSharingAfterChainingDisabled` of `StreamGraph`
* The property means, if there are some operators that can not be chained, disable slot sharing and translate these edges into `BLOCKING` result partition type.

## Verifying this change

* This change added unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **JavaDocs**
