### PR TITLE
[FLINK-13123] Align Stop/Cancel Commands in CLI and REST Interface and Improve Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ Configuration descriptions are auto generated from code. To trigger the generati
 mvn -Pgenerate-config-docs install
 ```
 
-The resulting html files will be written to `_include/generated`. Tables are regenerated each time the command is invoked.
+The resulting html files will be written to `_includes/generated`. Tables are regenerated each time the command is invoked.
 These tables can be directly included into the documentation:
 
 ```

--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -2385,7 +2385,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
 <table class="table table-bordered">
   <tbody>
     <tr>
-      <td class="text-left" colspan="2"><h5><strong>/jobs/:jobid/stop-with-savepoint</strong></h5></td>
+      <td class="text-left" colspan="2"><h5><strong>/jobs/:jobid/stop</strong></h5></td>
     </tr>
     <tr>
       <td class="text-left" style="width: 20%">Verb: <code>POST</code></td>
@@ -2406,8 +2406,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     </tr>
     <tr>
       <td colspan="2">
-        <button data-toggle="collapse" data-target="#1622419335">Request</button>
-        <div id="1622419335" class="collapse">
+        <button data-toggle="collapse" data-target="#1146617568">Request</button>
+        <div id="1146617568" class="collapse">
           <pre>
             <code>
 {
@@ -2417,7 +2417,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     "targetDirectory" : {
       "type" : "string"
     },
-    "endOfEventTime" : {
+    "drain" : {
       "type" : "boolean"
     }
   }
@@ -2428,8 +2428,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     </tr>
     <tr>
       <td colspan="2">
-        <button data-toggle="collapse" data-target="#1441715731">Response</button>
-        <div id="1441715731" class="collapse">
+        <button data-toggle="collapse" data-target="#965913964">Response</button>
+        <div id="965913964" class="collapse">
           <pre>
             <code>
 {

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -176,23 +176,7 @@ These examples about how to manage a job in CLI.
 
 -   Gracefully stop a job with a savepoint (streaming jobs only):
 
-        ./bin/flink stop -s [targetDirectory] -d <jobID>
-        
-
-**NOTE**: The difference between cancelling and stopping a (streaming) job is the following:
-
-On a cancel call, the operators in a job immediately receive a `cancel()` method call to cancel them as
-soon as possible.
-If operators are not not stopping after the cancel call, Flink will start interrupting the thread periodically
-until it stops.
-
-A "stop" call is a more graceful way of stopping a running streaming job, as the "stop" signal flows from 
-source to sink. When the user requests to stop a job, all sources will be requested to send the last checkpoint barrier
-that will trigger a savepoint, and after the successful completion of that savepoint, they will finish by calling their
-`cancel()` method. If the `-d` flag is specified, then a `MAX_WATERMARK` will be emitted before the last checkpoint 
-barrier. This will result all registered event-time timers to fire, thus flushing out any state that is waiting for 
-a specific watermark, e.g. windows. The job will keep running until all sources properly shut down. This allows the
- job to finish processing all in-flight data. 
+        ./bin/flink stop [-p targetDirectory] [-d] <jobID>
 
 ### Savepoints
 
@@ -220,6 +204,23 @@ If you don't specify a target directory, you need to have [configured a default 
 This will trigger a savepoint for the job with ID `jobId` and YARN application ID `yarnAppId`, and returns the path of the created savepoint.
 
 Everything else is the same as described in the above **Trigger a Savepoint** section.
+
+#### Stop
+
+Use the `stop` to gracefully stop a running streaming job with a savepoint.
+
+{% highlight bash %}
+./bin/flink stop [-p targetDirectory] [-d] <jobID>
+{% endhighlight %}
+
+A "stop" call is a more graceful way of stopping a running streaming job, as the "stop" signal flows from
+source to sink. When the user requests to stop a job, all sources will be requested to send the last checkpoint barrier
+that will trigger a savepoint, and after the successful completion of that savepoint, they will finish by calling their
+`cancel()` method. If the `-d` flag is specified, then a `MAX_WATERMARK` will be emitted before the last checkpoint
+barrier. This will result all registered event-time timers to fire, thus flushing out any state that is waiting for
+a specific watermark, e.g. windows. The job will keep running until all sources properly shut down. This allows the
+ job to finish processing all in-flight data.
+
 
 #### Cancel with a savepoint (deprecated)
 
@@ -431,7 +432,7 @@ Action "stop" stops a running program with a savepoint (streaming jobs only).
   "stop" action options:
      -d,--drain                           Send MAX_WATERMARK before taking the
                                           savepoint and stopping the pipelne.
-     -s,--withSavepoint <withSavepoint>   Path to the savepoint (for example
+     -p,--savepointPath <savepointPath>   Path to the savepoint (for example
                                           hdfs:///flink/savepoint-1537). If no
                                           directory is specified, the configured
                                           default will be used

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -340,6 +340,8 @@ Action "run" compiles and runs a program.
                                           shutdown when the CLI is terminated
                                           abruptly, e.g., in response to a user
                                           interrupt, such as typing Ctrl + C.
+     -yat,--yarnapplicationType <arg>     Set a custom application type for the
+                                          application on YARN
      -yD <property=value>                 use value for given property
      -yd,--yarndetached                   If present, runs the job in detached
                                           mode (deprecated; use non-YARN
@@ -430,6 +432,15 @@ Action "stop" stops a running program with a savepoint (streaming jobs only).
                                           directory is specified, the configured
                                           default will be used
                                           ("state.savepoints.dir").
+  Options for yarn-cluster mode:
+     -m,--jobmanager <arg>            Address of the JobManager (master) to
+                                      which to connect. Use this flag to connect
+                                      to a different JobManager than the one
+                                      specified in the configuration.
+     -yid,--yarnapplicationId <arg>   Attach to running YARN session
+     -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
+                                      sub-paths for high availability mode
+
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
                                      to connect. Use this flag to connect to a

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -170,11 +170,11 @@ These examples about how to manage a job in CLI.
 
         ./bin/flink cancel <jobID>
 
--   Cancel a job with a savepoint:
+-   Cancel a job with a savepoint (deprecated; use "stop" instead):
 
         ./bin/flink cancel -s [targetDirectory] <jobID>
 
--   Stop a job with a savepoint (streaming jobs only):
+-   Gracefully stop a job with a savepoint (streaming jobs only):
 
         ./bin/flink stop -s [targetDirectory] -d <jobID>
         
@@ -221,7 +221,7 @@ This will trigger a savepoint for the job with ID `jobId` and YARN application I
 
 Everything else is the same as described in the above **Trigger a Savepoint** section.
 
-#### Cancel with a savepoint
+#### Cancel with a savepoint (deprecated)
 
 You can atomically trigger a savepoint and cancel a job.
 
@@ -232,6 +232,10 @@ You can atomically trigger a savepoint and cancel a job.
 If no savepoint directory is configured, you need to configure a default savepoint directory for the Flink installation (see [Savepoints]({{site.baseurl}}/ops/state/savepoints.html#configuration)).
 
 The job will only be cancelled if the savepoint succeeds.
+
+<p style="border-radius: 5px; padding: 5px" class="bg-danger">
+    <b>Note</b>: Cancelling a job with savepoint is deprecated. Use "stop" instead.</p>
+{% endunless %}
 
 #### Restore a savepoint
 
@@ -455,7 +459,10 @@ Action "cancel" cancels a running program.
 
   Syntax: cancel [OPTIONS] <Job ID>
   "cancel" action options:
-     -s,--withSavepoint <targetDirectory>   Trigger savepoint and cancel job.
+     -s,--withSavepoint <targetDirectory>   **DEPRECATION WARNING**: Cancelling
+                                            a job with savepoint is deprecated.
+                                            Use "stop" instead.
+                                            Trigger savepoint and cancel job.
                                             The target directory is optional. If
                                             no directory is specified, the
                                             configured default directory

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -175,23 +175,7 @@ available.
 
 -   Gracefully stop a job with a savepoint (streaming jobs only):
 
-        ./bin/flink stop -s [targetDirectory] -d <jobID>
-
-
-**NOTE**: The difference between cancelling and stopping a (streaming) job is the following:
-
-On a cancel call, the operators in a job immediately receive a `cancel()` method call to cancel them as
-soon as possible.
-If operators are not not stopping after the cancel call, Flink will start interrupting the thread periodically
-until it stops.
-
-A "stop" call is a more graceful way of stopping a running streaming job, as the "stop" signal flows from
-source to sink. When the user requests to stop a job, all sources will be requested to send the last checkpoint barrier
-that will trigger a savepoint, and after the successful completion of that savepoint, they will finish by calling their
-`cancel()` method. If the `-d` flag is specified, then a `MAX_WATERMARK` will be emitted before the last checkpoint
-barrier. This will result all registered event-time timers to fire, thus flushing out any state that is waiting for
-a specific watermark, e.g. windows. The job will keep running until all sources properly shut down. This allows the
- job to finish processing all in-flight data.
+        ./bin/flink stop [-p targetDirectory] [-d] <jobID>
 
 ### Savepoints
 
@@ -219,6 +203,23 @@ If you don't specify a target directory, you need to have [configured a default 
 This will trigger a savepoint for the job with ID `jobId` and YARN application ID `yarnAppId`, and returns the path of the created savepoint.
 
 Everything else is the same as described in the above **Trigger a Savepoint** section.
+
+#### Stop
+
+Use the `stop` to gracefully stop a running streaming job with a savepoint.
+
+{% highlight bash %}
+./bin/flink stop [-p targetDirectory] [-d] <jobID>
+{% endhighlight %}
+
+A "stop" call is a more graceful way of stopping a running streaming job, as the "stop" signal flows from
+source to sink. When the user requests to stop a job, all sources will be requested to send the last checkpoint barrier
+that will trigger a savepoint, and after the successful completion of that savepoint, they will finish by calling their
+`cancel()` method. If the `-d` flag is specified, then a `MAX_WATERMARK` will be emitted before the last checkpoint
+barrier. This will result all registered event-time timers to fire, thus flushing out any state that is waiting for
+a specific watermark, e.g. windows. The job will keep running until all sources properly shut down. This allows the
+ job to finish processing all in-flight data.
+
 
 #### Cancel with a savepoint (deprecated)
 
@@ -426,7 +427,7 @@ Action "stop" stops a running program with a savepoint (streaming jobs only).
   "stop" action options:
      -d,--drain                           Send MAX_WATERMARK before taking the
                                           savepoint and stopping the pipelne.
-     -s,--withSavepoint <withSavepoint>   Path to the savepoint (for example
+     -p,--savepointPath <savepointPath>   Path to the savepoint (for example
                                           hdfs:///flink/savepoint-1537). If no
                                           directory is specified, the configured
                                           default will be used

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -169,11 +169,11 @@ available.
 
         ./bin/flink cancel <jobID>
 
--   Cancel a job with a savepoint:
+-   Cancel a job with a savepoint (deprecated; use "stop" instead):
 
         ./bin/flink cancel -s [targetDirectory] <jobID>
 
--   Stop a job with a savepoint (streaming jobs only):
+-   Gracefully stop a job with a savepoint (streaming jobs only):
 
         ./bin/flink stop -s [targetDirectory] -d <jobID>
 
@@ -220,7 +220,7 @@ This will trigger a savepoint for the job with ID `jobId` and YARN application I
 
 Everything else is the same as described in the above **Trigger a Savepoint** section.
 
-#### Cancel with a savepoint
+#### Cancel with a savepoint (deprecated)
 
 You can atomically trigger a savepoint and cancel a job.
 
@@ -231,6 +231,10 @@ You can atomically trigger a savepoint and cancel a job.
 If no savepoint directory is configured, you need to configure a default savepoint directory for the Flink installation (see [Savepoints]({{site.baseurl}}/ops/state/savepoints.html#configuration)).
 
 The job will only be cancelled if the savepoint succeeds.
+
+<p style="border-radius: 5px; padding: 5px" class="bg-danger">
+    <b>Note</b>: Cancelling a job with savepoint is deprecated. Use "stop" instead.</p>
+{% endunless %}
 
 #### Restore a savepoint
 
@@ -450,7 +454,10 @@ Action "cancel" cancels a running program.
 
   Syntax: cancel [OPTIONS] <Job ID>
   "cancel" action options:
-     -s,--withSavepoint <targetDirectory>   Trigger savepoint and cancel job.
+     -s,--withSavepoint <targetDirectory>   **DEPRECATION WARNING**: Cancelling
+                                            a job with savepoint is deprecated.
+                                            Use "stop" instead.
+                                            Trigger savepoint and cancel job.
                                             The target directory is optional. If
                                             no directory is specified, the
                                             configured default directory

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -335,6 +335,8 @@ Action "run" compiles and runs a program.
                                           shutdown when the CLI is terminated
                                           abruptly, e.g., in response to a user
                                           interrupt, such as typing Ctrl + C.
+     -yat,--yarnapplicationType <arg>     Set a custom application type for the
+                                          application on YARN
      -yD <property=value>                 use value for given property
      -yd,--yarndetached                   If present, runs the job in detached
                                           mode (deprecated; use non-YARN
@@ -425,6 +427,15 @@ Action "stop" stops a running program with a savepoint (streaming jobs only).
                                           directory is specified, the configured
                                           default will be used
                                           ("state.savepoints.dir").
+  Options for yarn-cluster mode:
+     -m,--jobmanager <arg>            Address of the JobManager (master) to
+                                      which to connect. Use this flag to connect
+                                      to a different JobManager than the one
+                                      specified in the configuration.
+     -yid,--yarnapplicationId <arg>   Attach to running YARN session
+     -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
+                                      sub-paths for high availability mode
+
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
                                      to connect. Use this flag to connect to a

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -568,6 +568,9 @@ public class CliFrontend {
 		final String[] cleanedArgs = cancelOptions.getArgs();
 
 		if (cancelOptions.isWithSavepoint()) {
+
+			logAndSysout("DEPRECATION WARNING: Cancelling a job with savepoint is deprecated. Use \"stop\" instead.");
+
 			final JobID jobId;
 			final String targetDirectory;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -113,7 +113,7 @@ public class CliFrontendParser {
 			"specified, the configured default directory (" +
 			CheckpointingOptions.SAVEPOINT_DIRECTORY.key() + ") is used.");
 
-	public static final Option STOP_WITH_SAVEPOINT = new Option("s", "withSavepoint", true,
+	public static final Option STOP_WITH_SAVEPOINT_PATH = new Option("p", "savepointPath", true,
 			"Path to the savepoint (for example hdfs:///flink/savepoint-1537). " +
 					"If no directory is specified, the configured default will be used (\"" + CheckpointingOptions.SAVEPOINT_DIRECTORY.key() + "\").");
 
@@ -176,9 +176,9 @@ public class CliFrontendParser {
 		CANCEL_WITH_SAVEPOINT_OPTION.setArgName("targetDirectory");
 		CANCEL_WITH_SAVEPOINT_OPTION.setOptionalArg(true);
 
-		STOP_WITH_SAVEPOINT.setRequired(false);
-		STOP_WITH_SAVEPOINT.setArgName("withSavepoint");
-		STOP_WITH_SAVEPOINT.setOptionalArg(true);
+		STOP_WITH_SAVEPOINT_PATH.setRequired(false);
+		STOP_WITH_SAVEPOINT_PATH.setArgName("savepointPath");
+		STOP_WITH_SAVEPOINT_PATH.setOptionalArg(true);
 
 		STOP_AND_DRAIN.setRequired(false);
 
@@ -256,7 +256,7 @@ public class CliFrontendParser {
 
 	static Options getStopCommandOptions() {
 		return buildGeneralOptions(new Options())
-				.addOption(STOP_WITH_SAVEPOINT)
+				.addOption(STOP_WITH_SAVEPOINT_PATH)
 				.addOption(STOP_AND_DRAIN);
 	}
 
@@ -293,7 +293,7 @@ public class CliFrontendParser {
 
 	private static Options getStopOptionsWithoutDeprecatedOptions(Options options) {
 		return options
-				.addOption(STOP_WITH_SAVEPOINT)
+				.addOption(STOP_WITH_SAVEPOINT_PATH)
 				.addOption(STOP_AND_DRAIN);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -107,9 +107,11 @@ public class CliFrontendParser {
 			"Namespace to create the Zookeeper sub-paths for high availability mode");
 
 	static final Option CANCEL_WITH_SAVEPOINT_OPTION = new Option(
-			"s", "withSavepoint", true, "Trigger savepoint and cancel job. The target " +
-			"directory is optional. If no directory is specified, the configured default " +
-			"directory (" + CheckpointingOptions.SAVEPOINT_DIRECTORY.key() + ") is used.");
+			"s", "withSavepoint", true, "**DEPRECATION WARNING**: " +
+			"Cancelling a job with savepoint is deprecated. Use \"stop\" instead. \n Trigger" +
+			" savepoint and cancel job. The target directory is optional. If no directory is " +
+			"specified, the configured default directory (" +
+			CheckpointingOptions.SAVEPOINT_DIRECTORY.key() + ") is used.");
 
 	public static final Option STOP_WITH_SAVEPOINT = new Option("s", "withSavepoint", true,
 			"Path to the savepoint (for example hdfs:///flink/savepoint-1537). " +

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
@@ -21,7 +21,7 @@ package org.apache.flink.client.cli;
 import org.apache.commons.cli.CommandLine;
 
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_AND_DRAIN;
-import static org.apache.flink.client.cli.CliFrontendParser.STOP_WITH_SAVEPOINT;
+import static org.apache.flink.client.cli.CliFrontendParser.STOP_WITH_SAVEPOINT_PATH;
 
 /**
  * Command line options for the STOP command.
@@ -41,8 +41,8 @@ class StopOptions extends CommandLineOptions {
 		super(line);
 		this.args = line.getArgs();
 
-		this.savepointFlag = line.hasOption(STOP_WITH_SAVEPOINT.getOpt());
-		this.targetDirectory = line.getOptionValue(STOP_WITH_SAVEPOINT.getOpt());
+		this.savepointFlag = line.hasOption(STOP_WITH_SAVEPOINT_PATH.getOpt());
+		this.targetDirectory = line.getOptionValue(STOP_WITH_SAVEPOINT_PATH.getOpt());
 
 		this.advanceToEndOfEventTime = line.hasOption(STOP_AND_DRAIN.getOpt());
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
@@ -80,7 +80,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 	public void testStopWithDefaultSavepointDir() throws Exception {
 		JobID jid = new JobID();
 
-		String[] parameters = { "-s", jid.toString() };
+		String[] parameters = {jid.toString() };
 		final ClusterClient<String> clusterClient = createClusterClient(null);
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 		testFrontend.stop(parameters);
@@ -93,7 +93,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 	public void testStopWithExplicitSavepointDir() throws Exception {
 		JobID jid = new JobID();
 
-		String[] parameters = { "-s", "test-target-dir", jid.toString() };
+		String[] parameters = { "-p", "test-target-dir", jid.toString() };
 		final ClusterClient<String> clusterClient = createClusterClient(null);
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 		testFrontend.stop(parameters);
@@ -119,7 +119,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 	public void testStopWithMaxWMAndDefaultSavepointDir() throws Exception {
 		JobID jid = new JobID();
 
-		String[] parameters = { "-s", "-d", jid.toString() };
+		String[] parameters = { "-p", "-d", jid.toString() };
 		final ClusterClient<String> clusterClient = createClusterClient(null);
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 		testFrontend.stop(parameters);
@@ -132,7 +132,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 	public void testStopWithMaxWMAndExplicitSavepointDir() throws Exception {
 		JobID jid = new JobID();
 
-		String[] parameters = { "-d", "-s", "test-target-dir", jid.toString() };
+		String[] parameters = { "-d", "-p", "test-target-dir", jid.toString() };
 		final ClusterClient<String> clusterClient = createClusterClient(null);
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 		testFrontend.stop(parameters);
@@ -181,7 +181,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		// test unknown job Id
 		JobID jid = new JobID();
 
-		String[] parameters = { "-s", "test-target-dir", jid.toString() };
+		String[] parameters = { "-p", "test-target-dir", jid.toString() };
 		String expectedMessage = "Test exception";
 		FlinkException testException = new FlinkException(expectedMessage);
 		final ClusterClient<String> clusterClient = createClusterClient(testException);

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1557,7 +1557,7 @@
       }
     }
   }, {
-    "url" : "/jobs/:jobid/stop-with-savepoint",
+    "url" : "/jobs/:jobid/stop",
     "method" : "POST",
     "status-code" : "202 Accepted",
     "file-upload" : false,
@@ -1576,7 +1576,7 @@
         "targetDirectory" : {
           "type" : "string"
         },
-        "endOfEventTime" : {
+        "drain" : {
           "type" : "boolean"
         }
       }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobCancellationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobCancellationHandler.java
@@ -83,7 +83,9 @@ public class JobCancellationHandler extends AbstractRestHandler<RestfulGateway, 
 				terminationFuture = gateway.cancelJob(jobId, timeout);
 				break;
 			case STOP:
-				throw new RestHandlerException("The \"stop\" command has been removed. Please use \"stop-with-savepoint\" instead.", HttpResponseStatus.PERMANENT_REDIRECT);
+				throw new RestHandlerException("The termination mode \"stop\" has been removed. For " +
+				"an ungraceful shutdown, please use \"cancel\" instead. For a graceful shutdown, " +
+				"please use \"jobs/:jobId/stop\" instead." , HttpResponseStatus.PERMANENT_REDIRECT);
 			default:
 				terminationFuture = FutureUtils.completedExceptionally(new RestHandlerException("Unknown termination mode " + terminationMode + '.', HttpResponseStatus.BAD_REQUEST));
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -150,7 +150,7 @@ public class SavepointHandlers extends AbstractAsynchronousOperationHandlers<Asy
 						HttpResponseStatus.BAD_REQUEST);
 			}
 
-			final boolean advanceToEndOfEventTime = request.getRequestBody().shouldAdvanceToEndOfEventTime();
+			final boolean advanceToEndOfEventTime = request.getRequestBody().shouldDrain();
 			final String targetDirectory = requestedTargetDirectory != null ? requestedTargetDirectory : defaultSavepointDir;
 			return gateway.stopWithSavepoint(jobId, targetDirectory, advanceToEndOfEventTime, RpcUtils.INF_TIMEOUT);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
@@ -22,7 +22,7 @@ import org.apache.flink.util.StringUtils;
 
 /**
  * Termination mode.
- * @deprecated Only kept to detect legacy usages of the cancel/stop command. Please use the "stop-with-savepoint" command instead.
+ * @deprecated Only kept to detect legacy usages of the cancel/stop command. Please use the "stop" command instead.
  */
 public class TerminationModeQueryParameter extends MessageQueryParameter<TerminationModeQueryParameter.TerminationMode> {
 
@@ -49,7 +49,7 @@ public class TerminationModeQueryParameter extends MessageQueryParameter<Termina
 	}
 
 	/**
-	 * @deprecated Please use the "stop-with-savepoint" command instead.
+	 * @deprecated Please use the "stop" command instead.
 	 */
 	public enum TerminationMode {
 		CANCEL,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
@@ -32,21 +32,21 @@ public class StopWithSavepointRequestBody implements RequestBody {
 
 	public static final String FIELD_NAME_TARGET_DIRECTORY = "targetDirectory";
 
-	private static final String FIELD_NAME_END_OF_EVENT_TIME = "endOfEventTime";
+	private static final String FIELD_NAME_DRAIN = "drain";
 
 	@JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
 	@Nullable
 	private final String targetDirectory;
 
-	@JsonProperty(FIELD_NAME_END_OF_EVENT_TIME)
-	private final boolean endOfEventTime;
+	@JsonProperty(FIELD_NAME_DRAIN)
+	private final boolean drain;
 
 	@JsonCreator
 	public StopWithSavepointRequestBody(
 			@Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
-			@JsonProperty(value = FIELD_NAME_END_OF_EVENT_TIME, defaultValue = "false") final boolean endOfEventTime) {
+			@JsonProperty(value = FIELD_NAME_DRAIN, defaultValue = "false") final boolean drain) {
 		this.targetDirectory = targetDirectory;
-		this.endOfEventTime = endOfEventTime;
+		this.drain = drain;
 	}
 
 	@Nullable
@@ -54,7 +54,7 @@ public class StopWithSavepointRequestBody implements RequestBody {
 		return targetDirectory;
 	}
 
-	public boolean shouldAdvanceToEndOfEventTime() {
-		return endOfEventTime;
+	public boolean shouldDrain() {
+		return drain;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointTriggerHeaders.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerMes
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
- * These headers define the protocol for triggering a "stop-with-savepoint" action.
+ * These headers define the protocol for triggering a "stop" action.
  */
 public class StopWithSavepointTriggerHeaders
 		extends AsynchronousOperationTriggerMessageHeaders<StopWithSavepointRequestBody, SavepointTriggerMessageParameters> {
@@ -34,7 +34,7 @@ public class StopWithSavepointTriggerHeaders
 	private static final StopWithSavepointTriggerHeaders INSTANCE = new StopWithSavepointTriggerHeaders();
 
 	private static final String URL = String.format(
-			"/jobs/:%s/stop-with-savepoint",
+			"/jobs/:%s/stop",
 			JobIDPathParameter.KEY);
 
 	private StopWithSavepointTriggerHeaders() {


### PR DESCRIPTION
## What is the purpose of the change

Currently, the REST API and CLI around stopping and cancelling jobs are not aligned in terms of terminology and the differences between cancel and job are not as clear as they could be.

I would like to make the following changes to the CLI:

    add deprecation warning for cancel -s command and redirect users to stop
    rename -s of stop command to -p for savepoint location. Emphasize that this is optional, as a savepoint is taken in any case

I would like to make the following changes to the REST API:

    Rename stop-with-savepoint to stop
    Rename "endOfEventTime" to "drain" in accordance with the CLI

## Brief change log


* [hotfix] [docs] add missing YARN options in CLI docs
* [cli] add deperecation warning to "cancel -s"
* [cli] rename "-s" parameter of stop command
* [rest] align terminology of "stop" endpoint with cli
* [hotfix] [docs] fix typo in docs/README.md 


## Verifying this change

* run tests in flink-clients, flink-runtime-web and flink-runtime

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
