### PR TITLE
[FLINK-13100][network] Fix the bug of throwing IOException while FileChannelBoundedData#nextBuffer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -153,6 +153,13 @@ public class NettyShuffleEnvironmentOptions {
 					"tasks have occupied all the buffers and the downstream tasks are waiting for the exclusive buffers. The timeout breaks" +
 					"the tie by failing the request of exclusive buffers and ask users to increase the number of total buffers.");
 
+	@Documentation.ExcludeFromDocumentation("This option is only used for testing at the moment.")
+	public static final ConfigOption<String> NETWORK_BOUNDED_BLOCKING_SUBPARTITION_TYPE =
+		key("taskmanager.network.bounded-blocking-subpartition-type")
+			.defaultValue("auto")
+			.withDescription("The bounded blocking subpartition type, either \"mmap\" or \"file\". The default \"auto\" means selecting the" +
+					"property type automatically based on system memory architecture.");
+
 	// ------------------------------------------------------------------------
 	//  Netty Options
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -101,6 +101,7 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 			resultPartitionManager,
 			fileChannelManager,
 			networkBufferPool,
+			config.getBlockingSubpartitionType(),
 			config.networkBuffersPerChannel(),
 			config.floatingNetworkBuffersPerGate(),
 			config.networkBufferSize());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -198,9 +198,8 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 
 			availability.notifyDataAvailable();
 
-			final BoundedData.Reader dataReader = data.createReader();
 			final BoundedBlockingSubpartitionReader reader = new BoundedBlockingSubpartitionReader(
-					this, dataReader, numDataBuffersWritten);
+					this, data, numDataBuffersWritten, availability);
 			readers.add(reader);
 			return reader;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionType.java
