### PR TITLE
[FLINK-13209] Following FLINK-12951: Remove TableEnvironment#sql and …

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -276,7 +276,7 @@ class TableEnvironment(object):
             # source_table is not registered to the table environment
             >>> table_env.sql_update("INSERT INTO sink_table SELECT * FROM %s" % source_table)
 
-        A DDL statement can also execute to create/drop a table:
+        A DDL statement can also be executed to create/drop a table:
         For example, the below DDL statement would create a CSV table named `tbl1`
         into the current catalog::
 
@@ -285,8 +285,9 @@ class TableEnvironment(object):
                 b bigint,
                 c varchar
             ) with (
-                connector = 'csv',
-                csv.path = 'xxx'
+                connector.type = 'filesystem',
+                format.type = 'csv',
+                connector.path = 'xxx'
             )
 
         SQL queries can directly execute as follows:
@@ -298,9 +299,11 @@ class TableEnvironment(object):
             ...     a int,
             ...     b varchar
             ... ) with (
-            ...     connector = 'kafka',
-            ...     kafka.topic = 'xxx',
-            ...     kafka.endpoint = 'x.x.x'
+            ...     connector.type = 'kafka',
+            ...     `update-mode` = 'append',
+            ...     connector.topic = 'xxx',
+            ...     connector.properties.0.key = 'k0',
+            ...     connector.properties.0.value = 'v0'
             ... )
             ... '''
 
@@ -310,8 +313,9 @@ class TableEnvironment(object):
             ...     a int,
             ...     b varchar
             ... ) with (
-            ...     connector = 'csv',
-            ...     csv.path = 'xxx'
+            ...     connector.type = 'filesystem',
+            ...     format.type = 'csv',
+            ...     connector.path = 'xxx'
             ... )
             ... '''
 

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -234,14 +234,49 @@ class TableEnvironment(object):
         """
         return self._j_tenv.explain(table._j_table)
 
-    def sql(self, query):
+    def sql_query(self, query):
         """
-        Evaluates single sql statement including DDLs and DMLs.
+        Evaluates a SQL query on registered tables and retrieves the result as a :class:`Table`.
 
-        Note: Always use this interface to execute a sql query. It only supports
-        to execute one sql statement a time.
+        All tables referenced by the query must be registered in the TableEnvironment.
 
-        A DDL statement can execute to create/drop a table/view:
+        A :class:`Table` is automatically registered when its :func:`~Table.__str__` method is
+        called, for example when it is embedded into a String.
+
+        Hence, SQL queries can directly reference a :class:`Table` as follows:
+        ::
+
+            >>> table = ...
+            # the table is not registered to the table environment
+            >>> table_env.sql_query("SELECT * FROM %s" % table)
+
+        :param query: The sql query string.
+        :return: The result :class:`Table`.
+        """
+        j_table = self._j_tenv.sqlQuery(query)
+        return Table(j_table)
+
+    def sql_update(self, stmt):
+        """
+        Evaluates a SQL statement such as INSERT, UPDATE or DELETE or a DDL statement
+
+        .. note::
+
+            Currently only SQL INSERT statements and CREATE TABLE statements are supported.
+
+        All tables referenced by the query must be registered in the TableEnvironment.
+        A :class:`Table` is automatically registered when its :func:`~Table.__str__` method is
+        called, for example when it is embedded into a String.
+        Hence, SQL queries can directly reference a :class:`Table` as follows:
+        ::
+
+            # register the table sink into which the result is inserted.
+            >>> table_env.register_table_sink("sink_table", table_sink)
+            >>> source_table = ...
+            # source_table is not registered to the table environment
+            >>> table_env.sql_update("INSERT INTO sink_table SELECT * FROM %s" % source_table)
+
+        A DDL statement can also execute to create/drop a table/view:
         For example, the below DDL statement would create a CSV table named `tbl1`
         into the current catalog::
 
@@ -253,14 +288,6 @@ class TableEnvironment(object):
                 connector = 'csv',
                 csv.path = 'xxx'
             )
