### PR TITLE
[FLINK-13136] Fix documentation error about stopping job with restful api

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1060,7 +1060,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>mode</code> (optional): String value that specifies the termination mode. Supported values are: "cancel, stop".</li>
+<li><code>mode</code> (optional): String value that specifies the termination mode. Supported value is: "cancel".</li>
         </ul>
       </td>
     </tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
@@ -18,11 +18,8 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import org.apache.flink.util.StringUtils;
-
 /**
- * Termination mode.
- * @deprecated Only kept to detect legacy usages of the cancel/stop command. Please use the "stop" command instead.
+ * Termination mode query parameter.
  */
 public class TerminationModeQueryParameter extends MessageQueryParameter<TerminationModeQueryParameter.TerminationMode> {
 
@@ -44,15 +41,18 @@ public class TerminationModeQueryParameter extends MessageQueryParameter<Termina
 
 	@Override
 	public String getDescription() {
-		return "String value that specifies the termination mode. Supported values are: " +
-			StringUtils.toQuotedListString(TerminationMode.values()) + '.';
+		return "String value that specifies the termination mode. Supported value is: \"cancel\"" + '.';
 	}
 
 	/**
-	 * @deprecated Please use the "stop" command instead.
+	 * Termination mode.
 	 */
 	public enum TerminationMode {
 		CANCEL,
+
+		/**
+		 * @deprecated Please use the "stop" command instead.
+		 */
 		STOP
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes documentation error about stopping job with restful api*

## Brief change log

  - *Fix documentation error about stopping job with restful api*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
