### PR TITLE
[FLINK-13166] Add support for batch slot requests to SlotPoolImpl

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolFactory.java
@@ -42,13 +42,18 @@ public class DefaultSlotPoolFactory implements SlotPoolFactory {
 	@Nonnull
 	private final Time slotIdleTimeout;
 
+	@Nonnull
+	private final Time batchSlotTimeout;
+
 	public DefaultSlotPoolFactory(
 			@Nonnull Clock clock,
 			@Nonnull Time rpcTimeout,
-			@Nonnull Time slotIdleTimeout) {
+			@Nonnull Time slotIdleTimeout,
+			@Nonnull Time batchSlotTimeout) {
 		this.clock = clock;
 		this.rpcTimeout = rpcTimeout;
 		this.slotIdleTimeout = slotIdleTimeout;
+		this.batchSlotTimeout = batchSlotTimeout;
 	}
 
 	@Override
@@ -58,17 +63,20 @@ public class DefaultSlotPoolFactory implements SlotPoolFactory {
 			jobId,
 			clock,
 			rpcTimeout,
-			slotIdleTimeout);
+			slotIdleTimeout,
+			batchSlotTimeout);
 	}
 
 	public static DefaultSlotPoolFactory fromConfiguration(@Nonnull Configuration configuration) {
 
 		final Time rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
 		final Time slotIdleTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
+		final Time batchSlotTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
 
 		return new DefaultSlotPoolFactory(
 			SystemClock.getInstance(),
 			rpcTimeout,
-			slotIdleTimeout);
+			slotIdleTimeout,
+			batchSlotTimeout);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 import java.util.AbstractCollection;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Set;
 
 /**
@@ -33,17 +33,17 @@ import java.util.Set;
  * @param <B> Type of key B
  * @param <V> Type of the value
  */
-public class DualKeyMap<A, B, V> {
+public class DualKeyLinkedMap<A, B, V> {
 
-	private final HashMap<A, Tuple2<B, V>> aMap;
+	private final LinkedHashMap<A, Tuple2<B, V>> aMap;
 
-	private final HashMap<B, A> bMap;
+	private final LinkedHashMap<B, A> bMap;
 
 	private transient Collection<V> values;
 
-	public DualKeyMap(int initialCapacity) {
-		this.aMap = new HashMap<>(initialCapacity);
-		this.bMap = new HashMap<>(initialCapacity);
+	public DualKeyLinkedMap(int initialCapacity) {
+		this.aMap = new LinkedHashMap<>(initialCapacity);
+		this.bMap = new LinkedHashMap<>(initialCapacity);
 	}
 
 	public int size() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
-import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -163,7 +162,7 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
 		@Nonnull SlotRequestId slotRequestId,
 		@Nonnull ResourceProfile resourceProfile,
-		@RpcTimeout Time timeout);
+		Time timeout);
 
 	/**
 	 * Create report about the allocated slots belonging to the specified task manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -165,6 +165,20 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 		Time timeout);
 
 	/**
+	 * Requests the allocation of a new batch slot from the resource manager. Unlike the normal slot, a batch
+	 * slot will only time out if the slot pool does not contain a suitable slot. Moreover, it won't react to
+	 * failure signals from the resource manager.
+	 *
+	 * @param slotRequestId identifying the requested slot
+	 * @param resourceProfile resource profile that specifies the resource requirements for the requested batch slot
+	 * @return a future which is completed with newly allocated batch slot
+	 */
+	@Nonnull
+	CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
+		@Nonnull SlotRequestId slotRequestId,
+		@Nonnull ResourceProfile resourceProfile);
+
+	/**
 	 * Create report about the allocated slots belonging to the specified task manager.
 	 *
 	 * @param taskManagerId identifies the task manager

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -105,10 +106,10 @@ public class SlotPoolImpl implements SlotPool {
 	private final AvailableSlots availableSlots;
 
 	/** All pending requests waiting for slots. */
-	private final DualKeyMap<SlotRequestId, AllocationID, PendingRequest> pendingRequests;
+	private final DualKeyLinkedMap<SlotRequestId, AllocationID, PendingRequest> pendingRequests;
 
 	/** The requests that are waiting for the resource manager to be connected. */
-	private final HashMap<SlotRequestId, PendingRequest> waitingForResourceManager;
+	private final LinkedHashMap<SlotRequestId, PendingRequest> waitingForResourceManager;
 
 	/** Timeout for external request calls (e.g. to the ResourceManager or the TaskExecutor). */
 	private final Time rpcTimeout;
