### PR TITLE
[FLINK-13211] Add drop table support for flink planner

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropOperation.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.operations.Operation;
+
+/**
+ * A {@link Operation} that describes the DROP DDL statements, e.g. DROP TABLE or DROP DATABASE.
+ *
+ * <p>Different sub operations can have their special target name. For example, a drop table
+ * operation may have a target table name and a flag to describe if is exists.
+ */
+public interface DropOperation extends Operation {
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a DROP TABLE statement.
+ */
+public class DropTableOperation implements DropOperation {
+	private final String[] tableName;
+	private final boolean ifExists;
+
+	public DropTableOperation(String[] tableName, boolean ifExists) {
+		this.tableName = tableName;
+		this.ifExists = ifExists;
+	}
+
+	public String[] getTableName() {
+		return this.tableName;
+	}
+
+	public boolean isIfExists() {
+		return this.ifExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("IfExists", ifExists);
+
+		return OperationUtils.formatWithChildren(
+			"DROP TABLE",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.sqlexec;
 
 import org.apache.flink.sql.parser.SqlProperty;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
@@ -31,6 +32,7 @@ import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.types.utils.TypeConversions;
 
 import org.apache.calcite.rel.RelRoot;
@@ -68,7 +70,7 @@ public class SqlToOperationConverter {
 
 	/**
 	 * This is the main entrance for executing all kinds of DDL/DML {@code SqlNode}s, different
-	 * SqlNode will have it's implementation in the #execute(type) method whose 'type' argument
+	 * SqlNode will have it's implementation in the #convert(type) method whose 'type' argument
 	 * is subclass of {@code SqlNode}.
 	 *
 	 * @param flinkPlanner     FlinkPlannerImpl to convert sql node to rel node
@@ -80,6 +82,8 @@ public class SqlToOperationConverter {
 		SqlToOperationConverter converter = new SqlToOperationConverter(flinkPlanner);
 		if (validated instanceof SqlCreateTable) {
 			return converter.convert((SqlCreateTable) validated);
+		} else if (validated instanceof SqlDropTable){
+			return converter.convert((SqlDropTable) validated);
 		} else {
 			return converter.convert(validated);
 		}
@@ -128,6 +132,11 @@ public class SqlToOperationConverter {
 			tableComment);
 		return new CreateTableOperation(sqlCreateTable.fullTableName(), catalogTable,
 			sqlCreateTable.isIfNotExists());
+	}
+
+	/** Convert DROP TABLE statement. */
+	private Operation convert(SqlDropTable sqlDropTable) {
+		return new DropTableOperation(sqlDropTable.fullTableName(), sqlDropTable.getIfExists());
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
@@ -465,6 +465,7 @@ class CatalogTableITCase(isStreaming: Boolean) {
 
     tableEnv.sqlUpdate(ddl1)
     tableEnv.sqlUpdate(ddl2)
+    assert(tableEnv.listTables().sameElements(Array[String]("t1", "t2")))
     tableEnv.sqlUpdate("DROP TABLE default_catalog.default_database.t2")
     assert(tableEnv.listTables().sameElements(Array("t1")))
   }
@@ -493,6 +494,7 @@ class CatalogTableITCase(isStreaming: Boolean) {
 
     tableEnv.sqlUpdate(ddl1)
     tableEnv.sqlUpdate(ddl2)
+    assert(tableEnv.listTables().sameElements(Array[String]("t1", "t2")))
     tableEnv.sqlUpdate("DROP TABLE default_database.t2")
     tableEnv.sqlUpdate("DROP TABLE t1")
     assert(tableEnv.listTables().isEmpty)
@@ -512,6 +514,7 @@ class CatalogTableITCase(isStreaming: Boolean) {
       """.stripMargin
 
     tableEnv.sqlUpdate(ddl1)
+    assert(tableEnv.listTables().sameElements(Array[String]("t1")))
     tableEnv.sqlUpdate("DROP TABLE catalog1.database1.t1")
     assert(tableEnv.listTables().isEmpty)
   }
@@ -530,6 +533,7 @@ class CatalogTableITCase(isStreaming: Boolean) {
       """.stripMargin
 
     tableEnv.sqlUpdate(ddl1)
+    assert(tableEnv.listTables().sameElements(Array[String]("t1")))
     tableEnv.sqlUpdate("DROP TABLE IF EXISTS catalog1.database1.t1")
     assert(tableEnv.listTables().sameElements(Array[String]("t1")))
   }


### PR DESCRIPTION
## What is the purpose of the change

Add `DROP TABLE [IF EXISTS] ...` grammar for flink-planner TableEnvironment#sqlUpdate


## Brief change log

  - Add a new drop table operation
  - Add support in TableEnv


## Verifying this change

See tests in CatalogTableITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? no