-
-        The returns table format for different kind of statement:
-
-        DDL: returns None.
-
-        DML: a sql insert returns None; a sql query(select) returns a table
-        to describe the query data set, it can be further queried through the Table API,
-        or directly write to sink with :func:`Table.insert_into`.
 
         SQL queries can directly execute as follows:
         ::
@@ -294,14 +321,11 @@ class TableEnvironment(object):
             >>> table_env.sql(query)
             >>> table_env.execute("MyJob")
 
-        This code snippet creates a job to read data from Kafka source into a CSV sink.
-
-        :param query: The SQL statement to evaluate.
+        :param stmt: The SQL statement to evaluate.
+        :param query_config: The :class:`QueryConfig` to use.
         """
-        j_table = self._j_tenv.sql(query)
-        if j_table is None:
-            return None
-        return Table(j_table)
+        # type: (str) -> None
+        self._j_tenv.sqlUpdate(stmt)
 
     def get_current_catalog(self):
         """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -276,7 +276,7 @@ class TableEnvironment(object):
             # source_table is not registered to the table environment
             >>> table_env.sql_update("INSERT INTO sink_table SELECT * FROM %s" % source_table)
 
-        A DDL statement can also execute to create/drop a table/view:
+        A DDL statement can also execute to create/drop a table:
         For example, the below DDL statement would create a CSV table named `tbl1`
         into the current catalog::
 

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -41,11 +41,10 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, unittest.Te
         # registerExternalCatalog, getRegisteredExternalCatalog, registerCatalog, getCatalog and
         # listTables should be supported when catalog supported in python.
         # getCompletionHints has been deprecated. It will be removed in the next release.
-        # sqlQuery and sqlUpdate has been deprecated. It will be removed in the next release.
         # TODO add TableEnvironment#create method with EnvironmentSettings as a parameter
         return {'registerExternalCatalog', 'getRegisteredExternalCatalog', 'registerCatalog',
                 'getCatalog', 'registerFunction', 'listUserDefinedFunctions', 'listTables',
-                'getCompletionHints', 'create', 'sqlQuery', 'sqlUpdate'}
+                'getCompletionHints', 'create'}
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -112,7 +112,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
             "sinks",
             source_sink_utils.TestAppendSink(field_names, field_types))
 
-        result = t_env.sql("select a + 1, b, c from %s" % source)
+        result = t_env.sql_query("select a + 1, b, c from %s" % source)
         result.insert_into("sinks")
         self.env.execute()
         actual = source_sink_utils.results()
@@ -129,7 +129,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
             "sinks",
             source_sink_utils.TestAppendSink(field_names, field_types))
 
