### PR TITLE
[FLINK-13155][hotfix][e2e] fix SQL Client end-to-end test

### DIFF
--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -74,6 +74,7 @@ under the License.
 											Cites a binary dependency on jersey, but this is neither reflected in the
 											dependency graph, nor are any jersey files bundled. -->
 										<exclude>NOTICE</exclude>
+										<execude>common/**</execude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -520,6 +520,7 @@ under the License.
 									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-cep_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-sql-parser</include>
 									<include>org.jline:*</include>
 								</includes>
 							</artifactSet>


### PR DESCRIPTION
## What is the purpose of the change

This PR fix SQL Client end-to-end test

## Brief change log

* Exclude kafka json files in flink-sql-connector-kafka
* packaging flink-sql-parser into flink sql client jar

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
