### PR TITLE
[FLINK-13116] [table-planner-blink] Fix Catalog statistics is not bridged to blink planner

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/TableStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/TableStats.java
@@ -28,6 +28,7 @@ import java.util.Map;
  */
 @PublicEvolving
 public final class TableStats {
+	public static final TableStats UNKNOWN = new TableStats(-1, new HashMap<>());
 
 	/**
 	 * cardinality of table.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/CatalogTableStatisticsConverter.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.util;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBinary;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBoolean;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataDate;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataDouble;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataLong;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TableStats;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for converting {@link CatalogTableStatistics} to {@link TableStats}.
+ */
+public class CatalogTableStatisticsConverter {
+
+	public static TableStats convertToTableStats(
+			CatalogTableStatistics tableStatistics,
+			CatalogColumnStatistics columnStatistics) {
+		if (tableStatistics == null || tableStatistics.equals(CatalogTableStatistics.UNKNOWN)) {
+			return TableStats.UNKNOWN;
+		}
+
+		long rowCount = tableStatistics.getRowCount();
+		Map<String, ColumnStats> columnStatsMap = null;
+		if (columnStatistics != null && !columnStatistics.equals(CatalogColumnStatistics.UNKNOWN)) {
+			columnStatsMap = convertToColumnStatsMap(columnStatistics.getColumnStatisticsData());
+		}
+		if (columnStatsMap == null) {
+			columnStatsMap = new HashMap<>();
+		}
+		return new TableStats(rowCount, columnStatsMap);
+	}
+
+	private static Map<String, ColumnStats> convertToColumnStatsMap(
+			Map<String, CatalogColumnStatisticsDataBase> columnStatisticsData) {
+		Map<String, ColumnStats> columnStatsMap = new HashMap<>();
+		for (Map.Entry<String, CatalogColumnStatisticsDataBase> entry : columnStatisticsData.entrySet()) {
+			ColumnStats columnStats = convertToColumnStats(entry.getValue());
+			columnStatsMap.put(entry.getKey(), columnStats);
+		}
+		return columnStatsMap;
+	}
+
+	private static ColumnStats convertToColumnStats(
+			CatalogColumnStatisticsDataBase columnStatisticsData) {
+		Long ndv = null;
+		Long nullCount = columnStatisticsData.getNullCount();
+		Double avgLen = null;
+		Integer maxLen = null;
+		Number max = null;
+		Number min = null;
+		if (columnStatisticsData instanceof CatalogColumnStatisticsDataBoolean) {
+			CatalogColumnStatisticsDataBoolean booleanData = (CatalogColumnStatisticsDataBoolean) columnStatisticsData;
+			avgLen = 1.0;
+			maxLen = 1;
+			if ((booleanData.getFalseCount() == 0 && booleanData.getTrueCount() > 0) ||
+					(booleanData.getFalseCount() > 0 && booleanData.getTrueCount() == 0)) {
+				ndv = 1L;
+			} else {
+				ndv = 2L;
+			}
+		} else if (columnStatisticsData instanceof CatalogColumnStatisticsDataLong) {
+			CatalogColumnStatisticsDataLong longData = (CatalogColumnStatisticsDataLong) columnStatisticsData;
+			ndv = longData.getNdv();
+			avgLen = 8.0;
+			maxLen = 8;
+			max = longData.getMax();
+			min = longData.getMin();
+		} else if (columnStatisticsData instanceof CatalogColumnStatisticsDataDouble) {
+			CatalogColumnStatisticsDataDouble doubleData = (CatalogColumnStatisticsDataDouble) columnStatisticsData;
+			ndv = doubleData.getNdv();
+			avgLen = 8.0;
+			maxLen = 8;
+			max = doubleData.getMax();
+			min = doubleData.getMin();
+		} else if (columnStatisticsData instanceof CatalogColumnStatisticsDataString) {
+			CatalogColumnStatisticsDataString strData = (CatalogColumnStatisticsDataString) columnStatisticsData;
+			ndv = strData.getNdv();
+			avgLen = strData.getAvgLength();
+			maxLen = (int) strData.getMaxLength();
+		} else if (columnStatisticsData instanceof CatalogColumnStatisticsDataBinary) {
+			CatalogColumnStatisticsDataBinary binaryData = (CatalogColumnStatisticsDataBinary) columnStatisticsData;
+			avgLen = binaryData.getAvgLength();
+			maxLen = (int) binaryData.getMaxLength();
+		} else if (columnStatisticsData instanceof CatalogColumnStatisticsDataDate) {
+			CatalogColumnStatisticsDataDate dateData = (CatalogColumnStatisticsDataDate) columnStatisticsData;
+			ndv = dateData.getNdv();
+		} else {
+			throw new TableException("Unsupported CatalogColumnStatisticsDataBase: " +
+					columnStatisticsData.getClass().getCanonicalName());
+		}
+		return new ColumnStats(ndv, nullCount, avgLen, maxLen, max, min);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.catalog;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBoolean;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataDate;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataDouble;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataLong;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.catalog.stats.Date;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+import org.apache.flink.table.planner.utils.TestTableSource;
+import org.apache.flink.table.types.DataType;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test for Catalog Statistics.
+ */
+public class CatalogStatisticsTest {
+
+	private TableSchema tableSchema = TableSchema.builder().fields(
+			new String[] { "b1", "l2", "s3", "d4", "dd5" },
+			new DataType[] { DataTypes.BOOLEAN(), DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.DATE(),
+					DataTypes.DOUBLE() }
+	).build();
+
+	@Test
+	public void testGetStatsFromCatalog() throws Exception {
+		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+		TableEnvironment tEnv = TableEnvironment.create(settings);
+		tEnv.registerTableSource("T1", new TestTableSource(true, tableSchema));
+		tEnv.registerTableSource("T2", new TestTableSource(true, tableSchema));
+		Catalog catalog = tEnv.getCatalog(tEnv.getCurrentCatalog()).orElse(null);
+		assertNotNull(catalog);
+
+		catalog.alterTableStatistics(ObjectPath.fromString("default_database.T1"),
+				new CatalogTableStatistics(100, 10, 1000L, 2000L), true);
+		catalog.alterTableStatistics(ObjectPath.fromString("default_database.T2"),
+				new CatalogTableStatistics(100000000, 1000, 1000000000L, 2000000000L), true);
+		catalog.alterTableColumnStatistics(ObjectPath.fromString("default_database.T1"), createColumnStats(), true);
+		catalog.alterTableColumnStatistics(ObjectPath.fromString("default_database.T2"), createColumnStats(), true);
+
+		Table table = tEnv.sqlQuery("select * from T1, T2 where T1.s3 = T2.s3");
+		String result = tEnv.explain(table);
+		// T1 is broadcast side
+		String expected = TableTestUtil.readFromResource("/testGetStatsFromCatalog.out");
+		assertEquals(expected, TableTestUtil.replaceStageId(result));
+	}
+
+	private CatalogColumnStatistics createColumnStats() {
+		CatalogColumnStatisticsDataBoolean booleanColStats = new CatalogColumnStatisticsDataBoolean(55L, 45L, 5L);
+		CatalogColumnStatisticsDataLong longColStats = new CatalogColumnStatisticsDataLong(-123L, 763322L, 23L, 79L);
+		CatalogColumnStatisticsDataString stringColStats = new CatalogColumnStatisticsDataString(152L, 43.5D, 20L, 0L);
+		CatalogColumnStatisticsDataDate dateColStats =
+				new CatalogColumnStatisticsDataDate(new Date(71L), new Date(17923L), 1321, 0L);
+		CatalogColumnStatisticsDataDouble doubleColStats =
+				new CatalogColumnStatisticsDataDouble(-123.35D, 7633.22D, 23L, 79L);
+		Map<String, CatalogColumnStatisticsDataBase> colStatsMap = new HashMap<>(6);
+		colStatsMap.put("b1", booleanColStats);
+		colStatsMap.put("l2", longColStats);
+		colStatsMap.put("s3", stringColStats);
+		colStatsMap.put("d4", dateColStats);
+		colStatsMap.put("dd5", doubleColStats);
+		return new CatalogColumnStatistics(colStatsMap);
+	}
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/testGetStatsFromCatalog.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/testGetStatsFromCatalog.out
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+== Abstract Syntax Tree ==
+LogicalProject(b1=[$0], l2=[$1], s3=[$2], d4=[$3], dd5=[$4], b10=[$5], l20=[$6], s30=[$7], d40=[$8], dd50=[$9])
++- LogicalFilter(condition=[=($2, $7)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(b1, l2, s3, d4, dd5)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(b1, l2, s3, d4, dd5)]]])
+
+== Optimized Logical Plan ==
+HashJoin(joinType=[InnerJoin], where=[=(s3, s30)], select=[b1, l2, s3, d4, dd5, b10, l20, s30, d40, dd50], isBroadcast=[true], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(b1, l2, s3, d4, dd5)]]], fields=[b1, l2, s3, d4, dd5])
++- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(b1, l2, s3, d4, dd5)]]], fields=[b1, l2, s3, d4, dd5])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : SourceConversion(table:Buffer(default_catalog, default_database, T1, source: [TestTableSource(b1, l2, s3, d4, dd5)]), fields:(b1, l2, s3, d4, dd5))
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : SourceConversion(table:Buffer(default_catalog, default_database, T2, source: [TestTableSource(b1, l2, s3, d4, dd5)]), fields:(b1, l2, s3, d4, dd5))
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : HashJoin(where: (s3 = s30), buildLeft)
+				ship_strategy : BROADCAST
+

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -90,7 +90,7 @@ object MetadataTestUtil {
         BasicTypeInfo.DOUBLE_TYPE_INFO,
         BasicTypeInfo.INT_TYPE_INFO))
 
