### PR TITLE
[hotfix][python] Update the package name from pyflink to apache-flink

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -140,7 +140,7 @@ run sdist.
     scripts.append("pyflink/find_flink_home.py")
 
     setup(
-        name='pyflink',
+        name='apache-flink',
         version=VERSION,
         packages=['pyflink',
                   'pyflink.table',


### PR DESCRIPTION
## What is the purpose of the change

*As discussed in the mail list, we want to add pip support for pyflink. As the name "pyflink" has been used by others, this pull request updates the package name from pyflink to apache-flink.*

## Brief change log

  - *Change the package name to apache-flink*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
