### PR TITLE
[FLINK-13165] Complete slot requests in request order

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 import java.util.AbstractCollection;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Set;
 
 /**
@@ -33,17 +33,17 @@ import java.util.Set;
  * @param <B> Type of key B
  * @param <V> Type of the value
  */
-public class DualKeyMap<A, B, V> {
+public class DualKeyLinkedMap<A, B, V> {
 
-	private final HashMap<A, Tuple2<B, V>> aMap;
+	private final LinkedHashMap<A, Tuple2<B, V>> aMap;
 
-	private final HashMap<B, A> bMap;
+	private final LinkedHashMap<B, A> bMap;
 
 	private transient Collection<V> values;
 
-	public DualKeyMap(int initialCapacity) {
-		this.aMap = new HashMap<>(initialCapacity);
-		this.bMap = new HashMap<>(initialCapacity);
+	public DualKeyLinkedMap(int initialCapacity) {
+		this.aMap = new LinkedHashMap<>(initialCapacity);
+		this.bMap = new LinkedHashMap<>(initialCapacity);
 	}
 
 	public int size() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
-import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -163,7 +162,7 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
 		@Nonnull SlotRequestId slotRequestId,
 		@Nonnull ResourceProfile resourceProfile,
-		@RpcTimeout Time timeout);
+		Time timeout);
 
 	/**
 	 * Create report about the allocated slots belonging to the specified task manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -105,10 +106,10 @@ public class SlotPoolImpl implements SlotPool {
 	private final AvailableSlots availableSlots;
 
 	/** All pending requests waiting for slots. */
-	private final DualKeyMap<SlotRequestId, AllocationID, PendingRequest> pendingRequests;
+	private final DualKeyLinkedMap<SlotRequestId, AllocationID, PendingRequest> pendingRequests;
 
 	/** The requests that are waiting for the resource manager to be connected. */
-	private final HashMap<SlotRequestId, PendingRequest> waitingForResourceManager;
+	private final LinkedHashMap<SlotRequestId, PendingRequest> waitingForResourceManager;
 
 	/** Timeout for external request calls (e.g. to the ResourceManager or the TaskExecutor). */
 	private final Time rpcTimeout;
@@ -153,8 +154,8 @@ public class SlotPoolImpl implements SlotPool {
 		this.registeredTaskManagers = new HashSet<>(16);
 		this.allocatedSlots = new AllocatedSlots();
 		this.availableSlots = new AvailableSlots();
-		this.pendingRequests = new DualKeyMap<>(16);
-		this.waitingForResourceManager = new HashMap<>(16);
+		this.pendingRequests = new DualKeyLinkedMap<>(16);
+		this.waitingForResourceManager = new LinkedHashMap<>(16);
 
 		this.jobMasterId = null;
 		this.resourceManagerGateway = null;
@@ -857,7 +858,7 @@ public class SlotPoolImpl implements SlotPool {
 	}
 
 	@VisibleForTesting
-	DualKeyMap<SlotRequestId, AllocationID, PendingRequest> getPendingRequests() {
+	DualKeyLinkedMap<SlotRequestId, AllocationID, PendingRequest> getPendingRequests() {
 		return pendingRequests;
 	}
 
@@ -915,11 +916,11 @@ public class SlotPoolImpl implements SlotPool {
 		private final Map<ResourceID, Set<AllocatedSlot>> allocatedSlotsByTaskManager;
 
 		/** All allocated slots organized by AllocationID. */
-		private final DualKeyMap<AllocationID, SlotRequestId, AllocatedSlot> allocatedSlotsById;
+		private final DualKeyLinkedMap<AllocationID, SlotRequestId, AllocatedSlot> allocatedSlotsById;
 
 		AllocatedSlots() {
 			this.allocatedSlotsByTaskManager = new HashMap<>(16);
-			this.allocatedSlotsById = new DualKeyMap<>(16);
+			this.allocatedSlotsById = new DualKeyLinkedMap<>(16);
 		}
 
 		/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
@@ -32,9 +32,9 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Tests for the {@link DualKeyMap}.
+ * Tests for the {@link DualKeyLinkedMap}.
  */
-public class DualKeyMapTest extends TestLogger {
+public class DualKeyLinkedMapTest extends TestLogger {
 
 	@Test
 	public void testKeySets() {
@@ -48,7 +48,7 @@ public class DualKeyMapTest extends TestLogger {
 			keys.add(Tuple2.of(keyA, keyB));
 		}
 
-		final DualKeyMap<Integer, Integer, String> dualKeyMap = new DualKeyMap<>(capacity);
+		final DualKeyLinkedMap<Integer, Integer, String> dualKeyMap = new DualKeyLinkedMap<>(capacity);
 
 		for (Tuple2<Integer, Integer> key : keys) {
 			dualKeyMap.put(key.f0, key.f1, "foobar");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.CheckedSupplier;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Tests how the {@link SlotPoolImpl} completes slot requests.
+ */
+public class SlotPoolRequestCompletionTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.seconds(10L);
+
+	/**
+	 * Tests that the {@link SlotPoolImpl} completes slots in request order.
+	 */
+	@Test
+	public void testRequestsAreCompletedInRequestOrder() throws Exception {
+		runSlotRequestCompletionTest(
+			CheckedSupplier.unchecked(this::setUpSlotPoolAndConnectToResourceManager),
+			slotPool -> {});
+	}
+
+	/**
+	 * Tests that the {@link SlotPoolImpl} completes stashed slot requests in request order.
+	 */
+	@Test
+	public void testStashOrderMaintainsRequestOrder() throws Exception {
+		runSlotRequestCompletionTest(
+			CheckedSupplier.unchecked(this::setUpSlotPool),
+			this::connectToResourceManager);
+	}
+
+	private void runSlotRequestCompletionTest(
+		Supplier<SlotPoolImpl> slotPoolSupplier,
+		Consumer<SlotPoolImpl> actionAfterSlotRequest) throws Exception {
+		try (final SlotPoolImpl slotPool = slotPoolSupplier.get()) {
+
+			final List<SlotRequestId> slotRequestIds = IntStream.range(0, 10)
+				.mapToObj(ignored -> new SlotRequestId())
+				.collect(Collectors.toList());
+
+			final List<CompletableFuture<PhysicalSlot>> slotRequests = slotRequestIds
+				.stream()
+				.map(slotRequestId -> slotPool.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, TIMEOUT))
+				.collect(Collectors.toList());
+
+			actionAfterSlotRequest.accept(slotPool);
+
+			final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+			slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+			final SlotOffer slotOffer = new SlotOffer(new AllocationID(), 0, ResourceProfile.UNKNOWN);
+			final Collection<SlotOffer> acceptedSlots = slotPool.offerSlots(taskManagerLocation, new SimpleAckingTaskManagerGateway(), Collections.singleton(slotOffer));
+
+			assertThat(acceptedSlots, containsInAnyOrder(slotOffer));
+
+			final FlinkException testingReleaseException = new FlinkException("Testing release exception");
+
+			// check that the slot requests get completed in sequential order
+			for (int i = 0; i < slotRequestIds.size(); i++) {
+				final CompletableFuture<PhysicalSlot> slotRequestFuture = slotRequests.get(i);
+				slotRequestFuture.get();
+				slotPool.releaseSlot(slotRequestIds.get(i), testingReleaseException);
+			}
+		}
+	}
+
+	private SlotPoolImpl setUpSlotPoolAndConnectToResourceManager() throws Exception {
+		final SlotPoolImpl slotPool = setUpSlotPool();
+		connectToResourceManager(slotPool);
+
+		return slotPool;
+	}
+
+	private void connectToResourceManager(SlotPoolImpl slotPool) {
+		slotPool.connectToResourceManager(new TestingResourceManagerGateway());
+	}
+
+	private SlotPoolImpl setUpSlotPool() throws Exception {
+		final SlotPoolImpl slotPool = new SlotPoolImpl(new JobID());
+
+		slotPool.start(JobMasterId.generate(), "foobar", ComponentMainThreadExecutorServiceAdapter.forMainThread());
+
+		return slotPool;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This commit makes sure that slot requests enqueued at the SlotPoolImpl will get completed
in the order in which they were requested. This makes sure that the original request order
will be respected, hence preventing deadlock situations where dependent requests get completed
first.

## Brief change log

- Use `LinkedHashMap` for `SlotPoolImpl#waitingForResourceManager`
- Renamed `DualKeyMap` to `DualKeyLinkedMap` and use `LinkedHashMap` for `DualKeyLinkedMap#aMap` and `DualKeyLinkedMap#bMap`

## Verifying this change

- Added `SlotPoolRequestCompletionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