@@ -64,6 +64,19 @@ public enum BoundedBlockingSubpartitionType {
 		public BoundedBlockingSubpartition create(int index, ResultPartition parent, File tempFile, int readBufferSize) throws IOException {
 			return BoundedBlockingSubpartition.createWithFileAndMemoryMappedReader(index, parent, tempFile);
 		}
+	},
+
+	/**
+	 * Selects the BoundedBlockingSubpartition type based on the current memory architecture. If 64-bit,
+	 * the type of {@link BoundedBlockingSubpartitionType#FILE_MMAP} is recommended. Otherwise, the type
+	 * of {@link BoundedBlockingSubpartitionType#FILE} is by default.
+	 */
+	AUTO {
+
+		@Override
+		public BoundedBlockingSubpartition create(int index, ResultPartition parent, File tempFile, int readBufferSize) throws IOException {
+			return ResultPartitionFactory.getBoundedBlockingType().create(index, parent, tempFile, readBufferSize);
+		}
 	};
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedData.java
@@ -34,7 +34,7 @@ import java.io.IOException;
  * through the {@link #writeBuffer(Buffer)} method.
  * The write phase is ended by calling {@link #finishWrite()}.
  * After the write phase is finished, the data can be read multiple times through readers created
- * via {@link #createReader()}.
+ * via {@link #createReader(ResultSubpartitionView)}.
  * Finally, the BoundedData is dropped / deleted by calling {@link #close()}.
  *
  * <h2>Thread Safety and Concurrency</h2>
@@ -60,7 +60,15 @@ interface BoundedData extends Closeable {
 	 * Gets a reader for the bounded data. Multiple readers may be created.
 	 * This call only succeeds once the write phase was finished via {@link #finishWrite()}.
 	 */
-	BoundedData.Reader createReader() throws IOException;
+	BoundedData.Reader createReader(ResultSubpartitionView subpartitionView) throws IOException;
+
+	/**
+	 * Gets a reader for the bounded data. Multiple readers may be created.
+	 * This call only succeeds once the write phase was finished via {@link #finishWrite()}.
+	 */
+	default BoundedData.Reader createReader() throws IOException {
+		return createReader(new NoOpResultSubpartitionView());
+	}
 
 	/**
 	 * Gets the number of bytes of all written data (including the metadata in the buffer headers).

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/FileChannelMemoryMappedBoundedData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/FileChannelMemoryMappedBoundedData.java
@@ -123,7 +123,7 @@ final class FileChannelMemoryMappedBoundedData implements BoundedData {
 	}
 
 	@Override
-	public BoundedData.Reader createReader() {
+	public BoundedData.Reader createReader(ResultSubpartitionView ignored) {
 		checkState(!fileChannel.isOpen());
 
 		final List<ByteBuffer> buffers = memoryMappedRegions.stream()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/MemoryMappedBoundedData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/MemoryMappedBoundedData.java
@@ -113,7 +113,7 @@ final class MemoryMappedBoundedData implements BoundedData {
 	}
 
 	@Override
-	public BufferSlicer createReader() {
+	public BufferSlicer createReader(ResultSubpartitionView ignored) {
 		assert currentBuffer == null;
 
 		final List<ByteBuffer> buffers = fullBuffers.stream()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import javax.annotation.Nullable;
+
+/**
+ * A dummy implementation of the {@link ResultSubpartitionView}.
+ */
+public class NoOpResultSubpartitionView implements ResultSubpartitionView {
+
+	@Nullable
+	public ResultSubpartition.BufferAndBacklog getNextBuffer() {
+		return null;
+	}
+
+	@Override
+	public void notifyDataAvailable() {
+	}
+
+	@Override
+	public void releaseAllResources() {
+	}
+
+	@Override
+	public void notifySubpartitionConsumed() {
+	}
+
+	@Override
+	public boolean isReleased() {
+		return true;
+	}
+
+	@Override
+	public Throwable getFailureCause() {
+		return null;
+	}
+
+	@Override
+	public boolean nextBufferIsEvent() {
+		return false;
+	}
+
+	@Override
+	public boolean isAvailable() {
+		return false;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
+import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartitionType;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.runtime.util.EnvironmentInformation;
@@ -141,7 +142,8 @@ public class NettyShuffleEnvironmentBuilder {
 				isCreditBased,
 				isNetworkDetailedMetrics,
 				nettyConfig,
-				tempDirs),
+				tempDirs,
+				BoundedBlockingSubpartitionType.AUTO),
 			taskManagerLocation,
 			taskEventDispatcher,
 			metricGroup);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.NetworkSequenceViewReader;
+import org.apache.flink.runtime.io.network.partition.NoOpResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
@@ -368,44 +369,5 @@ public class PartitionRequestQueueTest {
 		assertFalse(channel.isWritable());
 
 		return channelBlockingBuffer;
-	}
-
-	private static class NoOpResultSubpartitionView implements ResultSubpartitionView {
-		@Nullable
-		public BufferAndBacklog getNextBuffer() {
-			return null;
-		}
-
-		@Override
-		public void notifyDataAvailable() {
-		}
-
-		@Override
-		public void releaseAllResources() {
-		}
-
-		@Override
-		public void notifySubpartitionConsumed() {
-		}
-
-		@Override
-		public boolean isReleased() {
-			return true;
-		}
-
-		@Override
-		public Throwable getFailureCause() {
-			return null;
-		}
-
-		@Override
-		public boolean nextBufferIsEvent() {
-			return false;
-		}
-
-		@Override
-		public boolean isAvailable() {
-			return false;
-		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the availability handling of the BoundedBlockingSubpartitions with not constant
+ * availability.
+ */
+public class BoundedBlockingSubpartitionAvailabilityTest {
+
+	@ClassRule
+	public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+	private static final int BUFFER_SIZE = 32 * 1024;
+
+	@Test
+	public void testInitiallyAvailable() throws Exception {
+		final ResultSubpartition subpartition = createPartitionWithData(10);
+		final CountingAvailabilityListener listener = new CountingAvailabilityListener();
+
+		// test
+		final ResultSubpartitionView subpartitionView = subpartition.createReadView(listener);
+
+		// assert
+		assertEquals(1, listener.numNotifications);
+
+		// cleanup
+		subpartitionView.releaseAllResources();
+		subpartition.release();
+	}
+
+	@Test
+	public void testUnavailableWhenBuffersExhausted() throws Exception {
+		// setup
+		final BoundedBlockingSubpartition subpartition = createPartitionWithData(100_000);
+		final CountingAvailabilityListener listener = new CountingAvailabilityListener();
+		final ResultSubpartitionView reader = subpartition.createReadView(listener);
+
+		// test
+		final List<BufferAndBacklog> data = drainAvailableData(reader);
+
+		// assert
+		assertFalse(reader.isAvailable());
+		assertFalse(data.get(data.size() - 1).isMoreAvailable());
+
+		// cleanup
+		reader.releaseAllResources();
+		subpartition.release();
+	}
+
+	@Test
+	public void testAvailabilityNotificationWhenBuffersReturn() throws Exception {
+		// setup
+		final ResultSubpartition subpartition = createPartitionWithData(100_000);
+		final CountingAvailabilityListener listener = new CountingAvailabilityListener();
+		final ResultSubpartitionView reader = subpartition.createReadView(listener);
+
+		// test
+		final List<ResultSubpartition.BufferAndBacklog> data = drainAvailableData(reader);
+		data.get(0).buffer().recycleBuffer();
+		data.get(1).buffer().recycleBuffer();
+
+		// assert
+		assertTrue(reader.isAvailable());
+		assertEquals(2, listener.numNotifications); // one initial, one for new availability
+
+		// cleanup
+		reader.releaseAllResources();
+		subpartition.release();
+	}
+
+	@Test
+	public void testNotAvailableWhenEmpty() throws Exception {
+		// setup
+		final ResultSubpartition subpartition = createPartitionWithData(100_000);
+		final ResultSubpartitionView reader = subpartition.createReadView(new NoOpBufferAvailablityListener());
+
+		// test
+		drainAllData(reader);
+
+		// assert
+		assertFalse(reader.isAvailable());
+
+		// cleanup
+		reader.releaseAllResources();
+		subpartition.release();
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static BoundedBlockingSubpartition createPartitionWithData(int numberOfBuffers) throws IOException {
+		ResultPartition parent = PartitionTestUtils.createPartition();
+
+		BoundedBlockingSubpartition partition = BoundedBlockingSubpartition.createWithFileChannel(
+			0, parent, new File(TMP_FOLDER.newFolder(), "data"), BUFFER_SIZE);
+
+		writeBuffers(partition, numberOfBuffers);
+		partition.finish();
+
+		return partition;
+	}
+
+	private static void writeBuffers(ResultSubpartition partition, int numberOfBuffers) throws IOException {
+		for (int i = 0; i < numberOfBuffers; i++) {
+			partition.add(BufferBuilderTestUtils.createFilledBufferConsumer(BUFFER_SIZE, BUFFER_SIZE));
+		}
+	}
+
+	private static List<BufferAndBacklog> drainAvailableData(ResultSubpartitionView reader) throws Exception {
+		final ArrayList<BufferAndBacklog> list = new ArrayList<>();
+
+		BufferAndBacklog bab;
+		while ((bab = reader.getNextBuffer()) != null) {
+			list.add(bab);
+		}
+
+		return list;
+	}
+
+	private static void drainAllData(ResultSubpartitionView reader) throws Exception {
+		BufferAndBacklog bab;
+		while ((bab = reader.getNextBuffer()) != null) {
+			bab.buffer().recycleBuffer();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedDataTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedDataTestBase.java
@@ -59,7 +59,7 @@ public abstract class BoundedDataTestBase {
 
 	protected abstract BoundedData createBoundedDataWithRegion(Path tempFilePath, int regionSize) throws IOException;
 
-	private BoundedData createBoundedData() throws IOException {
+	protected BoundedData createBoundedData() throws IOException {
 		return createBoundedData(createTempPath());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/CountingAvailabilityListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/CountingAvailabilityListener.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+/**
+ * A simple BufferAvailabilityListener that counts the number of notifications.
+ */
+final class CountingAvailabilityListener implements BufferAvailabilityListener {
+
+	int numNotifications;
+
+	@Override
+	public void notifyDataAvailable() {
+		numNotifications++;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
@@ -18,13 +18,44 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.io.disk.FileChannelManager;
+import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+import org.apache.flink.runtime.util.EnvironmentInformation;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.nio.file.Path;
+
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSomeBuffer;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferConsumer;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests that read the BoundedBlockingSubpartition with multiple threads in parallel.
  */
 public class FileChannelBoundedDataTest extends BoundedDataTestBase {
+
+	private static final String tempDir = EnvironmentInformation.getTemporaryFileDirectory();
+
+	private static FileChannelManager fileChannelManager;
+
+	@BeforeClass
+	public static void setUp() {
+		fileChannelManager = new FileChannelManagerImpl(new String[] {tempDir}, "testing");
+	}
+
+	@AfterClass
+	public static void shutdown() throws Exception {
+		fileChannelManager.close();
+	}
 
 	@Override
 	protected boolean isRegionBased() {
@@ -39,5 +70,146 @@ public class FileChannelBoundedDataTest extends BoundedDataTestBase {
 	@Override
 	protected BoundedData createBoundedDataWithRegion(Path tempFilePath, int regionSize) throws IOException {
 		throw new UnsupportedOperationException();
+	}
+
+	@Test
+	public void testReadNextBuffer() throws Exception {
+		final int numberOfBuffers = 3;
+		try (final BoundedData data = createBoundedData()) {
+			writeBuffers(data, numberOfBuffers);
+
+			final BoundedData.Reader reader = data.createReader();
+			final Buffer buffer1 = reader.nextBuffer();
+			final Buffer buffer2 = reader.nextBuffer();
+
+			assertNotNull(buffer1);
+			assertNotNull(buffer2);
+			// there are only two available memory segments for reading data
+			assertNull(reader.nextBuffer());
+
+			// cleanup
+			buffer1.recycleBuffer();
+			buffer2.recycleBuffer();
+		}
+	}
+
+	@Test
+	public void testRecycleBufferForNotifyingSubpartitionView() throws Exception {
+		final int numberOfBuffers = 2;
+		try (final BoundedData data = createBoundedData()) {
+			writeBuffers(data, numberOfBuffers);
+
+			final VerifyNotificationResultSubpartitionView subpartitionView = new VerifyNotificationResultSubpartitionView();
+			final BoundedData.Reader reader = data.createReader(subpartitionView);
+			final Buffer buffer1 = reader.nextBuffer();
+			final Buffer buffer2 = reader.nextBuffer();
+			assertNotNull(buffer1);
+			assertNotNull(buffer2);
+
+			assertFalse(subpartitionView.isAvailable);
+			buffer1.recycleBuffer();
+			// the view is notified while recycling buffer if reader has not tagged finished
+			assertTrue(subpartitionView.isAvailable);
+
+			subpartitionView.resetAvailable();
+			assertFalse(subpartitionView.isAvailable);
+
+			// the next buffer is null to make reader tag finished
+			assertNull(reader.nextBuffer());
+
+			buffer2.recycleBuffer();
+			// the view is not notified while recycling buffer if reader already finished
+			assertFalse(subpartitionView.isAvailable);
+		}
+	}
+
+	@Test
+	public void testRecycleBufferForNotifyingBufferAvailabilityListener() throws Exception {
+		final ResultSubpartition subpartition = createFileBoundedBlockingSubpartition();
+		final int numberOfBuffers = 2;
+		writeBuffers(subpartition, numberOfBuffers);
+
+		final VerifyNotificationBufferAvailabilityListener listener = new VerifyNotificationBufferAvailabilityListener();
+		final ResultSubpartitionView subpartitionView = subpartition.createReadView(listener);
+		// the notification is triggered while creating view
+		assertTrue(listener.isAvailable);
+
+		listener.resetAvailable();
+		assertFalse(listener.isAvailable);
+
+		final BufferAndBacklog buffer1 = subpartitionView.getNextBuffer();
+		final BufferAndBacklog buffer2 = subpartitionView.getNextBuffer();
+		assertNotNull(buffer1);
+		assertNotNull(buffer2);
+
+		// the next buffer is null in view because FileBufferReader has no available buffers for reading ahead
+		assertFalse(subpartitionView.isAvailable());
+		// recycle a buffer to trigger notification of data available
+		buffer1.buffer().recycleBuffer();
+		assertTrue(listener.isAvailable);
+
+		// cleanup
+		buffer2.buffer().recycleBuffer();
+		subpartitionView.releaseAllResources();
+		subpartition.release();
+	}
+
+	private static ResultSubpartition createFileBoundedBlockingSubpartition() {
+		final ResultPartition resultPartition = new ResultPartitionBuilder()
+			.setNetworkBufferSize(BUFFER_SIZE)
+			.setResultPartitionType(ResultPartitionType.BLOCKING)
+			.setBoundedBlockingSubpartitionType(BoundedBlockingSubpartitionType.FILE)
+			.setFileChannelManager(fileChannelManager)
+			.build();
+		return resultPartition.subpartitions[0];
+	}
+
+	private static void writeBuffers(BoundedData data, int numberOfBuffers) throws IOException {
+		for (int i = 0; i < numberOfBuffers; i++) {
+			data.writeBuffer(buildSomeBuffer(BUFFER_SIZE));
+		}
+		data.finishWrite();
+	}
+
+	private static void writeBuffers(ResultSubpartition subpartition, int numberOfBuffers) throws IOException {
+		for (int i = 0; i < numberOfBuffers; i++) {
+			subpartition.add(createFilledBufferConsumer(BUFFER_SIZE, BUFFER_SIZE));
+		}
+		subpartition.finish();
+	}
+
+	/**
+	 * This subpartition view is used for verifying the {@link ResultSubpartitionView#notifyDataAvailable()}
+	 * was ever called before.
+	 */
+	private static class VerifyNotificationResultSubpartitionView extends NoOpResultSubpartitionView {
+
+		private boolean isAvailable;
+
+		@Override
+		public void notifyDataAvailable() {
+			isAvailable = true;
+		}
+
+		private void resetAvailable() {
+			isAvailable = false;
+		}
+	}
+
+	/**
+	 * This listener is used for verifying the notification logic in {@link ResultSubpartitionView#notifyDataAvailable()}.
+	 */
+	private static class VerifyNotificationBufferAvailabilityListener implements BufferAvailabilityListener {
+
+		private boolean isAvailable;
+
+		@Override
+		public void notifyDataAvailable() {
+			isAvailable = true;
+		}
+
+		private void resetAvailable() {
+			isAvailable = false;
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -38,6 +38,8 @@ public class ResultPartitionBuilder {
 
 	private ResultPartitionType partitionType = ResultPartitionType.PIPELINED;
 
+	private BoundedBlockingSubpartitionType blockingSubpartitionType = BoundedBlockingSubpartitionType.AUTO;
+
 	private int numberOfSubpartitions = 1;
 
 	private int numTargetKeyGroups = 1;
@@ -127,11 +129,17 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
+	public ResultPartitionBuilder setBoundedBlockingSubpartitionType(BoundedBlockingSubpartitionType blockingSubpartitionType) {
+		this.blockingSubpartitionType = blockingSubpartitionType;
+		return this;
+	}
+
 	public ResultPartition build() {
 		ResultPartitionFactory resultPartitionFactory = new ResultPartitionFactory(
 			partitionManager,
 			channelManager,
 			networkBufferPool,
+			blockingSubpartitionType,
 			networkBuffersPerChannel,
 			floatingNetworkBuffersPerGate,
 			networkBufferSize);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -73,6 +73,7 @@ public class ResultPartitionFactoryTest extends TestLogger {
 			new ResultPartitionManager(),
 			fileChannelManager,
 			new NetworkBufferPool(1, 64, 1),
+			BoundedBlockingSubpartitionType.AUTO,
 			1,
 			1,
 			64);

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.runtime;
+
+import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.client.program.MiniClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.api.reader.RecordReader;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
+import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartitionType;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.testutils.serialization.types.ByteArrayType;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests the bug reported in FLINK-131O0.
+ *
+ * <p>The implementation of {@link org.apache.flink.runtime.io.network.partition.BoundedData.Reader#nextBuffer()}
+ * for {@link BoundedBlockingSubpartitionType#FILE} assumes that there is always an available buffer, otherwise
+ * an IOException is thrown and it always assumes that pool of two buffers is enough (before using the 3rd buffer,
+ * first one was expected to be recycled already). But in the case of pending flush operation (when the socket channel
+ * is not writable while netty thread is calling {@link ChannelHandlerContext#writeAndFlush(Object, ChannelPromise)}),
+ * the first fetched buffer from {@link org.apache.flink.runtime.io.network.partition.FileChannelBoundedData} has not
+ * been recycled while fetching the second buffer to trigger next read ahead, which breaks the above assumption.
+ */
+public class FileBufferReaderITCase extends TestLogger {
+
+	private static final int parallelism = 8;
+
+	private static final int numRecords = 100_000;
+
+	private static final byte[] dataSource = new byte[1024];
+
+	@BeforeClass
+	public static void setup() {
+		for (int i = 0; i < dataSource.length; i++) {
+			dataSource[i] = 0;
+		}
+	}
+
+	@Test
+	public void testSequentialReading() throws Exception {
+		// setup
+		final Configuration configuration = new Configuration();
+		configuration.setString(RestOptions.BIND_PORT, "0");
+		configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BOUNDED_BLOCKING_SUBPARTITION_TYPE, "file");
+
+		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
+			.setConfiguration(configuration)
+			.setNumTaskManagers(parallelism)
+			.setNumSlotsPerTaskManager(1)
+			.build();
+
+		try (final MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration)) {
+			miniCluster.start();
+
+			final MiniClusterClient client = new MiniClusterClient(configuration, miniCluster);
+			final JobGraph jobGraph = createJobGraph();
+			final CompletableFuture<JobSubmissionResult> submitFuture = client.submitJob(jobGraph);
+			// wait for the submission to succeed
+			final JobSubmissionResult result = submitFuture.get();
+
+			final CompletableFuture<JobResult> resultFuture = client.requestJobResult(result.getJobID());
+			final JobResult jobResult = resultFuture.get();
+
+			assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
+		}
+	}
+
+	private static JobGraph createJobGraph() {
+		final SlotSharingGroup group1 = new SlotSharingGroup();
+		final SlotSharingGroup group2 = new SlotSharingGroup();
+
+		final JobVertex source = new JobVertex("source");
+		source.setInvokableClass(TestSourceInvokable.class);
+		source.setParallelism(parallelism);
+		source.setSlotSharingGroup(group1);
+
+		final JobVertex sink = new JobVertex("sink");
+		sink.setInvokableClass(TestSinkInvokable.class);
+		sink.setParallelism(parallelism);
+		sink.setSlotSharingGroup(group2);
+
+		sink.connectNewDataSetAsInput(source, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+		final JobGraph jobGraph = new JobGraph(source, sink);
+		jobGraph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES);
+
+		return jobGraph;
+	}
+
+	/**
+	 * Basic source {@link AbstractInvokable} which sends the elements to the
+	 * {@link TestSinkInvokable}.
+	 */
+	public static final class TestSourceInvokable extends AbstractInvokable {
+
+		/**
+		 * Create an Invokable task and set its environment.
+		 *
+		 * @param environment The environment assigned to this invokable.
+		 */
+		public TestSourceInvokable(Environment environment) {
+			super(environment);
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			final RecordWriter<ByteArrayType> writer = new RecordWriterBuilder().build(getEnvironment().getWriter(0));
+
+			final ByteArrayType bytes = new ByteArrayType(dataSource);
+			int counter = 0;
+			while (counter++ < numRecords) {
+				try {
+					writer.emit(bytes);
+					writer.flushAll();
+				} finally {
+					writer.clearBuffers();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Basic sink {@link AbstractInvokable} which verifies the sent elements
+	 * from the {@link TestSourceInvokable}.
+	 */
+	public static final class TestSinkInvokable extends AbstractInvokable {
+
+		private int numReceived = 0;
+
+		/**
+		 * Create an Invokable task and set its environment.
+		 *
+		 * @param environment The environment assigned to this invokable.
+		 */
+		public TestSinkInvokable(Environment environment) {
+			super(environment);
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			final RecordReader<ByteArrayType> reader = new RecordReader<>(
+				getEnvironment().getInputGate(0),
+				ByteArrayType.class,
+				getEnvironment().getTaskManagerInfo().getTmpDirectories());
+
+			while (reader.hasNext()) {
+				reader.next();
+				numReceived++;
+			}
+
+			assertThat(numReceived, is(numRecords));
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change 

*In the process of `FileChannelBoundedData#nextBuffer`, the implementation is based on the assumption that there always has an available buffer, otherwise an `IOException` is thrown. But in the case of pending flush operation that means the socket channel is not writable sometimes while netty thread calling `writeAndFlush` method, the first fetched buffer from `FileChannelBoundedData` has not been recycled while fetching the second buffer to trigger next read ahead. Then it would cause this problem to break above assumption.*
    
*In order to fix this problem, we could make the assumption that the read ahead is not always available for `FileChannelBoundedData`. If there are no available buffers to read the next data, we could retrigger the read ahead while recycling buffer via `ResultSubpartitionView#notifyDataAvailable`.*

*This PR relies on #9059 for better constructing the unit tests.*

## Brief change log

  - *Move private `NoOpResultSubpartitionView` class out of `PartitionRequestQueueTest`*
  - *Make `BoundedBlockingSubpartitionType` configurable in `ResultPartitionBuilder` for tests usage*
  - *Pass `BufferAvailabilityListener` in the constructor of `BoundedBlockingSubpartitionReader`*
  - *Implement the logic of `notifyDataAvailable` in `BoundedBlockingSubpartitionReader `*
  - *Fix the logic of `FileBufferReader#nextBuffer`*
  - *Fix the logic of `FileBufferReader#recycleBuffer`*

## Verifying this change

  - *Added `FileChannelBoundedDataTest#testReadNextBuffer` for verifying the logic of `nextBuffer`*
  - *Added `FileChannelBoundedDataTest#testRecycleBufferForNotifyingSubpartitionView` for verifying the notification of `ResultSubpartitionView`*
  - *Added `FileChannelBoundedDataTest#testRecycleBufferForNotifyingBufferAvailabilityListener` for verifying the notification of `BufferAvailabilityListener`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)