### PR TITLE
[FLINK-13141][network] Remove getBufferSize method from BufferPoolFactory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -101,7 +101,8 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 			fileChannelManager,
 			networkBufferPool,
 			config.networkBuffersPerChannel(),
-			config.floatingNetworkBuffersPerGate());
+			config.floatingNetworkBuffersPerGate(),
+			config.networkBufferSize());
 
 		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
 			taskExecutorResourceId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactory.java
@@ -58,10 +58,4 @@ public interface BufferPoolFactory {
 	 * Destroy callback for updating factory book keeping.
 	 */
 	void destroyBufferPool(BufferPool bufferPool) throws IOException;
-
-	/**
-	 * Gets the size of the buffers in the buffer pools produced by this factory.
-	 */
-	int getBufferSize();
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -121,11 +121,6 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 				allocatedMb, availableMemorySegments.size(), segmentSize);
 	}
 
-	@Override
-	public int getBufferSize() {
-		return memorySegmentSize;
-	}
-
 	@Nullable
 	public MemorySegment requestMemorySegment() {
 		return availableMemorySegments.poll();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -61,18 +61,22 @@ public class ResultPartitionFactory {
 
 	private final int floatingNetworkBuffersPerGate;
 
+	private final int networkBufferSize;
+
 	public ResultPartitionFactory(
 		@Nonnull ResultPartitionManager partitionManager,
 		@Nonnull FileChannelManager channelManager,
 		@Nonnull BufferPoolFactory bufferPoolFactory,
 		int networkBuffersPerChannel,
-		int floatingNetworkBuffersPerGate) {
+		int floatingNetworkBuffersPerGate,
+		int networkBufferSize) {
 
 		this.partitionManager = partitionManager;
 		this.channelManager = channelManager;
 		this.networkBuffersPerChannel = networkBuffersPerChannel;
 		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
 		this.bufferPoolFactory = bufferPoolFactory;
+		this.networkBufferSize = networkBufferSize;
 	}
 
 	public ResultPartition create(
@@ -119,7 +123,7 @@ public class ResultPartitionFactory {
 				partitionManager,
 				bufferPoolFactory);
 
-		createSubpartitions(partition, type, subpartitions, this.bufferPoolFactory.getBufferSize());
+		createSubpartitions(partition, type, subpartitions);
 
 		LOG.debug("{}: Initialized {}", taskNameWithSubtaskAndId, this);
 
@@ -129,8 +133,7 @@ public class ResultPartitionFactory {
 	private void createSubpartitions(
 			ResultPartition partition,
 			ResultPartitionType type,
-			ResultSubpartition[] subpartitions,
-			int networkBufferSize) {
+			ResultSubpartition[] subpartitions) {
 
 		// Create the subpartitions.
 		switch (type) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -52,6 +52,8 @@ public class ResultPartitionBuilder {
 
 	private int floatingNetworkBuffersPerGate = 1;
 
+	private int networkBufferSize = 1;
+
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	private Optional<FunctionWithException<BufferPoolOwner, BufferPool, IOException>> bufferPoolFactory = Optional.empty();
 
@@ -90,6 +92,7 @@ public class ResultPartitionBuilder {
 	public ResultPartitionBuilder setupBufferPoolFactoryFromNettyShuffleEnvironment(NettyShuffleEnvironment environment) {
 		return setNetworkBuffersPerChannel(environment.getConfiguration().networkBuffersPerChannel())
 			.setFloatingNetworkBuffersPerGate(environment.getConfiguration().floatingNetworkBuffersPerGate())
+			.setNetworkBufferSize(environment.getConfiguration().networkBufferSize())
 			.setNetworkBufferPool(environment.getNetworkBufferPool());
 	}
 
@@ -105,6 +108,11 @@ public class ResultPartitionBuilder {
 
 	private ResultPartitionBuilder setFloatingNetworkBuffersPerGate(int floatingNetworkBuffersPerGate) {
 		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
+		return this;
+	}
+
+	public ResultPartitionBuilder setNetworkBufferSize(int networkBufferSize) {
+		this.networkBufferSize = networkBufferSize;
 		return this;
 	}
 
@@ -125,7 +133,8 @@ public class ResultPartitionBuilder {
 			channelManager,
 			networkBufferPool,
 			networkBuffersPerChannel,
-			floatingNetworkBuffersPerGate);
+			floatingNetworkBuffersPerGate,
+			networkBufferSize);
 
 		FunctionWithException<BufferPoolOwner, BufferPool, IOException> factory = bufferPoolFactory.orElseGet(() ->
 			resultPartitionFactory.createBufferPoolFactory(numberOfSubpartitions, partitionType));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -74,8 +74,8 @@ public class ResultPartitionFactoryTest extends TestLogger {
 			fileChannelManager,
 			new NetworkBufferPool(1, 64, 1),
 			1,
-			1
-		);
+			1,
+			64);
 
 		ResultPartitionType partitionType = ResultPartitionType.BLOCKING;
 		final ResultPartitionDeploymentDescriptor descriptor = new ResultPartitionDeploymentDescriptor(


### PR DESCRIPTION
## What is the purpose of the change

*`BufferPoolFactory#getBufferSize` is only used for creating subpartitions in `ResultPartitionFactory`. We could pass the network buffer size from `NettyShuffleEnvironmentConfiguration` while constructing the `ResultPartitionFactory`, then the interface method `getBufferSize` could be removed form `BufferPoolFactory`.*

## Brief change log

  - *Pass network buffer size while constructing `ResultPartitionFactory`*
  - *Support update network buffer size in `ResultPartitionBuilder`*
  - *Remove `getBufferSize` from `BufferPoolFactory`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)