### PR TITLE
[FLINK-13102][travis] Optimize some travis stages by skipping mvn verify if possible

### DIFF
--- a/tools/travis/differential_build.sh
+++ b/tools/travis/differential_build.sh
@@ -56,3 +56,15 @@ function prepare_dependencies_tree_if_pr_build() {
 
     python3 ./tools/travis/mvn_diff_test.py process-mvn-dependencies mvn-dependencies-list.txt mvn-basedir-list.txt > "$MVN_DEPENDENCIES_TREE_FILEPATH"
 }
+
+function can_skip_mvn_test_run_for_stage() {
+    local stage=$1
+
+    if ! is_pr_build ; then
+        echo "Cannot skip non PR test run"
+        return 1
+    fi
+
+    python3 ./tools/travis/mvn_diff_test.py can-skip-mvn-test "$stage" "$PROFILE" "$MVN_DEPENDENCIES_TREE_FILEPATH" "$DIFF_LIST_FILEPATH"
+    return
+}

--- a/tools/travis/differential_build.sh
+++ b/tools/travis/differential_build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+#
+# Globals:
+# TRAVIS_PULL_REQUEST
+#   - Travis pull request number if current Travis job is triggered by a pull request, “false” otherwise.
+#     See: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+# TRAVIS_COMMIT_RANGE
+#   - Travis range of commits that were included in the push or pull request.
+#     See: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+# PROFILE
+#   - mvn "profile" parameters defined by invoking scripts
+#
+
+DIFF_LIST_FILEPATH=diff_files.txt
+MVN_DEPENDENCIES_TREE_FILEPATH=mvn-dependencies-tree.txt
+
+function is_pr_build() {
+    # For non-PR runs, we want to run all tests.
+    # Also, we can't tell what has been changed if we don't know git diff range ($TRAVIS_COMMIT_RANGE).
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "x$TRAVIS_COMMIT_RANGE" == "x" ]; then
+        return 1
+    fi
+    return 0
+}
+
+function prepare_dependencies_tree_if_pr_build() {
+    # This is a helper, preparation step to enable skipping running some stages' tests.
+    # If we know that the change doesn't affect some tests
+    if ! is_pr_build ; then
+        echo "Skipping Travis job optimization for non pull request build."
+        return
+    fi
+    echo "git diff range: $TRAVIS_COMMIT_RANGE"
+    git diff --name-only "$TRAVIS_COMMIT_RANGE" > "$DIFF_LIST_FILEPATH"
+
+    mvn dependency:list -DincludeGroupIds=org.apache.flink $PROFILE > mvn-dependencies-list.txt
+    mvn exec:exec -Dexec.executable="echo" -Dexec.args="[INFO] Basedir: \${project.basedir}" $PROFILE > mvn-basedir-list.txt
+
+    python3 ./tools/travis/mvn_diff_test.py process-mvn-dependencies mvn-dependencies-list.txt mvn-basedir-list.txt > "$MVN_DEPENDENCIES_TREE_FILEPATH"
+}

