### PR TITLE
[hotfix][python] Use the TableEnvironment.execute() method instead of ExecutionEnvironment.execute()/StreamExecutionEnvironment.execute().

### DIFF
--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -116,7 +116,7 @@ sql_result  = table_env.sql_query("SELECT ... FROM table2 ...")
 tapi_result.insert_into("outputTable")
 
 # execute
-env.execute()
+table_env.execute("python_job")
 
 {% endhighlight %}
 </div>

--- a/docs/dev/table/common.zh.md
+++ b/docs/dev/table/common.zh.md
@@ -116,7 +116,7 @@ sql_result  = table_env.sql_query("SELECT ... FROM table2 ...")
 tapi_result.insert_into("outputTable")
 
 # execute
-env.execute()
+table_env.execute("python_job")
 
 {% endhighlight %}
 </div>

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -119,7 +119,7 @@ orders = t_env.scan("Orders")  # schema (a, b, c, rowtime)
 
 orders.group_by("a").select("a, b.count as cnt").insert_into("result")
 
-env.execute()
+t_env.execute("python_job")
 
 {% endhighlight %}
 

--- a/docs/dev/table/tableApi.zh.md
+++ b/docs/dev/table/tableApi.zh.md
@@ -119,7 +119,7 @@ orders = t_env.scan("Orders")  # schema (a, b, c, rowtime)
 
 orders.group_by("a").select("a, b.count as cnt").insert_into("result")
 
-env.execute()
+t_env.execute("python_job")
 
 {% endhighlight %}
 

--- a/docs/ops/python_shell.md
+++ b/docs/ops/python_shell.md
@@ -70,7 +70,7 @@ The example below is a simple program in the Python shell:
 ...     .register_table_sink("stream_sink")
 >>> t.select("a + 1, b, c")\
 ...     .insert_into("stream_sink")
->>> s_env.execute()
+>>> st_env.execute("stream_job")
 >>> # If the job runs in local mode, you can exec following code in Python shell to see the result:
 >>> with open(sink_path, 'r') as f:
 ...     print(f.read())
@@ -102,7 +102,7 @@ The example below is a simple program in the Python shell:
 ...     .register_table_sink("batch_sink")
 >>> t.select("a + 1, b, c")\
 ...     .insert_into("batch_sink")
->>> b_env.execute()
+>>> bt_env.execute("batch_job")
 >>> # If the job runs in local mode, you can exec following code in Python shell to see the result:
 >>> with open(sink_path, 'r') as f:
 ...     print(f.read())

--- a/docs/ops/python_shell.zh.md
+++ b/docs/ops/python_shell.zh.md
@@ -69,7 +69,7 @@ bin/pyflink-shell.sh local
 ...     .register_table_sink("stream_sink")
 >>> t.select("a + 1, b, c")\
 ...     .insert_into("stream_sink")
->>> s_env.execute()
+>>> st_env.execute("stream_job")
 >>> # 如果作业运行在local模式, 你可以执行以下代码查看结果:
 >>> with open(sink_path, 'r') as f:
 ...     print(f.read())
@@ -101,7 +101,7 @@ bin/pyflink-shell.sh local
 ...     .register_table_sink("batch_sink")
 >>> t.select("a + 1, b, c")\
 ...     .insert_into("batch_sink")
->>> b_env.execute()
+>>> bt_env.execute("batch_job")
 >>> # 如果作业运行在local模式, 你可以执行以下代码查看结果:
 >>> with open(sink_path, 'r') as f:
 ...     print(f.read())

--- a/docs/tutorials/python_table_api.md
+++ b/docs/tutorials/python_table_api.md
@@ -94,11 +94,11 @@ t_env.scan('mySource') \
 
 The last thing is to start the actual Flink Python Table API job. All operations, such as
 creating sources, transformations and sinks only build up a graph of internal operations.
-Only when `exec_env.execute()` is called, this graph of operations will be thrown on a cluster or
+Only when `t_env.execute(job_name)` is called, this graph of operations will be thrown on a cluster or
 executed on your local machine.
 
 {% highlight python %}
-exec_env.execute()
+t_env.execute("tutorial_job")
 {% endhighlight %}
 
 The complete code so far is as follows:
