### PR TITLE
[FLINK-13169][tests][coordination] IT test for fine-grained recovery (task executor failures)

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -26,24 +26,33 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
+import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.minicluster.TestingMiniCluster;
 import org.apache.flink.runtime.minicluster.TestingMiniClusterConfiguration.Builder;
 import org.apache.flink.test.util.TestEnvironment;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static org.apache.flink.configuration.JobManagerOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION;
@@ -59,19 +68,35 @@ import static org.junit.Assert.assertThat;
  * the next mapper starts when the previous is done. The mappers are not chained into one task which makes them
  * separate fail-over regions.
  *
- * <p>The test verifies that fine-grained recovery works by randomly incuding failures in any of the mappers.
- * Since all mappers are connected via blocking partitions, which should be re-used on failure, and the consumer
- * of the mapper wasn't deployed yet, as the consumed partition was not fully produced yet, only the failed mapper
- * should actually restart.
+ * <p>The test verifies that fine-grained recovery works by randomly including failures in any of the mappers.
+ * There are multiple failure strategies:
+ *
+ * <ul>
+ *   <li> The {@link RandomExceptionFailureStrategy} throws an exception in the user function code.
+ *   Since all mappers are connected via blocking partitions, which should be re-used on failure, and the consumer
+ *   of the mapper wasn't deployed yet, as the consumed partition was not fully produced yet, only the failed mapper
+ *   should actually restart.
+ *   <li> The {@link RandomTaskExecutorFailureStrategy} abruptly shuts down the task executor. This leads to the loss
+ *   of all previously completed and the in-progress mapper result partitions. The fail-over strategy should restart
+ *   the current in-progress mapper which will get the {@link PartitionNotFoundException} because the previous result
+ *   becomes unavailable and the previous mapper has to be restarted as well. The same should happen subsequently with
+ *   all previous mappers. When the source is recomputed, all mappers has to be restarted again to recalculate their
+ *   lost results.
+ * </ul>
  */
 public class BatchFineGrainedRecoveryITCase extends TestLogger {
+	private static final Logger LOG = LoggerFactory.getLogger(BatchFineGrainedRecoveryITCase.class);
+
 	private static final int EMITTED_RECORD_NUMBER = 1000;
-	private static final int MAX_FAILURE_NUMBER = 10;
 	private static final int MAP_NUMBER = 3;
+	private static final int MAX_MAP_FAILURES = 4;
+	private static final int MAX_JOB_RESTART_ATTEMPTS = MAP_NUMBER * (MAP_NUMBER + 1) * MAX_MAP_FAILURES / 2;
+	private static final String TASK_NAME_PREFIX = "Test partition mapper ";
 	private static final List<Long> EXPECTED_JOB_OUTPUT =
 		LongStream.range(MAP_NUMBER, EMITTED_RECORD_NUMBER + MAP_NUMBER).boxed().collect(Collectors.toList());
 
-	private TestingMiniCluster miniCluster;
+	private static TestingMiniCluster miniCluster;
+	private static AtomicInteger lastTaskManagerIndexInMiniCluster;
 
 	@Before
 	public void setup() throws Exception {
@@ -81,13 +106,19 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 
 		miniCluster = new TestingMiniCluster(
 			new Builder()
-				.setNumTaskManagers(MAP_NUMBER)
+				.setNumTaskManagers(1)
 				.setNumSlotsPerTaskManager(1)
 				.setConfiguration(configuration)
+				.setRpcServiceSharing(RpcServiceSharing.DEDICATED)
 				.build(),
 			null);
 
 		miniCluster.start();
+
+		lastTaskManagerIndexInMiniCluster = new AtomicInteger(0);
+
+		StaticFailureCounter.reset();
+		StaticMapFailureTracker.reset();
 	}
 
 	@After
@@ -101,84 +132,116 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 	public void testProgram() throws Exception {
 		ExecutionEnvironment env = createExecutionEnvironment();
 
-		StaticFailureCounter.reset();
-		StaticMapFailureTracker.reset();
-
-		FailureStrategy failureStrategy = new RandomExceptionFailureStrategy(1, EMITTED_RECORD_NUMBER);
+		FailureStrategy failureStrategy = createFailureStrategy();
 
 		DataSet<Long> input = env.generateSequence(0, EMITTED_RECORD_NUMBER - 1);
-		for (int i = 0; i < MAP_NUMBER; i++) {
+		for (int trackingIndex = 0; trackingIndex < MAP_NUMBER; trackingIndex++) {
 			input = input
 				.mapPartition(new TestPartitionMapper(StaticMapFailureTracker.addNewMap(), failureStrategy))
-				.name("Test partition mapper " + i);
+				.name(TASK_NAME_PREFIX + trackingIndex);
 		}
 		assertThat(input.collect(), is(EXPECTED_JOB_OUTPUT));
 
 		StaticMapFailureTracker.verify();
 	}
 
-	private ExecutionEnvironment createExecutionEnvironment() {
+	private static FailureStrategy createFailureStrategy() {
+		CoinToss coin = new CoinToss(1, EMITTED_RECORD_NUMBER);
+		return new JoinedFailureStrategy(
+			new RandomExceptionFailureStrategy(coin),
+			new RandomTaskExecutorFailureStrategy(coin));
+	}
+
+	private static ExecutionEnvironment createExecutionEnvironment() {
 		@SuppressWarnings("StaticVariableUsedBeforeInitialization")
 		ExecutionEnvironment env = new TestEnvironment(miniCluster, 1, true);
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(MAX_FAILURE_NUMBER, Time.milliseconds(10)));
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(MAX_JOB_RESTART_ATTEMPTS, Time.milliseconds(10)));
 		env.getConfig().setExecutionMode(ExecutionMode.BATCH_FORCED); // forces all partitions to be blocking
 		return env;
 	}
 
-	private enum StaticMapFailureTracker {
-		;
-
-		private static final List<AtomicInteger> mapRestarts = new ArrayList<>(10);
-		private static final List<AtomicInteger> expectedMapRestarts = new ArrayList<>(10);
-
-		private static void reset() {
-			mapRestarts.clear();
-			expectedMapRestarts.clear();
-		}
-
-		private static int addNewMap() {
-			mapRestarts.add(new AtomicInteger(0));
-			expectedMapRestarts.add(new AtomicInteger(1));
-			return mapRestarts.size() - 1;
-		}
-
-		private static void mapRestart(int index) {
-			mapRestarts.get(index).incrementAndGet();
-		}
-
-		private static void mapFailure(int index) {
-			expectedMapRestarts.get(index).incrementAndGet();
-		}
-
-		private static void verify() {
-			assertThat(collect(mapRestarts), is(collect(expectedMapRestarts)));
-		}
-
-		private static int[] collect(Collection<AtomicInteger> list) {
-			return list.stream().mapToInt(AtomicInteger::get).toArray();
-		}
+	@SuppressWarnings({"StaticVariableUsedBeforeInitialization", "OverlyBroadThrowsClause"})
+	private static void restartTaskManager() throws Exception {
+		int tmi = lastTaskManagerIndexInMiniCluster.getAndIncrement();
+		miniCluster.terminateTaskExecutor(tmi).get();
+		miniCluster.startTaskExecutor();
 	}
 
 	@FunctionalInterface
 	private interface FailureStrategy extends Serializable {
-		void failOrNot();
+		boolean failOrNot(int trackingIndex);
 	}
 
-	private static class RandomExceptionFailureStrategy implements FailureStrategy {
+	private static class JoinedFailureStrategy implements FailureStrategy {
+		private static final long serialVersionUID = 1L;
+
+		private final FailureStrategy[] failureStrategies;
+
+		private JoinedFailureStrategy(FailureStrategy ... failureStrategies) {
+			this.failureStrategies = failureStrategies;
+		}
+
+		@Override
+		public boolean failOrNot(int trackingIndex) {
+			return Arrays
+				.stream(failureStrategies)
+				.anyMatch(failureStrategy -> failureStrategy.failOrNot(trackingIndex));
+		}
+	}
+
+	private static class RandomExceptionFailureStrategy extends AbstractRandomFailureStrategy {
+		private static final long serialVersionUID = 1L;
+
+		private RandomExceptionFailureStrategy(CoinToss coin) {
+			super(coin);
+		}
+
+		@Override
+		void fail(int trackingIndex) {
+			StaticMapFailureTracker.mapFailure(trackingIndex);
+			throw new FlinkRuntimeException("BAGA-BOOM!!! The user function generated test failure.");
+		}
+	}
+
+	private static class RandomTaskExecutorFailureStrategy extends AbstractRandomFailureStrategy {
+		private static final long serialVersionUID = 1L;
+
+		private RandomTaskExecutorFailureStrategy(CoinToss coin) {
+			super(coin);
+		}
+
+		@Override
+		void fail(int trackingIndex) {
+			StaticMapFailureTracker.mapFailureWithBacktracking(trackingIndex);
+			try {
+				restartTaskManager();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			} catch (Exception e) {
+				ExceptionUtils.rethrow(e);
+			}
+		}
+	}
+
+	private abstract static class AbstractRandomFailureStrategy implements FailureStrategy {
 		private static final long serialVersionUID = 1L;
 
 		private final CoinToss coin;
 
-		private RandomExceptionFailureStrategy(int probFraction, int probBase) {
-			this.coin = new CoinToss(probFraction, probBase);
+		private AbstractRandomFailureStrategy(CoinToss coin) {
+			this.coin = coin;
 		}
 
 		@Override
-		public void failOrNot() {
-			if (coin.toss() && StaticFailureCounter.failOrNot()) {
-				throw new FlinkRuntimeException("BAGA-BOOM!!! The user function generated test failure.");
+		public boolean failOrNot(int trackingIndex) {
+			boolean generateFailure = coin.toss() && StaticFailureCounter.failOrNot(trackingIndex);
+			if (generateFailure) {
+				fail(trackingIndex);
 			}
+			return generateFailure;
 		}
+
+		abstract void fail(int trackingIndex);
 	}
 
 	private static class CoinToss implements Serializable {
@@ -199,11 +262,84 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 		}
 	}
 
+	private enum StaticFailureCounter {
+		;
+
+		private static final Map<Integer, AtomicInteger> failureNumber = new HashMap<>(MAP_NUMBER);
+
+		private static boolean failOrNot(int trackingIndex) {
+			return failureNumber.get(trackingIndex).incrementAndGet() < MAX_MAP_FAILURES;
+		}
+
+		private static void reset() {
+			IntStream.range(0, MAP_NUMBER)
+				.forEach(trackingIndex -> failureNumber.put(trackingIndex, new AtomicInteger(0)));
+		}
+	}
+
+	private enum StaticMapFailureTracker {
+		;
+
+		private static final List<AtomicInteger> mapRestarts = new ArrayList<>(MAP_NUMBER);
+		private static final List<AtomicInteger> expectedMapRestarts = new ArrayList<>(MAP_NUMBER);
+		private static final List<AtomicInteger> mapFailures = new ArrayList<>(MAP_NUMBER);
+		private static final List<AtomicInteger> mapFailuresWithBacktracking = new ArrayList<>(MAP_NUMBER);
+
+		private static void reset() {
+			mapRestarts.clear();
+			expectedMapRestarts.clear();
+			mapFailures.clear();
+			mapFailuresWithBacktracking.clear();
+		}
+
+		private static int addNewMap() {
+			mapRestarts.add(new AtomicInteger(0));
+			expectedMapRestarts.add(new AtomicInteger(1));
+			mapFailures.add(new AtomicInteger(0));
+			mapFailuresWithBacktracking.add(new AtomicInteger(0));
+			return mapRestarts.size() - 1;
+		}
+
+		private static void mapRestart(int index) {
+			mapRestarts.get(index).incrementAndGet();
+		}
+
+		private static void mapFailure(int index) {
+			mapFailures.get(index).incrementAndGet();
+			expectedMapRestarts.get(index).incrementAndGet();
+		}
+
+		private static void mapFailureWithBacktracking(int index) {
+			mapFailuresWithBacktracking.get(index).incrementAndGet();
+			IntStream.range(0, index + 1).forEach(i -> expectedMapRestarts.get(i).incrementAndGet());
+			IntStream.range(0, index + 1).forEach(i -> expectedMapRestarts.get(i).incrementAndGet());
+		}
+
+		private static void verify() {
+			printStats();
+			assertThat(collect(mapRestarts), is(collect(expectedMapRestarts)));
+		}
+
+		private static int[] collect(Collection<AtomicInteger> list) {
+			return list.stream().mapToInt(AtomicInteger::get).toArray();
+		}
+
+		private static void printStats() {
+			LOG.info(
+				"Test stats - mapRestarts: {}; expectedMapRestarts: {}; mapFailures: {}; mapFailuresWithBacktracking: {}",
+				mapRestarts,
+				expectedMapRestarts,
+				mapFailures,
+				mapFailuresWithBacktracking);
+		}
+	}
+
 	private static class TestPartitionMapper extends RichMapPartitionFunction<Long, Long> {
 		private static final long serialVersionUID = 1L;
 
 		private final int trackingIndex;
 		private final FailureStrategy failureStrategy;
+		private transient boolean failed;
 
 		private TestPartitionMapper(int trackingIndex, FailureStrategy failureStrategy) {
 			this.trackingIndex = trackingIndex;
@@ -213,38 +349,19 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 		@Override
 		public void open(Configuration parameters) throws Exception {
 			super.open(parameters);
+			failed = false;
 			StaticMapFailureTracker.mapRestart(trackingIndex);
 		}
 
 		@Override
 		public void mapPartition(Iterable<Long> values, Collector<Long> out) {
 			values.forEach(value -> {
-				failOrNot();
+				// suppress subsequent failure generation
+				if (!failed) {
+					failed = failureStrategy.failOrNot(trackingIndex);
+				}
 				out.collect(value + 1);
 			});
-		}
-
-		private void failOrNot() {
-			try {
-				failureStrategy.failOrNot();
-			} catch (Throwable t) {
-				StaticMapFailureTracker.mapFailure(trackingIndex);
-				throw t;
-			}
-		}
-	}
-
-	private enum StaticFailureCounter {
-		;
-
-		private static final AtomicInteger failureNumber = new AtomicInteger(0);
-
-		private static boolean failOrNot() {
-			return failureNumber.incrementAndGet() < MAX_FAILURE_NUMBER;
-		}
-
-		private static void reset() {
-			failureNumber.set(0);
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -380,7 +380,6 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 		}
 	}
 
-	@SuppressWarnings("SynchronizationOnStaticField")
 	private static class GlobalMapFailureTracker {
 		private final List<AtomicInteger> mapRestarts;
 		private final List<Set<FailureStrategy>> mapFailures;


### PR DESCRIPTION
## What is the purpose of the change

The `BatchFineGrainedRecoveryITCase` can be extended with an additional test failure strategy which abruptly shuts down the task executor. This leads to the loss of all previously completed and the in-progress mapper result partitions. The fail-over strategy should restart the current in-progress mapper which will get the `PartitionNotFoundException` because the previous result becomes unavailable and the previous mapper has to be restarted as well. The same should happen subsequently with all previous mappers. When the source is recomputed, all mappers has to be restarted again to recalculate their lost results.

## Brief change log

Extend `BatchFineGrainedRecoveryITCase` with the `RandomTaskExecutorFailureStrategy`.

## Verifying this change

Run `BatchFineGrainedRecoveryITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
