### PR TITLE
[FLINK-13124] Don't forward exceptions when finishing SourceStreamTask

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -127,6 +127,10 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 
 	@Override
 	protected void finishTask() throws Exception {
+		// We tell the mailbox to finish, to prevent any exceptions that might occur during
+		// finishing from leading to a FAILED state. This could happen, for example, when cancelling
+		// sources as part of a "stop-with-savepoint".
+		mailboxProcessor.allActionsCompleted();
 		cancelTask();
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Before, exceptions that occurred after cancelling a source (as the
KafkaConsumer did, for example) would make a job fail when attempting a
"stop-with-savepoint". Now we ignore those exceptions.

## Brief change log

- add a `isFinished` flag in `SourceStreamTask`
- check this flag before re-throwing exceptions

## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests in `SourceStreamTaskTest`

## Does this pull request potentially affect one of the following parts:

  - Checkpointing, yes, because it fixes stop-with-savepoint

## Documentation

  - Does this pull request introduce a new feature? no