--- a/tools/travis/mvn_diff_test.py
+++ b/tools/travis/mvn_diff_test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from collections import defaultdict
+import re, sys
+
+def expand_node(graph, node):
+    visited = set([node])
+    all_dependencies = set()
+    queue = list(graph[node])
+
+    while queue:
+        n = queue.pop()
+        all_dependencies.add(n)
+        if n in visited:
+            continue
+        visited.add(n)
+        targets = graph.get(n)
+        if targets:
+            queue.extend(targets)
+    return all_dependencies
+
+def expand_graph(graph):
+    new_graph = {}
+    for node in graph.keys():
+        new_graph[node] = expand_node(graph, node)
+    return new_graph
+
+def print_graph(graph):
+    for node in sorted(graph.keys()):
+        print("{}\t{}".format(node, ','.join(sorted(graph[node]))))
+
+#-------------------------------------------------------------------------------
+
+MVN_INFO_PREFIX = "[INFO] "
+
+def read_mvn_log(filepath):
+    with open(filepath) as f:
+        for line in f:
+            line = line.split(MVN_INFO_PREFIX, 1)
+            if len(line) != 2:
+                continue
+            yield line[1].strip()
+
+def load_mvn_dependencies_graph(filepath):
+    # Generate the input file by running:
+    # mvn dependency:list $PROFILE > $filepath
+
+    # For example output snippet:
+    # [INFO]
+    # [INFO] --- maven-dependency-plugin:3.1.1:list (default-cli) @ flink-queryable-state-client-java_2.11 ---
+    # [INFO]
+    # [INFO] The following files have been resolved:
+    # [INFO]    org.apache.flink:flink-core:jar:1.9-SNAPSHOT:provided
+    # [INFO]    org.apache.flink:flink-annotations:jar:1.9-SNAPSHOT:provided
+    # [INFO]    org.apache.flink:flink-metrics-core:jar:1.9-SNAPSHOT:provided
+    # [INFO]    org.apache.flink:flink-shaded-asm-6:jar:6.2.1-7.0:provided
+    # [INFO]    org.apache.flink:flink-shaded-netty:jar:4.1.32.Final-7.0:compile
+    # [INFO]    org.apache.flink:flink-shaded-guava:jar:18.0-7.0:compile
+    # [INFO]    org.apache.flink:flink-core:test-jar:tests:1.9-SNAPSHOT:test
+    # [INFO]    org.apache.flink:flink-test-utils-junit:jar:1.9-SNAPSHOT:test
+    # [INFO]    org.apache.flink:force-shading:jar:1.9-SNAPSHOT:compile
+    # [INFO]
+    #
+    # should extract (key, value):
+    # "flink-queryable-state-client-java_2.11": [
+    #     "flink-core",
+    #     "flink-annotations",
+    #     "flink-metrics-core",
+    #     "flink-core",
+    #     "flink-test-utils-junit",
+    #     "force-shading",
+    # ]
+
+    graph = defaultdict(set)
+
+    mvn_artifact_pattern = re.compile(r"^-+ maven-dependency-plugin:(.*):list (.*) @ (.*) -+$")
+    artifact = None
+    dependencies = None
+    for line in read_mvn_log(filepath):
+        if artifact is None:
+            match = mvn_artifact_pattern.match(line)
+            if match:
+                artifact = match.group(3)
+
+        elif dependencies is None:
+            if line == "The following files have been resolved:":
+                dependencies = []
+
+        else:
+            if line:
+                dependency = line.split(':')
+                if dependency[0] == "org.apache.flink" and not dependency[1].startswith("flink-shaded-"):
+                    # keep only artifactId part
+                    dependencies.append(dependency[1])
+            else:
+                graph[artifact].update(dependencies)
+
+                artifact = None
+                dependencies = None
+
+    return graph
+
+def load_mvn_artifact_to_basedir(filepath):
+    # Generate the input file by running:
+    # mvn exec:exec -Dexec.executable="echo" -Dexec.args="[INFO] Basedir: ${project.basedir}" $PROFILE > $filepath
+
+    # For example output snippet:
+    # [INFO] --- exec-maven-plugin:1.6.0:exec (default-cli) @ flink-mapr-fs ---
+    # [INFO] Basedir: /users/travis/build/42/flink/flink-filesystems/flink-mapr-fs
+    #
+    # should extract (key, value):
+    # "flink-mapr-fs": "flink-filesystems/flink-mapr-fs"
+
+    artifact_to_basedir = {}
+
+    mvn_artifact_pattern = re.compile(r"^-+ exec-maven-plugin(.*)exec (.*) @ (.*) -+$")
+    artifact = None
+    for line in read_mvn_log(filepath):
+        if artifact is None:
+            match = mvn_artifact_pattern.match(line)
+            if match:
+                artifact = match.group(3)
+
+        else:
+            if line.startswith("Basedir: "):
+                basedir = line[len("Basedir: "):]
+                artifact_to_basedir[artifact] = basedir
+
+                artifact = None
+
+    # Make basedirs relative to project root.
+    # We assume that the parent pom.xml is located in the root of the project tree,
+    # and hence, it's basedir would be the project root.
+    prefix = min(map(len, artifact_to_basedir.values()))
+    for artifact in artifact_to_basedir.keys():
+        basedir = artifact_to_basedir[artifact][prefix:]\
+            .replace('\\', '/')\
+            .lstrip('/')
+        artifact_to_basedir[artifact] = basedir
+
+    return artifact_to_basedir
+
+#-------------------------------------------------------------------------------
+
+def process_mvn_dependencies(mvn_dependencies_list_filepath, mvn_artifact_basedir_filepath):
+    artifact_dependencies_graph = load_mvn_dependencies_graph(mvn_dependencies_list_filepath)
+    artifact_dependencies_graph = expand_graph(artifact_dependencies_graph)
+
+    artifact_to_basedir = load_mvn_artifact_to_basedir(mvn_artifact_basedir_filepath)
+
+    basedir_dependencies_graph = defaultdict(set)
+    for artifact, dependencies in artifact_dependencies_graph.items():
+        basedir = artifact_to_basedir[artifact]
+        for dependency in dependencies:
+            basedir_dependencies_graph[basedir].add(artifact_to_basedir[dependency])
+
+    print_graph(basedir_dependencies_graph)
+
+def main():
+    argv = sys.argv
+    command = argv[1]
+    if command == "process-mvn-dependencies":
+        process_mvn_dependencies(argv[2], argv[3])
+        return
+
+    print("Unknown command: {}".format(command), file=sys.stderr)
+    sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/tools/travis/stages.py
+++ b/tools/travis/stages.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+STAGE_CORE="core"
+STAGE_LIBRARIES="libraries"
+STAGE_BLINK_PLANNER="blink_planner"
+STAGE_CONNECTORS="connectors"
+STAGE_KAFKA_GELLY="kafka/gelly"
+STAGE_TESTS="tests"
+STAGE_MISC="misc"
+
+MODULES_CORE="\
+flink-annotations,\
+flink-test-utils-parent/flink-test-utils,\
+flink-state-backends/flink-statebackend-rocksdb,\
+flink-clients,\
+flink-core,\
+flink-java,\
+flink-optimizer,\
+flink-runtime,\
+flink-runtime-web,\
+flink-scala,\
+flink-streaming-java,\
+flink-streaming-scala,\
+flink-metrics,\
+flink-metrics/flink-metrics-core"\
+    .split(",")
+
+MODULES_LIBRARIES="\
+flink-libraries/flink-cep,\
+flink-libraries/flink-cep-scala,\
+flink-table/flink-table-common,\
+flink-table/flink-table-api-java,\
+flink-table/flink-table-api-scala,\
+flink-table/flink-table-api-java-bridge,\
+flink-table/flink-table-api-scala-bridge,\
+flink-table/flink-table-planner,\
+flink-table/flink-sql-client"\
+    .split(",")
+
+MODULES_BLINK_PLANNER="\
+flink-table/flink-table-planner-blink,\
+flink-table/flink-table-runtime-blink"\
+    .split(",")
+
+MODULES_CONNECTORS="\
+flink-contrib/flink-connector-wikiedits,\
+flink-filesystems,\
+flink-filesystems/flink-fs-hadoop-shaded,\
+flink-filesystems/flink-hadoop-fs,\
+flink-filesystems/flink-mapr-fs,\
+flink-filesystems/flink-oss-fs-hadoop,\
+flink-filesystems/flink-s3-fs-base,\
+flink-filesystems/flink-s3-fs-hadoop,\
+flink-filesystems/flink-s3-fs-presto,\
+flink-filesystems/flink-swift-fs-hadoop,\
+flink-fs-tests,\
+flink-formats,\
+flink-formats/flink-avro-confluent-registry,\
+flink-formats/flink-avro,\
+flink-formats/flink-parquet,\
+flink-formats/flink-sequence-file,\
+flink-formats/flink-json,\
+flink-formats/flink-csv,\
+flink-connectors/flink-hbase,\
+flink-connectors/flink-hcatalog,\
+flink-connectors/flink-hadoop-compatibility,\
+flink-connectors/flink-jdbc,\
+flink-connectors,\
+flink-connectors/flink-orc,\
+flink-connectors/flink-connector-cassandra,\
+flink-connectors/flink-connector-elasticsearch2,\
+flink-connectors/flink-connector-elasticsearch5,\
+flink-connectors/flink-connector-elasticsearch6,\
+flink-connectors/flink-sql-connector-elasticsearch6,\
+flink-connectors/flink-connector-elasticsearch-base,\
+flink-connectors/flink-connector-filesystem,\
+flink-connectors/flink-connector-kafka-0.9,\
+flink-connectors/flink-sql-connector-kafka-0.9,\
+flink-connectors/flink-connector-kafka-0.10,\
+flink-connectors/flink-sql-connector-kafka-0.10,\
+flink-connectors/flink-connector-kafka-0.11,\
+flink-connectors/flink-sql-connector-kafka-0.11,\
+flink-connectors/flink-connector-kafka-base,\
+flink-connectors/flink-connector-nifi,\
+flink-connectors/flink-connector-rabbitmq,\
+flink-connectors/flink-connector-twitter,\
+flink-metrics/flink-metrics-dropwizard,\
+flink-metrics/flink-metrics-graphite,\
+flink-metrics/flink-metrics-jmx,\
+flink-metrics/flink-metrics-influxdb,\
+flink-metrics/flink-metrics-prometheus,\
+flink-metrics/flink-metrics-statsd,\
+flink-metrics/flink-metrics-datadog,\
+flink-metrics/flink-metrics-slf4j,\
+flink-queryable-state/flink-queryable-state-runtime,\
+flink-queryable-state/flink-queryable-state-client-java"\
+    .split(",")
+
+MODULES_KAFKA_GELLY="\
+flink-libraries/flink-gelly,\
+flink-libraries/flink-gelly-scala,\
+flink-libraries/flink-gelly-examples,\
+flink-connectors/flink-connector-kafka,\
+flink-connectors/flink-sql-connector-kafka"\
+    .split(",")
+
+MODULES_JDK9_EXCLUSIONS="\
+flink-filesystems/flink-s3-fs-hadoop,\
+flink-filesystems/flink-s3-fs-presto,\
+flink-filesystems/flink-mapr-fs,\
+flink-connectors/flink-hbase"\
+    .split(",")
+
+MODULES_TESTS="\
+flink-tests"\
+    .split(",")
+
+STAGE_MODULES = {
+    STAGE_CORE: MODULES_CORE,
+    STAGE_LIBRARIES: MODULES_LIBRARIES,
+    STAGE_BLINK_PLANNER: MODULES_BLINK_PLANNER,
+    STAGE_CONNECTORS: MODULES_CONNECTORS,
+    STAGE_KAFKA_GELLY: MODULES_KAFKA_GELLY,
+    STAGE_TESTS: MODULES_TESTS,
+}
+
+def get_mvn_modules(stage, profile):
+    modules = STAGE_MODULES[stage][::]
+    if stage == STAGE_CONNECTORS:
+        if "include-kinesis" in profile:
+            modules += ["flink-connectors/flink-connector-kinesis"]
+        if "scala-2.11" in profile:
+            # we can only build the Kafka 0.8 connector when building for Scala 2.11
+            modules += ["flink-connectors/flink-connector-kafka-0.8"]
+    elif stage == STAGE_CORE:
+        if "scala-2.11" in profile:
+            # we can only build the Scala Shell when building for Scala 2.11
+            modules += ["flink-scala-shell"]
+    return modules
+
+def get_mvn_modules_for_test(stage, profile):
+    modules = get_mvn_modules(stage, profile)
+    if "jdk9" in profile:
+        # exclude modules that fail tests on JDK 9
+        modules = [module for module in modules if module not in MODULES_JDK9_EXCLUSIONS]
+    return modules

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -39,6 +39,7 @@ if [ -z "$HERE" ] ; then
 	exit 1  # fail
 fi
 
