### PR TITLE
[FLINK-13193][tests] Enable custom flink cluster config per test

### DIFF
--- a/flink-jepsen/docker/run-tests.sh
+++ b/flink-jepsen/docker/run-tests.sh
@@ -28,7 +28,7 @@ n2
 n3
 EOF
 
-common_jepsen_args+=(--ha-storage-dir hdfs:///flink
+common_jepsen_args+=(
 --tarball ${2}
 --ssh-private-key ~/.ssh/id_rsa
 --nodes-file ${dockerdir}/nodes)

--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -36,13 +36,13 @@
 
 (def taskmanager-slots 3)
 
-(defn flink-configuration
+(defn- default-flink-configuration
   [test node]
   {:high-availability                  "zookeeper"
    :high-availability.zookeeper.quorum (zookeeper-quorum test)
-   :high-availability.storageDir       (str (:ha-storage-dir test) "/ha")
+   :high-availability.storageDir       "hdfs:///flink/ha"
    :jobmanager.rpc.address             node
-   :state.savepoints.dir               (str (:ha-storage-dir test) "/savepoints")
+   :state.savepoints.dir               "hdfs:///flink/savepoints"
    :rest.address                       node
    :rest.port                          8081
    :rest.bind-address                  "0.0.0.0"
@@ -51,6 +51,12 @@
    :slotmanager.taskmanager-timeout    10000
    :state.backend.local-recovery       "true"
    :taskmanager.registration.timeout   "30 s"})
+
+(defn flink-configuration
+  [test node]
+  (let [additional-config (-> test :test-spec :flink-config)]
+    (merge (default-flink-configuration test node)
+           additional-config)))
 
 (defn write-configuration!
   "Writes the flink-conf.yaml to the flink conf directory"

--- a/flink-jepsen/src/jepsen/flink/flink.clj
+++ b/flink-jepsen/src/jepsen/flink/flink.clj
@@ -120,7 +120,6 @@
                      :parse-fn read-test-spec
                      :validate [#(->> % :dbs (map dbs) (every? (complement nil?)))
                                 (str "Invalid :dbs specification. " (keys->allowed-values-help-text dbs))]]
-                    [nil "--ha-storage-dir DIR" "high-availability.storageDir"]
                     [nil "--nemesis-gen GEN" (str "Which nemesis should be used?"
                                                   (keys->allowed-values-help-text fn/nemesis-generator-factories))
                      :parse-fn keyword

--- a/flink-jepsen/test/jepsen/flink/db_test.clj
+++ b/flink-jepsen/test/jepsen/flink/db_test.clj
@@ -1,0 +1,29 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns jepsen.flink.db-test
+  (:require [clojure.test :refer :all])
+  (:require [jepsen.flink.db :refer :all]))
+
+(deftest flink-configuration-test
+  (testing "High availability is zookeeper by default"
+    (is (= "zookeeper" (:high-availability (flink-configuration {} "n1")))))
+
+  (testing "Default configuration can be overridden"
+    (let [expected-config-value "NONE"
+          custom-flink-config {:high-availability expected-config-value}
+          test {:test-spec {:flink-config custom-flink-config}}]
+      (is (= expected-config-value (:high-availability (flink-configuration test "n1")))))))


### PR DESCRIPTION
## What is the purpose of the change

*Enable users to set a cluster configuration in the test spec which will have precedence over the default configuration.*


## Brief change log

  - *See commits*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test to verify that default Flink configuration can be overriden*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)


cc: @tillrohrmann 