### PR TITLE
[FLINK-13176][SQL CLI] remember current catalog and database in SQL CLI SessionContext

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ExecutionEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ExecutionEntry.java
@@ -97,9 +97,9 @@ public class ExecutionEntry extends ConfigEntry {
 
 	private static final String EXECUTION_RESTART_STRATEGY_MAX_FAILURES_PER_INTERVAL = "restart-strategy.max-failures-per-interval";
 
-	private static final String EXECUTION_CURRNET_CATALOG = "current-catalog";
+	public static final String EXECUTION_CURRNET_CATALOG = "current-catalog";
 
-	private static final String EXECUTION_CURRNET_DATABASE = "current-database";
+	public static final String EXECUTION_CURRNET_DATABASE = "current-database";
 
 	private ExecutionEntry(DescriptorProperties properties) {
 		super(properties);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
@@ -19,13 +19,18 @@
 package org.apache.flink.table.client.gateway;
 
 import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.config.entries.ExecutionEntry;
 import org.apache.flink.table.client.config.entries.ViewEntry;
+import org.apache.flink.util.StringUtils;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Context describing a session.
@@ -71,6 +76,26 @@ public class SessionContext {
 
 	public String getName() {
 		return name;
+	}
+
+	public Optional<String> getCurrentCatalog() {
+		return Optional.ofNullable(sessionProperties.get(ExecutionEntry.EXECUTION_CURRNET_CATALOG));
+	}
+
+	public void setCurrentCatalog(String currentCatalog) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(currentCatalog));
+
+		sessionProperties.put(ExecutionEntry.EXECUTION_CURRNET_CATALOG, currentCatalog);
+	}
+
+	public Optional<String> getCurrentDatabase() {
+		return Optional.ofNullable(sessionProperties.get(ExecutionEntry.EXECUTION_CURRNET_DATABASE));
+	}
+
+	public void setCurrentDatabase(String currentDatabase) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(currentDatabase));
+
+		sessionProperties.put(ExecutionEntry.EXECUTION_CURRNET_DATABASE, currentDatabase);
 	}
 
 	public Environment getEnvironment() {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -78,7 +78,6 @@ import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -303,14 +302,17 @@ public class ExecutionContext<T> {
 			// register catalogs
 			catalogs.forEach(tableEnv::registerCatalog);
 
-			Optional<String> potentialCurrentCatalog = mergedEnv.getExecution().getCurrentCatalog();
-			if (potentialCurrentCatalog.isPresent()) {
-				tableEnv.useCatalog(potentialCurrentCatalog.get());
+			// set current catalog and current database
+			if (sessionContext.getCurrentCatalog().isPresent()) {
+				tableEnv.useCatalog(sessionContext.getCurrentCatalog().get());
+			} else if (mergedEnv.getExecution().getCurrentCatalog().isPresent()) {
+				tableEnv.useCatalog(mergedEnv.getExecution().getCurrentCatalog().get());
 			}
 
-			Optional<String> potentialCurrentDatabase = mergedEnv.getExecution().getCurrentDatabase();
-			if (potentialCurrentDatabase.isPresent()) {
-				tableEnv.useDatabase(potentialCurrentDatabase.get());
+			if (sessionContext.getCurrentDatabase().isPresent()) {
+				tableEnv.useDatabase(sessionContext.getCurrentDatabase().get());
+			} else if (mergedEnv.getExecution().getCurrentDatabase().isPresent()) {
+				tableEnv.useDatabase(mergedEnv.getExecution().getCurrentDatabase().get());
 			}
 
 			// create query config

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -78,7 +78,6 @@ import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -304,19 +303,13 @@ public class ExecutionContext<T> {
 			catalogs.forEach(tableEnv::registerCatalog);
 
 			// set current catalog
-			Optional<String> potentialCatalog = Optional.empty();
 			if (sessionContext.getCurrentCatalog().isPresent()) {
-				potentialCatalog = sessionContext.getCurrentCatalog();
+				tableEnv.useCatalog(sessionContext.getCurrentCatalog().get());
 			} else if (mergedEnv.getExecution().getCurrentCatalog().isPresent()) {
-				potentialCatalog = mergedEnv.getExecution().getCurrentCatalog();
+				tableEnv.useCatalog(mergedEnv.getExecution().getCurrentCatalog().get());
 			}
 
-			// set current database to default
-			if (potentialCatalog.isPresent()) {
-				String currentCatalog = potentialCatalog.get();
-				tableEnv.useCatalog(currentCatalog);
-			}
-
+			// set current database
 			if (sessionContext.getCurrentDatabase().isPresent()) {
 				tableEnv.useDatabase(sessionContext.getCurrentDatabase().get());
 			} else if (mergedEnv.getExecution().getCurrentDatabase().isPresent()) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -315,13 +315,6 @@ public class ExecutionContext<T> {
 			if (potentialCatalog.isPresent()) {
 				String currentCatalog = potentialCatalog.get();
 				tableEnv.useCatalog(currentCatalog);
-
-				if (last command is use catalog) {
-					// set current db to the catalog's default db
-					sessionContext.setCurrentDatabase(tableEnv.getCatalog(currentCatalog).get().getDefaultDatabase());
-				} else if (last command is use database) {
-					// do nothing because sessionContext.current_db is the latest db
-				}
 			}
 
 			if (sessionContext.getCurrentDatabase().isPresent()) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -239,6 +239,7 @@ public class LocalExecutor implements Executor {
 
 		context.wrapClassLoader(() -> {
 			tableEnv.useCatalog(catalogName);
+			session.setCurrentCatalog(catalogName);
 			return null;
 		});
 	}
@@ -252,6 +253,7 @@ public class LocalExecutor implements Executor {
 
 		context.wrapClassLoader(() -> {
 			tableEnv.useDatabase(databaseName);
+			session.setCurrentDatabase(databaseName);
 			return null;
 		});
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -192,18 +192,24 @@ public class LocalExecutor implements Executor {
 
 	@Override
 	public List<String> listCatalogs(SessionContext session) throws SqlExecutionException {
-		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+
+		final TableEnvironment tableEnv = context
 			.createEnvironmentInstance()
 			.getTableEnvironment();
-		return Arrays.asList(tableEnv.listCatalogs());
+
+		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listCatalogs()));
 	}
 
 	@Override
 	public List<String> listDatabases(SessionContext session) throws SqlExecutionException {
-		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+
+		final TableEnvironment tableEnv = context
 			.createEnvironmentInstance()
 			.getTableEnvironment();
-		return Arrays.asList(tableEnv.listDatabases());
+
+		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listDatabases()));
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -238,8 +238,10 @@ public class LocalExecutor implements Executor {
 			.getTableEnvironment();
 
 		context.wrapClassLoader(() -> {
+			// Rely on TableEnvironment/CatalogManager to validate input
 			tableEnv.useCatalog(catalogName);
 			session.setCurrentCatalog(catalogName);
+			session.setCurrentDatabase(tableEnv.getCurrentDatabase());
 			return null;
 		});
 	}
@@ -252,6 +254,7 @@ public class LocalExecutor implements Executor {
 			.getTableEnvironment();
 
 		context.wrapClassLoader(() -> {
+			// Rely on TableEnvironment/CatalogManager to validate input
 			tableEnv.useDatabase(databaseName);
 			session.setCurrentDatabase(databaseName);
 			return null;

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -20,13 +20,19 @@ package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
@@ -165,6 +171,7 @@ public class DependencyTest {
 	 */
 	public static class TestHiveCatalogFactory extends HiveCatalogFactory {
 		public static final String ADDITIONAL_TEST_DATABASE = "additional_test_database";
+		public static final String TEST_TABLE = "test_table";
 
 		@Override
 		public Map<String, String> requiredContext() {
@@ -193,7 +200,20 @@ public class DependencyTest {
 					ADDITIONAL_TEST_DATABASE,
 					new CatalogDatabaseImpl(new HashMap<>(), null),
 					false);
-			} catch (DatabaseAlreadyExistException e) {
+				hiveCatalog.createTable(
+					new ObjectPath(ADDITIONAL_TEST_DATABASE, TEST_TABLE),
+					new CatalogTableImpl(
+						TableSchema.builder()
+							.field("testcol", DataTypes.INT())
+							.build(),
+						new HashMap<String, String>() {{
+							put(CatalogConfig.IS_GENERIC, String.valueOf(true));
+						}},
+						""
+					),
+					false
+				);
+			} catch (DatabaseAlreadyExistException | TableAlreadyExistException | DatabaseNotExistException e) {
 				throw new CatalogException(e);
 			}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR supports remembering current catalog and database that users set in SQL CLI SessionContext

## Brief change log

- added current catalog and database in SessionContext
- updated SQL commands execution logic

## Verifying this change

To be added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:(no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:(no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
