### PR TITLE
[FLINK-13115] [table-planner-blink] Introduce planner rule to support partition pruning for PartitionableTableSource

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/CodeGeneratorContext.scala
@@ -647,11 +647,11 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
 
     val openFunction = if (contextTerm != null) {
       s"""
-         |$fieldTerm.open(new ${classOf[FunctionContext].getCanonicalName}($contextTerm));
+         |$fieldTerm.open(new ${functionContextClass.getCanonicalName}($contextTerm));
        """.stripMargin
     } else {
       s"""
-         |$fieldTerm.open(new ${classOf[FunctionContext].getCanonicalName}(getRuntimeContext()));
+         |$fieldTerm.open(new ${functionContextClass.getCanonicalName}(getRuntimeContext()));
        """.stripMargin
     }
     reusableOpenStatements.add(openFunction)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/ExpressionReducer.scala
@@ -218,16 +218,14 @@ class ExpressionReducer(
   *
   * @param parameters User-defined configuration set in [[TableConfig]].
   */
-private class ConstantFunctionContext(parameters: Configuration) extends FunctionContext(null) {
+class ConstantFunctionContext(parameters: Configuration) extends FunctionContext(null) {
 
   override def getMetricGroup: MetricGroup = {
-    throw new UnsupportedOperationException(
-      "getMetricGroup is not supported when reducing expression")
+    throw new UnsupportedOperationException("getMetricGroup is not supported when optimizing")
   }
 
   override def getCachedFile(name: String): File = {
-    throw new UnsupportedOperationException(
-      "getCachedFile is not supported when reducing expression")
+    throw new UnsupportedOperationException("getCachedFile is not supported when optimizing")
   }
 
   /**
@@ -246,7 +244,7 @@ private class ConstantFunctionContext(parameters: Configuration) extends Functio
 /**
   * Constant expression code generator context.
   */
-private class ConstantCodeGeneratorContext(tableConfig: TableConfig)
+class ConstantCodeGeneratorContext(tableConfig: TableConfig)
   extends CodeGeneratorContext(tableConfig) {
   override def addReusableFunction(
       function: UserDefinedFunction,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnNullCount.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdColumnNullCount.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.plan.metadata
 
-import org.apache.flink.table.api.OptimizerConfigOptions
 import org.apache.flink.table.plan.metadata.FlinkMetadata.ColumnNullCount
 import org.apache.flink.table.plan.schema.FlinkRelOptTable
 import org.apache.flink.table.plan.util.{FlinkRelOptUtil, FlinkRexUtil}
@@ -160,7 +159,7 @@ class FlinkRelMdColumnNullCount private extends MetadataHandler[ColumnNullCount]
         val rexBuilder = rel.getCluster.getRexBuilder
         val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(rel)
         val maxCnfNodeCount = tableConfig.getConfiguration.getInteger(
-          SelectivityEstimator.SQL_OPTIMIZER_CNF_NODES_LIMIT)
+          FlinkRexUtil.SQL_OPTIMIZER_CNF_NODES_LIMIT)
         val cnf = FlinkRexUtil.toCnf(rexBuilder, maxCnfNodeCount, predicate)
         val conjunctions = RelOptUtil.conjunctions(cnf)
         val notNullPredicatesAtIndexField = conjunctions.exists {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdDistinctRowCount.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/FlinkRelMdDistinctRowCount.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.plan.metadata
 
-import org.apache.flink.table.api.{OptimizerConfigOptions, TableException}
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.plan.nodes.calcite.{Expand, Rank, WindowAggregate}
 import org.apache.flink.table.plan.nodes.physical.batch._
 import org.apache.flink.table.plan.schema.FlinkRelOptTable
@@ -205,7 +205,7 @@ class FlinkRelMdDistinctRowCount private extends MetadataHandler[BuiltInMetadata
       val rexBuilder = rel.getCluster.getRexBuilder
       val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(rel)
       val maxCnfNodeCount = tableConfig.getConfiguration.getInteger(
-        SelectivityEstimator.SQL_OPTIMIZER_CNF_NODES_LIMIT)
+        FlinkRexUtil.SQL_OPTIMIZER_CNF_NODES_LIMIT)
       val cnf = FlinkRexUtil.toCnf(rexBuilder, maxCnfNodeCount, predicate)
       val conjunctions = RelOptUtil.conjunctions(cnf)
       val conjunctionsWithoutExpandId = conjunctions.filterNot { c =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/SelectivityEstimator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/metadata/SelectivityEstimator.scala
@@ -18,9 +18,6 @@
 
 package org.apache.flink.table.plan.metadata
 
-import org.apache.flink.annotation.Experimental
-import org.apache.flink.configuration.ConfigOption
-import org.apache.flink.configuration.ConfigOptions.key
 import org.apache.flink.table.plan.metadata.SelectivityEstimator._
 import org.apache.flink.table.plan.stats._
 import org.apache.flink.table.plan.util.{FlinkRelOptUtil, FlinkRexUtil}
@@ -36,8 +33,6 @@ import org.apache.calcite.sql.`type`.{SqlTypeFamily, SqlTypeName}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
 import org.apache.calcite.sql.{SqlKind, SqlOperator}
 import org.apache.calcite.util.{ImmutableBitSet, TimeString}
-
-import java.lang.{Integer => JInteger}
 
 import scala.collection.JavaConversions._
 
@@ -63,7 +58,7 @@ class SelectivityEstimator(rel: RelNode, mq: FlinkRelMetadataQuery)
   private val rexBuilder = rel.getCluster.getRexBuilder
   private val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(rel)
   private val maxCnfNodeCount = tableConfig.getConfiguration.getInteger(
-    SelectivityEstimator.SQL_OPTIMIZER_CNF_NODES_LIMIT)
+    FlinkRexUtil.SQL_OPTIMIZER_CNF_NODES_LIMIT)
 
   // these default values is referred to RelMdUtil#guessSelectivity
   private[flink] val defaultComparisonSelectivity = Some(0.5d)
@@ -985,18 +980,6 @@ class SelectivityEstimator(rel: RelNode, mq: FlinkRelMetadataQuery)
 }
 
 object SelectivityEstimator {
-
-  // It is a experimental config, will may be removed later.
-  @Experimental
-  val SQL_OPTIMIZER_CNF_NODES_LIMIT: ConfigOption[JInteger] =
-    key("sql.optimizer.cnf.nodes.limit")
-        .defaultValue(JInteger.valueOf(-1))
-        .withDescription("When converting to conjunctive normal form (CNF, like '(a AND b) OR" +
-            " c' will be converted to '(a OR c) AND (b OR c)'), fail if the expression  exceeds " +
-            "this threshold; (e.g. predicate in TPC-DS q41.sql will be converted to hundreds of " +
-            "thousands of CNF nodes.) the threshold is expressed in terms of number of nodes " +
-            "(only count RexCall node, including leaves and interior nodes). " +
-            "Negative number to use the default threshold: double of number of nodes.")
 
   /**
     * Convert ValueInterval,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
@@ -159,11 +159,13 @@ object FlinkBatchRuleSets {
   )
 
   /**
-    * RuleSet to do push predicate into table scan
+    * RuleSet to do push predicate/partition into table scan
     */
   val FILTER_TABLESCAN_PUSHDOWN_RULES: RuleSet = RuleSets.ofList(
     // push a filter down into the table scan
-    PushFilterIntoTableSourceScanRule.INSTANCE
+    PushFilterIntoTableSourceScanRule.INSTANCE,
+    // push partition into the table scan
+    PushPartitionIntoTableSourceScanRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
@@ -158,11 +158,13 @@ object FlinkStreamRuleSets {
     ).asJava)
 
   /**
-    * RuleSet to do push predicate into table scan
+    * RuleSet to do push predicate/partition into table scan
     */
   val FILTER_TABLESCAN_PUSHDOWN_RULES: RuleSet = RuleSets.ofList(
     // push a filter down into the table scan
-    PushFilterIntoTableSourceScanRule.INSTANCE
+    PushFilterIntoTableSourceScanRule.INSTANCE,
+    // push partition into the table scan
+    PushPartitionIntoTableSourceScanRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/PushPartitionIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/PushPartitionIntoTableSourceScanRule.scala
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.flink.table.calcite.{FlinkContext, FlinkTypeFactory}
+import org.apache.flink.table.plan.schema.{FlinkRelOptTable, TableSourceTable}
+import org.apache.flink.table.plan.stats.FlinkStatistic
+import org.apache.flink.table.plan.util.{FlinkRelOptUtil, PartitionPruner, RexNodeExtractor}
+import org.apache.flink.table.sources.PartitionableTableSource
+
+import org.apache.calcite.plan.RelOptRule.{none, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.core.Filter
+import org.apache.calcite.rel.logical.LogicalTableScan
+import org.apache.calcite.rex.{RexInputRef, RexNode, RexShuttle}
+
+import scala.collection.JavaConversions._
+
+/**
+  * Planner rule that tries to push partitions evaluated by filter condition into a
+  * [[PartitionableTableSource]].
+  */
+class PushPartitionIntoTableSourceScanRule extends RelOptRule(
+  operand(classOf[Filter],
+    operand(classOf[LogicalTableScan], none)),
+  "PushPartitionIntoTableSourceScanRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val filter: Filter = call.rel(0)
+    if (filter.getCondition == null) {
+      return false
+    }
+
+    val scan: LogicalTableScan = call.rel(1)
+    scan.getTable.unwrap(classOf[TableSourceTable[_]]) match {
+      case table: TableSourceTable[_] =>
+        table.tableSource match {
+          case p: PartitionableTableSource => p.getPartitionFieldNames.nonEmpty
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val filter: Filter = call.rel(0)
+    val scan: LogicalTableScan = call.rel(1)
+    val table: FlinkRelOptTable = scan.getTable.asInstanceOf[FlinkRelOptTable]
+    pushPartitionIntoScan(call, filter, scan, table)
+  }
+
+  private def pushPartitionIntoScan(
+      call: RelOptRuleCall,
+      filter: Filter,
+      scan: LogicalTableScan,
+      relOptTable: FlinkRelOptTable): Unit = {
+
+    val tableSourceTable = relOptTable.unwrap(classOf[TableSourceTable[_]])
+    val tableSource = tableSourceTable.tableSource.asInstanceOf[PartitionableTableSource]
+    val partitionFieldNames = tableSource.getPartitionFieldNames.toList.toArray
+    val inputFieldType = filter.getInput.getRowType
+
+    val relBuilder = call.builder()
+    val maxCnfNodeCount = FlinkRelOptUtil.getMaxCnfNodeCount(scan)
+    val (partitionPredicate, nonPartitionPredicate) =
+      RexNodeExtractor.extractPartitionPredicates(
+        filter.getCondition,
+        maxCnfNodeCount,
+        inputFieldType.getFieldNames.toList.toArray,
+        relBuilder.getRexBuilder,
+        partitionFieldNames
+      )
+
+    if (partitionPredicate.isAlwaysTrue) {
+      // no partition predicates in filter
+      return
+    }
+
+    val finalPartitionPredicate = adjustPartitionPredicate(
+      inputFieldType.getFieldNames.toList.toArray,
+      partitionFieldNames,
+      partitionPredicate
+    )
+    val partitionFieldTypes = partitionFieldNames.map { name =>
+      val index = inputFieldType.getFieldNames.indexOf(name)
+      require(index >= 0, s"$name is not found in ${inputFieldType.getFieldNames.mkString(", ")}")
+      inputFieldType.getFieldList.get(index).getType
+    }.map(FlinkTypeFactory.toLogicalType)
+
+    val allPartitions = tableSource.getPartitions
+    val remainingPartitions = PartitionPruner.prunePartitions(
+      call.getPlanner.getContext.asInstanceOf[FlinkContext].getTableConfig,
+      partitionFieldNames,
+      partitionFieldTypes,
+      allPartitions,
+      finalPartitionPredicate
+    )
+
+    val newTableSource = tableSource.applyPartitionPruning(remainingPartitions)
+
+    val statistic = tableSourceTable.statistic
+    val newStatistic = if (remainingPartitions.size() == allPartitions.size()) {
+      // Keep all Statistics if no predicates can be pushed down
+      statistic
+    } else if (statistic == FlinkStatistic.UNKNOWN) {
+      statistic
+    } else {
+      // Remove tableStats after predicates pushed down
+      FlinkStatistic.builder().statistic(statistic).tableStats(null).build()
+    }
+    val newTableSourceTable = new TableSourceTable(
+      newTableSource, tableSourceTable.isStreaming, newStatistic)
+   val newRelOptTable = relOptTable.copy(newTableSourceTable, relOptTable.getRowType)
+
+    val newScan = new LogicalTableScan(scan.getCluster, scan.getTraitSet, newRelOptTable)
+    // check whether framework still need to do a filter
+    if (nonPartitionPredicate.isAlwaysTrue) {
+      call.transformTo(newScan)
+    } else {
+      val newFilter = filter.copy(filter.getTraitSet, newScan, nonPartitionPredicate)
+      call.transformTo(newFilter)
+    }
+  }
+
+  /**
+    * adjust the partition field reference index to evaluate the partition values.
+    * e.g. the original input fields is: a, b, c, p, and p is partition field. the partition values
+    * are: List(Map("p"->"1"), Map("p" -> "2"), Map("p" -> "3")). If the original partition
+    * predicate is $3 > 1. after adjusting, the new predicate is ($0 > 1).
+    * and use ($0 > 1) to evaluate partition values (row(1), row(2), row(3)).
+    */
+  private def adjustPartitionPredicate(
+      inputFieldNames: Array[String],
+      partitionFieldNames: Array[String],
+      partitionPredicate: RexNode): RexNode = {
+    partitionPredicate.accept(new RexShuttle() {
+      override def visitInputRef(inputRef: RexInputRef): RexNode = {
+        val index = inputRef.getIndex
+        val fieldName = inputFieldNames(index)
+        val newIndex = partitionFieldNames.indexOf(fieldName)
+        require(newIndex >= 0, s"$fieldName is not found in ${partitionFieldNames.mkString(", ")}")
+        if (index == newIndex) {
+          inputRef
+        } else {
+          new RexInputRef(newIndex, inputRef.getType)
+        }
+      }
+    })
+  }
+}
+
+object PushPartitionIntoTableSourceScanRule {
+  val INSTANCE: RelOptRule = new PushPartitionIntoTableSourceScanRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecScanTableSourceRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecScanTableSourceRule.scala
@@ -41,8 +41,8 @@ class BatchExecScanTableSourceRule
   /** Rule must only match if TableScan targets a bounded [[StreamTableSource]] */
   override def matches(call: RelOptRuleCall): Boolean = {
     val scan: TableScan = call.rel(0).asInstanceOf[TableScan]
-    val dataSetTable = scan.getTable.unwrap(classOf[TableSourceTable[_]])
-    dataSetTable match {
+    val tableSourceTable = scan.getTable.unwrap(classOf[TableSourceTable[_]])
+    tableSourceTable match {
       case tst: TableSourceTable[_] =>
         tst.tableSource match {
           case sts: StreamTableSource[_] => sts.isBounded

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/FlinkRelOptUtil.scala
@@ -17,10 +17,9 @@
  */
 package org.apache.flink.table.plan.util
 
-import org.apache.flink.table.api.{OptimizerConfigOptions, TableConfig}
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.calcite.{FlinkContext, FlinkPlannerImpl, FlinkTypeFactory}
 import org.apache.flink.table.plan.`trait`.{MiniBatchInterval, MiniBatchMode}
-import org.apache.flink.table.plan.metadata.SelectivityEstimator
 import org.apache.flink.table.{JBoolean, JByte, JDouble, JFloat, JLong, JShort}
 
 import com.google.common.collect.Lists
@@ -149,7 +148,7 @@ object FlinkRelOptUtil {
   /** Get max cnf node limit by context of rel */
   def getMaxCnfNodeCount(rel: RelNode): Int = {
     val tableConfig = getTableConfigFromContext(rel)
-    tableConfig.getConfiguration.getInteger(SelectivityEstimator.SQL_OPTIMIZER_CNF_NODES_LIMIT)
+    tableConfig.getConfiguration.getInteger(FlinkRexUtil.SQL_OPTIMIZER_CNF_NODES_LIMIT)
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/FlinkRexUtil.scala
@@ -17,6 +17,10 @@
  */
 package org.apache.flink.table.plan.util
 
+import org.apache.flink.annotation.Experimental
+import org.apache.flink.configuration.ConfigOption
+import org.apache.flink.configuration.ConfigOptions.key
+
 import com.google.common.base.Function
 import com.google.common.collect.{ImmutableList, Lists}
 import org.apache.calcite.plan.{RelOptPredicateList, RelOptUtil}
@@ -37,6 +41,18 @@ import scala.collection.mutable
   * Utility methods concerning [[RexNode]].
   */
 object FlinkRexUtil {
+
+  // It is a experimental config, will may be removed later.
+  @Experimental
+  private[flink] val SQL_OPTIMIZER_CNF_NODES_LIMIT: ConfigOption[Integer] =
+    key("sql.optimizer.cnf.nodes.limit")
+      .defaultValue(Integer.valueOf(-1))
+      .withDescription("When converting to conjunctive normal form (CNF, like '(a AND b) OR" +
+        " c' will be converted to '(a OR c) AND (b OR c)'), fail if the expression  exceeds " +
+        "this threshold; (e.g. predicate in TPC-DS q41.sql will be converted to hundreds of " +
+        "thousands of CNF nodes.) the threshold is expressed in terms of number of nodes " +
+        "(only count RexCall node, including leaves and interior nodes). " +
+        "Negative number to use the default threshold: double of number of nodes.")
 
   /**
     * Similar to [[RexUtil#toCnf(RexBuilder, Int, RexNode)]]; it lets you

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/PartitionPruner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/PartitionPruner.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.api.common.functions.util.ListCollector
+import org.apache.flink.api.common.functions.{FlatMapFunction, MapFunction, RichMapFunction}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.api.{TableConfig, TableException}
+import org.apache.flink.table.codegen.CodeGenUtils.DEFAULT_COLLECTOR_TERM
+import org.apache.flink.table.codegen.{ConstantCodeGeneratorContext, ExprCodeGenerator, FunctionCodeGenerator}
+import org.apache.flink.table.dataformat.{BinaryString, Decimal, GenericRow}
+import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.logical.{BooleanType, DecimalType, LogicalType}
+import org.apache.flink.table.typeutils.BaseRowTypeInfo
+
+import org.apache.calcite.rex.RexNode
+
+import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
+
+import scala.collection.JavaConversions._
+
+/**
+  * Utility class for partition pruning.
+  *
+  * Creates partition filter instance (a [[RichMapFunction]]) with partition predicates by code-gen,
+  * and then evaluates all partition values against the partition filter to get final partitions.
+  */
+object PartitionPruner {
+
+  // current supports partition field type
+  val supportedPartitionFieldTypes = Array(
+    VARCHAR, CHAR, BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, DOUBLE, DECIMAL
+  )
+
+  /**
+    * get pruned partitions from all partitions by partition filters
+    *
+    * @param partitionFieldNames Partition field names.
+    * @param partitionFieldTypes Partition field types.
+    * @param allPartitions       All partition values.
+    * @param partitionPredicate  A predicate that will be applied against partition values.
+    * @return Pruned partitions.
+    */
+  def prunePartitions(
+      config: TableConfig,
+      partitionFieldNames: Array[String],
+      partitionFieldTypes: Array[LogicalType],
+      allPartitions: JList[JMap[String, String]],
+      partitionPredicate: RexNode): JList[JMap[String, String]] = {
+
+    if (allPartitions.isEmpty || partitionPredicate.isAlwaysTrue) {
+      return allPartitions
+    }
+
+    val inputType = new BaseRowTypeInfo(partitionFieldTypes, partitionFieldNames).toRowType
+    val returnType: LogicalType = new BooleanType(false)
+
+    val ctx = new ConstantCodeGeneratorContext(config)
+    val collectorTerm = DEFAULT_COLLECTOR_TERM
+
+    val exprGenerator = new ExprCodeGenerator(ctx, false)
+      .bindInput(inputType)
+
+    val filterExpression = exprGenerator.generateExpression(partitionPredicate)
+
+    val filterFunctionBody =
+      s"""
+         |${filterExpression.code}
+         |return ${filterExpression.resultTerm};
+         |""".stripMargin
+
+    val genFunction = FunctionCodeGenerator.generateFunction(
+      ctx,
+      "PartitionPruner",
+      classOf[MapFunction[GenericRow, Boolean]],
+      filterFunctionBody,
+      returnType,
+      inputType,
+      collectorTerm = collectorTerm)
+
+    val function = genFunction.newInstance(getClass.getClassLoader)
+    val richMapFunction = function match {
+      case r: RichMapFunction[GenericRow, Boolean] => r
+      case _ => throw new TableException("RichMapFunction[GenericRow, Boolean] required here")
+    }
+
+    val results: JList[Boolean] = new JArrayList[Boolean](allPartitions.size)
+    val collector = new ListCollector[Boolean](results)
+
+    val parameters = if (config.getConfiguration != null) {
+      config.getConfiguration
+    } else {
+      new Configuration()
+    }
+    try {
+      richMapFunction.open(parameters)
+      // do filter against all partitions
+      allPartitions.foreach { partition =>
+        val row = convertPartitionToRow(partitionFieldNames, partitionFieldTypes, partition)
+        collector.collect(richMapFunction.map(row))
+      }
+    } finally {
+      richMapFunction.close()
+    }
+
+    // get pruned partitions
+    allPartitions.zipWithIndex.filter {
+      case (_, index) => results.get(index)
+    }.unzip._1
+  }
+
+  /**
+    * create new Row from partition, set partition values to corresponding positions of row.
+    */
+  private def convertPartitionToRow(
+      partitionFieldNames: Array[String],
+      partitionFieldTypes: Array[LogicalType],
+      partition: JMap[String, String]): GenericRow = {
+    val row = new GenericRow(partitionFieldNames.length)
+    partitionFieldNames.zip(partitionFieldTypes).zipWithIndex.foreach {
+      case ((fieldName, fieldType), index) =>
+        val value = convertPartitionFieldValue(partition(fieldName), fieldType)
+        row.setField(index, value)
+    }
+    row
+  }
+
+  private def convertPartitionFieldValue(
+      partitionFieldValue: String,
+      partitionFieldType: LogicalType): Any = {
+    partitionFieldValue match {
+      case null => null
+      case _ =>
+        val v = partitionFieldValue
+        partitionFieldType.getTypeRoot match {
+          case VARCHAR | CHAR => BinaryString.fromString(v)
+          case BOOLEAN => Boolean
+          case TINYINT => v.toByte
+          case SMALLINT => v.toShort
+          case INTEGER => v.toInt
+          case BIGINT => v.toLong
+          case FLOAT => v.toFloat
+          case DOUBLE => v.toDouble
+          case DECIMAL =>
+            val decimalType = partitionFieldType.asInstanceOf[DecimalType]
+            Decimal.castFrom(v, decimalType.getPrecision, decimalType.getScale)
+          case _ =>
+            throw new TableException(s"$partitionFieldType is not supported in PartitionPruner")
+        }
+    }
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/RankUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/RankUtil.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.plan.util
 
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.codegen.ExpressionReducer
-import org.apache.flink.table.plan.metadata.SelectivityEstimator.SQL_OPTIMIZER_CNF_NODES_LIMIT
 import org.apache.flink.table.plan.nodes.calcite.Rank
 import org.apache.flink.table.runtime.rank.{ConstantRankRange, ConstantRankRangeWithoutEnd, RankRange, VariableRankRange}
 
@@ -71,7 +70,8 @@ object RankUtil {
       config: TableConfig): (Option[RankRange], Option[RexNode]) = {
 
     // Converts the condition to conjunctive normal form (CNF)
-    val cnfNodeCount = config.getConfiguration.getInteger(SQL_OPTIMIZER_CNF_NODES_LIMIT)
+    val cnfNodeCount = config.getConfiguration.getInteger(
+      FlinkRexUtil.SQL_OPTIMIZER_CNF_NODES_LIMIT)
     val cnfCondition = FlinkRexUtil.toCnf(rexBuilder, cnfNodeCount, predicate)
 
     // split the condition into sort limit condition and other condition

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/WindowJoinUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/WindowJoinUtil.scala
@@ -19,12 +19,11 @@
 package org.apache.flink.table.plan.util
 
 import org.apache.flink.api.common.functions.FlatJoinFunction
-import org.apache.flink.table.api.{OptimizerConfigOptions, TableConfig}
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.calcite.{FlinkTypeFactory, RelTimeIndicatorConverter}
 import org.apache.flink.table.codegen.{CodeGenUtils, CodeGeneratorContext, ExprCodeGenerator, ExpressionReducer, FunctionCodeGenerator}
 import org.apache.flink.table.dataformat.{BaseRow, JoinedRow}
 import org.apache.flink.table.generated.GeneratedFunction
-import org.apache.flink.table.plan.metadata.SelectivityEstimator
 import org.apache.flink.table.plan.schema.TimeIndicatorRelDataType
 import org.apache.flink.table.types.logical.RowType
 
@@ -170,7 +169,7 @@ object WindowJoinUtil {
 
     // Converts the condition to conjunctive normal form (CNF)
     val cnfCondition = FlinkRexUtil.toCnf(rexBuilder,
-      config.getConfiguration.getInteger(SelectivityEstimator.SQL_OPTIMIZER_CNF_NODES_LIMIT),
+      config.getConfiguration.getInteger(FlinkRexUtil.SQL_OPTIMIZER_CNF_NODES_LIMIT),
       predicate)
 
     // split the condition into time predicates and other predicates

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/TableSourceTest.xml
@@ -185,6 +185,42 @@ Calc(select=[id, deepNested.nested1.name AS nestedName, nested.value AS nestedVa
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPartitionTableSource">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A' ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[AND(>($3, 1), >($0, 2), =($2, _UTF-16LE'A'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2], where=[>(id, 2)])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, source: [partitions={part1=A, part2=2}]]], fields=[id, name, part1, part2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartitionTableSourceWithUdf">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[id, name, part1, part2], where=[>(id, 2)])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, source: [partitions={part1=A, part2=1}, {part1=C, part2=1}]]], fields=[id, name, part1, part2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProjectWithoutInputRef">
     <Resource name="sql">
       <![CDATA[SELECT COUNT(1) FROM ProjectableTable]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/rules/logical/ExpressionReductionRulesTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/rules/logical/ExpressionReductionRulesTest.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testExpressionReductionWithUDF">
+    <Resource name="sql">
+      <![CDATA[SELECT MyUdf(1) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[MyUdf(1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[CAST(2) AS EXPR$0])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testExpressionReductionWithRichUDF">
+    <Resource name="sql">
+      <![CDATA[SELECT myUdf(1) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[myUdf(1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[11 AS EXPR$0])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/rules/logical/PushPartitionIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/rules/logical/PushPartitionIntoTableSourceScanRuleTest.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testNoPartitionFieldPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE id > 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[>($0, 2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[>($0, 2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyPartitionFieldPredicate1">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[=($2, _UTF-16LE'A')])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [partitions={part1=A, part2=1}, {part1=A, part2=2}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyPartitionFieldPredicate2">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE part2 > 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[>($3, 1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [partitions={part1=A, part2=2}, {part1=B, part2=3}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyPartitionFieldPredicate3">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A' AND part2 > 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [partitions={part1=A, part2=2}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyPartitionFieldPredicate4">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A' OR part2 > 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[OR(=($2, _UTF-16LE'A'), >($3, 1))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [partitions={part1=A, part2=1}, {part1=A, part2=2}, {part1=B, part2=3}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialPartitionFieldPredicatePushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[AND(OR(>($0, 2), =($2, _UTF-16LE'A')), >($3, 1))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[OR(>($0, 2), =($2, _UTF-16LE'A'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [partitions={part1=A, part2=2}, {part1=B, part2=3}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartitionFieldPredicateAndOtherPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE id > 2 AND part1 = 'A']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[AND(>($0, 2), =($2, _UTF-16LE'A'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[>($0, 2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [partitions={part1=A, part2=1}, {part1=A, part2=2}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithUdf">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[>($0, 2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [partitions={part1=A, part2=1}, {part1=C, part2=1}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartitionFieldPredicateOrOtherPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE id > 2 OR part1 = 'A']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[OR(>($0, 2), =($2, _UTF-16LE'A'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[OR(>($0, 2), =($2, _UTF-16LE'A'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/TableSourceTest.xml
@@ -214,6 +214,42 @@ Calc(select=[id, deepNested.nested1.name AS nestedName, nested.value AS nestedVa
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPartitionTableSource">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A' ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[AND(>($3, 1), >($0, 2), =($2, _UTF-16LE'A'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2], where=[>(id, 2)])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, source: [partitions={part1=A, part2=2}]]], fields=[id, name, part1, part2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartitionTableSourceWithUdf">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3])
++- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[id, name, part1, part2], where=[>(id, 2)])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, source: [partitions={part1=A, part2=1}, {part1=C, part2=1}]]], fields=[id, name, part1, part2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProcTimeTableSourceSimple">
     <Resource name="sql">
       <![CDATA[SELECT pTime, id, name, val FROM procTimeT]]>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/TableSourceTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.expressions.utils.Func1
 import org.apache.flink.table.types.TypeInfoDataTypeConverter
-import org.apache.flink.table.util._
+import org.apache.flink.table.util.{TestPartitionableTableSource, _}
 import org.apache.flink.types.Row
 
 import org.junit.{Before, Test}
@@ -46,6 +46,7 @@ class TableSourceTest extends TableTestBase {
       Seq.empty[Row])
     )
     util.tableEnv.registerTableSource("FilterableTable", TestFilterableTableSource(true))
+    util.tableEnv.registerTableSource("PartitionableTable", new TestPartitionableTableSource(true))
   }
 
   @Test
@@ -144,6 +145,17 @@ class TableSourceTest extends TableTestBase {
   def testFilterPushDownWithUdf(): Unit = {
     util.addFunction("myUdf", Func1)
     util.verifyPlan("SELECT * FROM FilterableTable WHERE amount > 2 AND myUdf(amount) < 32")
+  }
+
+  @Test
+  def testPartitionTableSource(): Unit = {
+    util.verifyPlan("SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A' ")
+  }
+
+  @Test
+  def testPartitionTableSourceWithUdf(): Unit = {
+    util.addFunction("MyUdf", Func1)
+    util.verifyPlan("SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/ExpressionReductionRulesTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.expressions.utils.{Func1, RichFunc1}
+import org.apache.flink.table.util.TableTestBase
+
+import org.junit.Test
+
+/**
+  * Test for [[org.apache.flink.table.codegen.ExpressionReducer]].
+  */
+class ExpressionReductionRulesTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+  util.addTableSource[(Int, Long, Int)]("MyTable", 'a, 'b, 'c)
+
+  @Test
+  def testExpressionReductionWithUDF(): Unit = {
+    util.addFunction("MyUdf", Func1)
+    util.verifyPlan("SELECT MyUdf(1) FROM MyTable")
+  }
+
+  @Test
+  def testExpressionReductionWithRichUDF(): Unit = {
+    util.addFunction("MyUdf", new RichFunc1)
+    util.getTableEnv.getConfig.getConfiguration.setString("int.value", "10")
+    util.verifyPlan("SELECT myUdf(1) FROM MyTable")
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/PushPartitionIntoTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/rules/logical/PushPartitionIntoTableSourceScanRuleTest.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.flink.table.expressions.utils.Func1
+import org.apache.flink.table.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
+import org.apache.flink.table.util.{TableConfigUtils, TableTestBase, TestPartitionableTableSource}
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.tools.RuleSets
+import org.junit.{Before, Test}
+
+/**
+  * Test for [[PushPartitionIntoTableSourceScanRule]].
+  */
+class PushPartitionIntoTableSourceScanRuleTest extends TableTestBase {
+  private val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    util.buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE)
+    val calciteConfig = TableConfigUtils.getCalciteConfig(util.tableEnv.getConfig)
+    calciteConfig.getBatchProgram.get.addLast(
+      "rules",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(RuleSets.ofList(PushPartitionIntoTableSourceScanRule.INSTANCE))
+        .build()
+    )
+
+    util.tableEnv.registerTableSource("MyTable", new TestPartitionableTableSource(true))
+  }
+
+  @Test
+  def testNoPartitionFieldPredicate(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE id > 2")
+  }
+
+  @Test
+  def testOnlyPartitionFieldPredicate1(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE part1 = 'A'")
+  }
+
+  @Test
+  def testOnlyPartitionFieldPredicate2(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE part2 > 1")
+  }
+
+  @Test
+  def testOnlyPartitionFieldPredicate3(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE part1 = 'A' AND part2 > 1")
+  }
+
+  @Test
+  def testOnlyPartitionFieldPredicate4(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE part1 = 'A' OR part2 > 1")
+  }
+
+  @Test
+  def testPartitionFieldPredicateAndOtherPredicate(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE id > 2 AND part1 = 'A'")
+  }
+
+  @Test
+  def testPartitionFieldPredicateOrOtherPredicate(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE id > 2 OR part1 = 'A'")
+  }
+
+  @Test
+  def testPartialPartitionFieldPredicatePushDown(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1")
+  }
+
+  @Test
+  def testWithUdf(): Unit = {
+    util.addFunction("MyUdf", Func1)
+    util.verifyPlan("SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3")
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/TableSourceTest.scala
@@ -34,6 +34,7 @@ class TableSourceTest extends TableTestBase {
   @Before
   def setup(): Unit = {
     util.tableEnv.registerTableSource("FilterableTable", TestFilterableTableSource(false))
+    util.tableEnv.registerTableSource("PartitionableTable", new TestPartitionableTableSource(false))
   }
 
   @Test
@@ -314,6 +315,17 @@ class TableSourceTest extends TableTestBase {
   def testFilterPushDownWithUdf(): Unit = {
     util.addFunction("myUdf", Func1)
     util.verifyPlan("SELECT * FROM FilterableTable WHERE amount > 2 AND myUdf(amount) < 32")
+  }
+
+  @Test
+  def testPartitionTableSource(): Unit = {
+    util.verifyPlan("SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A' ")
+  }
+
+  @Test
+  def testPartitionTableSourceWithUdf(): Unit = {
+    util.addFunction("MyUdf", Func1)
+    util.verifyPlan("SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/PartitionPrunerTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/PartitionPrunerTest.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.table.api.{DataTypes, TableConfig}
+import org.apache.flink.table.expressions.utils.Func1
+import org.apache.flink.table.functions.utils.ScalarSqlFunction
+
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import java.math.BigDecimal
+import java.util.{List => JList, Map => JMap}
+
+import scala.collection.JavaConverters._
+
+/**
+  * Test for [[PartitionPruner]].
+  */
+class PartitionPrunerTest extends RexNodeTestBase {
+
+  @Test
+  def testPrunePartitions(): Unit = {
+    // amount
+    val t0 = rexBuilder.makeInputRef(allFieldTypes.get(2), 0)
+    // 100
+    val t1 = rexBuilder.makeExactLiteral(BigDecimal.valueOf(100L))
+    val c1 = rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, t0, t1)
+    // name
+    val t2 = rexBuilder.makeInputRef(allFieldTypes.get(0), 1)
+    // 'test%'
+    val t3 = rexBuilder.makeLiteral("test%")
+    val c2 = rexBuilder.makeCall(SqlStdOperatorTable.LIKE, t2, t3)
+    // amount > 100 and name like 'test%'
+    val c3 = rexBuilder.makeCall(SqlStdOperatorTable.AND, c1, c2)
+
+    val partitionFieldNames = Array("amount", "name", "flag")
+    val partitionFieldTypes = Array(DataTypes.INT().getLogicalType,
+      DataTypes.VARCHAR(100).getLogicalType, DataTypes.BOOLEAN().getLogicalType)
+
+    val allPartitions: JList[JMap[String, String]] = List(
+      Map("amount" -> "20", "name" -> "test1", "flag" -> "true").asJava,
+      Map("amount" -> "150", "name" -> "test2", "flag" -> "false").asJava,
+      Map("amount" -> "200", "name" -> "Test3", "flag" -> "false").asJava
+    ).asJava
+
+    val config = new TableConfig
+    val prunedPartitions = PartitionPruner.prunePartitions(
+      config,
+      partitionFieldNames,
+      partitionFieldTypes,
+      allPartitions,
+      c3
+    )
+
+    assertEquals(1, prunedPartitions.size())
+    assertEquals("150", prunedPartitions.get(0).get("amount"))
+  }
+
+  @Test
+  def testPrunePartitionsWithUdf(): Unit = {
+    // amount
+    val t0 = rexBuilder.makeInputRef(allFieldTypes.get(2), 1)
+    // MyUdf(amount)
+    val t1 = rexBuilder.makeCall(new ScalarSqlFunction("MyUdf", "MyUdf", Func1, typeFactory), t0)
+    // 100
+    val t2 = rexBuilder.makeExactLiteral(BigDecimal.valueOf(100L))
+    // MyUdf(amount) > 100
+    val c = rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, t1, t2)
+
+    val partitionFieldNames = Array("name", "amount")
+    val partitionFieldTypes = Array(
+      DataTypes.VARCHAR(100).getLogicalType, DataTypes.INT().getLogicalType)
+
+    val allPartitions: JList[JMap[String, String]] = List(
+      Map("amount" -> "20", "name" -> "test1").asJava,
+      Map("amount" -> "150", "name" -> "test2").asJava,
+      Map("amount" -> "200", "name" -> "Test3").asJava
+    ).asJava
+
+    val config = new TableConfig
+    val prunedPartitions = PartitionPruner.prunePartitions(
+      config,
+      partitionFieldNames,
+      partitionFieldTypes,
+      allPartitions,
+      c
+    )
+
+    assertEquals(2, prunedPartitions.size())
+    assertEquals("150", prunedPartitions.get(0).get("amount"))
+    assertEquals("200", prunedPartitions.get(1).get("amount"))
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.runtime.utils.{BatchTestBase, TestData}
 import org.apache.flink.table.types.TypeInfoDataTypeConverter
-import org.apache.flink.table.util.{TestFilterableTableSource, TestNestedProjectableTableSource, TestProjectableTableSource, TestTableSources}
+import org.apache.flink.table.util.{TestFilterableTableSource, TestNestedProjectableTableSource, TestPartitionableTableSource, TestProjectableTableSource, TestTableSources}
 import org.apache.flink.types.Row
 
 import org.junit.{Before, Ignore, Test}
@@ -148,6 +148,15 @@ class TableSourceITCase extends BatchTestBase {
         row(6, "Record_6"),
         row(7, "Record_7"),
         row(8, "Record_8"))
+    )
+  }
+
+  @Test
+  def testTableSourceWithPartitionable(): Unit = {
+    tEnv.registerTableSource("PartitionableTable", new TestPartitionableTableSource(true))
+    checkResult(
+      "SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A'",
+      Seq(row(3, "John", "A", 2), row(4, "nosharp", "A", 2))
     )
   }
 


### PR DESCRIPTION


## What is the purpose of the change

*Introduce planner rule to support partition pruning for PartitionableTableSource*


## Brief change log

  - *Move SQL_OPTIMIZER_CNF_NODES_LIMIT from SelectivityEstimator into FlinkRexUtil*
  - *fix codegen error for udf in ExpressionReducer*
  - *add PushPartitionIntoTableSourceScanRule to push partition into PartitionableTableSource*


## Verifying this change


This change added tests and can be verified as follows:

  - *Added ExpressionReductionRulesTest to validate "codegen error for udf in ExpressionReducer"*
  - *Added test that validates logical plan & physical plan & execution result for partitionable table source*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