+source "${HERE}/travis/differential_build.sh"
 source "${HERE}/travis/fold.sh"
 source "${HERE}/travis/stage.sh"
 source "${HERE}/travis/shade.sh"
@@ -124,6 +125,10 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
         echo "=============================================================================="
         echo "Previous build failure detected, skipping shaded dependency check."
         echo "=============================================================================="
+    fi
+
+    if [ $EXIT_CODE == 0 ]; then
+        prepare_dependencies_tree_if_pr_build
     fi
 
     if [ $EXIT_CODE == 0 ]; then

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -63,7 +63,7 @@ MVN_TEST_MODULES=$(get_test_modules_for_stage ${TEST})
 MVN_LOGGING_OPTIONS="-Dlog.dir=${ARTIFACTS_DIR} -Dlog4j.configuration=file://$LOG4J_PROPERTIES -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 MVN_COMMON_OPTIONS="-nsu -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -B -Pskip-webui-build $MVN_LOGGING_OPTIONS"
 MVN_COMPILE_OPTIONS="-DskipTests"
-MVN_TEST_OPTIONS="$MVN_LOGGING_OPTIONS -Dflink.tests.with-openssl"
+MVN_TEST_OPTIONS="-Dflink.tests.with-openssl"
 
 MVN_COMPILE="mvn $MVN_COMMON_OPTIONS $MVN_COMPILE_OPTIONS $PROFILE $MVN_COMPILE_MODULES install"
 MVN_TEST="mvn $MVN_COMMON_OPTIONS $MVN_TEST_OPTIONS $PROFILE $MVN_TEST_MODULES verify"

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -25,6 +25,7 @@ if [ -z "$HERE" ] ; then
 	exit 1  # fail
 fi
 
