### PR TITLE
[FLINK-13125][docs] Make PubSub stability warning more prominent

### DIFF
--- a/docs/dev/connectors/pubsub.md
+++ b/docs/dev/connectors/pubsub.md
@@ -1,6 +1,6 @@
 ---
-title: "Google PubSub"
-nav-title: PubSub
+title: "Google Cloud PubSub"
+nav-title: Google Cloud PubSub
 nav-parent_id: connectors
 nav-pos: 7
 ---
@@ -24,7 +24,7 @@ under the License.
 -->
 
 This connector provides a Source and Sink that can read from and write to
-[Google PubSub](https://cloud.google.com/pubsub). To use this connector, add the
+[Google Cloud PubSub](https://cloud.google.com/pubsub). To use this connector, add the
 following dependency to your project:
 
 {% highlight xml %}
@@ -35,13 +35,17 @@ following dependency to your project:
 </dependency>
 {% endhighlight %}
 
+<p style="border-radius: 5px; padding: 5px" class="bg-danger">
+<b>Note</b>: This connector has been added to Flink recently. It has not received widespread testing yet.
+</p>
+
 Note that the streaming connectors are currently not part of the binary
 distribution. See
 [here]({{ site.baseurl }}/dev/projectsetup/dependencies.html)
 for information about how to package the program with the libraries for
 cluster execution.
- 
-This pubsub connector has not received widespread testing yet.
+
+
 
 ## Consuming or Producing PubSubMessages
 
@@ -143,7 +147,7 @@ env.addSource(pubsubSource)
 
 There are several reasons why a message might be send multiple times, such as failure scenarios on Google PubSub's side.
 
-Another reason is when the acknowledgement deadline has past. This is the time between receiving the message and between acknowledging the message. The PubSubSource will only acknowledge a message on successful checkpoints to guarantee Atleast-Once. This does mean if the time between successful checkpoints is larger than the acknowledgment deadline of your subscription messages will most likely be processed multiple times.
+Another reason is when the acknowledgement deadline has passed. This is the time between receiving the message and between acknowledging the message. The PubSubSource will only acknowledge a message on successful checkpoints to guarantee Atleast-Once. This does mean if the time between successful checkpoints is larger than the acknowledgment deadline of your subscription messages will most likely be processed multiple times.
 
 For this reason it's recommended to have a (much) lower checkpoint interval than acknowledgement deadline.
 


### PR DESCRIPTION
## What is the purpose of the change

Make the warning on the GCP PubSub connector stability more prominent

![image](https://user-images.githubusercontent.com/89049/60731169-27c18880-9f47-11e9-8d4e-e4da16ad578e.png)