@@ -136,7 +136,7 @@ t_env.scan('mySource') \
     .select('word, count(1)') \
     .insert_into('mySink')
 
-exec_env.execute()
+t_env.execute("tutorial_job")
 {% endhighlight %}
 
 ## Executing a Flink Python Table API Program

--- a/docs/tutorials/python_table_api.zh.md
+++ b/docs/tutorials/python_table_api.zh.md
@@ -86,11 +86,11 @@ t_env.scan('mySource') \
 {% endhighlight %}
 
 最后，需要做的就是启动Flink Python Table API作业。上面所有的操作，比如创建源表
-进行变换以及写入结果表的操作都只是构建作业逻辑图，只有当`exec_env.execute()`被调用的时候，
+进行变换以及写入结果表的操作都只是构建作业逻辑图，只有当`t_env.execute(job_name)`被调用的时候，
 作业才会被真正提交到集群或者本地进行执行。
 
 {% highlight python %}
-exec_env.execute()
+t_env.execute("python_job")
 {% endhighlight %}
 
 该教程的完整代码如下:
@@ -128,7 +128,7 @@ t_env.scan('mySource') \
     .select('word, count(1)') \
     .insert_into('mySink')
 
-exec_env.execute()
+t_env.execute("python_job")
 {% endhighlight %}
 
 ## 执行一个Flink Python Table API程序

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -109,7 +109,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *
     * t.select("a + 1, b, c").insert_into("batch_sink")
     *
-    * b_env.execute()
+    * bt_env.execute("batch_job")
 
   Streaming - Use 's_env' and 'st_env' variables
 
@@ -139,7 +139,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     * 
     * t.select("a + 1, b, c").insert_into("stream_sink")
     *
