### PR TITLE
[FLINK-13167] Introduce FlinkML import/export framework

### DIFF
--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/PipelineStage.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/PipelineStage.java
@@ -34,7 +34,7 @@ import java.io.Serializable;
  *            org.apache.flink.ml.api.misc.param.WithParams}
  * @see WithParams
  */
-interface PipelineStage<T extends PipelineStage<T>> extends WithParams<T>, Serializable {
+public interface PipelineStage<T extends PipelineStage<T>> extends WithParams<T>, Serializable {
 
 	default String toJson() {
 		return getParams().toJson();

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/exportation/Exporter.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/exportation/Exporter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.exportation;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.ml.api.core.Model;
+import org.apache.flink.ml.api.misc.model.ModelFormat;
+
+import java.util.List;
+
+/**
+ * Base interface of model exporters. Exporters export models to the specific target format which is
+ * defined in {@link ModelFormat}.
+ *
+ * <p>Users are recommended not to create an Exporter instance with constructors but use
+ * {@link ExporterLoader#getExporter}.
+ */
+@PublicEvolving
+public abstract class Exporter<M extends Model, V> {
+
+	/**
+	 * Exports the model to model data in target format.
+	 *
+	 * @param model model to export
+	 * @return model data in target format
+	 */
+	public abstract V export(M model);
+
+	/**
+	 * Returns the target format of this Exporter.
+	 *
+	 * @return target format of this Exporter
+	 */
+	public abstract ModelFormat getTargetFormat();
+
+	/**
+	 * Returns a list of model class names that this Exporter supports to export. The values in the
+	 * list should be in the same format returned by {@link java.lang.Class#getName}.
+	 *
+	 * @return a list of model class names that this Exporter supports to export
+	 */
+	public abstract List<String> supportedModelClassNames();
+}

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/exportation/ExporterFactory.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/exportation/ExporterFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.exportation;
+
+import org.apache.flink.ml.api.core.Model;
+import org.apache.flink.ml.api.misc.factory.BaseFactory;
+import org.apache.flink.ml.api.misc.model.ModelFormat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base factory to create an {@link Exporter} to export models into model data in specific target
+ * format.
+ *
+ * <p>ExporterFactories are loaded by ExporterLoader, and should be registered in the file
+ * META-INF/services/org.apache.flink.ml.api.misc.exportation.ExporterFactory.
+ *
+ * <p>ExporterFactories must have a zero-argument constructor, and have no state, according to
+ * the requirement of Java ServiceLoader.
+ */
+public abstract class ExporterFactory implements BaseFactory {
+
+	/**
+	 * Creates and returns an Exporter to export the model to target format with the properties.
+	 *
+	 * @param model      model to export
+	 * @param properties properties that describe the factory configuration
+	 * @return exporter to export the model to target format
+	 */
+	public abstract Exporter create(Model model, Map<String, String> properties);
+
+	/**
+	 * Returns the target format of this ExporterFactory.
+	 *
+	 * @return target format of this ExporterFactory
+	 */
+	public abstract ModelFormat getTargetFormat();
+
+	/**
+	 * Returns a list of model class names that this ExporterFactory supports. The values in the
+	 * list should be in the same format returned by {@link java.lang.Class#getName}.
+	 *
+	 * @return a list of model class names that this ExporterFactory supports
+	 */
+	public abstract List<String> supportedModelClassNames();
+
+	@Override
+	public final Map<String, String> requiredContext() {
+		Map<String, String> identifier = new HashMap<>();
+		identifier.put(ExporterLoader.MODEL_FORMAT_KEY, getTargetFormat().name());
+		return identifier;
+	}
+
+	@Override
+	public List<String> requiredProperties() {
+		return new ArrayList<>();
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> supportedProperties = new ArrayList<>();
+		supportedProperties.add(ExporterLoader.MODEL_FORMAT_KEY);
+		supportedProperties.add(ExporterLoader.MODEL_CLASS_NAME_KEY);
+		return supportedProperties;
+	}
+}

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/exportation/ExporterLoader.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/exportation/ExporterLoader.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.exportation;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.ml.api.core.Model;
+import org.apache.flink.ml.api.misc.factory.BaseFactoryLoader;
+import org.apache.flink.ml.api.misc.model.ModelFormat;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Loader to get an {@link Exporter} for a specific model format and a model.
+ */
+@PublicEvolving
+public class ExporterLoader extends BaseFactoryLoader<ExporterFactory> {
+	public static final String MODEL_FORMAT_KEY = "model_format";
+	public static final String MODEL_CLASS_NAME_KEY = "model_class_name";
+
+	private static final ExporterLoader INSTANCE = new ExporterLoader();
+
+	private ExporterLoader() {
+	}
+
+	/**
+	 * Creates and returns an exporter to export the model in the format with no addition
+	 * properties.
+	 *
+	 * @param format target format to export model in
+	 * @param model  model to be exported, used to choose Exporter implementation
+	 * @return an exporter to export the model in the target format
+	 */
+	public static <M extends Model<M>, V> Exporter<M, V> getExporter(ModelFormat format, M model) {
+		return getExporter(format, model, new HashMap<>());
+	}
+
+	/**
+	 * Creates and returns an exporter to export the model in the format with the properties.
+	 *
+	 * @param format     target format to export model in
+	 * @param model      model to be exported, used to choose Exporter implementation
+	 * @param properties properties required by the exporter
+	 * @return an exporter to export the model in the target format
+	 */
+	public static <M extends Model<M>, V> Exporter<M, V> getExporter(
+		ModelFormat format,
+		M model,
+		Map<String, String> properties) {
+
+		return getExporter(format, model, properties, null);
+	}
+
+	/**
+	 * Creates and returns an exporter to export the model in the format with the properties, the
+	 * exporter is loaded by the specific ClassLoader if the loader is not null.
+	 *
+	 * @param format     target format to export model in
+	 * @param model      model to be exported, used to choose Exporter implementation
+	 * @param properties properties required by the exporter
+	 * @param loader     classloader for exporter loading
+	 * @return an exporter to export the model in the target format
+	 */
+	public static <M extends Model<M>, V> Exporter<M, V> getExporter(
+		ModelFormat format,
+		M model,
+		Map<String, String> properties,
+		@Nullable ClassLoader loader) {
+
+		Map<String, String> fullProperties = new HashMap<>();
+		fullProperties.put(MODEL_FORMAT_KEY, format.name());
+		fullProperties.put(MODEL_CLASS_NAME_KEY, model.getClass().getName());
+		fullProperties.putAll(properties);
+
+		return INSTANCE.find(ExporterFactory.class, fullProperties, loader)
+			.create(model, properties);
+	}
+
+	@Override
+	protected Class<ExporterFactory> getFactoryClass() {
+		return ExporterFactory.class;
+	}
+
+	@Override
+	protected boolean matchCustomizedRequirements(
+		ExporterFactory factory,
+		Map<String, String> properties) {
+
+		return factory.supportedModelClassNames().contains(properties.get(MODEL_CLASS_NAME_KEY));
+	}
+}

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/factory/BaseFactory.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/factory/BaseFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.factory;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base interface of a factory to load with {@link BaseFactoryLoader}.
+ */
+@PublicEvolving
+public interface BaseFactory {
+
+	/**
+	 * Specifies the context that this factory is implemented for. BaseFactoryLoader matches this
+	 * factory only if all properties defined here are all provided with the required values.
+	 */
+	Map<String, String> requiredContext();
+
+	/**
+	 * Specifies the properties that this factory requires. BaseFactoryLoader matches this factory
+	 * only if all properties defined here are all provided. This may contain those defined in
+	 * requiredContext or not, results will be the same.
+	 */
+	List<String> requiredProperties();
+
+	/**
+	 * Specifies the properties that this factory supports. BaseFactoryLoader matches this factory
+	 * only if no properties outside the specified list are provided. A property defined in
+	 * requiredContext and requiredProperties will automatically added if it's not in this list.
+	 */
+	List<String> supportedProperties();
+}

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/factory/BaseFactoryLoader.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/factory/BaseFactoryLoader.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.factory;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract factory loader to search and load a specific BaseFactory with class and properties.
+ *
+ * @param <T> type of desired base factory class, subclasses for loading should be registered in the
+ *            file META-INF/services/{@code T.class.getName()}
+ */
+@PublicEvolving
+public abstract class BaseFactoryLoader<T extends BaseFactory> {
+	private final ServiceLoader<T> defaultLoader = ServiceLoader.load(getFactoryClass());
+
+	/**
+	 * Finds a factory of the given class and property map, using the current thread's {@linkplain
+	 * java.lang.Thread#getContextClassLoader context class loader}.
+	 *
+	 * @param <ST>         type of desired factory class, which is a subclass of the class returned
+	 *                     by getFactoryClass()
+	 * @param factoryClass desired factory class
+	 * @param propertyMap  properties that describe the factory configuration
+	 * @return the matching factory
+	 */
+	public <ST extends T> ST find(Class<ST> factoryClass, Map<String, String> propertyMap) {
+		return find(factoryClass, propertyMap, null);
+	}
+
+	/**
+	 * Finds a factory of the given class and property map using the given classloader.
+	 *
+	 * @param <ST>         type of desired factory class, which is a subclass of the class returned
+	 *                     by getFactoryClass()
+	 * @param factoryClass desired factory class
+	 * @param propertyMap  properties that describe the factory configuration
+	 * @param classLoader  classloader for factory loading, use the current thread's {@linkplain
+	 *                     java.lang.Thread#getContextClassLoader context class loader} if is null
+	 * @return the matching factory
+	 */
+	public <ST extends T> ST find(
+		Class<ST> factoryClass,
+		Map<String, String> propertyMap,
+		@Nullable ClassLoader classLoader) {
+
+		return findInternal(factoryClass, propertyMap, classLoader);
+	}
+
+	/**
+	 * Returns the factory class this factory loader is used to load. All factories found with find
+	 * methods are instances of this class or its subclasses.
+	 *
+	 * @return the factory class this factory loader is used to load.
+	 */
+	protected abstract Class<T> getFactoryClass();
+
+	/**
+	 * Validate whether a factory matches customized requirements. All factories match by default.
+	 * Implementations of BaseFactoryLoader may override this method for customized matching.
+	 *
+	 * @param factory    factory instance to validate
+	 * @param propertyMap properties that describe the factory configuration
+	 * @return whether the factory matches customized requirements, always true if not overridden
+	 */
+	protected boolean matchCustomizedRequirements(T factory, Map<String, String> propertyMap) {
+		return true;
+	}
+
+	@SuppressWarnings("unchecked")
+	private <ST extends T> ST findInternal(
+		Class<ST> factoryClass,
+		Map<String, String> properties,
+		@Nullable ClassLoader classLoader) {
+
+		List<T> foundFactorys = discoverFactorys(classLoader);
+
+		List<ST> factoryClassFactorys = foundFactorys.stream()
+			.filter(f -> matchClass(f, factoryClass))
+			.map(f -> (ST) f)
+			.collect(Collectors.toList());
+
+		List<ST> matchFactorys = factoryClassFactorys.stream()
+			.filter(f -> matchRequiredContext(f, properties))
+			.filter(f -> matchRequiredProperties(f, properties))
+			.filter(f -> matchSupportedProperties(f, properties))
+			.filter(f -> matchCustomizedRequirements(f, properties))
+			.collect(Collectors.toList());
+
+		return getTheOnlyMatchingFactory(matchFactorys, properties, foundFactorys);
+	}
+
+	private List<T> discoverFactorys(@Nullable ClassLoader classLoader) {
+		try {
+			List<T> result = new LinkedList<>();
+			ServiceLoader<T> loader = defaultLoader;
+			if (classLoader != null) {
+				loader = ServiceLoader.load(getFactoryClass(), classLoader);
+			}
+			loader.iterator().forEachRemaining(result::add);
+			return result;
+		} catch (ServiceConfigurationError e) {
+			throw new RuntimeException(
+				"Could not load factory provider for " + getFactoryClass().getTypeName(), e);
+		}
+	}
+
+	private <ST extends T> boolean matchClass(T factory, Class<ST> factoryClass) {
+		return factoryClass.isAssignableFrom(factory.getClass());
+	}
+
+	private boolean matchRequiredContext(T factory, Map<String, String> properties) {
+		for (Map.Entry<String, String> p : factory.requiredContext().entrySet()) {
+			String name = p.getKey();
+			String value = p.getValue();
+			if (properties.containsKey(name) && value.equals(properties.get(name))) {
+				continue;
+			}
+			return false;
+		}
+		return true;
+	}
+
+	private boolean matchRequiredProperties(T factory, Map<String, String> properties) {
+		return factory.requiredProperties().stream().filter(properties::containsKey).count() ==
+			factory.requiredProperties().size();
+	}
+
+	private boolean matchSupportedProperties(T factory, Map<String, String> properties) {
+		Set<String> supportedProperties = new HashSet<>();
+		supportedProperties.addAll(factory.requiredContext().keySet());
+		supportedProperties.addAll(factory.requiredProperties());
+		supportedProperties.addAll(factory.supportedProperties());
+
+		return properties.keySet().stream().filter(supportedProperties::contains).count() ==
+			properties.size();
+	}
+
+	private <S> S getTheOnlyMatchingFactory(
+		List<S> matchFactorys,
+		Map<String, String> properties,
+		List<?> foundFactorys) {
+
+		if (matchFactorys.size() > 1) {
+			throw new RuntimeException(String.format(
+				"More than one factories match, propertyMap is:\n%s,\n matched factories are:\n%s",
+				properties.toString(),
+				Arrays.toString(matchFactorys.stream()
+					.map(s -> s.getClass().getName())
+					.toArray(String[]::new))
+			));
+		}
+		if (matchFactorys.isEmpty()) {
+			throw new RuntimeException(String.format(
+				"No factory matches, propertyMap is:\n%s,\n all found factories are:\n%s",
+				properties.toString(),
+				Arrays.toString(foundFactorys.stream()
+					.map(s -> s.getClass().getName())
+					.toArray(String[]::new))
+			));
+		}
+		return matchFactorys.get(0);
+	}
+}

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/importation/Importer.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/importation/Importer.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.importation;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.ml.api.core.Model;
+import org.apache.flink.ml.api.misc.model.ModelFormat;
+
+/**
+ * Base interface of model importers. Importers import model data in the specific source format as a
+ * flink-ml Model. The source format is defined in {@link ModelFormat}.
+ *
+ * <p>Users are recommended not to create an Importer instance with constructors but use
+ * {@link ImporterLoader#getImporter}.
+ */
+@PublicEvolving
+public abstract class Importer<M extends Model, V> {
+
+	/**
+	 * Imports the model data in source format and returns the result Model.
+	 *
+	 * @param value model data to import
+	 * @return model loaded with the model data
+	 */
+	public abstract M load(V value);
+
+	/**
+	 * Returns the source format of this Importer.
+	 *
+	 * @return source format of this Importer
+	 */
+	public abstract ModelFormat getSourceFormat();
+}

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/importation/ImporterFactory.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/importation/ImporterFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.importation;
+
+import org.apache.flink.ml.api.misc.factory.BaseFactory;
+import org.apache.flink.ml.api.misc.model.ModelFormat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base factory to create an {@link Importer} to import model data in specific target format as a
+ * flink-ml Model.
+ *
+ * <p>ImporterFactories are loaded by ImporterLoader, and should be registered in the file
+ * META-INF/services/org.apache.flink.ml.api.misc.exportation.ImporterFactory.
+ *
+ * <p>ImporterFactories must have a zero-argument constructor, and have no state, according to
+ * the requirement of Java ServiceLoader.
+ */
+public abstract class ImporterFactory implements BaseFactory {
+
+	/**
+	 * Creates and returns an Importer to import model data in source format with the properties.
+	 *
+	 * @param properties properties that describe the factory configuration
+	 * @return importer to import model data in source format
+	 */
+	public abstract Importer create(Map<String, String> properties);
+
+	/**
+	 * Returns the source format of this ImporterFactory.
+	 *
+	 * @return source format of this ImporterFactory
+	 */
+	public abstract ModelFormat getSourceFormat();
+
+	@Override
+	public final Map<String, String> requiredContext() {
+		Map<String, String> identifier = new HashMap<>();
+		identifier.put(ImporterLoader.MODEL_FORMAT_KEY, getSourceFormat().name());
+		return identifier;
+	}
+
+	@Override
+	public List<String> requiredProperties() {
+		return new ArrayList<>();
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		return new ArrayList<>();
+	}
+}

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/importation/ImporterLoader.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/importation/ImporterLoader.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.importation;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.ml.api.core.Model;
+import org.apache.flink.ml.api.misc.factory.BaseFactoryLoader;
+import org.apache.flink.ml.api.misc.model.ModelFormat;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Loader to get an {@link Importer} for a specific model format.
+ */
+@PublicEvolving
+public class ImporterLoader extends BaseFactoryLoader<ImporterFactory> {
+	public static final String MODEL_FORMAT_KEY = "model_format";
+
+	private static final ImporterLoader INSTANCE = new ImporterLoader();
+
+	private ImporterLoader() {
+	}
+
+	/**
+	 * Creates and returns an importer to import model data in the source format with no addition
+	 * properties.
+	 *
+	 * @param format source format to import model
+	 * @return an import to import model data in the source format
+	 */
+	public static <M extends Model<M>, V> Importer<M, V> getImporter(ModelFormat format) {
+		return getImporter(format, new HashMap<>());
+	}
+
+	/**
+	 * Creates and returns an importer to import model data in the source format with the
+	 * properties.
+	 *
+	 * @param format     source format to import model
+	 * @param properties properties required by the importer
+	 * @return an import to import model data in the source format
+	 */
+	public static <M extends Model<M>, V> Importer<M, V> getImporter(
+		ModelFormat format,
+		Map<String, String> properties) {
+		return getImporter(format, properties, null);
+	}
+
+	/**
+	 * Creates and returns an importer to import model data in the source format with the
+	 * properties, the importer is loaded by the specific ClassLoader if the loader is not null.
+	 *
+	 * @param format     source format to import model
+	 * @param properties properties required by the importer
+	 * @param loader     classloader for importer loading
+	 * @return an import to import model data in the source format
+	 */
+	public static <M extends Model<M>, V> Importer<M, V> getImporter(
+		ModelFormat format,
+		Map<String, String> properties,
+		@Nullable ClassLoader loader) {
+
+		Map<String, String> fullProperties = new HashMap<>();
+		fullProperties.put(MODEL_FORMAT_KEY, format.name());
+		fullProperties.putAll(properties);
+
+		return INSTANCE.find(ImporterFactory.class, fullProperties, loader).create(properties);
+	}
+
+	@Override
+	protected Class<ImporterFactory> getFactoryClass() {
+		return ImporterFactory.class;
+	}
+}

--- a/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/model/ModelFormat.java
+++ b/flink-ml-parent/flink-ml-api/src/main/java/org/apache/flink/ml/api/misc/model/ModelFormat.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.api.misc.model;
+
+/**
+ * Enumeration of model formats that flink-ml supports for export or import.
+ */
+public enum ModelFormat {
+	PMML
+}


### PR DESCRIPTION
## What is the purpose of the change

Importing/exporting a trained model is an important part in machine learning lifecycle, especially for serving purpose, hence it triggered a heatedly discussion in the previous pull request for FlinkML basic interfaces. Some thoughts about this are summarized in the following doc.

https://docs.google.com/document/d/1B84b-1CvOXtwWQ6_tQyiaHwnSeiRqh-V96Or8uHqCp8/edit?usp=sharing

This pull request introduces the import/export framework based on the discussion. 

## Brief change log

Import and export framework have almost the same structure so we take export as example. Export framework has 3 basic components, including 2 interfaces for exporter authors to implement, and one util class for end-users to acquire an Exporter.

Interfaces:
 - Exporter: Interface of model exporters. Implementations can export supported models to a specific target model type, such as PMML.

 - ExporterFactory: Interface of factories to create Exporters. Each implementation supports only one model type. Typically an ExporterFactory is given a model instance with a property map if needed, and returns an Exporter that supports the model to export to target model type. ExporterFactories are loaded with ServiceLoader framework of Java, and should be registered in the file "META-INF/services/org.apache.flink.ml.api.misc.exportation.ExporterFactory".

Utility:
 - ExporterLoader: Loader to get an Exporter for a specific model format and a model instance. Users would get Exporters via this class rather than directly creating with constructors. This is a concrete util class and no one needs to override it.

Besides, a new enumeration named ModelType is also introduced, listing all types FlinkML may support. This would be extended when a new exporter support a new type.

## Verifying this change

This change would add tests for Factory and FactoryLoader, TBD.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
