### PR TITLE
[FLINK-13134][hive] override default hadoop version from 2.4.1 to 2.7.5 in flink-connector-hive

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -63,10 +63,15 @@ under the License.
 		<!-- Hadoop dependency -->
 		<!-- Hadoop as provided dependencies, so we can depend on them without pulling in Hadoop -->
 
+		<!--
+			Hive 2.3.4 relies on Hadoop 2.7.2 and later versions.
+			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5,
+			thus override the default hadoop version from 2.4.1 to 2.7.5
+		-->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop-2-uber</artifactId>
-			<version>${hadoop.version}-${flink.shaded.version}</version>
+			<version>${hivemetastore.hadoop.version}-${flink.shaded.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -439,7 +439,7 @@ under the License.
 			<id>hive-1.2.1</id>
 			<properties>
 				<hive.version>1.2.1</hive.version>
-				<hivemetastore.hadoop.version>2.6.0</hivemetastore.hadoop.version>
+				<hivemetastore.hadoop.version>2.6.5</hivemetastore.hadoop.version>
 			</properties>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,11 @@ under the License.
 		<minikdc.version>2.7.2</minikdc.version>
 		<generated.docs.dir>./docs/_includes/generated</generated.docs.dir>
 		<hive.version>2.3.4</hive.version>
-		<hivemetastore.hadoop.version>2.7.2</hivemetastore.hadoop.version>
+		<!--
+			Hive 2.3.4 relies on Hadoop 2.7.2 and later versions.
+			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5
+		-->
+		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
 		<jamicmp.referenceVersion>1.8.0</jamicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 	</properties>


### PR DESCRIPTION
## What is the purpose of the change

Hive 2.3.4 relies on Hadoop 2.7.2 or later version. The default hadoop version in Flink globally is 2.4.1 which misses some classes in 2.7.2 and thus doesn't meet the requirement.

For hadoop 2.7, the minor version supported in flink-shaded-hadoop-2-uber is 2.7.5.

Found this bug when running tests locally after merging FLINK-12934. Not sure why Travis CI succeeded for FLINK-12934 though, maybe because the build machine has all versioned hadoops cached locally.  

## Brief change log

- overrode the default hadoop version in flink-connector-hive to be 2.7.5

## Verifying this change

This change is already covered by existing tests in flink-connector-hive module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive):(no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