@@ -153,8 +154,8 @@ public class SlotPoolImpl implements SlotPool {
 		this.registeredTaskManagers = new HashSet<>(16);
 		this.allocatedSlots = new AllocatedSlots();
 		this.availableSlots = new AvailableSlots();
-		this.pendingRequests = new DualKeyMap<>(16);
-		this.waitingForResourceManager = new HashMap<>(16);
+		this.pendingRequests = new DualKeyLinkedMap<>(16);
+		this.waitingForResourceManager = new LinkedHashMap<>(16);
 
 		this.jobMasterId = null;
 		this.resourceManagerGateway = null;
@@ -857,7 +858,7 @@ public class SlotPoolImpl implements SlotPool {
 	}
 
 	@VisibleForTesting
-	DualKeyMap<SlotRequestId, AllocationID, PendingRequest> getPendingRequests() {
+	DualKeyLinkedMap<SlotRequestId, AllocationID, PendingRequest> getPendingRequests() {
 		return pendingRequests;
 	}
 
@@ -915,11 +916,11 @@ public class SlotPoolImpl implements SlotPool {
 		private final Map<ResourceID, Set<AllocatedSlot>> allocatedSlotsByTaskManager;
 
 		/** All allocated slots organized by AllocationID. */
-		private final DualKeyMap<AllocationID, SlotRequestId, AllocatedSlot> allocatedSlotsById;
+		private final DualKeyLinkedMap<AllocationID, SlotRequestId, AllocatedSlot> allocatedSlotsById;
 
 		AllocatedSlots() {
 			this.allocatedSlotsByTaskManager = new HashMap<>(16);
-			this.allocatedSlotsById = new DualKeyMap<>(16);
+			this.allocatedSlotsById = new DualKeyLinkedMap<>(16);
 		}
 
 		/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -36,10 +36,10 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.SchedulerImpl;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolImpl;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSharingManager;
+import org.apache.flink.runtime.jobmaster.slotpool.TestingSlotPoolImpl;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -71,7 +71,7 @@ public class SchedulerTestBase extends TestLogger {
 	@Before
 	public void setup() throws Exception {
 		final JobID jobId = new JobID();
-		final SlotPool slotPool = new SlotPoolImpl(jobId);
+		final SlotPool slotPool = new TestingSlotPoolImpl(jobId);
 		final TestingScheduler testingScheduler = new TestingScheduler(
 			new HashMap<>(16),
 			LocationPreferenceSlotSelectionStrategy.INSTANCE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -588,6 +588,12 @@ public class JobMasterTest extends TestLogger {
 			return new CompletableFuture<>();
 		}
 
+		@Nonnull
+		@Override
+		public CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile) {
+			return new CompletableFuture<>();
+		}
+
 		@Override
 		public AllocatedSlotReport createAllocatedSlotReport(ResourceID taskManagerId) {
 			final Collection<SlotInfo> slotInfos = registeredSlots.getOrDefault(taskManagerId, Collections.emptyList());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
@@ -32,9 +32,9 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Tests for the {@link DualKeyMap}.
+ * Tests for the {@link DualKeyLinkedMap}.
  */
-public class DualKeyMapTest extends TestLogger {
+public class DualKeyLinkedMapTest extends TestLogger {
 
 	@Test
 	public void testKeySets() {
@@ -48,7 +48,7 @@ public class DualKeyMapTest extends TestLogger {
 			keys.add(Tuple2.of(keyA, keyB));
 		}
 
-		final DualKeyMap<Integer, Integer, String> dualKeyMap = new DualKeyMap<>(capacity);
+		final DualKeyLinkedMap<Integer, Integer, String> dualKeyMap = new DualKeyLinkedMap<>(capacity);
 
 		for (Tuple2<Integer, Integer> key : keys) {
 			dualKeyMap.put(key.f0, key.f1, "foobar");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.clock.Clock;
+import org.apache.flink.runtime.util.clock.ManualClock;
+import org.apache.flink.runtime.util.clock.SystemClock;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for batch slot requests.
+ */
+public class SlotPoolBatchSlotRequestTest extends TestLogger {
+
+	private static final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1024);
+	private static final ResourceProfile smallerResourceProfile = new ResourceProfile(0.5, 512);
+	public static final CompletableFuture[] COMPLETABLE_FUTURES_EMPTY_ARRAY = new CompletableFuture[0];
+	private static ScheduledExecutorService singleThreadScheduledExecutorService;
+	private static ComponentMainThreadExecutor mainThreadExecutor;
+
+	@BeforeClass
+	public static void setupClass() {
+		singleThreadScheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+		mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(singleThreadScheduledExecutorService);
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		if (singleThreadScheduledExecutorService != null) {
+			singleThreadScheduledExecutorService.shutdownNow();
+		}
+	}
+
+	/**
+	 * Tests that a batch slot request fails if there is no slot which can fulfill the
+	 * slot request.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestTimeout() throws Exception {
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+				.build()) {
+			final CompletableFuture<PhysicalSlot> slotFuture = requestNewAllocatedBatchSlot(
+				slotPool,
+				mainThreadExecutor,
+				ResourceProfile.UNKNOWN);
+
+			try {
+				slotFuture.get();
+				fail("Expected that slot future times out.");
+			} catch (ExecutionException ee) {
+				assertThat(ExceptionUtils.stripExecutionException(ee), instanceOf(TimeoutException.class));
+			}
+		}
+	}
+
+	/**
+	 * Tests that a batch slot request won't time out if there exists a slot in the
+	 * SlotPool which fulfills the requested {@link ResourceProfile}.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestDoesNotTimeoutIfFulfillingSlotExists() throws Exception {
+		final Time batchSlotTimeout = Time.milliseconds(2L);
+		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+		final ManualClock clock = new ManualClock();
+
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+				.setComponentMainThreadExecutor(directMainThreadExecutor)
+				.setClock(clock)
+				.setBatchSlotTimeout(batchSlotTimeout)
+				.build()) {
+
+			offerSlots(slotPool, directMainThreadExecutor, Collections.singletonList(resourceProfile));
+
+			final CompletableFuture<PhysicalSlot> firstSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
+			final CompletableFuture<PhysicalSlot> secondSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, ResourceProfile.UNKNOWN);
+			final CompletableFuture<PhysicalSlot> thirdSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, smallerResourceProfile);
+
+			final List<CompletableFuture<PhysicalSlot>> slotFutures = Arrays.asList(firstSlotFuture, secondSlotFuture, thirdSlotFuture);
+			advanceTimeAndTriggerCheckBatchSlotTimeout(slotPool, clock, batchSlotTimeout);
+
+			for (CompletableFuture<PhysicalSlot> slotFuture : slotFutures) {
+				assertThat(slotFuture.isDone(), is(false));
+			}
+		}
+
+	}
+
+	/**
+	 * Tests that a batch slot request does not react to {@link SlotPool#failAllocation(AllocationID, Exception)}
+	 * signals.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestDoesNotFailIfAllocationFails() throws Exception {
+		final TestingResourceManagerGateway testingResourceManagerGateway = new TestingResourceManagerGateway();
+		final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
+		testingResourceManagerGateway.setRequestSlotConsumer(slotRequest -> allocationIdFuture.complete(slotRequest.getAllocationId()));
+
+		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+
+		final Time batchSlotTimeout = Time.milliseconds(1000L);
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+			.setComponentMainThreadExecutor(directMainThreadExecutor)
+			.setBatchSlotTimeout(batchSlotTimeout)
+			.setResourceManagerGateway(testingResourceManagerGateway)
+			.build()) {
+
+			final CompletableFuture<PhysicalSlot> slotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
+
+			failAllocation(slotPool, directMainThreadExecutor, allocationIdFuture.get());
+
+			assertThat(slotFuture.isDone(), is(false));
+		}
+	}
+
+	/**
+	 * Tests that a batch slot request won't fail if its resource manager request fails.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestDoesNotFailIfRMRequestFails() throws Exception {
+		final TestingResourceManagerGateway testingResourceManagerGateway = new TestingResourceManagerGateway();
+		testingResourceManagerGateway.setRequestSlotFuture(FutureUtils.completedExceptionally(new FlinkException("Failed request")));
+
+		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+
+		final Time batchSlotTimeout = Time.milliseconds(1000L);
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+			.setComponentMainThreadExecutor(directMainThreadExecutor)
+			.setBatchSlotTimeout(batchSlotTimeout)
+			.setResourceManagerGateway(testingResourceManagerGateway)
+			.build()) {
+
+			final CompletableFuture<PhysicalSlot> slotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
+
+			assertThat(slotFuture.isDone(), is(false));
+		}
+	}
+
+	/**
+	 * Tests that a pending batch slot request times out after the last fulfilling slot gets
+	 * released.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestTimeoutAfterSlotRelease() throws Exception {
+		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+		final ManualClock clock = new ManualClock();
+		final Time batchSlotTimeout = Time.milliseconds(1000L);
+
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+				.setComponentMainThreadExecutor(directMainThreadExecutor)
+				.setClock(clock)
+				.setBatchSlotTimeout(batchSlotTimeout)
+				.build()) {
+			final ResourceID taskManagerResourceId = offerSlots(slotPool, directMainThreadExecutor, Collections.singletonList(resourceProfile));
+			final CompletableFuture<PhysicalSlot> firstSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
+			final CompletableFuture<PhysicalSlot> secondSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, ResourceProfile.UNKNOWN);
+			final CompletableFuture<PhysicalSlot> thirdSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, smallerResourceProfile);
+
+			final List<CompletableFuture<PhysicalSlot>> slotFutures = Arrays.asList(firstSlotFuture, secondSlotFuture, thirdSlotFuture);
+
+			// initial batch slot timeout check
+			advanceTimeAndTriggerCheckBatchSlotTimeout(slotPool, clock, batchSlotTimeout);
+
+			assertThat(CompletableFuture.anyOf(slotFutures.toArray(COMPLETABLE_FUTURES_EMPTY_ARRAY)).isDone(), is(false));
+
+			releaseTaskManager(slotPool, directMainThreadExecutor, taskManagerResourceId);
+
+			advanceTimeAndTriggerCheckBatchSlotTimeout(slotPool, clock, batchSlotTimeout);
+
+			for (CompletableFuture<PhysicalSlot> slotFuture : slotFutures) {
+				assertThat(slotFuture.isCompletedExceptionally(), is(true));
+
+				try {
+					slotFuture.get();
+					fail("Expected that the slot future times out.");
+				} catch (ExecutionException ee) {
+					assertThat(ExceptionUtils.stripExecutionException(ee), instanceOf(TimeoutException.class));
+				}
+			}
+		}
+	}
+
+	private void advanceTimeAndTriggerCheckBatchSlotTimeout(SlotPoolImpl slotPool, ManualClock clock, Time batchSlotTimeout) {
+		// trigger batch slot timeout check which marks unfulfillable slots
+		slotPool.triggerCheckBatchSlotTimeout();
+
+		// advance clock behind timeout
+		clock.advanceTime(batchSlotTimeout.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+
+		// timeout all as unfulfillable marked slots
+		slotPool.triggerCheckBatchSlotTimeout();
+	}
+
+	private CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
+			SlotPool slotPool,
+			ComponentMainThreadExecutor mainThreadExecutor,
+			ResourceProfile resourceProfile) {
+		return CompletableFuture
+			.supplyAsync(() -> slotPool.requestNewAllocatedBatchSlot(new SlotRequestId(), resourceProfile), mainThreadExecutor)
+			.thenCompose(Function.identity());
+	}
+
+	private ResourceID offerSlots(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, List<ResourceProfile> resourceProfiles) {
+		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		CompletableFuture.runAsync(
+			() -> {
+				slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+				final Collection<SlotOffer> slotOffers = IntStream
+					.range(0, resourceProfiles.size())
+					.mapToObj(i -> new SlotOffer(new AllocationID(), i, resourceProfiles.get(i)))
+					.collect(Collectors.toList());
+
+				final Collection<SlotOffer> acceptedOffers = slotPool.offerSlots(
+					taskManagerLocation,
+					new SimpleAckingTaskManagerGateway(),
+					slotOffers);
+
+				assertThat(acceptedOffers, is(slotOffers));
+			},
+			mainThreadExecutor
+		).join();
+
+		return taskManagerLocation.getResourceID();
+	}
+
+	private void failAllocation(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, AllocationID allocationId) {
+		CompletableFuture.runAsync(
+			() -> slotPool.failAllocation(allocationId, new FlinkException("Test exception")),
+			mainThreadExecutor).join();
+	}
+
+	private void releaseTaskManager(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, ResourceID taskManagerResourceId) {
+		CompletableFuture.runAsync(
+			() -> slotPool.releaseTaskManager(taskManagerResourceId, new FlinkException("Let's get rid of the offered slot.")),
+			mainThreadExecutor
+		).join();
+	}
+
+	private static class SlotPoolBuilder {
+
+		private ComponentMainThreadExecutor componentMainThreadExecutor = mainThreadExecutor;
+		private ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
+		private Time batchSlotTimeout = Time.milliseconds(2L);
+		private Clock clock = SystemClock.getInstance();
+
+		private SlotPoolBuilder setComponentMainThreadExecutor(ComponentMainThreadExecutor componentMainThreadExecutor) {
+			this.componentMainThreadExecutor = componentMainThreadExecutor;
+			return this;
+		}
+
+		private SlotPoolBuilder setResourceManagerGateway(ResourceManagerGateway resourceManagerGateway) {
+			this.resourceManagerGateway = resourceManagerGateway;
+			return this;
+		}
+
+		private SlotPoolBuilder setBatchSlotTimeout(Time batchSlotTimeout) {
+			this.batchSlotTimeout = batchSlotTimeout;
+			return this;
+		}
+
+		private SlotPoolBuilder setClock(Clock clock) {
+			this.clock = clock;
+			return this;
+		}
+
+		private SlotPoolImpl build() throws Exception {
+			final SlotPoolImpl slotPool = new SlotPoolImpl(
+				new JobID(),
+				clock,
+				TestingUtils.infiniteTime(),
+				TestingUtils.infiniteTime(),
+				batchSlotTimeout);
+
+			slotPool.start(JobMasterId.generate(), "foobar", componentMainThreadExecutor);
+
+			CompletableFuture.runAsync(() -> slotPool.connectToResourceManager(resourceManagerGateway), componentMainThreadExecutor).join();
+
+			return slotPool;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
@@ -121,7 +121,7 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
 		final ManualClock clock = new ManualClock();
 
-		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+		try (final TestingSlotPoolImpl slotPool = new SlotPoolBuilder()
 				.setComponentMainThreadExecutor(directMainThreadExecutor)
 				.setClock(clock)
 				.setBatchSlotTimeout(batchSlotTimeout)
@@ -203,7 +203,7 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		final ManualClock clock = new ManualClock();
 		final Time batchSlotTimeout = Time.milliseconds(1000L);
 
-		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+		try (final TestingSlotPoolImpl slotPool = new SlotPoolBuilder()
 				.setComponentMainThreadExecutor(directMainThreadExecutor)
 				.setClock(clock)
 				.setBatchSlotTimeout(batchSlotTimeout)
@@ -237,7 +237,7 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		}
 	}
 
-	private void advanceTimeAndTriggerCheckBatchSlotTimeout(SlotPoolImpl slotPool, ManualClock clock, Time batchSlotTimeout) {
+	private void advanceTimeAndTriggerCheckBatchSlotTimeout(TestingSlotPoolImpl slotPool, ManualClock clock, Time batchSlotTimeout) {
 		// trigger batch slot timeout check which marks unfulfillable slots
 		slotPool.triggerCheckBatchSlotTimeout();
 
@@ -321,8 +321,8 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 			return this;
 		}
 
-		private SlotPoolImpl build() throws Exception {
-			final SlotPoolImpl slotPool = new SlotPoolImpl(
+		private TestingSlotPoolImpl build() throws Exception {
+			final TestingSlotPoolImpl slotPool = new TestingSlotPoolImpl(
 				new JobID(),
 				clock,
 				TestingUtils.infiniteTime(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -512,10 +512,11 @@ public class SlotPoolImplTest extends TestLogger {
 		final ManualClock clock = new ManualClock();
 
 		try (SlotPoolImpl slotPool = new SlotPoolImpl(
-			jobId,
-			clock,
-			TestingUtils.infiniteTime(),
-			timeout)) {
+				jobId,
+				clock,
+				TestingUtils.infiniteTime(),
+				timeout,
+				TestingUtils.infiniteTime())) {
 			final BlockingQueue<AllocationID> freedSlots = new ArrayBlockingQueue<>(1);
 			taskManagerGateway.setFreeSlotFunction(
 				(AllocationID allocationId, Throwable cause) -> {
@@ -565,10 +566,11 @@ public class SlotPoolImplTest extends TestLogger {
 		final ManualClock clock = new ManualClock();
 
 		try (SlotPoolImpl slotPool = new SlotPoolImpl(
-			jobId,
-			clock,
-			TestingUtils.infiniteTime(),
-			timeout)) {
+				jobId,
+				clock,
+				TestingUtils.infiniteTime(),
+				timeout,
+				TestingUtils.infiniteTime())) {
 
 			setupSlotPool(slotPool, resourceManagerGateway, mainThreadExecutor);
 			Scheduler scheduler = setupScheduler(slotPool, mainThreadExecutor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -717,39 +717,6 @@ public class SlotPoolImplTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that failing an allocation fails the pending slot request.
-	 */
-	@Test
-	public void testFailingAllocationFailsPendingSlotRequests() throws Exception {
-
-		try (SlotPoolImpl slotPool = new SlotPoolImpl(jobId)) {
-			final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
-			resourceManagerGateway.setRequestSlotConsumer(slotRequest -> allocationIdFuture.complete(slotRequest.getAllocationId()));
-
-			setupSlotPool(slotPool, resourceManagerGateway, mainThreadExecutor);
-			Scheduler scheduler = setupScheduler(slotPool, mainThreadExecutor);
-
-			final CompletableFuture<LogicalSlot> slotFuture = allocateSlot(scheduler, new SlotRequestId());
-
-			final AllocationID allocationId = allocationIdFuture.get();
-
-			assertThat(slotFuture.isDone(), is(false));
-
-			final FlinkException cause = new FlinkException("Fail pending slot request failure.");
-			final Optional<ResourceID> responseFuture = slotPool.failAllocation(allocationId, cause);
-
-			assertThat(responseFuture.isPresent(), is(false));
-
-			try {
-				slotFuture.get();
-				fail("Expected a slot allocation failure.");
-			} catch (ExecutionException ee) {
-				assertThat(ExceptionUtils.stripExecutionException(ee), equalTo(cause));
-			}
-		}
-	}
-
-	/**
 	 * Tests that create report of allocated slots on a {@link TaskExecutor}.
 	 */
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
@@ -86,6 +86,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 			jid,
 			SystemClock.getInstance(),
 			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime()
 		)) {
 
@@ -113,11 +114,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 	public void testCancelSlotAllocationWithoutResourceManager() throws Exception {
 		final JobID jid = new JobID();
 
-		try (TestingSlotPool pool = new TestingSlotPool(
-			jid,
-			SystemClock.getInstance(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (TestingSlotPool pool = createTestingSlotPool(jid)) {
 
 			final CompletableFuture<SlotRequestId> timeoutFuture = new CompletableFuture<>();
 			pool.setTimeoutPendingSlotRequestConsumer(timeoutFuture::complete);
@@ -147,6 +144,16 @@ public class SlotPoolInteractionsTest extends TestLogger {
 		}
 	}
 
+	@Nonnull
+	private TestingSlotPool createTestingSlotPool(JobID jid) {
+		return new TestingSlotPool(
+			jid,
+			SystemClock.getInstance(),
+			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime());
+	}
+
 	/**
 	 * Tests that a slot allocation times out wrt to the specified time out.
 	 */
@@ -154,11 +161,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 	public void testSlotAllocationTimeout() throws Exception {
 		final JobID jid = new JobID();
 
-		try (TestingSlotPool pool = new TestingSlotPool(
-			jid,
-			SystemClock.getInstance(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (TestingSlotPool pool = createTestingSlotPool(jid)) {
 
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
 
@@ -200,11 +203,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 	public void testExtraSlotsAreKept() throws Exception {
 		final JobID jid = new JobID();
 
-		try (TestingSlotPool pool = new TestingSlotPool(
-			jid,
-			SystemClock.getInstance(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (TestingSlotPool pool = createTestingSlotPool(jid)) {
 
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
 
@@ -266,11 +265,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 	public void testProviderAndOwnerSlotAllocationTimeout() throws Exception {
 		final JobID jid = new JobID();
 
-		try (TestingSlotPool pool = new TestingSlotPool(
-			jid,
-			SystemClock.getInstance(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (TestingSlotPool pool = createTestingSlotPool(jid)) {
 
 			final CompletableFuture<SlotRequestId> releaseSlotFuture = new CompletableFuture<>();
 
@@ -316,12 +311,14 @@ public class SlotPoolInteractionsTest extends TestLogger {
 				JobID jobId,
 				Clock clock,
 				Time rpcTimeout,
-				Time idleSlotTimeout) {
+				Time idleSlotTimeout,
+				Time batchSlotTimeout) {
 			super(
 				jobId,
 				clock,
 				rpcTimeout,
-				idleSlotTimeout);
+				idleSlotTimeout,
+				batchSlotTimeout);
 
 			releaseSlotConsumer = null;
 			timeoutPendingSlotRequestConsumer = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
@@ -175,7 +175,7 @@ public class SlotPoolPendingRequestFailureTest extends TestLogger {
 	}
 
 	private SlotPoolImpl setUpSlotPool(ComponentMainThreadExecutor componentMainThreadExecutor) throws Exception {
-		final SlotPoolImpl slotPool = new SlotPoolImpl(jobId);
+		final SlotPoolImpl slotPool = new TestingSlotPoolImpl(jobId);
 		slotPool.start(JobMasterId.generate(), "foobar", componentMainThreadExecutor);
 		slotPool.connectToResourceManager(resourceManagerGateway);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the failing of pending slot requests at the {@link SlotPool}.
+ */
+public class SlotPoolPendingRequestFailureTest extends TestLogger {
+
+	private static final JobID jobId = new JobID();
+
+	private static final ComponentMainThreadExecutor mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+	public static final Time TIMEOUT = Time.seconds(10L);
+
+	private TestingResourceManagerGateway resourceManagerGateway;
+
+	@Before
+	public void setup() {
+		resourceManagerGateway = new TestingResourceManagerGateway();
+	}
+
+	/**
+	 * Tests that failing an allocation fails the pending slot request.
+	 */
+	@Test
+	public void testFailingAllocationFailsPendingSlotRequests() throws Exception {
+		final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
+		resourceManagerGateway.setRequestSlotConsumer(slotRequest -> allocationIdFuture.complete(slotRequest.getAllocationId()));
+
+		try (SlotPoolImpl slotPool = setupSlotPool()) {
+
+			final CompletableFuture<PhysicalSlot> slotFuture = requestNewAllocatedSlot(slotPool, new SlotRequestId());
+
+			final AllocationID allocationId = allocationIdFuture.get();
+
+			assertThat(slotFuture.isDone(), is(false));
+
+			final FlinkException cause = new FlinkException("Fail pending slot request failure.");
+			final Optional<ResourceID> responseFuture = slotPool.failAllocation(allocationId, cause);
+
+			assertThat(responseFuture.isPresent(), is(false));
+
+			try {
+				slotFuture.get();
+				fail("Expected a slot allocation failure.");
+			} catch (ExecutionException ee) {
+				assertThat(ExceptionUtils.stripExecutionException(ee), equalTo(cause));
+			}
+		}
+	}
+
+	private CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(SlotPoolImpl slotPool, SlotRequestId slotRequestId) {
+		return slotPool.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, TIMEOUT);
+	}
+
+	private SlotPoolImpl setupSlotPool() throws Exception {
+		final SlotPoolImpl slotPool = new SlotPoolImpl(jobId);
+		slotPool.start(JobMasterId.generate(), "foobar", mainThreadExecutor);
+		slotPool.connectToResourceManager(resourceManagerGateway);
+
+		return slotPool;
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
@@ -121,7 +121,7 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 	}
 
 	private SlotPoolImpl setUpSlotPool() throws Exception {
-		final SlotPoolImpl slotPool = new SlotPoolImpl(new JobID());
+		final SlotPoolImpl slotPool = new TestingSlotPoolImpl(new JobID());
 
 		slotPool.start(JobMasterId.generate(), "foobar", ComponentMainThreadExecutorServiceAdapter.forMainThread());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.CheckedSupplier;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Tests how the {@link SlotPoolImpl} completes slot requests.
+ */
+public class SlotPoolRequestCompletionTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.seconds(10L);
+
+	/**
+	 * Tests that the {@link SlotPoolImpl} completes slots in request order.
+	 */
+	@Test
+	public void testRequestsAreCompletedInRequestOrder() throws Exception {
+		runSlotRequestCompletionTest(
+			CheckedSupplier.unchecked(this::setUpSlotPoolAndConnectToResourceManager),
+			slotPool -> {});
+	}
+
+	/**
+	 * Tests that the {@link SlotPoolImpl} completes stashed slot requests in request order.
+	 */
+	@Test
+	public void testStashOrderMaintainsRequestOrder() throws Exception {
+		runSlotRequestCompletionTest(
+			CheckedSupplier.unchecked(this::setUpSlotPool),
+			this::connectToResourceManager);
+	}
+
+	private void runSlotRequestCompletionTest(
+		Supplier<SlotPoolImpl> slotPoolSupplier,
+		Consumer<SlotPoolImpl> actionAfterSlotRequest) throws Exception {
+		try (final SlotPoolImpl slotPool = slotPoolSupplier.get()) {
+
+			final List<SlotRequestId> slotRequestIds = IntStream.range(0, 10)
+				.mapToObj(ignored -> new SlotRequestId())
+				.collect(Collectors.toList());
+
+			final List<CompletableFuture<PhysicalSlot>> slotRequests = slotRequestIds
+				.stream()
+				.map(slotRequestId -> slotPool.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, TIMEOUT))
+				.collect(Collectors.toList());
+
+			actionAfterSlotRequest.accept(slotPool);
+
+			final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+			slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+			final SlotOffer slotOffer = new SlotOffer(new AllocationID(), 0, ResourceProfile.UNKNOWN);
+			final Collection<SlotOffer> acceptedSlots = slotPool.offerSlots(taskManagerLocation, new SimpleAckingTaskManagerGateway(), Collections.singleton(slotOffer));
+
+			assertThat(acceptedSlots, containsInAnyOrder(slotOffer));
+
+			final FlinkException testingReleaseException = new FlinkException("Testing release exception");
+
+			// check that the slot requests get completed in sequential order
+			for (int i = 0; i < slotRequestIds.size(); i++) {
+				final CompletableFuture<PhysicalSlot> slotRequestFuture = slotRequests.get(i);
+				slotRequestFuture.get();
+				slotPool.releaseSlot(slotRequestIds.get(i), testingReleaseException);
+			}
+		}
+	}
+
+	private SlotPoolImpl setUpSlotPoolAndConnectToResourceManager() throws Exception {
+		final SlotPoolImpl slotPool = setUpSlotPool();
+		connectToResourceManager(slotPool);
+
+		return slotPool;
+	}
+
+	private void connectToResourceManager(SlotPoolImpl slotPool) {
+		slotPool.connectToResourceManager(new TestingResourceManagerGateway());
+	}
+
+	private SlotPoolImpl setUpSlotPool() throws Exception {
+		final SlotPoolImpl slotPool = new SlotPoolImpl(new JobID());
+
+		slotPool.start(JobMasterId.generate(), "foobar", ComponentMainThreadExecutorServiceAdapter.forMainThread());
+
+		return slotPool;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolResource.java
@@ -78,7 +78,7 @@ public class SlotPoolResource extends ExternalResource {
 
 		testingResourceManagerGateway = new TestingResourceManagerGateway();
 
-		slotPool = new SlotPoolImpl(new JobID());
+		slotPool = new TestingSlotPoolImpl(new JobID());
 		scheduler = new SchedulerImpl(schedulingStrategy, slotPool);
 		slotPool.start(JobMasterId.generate(), "foobar", mainThreadExecutor);
 		scheduler.start(mainThreadExecutor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.util.clock.Clock;
+import org.apache.flink.runtime.util.clock.SystemClock;
+
+/**
+ * Testing extension of the {@link SlotPoolImpl} which adds additional methods
+ * for testing.
+ */
+public class TestingSlotPoolImpl extends SlotPoolImpl {
+
+	public TestingSlotPoolImpl(JobID jobId) {
+		this(
+			jobId,
+			SystemClock.getInstance(),
+			AkkaUtils.getDefaultTimeout(),
+			AkkaUtils.getDefaultTimeout(),
+			Time.milliseconds(JobManagerOptions.SLOT_IDLE_TIMEOUT.defaultValue()));
+	}
+
+	public TestingSlotPoolImpl(
+			JobID jobId,
+			Clock clock,
+			Time rpcTimeout,
+			Time idleSlotTimeout,
+			Time batchSlotTimeout) {
+		super(jobId, clock, rpcTimeout, idleSlotTimeout, batchSlotTimeout);
+	}
+
+	void triggerCheckIdleSlot() {
+		runAsync(this::checkIdleSlot);
+	}
+
+	void triggerCheckBatchSlotTimeout() {
+		runAsync(this::checkBatchSlotTimeout);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #9043.

This commit adds a new type of slot request which can be issued to the SlotPoolImpl.
The batch slot request is intended for batch jobs which can be executed with a single
slot (having at least one slot for every requested resource profile equivalence class).
Usually, a job which fulfills this criterion must not contain a pipelined shuffle.

The new batch slot request behaves in the following aspects differently than the normal
slot request:

* Batch slot request don't time out if the SlotPool contains at least one allocated slot
which can fulfill the pending slot request
* Batch slot request don't react to the failAllocation signal from the ResourceManager
* Batch slot request don't fail if the slot request to the resource manager fails

In order to time out batch slot request which cannot be fulfilled with an allocated slot,
the SlotPoolImpl schedules a periodic task which checks for this condition. If a slot cannot
be fulfilled, it is marked as unfulfillable and the current timestamp is recorded. If the
slot cannot be marked as fulfillable until the batch slot timeout has been exceeded, the
slot request will be timed out.

The batch slot request will be requested by calling SlotPool#requestNewAllocatedBatchSlot.

cc @xintongsong @StephanEwen 

## Verifying this change

Added `SlotPoolBatchSlotRequestTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