-        t_env.sql("insert into sinks select * from %s" % source)
+        t_env.sql_update("insert into sinks select * from %s" % source)
         self.env.execute("test_sql_job")
 
         actual = source_sink_utils.results()

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -30,8 +30,6 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 
-import javax.annotation.Nullable;
-
 import java.util.Optional;
 
 /**
@@ -323,69 +321,6 @@ public interface TableEnvironment {
 	String[] getCompletionHints(String statement, int position);
 
 	/**
-	 * Evaluates single sql statement including DDLs and DMLs.
-	 *
-	 * <p>Note: Always use this interface to execute a sql query. It only supports
-	 * to execute one sql statement a time.
-	 *
-	 * <p>A DDL statement can execute to create/drop a table/view:
-	 * For example, the below DDL statement would create a CSV table named `tbl1`
-	 * into the current catalog:
-	 * <blockquote><pre>
-	 *   create table tbl1(
-	 *     a int,
-	 *     b bigint,
-	 *     c varchar
-	 *   ) with (
-	 *     connector = 'csv',
-	 *     csv.path = 'xxx'
-	 *   )
-	 * </pre></blockquote>
-	 *
-	 * <p>The returns table format for different kind of statement:
-	 * <ul>
-	 *   <li>DDL: returns null.</li>
-	 *   <li>DML: a sql insert returns null; a sql query(select) returns
-	 *   a table to describe the query data set, it can be further queried through
-	 *   the Table API, or directly write to sink with
-	 *   {@link #insertInto(Table, String, String...)}.</li>
-	 * </ul>
-	 *
-	 * <p>SQL queries can directly execute as follows:
-	 *
-	 * <blockquote><pre>
-	 *   String sinkDDL = "create table sinkTable(
-	 *                       a int,
-	 *                       b varchar
-	 *                     ) with (
-	 *                       connector = 'csv',
-	 *                       csv.path = 'xxx'
-	 *                     )";
-	 *
-	 *  String sourceDDL ="create table sourceTable(
-	 *                       a int,
-	 *                       b varchar
-	 *                     ) with (
-	 *                       connector = 'kafka',
-	 *                       kafka.topic = 'xxx',
-	 *                       kafka.endpoint = 'x.x.x'
-	 *                     )";
-	 *
-	 *  String query = "INSERT INTO sinkTable SELECT * FROM sourceTable";
-	 *
-	 *  tEnv.sql(sourceDDL);
-	 *  tEnv.sql(sinkDDL);
-	 *  tEnv.sql(query);
-	 *  tEnv.execute("MyJob");
-	 * </pre></blockquote>
-	 * This code snippet creates a job to read data from Kafka source into a CSV sink.
-	 *
-	 * @param statement The SQL statement to evaluate.
-	 */
-	@Nullable
-	Table sql(String statement);
-
-	/**
 	 * Evaluates a SQL query on registered tables and retrieves the result as a {@link Table}.
 	 *
 	 * <p>All tables referenced by the query must be registered in the TableEnvironment.
@@ -402,17 +337,14 @@ public interface TableEnvironment {
 	 * }
 	 * </pre>
 	 *
-	 * @deprecated Use {@link #sql(String)}.
-	 *
 	 * @param query The SQL query to evaluate.
 	 * @return The result of the query as Table
 	 */
-	@Deprecated
 	Table sqlQuery(String query);
 
 	/**
 	 * Evaluates a SQL statement such as INSERT, UPDATE or DELETE; or a DDL statement;
-	 * NOTE: Currently only SQL INSERT statements are supported.
+	 * NOTE: Currently only SQL INSERT statements and CREATE TABLE statements are supported.
 	 *
 	 * <p>All tables referenced by the query must be registered in the TableEnvironment.
 	 * A {@link Table} is automatically registered when its {@link Table#toString()} method is
@@ -430,11 +362,51 @@ public interface TableEnvironment {
 	 * }
 	 * </pre>
 	 *
-	 * @deprecated Use {@link #sql(String)}.
+	 * <p>A DDL statement can also execute to create a table/view:
+	 * For example, the below DDL statement would create a CSV table named `tbl1`
+	 * into the current catalog:
+	 * <blockquote><pre>
+	 *    create table tbl1(
+	 *      a int,
+	 *      b bigint,
+	 *      c varchar
+	 *    ) with (
+	 *      connector = 'csv',
+	 *      csv.path = 'xxx'
+	 *    )
+	 * </pre></blockquote>
+	 *
+	 * <p>SQL queries can directly execute as follows:
+	 *
+	 * <blockquote><pre>
+	 *    String sinkDDL = "create table sinkTable(
+	 *                        a int,
+	 *                        b varchar
+	 *                      ) with (
+	 *                        connector = 'csv',
+	 *                        csv.path = 'xxx'
+	 *                      )";
+	 *
+	 *    String sourceDDL ="create table sourceTable(
+	 *                        a int,
+	 *                        b varchar
+	 *                      ) with (
+	 *                        connector = 'kafka',
+	 *                        kafka.topic = 'xxx',
+	 *                        kafka.endpoint = 'x.x.x'
+	 *                      )";
+	 *
+	 *    String query = "INSERT INTO sinkTable SELECT * FROM sourceTable";
+	 *
+	 *    tEnv.sqlUpdate(sourceDDL);
+	 *    tEnv.sqlUpdate(sinkDDL);
+	 *    tEnv.sqlUpdate(query);
+	 *    tEnv.execute("MyJob");
+	 * </pre></blockquote>
+	 * This code snippet creates a job to read data from Kafka source into a CSV sink.
 	 *
 	 * @param stmt The SQL statement to evaluate.
 	 */
