### PR TITLE
[FLINK-13112][table-planner-blink] Support LocalZonedTimestampType in blink

### DIFF
--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -47,16 +47,17 @@ class TableConfig(object):
         """
         self._j_table_config.setConf(key, value)
 
-    def get_timezone(self):
+    def get_local_timezone(self):
         """
-        Returns the timezone id, either an abbreviation such as "PST", a full name such as
-        "America/Los_Angeles", or a custom timezone_id such as "GMT-8:00".
+        Returns the local timezone id for timestamp with local time zone, either an abbreviation
+        such as "PST", a full name such as "America/Los_Angeles", or a custom timezone_id such
+        as "GMT-8:00".
         """
         return self._j_table_config.getLocalTimeZone().getId()
 
-    def set_timezone(self, timezone_id):
+    def set_local_timezone(self, timezone_id):
         """
-        Sets the timezone id for date/time/timestamp conversions.
+        Sets the local timezone id for timestamp with local time zone.
 
         :param timezone_id: The timezone id, either an abbreviation such as "PST", a full name
                             such as "America/Los_Angeles", or a custom timezone_id such as

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -52,7 +52,7 @@ class TableConfig(object):
         Returns the timezone id, either an abbreviation such as "PST", a full name such as
         "America/Los_Angeles", or a custom timezone_id such as "GMT-8:00".
         """
-        return self._j_table_config.getTimeZone().getID()
+        return self._j_table_config.getLocalTimeZone().getId()
 
     def set_timezone(self, timezone_id):
         """
