### PR TITLE
[FLINK-13013][network] Request partitions during InputGate#setup

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/CloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/CloseableRegistry.java
@@ -24,7 +24,10 @@ import org.apache.flink.util.AbstractCloseableRegistry;
 import javax.annotation.Nonnull;
 
 import java.io.Closeable;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -33,6 +36,8 @@ import java.util.Map;
  * <p>Registering to an already closed registry will throw an exception and close the provided {@link Closeable}
  *
  * <p>All methods in this class are thread-safe.
+ *
+ * <p>This class closes all registered {@link Closeable}s in the reverse registration order.
  */
 @Internal
 public class CloseableRegistry extends AbstractCloseableRegistry<Closeable, Object> {
@@ -40,7 +45,7 @@ public class CloseableRegistry extends AbstractCloseableRegistry<Closeable, Obje
 	private static final Object DUMMY = new Object();
 
 	public CloseableRegistry() {
-		super(new HashMap<>());
+		super(new LinkedHashMap<>());
 	}
 
 	@Override
@@ -51,5 +56,12 @@ public class CloseableRegistry extends AbstractCloseableRegistry<Closeable, Obje
 	@Override
 	protected boolean doUnRegister(@Nonnull Closeable closeable, @Nonnull Map<Closeable, Object> closeableMap) {
 		return closeableMap.remove(closeable) != null;
+	}
+
+	@Override
+	protected Collection<Closeable> getReferencesToClose() {
+		ArrayList<Closeable> closeablesToClose = new ArrayList<>(closeableToRef.keySet());
+		Collections.reverse(closeablesToClose);
+		return closeablesToClose;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
@@ -49,7 +49,7 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 
 	/** Map from tracked Closeables to some associated meta data. */
 	@GuardedBy("lock")
-	private final Map<Closeable, T> closeableToRef;
+	protected final Map<Closeable, T> closeableToRef;
 
 	/** Indicates if this registry is closed. */
 	@GuardedBy("lock")
@@ -114,7 +114,7 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 
 			closed = true;
 
-			toCloseCopy = new ArrayList<>(closeableToRef.keySet());
+			toCloseCopy = getReferencesToClose();
 
 			closeableToRef.clear();
 		}
@@ -126,6 +126,10 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 		synchronized (getSynchronizationLock()) {
 			return closed;
 		}
+	}
+
+	protected Collection<Closeable> getReferencesToClose() {
+		return new ArrayList<>(closeableToRef.keySet());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -130,5 +130,5 @@ public abstract class InputGate implements AsyncDataInput<BufferOrEvent>, AutoCl
 	/**
 	 * Setup gate, potentially heavy-weight, blocking operation comparing to just creation.
 	 */
-	public abstract void setup() throws IOException;
+	public abstract void setup() throws IOException, InterruptedException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -77,8 +77,6 @@ public abstract class InputGate implements AsyncDataInput<BufferOrEvent>, AutoCl
 
 	public abstract boolean isFinished();
 
-	public abstract void requestPartitions() throws IOException, InterruptedException;
-
 	/**
 	 * Blocking call waiting for next {@link BufferOrEvent}.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteChannelStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteChannelStateChecker.java
@@ -46,7 +46,8 @@ public class RemoteChannelStateChecker {
 
 	public boolean isProducerReadyOrAbortConsumption(ResponseHandle responseHandle) {
 		Either<ExecutionState, Throwable> result = responseHandle.getProducerExecutionState();
-		if (responseHandle.getConsumerExecutionState() != ExecutionState.RUNNING) {
+		ExecutionState consumerExecutionState = responseHandle.getConsumerExecutionState();
+		if (!isConsumerStateValidForConsumption(consumerExecutionState)) {
 			LOG.debug(
 				"Ignore a partition producer state notification for task {}, because it's not running.",
 				taskNameWithSubtask);
@@ -62,6 +63,12 @@ public class RemoteChannelStateChecker {
 			handleFailedCheckResult(responseHandle);
 		}
 		return false;
+	}
+
+	private static boolean isConsumerStateValidForConsumption(
+			ExecutionState consumerExecutionState) {
+		return consumerExecutionState == ExecutionState.RUNNING ||
+			consumerExecutionState == ExecutionState.DEPLOYING;
 	}
 
 	private boolean isProducerConsumerReady(ResponseHandle responseHandle) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -202,7 +202,7 @@ public class SingleInputGate extends InputGate {
 	}
 
 	@Override
-	public void setup() throws IOException {
+	public void setup() throws IOException, InterruptedException {
 		checkState(this.bufferPool == null, "Bug in input gate setup logic: Already registered buffer pool.");
 		if (isCreditBased) {
 			// assign exclusive buffers to input channels directly and use the rest for floating buffers
@@ -211,6 +211,8 @@ public class SingleInputGate extends InputGate {
 
 		BufferPool bufferPool = bufferPoolFactory.get();
 		setBufferPool(bufferPool);
+
+		requestPartitions();
 	}
 
 	// ------------------------------------------------------------------------
@@ -481,7 +483,6 @@ public class SingleInputGate extends InputGate {
 			throw new IllegalStateException("Released");
 		}
 
-		requestPartitions();
 		Optional<InputWithData<InputChannel, BufferAndAvailability>> next = waitAndGetNextData(blocking);
 		if (!next.isPresent()) {
 			return Optional.empty();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -167,9 +167,6 @@ public class UnionInputGate extends InputGate {
 			return Optional.empty();
 		}
 
-		// Make sure to request the partitions, if they have not been requested before.
-		requestPartitions();
-
 		Optional<InputWithData<InputGate, BufferOrEvent>> next = waitAndGetNextData(blocking);
 		if (!next.isPresent()) {
 			return Optional.empty();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -86,9 +86,6 @@ public class UnionInputGate extends InputGate {
 	 */
 	private final Map<InputGate, Integer> inputGateToIndexOffsetMap;
 
-	/** Flag indicating whether partitions have been requested. */
-	private boolean requestedPartitionsFlag;
-
 	public UnionInputGate(InputGate... inputGates) {
 		this.inputGates = checkNotNull(inputGates);
 		checkArgument(inputGates.length > 1, "Union input gate should union at least two input gates.");
@@ -139,17 +136,6 @@ public class UnionInputGate extends InputGate {
 	@Override
 	public boolean isFinished() {
 		return inputGatesWithRemainingData.isEmpty();
-	}
-
-	@Override
-	public void requestPartitions() throws IOException, InterruptedException {
-		if (!requestedPartitionsFlag) {
-			for (InputGate inputGate : inputGates) {
-				inputGate.requestPartitions();
-			}
-
-			requestedPartitionsFlag = true;
-		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -61,7 +61,7 @@ public class InputGateWithMetrics extends InputGate {
 	}
 
 	@Override
-	public void setup() throws IOException {
+	public void setup() throws IOException, InterruptedException {
 		inputGate.setup();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -66,11 +66,6 @@ public class InputGateWithMetrics extends InputGate {
 	}
 
 	@Override
-	public void requestPartitions() throws IOException, InterruptedException {
-		inputGate.requestPartitions();
-	}
-
-	@Override
 	public Optional<BufferOrEvent> getNext() throws IOException, InterruptedException {
 		return updateMetrics(inputGate.getNext());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -834,12 +834,14 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 
 	@VisibleForTesting
 	public static void setupPartitionsAndGates(
-		ResultPartitionWriter[] producedPartitions, InputGate[] inputGates) throws IOException {
+		ResultPartitionWriter[] producedPartitions, InputGate[] inputGates) throws IOException, InterruptedException {
 
 		for (ResultPartitionWriter partition : producedPartitions) {
 			partition.setup();
 		}
 
+		// InputGates must be initialized after the partitions, since during InputGate#setup
+		// we are requesting partitions
 		for (InputGate gate : inputGates) {
 			gate.setup();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -30,9 +30,11 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
  */
 public class NettyShuffleEnvironmentBuilder {
 
+	public static final int DEFAULT_NUM_NETWORK_BUFFERS = 1024;
+
 	private static final String[] DEFAULT_TEMP_DIRS = new String[] {EnvironmentInformation.getTemporaryFileDirectory()};
 
-	private int numNetworkBuffers = 1024;
+	private int numNetworkBuffers = DEFAULT_NUM_NETWORK_BUFFERS;
 
 	private int networkBufferSize = 32 * 1024;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -89,62 +89,7 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 	 */
 	@Test
 	public void testRegisterTaskUsesBoundedBuffers() throws Exception {
-		final NettyShuffleEnvironment network = new NettyShuffleEnvironmentBuilder()
-			.setIsCreditBased(enableCreditBasedFlowControl)
-			.build();
-
-		// result partitions
-		ResultPartition rp1 = createPartition(network, ResultPartitionType.PIPELINED, 2);
-		ResultPartition rp2 = createPartition(network, fileChannelManager, ResultPartitionType.BLOCKING, 2);
-		ResultPartition rp3 = createPartition(network, ResultPartitionType.PIPELINED_BOUNDED, 2);
-		ResultPartition rp4 = createPartition(network, ResultPartitionType.PIPELINED_BOUNDED, 8);
-		final ResultPartition[] resultPartitions = new ResultPartition[] {rp1, rp2, rp3, rp4};
-
-		// input gates
-		SingleInputGate ig1 = createSingleInputGate(network, ResultPartitionType.PIPELINED, 2);
-		SingleInputGate ig2 = createSingleInputGate(network, ResultPartitionType.BLOCKING, 2);
-		SingleInputGate ig3 = createSingleInputGate(network, ResultPartitionType.PIPELINED_BOUNDED, 2);
-		SingleInputGate ig4 = createSingleInputGate(network, ResultPartitionType.PIPELINED_BOUNDED, 8);
-		final SingleInputGate[] inputGates = new SingleInputGate[] {ig1, ig2, ig3, ig4};
-
-		Task.setupPartitionsAndGates(resultPartitions, inputGates);
-
-		// verify buffer pools for the result partitions
-		assertEquals(rp1.getNumberOfSubpartitions(), rp1.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(rp2.getNumberOfSubpartitions(), rp2.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(rp3.getNumberOfSubpartitions(), rp3.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(rp4.getNumberOfSubpartitions(), rp4.getBufferPool().getNumberOfRequiredMemorySegments());
-
-		assertEquals(Integer.MAX_VALUE, rp1.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(Integer.MAX_VALUE, rp2.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(2 * 2 + 8, rp3.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(8 * 2 + 8, rp4.getBufferPool().getMaxNumberOfMemorySegments());
-
-		// verify buffer pools for the input gates (NOTE: credit-based uses minimum required buffers
-		// for exclusive buffers not managed by the buffer pool)
-		assertEquals(enableCreditBasedFlowControl ? 0 : 2, ig1.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(enableCreditBasedFlowControl ? 0 : 2, ig2.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(enableCreditBasedFlowControl ? 0 : 2, ig3.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(enableCreditBasedFlowControl ? 0 : 8, ig4.getBufferPool().getNumberOfRequiredMemorySegments());
-
-		assertEquals(Integer.MAX_VALUE, ig1.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(Integer.MAX_VALUE, ig2.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(enableCreditBasedFlowControl ? 8 : 2 * 2 + 8, ig3.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(enableCreditBasedFlowControl ? 8 : 8 * 2 + 8, ig4.getBufferPool().getMaxNumberOfMemorySegments());
-
-		int invokations = enableCreditBasedFlowControl ? 1 : 0;
-		verify(ig1, times(invokations)).assignExclusiveSegments();
-		verify(ig2, times(invokations)).assignExclusiveSegments();
-		verify(ig3, times(invokations)).assignExclusiveSegments();
-		verify(ig4, times(invokations)).assignExclusiveSegments();
-
-		for (ResultPartition rp : resultPartitions) {
-			rp.release();
-		}
-		for (SingleInputGate ig : inputGates) {
-			ig.close();
-		}
-		network.close();
+		testRegisterTaskWithLimitedBuffers(NettyShuffleEnvironmentBuilder.DEFAULT_NUM_NETWORK_BUFFERS, false);
 	}
 
 	/**
@@ -164,7 +109,7 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 			bufferCount = 10 + 10 * NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue();
 		}
 
-		testRegisterTaskWithLimitedBuffers(bufferCount);
+		testRegisterTaskWithLimitedBuffers(bufferCount, true);
 	}
 
 	/**
@@ -185,10 +130,10 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 
 		expectedException.expect(IOException.class);
 		expectedException.expectMessage("Insufficient number of network buffers");
-		testRegisterTaskWithLimitedBuffers(bufferCount);
+		testRegisterTaskWithLimitedBuffers(bufferCount, true);
 	}
 
-	private void testRegisterTaskWithLimitedBuffers(int bufferPoolSize) throws Exception {
+	private void testRegisterTaskWithLimitedBuffers(int bufferPoolSize, boolean assertNumBuffers) throws Exception {
 		final NettyShuffleEnvironment network = new NettyShuffleEnvironmentBuilder()
 			.setNumNetworkBuffers(bufferPoolSize)
 			.setIsCreditBased(enableCreditBasedFlowControl)
@@ -238,7 +183,9 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 
 		for (ResultPartition rp : resultPartitions) {
 			assertEquals(rp.getNumberOfSubpartitions(), rp.getBufferPool().getNumberOfRequiredMemorySegments());
-			assertEquals(rp.getNumberOfSubpartitions(), rp.getBufferPool().getNumBuffers());
+			if (assertNumBuffers) {
+				assertEquals(rp.getNumberOfSubpartitions(), rp.getBufferPool().getNumBuffers());
+			}
 		}
 
 		// verify buffer pools for the input gates (NOTE: credit-based uses minimum required buffers

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -155,23 +155,19 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 		SingleInputGate ig4 = createSingleInputGate(network, ResultPartitionType.PIPELINED_BOUNDED, 4);
 		final SingleInputGate[] inputGates = new SingleInputGate[] {ig1, ig2, ig3, ig4};
 
-		// set up remote input channels for the exclusive buffers of the credit-based flow control
-		// (note that this does not obey the partition types which is ok for the scope of the test)
-		if (enableCreditBasedFlowControl) {
-			createRemoteInputChannel(ig4, 0, rp1, connManager, network.getNetworkBufferPool());
-			createRemoteInputChannel(ig4, 0, rp2, connManager, network.getNetworkBufferPool());
-			createRemoteInputChannel(ig4, 0, rp3, connManager, network.getNetworkBufferPool());
-			createRemoteInputChannel(ig4, 0, rp4, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig4, 0, rp1, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig4, 0, rp2, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig4, 0, rp3, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig4, 0, rp4, connManager, network.getNetworkBufferPool());
 
-			createRemoteInputChannel(ig1, 1, rp1, connManager, network.getNetworkBufferPool());
-			createRemoteInputChannel(ig1, 1, rp4, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig1, 1, rp1, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig1, 1, rp4, connManager, network.getNetworkBufferPool());
 
-			createRemoteInputChannel(ig2, 1, rp2, connManager, network.getNetworkBufferPool());
-			createRemoteInputChannel(ig2, 2, rp4, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig2, 1, rp2, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig2, 2, rp4, connManager, network.getNetworkBufferPool());
 
-			createRemoteInputChannel(ig3, 1, rp3, connManager, network.getNetworkBufferPool());
-			createRemoteInputChannel(ig3, 3, rp4, connManager, network.getNetworkBufferPool());
-		}
+		createRemoteInputChannel(ig3, 1, rp3, connManager, network.getNetworkBufferPool());
+		createRemoteInputChannel(ig3, 3, rp4, connManager, network.getNetworkBufferPool());
 
 		Task.setupPartitionsAndGates(resultPartitions, inputGates);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
@@ -1,0 +1,95 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// We have it in this package because we could not mock the methods otherwise
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import org.apache.flink.core.memory.MemorySegment;
+
+import java.io.IOException;
+
+/**
+ * No-op implementation of {@link BufferPool}.
+ */
+public class NoOpBufferPool implements BufferPool {
+
+	@Override
+	public void lazyDestroy() {
+	}
+
+	@Override
+	public Buffer requestBuffer() throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Buffer requestBufferBlocking() throws IOException, InterruptedException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public BufferBuilder requestBufferBuilderBlocking() throws IOException, InterruptedException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean addBufferListener(BufferListener listener) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isDestroyed() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int getNumberOfRequiredMemorySegments() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int getMaxNumberOfMemorySegments() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int getNumBuffers() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setNumBuffers(int numBuffers) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int getNumberOfAvailableMemorySegments() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int bestEffortGetNumOfUsedBuffers() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void recycle(MemorySegment memorySegment) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -189,6 +190,26 @@ public class InputChannelTestUtils {
 		@Override
 		public Collection<MemorySegment> requestMemorySegments() {
 			return Collections.emptyList();
+		}
+
+		@Override
+		public void recycleMemorySegments(Collection<MemorySegment> segments) {
+		}
+	}
+
+	/**
+	 * {@link MemorySegmentProvider} that provides unpooled {@link MemorySegment}s.
+	 */
+	public static class UnpooledMemorySegmentProvider implements MemorySegmentProvider {
+		private final int pageSize;
+
+		public UnpooledMemorySegmentProvider(int pageSize) {
+			this.pageSize = pageSize;
+		}
+
+		@Override
+		public Collection<MemorySegment> requestMemorySegments() {
+			return Collections.singletonList(MemorySegmentFactory.allocateUnpooledSegment(pageSize));
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -63,6 +63,7 @@ public class PartitionTestUtils {
 			ResultPartitionType partitionType,
 			int numChannels) {
 		return new ResultPartitionBuilder()
+			.setResultPartitionManager(environment.getResultPartitionManager())
 			.setupBufferPoolFactoryFromNettyShuffleEnvironment(environment)
 			.setResultPartitionType(partitionType)
 			.setNumberOfSubpartitions(numChannels)
@@ -75,6 +76,7 @@ public class PartitionTestUtils {
 			ResultPartitionType partitionType,
 			int numChannels) {
 		return new ResultPartitionBuilder()
+			.setResultPartitionManager(environment.getResultPartitionManager())
 			.setupBufferPoolFactoryFromNettyShuffleEnvironment(environment)
 			.setFileChannelManager(channelManager)
 			.setResultPartitionType(partitionType)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -493,7 +493,7 @@ public class LocalInputChannelTest {
 				BufferPool bufferPool,
 				ResultPartitionManager partitionManager,
 				TaskEventDispatcher taskEventDispatcher,
-				ResultPartitionID[] consumedPartitionIds) {
+				ResultPartitionID[] consumedPartitionIds) throws IOException, InterruptedException {
 
 			checkArgument(numberOfInputChannels >= 1);
 			checkArgument(numberOfExpectedBuffersPerChannel >= 1);
@@ -501,10 +501,8 @@ public class LocalInputChannelTest {
 			this.inputGate = new SingleInputGateBuilder()
 				.setConsumedSubpartitionIndex(subpartitionIndex)
 				.setNumberOfChannels(numberOfInputChannels)
+				.setBufferPoolFactory(bufferPool)
 				.build();
-
-			// Set buffer pool
-			inputGate.setBufferPool(bufferPool);
 
 			// Setup input channels
 			for (int i = 0; i < numberOfInputChannels; i++) {
@@ -515,6 +513,8 @@ public class LocalInputChannelTest {
 					.setTaskEventPublisher(taskEventDispatcher)
 					.buildLocalAndSetToGate(inputGate);
 			}
+
+			inputGate.setup();
 
 			this.numberOfInputChannels = numberOfInputChannels;
 			this.numberOfExpectedBuffersPerChannel = numberOfExpectedBuffersPerChannel;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -87,6 +87,11 @@ public class SingleInputGateBuilder {
 		return this;
 	}
 
+	public SingleInputGateBuilder setBufferPoolFactory(BufferPool bufferPool) {
+		this.bufferPoolFactory = () -> bufferPool;
+		return this;
+	}
+
 	public SingleInputGate build() {
 		return new SingleInputGate(
 			"Single Input Gate",

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
@@ -152,9 +152,6 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 		}
 
 		@Override
-		public void requestPartitions() {}
-
-		@Override
 		public Optional<BufferOrEvent> getNext() throws IOException, InterruptedException {
 			currentChannel = (currentChannel + 1) % numberOfChannels;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -98,10 +98,6 @@ public class MockInputGate extends InputGate {
 	}
 
 	@Override
-	public void requestPartitions() {
-	}
-
-	@Override
 	public void sendTaskEvent(TaskEvent event) {
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -50,7 +50,6 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -231,7 +230,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 		return consumableNotifyingPartitionWriter;
 	}
 
-	private InputGate createInputGate(TaskManagerLocation senderLocation) throws IOException {
+	private InputGate createInputGate(TaskManagerLocation senderLocation) throws Exception {
 		InputGate[] gates = new InputGate[channels];
 		for (int channel = 0; channel < channels; ++channel) {
 			final InputGateDeploymentDescriptor gateDescriptor = createInputGateDeploymentDescriptor(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
@@ -77,8 +77,8 @@ public class StreamNetworkPointToPointBenchmark {
 		environment = new StreamNetworkBenchmarkEnvironment<>();
 		environment.setUp(1, 1, false, false, -1, -1, config);
 
-		receiver = environment.createReceiver();
 		recordWriter = environment.createRecordWriter(0, flushTimeout);
+		receiver = environment.createReceiver();
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
@@ -110,7 +110,6 @@ public class StreamNetworkThroughputBenchmark {
 			senderBufferPoolSize,
 			receiverBufferPoolSize,
 			config);
-		receiver = environment.createReceiver();
 		writerThreads = new LongRecordWriterThread[recordWriters];
 		for (int writer = 0; writer < recordWriters; writer++) {
 			writerThreads[writer] = new LongRecordWriterThread(
@@ -118,6 +117,7 @@ public class StreamNetworkThroughputBenchmark {
 				broadcastMode);
 			writerThreads[writer].start();
 		}
+		receiver = environment.createReceiver();
 	}
 
 	/**


### PR DESCRIPTION
Before partitions were being requested on first polling/getting next buffer which was causing a couple of issues:
- it was a little bit confusing
- after first requestPartitions call, this was causing unnecessary synchronisation overhead
- this was preventing data notifications to come through and isAvailable() future was always not completed before the first attempt to read the data from the input gate

On top of that, this PR includes a couple of hotfixes, for which please look at the individual commits/commit messages.

## Verifying this change

This change is covered by existing unit and integration tests and it also adds a new unit test to add a test coverage for one issue found by ITCase.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no ****/ don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