-    * s_env.execute()
+    * st_env.execute("stream_job")
 '''
 utf8_out.write(welcome_msg)
 

--- a/flink-python/pyflink/table/examples/batch/word_count.py
+++ b/flink-python/pyflink/table/examples/batch/word_count.py
@@ -70,7 +70,7 @@ def word_count():
          .select("word, count(1) as count") \
          .insert_into("Results")
 
-    env.execute()
+    t_env.execute("word_count")
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -52,7 +52,7 @@ class Table(object):
         >>> ...
         >>> t_env.register_table_sink("result", ...)
         >>> t.insert_into("result")
-        >>> env.execute()
+        >>> t_env.execute("table_job")
 
     Operations such as :func:`~pyflink.table.Table.join`, :func:`~pyflink.table.Table.select`,
     :func:`~pyflink.table.Table.where` and :func:`~pyflink.table.Table.group_by`

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -496,17 +496,20 @@ class TableEnvironment(object):
         Triggers the program execution. The environment will execute all parts of
         the program.
 
-        <p>The program execution will be logged and displayed with the provided name
+        The program execution will be logged and displayed with the provided name.
 
-        <p><b>NOTE:</b>It is highly advised to set all parameters in the :class:`TableConfig`
-        on the very beginning of the program. It is undefined what configurations values will
-        be used for the execution if queries are mixed with config changes. It depends on
-        the characteristic of the particular parameter. For some of them the value from the
-        point in time of query construction (e.g. the currentCatalog) will be used. On the
-        other hand some values might be evaluated according to the state from the time when
-        this method is called (e.g. timeZone).
+        .. note::
 
-        :param job_name Desired name of the job
+            It is highly advised to set all parameters in the :class:`TableConfig`
+            on the very beginning of the program. It is undefined what configurations values will
+            be used for the execution if queries are mixed with config changes. It depends on
+            the characteristic of the particular parameter. For some of them the value from the
+            point in time of query construction (e.g. the current catalog) will be used. On the
+            other hand some values might be evaluated according to the state from the time when
+            this method is called (e.g. timezone).
+
+        :param job_name: Desired name of the job.
+        :type job_name: str
         """
         self._j_tenv.execute(job_name)
 
@@ -687,20 +690,6 @@ class StreamTableEnvironment(TableEnvironment):
         return StreamTableDescriptor(
             self._j_tenv.connect(connector_descriptor._j_connector_descriptor))
 
-    def execute(self, job_name):
-        """
-        Triggers the program execution. The environment will execute all parts of
-        the program.
-
-        The program execution will be logged and displayed with the provided name
-
-        It calls the StreamExecutionEnvironment#execute on the underlying
-        :class:`StreamExecutionEnvironment`. This environment translates queries eagerly.
-
-        :param job_name Desired name of the job
-        """
-        self._j_tenv.execute(job_name)
-
     @staticmethod
     def create(stream_execution_environment, table_config=None):
         """
@@ -787,20 +776,6 @@ class BatchTableEnvironment(TableEnvironment):
         # type: (ConnectorDescriptor) -> BatchTableDescriptor
         return BatchTableDescriptor(
             self._j_tenv.connect(connector_descriptor._j_connector_descriptor))
-
-    def execute(self, job_name):
-        """
-        Triggers the program execution. The environment will execute all parts of
-        the program.
-
-        The program execution will be logged and displayed with the provided name
-
-        It calls the ExecutionEnvironment#execute on the underlying
-        :class:`ExecutionEnvironment`. This environment translates queries eagerly.
-
-        :param job_name Desired name of the job
-        """
-        self._j_tenv.execute(job_name)
 
     @staticmethod
     def create(execution_environment, table_config=None):

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -97,7 +97,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
               PythonOnlyPoint(3.0, 4.0))],
             schema)
         t.insert_into("Results")
-        self.env.execute()
+        self.t_env.execute("test")
         actual = source_sink_utils.results()
 
         expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,'

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -989,7 +989,7 @@ class AbstractTableDescriptorTests(object):
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
-        self.env.execute()
+        self.t_env.execute("test")
 
         with open(sink_path, 'r') as f:
             lines = f.read()
@@ -1031,7 +1031,7 @@ class AbstractTableDescriptorTests(object):
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
-        self.env.execute()
+        self.t_env.execute("test")
 
         with open(sink_path, 'r') as f:
             lines = f.read()

--- a/flink-python/pyflink/table/tests/test_shell_example.py
+++ b/flink-python/pyflink/table/tests/test_shell_example.py
@@ -52,7 +52,7 @@ class ShellExampleTests(PyFlinkTestCase):
 
         t.select("a + 1, b, c").insert_into("batch_sink")
 
-        b_env.execute()
+        bt_env.execute("batch_job")
 
         # verify code, do not copy these code to shell.py
         with open(sink_path, 'r') as f:
@@ -88,7 +88,7 @@ class ShellExampleTests(PyFlinkTestCase):
 
         t.select("a + 1, b, c").insert_into("stream_sink")
 
-        s_env.execute()
+        st_env.execute("stream_job")
 
         # verify code, do not copy these code to shell.py
         with open(sink_path, 'r') as f:

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -53,7 +53,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
             source_sink_utils.TestAppendSink(field_names, field_types))
 
         t_env.from_elements([(1, "Hi", "Hello")], ["a", "b", "c"]).insert_into("Sinks")
-        self.env.execute()
+        self.t_env.execute("test")
         actual = source_sink_utils.results()
 
         expected = ['1,Hi,Hello']
@@ -114,7 +114,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
 
         result = t_env.sql_query("select a + 1, b, c from %s" % source)
         result.insert_into("sinks")
-        self.env.execute()
+        self.t_env.execute("test")
         actual = source_sink_utils.results()
 
         expected = ['2,Hi,Hello', '3,Hello,Hello']
@@ -130,7 +130,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
             source_sink_utils.TestAppendSink(field_names, field_types))
 
         t_env.sql_update("insert into sinks select * from %s" % source)
-        self.env.execute("test_sql_job")
+        self.t_env.execute("test_sql_job")
 
         actual = source_sink_utils.results()
         expected = ['1,Hi,Hello', '2,Hello,Hello']


### PR DESCRIPTION
## What is the purpose of the change

*This pull request replace current ExecutionEnvironment.execute()/StreamExecutionEnvironment.execute() method call in pyflink with TableEnvironment.execute() method call to align with java table API.*


## Brief change log

  - *Replace execute() method call in python files.*
  - *Replace execute() method call in document files.*
  - *Remove unnecessary StreamTableEnvironment.execute() and BatchTableEnvironment.execute().*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
