### PR TITLE
[fink-table]Add constructor function for CsvTableSink to meet more scene

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
@@ -82,6 +82,17 @@ public class CsvTableSink implements BatchTableSink<Row>, AppendStreamTableSink<
 		this(path, fieldDelim, -1, null);
 	}
 
+	/**
+	 * A simple {@link TableSink} to emit data as CSV files, with default parallelism.
+	 *
+	 * @param path       The output path to write the Table to.
+	 * @param fieldDelim The field delimiter
+	 * @param writeMode  The write mode to specify whether existing files are overwritten or not.
+	 */
+	public CsvTableSink(String path, String fieldDelim, FileSystem.WriteMode writeMode) {
+		this(path, fieldDelim, -1, writeMode);
+	}
+
 	@Override
 	public void emitDataSet(DataSet<Row> dataSet) {
 		MapOperator<Row, String> csvRows =


### PR DESCRIPTION
## What is the purpose of the change
Use  the parameter of writeMode but do not use the parameter of numFiles   when new CsvTableSink.

## Brief change log

Add a constructor function for CsvTableSink, the parameters are 
         @param path       The output path to write the Table to.
	 @param fieldDelim The field delimiter
	 @param writeMode  The write mode to specify whether existing files are overwritten or not.
	 



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