-	@Deprecated
 	void sqlUpdate(String stmt);
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -362,7 +362,7 @@ public interface TableEnvironment {
 	 * }
 	 * </pre>
 	 *
-	 * <p>A DDL statement can also execute to create a table:
+	 * <p>A DDL statement can also be executed to create a table:
 	 * For example, the below DDL statement would create a CSV table named `tbl1`
 	 * into the current catalog:
 	 * <blockquote><pre>
@@ -371,8 +371,9 @@ public interface TableEnvironment {
 	 *      b bigint,
 	 *      c varchar
 	 *    ) with (
-	 *      connector = 'csv',
-	 *      csv.path = 'xxx'
+	 *      connector.type = 'filesystem',
+	 *      format.type = 'csv',
+	 *      connector.path = 'xxx'
 	 *    )
 	 * </pre></blockquote>
 	 *
@@ -383,17 +384,21 @@ public interface TableEnvironment {
 	 *                        a int,
 	 *                        b varchar
 	 *                      ) with (
-	 *                        connector = 'csv',
-	 *                        csv.path = 'xxx'
+	 *                        connector.type = 'filesystem',
+	 *                        format.type = 'csv',
+	 *                        connector.path = 'xxx'
 	 *                      )";
 	 *
 	 *    String sourceDDL ="create table sourceTable(
 	 *                        a int,
 	 *                        b varchar
 	 *                      ) with (
-	 *                        connector = 'kafka',
-	 *                        kafka.topic = 'xxx',
-	 *                        kafka.endpoint = 'x.x.x'
+	 *                        connector.type = 'kafka',
+	 *                        `update-mode` = 'append',
+	 *                        connector.topic = 'xxx',
+	 *                        connector.properties.0.key = 'k0',
+	 *                        connector.properties.0.value = 'v0',
+	 *                        ...
 	 *                      )";
 	 *
 	 *    String query = "INSERT INTO sinkTable SELECT * FROM sourceTable";

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -362,7 +362,7 @@ public interface TableEnvironment {
 	 * }
 	 * </pre>
 	 *
-	 * <p>A DDL statement can also execute to create a table/view:
+	 * <p>A DDL statement can also execute to create a table:
 	 * For example, the below DDL statement would create a CSV table named `tbl1`
 	 * into the current catalog:
 	 * <blockquote><pre>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
@@ -131,9 +131,9 @@ class CatalogTableITCase(isStreaming: Boolean) {
         |insert into t2
         |select t1.a, t1.b, (t1.a + 1) as c from t1
       """.stripMargin
-    tableEnv.sql(sourceDDL)
-    tableEnv.sql(sinkDDL)
-    tableEnv.sql(query)
+    tableEnv.sqlUpdate(sourceDDL)
+    tableEnv.sqlUpdate(sinkDDL)
+    tableEnv.sqlUpdate(query)
     execJob("testJob")
     assertEquals(sourceData.sorted, TestCollectionTableFactory.RESULT.sorted)
   }
@@ -167,9 +167,9 @@ class CatalogTableITCase(isStreaming: Boolean) {
         |insert into t2(a, b)
         |select t1.a, t1.b from t1
       """.stripMargin
-    tableEnv.sql(sourceDDL)
-    tableEnv.sql(sinkDDL)
-    tableEnv.sql(query)
+    tableEnv.sqlUpdate(sourceDDL)
+    tableEnv.sqlUpdate(sinkDDL)
+    tableEnv.sqlUpdate(query)
     execJob("testJob")
     assertEquals(SOURCE_DATA.sorted, TestCollectionTableFactory.RESULT.sorted)
   }
