### PR TITLE
[Table]Add a PrintTableSink 

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/BatchTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/BatchTableSink.java
@@ -31,5 +31,5 @@ import org.apache.flink.table.api.Table;
 public interface BatchTableSink<T> extends TableSink<T> {
 
 	/** Emits the DataSet. */
-	void emitDataSet(DataSet<T> dataSet);
+	void emitDataSet(DataSet<T> dataSet) throws Exception;
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/BatchTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/BatchTableSink.java
@@ -31,5 +31,5 @@ import org.apache.flink.table.api.Table;
 public interface BatchTableSink<T> extends TableSink<T> {
 
 	/** Emits the DataSet. */
-	void emitDataSet(DataSet<T> dataSet) throws Exception;
+	void emitDataSet(DataSet<T> dataSet);
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/PrintTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/PrintTableSink.java
@@ -1,6 +1,7 @@
 package org.apache.flink.table.sinks;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -10,10 +11,15 @@ import org.apache.flink.table.utils.TableConnectorUtils;
 /**
  * A simple {@link TableSink} to emit data to the standard output or standard error stream.
  */
-public class PrintTableSink implements AppendStreamTableSink {
+public class PrintTableSink implements BatchTableSink , AppendStreamTableSink {
 
 	private String[] fieldNames;
 	private TypeInformation<?>[] fieldTypes;
+
+	@Override
+	public void emitDataSet(DataSet dataSet) throws Exception {
+		dataSet.print();
+	}
 
 	@Override
 	public void emitDataStream(DataStream dataStream) {

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/PrintTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/PrintTableSink.java
@@ -1,0 +1,53 @@
+package org.apache.flink.table.sinks;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
+import org.apache.flink.table.utils.TableConnectorUtils;
+
+/**
+ * A simple {@link TableSink} to emit data to the standard output or standard error stream.
+ */
+public class PrintTableSink implements AppendStreamTableSink {
+
+	private String[] fieldNames;
+	private TypeInformation<?>[] fieldTypes;
+
+	@Override
+	public void emitDataStream(DataStream dataStream) {
+		consumeDataStream(dataStream);
+	}
+
+	@Override
+	public DataStreamSink<?> consumeDataStream(DataStream dataStream) {
+
+		DataStreamSink sink = dataStream.addSink(new PrintSinkFunction());
+		sink.name(TableConnectorUtils.generateRuntimeName(PrintTableSink.class, fieldNames));
+		return sink;
+	}
+
+	@Override
+	public TypeInformation getOutputType() {
+		return new RowTypeInfo(getFieldTypes(), getFieldNames());
+	}
+
+	@Override
+	public String[] getFieldNames() {
+		return fieldNames;
+	}
+
+	@Override
+	public TypeInformation<?>[] getFieldTypes() {
+		return fieldTypes;
+	}
+
+	@Override
+	public TableSink configure(String[] fieldNames, TypeInformation[] fieldTypes) {
+		PrintTableSink configuredSink = new PrintTableSink();
+		configuredSink.fieldNames = fieldNames;
+		configuredSink.fieldTypes = fieldTypes;
+		return configuredSink;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change



This is very convenient for local mode and it is convenient for  learning the Table & SQL Api 

## Brief change log

Add a PrintTableSink class.

## Use method
```scala
PrintTableSink printsink = new PrintTableSink();
tableEnvironment.registerTableSink("printsinktable",printsink.configure(new String[]{"name"},new TypeInformation[]{Types.STRING} ));
tableEnvironment.sqlUpdate("INSERT INTO printsinktable SELECT name from table_name" );
```


