### PR TITLE
[FLINK-13078][table-common] Preparation for a type parser utility

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/AnyType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/AnyType.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * Logical type of an arbitrary serialized type. This type is a black box within the table ecosystem
  * and is only deserialized at the edges. The any type is an extension to the SQL standard.
  *
- * <p>The serialized string representation is {@code ANY(c, s)} where {@code c} is the originating
+ * <p>The serialized string representation is {@code ANY('c', 's')} where {@code c} is the originating
  * class and {@code s} is the serialized {@link TypeSerializerSnapshot} in Base64 encoding.
  *
  * @param <T> originating class for this type
@@ -43,7 +43,7 @@ import java.util.Set;
 @PublicEvolving
 public final class AnyType<T> extends LogicalType {
 
-	private static final String FORMAT = "ANY(%s, %s)";
+	private static final String FORMAT = "ANY('%s', '%s')";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		byte[].class.getName(),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DecimalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DecimalType.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * digits in a number (=precision) and {@code s} is the number of digits to the right of the decimal
  * point in a number (=scale). {@code p} must have a value between 1 and 38 (both inclusive). {@code s}
  * must have a value between 0 and {@code p} (both inclusive). The default value for {@code p} is 10.
- * The default value for {@code s} is 0.
+ * The default value for {@code s} is 0. {@code NUMERIC} and {@code DEC} are synonyms for this type.
  */
 @PublicEvolving
 public final class DecimalType extends LogicalType {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
@@ -27,7 +27,8 @@ import java.util.Set;
 /**
  * Logical type of an 8-byte double precision floating point number.
  *
- * <p>The serialized string representation is {@code DOUBLE}.
+ * <p>The serialized string representation is {@code DOUBLE}. {@code DOUBLE PRECISION} is a synonym
+ * for this type.
  */
 @PublicEvolving
 public final class DoubleType extends LogicalType {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
@@ -53,11 +53,11 @@ import java.util.Set;
 @PublicEvolving
 public final class LocalZonedTimestampType extends LogicalType {
 
-	public static final int MIN_PRECISION = 0;
+	public static final int MIN_PRECISION = TimestampType.MIN_PRECISION;
 
-	public static final int MAX_PRECISION = 9;
+	public static final int MAX_PRECISION = TimestampType.MAX_PRECISION;
 
-	public static final int DEFAULT_PRECISION = 6;
+	public static final int DEFAULT_PRECISION = TimestampType.DEFAULT_PRECISION;
 
 	private static final String FORMAT = "TIMESTAMP(%d) WITH LOCAL TIME ZONE";
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SymbolType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SymbolType.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 @PublicEvolving
 public final class SymbolType<T extends TableSymbol> extends LogicalType {
 
-	private static final String FORMAT = "SYMBOL(%s)";
+	private static final String FORMAT = "SYMBOL('%s')";
 
 	private final Class<T> symbolClass;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
@@ -35,7 +35,8 @@ import java.util.Set;
  *
  * <p>The serialized string representation is {@code TIME(p)} where {@code p} is the number of digits
  * of fractional seconds (=precision). {@code p} must have a value between 0 and 9 (both inclusive).
- * If no precision is specified, {@code p} is equal to 0.
+ * If no precision is specified, {@code p} is equal to 0. {@code TIME(p) WITHOUT TIME ZONE} is a synonym
+ * for this type.
  *
  * <p>A conversion from and to {@code int} describes the number of milliseconds of the day. A
  * conversion from and to {@code long} describes the number of nanoseconds of the day.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
@@ -35,7 +35,8 @@ import java.util.Set;
  *
  * <p>The serialized string representation is {@code TIMESTAMP(p)} where {@code p} is the number of
  * digits of fractional seconds (=precision). {@code p} must have a value between 0 and 9 (both inclusive).
- * If no precision is specified, {@code p} is equal to 6.
+ * If no precision is specified, {@code p} is equal to 6. {@code TIMESTAMP(p) WITHOUT TIME ZONE} is a
+ * synonym for this type.
  *
  * <p>A conversion from and to {@code long} is not supported as this would imply a time zone. However,
  * this type is time zone free. For more {@link java.time.Instant}-like semantics use

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TypeInformationAnyType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TypeInformationAnyType.java
@@ -49,7 +49,7 @@ import java.util.Set;
 @PublicEvolving
 public final class TypeInformationAnyType<T> extends LogicalType {
 
-	private static final String FORMAT = "ANY(%s, ?)";
+	private static final String FORMAT = "ANY('%s', ?)";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		byte[].class.getName(),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ZonedTimestampType.java
@@ -49,11 +49,11 @@ import java.util.Set;
 @PublicEvolving
 public final class ZonedTimestampType extends LogicalType {
 
-	public static final int MIN_PRECISION = 0;
+	public static final int MIN_PRECISION = TimestampType.MIN_PRECISION;
 
-	public static final int MAX_PRECISION = 9;
+	public static final int MAX_PRECISION = TimestampType.MAX_PRECISION;
 
-	public static final int DEFAULT_PRECISION = 6;
+	public static final int DEFAULT_PRECISION = TimestampType.DEFAULT_PRECISION;
 
 	private static final String FORMAT = "TIMESTAMP(%d) WITH TIME ZONE";
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -557,7 +557,7 @@ public class LogicalTypesTest {
 
 		testEquality(anyType, new TypeInformationAnyType<>(Types.TUPLE(Types.STRING, Types.LONG)));
 
-		testStringSummary(anyType, "ANY(org.apache.flink.api.java.tuple.Tuple2, ?)");
+		testStringSummary(anyType, "ANY('org.apache.flink.api.java.tuple.Tuple2', ?)");
 
 		testNullability(anyType);
 
@@ -572,8 +572,8 @@ public class LogicalTypesTest {
 	public void testAnyType() {
 		testAll(
 			new AnyType<>(Human.class, new KryoSerializer<>(Human.class, new ExecutionConfig())),
-				"ANY(org.apache.flink.table.types.LogicalTypesTest$Human, " +
-					"AEdvcmcuYXBhY2hlLmZsaW5rLmFwaS5qYXZhLnR5cGV1dGlscy5ydW50aW1lLmtyeW8uS3J5b1Nlcml" +
+				"ANY('org.apache.flink.table.types.LogicalTypesTest$Human', " +
+					"'AEdvcmcuYXBhY2hlLmZsaW5rLmFwaS5qYXZhLnR5cGV1dGlscy5ydW50aW1lLmtyeW8uS3J5b1Nlcml" +
 					"hbGl6ZXJTbmFwc2hvdAAAAAIAM29yZy5hcGFjaGUuZmxpbmsudGFibGUudHlwZXMuTG9naWNhbFR5cG" +
 					"VzVGVzdCRIdW1hbgAABPLGmj1wAAAAAgAzb3JnLmFwYWNoZS5mbGluay50YWJsZS50eXBlcy5Mb2dpY" +
 					"2FsVHlwZXNUZXN0JEh1bWFuAQAAADUAM29yZy5hcGFjaGUuZmxpbmsudGFibGUudHlwZXMuTG9naWNh" +
@@ -583,8 +583,8 @@ public class LogicalTypesTest {
 					"mcuYXBhY2hlLmZsaW5rLmFwaS5qYXZhLnR5cGV1dGlscy5ydW50aW1lLmtyeW8uU2VyaWFsaXplcnMk" +
 					"RHVtbXlBdnJvUmVnaXN0ZXJlZENsYXNzAAAAAQBZb3JnLmFwYWNoZS5mbGluay5hcGkuamF2YS50eXB" +
 					"ldXRpbHMucnVudGltZS5rcnlvLlNlcmlhbGl6ZXJzJER1bW15QXZyb0tyeW9TZXJpYWxpemVyQ2xhc3" +
-					"MAAATyxpo9cAAAAAAAAATyxpo9cAAAAAA=)",
-			"ANY(org.apache.flink.table.types.LogicalTypesTest$Human, ...)",
+					"MAAATyxpo9cAAAAAAAAATyxpo9cAAAAAA=')",
+			"ANY('org.apache.flink.table.types.LogicalTypesTest$Human', '...')",
 			new Class[]{Human.class, User.class}, // every User is Human
 			new Class[]{Human.class},
 			new LogicalType[]{},
@@ -598,7 +598,7 @@ public class LogicalTypesTest {
 
 		testEquality(symbolType, new SymbolType<>(TimePointUnit.class));
 
-		testStringSummary(symbolType, "SYMBOL(" + TimeIntervalUnit.class.getName() + ")");
+		testStringSummary(symbolType, "SYMBOL('" + TimeIntervalUnit.class.getName() + "')");
 
 		testNullability(symbolType);
 


### PR DESCRIPTION
## What is the purpose of the change

This adds some last minute changes to the serialization format of the logical types. These are prerequisites also for a type parser utility.

## Brief change log

See commit messages.

## Verifying this change

This change is already covered by existing tests, such as `LogicalTypesTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