-    getDataStreamTable(schema, new FlinkStatistic(null))
+    getDataStreamTable(schema, new FlinkStatistic(TableStats.UNKNOWN))
   }
 
   private def createMyTable1(): DataStreamTable[BaseRow] = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RelDigestUtilTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RelDigestUtilTest.scala
@@ -29,7 +29,6 @@ import org.junit.Assert.assertEquals
 import org.junit.{Before, Test}
 
 import scala.collection.Seq
-import scala.io.Source
 
 class RelDigestUtilTest {
 
@@ -59,7 +58,7 @@ class RelDigestUtilTest {
         |(SELECT id AS random FROM MyTable ORDER BY rand() LIMIT 1)
       """.stripMargin)
     val rel = TableTestUtil.toRelNode(table)
-    val expected = readFromResource("testGetDigestWithDynamicFunction.out")
+    val expected = TableTestUtil.readFromResource("/digest/testGetDigestWithDynamicFunction.out")
     assertEquals(expected, RelDigestUtil.getDigest(rel))
   }
 
@@ -76,33 +75,9 @@ class RelDigestUtilTest {
         |(SELECT * FROM MyView)
       """.stripMargin)
     val rel = TableTestUtil.toRelNode(table).accept(new ExpandTableScanShuttle())
-    val expected = readFromResource("testGetDigestWithDynamicFunctionView.out")
+    val expected = TableTestUtil.readFromResource(
+      "/digest/testGetDigestWithDynamicFunctionView.out")
     assertEquals(expected, RelDigestUtil.getDigest(rel))
-  }
-
-  private def readFromResource(name: String): String = {
-    val inputStream = getClass.getResource("/digest/" + name).getFile
-    val fullContent = Source.fromFile(inputStream).mkString
-    val license =
-      """/*
-        | * Licensed to the Apache Software Foundation (ASF) under one
-        | * or more contributor license agreements.  See the NOTICE file
-        | * distributed with this work for additional information
-        | * regarding copyright ownership.  The ASF licenses this file
-        | * to you under the Apache License, Version 2.0 (the
-        | * "License"); you may not use this file except in compliance
-        | * with the License.  You may obtain a copy of the License at
-        | *
-        | *     http://www.apache.org/licenses/LICENSE-2.0
-        | *
-        | * Unless required by applicable law or agreed to in writing, software
-        | * distributed under the License is distributed on an "AS IS" BASIS,
-        | * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        | * See the License for the specific language governing permissions and
-        | * limitations under the License.
-        | */
-        |""".stripMargin
-    fullContent.replace(license, "")
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -68,6 +68,7 @@ import org.junit.rules.{ExpectedException, TestName}
 import _root_.java.util
 
 import _root_.scala.collection.JavaConversions._
+import _root_.scala.io.Source
 
 /**
   * Test base for testing Table API / SQL plans.
@@ -408,7 +409,7 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
     } else {
       explainResult
     }
-    assertEqualsOrExpand("explain", replaceStageId(actual), expand = false)
+    assertEqualsOrExpand("explain", TableTestUtil.replaceStageId(actual), expand = false)
   }
 
   protected def getOptimizedPlan(
@@ -439,14 +440,6 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
             withRowType = withRowType)
         }.mkString("\n")
     }
-  }
-
-  /**
-    * Stage {id} is ignored, because id keeps incrementing in test class
-    * while StreamExecutionEnvironment is up
-    */
-  protected def replaceStageId(s: String): String = {
-    s.replaceAll("\\r\\n", "\n").replaceAll("Stage \\d+", "")
   }
 
   /**
@@ -1070,5 +1063,38 @@ object TableTestUtil {
     }
     createTableMethod.setAccessible(true)
     createTableMethod.invoke(tEnv, queryOperation).asInstanceOf[Table]
+  }
+
+  def readFromResource(path: String): String = {
+    val inputStream = getClass.getResource(path).getFile
+    val fullContent = Source.fromFile(inputStream).mkString
+    val license =
+      """/*
+        | * Licensed to the Apache Software Foundation (ASF) under one
+        | * or more contributor license agreements.  See the NOTICE file
+        | * distributed with this work for additional information
+        | * regarding copyright ownership.  The ASF licenses this file
+        | * to you under the Apache License, Version 2.0 (the
+        | * "License"); you may not use this file except in compliance
+        | * with the License.  You may obtain a copy of the License at
+        | *
+        | *     http://www.apache.org/licenses/LICENSE-2.0
+        | *
+        | * Unless required by applicable law or agreed to in writing, software
+        | * distributed under the License is distributed on an "AS IS" BASIS,
+        | * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        | * See the License for the specific language governing permissions and
+        | * limitations under the License.
+        | */
+        |""".stripMargin
+    fullContent.replace(license, "")
+  }
+
+  /**
+    * Stage {id} is ignored, because id keeps incrementing in test class
+    * while StreamExecutionEnvironment is up
+    */
+  def replaceStageId(s: String): String = {
+    s.replaceAll("\\r\\n", "\n").replaceAll("Stage \\d+", "")
   }
 }


### PR DESCRIPTION

## What is the purpose of the change

*Supports catalog statistics in blink planner*


## Brief change log

  - *Supports catalog statistics in blink planner*


## Verifying this change


This change added tests and can be verified as follows:

  - *Added CatalogStatsTest that validates the catalog statistics is used in optimizer*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
