### PR TITLE
[FLINK-13186] Remove dispatcherRetrievalService and dispatcherLeaderRetriever from RestClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -139,11 +139,7 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 
 	private final LeaderRetrievalService webMonitorRetrievalService;
 
-	private final LeaderRetrievalService dispatcherRetrievalService;
-
 	private final LeaderRetriever webMonitorLeaderRetriever = new LeaderRetriever();
-
-	private final LeaderRetriever dispatcherLeaderRetriever = new LeaderRetriever();
 
 	/** ExecutorService to run operations that can be retried on exceptions. */
 	private ScheduledExecutorService retryExecutorService;
@@ -193,14 +189,12 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 		} else {
 			this.webMonitorRetrievalService = webMonitorRetrievalService;
 		}
-		this.dispatcherRetrievalService = highAvailabilityServices.getDispatcherLeaderRetriever();
 		this.retryExecutorService = Executors.newSingleThreadScheduledExecutor(new ExecutorThreadFactory("Flink-RestClusterClient-Retry"));
 		startLeaderRetrievers();
 	}
 
 	private void startLeaderRetrievers() throws Exception {
 		this.webMonitorRetrievalService.start(webMonitorLeaderRetriever);
-		this.dispatcherRetrievalService.start(dispatcherLeaderRetriever);
 	}
 
 	@Override
@@ -214,12 +208,6 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 			webMonitorRetrievalService.stop();
 		} catch (Exception e) {
 			log.error("An error occurred during stopping the webMonitorRetrievalService", e);
-		}
-
-		try {
-			dispatcherRetrievalService.stop();
-		} catch (Exception e) {
-			log.error("An error occurred during stopping the dispatcherLeaderRetriever", e);
 		}
 
 		try {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request remove dispatcherRetrievalService and dispatcherLeaderRetriever from RestClusterClient*

## Brief change log

  - *Remove dispatcherRetrievalService and dispatcherLeaderRetriever from RestClusterClient*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
