### PR TITLE
[FLINK-13187] Introduce ScheduleMode#LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -51,7 +51,6 @@ import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
@@ -411,7 +410,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 	public CompletableFuture<Void> scheduleForExecution() {
 		final ExecutionGraph executionGraph = getVertex().getExecutionGraph();
-		final SlotProvider resourceProvider = executionGraph.getSlotProvider();
+		final SlotProviderStrategy resourceProvider = executionGraph.getSlotProviderStrategy();
 		final boolean allowQueued = executionGraph.isQueuedSchedulingAllowed();
 		return scheduleForExecution(
 			resourceProvider,
@@ -425,7 +424,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 *       to be scheduled immediately and no resource is available. If the task is accepted by the schedule, any
 	 *       error sets the vertex state to failed and triggers the recovery logic.
 	 *
-	 * @param slotProvider The slot provider to use to allocate slot for this execution attempt.
+	 * @param slotProviderStrategy The slot provider strategy to use to allocate slot for this execution attempt.
 	 * @param queued Flag to indicate whether the scheduler may queue this task if it cannot
 	 *               immediately deploy it.
 	 * @param locationPreferenceConstraint constraint for the location preferences
@@ -434,7 +433,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * @return Future which is completed once the Execution has been deployed
 	 */
 	public CompletableFuture<Void> scheduleForExecution(
-			SlotProvider slotProvider,
+			SlotProviderStrategy slotProviderStrategy,
 			boolean queued,
 			LocationPreferenceConstraint locationPreferenceConstraint,
 			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds) {
@@ -444,7 +443,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		final Time allocationTimeout = executionGraph.getAllocationTimeout();
 		try {
 			final CompletableFuture<Execution> allocationFuture = allocateResourcesForExecution(
-				slotProvider,
+				slotProviderStrategy,
 				queued,
 				locationPreferenceConstraint,
 				allPreviousExecutionGraphAllocationIds,
@@ -491,7 +490,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 *  <li>registers produced partitions with the {@link org.apache.flink.runtime.shuffle.ShuffleMaster}</li>
 	 * </ol>
 	 *
-	 * @param slotProvider to obtain a new slot from
+	 * @param slotProviderStrategy to obtain a new slot from
 	 * @param queued if the allocation can be queued
 	 * @param locationPreferenceConstraint constraint for the location preferences
 	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
@@ -501,13 +500,13 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * 			or with an exception if an error occurred.
 	 */
 	CompletableFuture<Execution> allocateResourcesForExecution(
-			SlotProvider slotProvider,
+			SlotProviderStrategy slotProviderStrategy,
 			boolean queued,
 			LocationPreferenceConstraint locationPreferenceConstraint,
 			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds,
 			Time allocationTimeout) {
 		return allocateAndAssignSlotForExecution(
-			slotProvider,
+			slotProviderStrategy,
 			queued,
 			locationPreferenceConstraint,
 			allPreviousExecutionGraphAllocationIds,
@@ -518,7 +517,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	/**
 	 * Allocates and assigns a slot obtained from the slot provider to the execution.
 	 *
-	 * @param slotProvider to obtain a new slot from
+	 * @param slotProviderStrategy to obtain a new slot from
 	 * @param queued if the allocation can be queued
 	 * @param locationPreferenceConstraint constraint for the location preferences
 	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
@@ -528,13 +527,13 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * 			or with an exception if an error occurred.
 	 */
 	private CompletableFuture<LogicalSlot> allocateAndAssignSlotForExecution(
-			SlotProvider slotProvider,
+			SlotProviderStrategy slotProviderStrategy,
 			boolean queued,
 			LocationPreferenceConstraint locationPreferenceConstraint,
 			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds,
 			Time allocationTimeout) {
 
-		checkNotNull(slotProvider);
+		checkNotNull(slotProviderStrategy);
 
 		assertRunningInJobMasterMainThread();
 
@@ -572,22 +571,20 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			final CompletableFuture<LogicalSlot> logicalSlotFuture =
 				preferredLocationsFuture.thenCompose(
 					(Collection<TaskManagerLocation> preferredLocations) ->
-						slotProvider.allocateSlot(
+						slotProviderStrategy.allocateSlot(
 							slotRequestId,
 							toSchedule,
 							new SlotProfile(
 								vertex.getResourceProfile(),
 								preferredLocations,
 								previousAllocationIDs,
-								allPreviousExecutionGraphAllocationIds),
-							queued,
-							allocationTimeout));
+								allPreviousExecutionGraphAllocationIds)));
 
 			// register call back to cancel slot request in case that the execution gets canceled
 			releaseFuture.whenComplete(
 				(Object ignored, Throwable throwable) -> {
 					if (logicalSlotFuture.cancel(false)) {
-						slotProvider.cancelSlotRequest(
+						slotProviderStrategy.cancelSlotRequest(
 							slotRequestId,
 							slotSharingGroupId,
 							new FlinkException("Execution " + this + " was released."));
@@ -858,7 +855,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		try {
 			final ExecutionGraph executionGraph = consumerVertex.getExecutionGraph();
 			consumerVertex.scheduleForExecution(
-				executionGraph.getSlotProvider(),
+				executionGraph.getSlotProviderStrategy(),
 				executionGraph.isQueuedSchedulingAllowed(),
 				LocationPreferenceConstraint.ANY, // there must be at least one known location
 				Collections.emptySet());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -940,21 +940,10 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 		if (transitionState(JobStatus.CREATED, JobStatus.RUNNING)) {
 
-			final CompletableFuture<Void> newSchedulingFuture;
-
-			switch (scheduleMode) {
-
-				case LAZY_FROM_SOURCES:
-					newSchedulingFuture = scheduleLazy();
-					break;
-
-				case EAGER:
-					newSchedulingFuture = scheduleEager();
-					break;
-
-				default:
-					throw new JobException("Schedule mode is invalid.");
-			}
+			final CompletableFuture<Void> newSchedulingFuture = SchedulingUtils.schedule(
+				scheduleMode,
+				getAllExecutionVertices(),
+				this);
 
 			if (state == JobStatus.RUNNING && currentGlobalModVersion == globalModVersion) {
 				schedulingFuture = newSchedulingFuture;
@@ -976,18 +965,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		else {
 			throw new IllegalStateException("Job may only be scheduled from state " + JobStatus.CREATED);
 		}
-	}
-
-	private CompletableFuture<Void> scheduleLazy() {
-		return SchedulingUtils.scheduleLazy(getAllExecutionVertices(), this);
-	}
-
-	/**
-	 * @return Future which is completed once the {@link ExecutionGraph} has been scheduled.
-	 * The future can also be completed exceptionally if an error happened.
-	 */
-	private CompletableFuture<Void> scheduleEager() {
-		return SchedulingUtils.scheduleEager(getAllExecutionVertices(), this);
 	}
 
 	public void cancel() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -100,13 +100,52 @@ public class ExecutionGraphBuilder {
 			ShuffleMaster<?> shuffleMaster,
 			PartitionTracker partitionTracker) throws JobExecutionException, JobException {
 
+		final FailoverStrategy.Factory failoverStrategy =
+			FailoverStrategyLoader.loadFailoverStrategy(jobManagerConfig, log);
+
+		return buildGraph(
+			prior,
+			jobGraph,
+			jobManagerConfig,
+			futureExecutor,
+			ioExecutor,
+			slotProvider,
+			classLoader,
+			recoveryFactory,
+			rpcTimeout,
+			restartStrategy,
+			metrics,
+			blobWriter,
+			allocationTimeout,
+			log,
+			shuffleMaster,
+			partitionTracker,
+			failoverStrategy);
+	}
+
+	public static ExecutionGraph buildGraph(
+		@Nullable ExecutionGraph prior,
+		JobGraph jobGraph,
+		Configuration jobManagerConfig,
+		ScheduledExecutorService futureExecutor,
+		Executor ioExecutor,
+		SlotProvider slotProvider,
+		ClassLoader classLoader,
+		CheckpointRecoveryFactory recoveryFactory,
+		Time rpcTimeout,
+		RestartStrategy restartStrategy,
+		MetricGroup metrics,
+		BlobWriter blobWriter,
+		Time allocationTimeout,
+		Logger log,
+		ShuffleMaster<?> shuffleMaster,
+		PartitionTracker partitionTracker,
+		FailoverStrategy.Factory failoverStrategyFactory) throws JobExecutionException, JobException {
+
 		checkNotNull(jobGraph, "job graph cannot be null");
 
 		final String jobName = jobGraph.getName();
 		final JobID jobId = jobGraph.getJobID();
-
-		final FailoverStrategy.Factory failoverStrategy =
-				FailoverStrategyLoader.loadFailoverStrategy(jobManagerConfig, log);
 
 		final JobInformation jobInformation = new JobInformation(
 			jobId,
@@ -136,7 +175,7 @@ public class ExecutionGraphBuilder {
 					rpcTimeout,
 					restartStrategy,
 					maxPriorAttemptsHistoryLength,
-					failoverStrategy,
+					failoverStrategyFactory,
 					slotProvider,
 					classLoader,
 					blobWriter,
@@ -144,15 +183,14 @@ public class ExecutionGraphBuilder {
 					partitionReleaseStrategyFactory,
 					shuffleMaster,
 					forcePartitionReleaseOnConsumption,
-					partitionTracker);
+					partitionTracker,
+					jobGraph.getScheduleMode(),
+					jobGraph.getAllowQueuedScheduling());
 		} catch (IOException e) {
 			throw new JobException("Could not create the ExecutionGraph.", e);
 		}
 
 		// set the basic properties
-
-		executionGraph.setScheduleMode(jobGraph.getScheduleMode());
-		executionGraph.setQueuedSchedulingAllowed(jobGraph.getAllowQueuedScheduling());
 
 		try {
 			executionGraph.setJsonPlan(JsonPlanGenerator.generatePlan(jobGraph));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -45,9 +44,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
-import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.OptionalFailure;
@@ -67,7 +64,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -478,80 +474,6 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	//---------------------------------------------------------------------------------------------
 	//  Actions
 	//---------------------------------------------------------------------------------------------
-
-	/**
-	 * Schedules all execution vertices of this ExecutionJobVertex.
-	 *
-	 * @param slotProvider to allocate the slots from
-	 * @param queued if the allocations can be queued
-	 * @param locationPreferenceConstraint constraint for the location preferences
-	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
-	 *                                                 Can be empty if the allocation ids are not required for scheduling.
-	 * @return Future which is completed once all {@link Execution} could be deployed
-	 */
-	public CompletableFuture<Void> scheduleAll(
-			SlotProvider slotProvider,
-			boolean queued,
-			LocationPreferenceConstraint locationPreferenceConstraint,
-			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds) {
-
-		final ExecutionVertex[] vertices = this.taskVertices;
-
-		final ArrayList<CompletableFuture<Void>> scheduleFutures = new ArrayList<>(vertices.length);
-
-		// kick off the tasks
-		for (ExecutionVertex ev : vertices) {
-			scheduleFutures.add(ev.scheduleForExecution(
-				slotProvider,
-				queued,
-				locationPreferenceConstraint,
-				allPreviousExecutionGraphAllocationIds));
-		}
-
-		return FutureUtils.waitForAll(scheduleFutures);
-	}
-
-	/**
-	 * Acquires a slot for all the execution vertices of this ExecutionJobVertex. The method returns
-	 * pairs of the slots and execution attempts, to ease correlation between vertices and execution
-	 * attempts.
-	 *
-	 * <p>If this method throws an exception, it makes sure to release all so far requested slots.
-	 *
-	 * @param resourceProvider The resource provider from whom the slots are requested.
-	 * @param queued if the allocation can be queued
-	 * @param locationPreferenceConstraint constraint for the location preferences
-	 * @param allPreviousExecutionGraphAllocationIds the allocation ids of all previous executions in the execution job graph.
-	 * @param allocationTimeout timeout for allocating the individual slots
-	 */
-	public Collection<CompletableFuture<Execution>> allocateResourcesForAll(
-			SlotProvider resourceProvider,
-			boolean queued,
-			LocationPreferenceConstraint locationPreferenceConstraint,
-			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds,
-			Time allocationTimeout) {
-		final ExecutionVertex[] vertices = this.taskVertices;
-
-		@SuppressWarnings("unchecked")
-		final CompletableFuture<Execution>[] slots = new CompletableFuture[vertices.length];
-
-		// try to acquire a slot future for each execution.
-		// we store the execution with the future just to be on the safe side
-		for (int i = 0; i < vertices.length; i++) {
-			// allocate the next slot (future)
-			final Execution exec = vertices[i].getCurrentExecutionAttempt();
-			final CompletableFuture<Execution> allocationFuture = exec.allocateResourcesForExecution(
-				resourceProvider,
-				queued,
-				locationPreferenceConstraint,
-				allPreviousExecutionGraphAllocationIds,
-				allocationTimeout);
-			slots[i] = allocationFuture;
-		}
-
-		// all good, we acquired all slots
-		return Arrays.asList(slots);
-	}
 
 	/**
 	 * Cancels all currently running vertex executions.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -659,7 +659,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	/**
 	 * Schedules the current execution of this ExecutionVertex.
 	 *
-	 * @param slotProvider to allocate the slots from
+	 * @param slotProviderStrategy to allocate the slots from
 	 * @param queued if the allocation can be queued
 	 * @param locationPreferenceConstraint constraint for the location preferences
 	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
@@ -668,12 +668,12 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 * can also completed exceptionally.
 	 */
 	public CompletableFuture<Void> scheduleForExecution(
-			SlotProvider slotProvider,
+			SlotProviderStrategy slotProviderStrategy,
 			boolean queued,
 			LocationPreferenceConstraint locationPreferenceConstraint,
 			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds) {
 		return this.currentExecution.scheduleForExecution(
-			slotProvider,
+			slotProviderStrategy,
 			queued,
 			locationPreferenceConstraint,
 			allPreviousExecutionGraphAllocationIds);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -39,7 +39,6 @@ import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.EvictingBoundedList;
@@ -660,7 +659,6 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 * Schedules the current execution of this ExecutionVertex.
 	 *
 	 * @param slotProviderStrategy to allocate the slots from
-	 * @param queued if the allocation can be queued
 	 * @param locationPreferenceConstraint constraint for the location preferences
 	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
 	 *                                                 Can be empty if the allocation ids are not required for scheduling.
@@ -669,12 +667,10 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 */
 	public CompletableFuture<Void> scheduleForExecution(
 			SlotProviderStrategy slotProviderStrategy,
-			boolean queued,
 			LocationPreferenceConstraint locationPreferenceConstraint,
 			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds) {
 		return this.currentExecution.scheduleForExecution(
 			slotProviderStrategy,
-			queued,
 			locationPreferenceConstraint,
 			allPreviousExecutionGraphAllocationIds);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SchedulingUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SchedulingUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils.ConjunctFuture;
 import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmaster.slotpool.Scheduler;
@@ -45,6 +46,23 @@ import static org.apache.flink.util.Preconditions.checkState;
  * It is used for normal scheduling and legacy failover strategy re-scheduling.
  */
 public class SchedulingUtils {
+
+	public static CompletableFuture<Void> schedule(
+			ScheduleMode scheduleMode,
+			final Iterable<ExecutionVertex> vertices,
+			final ExecutionGraph executionGraph) {
+
+		switch (scheduleMode) {
+			case LAZY_FROM_SOURCES:
+				return scheduleLazy(vertices, executionGraph);
+
+			case EAGER:
+				return scheduleEager(vertices, executionGraph);
+
+			default:
+				throw new IllegalStateException(String.format("Schedule mode %s is invalid.", scheduleMode));
+		}
+	}
 
 	/**
 	 * Schedule vertices lazy. That means only vertices satisfying its input constraint will be scheduled.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SchedulingUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SchedulingUtils.java
@@ -89,7 +89,6 @@ public class SchedulingUtils {
 
 				final CompletableFuture<Void> schedulingVertexFuture = executionVertex.scheduleForExecution(
 					slotProviderStrategy,
-					executionGraph.isQueuedSchedulingAllowed(),
 					LocationPreferenceConstraint.ANY,
 					previousAllocations);
 
@@ -118,7 +117,6 @@ public class SchedulingUtils {
 		// that way we do not have any operation that can fail between allocating the slots
 		// and adding them to the list. If we had a failure in between there, that would
 		// cause the slots to get lost
-		final boolean queued = executionGraph.isQueuedSchedulingAllowed();
 
 		// collecting all the slots may resize and fail in that operation without slots getting lost
 		final ArrayList<CompletableFuture<Execution>> allAllocationFutures = new ArrayList<>();
@@ -132,10 +130,8 @@ public class SchedulingUtils {
 			// these calls are not blocking, they only return futures
 			CompletableFuture<Execution> allocationFuture = ev.getCurrentExecutionAttempt().allocateResourcesForExecution(
 				slotProviderStrategy,
-				queued,
 				LocationPreferenceConstraint.ALL,
-				allPreviousAllocationIds,
-				executionGraph.getAllocationTimeout());
+				allPreviousAllocationIds);
 
 			allAllocationFutures.add(allocationFuture);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SlotProviderStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SlotProviderStrategy.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Strategy to switch between different {@link SlotProvider} allocation strategies.
+ */
+abstract class SlotProviderStrategy {
+
+	protected final SlotProvider slotProvider;
+
+	protected final boolean allowQueuedScheduling;
+
+	SlotProviderStrategy(SlotProvider slotProvider, boolean allowQueuedScheduling) {
+		this.slotProvider = Preconditions.checkNotNull(slotProvider);
+		this.allowQueuedScheduling = allowQueuedScheduling;
+	}
+
+	/**
+	 * Allocating slot with specific requirement.
+	 *
+	 * @param slotRequestId identifying the slot request
+	 * @param scheduledUnit The task to allocate the slot for
+	 * @param slotProfile profile of the requested slot
+	 * @return The future of the allocation
+	 */
+	abstract CompletableFuture<LogicalSlot> allocateSlot(
+		SlotRequestId slotRequestId,
+		ScheduledUnit scheduledUnit,
+		SlotProfile slotProfile);
+
+	/**
+	 * Cancels the slot request with the given {@link SlotRequestId} and {@link SlotSharingGroupId}.
+	 *
+	 * @param slotRequestId identifying the slot request to cancel
+	 * @param slotSharingGroupId identifying the slot request to cancel
+	 * @param cause of the cancellation
+	 */
+	void cancelSlotRequest(
+		SlotRequestId slotRequestId,
+		@Nullable SlotSharingGroupId slotSharingGroupId,
+		Throwable cause) {
+		slotProvider.cancelSlotRequest(slotRequestId, slotSharingGroupId, cause);
+	}
+
+	static SlotProviderStrategy from(
+		ScheduleMode scheduleMode,
+		SlotProvider slotProvider,
+		Time allocationTimeout,
+		boolean allowQueuedScheduling) {
+
+		switch (scheduleMode) {
+			case LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST:
+				return new BatchSlotProviderStrategy(slotProvider, allowQueuedScheduling);
+			case LAZY_FROM_SOURCES:
+			case EAGER:
+				return new NormalSlotProviderStrategy(slotProvider, allocationTimeout, allowQueuedScheduling);
+			default:
+				throw new IllegalArgumentException(String.format("Unknown scheduling mode: %s", scheduleMode));
+		}
+	}
+
+	SlotProvider asSlotProvider() {
+		return slotProvider;
+	}
+
+	static class BatchSlotProviderStrategy extends SlotProviderStrategy {
+
+		BatchSlotProviderStrategy(SlotProvider slotProvider, boolean allowQueuedScheduling) {
+			super(slotProvider, allowQueuedScheduling);
+		}
+
+		@Override
+		public CompletableFuture<LogicalSlot> allocateSlot(SlotRequestId slotRequestId, ScheduledUnit scheduledUnit, SlotProfile slotProfile) {
+			return slotProvider.allocateBatchSlot(slotRequestId, scheduledUnit, slotProfile, allowQueuedScheduling);
+		}
+	}
+
+	static class NormalSlotProviderStrategy extends SlotProviderStrategy {
+		private final Time allocationTimeout;
+
+		NormalSlotProviderStrategy(SlotProvider slotProvider, Time allocationTimeout, boolean allowQueuedScheduling) {
+			super(slotProvider, allowQueuedScheduling);
+			this.allocationTimeout = Preconditions.checkNotNull(allocationTimeout);
+		}
+
+		@Override
+		public CompletableFuture<LogicalSlot> allocateSlot(SlotRequestId slotRequestId, ScheduledUnit scheduledUnit, SlotProfile slotProfile) {
+			return slotProvider.allocateSlot(slotRequestId, scheduledUnit, slotProfile, allowQueuedScheduling, allocationTimeout);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SlotProviderStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SlotProviderStrategy.java
@@ -46,6 +46,10 @@ abstract class SlotProviderStrategy {
 		this.allowQueuedScheduling = allowQueuedScheduling;
 	}
 
+	boolean isQueuedSchedulingAllowed() {
+		return allowQueuedScheduling;
+	}
+
 	/**
 	 * Allocating slot with specific requirement.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
@@ -232,7 +232,7 @@ public class FailoverRegion {
 				for (ExecutionVertex ev : connectedExecutionVertexes) {
 					try {
 						ev.scheduleForExecution(
-							executionGraph.getSlotProvider(),
+							executionGraph.getSlotProviderStrategy(),
 							executionGraph.isQueuedSchedulingAllowed(),
 							LocationPreferenceConstraint.ANY,
 							previousAllocationsInRegion); // some inputs not belonging to the failover region might have failed concurrently

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
@@ -233,7 +233,6 @@ public class FailoverRegion {
 					try {
 						ev.scheduleForExecution(
 							executionGraph.getSlotProviderStrategy(),
-							executionGraph.isQueuedSchedulingAllowed(),
 							LocationPreferenceConstraint.ANY,
 							previousAllocationsInRegion); // some inputs not belonging to the failover region might have failed concurrently
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/ScheduleMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/ScheduleMode.java
@@ -19,21 +19,32 @@
 package org.apache.flink.runtime.jobgraph;
 
 /**
- * The ScheduleMode decides how tasks of an execution graph are started.  
+ * The ScheduleMode decides how tasks of an execution graph are started.
  */
 public enum ScheduleMode {
-
 	/** Schedule tasks lazily from the sources. Downstream tasks are started once their input data are ready */
-	LAZY_FROM_SOURCES,
+	LAZY_FROM_SOURCES(true),
+
+	/**
+	 * Same as LAZY_FROM_SOURCES just with the difference that it uses batch slot requests which support the
+	 * execution of jobs with fewer slots than requested. However, the user needs to make sure that the job
+	 * does not contain any pipelined shuffles (every pipelined region can be executed with a single slot).
+	 */
+	LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST(true),
 
 	/** Schedules all tasks immediately. */
-	EAGER;
-	
+	EAGER(false);
+
+	private final boolean allowLazyDeployment;
+
+	ScheduleMode(boolean allowLazyDeployment) {
+		this.allowLazyDeployment = allowLazyDeployment;
+	}
+
 	/**
 	 * Returns whether we are allowed to deploy consumers lazily.
 	 */
 	public boolean allowLazyDeployment() {
-		return this == LAZY_FROM_SOURCES;
+		return allowLazyDeployment;
 	}
-	
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolFactory.java
@@ -42,13 +42,18 @@ public class DefaultSlotPoolFactory implements SlotPoolFactory {
 	@Nonnull
 	private final Time slotIdleTimeout;
 
+	@Nonnull
+	private final Time batchSlotTimeout;
+
 	public DefaultSlotPoolFactory(
 			@Nonnull Clock clock,
 			@Nonnull Time rpcTimeout,
-			@Nonnull Time slotIdleTimeout) {
+			@Nonnull Time slotIdleTimeout,
+			@Nonnull Time batchSlotTimeout) {
 		this.clock = clock;
 		this.rpcTimeout = rpcTimeout;
 		this.slotIdleTimeout = slotIdleTimeout;
+		this.batchSlotTimeout = batchSlotTimeout;
 	}
 
 	@Override
@@ -58,17 +63,20 @@ public class DefaultSlotPoolFactory implements SlotPoolFactory {
 			jobId,
 			clock,
 			rpcTimeout,
-			slotIdleTimeout);
+			slotIdleTimeout,
+			batchSlotTimeout);
 	}
 
 	public static DefaultSlotPoolFactory fromConfiguration(@Nonnull Configuration configuration) {
 
 		final Time rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
 		final Time slotIdleTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
+		final Time batchSlotTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
 
 		return new DefaultSlotPoolFactory(
 			SystemClock.getInstance(),
 			rpcTimeout,
-			slotIdleTimeout);
+			slotIdleTimeout,
+			batchSlotTimeout);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 import java.util.AbstractCollection;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Set;
 
 /**
@@ -33,17 +33,17 @@ import java.util.Set;
  * @param <B> Type of key B
  * @param <V> Type of the value
  */
-public class DualKeyMap<A, B, V> {
+public class DualKeyLinkedMap<A, B, V> {
 
-	private final HashMap<A, Tuple2<B, V>> aMap;
+	private final LinkedHashMap<A, Tuple2<B, V>> aMap;
 
-	private final HashMap<B, A> bMap;
+	private final LinkedHashMap<B, A> bMap;
 
 	private transient Collection<V> values;
 
-	public DualKeyMap(int initialCapacity) {
-		this.aMap = new HashMap<>(initialCapacity);
-		this.bMap = new HashMap<>(initialCapacity);
+	public DualKeyLinkedMap(int initialCapacity) {
+		this.aMap = new LinkedHashMap<>(initialCapacity);
+		this.bMap = new LinkedHashMap<>(initialCapacity);
 	}
 
 	public int size() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
-import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -163,7 +162,7 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
 		@Nonnull SlotRequestId slotRequestId,
 		@Nonnull ResourceProfile resourceProfile,
-		@RpcTimeout Time timeout);
+		Time timeout);
 
 	/**
 	 * Create report about the allocated slots belonging to the specified task manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -165,6 +165,20 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 		Time timeout);
 
 	/**
+	 * Requests the allocation of a new batch slot from the resource manager. Unlike the normal slot, a batch
+	 * slot will only time out if the slot pool does not contain a suitable slot. Moreover, it won't react to
+	 * failure signals from the resource manager.
+	 *
+	 * @param slotRequestId identifying the requested slot
+	 * @param resourceProfile resource profile that specifies the resource requirements for the requested batch slot
+	 * @return a future which is completed with newly allocated batch slot
+	 */
+	@Nonnull
+	CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
+		@Nonnull SlotRequestId slotRequestId,
+		@Nonnull ResourceProfile resourceProfile);
+
+	/**
 	 * Create report about the allocated slots belonging to the specified task manager.
 	 *
 	 * @param taskManagerId identifies the task manager

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -105,10 +106,10 @@ public class SlotPoolImpl implements SlotPool {
 	private final AvailableSlots availableSlots;
 
 	/** All pending requests waiting for slots. */
-	private final DualKeyMap<SlotRequestId, AllocationID, PendingRequest> pendingRequests;
+	private final DualKeyLinkedMap<SlotRequestId, AllocationID, PendingRequest> pendingRequests;
 
 	/** The requests that are waiting for the resource manager to be connected. */
-	private final HashMap<SlotRequestId, PendingRequest> waitingForResourceManager;
+	private final LinkedHashMap<SlotRequestId, PendingRequest> waitingForResourceManager;
 
 	/** Timeout for external request calls (e.g. to the ResourceManager or the TaskExecutor). */
 	private final Time rpcTimeout;
@@ -153,8 +154,8 @@ public class SlotPoolImpl implements SlotPool {
 		this.registeredTaskManagers = new HashSet<>(16);
 		this.allocatedSlots = new AllocatedSlots();
 		this.availableSlots = new AvailableSlots();
-		this.pendingRequests = new DualKeyMap<>(16);
-		this.waitingForResourceManager = new HashMap<>(16);
+		this.pendingRequests = new DualKeyLinkedMap<>(16);
+		this.waitingForResourceManager = new LinkedHashMap<>(16);
 
 		this.jobMasterId = null;
 		this.resourceManagerGateway = null;
@@ -857,7 +858,7 @@ public class SlotPoolImpl implements SlotPool {
 	}
 
 	@VisibleForTesting
-	DualKeyMap<SlotRequestId, AllocationID, PendingRequest> getPendingRequests() {
+	DualKeyLinkedMap<SlotRequestId, AllocationID, PendingRequest> getPendingRequests() {
 		return pendingRequests;
 	}
 
@@ -915,11 +916,11 @@ public class SlotPoolImpl implements SlotPool {
 		private final Map<ResourceID, Set<AllocatedSlot>> allocatedSlotsByTaskManager;
 
 		/** All allocated slots organized by AllocationID. */
-		private final DualKeyMap<AllocationID, SlotRequestId, AllocatedSlot> allocatedSlotsById;
+		private final DualKeyLinkedMap<AllocationID, SlotRequestId, AllocatedSlot> allocatedSlotsById;
 
 		AllocatedSlots() {
 			this.allocatedSlotsByTaskManager = new HashMap<>(16);
-			this.allocatedSlotsById = new DualKeyMap<>(16);
+			this.allocatedSlotsById = new DualKeyLinkedMap<>(16);
 		}
 
 		/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotProvider.java
@@ -60,6 +60,23 @@ public interface SlotProvider {
 		Time allocationTimeout);
 
 	/**
+	 * Allocating batch slot with specific requirement.
+	 *
+	 * @param slotRequestId identifying the slot request
+	 * @param scheduledUnit The task to allocate the slot for
+	 * @param slotProfile profile of the requested slot
+	 * @param allowQueuedScheduling Whether allow the task be queued if we do not have enough resource
+	 * @return The future of the allocation
+	 */
+	default CompletableFuture<LogicalSlot> allocateBatchSlot(
+		SlotRequestId slotRequestId,
+		ScheduledUnit scheduledUnit,
+		SlotProfile slotProfile,
+		boolean allowQueuedScheduling) {
+		throw new UnsupportedOperationException("Not properly implemented.");
+	}
+
+	/**
 	 * Allocating slot with specific requirement.
 	 *
 	 * @param scheduledUnit The task to allocate the slot for

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -19,24 +19,18 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.DummyJobInformation;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.executiongraph.TestingSlotProvider;
-import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
-import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
-import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Matchers;
@@ -140,17 +134,15 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 			CheckpointIDCounter counter,
 			CompletedCheckpointStore store) throws Exception {
 		final Time timeout = Time.days(1L);
-		ExecutionGraph executionGraph = new ExecutionGraph(
-			new DummyJobInformation(),
-			TestingUtils.defaultExecutor(),
-			TestingUtils.defaultExecutor(),
-			timeout,
-			new NoRestartStrategy(),
-			new RestartAllStrategy.Factory(),
-			new TestingSlotProvider(slotRequestId -> CompletableFuture.completedFuture(new TestingLogicalSlot())),
-			ClassLoader.getSystemClassLoader(),
-			VoidBlobWriter.getInstance(),
-			timeout);
+
+		JobVertex jobVertex = new JobVertex("MockVertex");
+		jobVertex.setInvokableClass(AbstractInvokable.class);
+
+		final ExecutionGraph executionGraph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobVertex)
+			.setRpcTimeout(timeout)
+			.setAllocationTimeout(timeout)
+			.allowQueuedScheduling()
+			.build();
 
 		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
@@ -174,11 +166,6 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 				store,
 				new MemoryStateBackend(),
 				CheckpointStatsTrackerTest.createTestTracker());
-
-		JobVertex jobVertex = new JobVertex("MockVertex");
-		jobVertex.setInvokableClass(AbstractInvokable.class);
-		executionGraph.attachJobGraph(Collections.singletonList(jobVertex));
-		executionGraph.setQueuedSchedulingAllowed(true);
 
 		return executionGraph;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobStatus;
@@ -64,17 +63,16 @@ public class ExecutionGraphCoLocationRestartTest extends SchedulerTestBase {
 		groupVertex.setStrictlyCoLocatedWith(groupVertex2);
 
 		//initiate and schedule job
-		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
-			testingSlotProvider,
-			new TestRestartStrategy(
-				1,
-				false),
-			groupVertex,
-			groupVertex2);
+		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(groupVertex, groupVertex2)
+			.setSlotProvider(testingSlotProvider)
+			.setRestartStrategy(
+				new TestRestartStrategy(
+					1,
+					false))
+			.allowQueuedScheduling()
+			.build();
 
 		// enable the queued scheduling for the slot pool
-		eg.setQueuedSchedulingAllowed(true);
 		eg.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		assertEquals(JobStatus.CREATED, eg.getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -123,6 +123,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final JobGraph jobGraph = new JobGraph(jobId, "test", sourceVertex, targetVertex);
+		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+		jobGraph.setAllowQueuedScheduling(true);
 
 		final CompletableFuture<LogicalSlot> sourceFuture = new CompletableFuture<>();
 		final CompletableFuture<LogicalSlot> targetFuture = new CompletableFuture<>();
@@ -142,8 +144,6 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		final SimpleSlot sourceSlot = createSlot(gatewaySource, jobId);
 		final SimpleSlot targetSlot = createSlot(gatewayTarget, jobId);
 
-		eg.setScheduleMode(ScheduleMode.EAGER);
-		eg.setQueuedSchedulingAllowed(true);
 		eg.scheduleForExecution();
 
 		// job should be running
@@ -191,6 +191,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final JobGraph jobGraph = new JobGraph(jobId, "test", sourceVertex, targetVertex);
+		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+		jobGraph.setAllowQueuedScheduling(true);
 
 		@SuppressWarnings({"unchecked", "rawtypes"})
 		final CompletableFuture<LogicalSlot>[] sourceFutures = new CompletableFuture[parallelism];
@@ -233,8 +235,6 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		//
 		//  kick off the scheduling
 		eg.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-		eg.setScheduleMode(ScheduleMode.EAGER);
-		eg.setQueuedSchedulingAllowed(true);
 		eg.scheduleForExecution();
 
 		verifyNothingDeployed(eg, sourceTaskManagers);
@@ -288,6 +288,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final JobGraph jobGraph = new JobGraph(jobId, "test", sourceVertex, targetVertex);
+		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+		jobGraph.setAllowQueuedScheduling(true);
 
 		//
 		//  Create the slots, futures, and the slot provider
@@ -329,11 +331,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			targetFutures[i].complete(targetSlots[i]);
 		}
 
-		//
 		//  kick off the scheduling
-
-		eg.setScheduleMode(ScheduleMode.EAGER);
-		eg.setQueuedSchedulingAllowed(true);
 		eg.scheduleForExecution();
 
 		// fail one slot
@@ -374,6 +372,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final JobGraph jobGraph = new JobGraph(jobId, "test", vertex);
+		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+		jobGraph.setAllowQueuedScheduling(true);
 
 		final BlockingQueue<AllocationID> returnedSlots = new ArrayBlockingQueue<>(2);
 		final TestingSlotOwner slotOwner = new TestingSlotOwner();
@@ -400,8 +400,6 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 
 		//  kick off the scheduling
 		eg.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-		eg.setScheduleMode(ScheduleMode.EAGER);
-		eg.setQueuedSchedulingAllowed(true);
 		eg.scheduleForExecution();
 
 		//  we complete another future

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -138,10 +138,8 @@ public class ExecutionTest extends TestLogger {
 
 		CompletableFuture<Execution> allocationFuture = execution.allocateResourcesForExecution(
 			executionGraph.getSlotProviderStrategy(),
-			false,
 			LocationPreferenceConstraint.ALL,
-			Collections.emptySet(),
-			TestingUtils.infiniteTime());
+			Collections.emptySet());
 
 		assertFalse(allocationFuture.isDone());
 
@@ -190,10 +188,8 @@ public class ExecutionTest extends TestLogger {
 
 		CompletableFuture<Execution> allocationFuture = execution.allocateResourcesForExecution(
 			executionGraph.getSlotProviderStrategy(),
-			false,
 			LocationPreferenceConstraint.ALL,
-			Collections.emptySet(),
-			TestingUtils.infiniteTime());
+			Collections.emptySet());
 
 		assertTrue(allocationFuture.isDone());
 
@@ -240,10 +236,8 @@ public class ExecutionTest extends TestLogger {
 
 		CompletableFuture<Execution> allocationFuture = execution.allocateResourcesForExecution(
 			executionGraph.getSlotProviderStrategy(),
-			false,
 			LocationPreferenceConstraint.ALL,
-			Collections.emptySet(),
-			TestingUtils.infiniteTime());
+			Collections.emptySet());
 
 		assertTrue(allocationFuture.isDone());
 
@@ -292,10 +286,8 @@ public class ExecutionTest extends TestLogger {
 
 		final CompletableFuture<Execution> allocationFuture = currentExecutionAttempt.allocateResourcesForExecution(
 			executionGraph.getSlotProviderStrategy(),
-			false,
 			LocationPreferenceConstraint.ALL,
-			Collections.emptySet(),
-			TestingUtils.infiniteTime());
+			Collections.emptySet());
 
 		assertThat(allocationFuture.isDone(), is(false));
 
@@ -400,7 +392,10 @@ public class ExecutionTest extends TestLogger {
 
 		ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
 
-		executionVertex.scheduleForExecution(executionGraph.getSlotProviderStrategy(), false, LocationPreferenceConstraint.ANY, Collections.emptySet()).get();
+		executionVertex.scheduleForExecution(
+			executionGraph.getSlotProviderStrategy(),
+			LocationPreferenceConstraint.ANY,
+			Collections.emptySet()).get();
 
 		Execution currentExecutionAttempt = executionVertex.getCurrentExecutionAttempt();
 
@@ -452,7 +447,11 @@ public class ExecutionTest extends TestLogger {
 		assertThat(execution.getTaskRestore(), is(notNullValue()));
 
 		// schedule the execution vertex and wait for its deployment
-		executionVertex.scheduleForExecution(executionGraph.getSlotProviderStrategy(), false, LocationPreferenceConstraint.ANY, Collections.emptySet()).get();
+		executionVertex.scheduleForExecution(
+			executionGraph.getSlotProviderStrategy(),
+			LocationPreferenceConstraint.ANY,
+			Collections.emptySet())
+			.get();
 
 		assertThat(execution.getTaskRestore(), is(nullValue()));
 	}
@@ -514,7 +513,6 @@ public class ExecutionTest extends TestLogger {
 		final CompletableFuture<Void> schedulingFuture = testMainThreadUtil.execute(
 			() -> execution.scheduleForExecution(
 				executionGraph.getSlotProviderStrategy(),
-				false,
 				LocationPreferenceConstraint.ANY,
 				Collections.emptySet()));
 
@@ -606,10 +604,8 @@ public class ExecutionTest extends TestLogger {
 
 		execution.allocateResourcesForExecution(
 			executionGraph.getSlotProviderStrategy(),
-			false,
 			LocationPreferenceConstraint.ALL,
-			Collections.emptySet(),
-			TestingUtils.infiniteTime());
+			Collections.emptySet());
 
 		assertThat(partitionStartTrackingFuture.isDone(), is(true));
 		final Tuple2<ResourceID, ResultPartitionDeploymentDescriptor> startTrackingCall = partitionStartTrackingFuture.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -137,7 +137,7 @@ public class ExecutionTest extends TestLogger {
 		final LogicalSlot otherSlot = new TestingLogicalSlot();
 
 		CompletableFuture<Execution> allocationFuture = execution.allocateResourcesForExecution(
-			slotProvider,
+			executionGraph.getSlotProviderStrategy(),
 			false,
 			LocationPreferenceConstraint.ALL,
 			Collections.emptySet(),
@@ -189,7 +189,7 @@ public class ExecutionTest extends TestLogger {
 		final Execution execution = executionJobVertex.getTaskVertices()[0].getCurrentExecutionAttempt();
 
 		CompletableFuture<Execution> allocationFuture = execution.allocateResourcesForExecution(
-			slotProvider,
+			executionGraph.getSlotProviderStrategy(),
 			false,
 			LocationPreferenceConstraint.ALL,
 			Collections.emptySet(),
@@ -239,7 +239,7 @@ public class ExecutionTest extends TestLogger {
 		final Execution execution = executionJobVertex.getTaskVertices()[0].getCurrentExecutionAttempt();
 
 		CompletableFuture<Execution> allocationFuture = execution.allocateResourcesForExecution(
-			slotProvider,
+			executionGraph.getSlotProviderStrategy(),
 			false,
 			LocationPreferenceConstraint.ALL,
 			Collections.emptySet(),
@@ -291,7 +291,7 @@ public class ExecutionTest extends TestLogger {
 		final Execution currentExecutionAttempt = executionJobVertex.getTaskVertices()[0].getCurrentExecutionAttempt();
 
 		final CompletableFuture<Execution> allocationFuture = currentExecutionAttempt.allocateResourcesForExecution(
-			slotProvider,
+			executionGraph.getSlotProviderStrategy(),
 			false,
 			LocationPreferenceConstraint.ALL,
 			Collections.emptySet(),
@@ -400,7 +400,7 @@ public class ExecutionTest extends TestLogger {
 
 		ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
 
-		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY, Collections.emptySet()).get();
+		executionVertex.scheduleForExecution(executionGraph.getSlotProviderStrategy(), false, LocationPreferenceConstraint.ANY, Collections.emptySet()).get();
 
 		Execution currentExecutionAttempt = executionVertex.getCurrentExecutionAttempt();
 
@@ -452,7 +452,7 @@ public class ExecutionTest extends TestLogger {
 		assertThat(execution.getTaskRestore(), is(notNullValue()));
 
 		// schedule the execution vertex and wait for its deployment
-		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY, Collections.emptySet()).get();
+		executionVertex.scheduleForExecution(executionGraph.getSlotProviderStrategy(), false, LocationPreferenceConstraint.ANY, Collections.emptySet()).get();
 
 		assertThat(execution.getTaskRestore(), is(nullValue()));
 	}
@@ -513,7 +513,7 @@ public class ExecutionTest extends TestLogger {
 
 		final CompletableFuture<Void> schedulingFuture = testMainThreadUtil.execute(
 			() -> execution.scheduleForExecution(
-				slotProvider,
+				executionGraph.getSlotProviderStrategy(),
 				false,
 				LocationPreferenceConstraint.ANY,
 				Collections.emptySet()));
@@ -605,7 +605,7 @@ public class ExecutionTest extends TestLogger {
 		final Execution execution = executionVertex.getCurrentExecutionAttempt();
 
 		execution.allocateResourcesForExecution(
-			slotProvider,
+			executionGraph.getSlotProviderStrategy(),
 			false,
 			LocationPreferenceConstraint.ALL,
 			Collections.emptySet(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -294,7 +294,6 @@ public class ExecutionVertexCancelTest extends TestLogger {
 			{
 				vertex.scheduleForExecution(
 					TestingSlotProviderStrategy.from(new ProgrammedSlotProvider(1), false),
-					false,
 					LocationPreferenceConstraint.ALL,
 					Collections.emptySet());
 
@@ -335,7 +334,6 @@ public class ExecutionVertexCancelTest extends TestLogger {
 				setVertexState(vertex, ExecutionState.CANCELING);
 				vertex.scheduleForExecution(
 					TestingSlotProviderStrategy.from(new ProgrammedSlotProvider(1), false),
-					false,
 					LocationPreferenceConstraint.ALL,
 					Collections.emptySet());
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -292,7 +292,11 @@ public class ExecutionVertexCancelTest extends TestLogger {
 			// scheduling after being canceled should be tolerated (no exception) because
 			// it can occur as the result of races
 			{
-				vertex.scheduleForExecution(new ProgrammedSlotProvider(1), false, LocationPreferenceConstraint.ALL, Collections.emptySet());
+				vertex.scheduleForExecution(
+					TestingSlotProviderStrategy.from(new ProgrammedSlotProvider(1), false),
+					false,
+					LocationPreferenceConstraint.ALL,
+					Collections.emptySet());
 
 				assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 			}
@@ -329,7 +333,11 @@ public class ExecutionVertexCancelTest extends TestLogger {
 				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 						AkkaUtils.getDefaultTimeout());
 				setVertexState(vertex, ExecutionState.CANCELING);
-				vertex.scheduleForExecution(new ProgrammedSlotProvider(1), false, LocationPreferenceConstraint.ALL, Collections.emptySet());
+				vertex.scheduleForExecution(
+					TestingSlotProviderStrategy.from(new ProgrammedSlotProvider(1), false),
+					false,
+					LocationPreferenceConstraint.ALL,
+					Collections.emptySet());
 			}
 			catch (Exception e) {
 				fail("should not throw an exception");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -56,7 +56,11 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
-			vertex.scheduleForExecution(new TestingSlotProvider((i) -> future), false, LocationPreferenceConstraint.ALL, Collections.emptySet());
+			vertex.scheduleForExecution(
+				TestingSlotProviderStrategy.from(new TestingSlotProvider((i) -> future), false),
+				false,
+				LocationPreferenceConstraint.ALL,
+				Collections.emptySet());
 
 			// will have failed
 			assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
@@ -85,7 +89,7 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
 			vertex.scheduleForExecution(
-				new TestingSlotProvider(ignore -> future),
+				TestingSlotProviderStrategy.from(new TestingSlotProvider(ignore -> future), true),
 				true,
 				LocationPreferenceConstraint.ALL,
 				Collections.emptySet());
@@ -119,7 +123,7 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 
 			// try to deploy to the slot
 			vertex.scheduleForExecution(
-				new TestingSlotProvider(ignore -> future),
+				TestingSlotProviderStrategy.from(new TestingSlotProvider(ignore -> future), false),
 				false,
 				LocationPreferenceConstraint.ALL,
 				Collections.emptySet());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -58,7 +58,6 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 			// try to deploy to the slot
 			vertex.scheduleForExecution(
 				TestingSlotProviderStrategy.from(new TestingSlotProvider((i) -> future), false),
-				false,
 				LocationPreferenceConstraint.ALL,
 				Collections.emptySet());
 
@@ -90,7 +89,6 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 			// try to deploy to the slot
 			vertex.scheduleForExecution(
 				TestingSlotProviderStrategy.from(new TestingSlotProvider(ignore -> future), true),
-				true,
 				LocationPreferenceConstraint.ALL,
 				Collections.emptySet());
 
@@ -124,7 +122,6 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 			// try to deploy to the slot
 			vertex.scheduleForExecution(
 				TestingSlotProviderStrategy.from(new TestingSlotProvider(ignore -> future), false),
-				false,
 				LocationPreferenceConstraint.ALL,
 				Collections.emptySet());
 			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -214,7 +214,7 @@ public class FailoverRegionTest extends TestLogger {
 
 		acknowledgeAllCheckpoints(eg.getCheckpointCoordinator(), Arrays.asList(ev11, ev21, ev12, ev22, ev31, ev32, ev4).iterator());
 
-		ev21.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, Collections.emptySet());
+		ev21.scheduleForExecution(eg.getSlotProviderStrategy(), true, LocationPreferenceConstraint.ALL, Collections.emptySet());
 		ev21.getCurrentExecutionAttempt().fail(new Exception("New fail"));
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
@@ -229,7 +229,7 @@ public class FailoverRegionTest extends TestLogger {
 
 		ev11.getCurrentExecutionAttempt().markFinished();
 		ev21.getCurrentExecutionAttempt().markFinished();
-		ev22.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, Collections.emptySet());
+		ev22.scheduleForExecution(eg.getSlotProviderStrategy(), true, LocationPreferenceConstraint.ALL, Collections.emptySet());
 		ev22.getCurrentExecutionAttempt().markFinished();
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingSlotProviderStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingSlotProviderStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+
+/**
+ * Testing implementation of the {@link SlotProviderStrategy} which uses {@link ScheduleMode#LAZY_FROM_SOURCES}
+ * and sets the allocation timeout to 10s.
+ */
+public class TestingSlotProviderStrategy extends SlotProviderStrategy.NormalSlotProviderStrategy{
+
+	private TestingSlotProviderStrategy(SlotProvider slotProvider, Time allocationTimeout, boolean allowQueuedScheduling) {
+		super(slotProvider, allocationTimeout, allowQueuedScheduling);
+	}
+
+	public static TestingSlotProviderStrategy from(SlotProvider slotProvider, boolean allowQueuedScheduling) {
+		return new TestingSlotProviderStrategy(slotProvider, Time.seconds(10L), allowQueuedScheduling);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -36,10 +36,10 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.SchedulerImpl;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolImpl;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSharingManager;
+import org.apache.flink.runtime.jobmaster.slotpool.TestingSlotPoolImpl;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -71,7 +71,7 @@ public class SchedulerTestBase extends TestLogger {
 	@Before
 	public void setup() throws Exception {
 		final JobID jobId = new JobID();
-		final SlotPool slotPool = new SlotPoolImpl(jobId);
+		final SlotPool slotPool = new TestingSlotPoolImpl(jobId);
 		final TestingScheduler testingScheduler = new TestingScheduler(
 			new HashMap<>(16),
 			LocationPreferenceSlotSelectionStrategy.INSTANCE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -588,6 +588,12 @@ public class JobMasterTest extends TestLogger {
 			return new CompletableFuture<>();
 		}
 
+		@Nonnull
+		@Override
+		public CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile) {
+			return new CompletableFuture<>();
+		}
+
 		@Override
 		public AllocatedSlotReport createAllocatedSlotReport(ResourceID taskManagerId) {
 			final Collection<SlotInfo> slotInfos = registeredSlots.getOrDefault(taskManagerId, Collections.emptyList());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
@@ -32,9 +32,9 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Tests for the {@link DualKeyMap}.
+ * Tests for the {@link DualKeyLinkedMap}.
  */
-public class DualKeyMapTest extends TestLogger {
+public class DualKeyLinkedMapTest extends TestLogger {
 
 	@Test
 	public void testKeySets() {
@@ -48,7 +48,7 @@ public class DualKeyMapTest extends TestLogger {
 			keys.add(Tuple2.of(keyA, keyB));
 		}
 
-		final DualKeyMap<Integer, Integer, String> dualKeyMap = new DualKeyMap<>(capacity);
+		final DualKeyLinkedMap<Integer, Integer, String> dualKeyMap = new DualKeyLinkedMap<>(capacity);
 
 		for (Tuple2<Integer, Integer> key : keys) {
 			dualKeyMap.put(key.f0, key.f1, "foobar");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.clock.Clock;
+import org.apache.flink.runtime.util.clock.ManualClock;
+import org.apache.flink.runtime.util.clock.SystemClock;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for batch slot requests.
+ */
+public class SlotPoolBatchSlotRequestTest extends TestLogger {
+
+	private static final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1024);
+	private static final ResourceProfile smallerResourceProfile = new ResourceProfile(0.5, 512);
+	public static final CompletableFuture[] COMPLETABLE_FUTURES_EMPTY_ARRAY = new CompletableFuture[0];
+	private static ScheduledExecutorService singleThreadScheduledExecutorService;
+	private static ComponentMainThreadExecutor mainThreadExecutor;
+
+	@BeforeClass
+	public static void setupClass() {
+		singleThreadScheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+		mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(singleThreadScheduledExecutorService);
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		if (singleThreadScheduledExecutorService != null) {
+			singleThreadScheduledExecutorService.shutdownNow();
+		}
+	}
+
+	/**
+	 * Tests that a batch slot request fails if there is no slot which can fulfill the
+	 * slot request.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestTimeout() throws Exception {
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+				.build()) {
+			final CompletableFuture<PhysicalSlot> slotFuture = requestNewAllocatedBatchSlot(
+				slotPool,
+				mainThreadExecutor,
+				ResourceProfile.UNKNOWN);
+
+			try {
+				slotFuture.get();
+				fail("Expected that slot future times out.");
+			} catch (ExecutionException ee) {
+				assertThat(ExceptionUtils.stripExecutionException(ee), instanceOf(TimeoutException.class));
+			}
+		}
+	}
+
+	/**
+	 * Tests that a batch slot request won't time out if there exists a slot in the
+	 * SlotPool which fulfills the requested {@link ResourceProfile}.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestDoesNotTimeoutIfFulfillingSlotExists() throws Exception {
+		final Time batchSlotTimeout = Time.milliseconds(2L);
+		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+		final ManualClock clock = new ManualClock();
+
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+				.setComponentMainThreadExecutor(directMainThreadExecutor)
+				.setClock(clock)
+				.setBatchSlotTimeout(batchSlotTimeout)
+				.build()) {
+
+			offerSlots(slotPool, directMainThreadExecutor, Collections.singletonList(resourceProfile));
+
+			final CompletableFuture<PhysicalSlot> firstSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
+			final CompletableFuture<PhysicalSlot> secondSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, ResourceProfile.UNKNOWN);
+			final CompletableFuture<PhysicalSlot> thirdSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, smallerResourceProfile);
+
+			final List<CompletableFuture<PhysicalSlot>> slotFutures = Arrays.asList(firstSlotFuture, secondSlotFuture, thirdSlotFuture);
+			advanceTimeAndTriggerCheckBatchSlotTimeout(slotPool, clock, batchSlotTimeout);
+
+			for (CompletableFuture<PhysicalSlot> slotFuture : slotFutures) {
+				assertThat(slotFuture.isDone(), is(false));
+			}
+		}
+
+	}
+
+	/**
+	 * Tests that a batch slot request does not react to {@link SlotPool#failAllocation(AllocationID, Exception)}
+	 * signals.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestDoesNotFailIfAllocationFails() throws Exception {
+		final TestingResourceManagerGateway testingResourceManagerGateway = new TestingResourceManagerGateway();
+		final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
+		testingResourceManagerGateway.setRequestSlotConsumer(slotRequest -> allocationIdFuture.complete(slotRequest.getAllocationId()));
+
+		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+
+		final Time batchSlotTimeout = Time.milliseconds(1000L);
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+			.setComponentMainThreadExecutor(directMainThreadExecutor)
+			.setBatchSlotTimeout(batchSlotTimeout)
+			.setResourceManagerGateway(testingResourceManagerGateway)
+			.build()) {
+
+			final CompletableFuture<PhysicalSlot> slotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
+
+			failAllocation(slotPool, directMainThreadExecutor, allocationIdFuture.get());
+
+			assertThat(slotFuture.isDone(), is(false));
+		}
+	}
+
+	/**
+	 * Tests that a batch slot request won't fail if its resource manager request fails.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestDoesNotFailIfRMRequestFails() throws Exception {
+		final TestingResourceManagerGateway testingResourceManagerGateway = new TestingResourceManagerGateway();
+		testingResourceManagerGateway.setRequestSlotFuture(FutureUtils.completedExceptionally(new FlinkException("Failed request")));
+
+		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+
+		final Time batchSlotTimeout = Time.milliseconds(1000L);
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+			.setComponentMainThreadExecutor(directMainThreadExecutor)
+			.setBatchSlotTimeout(batchSlotTimeout)
+			.setResourceManagerGateway(testingResourceManagerGateway)
+			.build()) {
+
+			final CompletableFuture<PhysicalSlot> slotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
+
+			assertThat(slotFuture.isDone(), is(false));
+		}
+	}
+
+	/**
+	 * Tests that a pending batch slot request times out after the last fulfilling slot gets
+	 * released.
+	 */
+	@Test
+	public void testPendingBatchSlotRequestTimeoutAfterSlotRelease() throws Exception {
+		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+		final ManualClock clock = new ManualClock();
+		final Time batchSlotTimeout = Time.milliseconds(1000L);
+
+		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+				.setComponentMainThreadExecutor(directMainThreadExecutor)
+				.setClock(clock)
+				.setBatchSlotTimeout(batchSlotTimeout)
+				.build()) {
+			final ResourceID taskManagerResourceId = offerSlots(slotPool, directMainThreadExecutor, Collections.singletonList(resourceProfile));
+			final CompletableFuture<PhysicalSlot> firstSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
+			final CompletableFuture<PhysicalSlot> secondSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, ResourceProfile.UNKNOWN);
+			final CompletableFuture<PhysicalSlot> thirdSlotFuture = requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, smallerResourceProfile);
+
+			final List<CompletableFuture<PhysicalSlot>> slotFutures = Arrays.asList(firstSlotFuture, secondSlotFuture, thirdSlotFuture);
+
+			// initial batch slot timeout check
+			advanceTimeAndTriggerCheckBatchSlotTimeout(slotPool, clock, batchSlotTimeout);
+
+			assertThat(CompletableFuture.anyOf(slotFutures.toArray(COMPLETABLE_FUTURES_EMPTY_ARRAY)).isDone(), is(false));
+
+			releaseTaskManager(slotPool, directMainThreadExecutor, taskManagerResourceId);
+
+			advanceTimeAndTriggerCheckBatchSlotTimeout(slotPool, clock, batchSlotTimeout);
+
+			for (CompletableFuture<PhysicalSlot> slotFuture : slotFutures) {
+				assertThat(slotFuture.isCompletedExceptionally(), is(true));
+
+				try {
+					slotFuture.get();
+					fail("Expected that the slot future times out.");
+				} catch (ExecutionException ee) {
+					assertThat(ExceptionUtils.stripExecutionException(ee), instanceOf(TimeoutException.class));
+				}
+			}
+		}
+	}
+
+	private void advanceTimeAndTriggerCheckBatchSlotTimeout(SlotPoolImpl slotPool, ManualClock clock, Time batchSlotTimeout) {
+		// trigger batch slot timeout check which marks unfulfillable slots
+		slotPool.triggerCheckBatchSlotTimeout();
+
+		// advance clock behind timeout
+		clock.advanceTime(batchSlotTimeout.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+
+		// timeout all as unfulfillable marked slots
+		slotPool.triggerCheckBatchSlotTimeout();
+	}
+
+	private CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
+			SlotPool slotPool,
+			ComponentMainThreadExecutor mainThreadExecutor,
+			ResourceProfile resourceProfile) {
+		return CompletableFuture
+			.supplyAsync(() -> slotPool.requestNewAllocatedBatchSlot(new SlotRequestId(), resourceProfile), mainThreadExecutor)
+			.thenCompose(Function.identity());
+	}
+
+	private ResourceID offerSlots(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, List<ResourceProfile> resourceProfiles) {
+		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		CompletableFuture.runAsync(
+			() -> {
+				slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+				final Collection<SlotOffer> slotOffers = IntStream
+					.range(0, resourceProfiles.size())
+					.mapToObj(i -> new SlotOffer(new AllocationID(), i, resourceProfiles.get(i)))
+					.collect(Collectors.toList());
+
+				final Collection<SlotOffer> acceptedOffers = slotPool.offerSlots(
+					taskManagerLocation,
+					new SimpleAckingTaskManagerGateway(),
+					slotOffers);
+
+				assertThat(acceptedOffers, is(slotOffers));
+			},
+			mainThreadExecutor
+		).join();
+
+		return taskManagerLocation.getResourceID();
+	}
+
+	private void failAllocation(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, AllocationID allocationId) {
+		CompletableFuture.runAsync(
+			() -> slotPool.failAllocation(allocationId, new FlinkException("Test exception")),
+			mainThreadExecutor).join();
+	}
+
+	private void releaseTaskManager(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, ResourceID taskManagerResourceId) {
+		CompletableFuture.runAsync(
+			() -> slotPool.releaseTaskManager(taskManagerResourceId, new FlinkException("Let's get rid of the offered slot.")),
+			mainThreadExecutor
+		).join();
+	}
+
+	private static class SlotPoolBuilder {
+
+		private ComponentMainThreadExecutor componentMainThreadExecutor = mainThreadExecutor;
+		private ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
+		private Time batchSlotTimeout = Time.milliseconds(2L);
+		private Clock clock = SystemClock.getInstance();
+
+		private SlotPoolBuilder setComponentMainThreadExecutor(ComponentMainThreadExecutor componentMainThreadExecutor) {
+			this.componentMainThreadExecutor = componentMainThreadExecutor;
+			return this;
+		}
+
+		private SlotPoolBuilder setResourceManagerGateway(ResourceManagerGateway resourceManagerGateway) {
+			this.resourceManagerGateway = resourceManagerGateway;
+			return this;
+		}
+
+		private SlotPoolBuilder setBatchSlotTimeout(Time batchSlotTimeout) {
+			this.batchSlotTimeout = batchSlotTimeout;
+			return this;
+		}
+
+		private SlotPoolBuilder setClock(Clock clock) {
+			this.clock = clock;
+			return this;
+		}
+
+		private SlotPoolImpl build() throws Exception {
+			final SlotPoolImpl slotPool = new SlotPoolImpl(
+				new JobID(),
+				clock,
+				TestingUtils.infiniteTime(),
+				TestingUtils.infiniteTime(),
+				batchSlotTimeout);
+
+			slotPool.start(JobMasterId.generate(), "foobar", componentMainThreadExecutor);
+
+			CompletableFuture.runAsync(() -> slotPool.connectToResourceManager(resourceManagerGateway), componentMainThreadExecutor).join();
+
+			return slotPool;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
@@ -121,7 +121,7 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
 		final ManualClock clock = new ManualClock();
 
-		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+		try (final TestingSlotPoolImpl slotPool = new SlotPoolBuilder()
 				.setComponentMainThreadExecutor(directMainThreadExecutor)
 				.setClock(clock)
 				.setBatchSlotTimeout(batchSlotTimeout)
@@ -203,7 +203,7 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		final ManualClock clock = new ManualClock();
 		final Time batchSlotTimeout = Time.milliseconds(1000L);
 
-		try (final SlotPoolImpl slotPool = new SlotPoolBuilder()
+		try (final TestingSlotPoolImpl slotPool = new SlotPoolBuilder()
 				.setComponentMainThreadExecutor(directMainThreadExecutor)
 				.setClock(clock)
 				.setBatchSlotTimeout(batchSlotTimeout)
@@ -237,7 +237,7 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		}
 	}
 
-	private void advanceTimeAndTriggerCheckBatchSlotTimeout(SlotPoolImpl slotPool, ManualClock clock, Time batchSlotTimeout) {
+	private void advanceTimeAndTriggerCheckBatchSlotTimeout(TestingSlotPoolImpl slotPool, ManualClock clock, Time batchSlotTimeout) {
 		// trigger batch slot timeout check which marks unfulfillable slots
 		slotPool.triggerCheckBatchSlotTimeout();
 
@@ -321,8 +321,8 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 			return this;
 		}
 
-		private SlotPoolImpl build() throws Exception {
-			final SlotPoolImpl slotPool = new SlotPoolImpl(
+		private TestingSlotPoolImpl build() throws Exception {
+			final TestingSlotPoolImpl slotPool = new TestingSlotPoolImpl(
 				new JobID(),
 				clock,
 				TestingUtils.infiniteTime(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBuilder.java
@@ -59,7 +59,7 @@ public class SlotPoolBuilder {
 		return this;
 	}
 
-	TestingSlotPoolImpl build() throws Exception {
+	public TestingSlotPoolImpl build() throws Exception {
 		final TestingSlotPoolImpl slotPool = new TestingSlotPoolImpl(
 			new JobID(),
 			clock,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.clock.Clock;
+import org.apache.flink.runtime.util.clock.SystemClock;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Builder for a {@link TestingSlotPoolImpl}.
+ */
+public class SlotPoolBuilder {
+
+	private ComponentMainThreadExecutor componentMainThreadExecutor;
+	private ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
+	private Time batchSlotTimeout = Time.milliseconds(2L);
+	private Clock clock = SystemClock.getInstance();
+
+	public SlotPoolBuilder(ComponentMainThreadExecutor componentMainThreadExecutor) {
+		this.componentMainThreadExecutor = componentMainThreadExecutor;
+	}
+
+	public SlotPoolBuilder setResourceManagerGateway(ResourceManagerGateway resourceManagerGateway) {
+		this.resourceManagerGateway = resourceManagerGateway;
+		return this;
+	}
+
+	public SlotPoolBuilder setBatchSlotTimeout(Time batchSlotTimeout) {
+		this.batchSlotTimeout = batchSlotTimeout;
+		return this;
+	}
+
+	public SlotPoolBuilder setClock(Clock clock) {
+		this.clock = clock;
+		return this;
+	}
+
+	TestingSlotPoolImpl build() throws Exception {
+		final TestingSlotPoolImpl slotPool = new TestingSlotPoolImpl(
+			new JobID(),
+			clock,
+			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime(),
+			batchSlotTimeout);
+
+		slotPool.start(JobMasterId.generate(), "foobar", componentMainThreadExecutor);
+
+		CompletableFuture.runAsync(() -> slotPool.connectToResourceManager(resourceManagerGateway), componentMainThreadExecutor).join();
+
+		return slotPool;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -512,10 +512,11 @@ public class SlotPoolImplTest extends TestLogger {
 		final ManualClock clock = new ManualClock();
 
 		try (SlotPoolImpl slotPool = new SlotPoolImpl(
-			jobId,
-			clock,
-			TestingUtils.infiniteTime(),
-			timeout)) {
+				jobId,
+				clock,
+				TestingUtils.infiniteTime(),
+				timeout,
+				TestingUtils.infiniteTime())) {
 			final BlockingQueue<AllocationID> freedSlots = new ArrayBlockingQueue<>(1);
 			taskManagerGateway.setFreeSlotFunction(
 				(AllocationID allocationId, Throwable cause) -> {
@@ -565,10 +566,11 @@ public class SlotPoolImplTest extends TestLogger {
 		final ManualClock clock = new ManualClock();
 
 		try (SlotPoolImpl slotPool = new SlotPoolImpl(
-			jobId,
-			clock,
-			TestingUtils.infiniteTime(),
-			timeout)) {
+				jobId,
+				clock,
+				TestingUtils.infiniteTime(),
+				timeout,
+				TestingUtils.infiniteTime())) {
 
 			setupSlotPool(slotPool, resourceManagerGateway, mainThreadExecutor);
 			Scheduler scheduler = setupScheduler(slotPool, mainThreadExecutor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -717,39 +717,6 @@ public class SlotPoolImplTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that failing an allocation fails the pending slot request.
-	 */
-	@Test
-	public void testFailingAllocationFailsPendingSlotRequests() throws Exception {
-
-		try (SlotPoolImpl slotPool = new SlotPoolImpl(jobId)) {
-			final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
-			resourceManagerGateway.setRequestSlotConsumer(slotRequest -> allocationIdFuture.complete(slotRequest.getAllocationId()));
-
-			setupSlotPool(slotPool, resourceManagerGateway, mainThreadExecutor);
-			Scheduler scheduler = setupScheduler(slotPool, mainThreadExecutor);
-
-			final CompletableFuture<LogicalSlot> slotFuture = allocateSlot(scheduler, new SlotRequestId());
-
-			final AllocationID allocationId = allocationIdFuture.get();
-
-			assertThat(slotFuture.isDone(), is(false));
-
-			final FlinkException cause = new FlinkException("Fail pending slot request failure.");
-			final Optional<ResourceID> responseFuture = slotPool.failAllocation(allocationId, cause);
-
-			assertThat(responseFuture.isPresent(), is(false));
-
-			try {
-				slotFuture.get();
-				fail("Expected a slot allocation failure.");
-			} catch (ExecutionException ee) {
-				assertThat(ExceptionUtils.stripExecutionException(ee), equalTo(cause));
-			}
-		}
-	}
-
-	/**
 	 * Tests that create report of allocated slots on a {@link TaskExecutor}.
 	 */
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
@@ -86,6 +86,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 			jid,
 			SystemClock.getInstance(),
 			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime()
 		)) {
 
@@ -113,11 +114,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 	public void testCancelSlotAllocationWithoutResourceManager() throws Exception {
 		final JobID jid = new JobID();
 
-		try (TestingSlotPool pool = new TestingSlotPool(
-			jid,
-			SystemClock.getInstance(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (TestingSlotPool pool = createTestingSlotPool(jid)) {
 
 			final CompletableFuture<SlotRequestId> timeoutFuture = new CompletableFuture<>();
 			pool.setTimeoutPendingSlotRequestConsumer(timeoutFuture::complete);
@@ -147,6 +144,16 @@ public class SlotPoolInteractionsTest extends TestLogger {
 		}
 	}
 
+	@Nonnull
+	private TestingSlotPool createTestingSlotPool(JobID jid) {
+		return new TestingSlotPool(
+			jid,
+			SystemClock.getInstance(),
+			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime());
+	}
+
 	/**
 	 * Tests that a slot allocation times out wrt to the specified time out.
 	 */
@@ -154,11 +161,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 	public void testSlotAllocationTimeout() throws Exception {
 		final JobID jid = new JobID();
 
-		try (TestingSlotPool pool = new TestingSlotPool(
-			jid,
-			SystemClock.getInstance(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (TestingSlotPool pool = createTestingSlotPool(jid)) {
 
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
 
@@ -200,11 +203,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 	public void testExtraSlotsAreKept() throws Exception {
 		final JobID jid = new JobID();
 
-		try (TestingSlotPool pool = new TestingSlotPool(
-			jid,
-			SystemClock.getInstance(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (TestingSlotPool pool = createTestingSlotPool(jid)) {
 
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
 
@@ -266,11 +265,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 	public void testProviderAndOwnerSlotAllocationTimeout() throws Exception {
 		final JobID jid = new JobID();
 
-		try (TestingSlotPool pool = new TestingSlotPool(
-			jid,
-			SystemClock.getInstance(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (TestingSlotPool pool = createTestingSlotPool(jid)) {
 
 			final CompletableFuture<SlotRequestId> releaseSlotFuture = new CompletableFuture<>();
 
@@ -316,12 +311,14 @@ public class SlotPoolInteractionsTest extends TestLogger {
 				JobID jobId,
 				Clock clock,
 				Time rpcTimeout,
-				Time idleSlotTimeout) {
+				Time idleSlotTimeout,
+				Time batchSlotTimeout) {
 			super(
 				jobId,
 				clock,
 				rpcTimeout,
-				idleSlotTimeout);
+				idleSlotTimeout,
+				batchSlotTimeout);
 
 			releaseSlotConsumer = null;
 			timeoutPendingSlotRequestConsumer = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
@@ -175,7 +175,7 @@ public class SlotPoolPendingRequestFailureTest extends TestLogger {
 	}
 
 	private SlotPoolImpl setUpSlotPool(ComponentMainThreadExecutor componentMainThreadExecutor) throws Exception {
-		final SlotPoolImpl slotPool = new SlotPoolImpl(jobId);
+		final SlotPoolImpl slotPool = new TestingSlotPoolImpl(jobId);
 		slotPool.start(JobMasterId.generate(), "foobar", componentMainThreadExecutor);
 		slotPool.connectToResourceManager(resourceManagerGateway);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the failing of pending slot requests at the {@link SlotPool}.
+ */
+public class SlotPoolPendingRequestFailureTest extends TestLogger {
+
+	private static final JobID jobId = new JobID();
+
+	private static final ComponentMainThreadExecutor mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+	public static final Time TIMEOUT = Time.seconds(10L);
+
+	private TestingResourceManagerGateway resourceManagerGateway;
+
+	@Before
+	public void setup() {
+		resourceManagerGateway = new TestingResourceManagerGateway();
+	}
+
+	/**
+	 * Tests that failing an allocation fails the pending slot request.
+	 */
+	@Test
+	public void testFailingAllocationFailsPendingSlotRequests() throws Exception {
+		final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
+		resourceManagerGateway.setRequestSlotConsumer(slotRequest -> allocationIdFuture.complete(slotRequest.getAllocationId()));
+
+		try (SlotPoolImpl slotPool = setupSlotPool()) {
+
+			final CompletableFuture<PhysicalSlot> slotFuture = requestNewAllocatedSlot(slotPool, new SlotRequestId());
+
+			final AllocationID allocationId = allocationIdFuture.get();
+
+			assertThat(slotFuture.isDone(), is(false));
+
+			final FlinkException cause = new FlinkException("Fail pending slot request failure.");
+			final Optional<ResourceID> responseFuture = slotPool.failAllocation(allocationId, cause);
+
+			assertThat(responseFuture.isPresent(), is(false));
+
+			try {
+				slotFuture.get();
+				fail("Expected a slot allocation failure.");
+			} catch (ExecutionException ee) {
+				assertThat(ExceptionUtils.stripExecutionException(ee), equalTo(cause));
+			}
+		}
+	}
+
+	private CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(SlotPoolImpl slotPool, SlotRequestId slotRequestId) {
+		return slotPool.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, TIMEOUT);
+	}
+
+	private SlotPoolImpl setupSlotPool() throws Exception {
+		final SlotPoolImpl slotPool = new SlotPoolImpl(jobId);
+		slotPool.start(JobMasterId.generate(), "foobar", mainThreadExecutor);
+		slotPool.connectToResourceManager(resourceManagerGateway);
+
+		return slotPool;
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
@@ -121,7 +121,7 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 	}
 
 	private SlotPoolImpl setUpSlotPool() throws Exception {
-		final SlotPoolImpl slotPool = new SlotPoolImpl(new JobID());
+		final SlotPoolImpl slotPool = new TestingSlotPoolImpl(new JobID());
 
 		slotPool.start(JobMasterId.generate(), "foobar", ComponentMainThreadExecutorServiceAdapter.forMainThread());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.CheckedSupplier;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Tests how the {@link SlotPoolImpl} completes slot requests.
+ */
+public class SlotPoolRequestCompletionTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.seconds(10L);
+
+	/**
+	 * Tests that the {@link SlotPoolImpl} completes slots in request order.
+	 */
+	@Test
+	public void testRequestsAreCompletedInRequestOrder() throws Exception {
+		runSlotRequestCompletionTest(
+			CheckedSupplier.unchecked(this::setUpSlotPoolAndConnectToResourceManager),
+			slotPool -> {});
+	}
+
+	/**
+	 * Tests that the {@link SlotPoolImpl} completes stashed slot requests in request order.
+	 */
+	@Test
+	public void testStashOrderMaintainsRequestOrder() throws Exception {
+		runSlotRequestCompletionTest(
+			CheckedSupplier.unchecked(this::setUpSlotPool),
+			this::connectToResourceManager);
+	}
+
+	private void runSlotRequestCompletionTest(
+		Supplier<SlotPoolImpl> slotPoolSupplier,
+		Consumer<SlotPoolImpl> actionAfterSlotRequest) throws Exception {
+		try (final SlotPoolImpl slotPool = slotPoolSupplier.get()) {
+
+			final List<SlotRequestId> slotRequestIds = IntStream.range(0, 10)
+				.mapToObj(ignored -> new SlotRequestId())
+				.collect(Collectors.toList());
+
+			final List<CompletableFuture<PhysicalSlot>> slotRequests = slotRequestIds
+				.stream()
+				.map(slotRequestId -> slotPool.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, TIMEOUT))
+				.collect(Collectors.toList());
+
+			actionAfterSlotRequest.accept(slotPool);
+
+			final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+			slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+			final SlotOffer slotOffer = new SlotOffer(new AllocationID(), 0, ResourceProfile.UNKNOWN);
+			final Collection<SlotOffer> acceptedSlots = slotPool.offerSlots(taskManagerLocation, new SimpleAckingTaskManagerGateway(), Collections.singleton(slotOffer));
+
+			assertThat(acceptedSlots, containsInAnyOrder(slotOffer));
+
+			final FlinkException testingReleaseException = new FlinkException("Testing release exception");
+
+			// check that the slot requests get completed in sequential order
+			for (int i = 0; i < slotRequestIds.size(); i++) {
+				final CompletableFuture<PhysicalSlot> slotRequestFuture = slotRequests.get(i);
+				slotRequestFuture.get();
+				slotPool.releaseSlot(slotRequestIds.get(i), testingReleaseException);
+			}
+		}
+	}
+
+	private SlotPoolImpl setUpSlotPoolAndConnectToResourceManager() throws Exception {
+		final SlotPoolImpl slotPool = setUpSlotPool();
+		connectToResourceManager(slotPool);
+
+		return slotPool;
+	}
+
+	private void connectToResourceManager(SlotPoolImpl slotPool) {
+		slotPool.connectToResourceManager(new TestingResourceManagerGateway());
+	}
+
+	private SlotPoolImpl setUpSlotPool() throws Exception {
+		final SlotPoolImpl slotPool = new SlotPoolImpl(new JobID());
+
+		slotPool.start(JobMasterId.generate(), "foobar", ComponentMainThreadExecutorServiceAdapter.forMainThread());
+
+		return slotPool;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolResource.java
@@ -78,7 +78,7 @@ public class SlotPoolResource extends ExternalResource {
 
 		testingResourceManagerGateway = new TestingResourceManagerGateway();
 
-		slotPool = new SlotPoolImpl(new JobID());
+		slotPool = new TestingSlotPoolImpl(new JobID());
 		scheduler = new SchedulerImpl(schedulingStrategy, slotPool);
 		slotPool.start(JobMasterId.generate(), "foobar", mainThreadExecutor);
 		scheduler.start(mainThreadExecutor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -57,7 +58,22 @@ public class SlotPoolUtils {
 			.thenCompose(Function.identity());
 	}
 
-	public static ResourceID offerSlots(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, List<ResourceProfile> resourceProfiles) {
+	public static ResourceID offerSlots(
+			SlotPoolImpl slotPool,
+			ComponentMainThreadExecutor mainThreadExecutor,
+			List<ResourceProfile> resourceProfiles) {
+		return offerSlots(
+			slotPool,
+			mainThreadExecutor,
+			resourceProfiles,
+			new SimpleAckingTaskManagerGateway());
+	}
+
+	public static ResourceID offerSlots(
+			SlotPoolImpl slotPool,
+			ComponentMainThreadExecutor mainThreadExecutor,
+			List<ResourceProfile> resourceProfiles,
+			TaskManagerGateway taskManagerGateway) {
 		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
 		CompletableFuture.runAsync(
 			() -> {
@@ -70,7 +86,7 @@ public class SlotPoolUtils {
 
 				final Collection<SlotOffer> acceptedOffers = slotPool.offerSlots(
 					taskManagerLocation,
-					new SimpleAckingTaskManagerGateway(),
+					taskManagerGateway,
 					slotOffers);
 
 				assertThat(acceptedOffers, is(slotOffers));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Testing utility functions for the {@link SlotPool}.
+ */
+public class SlotPoolUtils {
+
+	private SlotPoolUtils() {
+		throw new UnsupportedOperationException("Cannot instantiate this class.");
+	}
+
+	public static CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
+		SlotPool slotPool,
+		ComponentMainThreadExecutor mainThreadExecutor,
+		ResourceProfile resourceProfile) {
+		return CompletableFuture
+			.supplyAsync(() -> slotPool.requestNewAllocatedBatchSlot(new SlotRequestId(), resourceProfile), mainThreadExecutor)
+			.thenCompose(Function.identity());
+	}
+
+	public static ResourceID offerSlots(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, List<ResourceProfile> resourceProfiles) {
+		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		CompletableFuture.runAsync(
+			() -> {
+				slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+				final Collection<SlotOffer> slotOffers = IntStream
+					.range(0, resourceProfiles.size())
+					.mapToObj(i -> new SlotOffer(new AllocationID(), i, resourceProfiles.get(i)))
+					.collect(Collectors.toList());
+
+				final Collection<SlotOffer> acceptedOffers = slotPool.offerSlots(
+					taskManagerLocation,
+					new SimpleAckingTaskManagerGateway(),
+					slotOffers);
+
+				assertThat(acceptedOffers, is(slotOffers));
+			},
+			mainThreadExecutor
+		).join();
+
+		return taskManagerLocation.getResourceID();
+	}
+
+	public static void failAllocation(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, AllocationID allocationId) {
+		CompletableFuture.runAsync(
+			() -> slotPool.failAllocation(allocationId, new FlinkException("Test exception")),
+			mainThreadExecutor).join();
+	}
+
+	public static void releaseTaskManager(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, ResourceID taskManagerResourceId) {
+		CompletableFuture.runAsync(
+			() -> slotPool.releaseTaskManager(taskManagerResourceId, new FlinkException("Let's get rid of the offered slot.")),
+			mainThreadExecutor
+		).join();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.util.clock.Clock;
+import org.apache.flink.runtime.util.clock.SystemClock;
+
+/**
+ * Testing extension of the {@link SlotPoolImpl} which adds additional methods
+ * for testing.
+ */
+public class TestingSlotPoolImpl extends SlotPoolImpl {
+
+	public TestingSlotPoolImpl(JobID jobId) {
+		this(
+			jobId,
+			SystemClock.getInstance(),
+			AkkaUtils.getDefaultTimeout(),
+			AkkaUtils.getDefaultTimeout(),
+			Time.milliseconds(JobManagerOptions.SLOT_IDLE_TIMEOUT.defaultValue()));
+	}
+
+	public TestingSlotPoolImpl(
+			JobID jobId,
+			Clock clock,
+			Time rpcTimeout,
+			Time idleSlotTimeout,
+			Time batchSlotTimeout) {
+		super(jobId, clock, rpcTimeout, idleSlotTimeout, batchSlotTimeout);
+	}
+
+	void triggerCheckIdleSlot() {
+		runAsync(this::checkIdleSlot);
+	}
+
+	void triggerCheckBatchSlotTimeout() {
+		runAsync(this::checkBatchSlotTimeout);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LegacySchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LegacySchedulerBatchSchedulingTest.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.VoidBlobWriter;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.io.network.partition.NoOpPartitionTracker;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
+import org.apache.flink.runtime.jobmaster.slotpool.Scheduler;
+import org.apache.flink.runtime.jobmaster.slotpool.SchedulerImpl;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolBuilder;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolImpl;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolUtils;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.VoidBackPressureStatsTracker;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.CheckedSupplier;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the scheduling of batch jobs.
+ */
+public class LegacySchedulerBatchSchedulingTest extends TestLogger {
+
+	private static final Logger LOG = LoggerFactory.getLogger(LegacySchedulerBatchSchedulingTest.class);
+
+	private static final JobID jobId = new JobID();
+
+	private static ScheduledExecutorService singleThreadScheduledExecutorService;
+	private static ComponentMainThreadExecutor mainThreadExecutor;
+
+	@BeforeClass
+	public static void setupClass() {
+		singleThreadScheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+		mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(singleThreadScheduledExecutorService);
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		if (singleThreadScheduledExecutorService != null) {
+			singleThreadScheduledExecutorService.shutdownNow();
+		}
+	}
+
+	/**
+	 * Tests that a batch job can be executed with fewer slots than its parallelism.
+	 * See FLINK-13187 for more information.
+	 */
+	@Test
+	public void testSchedulingOfJobWithFewerSlotsThanParallelism() throws Exception {
+		final int parallelism = 5;
+		final Time batchSlotTimeout = Time.milliseconds(5L);
+		final JobGraph jobGraph = createJobGraph(parallelism);
+		jobGraph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
+
+		try (final SlotPoolImpl slotPool = createSlotPool(mainThreadExecutor, batchSlotTimeout)) {
+			final ArrayBlockingQueue<ExecutionAttemptID> submittedTasksQueue = new ArrayBlockingQueue<>(parallelism);
+			TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+				.setSubmitTaskConsumer(
+					(tdd, ignored) -> {
+						submittedTasksQueue.offer(tdd.getExecutionAttemptId());
+						return CompletableFuture.completedFuture(Acknowledge.get());
+					})
+				.createTestingTaskExecutorGateway();
+
+			// register a single slot at the slot pool
+			SlotPoolUtils.offerSlots(
+				slotPool,
+				mainThreadExecutor,
+				Collections.singletonList(ResourceProfile.ANY),
+				new RpcTaskManagerGateway(testingTaskExecutorGateway, JobMasterId.generate()));
+
+			final LegacyScheduler legacyScheduler = createLegacyScheduler(jobGraph, slotPool, mainThreadExecutor, batchSlotTimeout);
+
+			final GloballyTerminalJobStatusListener jobStatusListener = new GloballyTerminalJobStatusListener();
+			legacyScheduler.registerJobStatusListener(jobStatusListener);
+			startScheduling(legacyScheduler, mainThreadExecutor);
+
+			// wait until the batch slot timeout has been reached
+			Thread.sleep(batchSlotTimeout.toMilliseconds());
+
+			final CompletableFuture<JobStatus> terminationFuture = jobStatusListener.getTerminationFuture();
+
+			for (int i = 0; i < parallelism; i++) {
+				final CompletableFuture<ExecutionAttemptID> submittedTaskFuture = CompletableFuture.supplyAsync(CheckedSupplier.unchecked(submittedTasksQueue::take));
+
+				// wait until one of them is completed
+				CompletableFuture.anyOf(submittedTaskFuture, terminationFuture).join();
+
+				if (submittedTaskFuture.isDone()) {
+					finishExecution(submittedTaskFuture.get(), legacyScheduler, mainThreadExecutor);
+				} else {
+					fail(String.format("Job reached a globally terminal state %s before all executions were finished.", terminationFuture.get()));
+				}
+			}
+
+			assertThat(terminationFuture.get(), is(JobStatus.FINISHED));
+		}
+	}
+
+	private void finishExecution(
+			ExecutionAttemptID executionAttemptId,
+			LegacyScheduler legacyScheduler,
+			ComponentMainThreadExecutor mainThreadExecutor) {
+		CompletableFuture.runAsync(
+			() -> {
+				legacyScheduler.updateTaskExecutionState(new TaskExecutionState(jobId, executionAttemptId, ExecutionState.RUNNING));
+				legacyScheduler.updateTaskExecutionState(new TaskExecutionState(jobId, executionAttemptId, ExecutionState.FINISHED));
+			},
+			mainThreadExecutor
+		).join();
+	}
+
+	@Nonnull
+	private SchedulerImpl createScheduler(SlotPool slotPool, ComponentMainThreadExecutor mainThreadExecutor) {
+		final SchedulerImpl scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
+		scheduler.start(mainThreadExecutor);
+
+		return scheduler;
+	}
+
+	private void startScheduling(LegacyScheduler legacyScheduler, ComponentMainThreadExecutor mainThreadExecutor) {
+		CompletableFuture.runAsync(
+			legacyScheduler::startScheduling,
+			mainThreadExecutor)
+			.join();
+	}
+
+	private SlotPoolImpl createSlotPool(ComponentMainThreadExecutor mainThreadExecutor, Time batchSlotTimeout) throws Exception {
+		return new SlotPoolBuilder(mainThreadExecutor)
+			.setBatchSlotTimeout(batchSlotTimeout)
+			.build();
+	}
+
+	private LegacyScheduler createLegacyScheduler(JobGraph jobGraph, SlotPool slotPool, ComponentMainThreadExecutor mainThreadExecutor, Time slotRequestTimeout) throws Exception {
+		final Scheduler scheduler = createScheduler(slotPool, mainThreadExecutor);
+		final LegacyScheduler legacyScheduler = new LegacyScheduler(
+			LOG,
+			jobGraph,
+			VoidBackPressureStatsTracker.INSTANCE,
+			TestingUtils.defaultExecutor(),
+			new Configuration(),
+			scheduler,
+			TestingUtils.defaultExecutor(),
+			getClass().getClassLoader(),
+			new StandaloneCheckpointRecoveryFactory(),
+			TestingUtils.TIMEOUT(),
+			new NoRestartStrategy.NoRestartStrategyFactory(),
+			VoidBlobWriter.getInstance(),
+			UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup(),
+			slotRequestTimeout,
+			NettyShuffleMaster.INSTANCE,
+			NoOpPartitionTracker.INSTANCE);
+
+		legacyScheduler.setMainThreadExecutor(mainThreadExecutor);
+
+		return legacyScheduler;
+	}
+
+	private JobGraph createJobGraph(int parallelism) {
+		final JobVertex jobVertex = new JobVertex("testing task");
+		jobVertex.setParallelism(parallelism);
+		jobVertex.setInvokableClass(NoOpInvokable.class);
+		final JobGraph jobGraph = new JobGraph(jobId, "test job", jobVertex);
+		jobGraph.setAllowQueuedScheduling(true);
+
+		return jobGraph;
+	}
+
+	private static class GloballyTerminalJobStatusListener implements JobStatusListener {
+
+		private final CompletableFuture<JobStatus> globallyTerminalJobStatusFuture = new CompletableFuture<>();
+
+		@Override
+		public void jobStatusChanges(JobID jobId, JobStatus newJobStatus, long timestamp, Throwable error) {
+			if (newJobStatus.isGloballyTerminalState()) {
+				globallyTerminalJobStatusFuture.complete(newJobStatus);
+			}
+		}
+
+		public CompletableFuture<JobStatus> getTerminationFuture() {
+			return globallyTerminalJobStatusFuture;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #9058.

The new ScheduleMode#LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST works similar to the
old ScheduleMode#LAZY_FROM_SOURCES just with the difference that the slot requests
call the SlotPool#requestNewAllocatedBatchSlot which requests batch slots. The
idea of batch slots is that the requests won't time out as long as there is an
allocated slot registered at the SlotPool which can fulfill the slot request
(being equal or larger than the requested ResourceProfile).

Hence, this ScheduleMode allows for batch job execution with fewer slots than requested.
The user, however, has to make sure that every pipelined region of the submitted job requires
only one slot to be executed!

The different types of slot requests are encapsulated in the newly introduced
SlotProviderStrategy. Depending on the ScheduleMode, the strategy will either call
SlotProvider#allocateSlot or SlotProvider#allocateBatchSlot.

cc @StephanEwen, @xintongsong 

## Verifying this change

Added `LegacySchedulerBatchSchedulingTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
