### PR TITLE
[hotfix][python]Fix the install failure of pyflink used previous version of python 2.7

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -170,7 +170,7 @@ run sdist.
         package_data={
             'pyflink': ['LICENSE', 'NOTICE', 'README.txt'],
             'pyflink.lib': ['*.jar'],
-            'pyflink.opt': ['*', '*/*'],
+            'pyflink.opt': ['*.*', '*/*'],
             'pyflink.conf': ['*'],
             'pyflink.log': ['*'],
             'pyflink.examples': ['*.py', '*/*.py'],


### PR DESCRIPTION
## What is the purpose of the change

*If you install pyflink used previous version of python 2.7(e.g. 2.7.10), it will throw a error "error: can't copy 'deps/opt/python': doesn't exist or not a regular file"*.This can be fixed by changing 'pyflink.opt': ['*', '\*/\*']" to 'pyflink.opt': ['\*.\*', '\*/\*'] in setup.py


## Brief change log

  - *Change 'pyflink.opt': ['*', '\*/\*']" to 'pyflink.opt': ['\*.\*', '\*/\*'] in setup.py*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
