### PR TITLE
[FLINK-13181][Table]Add Builder to build CsvTableSink instances

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
@@ -82,6 +82,17 @@ public class CsvTableSink implements BatchTableSink<Row>, AppendStreamTableSink<
 		this(path, fieldDelim, -1, null);
 	}
 
+	/**
+	 * A simple {@link TableSink} to emit data as CSV files, with default parallelism.
+	 *
+	 * @param path       The output path to write the Table to.
+	 * @param fieldDelim The field delimiter
+	 * @param writeMode  The write mode to specify whether existing files are overwritten or not.
+	 */
+	public CsvTableSink(String path, String fieldDelim, FileSystem.WriteMode writeMode) {
+		this(path, fieldDelim, -1, writeMode);
+	}
+
 	@Override
 	public void emitDataSet(DataSet<Row> dataSet) {
 		MapOperator<Row, String> csvRows =

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
@@ -157,7 +157,7 @@ public class CsvTableSink implements BatchTableSink<Row>, AppendStreamTableSink<
 	/**
 	 * Return a new builder that builds a CsvTableSink. For example:
 	 * <pre>
-	 * CsvTableSource source = new CsvTableSource.builder()
+	 * CsvTableSink sink = new CsvTableSink.builder()
 	 *     .path("/path/to/..")
 	 *     .field("myfield", Types.STRING)
 	 *     .field("myfield2", Types.INT)

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
@@ -31,6 +31,8 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.types.Row;
 
+import java.util.LinkedHashMap;
+
 /**
  * A simple {@link TableSink} to emit data as CSV files.
  */
@@ -80,17 +82,6 @@ public class CsvTableSink implements BatchTableSink<Row>, AppendStreamTableSink<
 	 */
 	public CsvTableSink(String path, String fieldDelim) {
 		this(path, fieldDelim, -1, null);
-	}
-
-	/**
-	 * A simple {@link TableSink} to emit data as CSV files, with default parallelism.
-	 *
-	 * @param path       The output path to write the Table to.
-	 * @param fieldDelim The field delimiter
-	 * @param writeMode  The write mode to specify whether existing files are overwritten or not.
-	 */
-	public CsvTableSink(String path, String fieldDelim, FileSystem.WriteMode writeMode) {
-		this(path, fieldDelim, -1, writeMode);
 	}
 
 	@Override
@@ -161,6 +152,112 @@ public class CsvTableSink implements BatchTableSink<Row>, AppendStreamTableSink<
 	@Override
 	public TypeInformation<?>[] getFieldTypes() {
 		return fieldTypes;
+	}
+
+	/**
+	 * Return a new builder that builds a CsvTableSink. For example:
+	 * <pre>
+	 * CsvTableSource source = new CsvTableSource.builder()
+	 *     .path("/path/to/..")
+	 *     .field("myfield", Types.STRING)
+	 *     .field("myfield2", Types.INT)
+	 *     .build();
+	 * </pre>
+	 *
+	 * @return a new builder to build a CsvTableSink
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * A builder for creating CsvTableSink instances.
+	 */
+	public static class Builder {
+		private LinkedHashMap<String, TypeInformation<?>> schema = new LinkedHashMap<>();
+		private String path;
+		private String fieldDelim;
+		private int numFiles = -1; ;
+		private FileSystem.WriteMode writeMode;
+
+		/**
+		 * Sets the path to the CSV file. Required.
+		 *
+		 * @param path the path to the CSV file
+		 */
+		public Builder path(String path) {
+			this.path = path;
+			return this;
+		}
+
+		/**
+		 * Sets the field delimiter, "," by default.
+		 *
+		 * @param delim the field delimiter
+		 */
+		public Builder fieldDelimiter(String delim) {
+			this.fieldDelim = delim;
+			return this;
+		}
+
+		/**
+		 * Sets the number of files to write to.
+		 *
+		 * @param numFiles the number of files to write to
+		 */
+		public Builder numFiles(int numFiles) {
+			this.numFiles = numFiles;
+			return this;
+		}
+
+		/**
+		 * Sets the write mode to specify whether existing files are overwritten or not.
+		 *
+		 * @param writeMode the write mode to specify whether existing files are overwritten or not
+		 */
+		public Builder writeMode(FileSystem.WriteMode writeMode) {
+			this.writeMode = writeMode;
+			return this;
+		}
+
+		/**
+		 * Adds a field with the field name and the type information. This method can be
+		 * called multiple times. The call order of this method defines also the order of the fields
+		 * in a row.
+		 *
+		 * @param fieldName the field name
+		 * @param fieldType the type information of the field
+		 */
+		public Builder field(String fieldName, TypeInformation<?> fieldType) {
+			if (schema.containsKey(fieldName)) {
+				throw new IllegalArgumentException("Duplicate field name " + fieldName);
+			}
+			schema.put(fieldName, fieldType);
+			return this;
+		}
+
+		/**
+		 * Apply the current values and constructs a newly-created CsvTableSink.
+		 *
+		 * @return a newly-created CsvTableSink
+		 */
+		public CsvTableSink build() {
+			if (path == null) {
+				throw new IllegalArgumentException("Path must be defined.");
+			}
+
+			CsvTableSink csvTableSink = new CsvTableSink(
+				path,
+				fieldDelim,
+				numFiles,
+				writeMode);
+
+			if(schema.size() != 0){
+				csvTableSink.fieldNames = schema.keySet().toArray(new String[0]);
+				csvTableSink.fieldTypes	= schema.values().toArray(new TypeInformation<?>[0]);
+			}
+			return csvTableSink;
+		}
 	}
 
 	/**

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -123,6 +123,51 @@ class TableSinkITCase extends AbstractTestBase {
   }
 
   @Test
+  def testCsvTableSink(): Unit = {
+    val tmpFile = File.createTempFile("flink-table-sink-test", ".tmp")
+    tmpFile.deleteOnExit()
+    val path = tmpFile.toURI.toString
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.getConfig.enableObjectReuse()
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+
+    val tEnv = StreamTableEnvironment.create(env)
+    env.setParallelism(4)
+
+    val csvSink = CsvTableSink.builder()
+      .path(path)
+      .field("c",Types.STRING())
+      .field("b",Types.SQL_TIMESTAMP())
+      .build()
+
+    tEnv.registerTableSink("csvSink", csvSink)
+
+    val input = StreamTestData.get3TupleDataStream(env)
+      .assignAscendingTimestamps(_._2)
+      .map(x => x).setParallelism(4) // increase DOP to 4
+
+    input.toTable(tEnv, 'a, 'b.rowtime, 'c)
+      .where('a < 5 || 'a > 17)
+      .select('c, 'b)
+      .insertInto("csvSink")
+
+    env.execute()
+
+    val expected = Seq(
+      "Hi,1970-01-01 00:00:00.001",
+      "Hello,1970-01-01 00:00:00.002",
+      "Hello world,1970-01-01 00:00:00.002",
+      "Hello world, how are you?,1970-01-01 00:00:00.003",
+      "Comment#12,1970-01-01 00:00:00.006",
+      "Comment#13,1970-01-01 00:00:00.006",
+      "Comment#14,1970-01-01 00:00:00.006",
+      "Comment#15,1970-01-01 00:00:00.006").mkString("\n")
+
+    TestBaseUtils.compareResultsByLinesInMemory(expected, path)
+  }
+
+  @Test
   def testAppendSinkOnAppendTable(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()


### PR DESCRIPTION
## What is the purpose of the change

Add a constructor for CsvTableSink, because this will make constructors to be more and more.

## Brief change log

val csvSink = CsvTableSink.builder()
       .path(path)
       .field("c",Types.STRING())
       .field("b",Types.SQL_TIMESTAMP())
       .build()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)