@@ -220,9 +220,9 @@ class CatalogTableITCase(isStreaming: Boolean) {
         |  join t1 b
         |  on a.a = b.b
       """.stripMargin
-    tableEnv.sql(sourceDDL)
-    tableEnv.sql(sinkDDL)
-    tableEnv.sql(query)
+    tableEnv.sqlUpdate(sourceDDL)
+    tableEnv.sqlUpdate(sinkDDL)
+    tableEnv.sqlUpdate(query)
     execJob("testJob")
     assertEquals(expected.sorted, TestCollectionTableFactory.RESULT.sorted)
   }
@@ -270,9 +270,9 @@ class CatalogTableITCase(isStreaming: Boolean) {
         |insert into t2
         |select sum(a), t1.b from t1 group by t1.b
       """.stripMargin
-    tableEnv.sql(sourceDDL)
-    tableEnv.sql(sinkDDL)
-    tableEnv.sql(query)
+    tableEnv.sqlUpdate(sourceDDL)
+    tableEnv.sqlUpdate(sinkDDL)
+    tableEnv.sqlUpdate(query)
     execJob("testJob")
     assertEquals(expected.sorted, TestCollectionTableFactory.RESULT.sorted)
   }
@@ -311,9 +311,9 @@ class CatalogTableITCase(isStreaming: Boolean) {
         |select sum(a), sum(b) from t1 group by TUMBLE(c, INTERVAL '1' SECOND)
       """.stripMargin
 
-    tableEnv.sql(sourceDDL)
-    tableEnv.sql(sinkDDL)
-    tableEnv.sql(query)
+    tableEnv.sqlUpdate(sourceDDL)
+    tableEnv.sqlUpdate(sinkDDL)
+    tableEnv.sqlUpdate(query)
     execJob("testJob")
     assertEquals(TestCollectionTableFactory.RESULT.sorted, sourceData.sorted)
   }
@@ -352,9 +352,9 @@ class CatalogTableITCase(isStreaming: Boolean) {
         |select sum(a), sum(b) from t1 group by TUMBLE(wm, INTERVAL '1' SECOND)
       """.stripMargin
 
-    tableEnv.sql(sourceDDL)
-    tableEnv.sql(sinkDDL)
-    tableEnv.sql(query)
+    tableEnv.sqlUpdate(sourceDDL)
+    tableEnv.sqlUpdate(sinkDDL)
+    tableEnv.sqlUpdate(query)
     execJob("testJob")
     assertEquals(TestCollectionTableFactory.RESULT.sorted, sourceData.sorted)
   }
@@ -393,9 +393,9 @@ class CatalogTableITCase(isStreaming: Boolean) {
         |select sum(a), sum(b) from t1 group by TUMBLE(c, INTERVAL '1' SECOND)
       """.stripMargin
 
-    tableEnv.sql(sourceDDL)
-    tableEnv.sql(sinkDDL)
-    tableEnv.sql(query)
+    tableEnv.sqlUpdate(sourceDDL)
+    tableEnv.sqlUpdate(sinkDDL)
+    tableEnv.sqlUpdate(query)
     execJob("testJob")
     assertEquals(TestCollectionTableFactory.RESULT.sorted, sourceData.sorted)
   }
@@ -434,9 +434,9 @@ class CatalogTableITCase(isStreaming: Boolean) {
         |select sum(a), sum(b) from t1 group by TUMBLE(wm, INTERVAL '1' SECOND)
       """.stripMargin
 
-    tableEnv.sql(sourceDDL)
-    tableEnv.sql(sinkDDL)
-    tableEnv.sql(query)
+    tableEnv.sqlUpdate(sourceDDL)
+    tableEnv.sqlUpdate(sinkDDL)
+    tableEnv.sqlUpdate(query)
     execJob("testJob")
     assertEquals(TestCollectionTableFactory.RESULT.sorted, sourceData.sorted)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -96,6 +96,4 @@ class MockTableEnvironment extends TableEnvironment {
     sinkPathContinued: String*): Unit = ???
 
   override def execute(jobName: String): JobExecutionResult = ???
-
-  override def sql(statement: String): Table = ???
 }


### PR DESCRIPTION
## What is the purpose of the change

This patch move create table ddl support from `#sql` to `#sqlUpdate`, also remove the deprecation of `sqlUpdate` and `sqlQuery`