### PR TITLE
[FLINK-13195] Add create table support for SqlClient

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -281,6 +281,9 @@ public class CliClient {
 			case USE_DATABASE:
 				callUseDatabase(cmdCall);
 				break;
+			case CREATE_TABLE:
+				callCreateTable(cmdCall);
+				break;
 			case DESCRIBE:
 				callDescribe(cmdCall);
 				break;
@@ -432,6 +435,16 @@ public class CliClient {
 	private void callUseDatabase(SqlCommandCall cmdCall) {
 		try {
 			executor.useDatabase(context, cmdCall.operands[0]);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
+		}
+		terminal.flush();
+	}
+
+	private void callCreateTable(SqlCommandCall cmdCall) {
+		try {
+			executor.createTable(context, cmdCall.operands[0]);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -123,6 +123,10 @@ public final class SqlCommandParser {
 			"(INSERT\\s+INTO.*)",
 			SINGLE_OPERAND),
 
+		CREATE_TABLE(
+			"(CREATE\\s+TABLE.*)",
+			SINGLE_OPERAND),
+
 		CREATE_VIEW(
 			"CREATE\\s+VIEW\\s+(\\S+)\\s+AS\\s+(.*)",
 			(operands) -> {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -71,6 +71,11 @@ public interface Executor {
 	void useDatabase(SessionContext session, String databaseName) throws SqlExecutionException;
 
 	/**
+	 * Create a table with a DDL.
+	 */
+	void createTable(SessionContext session, String ddl) throws SqlExecutionException;
+
+	/**
 	 * Returns the schema of a table. Throws an exception if the table could not be found. The
 	 * schema might contain time attribute types for helping the user during debugging a query.
 	 */

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
@@ -42,7 +42,6 @@ public class SessionContext {
 
 	private final Map<String, ViewEntry> views;
 
-	// Make current catalog static so that every session instance can see it.
 	private volatile Catalog currentCatalog;
 
 	public SessionContext(String name, Environment defaultEnvironment) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.client.gateway;
 
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.ViewEntry;
 
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Context describing a session.
@@ -39,6 +41,9 @@ public class SessionContext {
 	private final Map<String, String> sessionProperties;
 
 	private final Map<String, ViewEntry> views;
+
+	// Make current catalog static so that every session instance can see it.
+	private volatile Catalog currentCatalog;
 
 	public SessionContext(String name, Environment defaultEnvironment) {
 		this.name = name;
@@ -69,6 +74,14 @@ public class SessionContext {
 		return Collections.unmodifiableMap(views);
 	}
 
+	public void setCurrentCatalog(Catalog catalog) {
+		this.currentCatalog = catalog;
+	}
+
+	public Optional<Catalog> getCurrentCatalog() {
+		return Optional.ofNullable(this.currentCatalog);
+	}
+
 	public String getName() {
 		return name;
 	}
@@ -84,6 +97,7 @@ public class SessionContext {
 		final SessionContext session = new SessionContext(name, defaultEnvironment);
 		session.sessionProperties.putAll(sessionProperties);
 		session.views.putAll(views);
+		session.setCurrentCatalog(currentCatalog);
 		return session;
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -251,6 +251,19 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public void createTable(SessionContext session, String ddl) throws SqlExecutionException {
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+		final TableEnvironment tEnv = context
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+		try {
+			tEnv.sql(ddl);
+		} catch (Exception e) {
+			throw new SqlExecutionException("Could not create a table from ddl: " + ddl, e);
+		}
+	}
+
+	@Override
 	public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
 		final TableEnvironment tableEnv = context

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -194,11 +194,6 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
-		public void dropTable(SessionContext session, String ddl) throws SqlExecutionException {
-
-		}
-
-		@Override
 		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -189,6 +189,16 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public void createTable(SessionContext session, String ddl) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void dropTable(SessionContext session, String ddl) throws SqlExecutionException {
+
+		}
+
+		@Override
 		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -161,11 +161,6 @@ public class CliResultViewTest {
 		}
 
 		@Override
-		public void dropTable(SessionContext session, String ddl) throws SqlExecutionException {
-
-		}
-
-		@Override
 		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -156,6 +156,16 @@ public class CliResultViewTest {
 		}
 
 		@Override
+		public void createTable(SessionContext session, String ddl) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void dropTable(SessionContext session, String ddl) throws SqlExecutionException {
+
+		}
+
+		@Override
 		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-ddl-table.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-ddl-table.yaml
@@ -1,0 +1,142 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+#==============================================================================
+# TEST ENVIRONMENT FILE
+# General purpose default environment file.
+#==============================================================================
+
+# this file has variables that can be filled with content by replacing $VAR_XXX
+
+tables:
+- name: TableNumber1
+  type: source-table
+  $VAR_UPDATE_MODE
+  schema:
+  - name: IntegerField1
+    type: INT
+  - name: StringField1
+    type: VARCHAR
+  connector:
+    type: filesystem
+    path: "$VAR_SOURCE_PATH1"
+  format:
+    type: csv
+    fields:
+    - name: IntegerField1
+      type: INT
+    - name: StringField1
+      type: VARCHAR
+    line-delimiter: "\n"
+    comment-prefix: "#"
+- name: TestView1
+  type: view
+  query: SELECT scalarUDF(IntegerField1) FROM default_catalog.default_database.TableNumber1
+- name: TableNumber2
+  # Test backwards compatibility ("source" -> "source-table")
+  type: source
+  $VAR_UPDATE_MODE
+  schema:
+  - name: IntegerField2
+    type: INT
+  - name: StringField2
+    type: VARCHAR
+  connector:
+    type: filesystem
+    path: "$VAR_SOURCE_PATH2"
+  format:
+    type: csv
+    fields:
+    - name: IntegerField2
+      type: INT
+    - name: StringField2
+      type: VARCHAR
+    line-delimiter: "\n"
+    comment-prefix: "#"
+- name: TableSourceSink
+  type: source-sink-table
+  $VAR_UPDATE_MODE
+  schema:
+  - name: BooleanField
+    type: BOOLEAN
+  - name: StringField
+    type: VARCHAR
+  connector:
+    type: filesystem
+    path: "$VAR_SOURCE_SINK_PATH"
+  format:
+    type: csv
+    fields:
+    - name: BooleanField
+      type: BOOLEAN
+    - name: StringField
+      type: VARCHAR
+- name: TestView2
+  type: view
+  query: SELECT * FROM default_catalog.default_database.TestView1
+
+functions:
+- name: scalarUDF
+  from: class
+  class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$ScalarUDF
+  constructor:
+  - 5
+- name: aggregateUDF
+  from: class
+  class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$AggregateUDF
+  constructor:
+  - StarryName
+  - false
+  - class: java.lang.Integer
+    constructor:
+    - class: java.lang.String
+      constructor:
+      - type: VARCHAR
+        value: 3
+- name: tableUDF
+  from: class
+  class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$TableUDF
+  constructor:
+  - type: LONG
+    value: 5
+
+execution:
+  type: "$VAR_EXECUTION_TYPE"
+  time-characteristic: event-time
+  periodic-watermarks-interval: 99
+  parallelism: 1
+  max-parallelism: 16
+  min-idle-state-retention: 0
+  max-idle-state-retention: 0
+  result-mode: "$VAR_RESULT_MODE"
+  max-table-result-rows: "$VAR_MAX_ROWS"
+  restart-strategy:
+    type: failure-rate
+    max-failures-per-interval: 10
+    failure-rate-interval: 99000
+    delay: 1000
+  current-catalog: catalog2
+  current-database: default_database
+
+deployment:
+  response-timeout: 5000
+
+catalogs:
+- name: catalog2
+  type: generic_in_memory
+  default-database: default_database


### PR DESCRIPTION
## What is the purpose of the change

Support create table for SqlClient


## Brief change log

  - Add create table command support for SqlClient
  - Always cache the current catalog to the original session, so that when we set a variable, the current catalog table still can be reused


## Verifying this change

See tests in LocalExecutorITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