@@ -63,8 +63,8 @@ class TableConfig(object):
                             "GMT-8:00".
         """
         if timezone_id is not None and isinstance(timezone_id, (str, unicode)):
-            j_timezone = get_gateway().jvm.java.util.TimeZone.getTimeZone(timezone_id)
-            self._j_table_config.setTimeZone(j_timezone)
+            j_timezone = get_gateway().jvm.java.time.ZoneId.of(timezone_id)
+            self._j_table_config.setLocalTimeZone(j_timezone)
         else:
             raise Exception("TableConfig.timezone should be a string!")
 

--- a/flink-python/pyflink/table/tests/test_table_config_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_config_completeness.py
@@ -44,8 +44,9 @@ class TableConfigCompletenessTests(PythonAPICompletenessTestCase, unittest.TestC
     @classmethod
     def java_method_name(cls, python_method_name):
         # Most time zone related libraries in Python use 'timezone' instead of 'time_zone'.
-        return {'get_timezone': 'get_time_zone',
-                'set_timezone': 'set_time_zone'}.get(python_method_name, python_method_name)
+        return {'get_local_timezone': 'get_local_time_zone',
+                'set_local_timezone': 'set_local_time_zone'}\
+            .get(python_method_name, python_method_name)
 
 if __name__ == '__main__':
     import unittest

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -166,7 +166,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         table_config = TableConfig()
         table_config.set_max_generated_code_length(32000)
         table_config.set_null_check(False)
-        table_config.set_timezone("Asia/Shanghai")
+        table_config.set_local_timezone("Asia/Shanghai")
 
         env = StreamExecutionEnvironment.get_execution_environment()
         t_env = StreamTableEnvironment.create(env, table_config)
@@ -175,7 +175,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
 
         self.assertFalse(readed_table_config.get_null_check())
         self.assertEqual(readed_table_config.get_max_generated_code_length(), 32000)
-        self.assertEqual(readed_table_config.get_timezone(), "Asia/Shanghai")
+        self.assertEqual(readed_table_config.get_local_timezone(), "Asia/Shanghai")
 
 
 class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
@@ -198,19 +198,19 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
     def test_table_config(self):
 
         table_config = TableConfig()
-        table_config.set_timezone("Asia/Shanghai")
+        table_config.set_local_timezone("Asia/Shanghai")
         table_config.set_max_generated_code_length(64000)
         table_config.set_null_check(True)
 
         self.assertTrue(table_config.get_null_check())
         self.assertEqual(table_config.get_max_generated_code_length(), 64000)
-        self.assertEqual(table_config.get_timezone(), "Asia/Shanghai")
+        self.assertEqual(table_config.get_local_timezone(), "Asia/Shanghai")
 
     def test_create_table_environment(self):
         table_config = TableConfig()
         table_config.set_max_generated_code_length(32000)
         table_config.set_null_check(False)
-        table_config.set_timezone("Asia/Shanghai")
+        table_config.set_local_timezone("Asia/Shanghai")
 
         env = ExecutionEnvironment.get_execution_environment()
         t_env = BatchTableEnvironment.create(env, table_config)
@@ -219,4 +219,4 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
 
         self.assertFalse(readed_table_config.get_null_check())
         self.assertEqual(readed_table_config.get_max_generated_code_length(), 32000)
-        self.assertEqual(readed_table_config.get_timezone(), "Asia/Shanghai")
+        self.assertEqual(readed_table_config.get_local_timezone(), "Asia/Shanghai")

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
 
 import java.math.MathContext;
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * A config to define the runtime behavior of the Table API.
@@ -33,9 +33,9 @@ import java.util.TimeZone;
 public class TableConfig {
 
 	/**
-	 * Defines the timezone for date/time/timestamp conversions.
+	 * Defines the zone id for timestamp with local time zone.
 	 */
-	private TimeZone timeZone = TimeZone.getTimeZone("UTC");
+	private ZoneId localZoneId = ZoneId.systemDefault();
 
 	/**
 	 * Defines if all fields need to be checked for NULL first.
@@ -104,17 +104,17 @@ public class TableConfig {
 	}
 
 	/**
-	 * Returns the timezone for date/time/timestamp conversions.
+	 * Returns the zone id for timestamp with local time zone.
 	 */
-	public TimeZone getTimeZone() {
-		return timeZone;
+	public ZoneId getLocalTimeZone() {
+		return localZoneId;
 	}
 
 	/**
-	 * Sets the timezone for date/time/timestamp conversions.
+	 * Sets the zone id for timestamp with local time zone.
 	 */
-	public void setTimeZone(TimeZone timeZone) {
-		this.timeZone = Preconditions.checkNotNull(timeZone);
+	public void setLocalTimeZone(ZoneId zoneId) {
+		this.localZoneId = Preconditions.checkNotNull(zoneId);
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -104,6 +105,7 @@ public final class LegacyTypeInfoDataTypeConverter {
 		addMapping(Types.LOCAL_DATE, DataTypes.DATE().bridgedTo(LocalDate.class));
 		addMapping(Types.LOCAL_TIME, DataTypes.TIME(0).bridgedTo(LocalTime.class));
 		addMapping(Types.LOCAL_DATE_TIME, DataTypes.TIMESTAMP(3).bridgedTo(LocalDateTime.class));
+		addMapping(Types.INSTANT, DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).bridgedTo(Instant.class));
 		addMapping(Types.SQL_DATE, DataTypes.DATE().bridgedTo(java.sql.Date.class));
 		addMapping(Types.SQL_TIME, DataTypes.TIME(0).bridgedTo(java.sql.Time.class));
 		addMapping(Types.SQL_TIMESTAMP, DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class));

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/FlinkTypeSystem.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/FlinkTypeSystem.scala
@@ -42,7 +42,7 @@ class FlinkTypeSystem extends RelDataTypeSystemImpl {
       Int.MaxValue
 
     // we currently support only timestamps with milliseconds precision
-    case SqlTypeName.TIMESTAMP =>
+    case SqlTypeName.TIMESTAMP | SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
       3
 
     case _ =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/CodeGenUtils.scala
@@ -46,6 +46,8 @@ object CodeGenUtils {
 
   val DEFAULT_TIMEZONE_TERM = "timeZone"
 
+  val DEFAULT_TIMEZONE_ID_TERM = "zoneId"
+
   val DEFAULT_INPUT1_TERM = "in1"
 
   val DEFAULT_INPUT2_TERM = "in2"
@@ -130,7 +132,7 @@ object CodeGenUtils {
 
     case DATE => "int"
     case TIME_WITHOUT_TIME_ZONE => "int"
-    case TIMESTAMP_WITHOUT_TIME_ZONE => "long"
+    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => "long"
     case INTERVAL_YEAR_MONTH => "int"
     case INTERVAL_DAY_TIME => "long"
 
@@ -148,7 +150,7 @@ object CodeGenUtils {
 
     case DATE => className[JInt]
     case TIME_WITHOUT_TIME_ZONE => className[JInt]
-    case TIMESTAMP_WITHOUT_TIME_ZONE => className[JLong]
+    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => className[JLong]
     case INTERVAL_YEAR_MONTH => className[JInt]
     case INTERVAL_DAY_TIME => className[JLong]
 
@@ -187,7 +189,7 @@ object CodeGenUtils {
     case VARCHAR | CHAR => s"$BINARY_STRING.EMPTY_UTF8"
 
     case DATE | TIME_WITHOUT_TIME_ZONE => "-1"
-    case TIMESTAMP_WITHOUT_TIME_ZONE => "-1L"
+    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => "-1L"
     case INTERVAL_YEAR_MONTH => "-1"
     case INTERVAL_DAY_TIME => "-1L"
 
@@ -218,7 +220,8 @@ object CodeGenUtils {
     case DECIMAL => s"$term.hashCode()"
     case DATE => s"${className[JInt]}.hashCode($term)"
     case TIME_WITHOUT_TIME_ZONE => s"${className[JInt]}.hashCode($term)"
-    case TIMESTAMP_WITHOUT_TIME_ZONE => s"${className[JLong]}.hashCode($term)"
+    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+      s"${className[JLong]}.hashCode($term)"
     case INTERVAL_YEAR_MONTH => s"${className[JInt]}.hashCode($term)"
     case INTERVAL_DAY_TIME => s"${className[JLong]}.hashCode($term)"
     case ARRAY => throw new IllegalArgumentException(s"Not support type to hash: $t")
@@ -408,7 +411,8 @@ object CodeGenUtils {
       // temporal types
       case DATE => s"$rowTerm.getInt($indexTerm)"
       case TIME_WITHOUT_TIME_ZONE => s"$rowTerm.getInt($indexTerm)"
-      case TIMESTAMP_WITHOUT_TIME_ZONE => s"$rowTerm.getLong($indexTerm)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE |
+           TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$rowTerm.getLong($indexTerm)"
       case INTERVAL_YEAR_MONTH => s"$rowTerm.getInt($indexTerm)"
       case INTERVAL_DAY_TIME => s"$rowTerm.getLong($indexTerm)"
 
@@ -532,7 +536,8 @@ object CodeGenUtils {
       case BOOLEAN => s"$binaryRowTerm.setBoolean($index, $fieldValTerm)"
       case DATE =>  s"$binaryRowTerm.setInt($index, $fieldValTerm)"
       case TIME_WITHOUT_TIME_ZONE =>  s"$binaryRowTerm.setInt($index, $fieldValTerm)"
-      case TIMESTAMP_WITHOUT_TIME_ZONE =>  s"$binaryRowTerm.setLong($index, $fieldValTerm)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE |
+           TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$binaryRowTerm.setLong($index, $fieldValTerm)"
       case INTERVAL_YEAR_MONTH =>  s"$binaryRowTerm.setInt($index, $fieldValTerm)"
       case INTERVAL_DAY_TIME =>  s"$binaryRowTerm.setLong($index, $fieldValTerm)"
       case DECIMAL =>
@@ -560,7 +565,8 @@ object CodeGenUtils {
       case BOOLEAN => s"$rowTerm.setBoolean($indexTerm, $fieldTerm)"
       case DATE =>  s"$rowTerm.setInt($indexTerm, $fieldTerm)"
       case TIME_WITHOUT_TIME_ZONE =>  s"$rowTerm.setInt($indexTerm, $fieldTerm)"
-      case TIMESTAMP_WITHOUT_TIME_ZONE =>  s"$rowTerm.setLong($indexTerm, $fieldTerm)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE |
+           TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$rowTerm.setLong($indexTerm, $fieldTerm)"
       case INTERVAL_YEAR_MONTH => s"$rowTerm.setInt($indexTerm, $fieldTerm)"
       case INTERVAL_DAY_TIME => s"$rowTerm.setLong($indexTerm, $fieldTerm)"
       case _ => s"$rowTerm.setNonPrimitiveValue($indexTerm, $fieldTerm)"
@@ -581,7 +587,8 @@ object CodeGenUtils {
     case DOUBLE => s"$arrayTerm.setNullDouble($index)"
     case TIME_WITHOUT_TIME_ZONE => s"$arrayTerm.setNullInt($index)"
     case DATE => s"$arrayTerm.setNullInt($index)"
-    case TIMESTAMP_WITHOUT_TIME_ZONE => s"$arrayTerm.setNullLong($index)"
+    case TIMESTAMP_WITHOUT_TIME_ZONE |
+         TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$arrayTerm.setNullLong($index)"
     case INTERVAL_YEAR_MONTH => s"$arrayTerm.setNullInt($index)"
     case INTERVAL_DAY_TIME => s"$arrayTerm.setNullLong($index)"
     case _ => s"$arrayTerm.setNullLong($index)"
@@ -630,7 +637,8 @@ object CodeGenUtils {
         s"$writerTerm.writeDecimal($indexTerm, $fieldValTerm, ${dt.getPrecision})"
       case DATE => s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
       case TIME_WITHOUT_TIME_ZONE => s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
-      case TIMESTAMP_WITHOUT_TIME_ZONE => s"$writerTerm.writeLong($indexTerm, $fieldValTerm)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE |
+           TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$writerTerm.writeLong($indexTerm, $fieldValTerm)"
       case INTERVAL_YEAR_MONTH => s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
       case INTERVAL_DAY_TIME => s"$writerTerm.writeLong($indexTerm, $fieldValTerm)"
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/CodeGeneratorContext.scala
@@ -35,6 +35,8 @@ import org.apache.flink.util.InstantiationUtil
 
 import org.apache.calcite.avatica.util.DateTimeUtils
 
+import java.util.TimeZone
+
 import scala.collection.mutable
 
 /**
@@ -526,7 +528,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     * Adds a reusable TimeZone to the member area of the generated class.
     */
   def addReusableTimeZone(): String = {
-    val zoneID = tableConfig.getTimeZone.getID
+    val zoneID = TimeZone.getTimeZone(tableConfig.getLocalTimeZone).getID
     val stmt =
       s"""private static final java.util.TimeZone $DEFAULT_TIMEZONE_TERM =
          |                 java.util.TimeZone.getTimeZone("$zoneID");""".stripMargin
@@ -534,6 +536,16 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     DEFAULT_TIMEZONE_TERM
   }
 
+  /**
+    * Adds a reusable Time ZoneId to the member area of the generated class.
+    */
+  def addReusableTimeZoneID(): String = {
+    val zoneID = tableConfig.getLocalTimeZone.getId
+    val stmt =
+      s"""private static final java.time.ZoneId $DEFAULT_TIMEZONE_TERM =
+         |                 java.time.ZoneId.of("$zoneID");""".stripMargin
+    DEFAULT_TIMEZONE_ID_TERM
+  }
 
   /**
     * Adds a reusable [[java.util.Random]] to the member area of the generated class.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/EqualiserCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/EqualiserCodeGenerator.scala
@@ -135,12 +135,8 @@ class EqualiserCodeGenerator(fieldTypes: Seq[LogicalType]) {
   private def isInternalPrimitive(t: LogicalType): Boolean = t.getTypeRoot match {
     case _ if PlannerTypeUtils.isPrimitive(t) => true
 
-    case DATE => true
-    case TIME_WITHOUT_TIME_ZONE => true
-    case TIMESTAMP_WITHOUT_TIME_ZONE => true
-    case INTERVAL_YEAR_MONTH => true
-    case INTERVAL_DAY_TIME => true
-
+    case DATE | TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE |
+         TIMESTAMP_WITH_LOCAL_TIME_ZONE | INTERVAL_YEAR_MONTH |INTERVAL_DAY_TIME => true
     case _ => false
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/LongHashJoinGenerator.scala
@@ -51,7 +51,8 @@ object LongHashJoinGenerator {
         keyType.getFieldCount == 1 && {
       keyType.getTypeAt(0).getTypeRoot match {
         case BIGINT | INTEGER | SMALLINT | TINYINT | FLOAT | DOUBLE | DATE |
-             TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE => true
+             TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE |
+             TIMESTAMP_WITH_LOCAL_TIME_ZONE => true
         case _ => false
       }
       // TODO decimal and multiKeys support.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -226,6 +226,16 @@ object BuiltInMethods {
     "timestampToString",
     classOf[Long], classOf[Int], classOf[TimeZone])
 
+  val TIMESTAMP_TO_TIMESTAMP_WITH_LOCAL_ZONE = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "timestampToTimestampWithLocalZone",
+    classOf[Long], classOf[TimeZone])
+
+  val TIMESTAMP_WITH_LOCAL_ZONE_TO_TIMESTAMP = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "timestampWithLocalZoneToTimestamp",
+    classOf[Long], classOf[TimeZone])
+
   val STRING_TO_DATE_WITH_FORMAT = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "strToDate",
@@ -393,6 +403,26 @@ object BuiltInMethods {
     classOf[SqlDateTimeUtils],
     "toTimestamp",
     classOf[String], classOf[String], classOf[TimeZone])
+
+  val TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_DATE = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "timestampWithLocalZoneToDate",
+    classOf[Long], classOf[TimeZone])
+
+  val TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_TIME = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "timestampWithLocalZoneToTime",
+    classOf[Long], classOf[TimeZone])
+
+  val DATE_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "dateToTimestampWithLocalZone",
+    classOf[Int], classOf[TimeZone])
+
+  val TIME_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "timeToTimestampWithLocalZone",
+    classOf[Int], classOf[TimeZone])
 
   val TIMESTAMP_TO_BIGINT = Types.lookupMethod(
     classOf[SqlDateTimeUtils],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -386,6 +386,11 @@ object FunctionGenerator {
 
   addSqlFunction(
     EXTRACT,
+    Seq(ANY, TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+    new MethodCallGen(BuiltInMethods.EXTRACT_FROM_TIMESTAMP_TIME_ZONE))
+
+  addSqlFunction(
+    EXTRACT,
     Seq(ANY, INTERVAL_DAY_TIME),
     new ExtractCallGen(BuiltInMethod.UNIX_DATE_EXTRACT.method))
 
@@ -439,6 +444,13 @@ object FunctionGenerator {
       Some(BuiltInMethod.UNIX_TIMESTAMP_FLOOR.method)))
 
   addSqlFunction(
+    FLOOR,
+    Seq(TIMESTAMP_WITH_LOCAL_TIME_ZONE, ANY),
+    new FloorCeilCallGen(
+      BuiltInMethod.FLOOR.method,
+      Some(BuiltInMethods.TIMESTAMP_FLOOR_TIME_ZONE)))
+
+  addSqlFunction(
     CEIL,
     Seq(DATE, ANY),
     new FloorCeilCallGen(
@@ -458,6 +470,13 @@ object FunctionGenerator {
     new FloorCeilCallGen(
       BuiltInMethod.CEIL.method,
       Some(BuiltInMethod.UNIX_TIMESTAMP_CEIL.method)))
+
+  addSqlFunction(
+    CEIL,
+    Seq(TIMESTAMP_WITH_LOCAL_TIME_ZONE, ANY),
+    new FloorCeilCallGen(
+      BuiltInMethod.CEIL.method,
+      Some(BuiltInMethods.TIMESTAMP_CEIL_TIME_ZONE)))
 
   addSqlFunction(
     CURRENT_DATE,
@@ -622,6 +641,11 @@ object FunctionGenerator {
   addSqlFunctionMethod(
     UNIX_TIMESTAMP,
     Seq(TIMESTAMP_WITHOUT_TIME_ZONE),
+    BuiltInMethods.UNIX_TIMESTAMP_TS)
+
+  addSqlFunctionMethod(
+    UNIX_TIMESTAMP,
+    Seq(TIMESTAMP_WITH_LOCAL_TIME_ZONE),
     BuiltInMethods.UNIX_TIMESTAMP_TS)
 
   addSqlFunctionMethod(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/StringCallGen.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.dataformat.DataFormatConverters
 import org.apache.flink.table.functions.sql.FlinkSqlOperatorTable._
 import org.apache.flink.table.runtime.functions.SqlFunctionUtils
 import org.apache.flink.table.types.logical.{BooleanType, IntType, LogicalType, MapType, VarBinaryType, VarCharType}
-import org.apache.flink.table.typeutils.TypeCheckUtils.{isCharacterString, isTimestamp}
+import org.apache.flink.table.typeutils.TypeCheckUtils.{isCharacterString, isTimestamp, isTimestampWithLocalZone}
 
 import org.apache.calcite.runtime.SqlFunctions
 import org.apache.calcite.sql.SqlOperator
@@ -223,6 +223,11 @@ object StringCallGen {
           isTimestamp(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) =>
         methodGen(BuiltInMethods.DATE_FORMAT_LONG_STRING)
+
+      case DATE_FORMAT if operands.size == 2 &&
+          isTimestampWithLocalZone(operands.head.resultType) &&
+          isCharacterString(operands(1).resultType) =>
+        methodGen(BuiltInMethods.DATE_FORMAT_LONG_STRING_TIME_ZONE)
 
       case DATE_FORMAT if operands.size == 2 &&
           isCharacterString(operands.head.resultType) &&

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdSize.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdSize.scala
@@ -426,7 +426,8 @@ object FlinkRelMdSize {
     case typeName if SqlTypeName.YEAR_INTERVAL_TYPES.contains(typeName) => 8D
     case typeName if SqlTypeName.DAY_INTERVAL_TYPES.contains(typeName) => 4D
     // TODO after time/date => int, timestamp => long, this estimate value should update
-    case SqlTypeName.TIME | SqlTypeName.TIMESTAMP | SqlTypeName.DATE => 12D
+    case SqlTypeName.TIME | SqlTypeName.TIMESTAMP |
+         SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE | SqlTypeName.DATE => 12D
     case SqlTypeName.ANY => 128D // 128 is an arbitrary estimate
     case SqlTypeName.BINARY | SqlTypeName.VARBINARY => 16D // 16 is an arbitrary estimate
     case _ => throw new TableException(s"Unsupported data type encountered: $sqlType")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
@@ -36,7 +36,6 @@ import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelNode, RelWriter}
 
 import java.util
-import java.util.Calendar
 
 import scala.collection.JavaConversions._
 
@@ -137,12 +136,10 @@ class StreamExecWatermarkAssigner(
     } else {
       require(rowtimeFieldIndex.isDefined, "rowtimeFieldIndex should not be None")
       require(watermarkDelay.isDefined, "watermarkDelay should not be None")
-      // get the timezone offset.
-      val tzOffset = config.getTimeZone.getOffset(Calendar.ZONE_OFFSET)
       val op = new MiniBatchedWatermarkAssignerOperator(
         rowtimeFieldIndex.get,
         watermarkDelay.get,
-        tzOffset,
+        0,
         idleTimeout,
         inferredInterval.interval)
       val opName = s"MiniBatchedWatermarkAssigner(rowtime: ${rowtimeFieldIndex.get}," +

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
@@ -33,6 +33,7 @@ import org.apache.calcite.rel.core.Filter
 import org.apache.calcite.rel.logical.LogicalTableScan
 
 import java.util
+import java.util.TimeZone
 
 import scala.collection.JavaConversions._
 
@@ -89,7 +90,9 @@ class PushFilterIntoTableSourceScanRule extends RelOptRule(
         maxCnfNodeCount,
         filter.getInput.getRowType.getFieldNames,
         relBuilder.getRexBuilder,
-        functionCatalog)
+        functionCatalog,
+        TimeZone.getTimeZone(scan.getCluster.getPlanner.getContext
+            .asInstanceOf[FlinkContext].getTableConfig.getLocalTimeZone))
 
     if (predicates.isEmpty) {
       // no condition can be translated to expression

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/typeutils/TypeCoercion.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/typeutils/TypeCoercion.scala
@@ -99,6 +99,7 @@ object TypeCoercion {
     case (VARCHAR | CHAR, DATE) => true
     case (VARCHAR | CHAR, TIME_WITHOUT_TIME_ZONE) => true
     case (VARCHAR | CHAR, TIMESTAMP_WITHOUT_TIME_ZONE) => true
+    case (VARCHAR | CHAR, TIMESTAMP_WITH_LOCAL_TIME_ZONE) => true
 
     case (BOOLEAN, _) if isNumeric(to) => true
     case (BOOLEAN, DECIMAL) => true

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/calcite/FlinkTypeFactoryTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/calcite/FlinkTypeFactoryTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.calcite
 
-import org.apache.flink.table.types.logical.{ArrayType, BigIntType, BooleanType, DateType, DecimalType, DoubleType, FloatType, IntType, LogicalType, MapType, RowType, SmallIntType, TimeType, TimestampType, TinyIntType, VarBinaryType, VarCharType}
+import org.apache.flink.table.types.logical.{ArrayType, BigIntType, BooleanType, DateType, DecimalType, DoubleType, FloatType, IntType, LocalZonedTimestampType, LogicalType, MapType, RowType, SmallIntType, TimeType, TimestampType, TinyIntType, VarBinaryType, VarCharType}
 
 import org.junit.{Assert, Test}
 
@@ -67,6 +67,7 @@ class FlinkTypeFactoryTest {
     test(new DateType())
     test(new TimeType())
     test(new TimestampType(3))
+    test(new LocalZonedTimestampType(3))
 
     test(new ArrayType(new DoubleType()))
     test(new MapType(new DoubleType(), new VarCharType(VarCharType.MAX_LENGTH)))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/expressions/TemporalTypesTest.scala
@@ -25,10 +25,11 @@ import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
 import org.apache.flink.table.util.DateTimeTestUtil._
 import org.apache.flink.types.Row
 
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
+import java.time.{Instant, ZoneId}
 import java.util.TimeZone
 
 class TemporalTypesTest extends ExpressionTestBase {
@@ -400,145 +401,81 @@ class TemporalTypesTest extends ExpressionTestBase {
     )
   }
 
-  @Ignore // TODO support timestamp with local time zone
   @Test
   def testDateAndTime(): Unit = {
-    val zones = Seq (
-      "UTC",
-      "Asia/Kolkata",
-      "Asia/Rangoon",
-      "Asia/Shanghai",
-      "America/New_York"
-    )
+    testSqlApi(
+      "DATE '2018-03-14'",
+      "2018-03-14")
+    testSqlApi(
+      "TIME '19:01:02.123'",
+      "19:01:02")
 
-    zones.foreach { tz =>
-      config.setTimeZone(TimeZone.getTimeZone(tz))
+    // DATE & TIME
+    testSqlApi("CAST('12:44:31' AS TIME)", "12:44:31")
+    testSqlApi("CAST('2018-03-18' AS DATE)", "2018-03-18")
+    testSqlApi("TIME '12:44:31'", "12:44:31")
+    testSqlApi("TO_DATE('2018-03-18')", "2018-03-18")
 
-      testSqlApi(
-        "DATE '2018-03-14'",
-        "2018-03-14")
-      testSqlApi(
-        "TIME '19:01:02.123'",
-        "19:01:02")
+    // EXTRACT
+    //testSqlApi("TO_DATE(1521331200)", "2018-03-18")
+    testSqlApi("EXTRACT(HOUR FROM TIME '06:07:08')", "6")
+    testSqlApi("EXTRACT(MINUTE FROM TIME '06:07:08')", "7")
+    //testSqlApi("EXTRACT(HOUR FROM TO_TIME('06:07:08'))", "6")  NO TO_TIME funciton
+    testSqlApi("EXTRACT(HOUR FROM CAST('06:07:08' AS TIME))", "6")
+    testSqlApi("EXTRACT(DAY FROM CAST('2018-03-18' AS DATE))", "18")
+    testSqlApi("EXTRACT(DAY FROM DATE '2018-03-18')", "18")
+    testSqlApi("EXTRACT(DAY FROM TO_DATE('2018-03-18'))", "18")
+    testSqlApi("EXTRACT(MONTH FROM TO_DATE('2018-01-01'))", "1")
+    testSqlApi("EXTRACT(YEAR FROM TO_DATE('2018-01-01'))", "2018")
+    testSqlApi("EXTRACT(QUARTER FROM TO_DATE('2018-01-01'))", "1")
 
-      // DATE & TIME
-      testSqlApi("CAST('12:44:31' AS TIME)", "12:44:31")
-      testSqlApi("CAST('2018-03-18' AS DATE)", "2018-03-18")
-      testSqlApi("TIME '12:44:31'", "12:44:31")
-      testSqlApi("TO_DATE('2018-03-18')", "2018-03-18")
-
-      // EXTRACT
-      //testSqlApi("TO_DATE(1521331200)", "2018-03-18")
-      testSqlApi("EXTRACT(HOUR FROM TIME '06:07:08')", "6")
-      testSqlApi("EXTRACT(MINUTE FROM TIME '06:07:08')", "7")
-      //testSqlApi("EXTRACT(HOUR FROM TO_TIME('06:07:08'))", "6")  NO TO_TIME funciton
-      testSqlApi("EXTRACT(HOUR FROM CAST('06:07:08' AS TIME))", "6")
-      testSqlApi("EXTRACT(DAY FROM CAST('2018-03-18' AS DATE))", "18")
-      testSqlApi("EXTRACT(DAY FROM DATE '2018-03-18')", "18")
-      testSqlApi("EXTRACT(DAY FROM TO_DATE('2018-03-18'))", "18")
-      testSqlApi("EXTRACT(MONTH FROM TO_DATE('2018-01-01'))", "1")
-      testSqlApi("EXTRACT(YEAR FROM TO_DATE('2018-01-01'))", "2018")
-      testSqlApi("EXTRACT(QUARTER FROM TO_DATE('2018-01-01'))", "1")
-
-      // Floor & Ceil
-      // TODO: fix this legacy bug
-      //testSqlApi("CEIL(TO_DATE('2018-03-18') TO DAY)", "2018-04-01")
-      //testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:10:31' TO HOUR)", "2018-03-20 07:00:00.000")
-    }
+    // Floor & Ceil
+    // TODO: fix this legacy bug
+    //testSqlApi("CEIL(TO_DATE('2018-03-18') TO DAY)", "2018-04-01")
+    //testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:10:31' TO HOUR)", "2018-03-20 07:00:00.000")
   }
 
-  @Ignore // TODO support timestamp with local time zone
+  private def timestampTz(str: String) = {
+    s"CAST(TIMESTAMP '$str' AS TIMESTAMP_WITH_LOCAL_TIME_ZONE)"
+  }
+
   @Test
   def testTemporalShanghai(): Unit = {
-    config.setTimeZone(TimeZone.getTimeZone("Asia/Shanghai"))
+    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 
-    // Test Calcite's RexLiteral
-    // TIMESTAMP, DATE, TIME
-    testSqlApi(
-      "TIMESTAMP '2018-03-14 19:01:02.123'",
-      "2018-03-14 19:01:02.123")
-
-    // TO_TIMESTAMP
-    testSqlApi("TO_TIMESTAMP('2018-03-14 19:00:00.0', 'yyyy-MM-dd HH:mm:ss')",
-      "2018-03-14 19:00:00.000")
-    testSqlApi("TO_TIMESTAMP('2018-03-14 19:00:00.010')",
-      "2018-03-14 19:00:00.010")
-    testSqlApi("TO_TIMESTAMP(1521025200000)", "2018-03-14 19:00:00.000")
-
-    // UNIX_TIMESTAMP
-    testSqlApi("UNIX_TIMESTAMP(TO_TIMESTAMP(1521025200000))", "1521025200")
-    testSqlApi("UNIX_TIMESTAMP('2018-03-14 19:00:00')", "1521025200")
-    testSqlApi("UNIX_TIMESTAMP('2018/03/14 19:00:00','yyyy/MM/dd HH:mm:ss')", "1521025200")
-
-    // FROM_UNIXTIME
-    testSqlApi("FROM_UNIXTIME(1521025200)",
-      "2018-03-14 19:00:00")
-    testSqlApi("FROM_UNIXTIME(1521025200, 'yyyy-MM-dd HH:mm:ss')",
-      "2018-03-14 19:00:00")
-    testSqlApi("FROM_UNIXTIME(UNIX_TIMESTAMP(TO_TIMESTAMP('2018-03-14 19:00:00.0')))",
-      "2018-03-14 19:00:00")
-    testSqlApi("FROM_UNIXTIME(UNIX_TIMESTAMP('2018-03-14 19:00:00.0'))",  "2018-03-14 19:00:00")
-
-    // DATE_ADD/SUB
-    // 1520960523000  "2018-03-14T01:02:03+0800"
-    testSqlApi("Date_ADD(TO_TIMESTAMP(1520960523000), 2)", "2018-03-16")
-    testSqlApi("Date_ADD(TO_TIMESTAMP('2018-03-14 01:02:03'), 2)", "2018-03-16")
-    testSqlApi("Date_ADD('2018-03-14 01:02:03', 2)", "2018-03-16")
-    testSqlApi("Date_SUB(TO_TIMESTAMP(1520960523000), 2)", "2018-03-12")
-    testSqlApi("Date_SUB(TO_TIMESTAMP('2018-03-14 01:02:03'), 2)", "2018-03-12")
-    testSqlApi("Date_SUB('2018-03-14 01:02:03', 14)", "2018-02-28")
-    testSqlApi("date_add('2017--10-11', 30)", "null")
-    testSqlApi("date_sub('2017--10-11', 30)", "null")
-
-    // DATE_DIFF
-    // 1520827201000  2018-03-12T04:00:01+0000, 2018-03-12T12:00:01+0800
-    // 1520740801000  2018-03-11T04:00:01+0000, 2018-03-11T12:00:01+0800
-    testSqlApi("DATEDIFF(TO_TIMESTAMP(1520827201000), '2018-03-11 12:00:01')", "1")
-    testSqlApi("DATEDIFF(TO_TIMESTAMP(1520827201000), TO_TIMESTAMP(1520740801000))", "1")
-    testSqlApi("DATEDIFF('2018-03-12 12:00:01', '2018-03-11 12:00:01')", "1")
-    testSqlApi("DATEDIFF('2018-03-13 00:00:00', '2018-03-12 23:59:59.123')", "1")
-    testSqlApi("DATEDIFF('2018-03-12 12:00:01', TO_TIMESTAMP(1520740801000))", "1")
-    testSqlApi("DATEDIFF(TO_TIMESTAMP(1520740801000), '2018-03-12 12:00:01')", "-1")
-
-    // TO_DATE
-    testSqlApi("TO_DATE('1970-01-01 00:00:00','yyyy-MM-dd HH:mm:ss')", "1970-01-01")
-    testSqlApi("TO_DATE('1970-01-01')", "1970-01-01")
-    testSqlApi("TO_DATE(0)", "1970-01-01")
+    testSqlApi(timestampTz("2018-03-14 19:01:02.123"), "2018-03-14 19:01:02.123")
+    testSqlApi(timestampTz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.010")
 
     // DATE_FORMAT
-    // 1520960523000  "2018-03-14T01:02:03+0800"
     testSqlApi("DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
       "2018/03/14 01:02:03")
     testSqlApi("DATE_FORMAT('2018-03-14 01:02:03', 'yyyy-MM-dd HH:mm:ss', " +
       "'yyyy/MM/dd HH:mm:ss')", "2018/03/14 01:02:03")
-    testSqlApi("DATE_FORMAT(TO_TIMESTAMP(1520960523000), 'yyyy-MM-dd HH:mm:ss')",
+    testSqlApi(s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}," +
+        " 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
 
-
     // EXTRACT
-    // 1521503999000  2018-03-19T23:59:59+0000, 2018-03-20T07:59:59+0000
-    testSqlApi("EXTRACT(DAY FROM TO_TIMESTAMP(1521503999000))", "20")
-    testSqlApi("EXTRACT(HOUR FROM TO_TIMESTAMP(1521503999000))", "7")
+    val extractT1 = timestampTz("2018-03-20 07:59:59")
+    testSqlApi(s"EXTRACT(DAY FROM $extractT1)", "20")
+    testSqlApi(s"EXTRACT(HOUR FROM $extractT1)", "7")
+    testSqlApi(s"EXTRACT(MONTH FROM $extractT1)", "3")
+    testSqlApi(s"EXTRACT(YEAR FROM $extractT1)", "2018")
     testSqlApi("EXTRACT(DAY FROM INTERVAL '19 12:10:10.123' DAY TO SECOND(3))", "19")
     testSqlApi("EXTRACT(HOUR FROM TIME '01:02:03')", "1")
     testSqlApi("EXTRACT(DAY FROM INTERVAL '19 12:10:10.123' DAY TO SECOND(3))", "19")
-    testSqlApi("EXTRACT(HOUR FROM TIMESTAMP '2018-03-20 01:02:03')", "1")
-    testSqlApi("EXTRACT(DAY FROM TIMESTAMP '2018-03-20 01:02:03')", "20")
-    testSqlApi("EXTRACT(MONTH FROM TIMESTAMP '2018-03-20 01:02:03')", "3")
 
     // FLOOR & CEIL
     testSqlApi("FLOOR(TIME '12:44:31' TO MINUTE)", "12:44:00")
     testSqlApi("FLOOR(TIME '12:44:31' TO HOUR)", "12:00:00")
+    testSqlApi("CEIL(TIME '12:44:31' TO MINUTE)", "12:45:00")
+    testSqlApi("CEIL(TIME '12:44:31' TO HOUR)", "13:00:00")
+
     testSqlApi("FLOOR(TIMESTAMP '2018-03-20 06:44:31' TO HOUR)", "2018-03-20 06:00:00.000")
     testSqlApi("FLOOR(TIMESTAMP '2018-03-20 06:44:31' TO DAY)", "2018-03-20 00:00:00.000")
     testSqlApi("FLOOR(TIMESTAMP '2018-03-20 00:00:00' TO DAY)", "2018-03-20 00:00:00.000")
     testSqlApi("FLOOR(TIMESTAMP '2018-04-01 06:44:31' TO MONTH)", "2018-04-01 00:00:00.000")
     testSqlApi("FLOOR(TIMESTAMP '2018-01-01 06:44:31' TO MONTH)", "2018-01-01 00:00:00.000")
-    testSqlApi("FLOOR(TIMESTAMP '2018-02-01 21:00:01' TO QUARTER)", "2018-01-01 00:00:00.000")
-    testSqlApi("FLOOR(TIMESTAMP '2018-01-02 21:00:01' TO QUARTER)", "2018-01-01 00:00:00.000")
-    testSqlApi("FLOOR(TIMESTAMP '2018-05-02 21:00:01' TO QUARTER)", "2018-04-01 00:00:00.000")
-    testSqlApi("CEIL(TIME '12:44:31' TO MINUTE)", "12:45:00")
-    testSqlApi("CEIL(TIME '12:44:31' TO HOUR)", "13:00:00")
     testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:44:31' TO HOUR)", "2018-03-20 07:00:00.000")
     testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:00:00' TO HOUR)", "2018-03-20 06:00:00.000")
     testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:44:31' TO DAY)", "2018-03-21 00:00:00.000")
@@ -549,20 +486,34 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi("CEIL(TIMESTAMP '2018-12-02 00:00:00' TO MONTH)", "2019-01-01 00:00:00.000")
     testSqlApi("CEIL(TIMESTAMP '2018-01-01 21:00:01' TO YEAR)", "2018-01-01 00:00:00.000")
     testSqlApi("CEIL(TIMESTAMP '2018-01-02 21:00:01' TO YEAR)", "2019-01-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-01-01 21:00:01' TO QUARTER)", "2018-01-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-01-02 21:00:01' TO QUARTER)", "2018-04-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-02-01 21:00:01' TO QUARTER)", "2018-04-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-05-01 21:00:01' TO QUARTER)", "2018-07-01 00:00:00.000")
+
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 06:00:00.000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-20 00:00:00.000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 00:00:00")} TO DAY)", "2018-03-20 00:00:00.000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-04-01 06:44:31")} TO MONTH)", "2018-04-01 00:00:00.000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-01-01 06:44:31")} TO MONTH)", "2018-01-01 00:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 07:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:00:00")} TO HOUR)", "2018-03-20 06:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-21 00:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-1 00:00:00")} TO DAY)", "2018-03-01 00:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-31 00:00:01")} TO DAY)", "2018-04-01 00:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-01 21:00:01")} TO MONTH)", "2018-03-01 00:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-01 00:00:00")} TO MONTH)", "2018-03-01 00:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-12-02 00:00:00")} TO MONTH)", "2019-01-01 00:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-01-01 21:00:01")} TO YEAR)", "2018-01-01 00:00:00.000")
+    testSqlApi(s"CEIL(${timestampTz("2018-01-02 21:00:01")} TO YEAR)", "2019-01-01 00:00:00.000")
+
+    // others
     testSqlApi("QUARTER(DATE '2016-04-12')", "2")
     testSqlApi(
       "(TIME '2:55:00', INTERVAL '1' HOUR) OVERLAPS (TIME '3:30:00', INTERVAL '2' HOUR)",
       "true")
     testSqlApi(
-      "CEIL(f6 TO HOUR)",
+      "CEIL(f17 TO HOUR)",
       "1990-10-14 08:00:00.000"
     )
     testSqlApi(
-      "FLOOR(f6 TO DAY)",
+      "FLOOR(f17 TO DAY)",
       "1990-10-14 00:00:00.000"
     )
 
@@ -572,7 +523,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2017-11-29 18:58:58.998")
 
     val sdf = new SimpleDateFormat("yyyy-MM-dd")
-    sdf.setTimeZone(config.getTimeZone)
+    sdf.setTimeZone(TimeZone.getTimeZone(config.getLocalTimeZone))
     val currMillis = System.currentTimeMillis()
     val ts = new Timestamp(currMillis)
     val currDateStr = sdf.format(ts)
@@ -580,10 +531,9 @@ class TemporalTypesTest extends ExpressionTestBase {
     //testSqlApi("CURRENT_TIME", "")
   }
 
-  @Ignore // TODO support timestamp with local time zone
   @Test
   def testUTCTimeZone(): Unit = {
-    config.setTimeZone(TimeZone.getTimeZone("UTC"))
+    config.setLocalTimeZone(ZoneId.of("UTC"))
 
     // Test Calcite's RexLiteral
     // 1521025200000  =  UTC: 2018-03-14 11:00:00
@@ -630,10 +580,9 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018-03-13 17:02:03")
   }
 
-  @Ignore // TODO support timestamp with local time zone
   @Test
   def testDaylightSavingTimeZone(): Unit = {
-    config.setTimeZone(TimeZone.getTimeZone("America/New_York"))
+    config.setLocalTimeZone(ZoneId.of("America/New_York"))
 
     // TODO: add more testcases & fully support DST
     // Daylight Saving
@@ -648,64 +597,32 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018-03-14 07:00:00.000")
     testSqlApi("TO_TIMESTAMP('2018-03-14 07:00:00')",
       "2018-03-14 07:00:00.000")
-    testSqlApi("TO_TIMESTAMP(1521025200000)", "2018-03-14 07:00:00.000")
+    testSqlApi("f18", "2018-03-14 07:00:00.000")
 
-    // 1521025200000  "2018-03-14T11:00:00-0400"
-    testSqlApi("FROM_UNIXTIME(1521025200)",
-      "2018-03-14 07:00:00")
-    testSqlApi("FROM_UNIXTIME(1521025200, 'yyyy-MM-dd HH:mm:ss')",
-      "2018-03-14 07:00:00")
     testSqlApi("FROM_UNIXTIME(UNIX_TIMESTAMP(TO_TIMESTAMP('2018-03-14 07:00:00.0')))",
       "2018-03-14 07:00:00")
     testSqlApi("FROM_UNIXTIME(UNIX_TIMESTAMP('2018-03-14 07:00:00.0'))",
       "2018-03-14 07:00:00")
 
-    // 1520960523000  "2018-03-13T13:02:03-0400" // DST-0400
-    testSqlApi("Date_ADD(TO_TIMESTAMP(1520960523000), 2)", "2018-03-15")
-    testSqlApi("Date_ADD(TO_TIMESTAMP('2018-03-13 13:02:03'), 2)", "2018-03-15")
-    testSqlApi("Date_ADD('2018-03-13 13:02:03', 2)", "2018-03-15")
-    testSqlApi("Date_SUB(TO_TIMESTAMP(1520960523000), 2)", "2018-03-11")
-    testSqlApi("Date_SUB(TO_TIMESTAMP('2018-03-13 13:02:03'), 2)", "2018-03-11")
-    testSqlApi("Date_SUB('2018-03-13 13:02:03', 2)", "2018-03-11")
-
     // DATE_FORMAT
-    // 1520960523000  "2018-03-13 13:02:03-0400"
     testSqlApi("DATE_FORMAT('2018-03-13 13:02:03', 'yyyy-MM-dd HH:mm:ss', " +
       "'yyyy/MM/dd HH:mm:ss')", "2018/03/13 13:02:03")
-    testSqlApi("DATE_FORMAT(TO_TIMESTAMP(1520960523000), 'yyyy-MM-dd HH:mm:ss')",
-      "2018-03-13 13:02:03")
-
-    // DATE_DIFF, Pay attention to the DaylightSaving corner case
-    testSqlApi("DATEDIFF(TO_TIMESTAMP(1520960523000), '2018-03-13 13:02:03')", "0")
-    // 1520827201000  2018-03-12T04:00:01+0000, 2018-03-12T00:00:01-0400(DST)
-    // 1520740801000  2018-03-11T04:00:01+0000, 2018-03-10T23:00:01-0400(DST)
-    testSqlApi("DATEDIFF(TO_TIMESTAMP(1520827201000), TO_TIMESTAMP(1520740801000))", "2")
-    testSqlApi("DATEDIFF('2018-03-12 00:00:01', TO_TIMESTAMP(1520740801000))", "2")
-    testSqlApi("DATEDIFF(TO_TIMESTAMP(1520827201000), '2018-03-10 23:00:01')", "2")
-    testSqlApi("DATEDIFF('2018-03-12 00:00:01', '2018-03-10 23:00:01')", "2")
-
-    // 'Current Time Functions'
-    //val ldt = LocalDateTime.now()
-    //testSqlApi("LOCALTIMESTAMP, PROCTIME()", ldt.toString)
-    //testSqlApi("PROCTIME()", ldt.toString)
+    testSqlApi("DATE_FORMAT(f19, 'yyyy-MM-dd HH:mm:ss')", "2018-03-13 13:02:03")
   }
 
-  @Ignore // TODO support timestamp with local time zone
   @Test
   def testHourUnitRangoonTimeZone(): Unit = {
     // Asia/Rangoon UTC Offset 6.5
-    config.setTimeZone(TimeZone.getTimeZone("Asia/Rangoon"))
+    config.setLocalTimeZone(ZoneId.of("Asia/Rangoon"))
 
+    val t1 = timestampTz("2018-03-20 06:10:31")
+    val t2 = timestampTz("2018-03-20 06:00:00")
     // 1521502831000,  2018-03-19 23:40:31 UTC,  2018-03-20 06:10:31 +06:30
-    testSqlApi("EXTRACT(HOUR FROM TO_TIMESTAMP('2018-03-20 06:10:31'))", "6")
-    testSqlApi("EXTRACT(HOUR FROM TO_TIMESTAMP(1521502831000))", "6")
-    testSqlApi("EXTRACT(HOUR FROM TIMESTAMP '2018-03-20 06:10:31')", "6")
-    testSqlApi("FLOOR(TIMESTAMP '2018-03-20 06:10:31' TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi("FLOOR(TO_TIMESTAMP(1521502831000) TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi("FLOOR(TIMESTAMP '2018-03-20 06:00:00' TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:00:00' TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi("CEIL(TO_TIMESTAMP(1521502831000) TO HOUR)", "2018-03-20 07:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:10:31' TO HOUR)", "2018-03-20 07:00:00.000")
+    testSqlApi(s"EXTRACT(HOUR FROM $t1)", "6")
+    testSqlApi(s"FLOOR($t1 TO HOUR)", "2018-03-20 06:00:00.000")
+    testSqlApi(s"FLOOR($t2 TO HOUR)", "2018-03-20 06:00:00.000")
+    testSqlApi(s"CEIL($t2 TO HOUR)", "2018-03-20 06:00:00.000")
+    testSqlApi(s"CEIL($t1 TO HOUR)", "2018-03-20 07:00:00.000")
   }
 
   @Test
@@ -727,24 +644,11 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   }
 
-  @Ignore // TODO support timestamp with local time zone
   @Test
   def testTimeZoneFunction(): Unit = {
-    config.setTimeZone(TimeZone.getTimeZone("Asia/Shanghai"))
-
-    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'UTC')", "2018-03-14 19:00:00.000")
-    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'yyyy-MM-dd HH:mm:ss', 'UTC')",
-      "2018-03-14 19:00:00.000")
-
-    //testSqlApi("TO_TIMESTAMP(1521025200000)", "2018-03-14 19:00:00.000")
-    testSqlApi("DATE_FORMAT_TZ(TO_TIMESTAMP(1521025200000), 'UTC')", "2018-03-14 11:00:00")
-    testSqlApi(
-      "DATE_FORMAT_TZ(TO_TIMESTAMP(1521025200000), 'yyyy/MM/dd HH:mm:ss', 'Asia/Shanghai')",
-      "2018/03/14 19:00:00")
-
-    testSqlApi(
-      "TO_TIMESTAMP_TZ(DATE_FORMAT_TZ(TO_TIMESTAMP(1521025200000), 'UTC'), 'Asia/Shanghai')",
-      "2018-03-14 11:00:00.000")
+    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'Asia/Shanghai')", "2018-03-14 03:00:00.000")
+    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'yyyy-MM-dd HH:mm:ss', 'Asia/Shanghai')",
+      "2018-03-14 03:00:00.000")
 
     testSqlApi("CONVERT_TZ('2018-03-14 11:00:00', 'yyyy-MM-dd HH:mm:ss', 'UTC', 'Asia/Shanghai')",
       "2018-03-14 19:00:00")
@@ -754,14 +658,14 @@ class TemporalTypesTest extends ExpressionTestBase {
     // Note that, if timezone is invalid, here we follow the default behavior of JDK's getTimeZone()
     // It will use UTC timezone by default.
     // TODO: it is would be better to report the error at compiling stage. timezone/format codegen
-    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'invalid_tz')", "2018-03-14 19:00:00.000")
+    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'invalid_tz')", "2018-03-14 11:00:00.000")
   }
 
 
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = {
-    val testData = new Row(16)
+    val testData = new Row(21)
     testData.setField(0, localDate("1990-10-14"))
     testData.setField(1, localTime("10:20:45"))
     testData.setField(2, localDateTime("1990-10-14 10:20:45.123"))
@@ -780,6 +684,13 @@ class TemporalTypesTest extends ExpressionTestBase {
     testData.setField(14, null)
 
     testData.setField(15, 1467012213L)
+    testData.setField(16,
+      localDateTime("1990-10-14 10:20:45.123").atZone(ZoneId.of("UTC")).toInstant)
+    testData.setField(17,
+      localDateTime("1990-10-14 00:00:00.0").atZone(ZoneId.of("UTC")).toInstant)
+    testData.setField(18, Instant.ofEpochMilli(1521025200000L))
+    testData.setField(19, Instant.ofEpochMilli(1520960523000L))
+    testData.setField(20, Instant.ofEpochMilli(1520827201000L))
     testData
   }
 
@@ -800,6 +711,11 @@ class TemporalTypesTest extends ExpressionTestBase {
       /* 12 */ Types.LOCAL_TIME,
       /* 13 */ Types.LOCAL_DATE_TIME,
       /* 14 */ Types.STRING,
-      /* 15 */ Types.LONG)
+      /* 15 */ Types.LONG,
+      /* 16 */ Types.INSTANT,
+      /* 17 */ Types.INSTANT,
+      /* 18 */ Types.INSTANT,
+      /* 19 */ Types.INSTANT,
+      /* 20 */ Types.INSTANT)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/TableSourceTest.scala
@@ -28,15 +28,12 @@ import org.apache.flink.types.Row
 
 import org.junit.{Before, Test}
 
-import java.util.TimeZone
-
 class TableSourceTest extends TableTestBase {
 
   private val util = batchTestUtil()
 
   @Before
   def setup(): Unit = {
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     val tableSchema = TableSchema.builder().fields(
       Array("a", "b", "c"),
       Array(DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING())).build()

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/TableSourceTest.scala
@@ -27,15 +27,12 @@ import org.apache.flink.types.Row
 
 import org.junit.{Before, Test}
 
-import java.util.TimeZone
-
 class TableSourceTest extends TableTestBase {
 
   private val util = streamTestUtil()
 
   @Before
   def setup(): Unit = {
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     util.tableEnv.registerTableSource("FilterableTable", TestFilterableTableSource(false))
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/RexNodeExtractorTest.scala
@@ -43,7 +43,7 @@ import org.junit.Test
 
 import java.math.BigDecimal
 import java.sql.{Date, Time, Timestamp}
-import java.util.{List => JList}
+import java.util.{TimeZone, List => JList}
 
 import scala.collection.JavaConverters._
 
@@ -224,7 +224,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     val expected: Array[Expression] = Array(firstExp, secondExp)
 
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         expr,
         -1,
         allFieldNames,
@@ -247,7 +247,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         a,
         -1,
         allFieldNames,
@@ -296,7 +296,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         complexNode,
         -1,
         allFieldNames,
@@ -336,7 +336,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         and,
         -1,
         allFieldNames,
@@ -381,7 +381,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         and,
         -1,
         allFieldNames,
@@ -424,7 +424,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     val and = rexBuilder.makeCall(SqlStdOperatorTable.AND, condition)
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
-    val (converted, _) = RexNodeExtractor.extractConjunctiveConditions(
+    val (converted, _) = extractConjunctiveConditions(
       and,
       -1,
       fieldNames,
@@ -510,7 +510,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     val complexExpr = rexBuilder.makeCall(SqlStdOperatorTable.AND, condition)
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         complexExpr,
         -1,
         allFieldNames,
@@ -564,7 +564,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     val complexExpr = rexBuilder.makeCall(SqlStdOperatorTable.AND, condition1, condition2)
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
-    val (convertedExpressions, unconvertedRexNodes) = RexNodeExtractor.extractConjunctiveConditions(
+    val (convertedExpressions, unconvertedRexNodes) = extractConjunctiveConditions(
       complexExpr,
       -1,
       allFieldNames,
@@ -622,7 +622,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         conditionExpr,
         -1,
         allFieldNames,
@@ -678,7 +678,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         and,
         -1,
         allFieldNames,
@@ -703,7 +703,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
 
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         condition,
         -1,
         allFieldNames,
@@ -727,7 +727,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     val conditionExpr = rexBuilder.makeCall(op, t0)
     val relBuilder: RexBuilder = new RexBuilder(typeFactory)
     val (convertedExpressions, unconvertedRexNodes) =
-      RexNodeExtractor.extractConjunctiveConditions(
+      extractConjunctiveConditions(
         conditionExpr,
         -1,
         allFieldNames,
@@ -762,6 +762,16 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     sortedExpected.zip(sortedActual).foreach {
       case (l, r) => assertEquals(l.toString, r.toString)
     }
+  }
+
+  private def extractConjunctiveConditions(
+      expr: RexNode,
+      maxCnfNodeCount: Int,
+      inputFieldNames: JList[String],
+      rexBuilder: RexBuilder,
+      catalog: FunctionCatalog): (Array[Expression], Array[RexNode]) = {
+    RexNodeExtractor.extractConjunctiveConditions(expr, maxCnfNodeCount,
+      inputFieldNames, rexBuilder, catalog, TimeZone.getDefault)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo.{LOCAL_DATE, LOCAL
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.{DATE, TIME, TIMESTAMP}
 import org.apache.flink.api.common.typeinfo.Types
+import org.apache.flink.api.common.typeinfo.Types.INSTANT
 import org.apache.flink.api.java.typeutils._
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.{ExecutionConfigOptions, ValidationException}
@@ -324,10 +325,11 @@ class CalcITCase extends BatchTestBase {
       DateTimeTestUtil.localTime("08:03:09"),
       Time.valueOf("08:03:09"),
       localDateTime("2019-09-19 08:03:09"),
-      Timestamp.valueOf("2019-09-19 08:03:09")))
+      Timestamp.valueOf("2019-09-19 08:03:09"),
+      Timestamp.valueOf("2019-09-19 08:03:09").toInstant))
     registerCollection("MyTable", data,
-      new RowTypeInfo(LOCAL_DATE, DATE, LOCAL_TIME, TIME, LOCAL_DATE_TIME, TIMESTAMP),
-      "a, b, c, d, e, f")
+      new RowTypeInfo(LOCAL_DATE, DATE, LOCAL_TIME, TIME, LOCAL_DATE_TIME, TIMESTAMP, INSTANT),
+      "a, b, c, d, e, f, g")
 
     tEnv.registerFunction("dateFunc", DateFunction)
     tEnv.registerFunction("localDateFunc", LocalDateFunction)
@@ -335,6 +337,7 @@ class CalcITCase extends BatchTestBase {
     tEnv.registerFunction("localTimeFunc", LocalTimeFunction)
     tEnv.registerFunction("timestampFunc", TimestampFunction)
     tEnv.registerFunction("datetimeFunc", DateTimeFunction)
+    tEnv.registerFunction("instantFunc", InstantFunction)
 
     val v1 = "1984-07-12"
     val v2 = "08:03:09"
@@ -344,12 +347,15 @@ class CalcITCase extends BatchTestBase {
       "SELECT" +
           " dateFunc(a), localDateFunc(a), dateFunc(b), localDateFunc(b)," +
           " timeFunc(c), localTimeFunc(c), timeFunc(d), localTimeFunc(d)," +
-          " timestampFunc(e), datetimeFunc(e), timestampFunc(f), datetimeFunc(f)" +
+          " timestampFunc(e), datetimeFunc(e), timestampFunc(f), datetimeFunc(f)," +
+          " CAST(instantFunc(g) AS TIMESTAMP), instantFunc(g)" +
           " FROM MyTable",
       Seq(row(
         v1, v1, v1, v1,
         v2, v2, v2, v2,
-        v3, v4, v3, v4)))
+        v3, v4, v3, v4,
+        localDateTime("2019-09-19 08:03:09"),
+        Timestamp.valueOf("2019-09-19 08:03:09").toInstant)))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/UserDefinedFunctionTestUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/UserDefinedFunctionTestUtils.scala
@@ -35,7 +35,7 @@ import com.google.common.io.Files
 import java.io.File
 import java.lang.{Iterable => JIterable}
 import java.sql.{Date, Timestamp}
-import java.time.{LocalDate, LocalDateTime, LocalTime}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import java.util
 import java.util.TimeZone
 import java.util.concurrent.atomic.AtomicInteger
@@ -223,6 +223,12 @@ object UserDefinedFunctionTestUtils {
 
   object LocalTimeFunction extends ScalarFunction {
     def eval(t: LocalTime): String = t.toString
+  }
+
+  object InstantFunction extends ScalarFunction {
+    def eval(t: Instant): Instant = t
+
+    override def getResultType(signature: Array[Class[_]]) = Types.INSTANT
   }
 
   // Understand type: Row wrapped as TypeInfoWrappedDataType.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArrayWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArrayWriter.java
@@ -126,6 +126,7 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 				break;
 			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				setNullLong(pos);
 				break;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
@@ -81,6 +81,7 @@ public final class BinaryRow extends BinaryFormat implements BaseRow {
 			case INTERVAL_YEAR_MONTH:
 			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 			case FLOAT:
 			case DOUBLE:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
@@ -95,6 +95,7 @@ public interface BinaryWriter {
 				break;
 			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				writer.writeLong(pos, (long) o);
 				break;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -53,6 +53,7 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -117,6 +118,9 @@ public class DataFormatConverters {
 
 		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(Timestamp.class), TimestampConverter.INSTANCE);
 		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(LocalDateTime.class), LocalDateTimeConverter.INSTANCE);
+
+		t2C.put(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).bridgedTo(Long.class), LongConverter.INSTANCE);
+		t2C.put(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).bridgedTo(Instant.class), InstantConverter.INSTANCE);
 
 		t2C.put(DataTypes.INTERVAL(DataTypes.MONTH()).bridgedTo(Integer.class), IntConverter.INSTANCE);
 		t2C.put(DataTypes.INTERVAL(DataTypes.MONTH()).bridgedTo(int.class), IntConverter.INSTANCE);
@@ -708,6 +712,33 @@ public class DataFormatConverters {
 
 		@Override
 		LocalDateTime toExternalImpl(BaseRow row, int column) {
+			return toExternalImpl(row.getLong(column));
+		}
+	}
+
+	/**
+	 * Converter for Instant.
+	 */
+	public static final class InstantConverter extends DataFormatConverter<Long, Instant> {
+
+		private static final long serialVersionUID = 1L;
+
+		public static final InstantConverter INSTANCE = new InstantConverter();
+
+		private InstantConverter() {}
+
+		@Override
+		Long toInternalImpl(Instant value) {
+			return value.toEpochMilli();
+		}
+
+		@Override
+		Instant toExternalImpl(Long value) {
+			return Instant.ofEpochMilli(value);
+		}
+
+		@Override
+		Instant toExternalImpl(BaseRow row, int column) {
 			return toExternalImpl(row.getLong(column));
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
@@ -175,6 +175,7 @@ public interface TypeGetterSetters {
 				return row.getInt(ordinal);
 			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				return row.getLong(ordinal);
 			case FLOAT:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/AbstractHeapVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/AbstractHeapVector.java
@@ -110,6 +110,7 @@ public abstract class AbstractHeapVector extends AbstractColumnVector {
 				return new HeapIntVector(maxRows);
 			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 				return new HeapLongVector(maxRows);
 			case DECIMAL:
 				DecimalType decimalType = (DecimalType) fieldType;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1063,4 +1063,32 @@ public class SqlDateTimeUtils {
 				+ (long) second * MILLIS_PER_SECOND
 				+ mills;
 	}
+
+	public static long timestampToTimestampWithLocalZone(long ts, TimeZone tz) {
+		return unixTimestampToLocalDateTime(ts).atZone(tz.toZoneId()).toInstant().toEpochMilli();
+	}
+
+	public static long timestampWithLocalZoneToTimestamp(long ts, TimeZone tz) {
+		return localDateTimeToUnixTimestamp(
+				LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), tz.toZoneId()));
+	}
+
+	public static long timestampWithLocalZoneToDate(long ts, TimeZone tz) {
+		return localDateToUnixDate(LocalDateTime.ofInstant(
+				Instant.ofEpochMilli(ts), tz.toZoneId()).toLocalDate());
+	}
+
+	public static long timestampWithLocalZoneToTime(long ts, TimeZone tz) {
+		return localTimeToUnixDate(LocalDateTime.ofInstant(
+				Instant.ofEpochMilli(ts), tz.toZoneId()).toLocalTime());
+	}
+
+	public static long dateToTimestampWithLocalZone(int date, TimeZone tz) {
+		return LocalDateTime.of(unixDateToLocalDate(date), LocalTime.MIDNIGHT)
+				.atZone(tz.toZoneId()).toInstant().toEpochMilli();
+	}
+
+	public static long timeToTimestampWithLocalZone(int time, TimeZone tz) {
+		return unixTimestampToLocalDateTime(time).atZone(tz.toZoneId()).toInstant().toEpochMilli();
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/types/ClassLogicalTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/types/ClassLogicalTypeConverter.java
@@ -55,6 +55,7 @@ public class ClassLogicalTypeConverter {
 				return Integer.class;
 			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				return Long.class;
 			case FLOAT:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/types/InternalSerializers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/types/InternalSerializers.java
@@ -63,6 +63,7 @@ public class InternalSerializers {
 				return IntSerializer.INSTANCE;
 			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				return LongSerializer.INSTANCE;
 			case FLOAT:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/TypeCheckUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/TypeCheckUtils.java
@@ -32,6 +32,7 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTEGER;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.MAP;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 
 /**
  * Utils for type.
@@ -47,14 +48,7 @@ public class TypeCheckUtils {
 	}
 
 	public static boolean isTimePoint(LogicalType type) {
-		switch (type.getTypeRoot()) {
-			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				return true;
-			default:
-				return false;
-		}
+		return type.getTypeRoot().getFamilies().contains(LogicalTypeFamily.DATETIME);
 	}
 
 	public static boolean isRowTime(LogicalType type) {
@@ -85,6 +79,10 @@ public class TypeCheckUtils {
 
 	public static boolean isTimestamp(LogicalType type) {
 		return type.getTypeRoot() == TIMESTAMP_WITHOUT_TIME_ZONE;
+	}
+
+	public static boolean isTimestampWithLocalZone(LogicalType type) {
+		return type.getTypeRoot() == TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 	}
 
 	public static boolean isBoolean(LogicalType type) {


### PR DESCRIPTION
## What is the purpose of the change

Now we just support TimestampType, it is without time zone.
We need support LocalZonedTimestampType, and define time zone in config.

Now, for the functions of `TIMESTAMP_WITH_LOCAL_TIME_ZONE`:
1.cast: only support cast to and cast from `Char/VarChar/Date/Time/Timestamp`. (Limitation of calcite)
2.Support calcite functions: EXTRACT, FLOOR, CEIL, UNIX_TIMESTAMP, DATE_FORMAT.
3.Not support functions of blink extension.

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no