+source "${HERE}/travis/differential_build.sh"
 source "${HERE}/travis/stage.sh"
 
 ARTIFACTS_DIR="${HERE}/artifacts"
@@ -234,12 +235,16 @@ run_with_watchdog "$CMD"
 
 # Run tests if compilation was successful
 if [ $CMD_TYPE == "MVN" ]; then
-	if [ $EXIT_CODE == 0 ]; then
-		run_with_watchdog "$MVN_TEST"
-	else
+	if [ $EXIT_CODE != 0 ]; then
 		echo "=============================================================================="
 		echo "Compilation failure detected, skipping test execution."
 		echo "=============================================================================="
+	elif can_skip_mvn_test_run_for_stage "$TEST" ; then
+		echo "=============================================================================="
+		echo "Skipping mvn verify phase for stage '$TEST'"
+		echo "=============================================================================="
+	else
+		run_with_watchdog "$MVN_TEST"
 	fi
 fi
 

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -175,6 +175,10 @@ the_time() {
 	echo `date +%s`
 }
 
+# =============================================================================
+# WATCHDOG
+# =============================================================================
+
 watchdog () {
 	touch $CMD_OUT
 
@@ -197,67 +201,41 @@ watchdog () {
 	done
 }
 
-# =============================================================================
-# WATCHDOG
-# =============================================================================
+run_with_watchdog() {
+	local cmd="$1"
 
-# Start watching $MVN_OUT
-watchdog &
+	watchdog &
+	WD_PID=$!
+	echo "STARTED watchdog (${WD_PID})."
 
-WD_PID=$!
+	# Make sure to be in project root
+	cd "$HERE/../"
 
-echo "STARTED watchdog (${WD_PID})."
+	echo "RUNNING '${cmd}'."
 
-# Make sure to be in project root
-cd $HERE/../
+	# Run $CMD and pipe output to $CMD_OUT for the watchdog. The PID is written to $CMD_PID to
+	# allow the watchdog to kill $CMD if it is not producing any output anymore. $CMD_EXIT contains
+	# the exit code. This is important for Travis' build life-cycle (success/failure).
+	( $cmd & PID=$! ; echo $PID >&3 ; wait $PID ; echo $? >&4 ) 3>$CMD_PID 4>$CMD_EXIT | tee $CMD_OUT
 
-# Compile modules
+	EXIT_CODE=$(<$CMD_EXIT)
 
-echo "RUNNING '${CMD}'."
+	echo "${CMD_TYPE} exited with EXIT CODE: ${EXIT_CODE}."
 
-# Run $CMD and pipe output to $CMD_OUT for the watchdog. The PID is written to $CMD_PID to
-# allow the watchdog to kill $CMD if it is not producing any output anymore. $CMD_EXIT contains
-# the exit code. This is important for Travis' build life-cycle (success/failure).
-( $CMD & PID=$! ; echo $PID >&3 ; wait $PID ; echo $? >&4 ) 3>$CMD_PID 4>$CMD_EXIT | tee $CMD_OUT
+	# Make sure to kill the watchdog in any case after $CMD has completed
+	echo "Trying to KILL watchdog (${WD_PID})."
+	( kill $WD_PID 2>&1 ) > /dev/null
 
-EXIT_CODE=$(<$CMD_EXIT)
+	rm $CMD_PID
+	rm $CMD_EXIT
+}
 
-echo "${CMD_TYPE} exited with EXIT CODE: ${EXIT_CODE}."
-
-# Make sure to kill the watchdog in any case after $CMD has completed
-echo "Trying to KILL watchdog (${WD_PID})."
-( kill $WD_PID 2>&1 ) > /dev/null
-
-rm $CMD_PID
-rm $CMD_EXIT
+run_with_watchdog "$CMD"
 
 # Run tests if compilation was successful
 if [ $CMD_TYPE == "MVN" ]; then
 	if [ $EXIT_CODE == 0 ]; then
-
-		# Start watching $MVN_OUT
-		watchdog &
-		echo "STARTED watchdog (${WD_PID})."
-
-		WD_PID=$!
-
-		echo "RUNNING '${MVN_TEST}'."
-
-		# Run $MVN_TEST and pipe output to $MVN_OUT for the watchdog. The PID is written to $MVN_PID to
-		# allow the watchdog to kill $MVN if it is not producing any output anymore. $MVN_EXIT contains
-		# the exit code. This is important for Travis' build life-cycle (success/failure).
-		( $MVN_TEST & PID=$! ; echo $PID >&3 ; wait $PID ; echo $? >&4 ) 3>$MVN_PID 4>$MVN_EXIT | tee $MVN_OUT
-
-		EXIT_CODE=$(<$MVN_EXIT)
-
-		echo "MVN exited with EXIT CODE: ${EXIT_CODE}."
-
-		# Make sure to kill the watchdog in any case after $MVN_TEST has completed
-		echo "Trying to KILL watchdog (${WD_PID})."
-		( kill $WD_PID 2>&1 ) > /dev/null
-
-		rm $MVN_PID
-		rm $MVN_EXIT
+		run_with_watchdog "$MVN_TEST"
 	else
 		echo "=============================================================================="
 		echo "Compilation failure detected, skipping test execution."


### PR DESCRIPTION
## What is the purpose of the change

This PR minimizes total Travis CI time for pull request triggered builds by skipping `mvn verify` steps for non `python` and `misc` jobs in Travis `test` stage.

## Brief change log

  - added script to build `mvn` dependencies tree and list all changed files in a PR build run. This happens at the very first `compile` stage;
  - added script to detect if `mvn verify` can be skipped for given list of maven modules and list of changed files.

## Verifying this change

This change can be verified as follows:

  - run different PRs (build in Travis CI) with this changes included and manually verifying that build is correct and some tests are not run because changes in a PR are not affecting them.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
