### PR TITLE
[FLINK-13173][tests] only run openSSL-based tests with flink.tests.with-openssl

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -43,7 +43,6 @@ import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -63,12 +62,12 @@ public class SSLUtilsTest extends TestLogger {
 
 	public static final List<String> AVAILABLE_SSL_PROVIDERS;
 	static {
-		if (OpenSsl.isAvailable()) {
+		if (System.getProperty("flink.tests.with-openssl") != null) {
+			assertTrue(
+				"openSSL not available but required (property 'flink.tests.with-openssl' is set)",
+				OpenSsl.isAvailable());
 			AVAILABLE_SSL_PROVIDERS = Arrays.asList("JDK", "OPENSSL");
 		} else {
-			assertNull(
-				"openSSL not available but required (property 'flink.tests.force-openssl' is set)",
-				System.getProperty("flink.tests.force-openssl"));
 			AVAILABLE_SSL_PROVIDERS = Collections.singletonList("JDK");
 		}
 	}

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -62,7 +62,7 @@ MVN_TEST_MODULES=$(get_test_modules_for_stage ${TEST})
 MVN_LOGGING_OPTIONS="-Dlog.dir=${ARTIFACTS_DIR} -Dlog4j.configuration=file://$LOG4J_PROPERTIES -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 MVN_COMMON_OPTIONS="-nsu -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -B -Pskip-webui-build $MVN_LOGGING_OPTIONS"
 MVN_COMPILE_OPTIONS="-DskipTests"
-MVN_TEST_OPTIONS="$MVN_LOGGING_OPTIONS -Dflink.tests.force-openssl"
+MVN_TEST_OPTIONS="$MVN_LOGGING_OPTIONS -Dflink.tests.with-openssl"
 
 MVN_COMPILE="mvn $MVN_COMMON_OPTIONS $MVN_COMPILE_OPTIONS $PROFILE $MVN_COMPILE_MODULES install"
 MVN_TEST="mvn $MVN_COMMON_OPTIONS $MVN_TEST_OPTIONS $PROFILE $MVN_TEST_MODULES verify"


### PR DESCRIPTION
## What is the purpose of the change

Rename `flink.tests.force-openssl` (introduced for Flink 1.9) to `flink.tests.with-openssl` and only run openSSL-based unit tests if this is set. This way, we avoid systems where the bundled dynamic libraries do not work. Travis seems to run fine and will have this property set.

For examples of such scenarios and why (for now) we cannot rely on automatic openSSL detection, please refer to https://issues.apache.org/jira/browse/FLINK-13172.

## Brief change log

- rename `flink.tests.force-openssl` to `flink.tests.with-openssl`
- adapt `SSLUtilsTest` to the inverse logic and provide `SSLUtilsTest#AVAILABLE_SSL_PROVIDERS` accordingly

## Verifying this change

I tested `SSLUtilsTest` in all combinations of having openSSL (not) available and w/o `flink.tests.with-openssl` so that openSSL is picked up or the test is failing if it is not.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
