### PR TITLE
[FLINK-13220][FLINK-13211] [flink-table] Add drop table support for flink planner and add DDL support for blink planner

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropOperation.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.operations.Operation;
+
+/**
+ * A {@link Operation} that describes the DROP DDL statements, e.g. DROP TABLE or DROP DATABASE.
+ *
+ * <p>Different sub operations can have their special target name. For example, a drop table
+ * operation may have a target table name and a flag to describe if is exists.
+ */
+public interface DropOperation extends Operation {
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
@@ -48,6 +48,7 @@ public class DropTableOperation implements DropOperation {
 	@Override
 	public String asSummaryString() {
 		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("tableName", tableName);
 		params.put("IfExists", ifExists);
 
 		return OperationUtils.formatWithChildren(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a DROP TABLE statement.
+ */
+public class DropTableOperation implements DropOperation {
+	private final String[] tableName;
+	private final boolean ifExists;
+
+	public DropTableOperation(String[] tableName, boolean ifExists) {
+		this.tableName = tableName;
+		this.ifExists = ifExists;
+	}
+
+	public String[] getTableName() {
+		return this.tableName;
+	}
+
+	public boolean isIfExists() {
+		return this.ifExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("IfExists", ifExists);
+
+		return OperationUtils.formatWithChildren(
+			"DROP TABLE",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -114,6 +114,18 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-parser</artifactId>
+			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.calcite</groupId>
+					<artifactId>calcite-core</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -324,6 +336,7 @@ under the License.
 									<include>commons-codec:commons-codec</include>
 
 									<!-- flink-table-runtime-blink dependencies -->
+									<include>org.apache.flink.sql.parser:*</include>
 									<include>org.codehaus.janino:*</include>
 								</includes>
 							</artifactSet>

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/PlannerContext.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.planner;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
+import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.calcite.CalciteConfig;
 import org.apache.flink.table.calcite.CalciteConfig$;
@@ -185,6 +187,8 @@ public class PlannerContext {
 				// and cases are preserved
 				() -> SqlParser
 						.configBuilder()
+						.setParserFactory(FlinkSqlParserImpl.FACTORY)
+						.setConformance(FlinkSqlConformance.DEFAULT)
 						.setLex(Lex.JAVA)
 						.setIdentifierMaxLength(256)
 						.build());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/sqlexec/SqlConversionException.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/sqlexec/SqlConversionException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sqlexec;
+
+/**
+ * Exception thrown during the execution of SQL statements.
+ */
+public class SqlConversionException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public SqlConversionException(String message) {
+		super(message);
+	}
+
+	public SqlConversionException(String message, Throwable e) {
+		super(message, e);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
-import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.table.types.LogicalTypeDataTypeConverter;
 
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
@@ -73,7 +73,7 @@ public class SqlToOperationConverter {
 	 * SqlNode will have it's implementation in the #convert(type) method whose 'type' argument
 	 * is subclass of {@code SqlNode}.
 	 *
-	 * @param flinkPlanner     FlinkPlannerImpl to convert sql node to rel node
+	 * @param flinkPlanner     FlinkPlannerImpl to convertCreateTable sql node to rel node
 	 * @param sqlNode          SqlNode to execute on
 	 */
 	public static Operation convert(FlinkPlannerImpl flinkPlanner, SqlNode sqlNode) {
@@ -182,7 +182,8 @@ public class SqlToOperationConverter {
 			final RelDataType relType = column.getType().deriveType(factory,
 				column.getType().getNullable());
 			builder.field(column.getName().getSimple(),
-				TypeConversions.fromLegacyInfoToDataType(FlinkTypeFactory.toTypeInfo(relType)));
+				LogicalTypeDataTypeConverter.fromLogicalTypeToDataType(
+					FlinkTypeFactory.toLogicalType(relType)));
 			physicalSchema = builder.build();
 		}
 		assert physicalSchema != null;

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/PreValidateReWriter.scala
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.calcite
+
+import org.apache.flink.sql.parser.SqlProperty
+import org.apache.flink.sql.parser.dml.RichSqlInsert
+import org.apache.flink.table.calcite.PreValidateReWriter.appendPartitionProjects
+
+import org.apache.calcite.plan.RelOptTable
+import org.apache.calcite.prepare.CalciteCatalogReader
+import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory, RelDataTypeField}
+import org.apache.calcite.runtime.{CalciteContextException, Resources}
+import org.apache.calcite.sql.`type`.SqlTypeUtil
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.sql.parser.SqlParserPos
+import org.apache.calcite.sql.util.SqlBasicVisitor
+import org.apache.calcite.sql.validate.{SqlValidatorException, SqlValidatorTable, SqlValidatorUtil}
+import org.apache.calcite.sql.{SqlCall, SqlIdentifier, SqlLiteral, SqlNode, SqlNodeList, SqlSelect, SqlUtil}
+import org.apache.calcite.util.Static.RESOURCE
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/** Implements [[org.apache.calcite.sql.util.SqlVisitor]]
+  * interface to do some rewrite work before sql node validation. */
+class PreValidateReWriter(
+  val catalogReader: CalciteCatalogReader,
+  val typeFactory: RelDataTypeFactory) extends SqlBasicVisitor[Unit] {
+  override def visit(call: SqlCall): Unit = {
+    call match {
+      case r: RichSqlInsert if r.getStaticPartitions.nonEmpty
+        && r.getSource.isInstanceOf[SqlSelect] =>
+        appendPartitionProjects(r, catalogReader, typeFactory,
+          r.getSource.asInstanceOf[SqlSelect], r.getStaticPartitions)
+      case _ =>
+    }
+  }
+}
+
+object PreValidateReWriter {
+  //~ Tools ------------------------------------------------------------------
+  /**
+    * Append the static partitions to the data source projection list. The columns are appended to
+    * the corresponding positions.
+    *
+    * <p>If we have a table A with schema (&lt;a&gt;, &lt;b&gt;, &lt;c&gt) whose
+    * partition columns are (&lt;a&gt;, &lt;c&gt;), and got a query
+    * <blockquote><pre>
+    * insert into A partition(a='11', c='22')
+    * select b from B
+    * </pre></blockquote>
+    * The query would be rewritten to:
+    * <blockquote><pre>
+    * insert into A partition(a='11', c='22')
+    * select cast('11' as tpe1), b, cast('22' as tpe2) from B
+    * </pre></blockquote>
+    * Where the "tpe1" and "tpe2" are data types of column a and c of target table A.
+    *
+    * @param sqlInsert            RichSqlInsert instance
+    * @param calciteCatalogReader catalog reader
+    * @param typeFactory          type factory
+    * @param select               Source sql select
+    * @param partitions           Static partition statements
+    */
+  def appendPartitionProjects(sqlInsert: RichSqlInsert,
+    calciteCatalogReader: CalciteCatalogReader,
+    typeFactory: RelDataTypeFactory,
+    select: SqlSelect,
+    partitions: SqlNodeList): Unit = {
+    val names = sqlInsert.getTargetTable.asInstanceOf[SqlIdentifier].names
+    val table = calciteCatalogReader.getTable(names)
+    if (table == null) {
+      // There is no table exists in current catalog,
+      // just skip to let other validation error throw.
+      return
+    }
+    val targetRowType = createTargetRowType(typeFactory,
+      calciteCatalogReader, table, sqlInsert.getTargetColumnList)
+    // validate partition fields first.
+    val assignedFields = new util.LinkedHashMap[Integer, SqlNode]
+    val relOptTable = table match {
+      case t: RelOptTable => t
+      case _ => null
+    }
+    for (node <- partitions.getList) {
+      val sqlProperty = node.asInstanceOf[SqlProperty]
+      val id = sqlProperty.getKey
+      val targetField = SqlValidatorUtil.getTargetField(targetRowType,
+        typeFactory, id, calciteCatalogReader, relOptTable)
+      validateField(assignedFields.containsValue, id, targetField)
+      val value = sqlProperty.getValue.asInstanceOf[SqlLiteral]
+      assignedFields.put(targetField.getIndex,
+        maybeCast(value, value.createSqlType(typeFactory), targetField.getType, typeFactory))
+    }
+    val currentNodes = new util.ArrayList[SqlNode](select.getSelectList.getList)
+    val fixedNodes = new util.ArrayList[SqlNode]
+    0 until targetRowType.getFieldList.length foreach {
+      idx =>
+        if (assignedFields.containsKey(idx)) {
+          fixedNodes.add(assignedFields.get(idx))
+        } else if (currentNodes.size() > 0) {
+          fixedNodes.add(currentNodes.remove(0))
+        }
+    }
+    // Although it is error case, we still append the old remaining
+    // projection nodes to new projection.
+    if (currentNodes.size > 0) {
+      fixedNodes.addAll(currentNodes)
+    }
+    select.setSelectList(new SqlNodeList(fixedNodes, select.getSelectList.getParserPosition))
+  }
+
+  /**
+    * Derives a row-type for INSERT and UPDATE operations.
+    *
+    * <p>This code snippet is almost inspired by
+    * [[org.apache.calcite.sql.validate.SqlValidatorImpl#createTargetRowType]].
+    * It is the best that the logic can be merged into Apache Calcite,
+    * but this needs time.
+    *
+    * @param typeFactory      TypeFactory
+    * @param catalogReader    CalciteCatalogReader
+    * @param table            Target table for INSERT/UPDATE
+    * @param targetColumnList List of target columns, or null if not specified
+    * @return Rowtype
+    */
+  private def createTargetRowType(
+    typeFactory: RelDataTypeFactory,
+    catalogReader: CalciteCatalogReader,
+    table: SqlValidatorTable,
+    targetColumnList: SqlNodeList): RelDataType = {
+    val baseRowType = table.getRowType
+    if (targetColumnList == null) return baseRowType
+    val fields = new util.ArrayList[util.Map.Entry[String, RelDataType]]
+    val assignedFields = new util.HashSet[Integer]
+    val relOptTable = table match {
+      case t: RelOptTable => t
+      case _ => null
+    }
+    for (node <- targetColumnList) {
+      val id = node.asInstanceOf[SqlIdentifier]
+      val targetField = SqlValidatorUtil.getTargetField(baseRowType,
+        typeFactory, id, catalogReader, relOptTable)
+      validateField(assignedFields.add, id, targetField)
+      fields.add(targetField)
+    }
+    typeFactory.createStructType(fields)
+  }
+
+  /** Check whether the field is valid. **/
+  private def validateField(tester: Function[Integer, Boolean],
+    id: SqlIdentifier,
+    targetField: RelDataTypeField): Unit = {
+    if (targetField == null) {
+      throw newValidationError(id, RESOURCE.unknownTargetColumn(id.toString))
+    }
+    if (!tester.apply(targetField.getIndex)) {
+      throw newValidationError(id, RESOURCE.duplicateTargetColumn(targetField.getName))
+    }
+  }
+
+  private def newValidationError(node: SqlNode,
+    e: Resources.ExInst[SqlValidatorException]): CalciteContextException = {
+    assert(node != null)
+    val pos = node.getParserPosition
+    SqlUtil.newContextException(pos, e)
+  }
+
+  // This code snippet is copied from the SqlValidatorImpl.
+  private def maybeCast(node: SqlNode,
+    currentType: RelDataType,
+    desiredType: RelDataType,
+    typeFactory: RelDataTypeFactory): SqlNode = {
+    if (currentType == desiredType
+      || (currentType.isNullable != desiredType.isNullable
+      && typeFactory.createTypeWithNullability(currentType, desiredType.isNullable)
+      == desiredType)) {
+      node
+    } else {
+      SqlStdOperatorTable.CAST.createCall(SqlParserPos.ZERO,
+        node, SqlTypeUtil.convertTypeToSpec(desiredType))
+    }
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.factories.utils.TestCollectionTableFactory

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/factories/utils/TestCollectionTableFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/factories/utils/TestCollectionTableFactory.scala
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories.utils
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.java.io.{CollectionInputFormat, LocalCollectionOutputFormat}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink, DataStreamSource}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
+import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR
+import org.apache.flink.table.descriptors.{DescriptorProperties, Schema}
+import org.apache.flink.table.factories.utils.TestCollectionTableFactory.{getCollectionSink, getCollectionSource}
+import org.apache.flink.table.factories.{BatchTableSinkFactory, BatchTableSourceFactory, StreamTableSinkFactory, StreamTableSourceFactory}
+import org.apache.flink.table.functions.{AsyncTableFunction, TableFunction}
+import org.apache.flink.table.sinks.{AppendStreamTableSink, BatchTableSink, StreamTableSink, TableSink}
+import org.apache.flink.table.sources.{BatchTableSource, LookupableTableSource, StreamTableSource, TableSource}
+import org.apache.flink.types.Row
+
+import java.io.IOException
+import java.util
+import java.util.{ArrayList => JArrayList, LinkedList => JLinkedList, List => JList, Map => JMap}
+
+import scala.collection.JavaConversions._
+
+class TestCollectionTableFactory
+  extends StreamTableSourceFactory[Row]
+    with StreamTableSinkFactory[Row]
+    with BatchTableSourceFactory[Row]
+    with BatchTableSinkFactory[Row]
+{
+
+  override def createTableSource(properties: JMap[String, String]): TableSource[Row] = {
+    getCollectionSource(properties, isStreaming = TestCollectionTableFactory.isStreaming)
+  }
+
+  override def createTableSink(properties: JMap[String, String]): TableSink[Row] = {
+    getCollectionSink(properties)
+  }
+
+  override def createStreamTableSource(properties: JMap[String, String]): StreamTableSource[Row] = {
+    getCollectionSource(properties, isStreaming = true)
+  }
+
+  override def createStreamTableSink(properties: JMap[String, String]): StreamTableSink[Row] = {
+    getCollectionSink(properties)
+  }
+
+  override def createBatchTableSource(properties: JMap[String, String]): BatchTableSource[Row] = {
+    getCollectionSource(properties, isStreaming = false)
+  }
+
+  override def createBatchTableSink(properties: JMap[String, String]): BatchTableSink[Row] = {
+    getCollectionSink(properties)
+  }
+
+  override def requiredContext(): JMap[String, String] = {
+    val context = new util.HashMap[String, String]()
+    context.put(CONNECTOR, "COLLECTION")
+    context
+  }
+
+  override def supportedProperties(): JList[String] = {
+    val supported = new JArrayList[String]()
+    supported.add("*")
+    supported
+  }
+}
+
+object TestCollectionTableFactory {
+  var isStreaming: Boolean = true
+
+  val SOURCE_DATA = new JLinkedList[Row]()
+  val DIM_DATA = new JLinkedList[Row]()
+  val RESULT = new JLinkedList[Row]()
+  private var emitIntervalMS = -1L
+
+  def initData(sourceData: JList[Row],
+    dimData: JList[Row] = List(),
+    emitInterval: Long = -1L): Unit ={
+    SOURCE_DATA.addAll(sourceData)
+    DIM_DATA.addAll(dimData)
+    emitIntervalMS = emitInterval
+  }
+
+  def reset(): Unit ={
+    RESULT.clear()
+    SOURCE_DATA.clear()
+    DIM_DATA.clear()
+    emitIntervalMS = -1L
+  }
+
+  def getCollectionSource(props: JMap[String, String],
+    isStreaming: Boolean): CollectionTableSource = {
+    val properties = new DescriptorProperties()
+    properties.putProperties(props)
+    val schema = properties.getTableSchema(Schema.SCHEMA)
+    new CollectionTableSource(emitIntervalMS, schema, isStreaming)
+  }
+
+  def getCollectionSink(props: JMap[String, String]): CollectionTableSink = {
+    val properties = new DescriptorProperties()
+    properties.putProperties(props)
+    val schema = properties.getTableSchema(Schema.SCHEMA)
+    new CollectionTableSink(schema.toRowType.asInstanceOf[RowTypeInfo])
+  }
+
+  /**
+    * Table source of collection.
+    */
+  class CollectionTableSource(
+    val emitIntervalMs: Long,
+    val schema: TableSchema,
+    val isStreaming: Boolean)
+    extends BatchTableSource[Row]
+      with StreamTableSource[Row]
+      with LookupableTableSource[Row] {
+
+    private val rowType: TypeInformation[Row] = schema.toRowType
+
+    override def isBounded: Boolean = !isStreaming
+
+    def getDataSet(execEnv: ExecutionEnvironment): DataSet[Row] = {
+      execEnv.createInput(new TestCollectionInputFormat[Row](emitIntervalMs,
+        SOURCE_DATA,
+        rowType.createSerializer(new ExecutionConfig)),
+        rowType)
+    }
+
+    override def getDataStream(streamEnv: StreamExecutionEnvironment): DataStreamSource[Row] = {
+      streamEnv.createInput(new TestCollectionInputFormat[Row](emitIntervalMs,
+        SOURCE_DATA,
+        rowType.createSerializer(new ExecutionConfig)),
+        rowType)
+    }
+
+    override def getReturnType: TypeInformation[Row] = rowType
+
+    override def getTableSchema: TableSchema = {
+      schema
+    }
+
+    override def getLookupFunction(lookupKeys: Array[String]): TemporalTableFetcher = {
+      new TemporalTableFetcher(DIM_DATA, lookupKeys.map(schema.getFieldNames.indexOf(_)))
+    }
+
+    override def getAsyncLookupFunction(lookupKeys: Array[String]): AsyncTableFunction[Row] = null
+
+    override def isAsyncEnabled: Boolean = false
+  }
+
+  /**
+    * Table sink of collection.
+    */
+  class CollectionTableSink(val outputType: RowTypeInfo)
+    extends BatchTableSink[Row]
+      with AppendStreamTableSink[Row] {
+    override def emitDataSet(dataSet: DataSet[Row]): Unit = {
+      dataSet.output(new LocalCollectionOutputFormat[Row](RESULT)).setParallelism(1)
+    }
+
+    override def getOutputType: RowTypeInfo = outputType
+
+    override def getFieldNames: Array[String] = outputType.getFieldNames
+
+    override def getFieldTypes: Array[TypeInformation[_]] = {
+      outputType.getFieldTypes
+    }
+
+    override def emitDataStream(dataStream: DataStream[Row]): Unit = {
+      dataStream.addSink(new UnsafeMemorySinkFunction(outputType)).setParallelism(1)
+    }
+
+    override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
+      dataStream.addSink(new UnsafeMemorySinkFunction(outputType)).setParallelism(1)
+    }
+
+    override def configure(fieldNames: Array[String],
+      fieldTypes: Array[TypeInformation[_]]): TableSink[Row] = this
+  }
+
+  /**
+    * Sink function of unsafe memory.
+    */
+  class UnsafeMemorySinkFunction(outputType: TypeInformation[Row]) extends RichSinkFunction[Row] {
+    private var serializer: TypeSerializer[Row] = _
+
+    override def open(param: Configuration): Unit = {
+      serializer = outputType.createSerializer(new ExecutionConfig)
+    }
+
+    @throws[Exception]
+    override def invoke(row: Row): Unit = {
+      RESULT.add(serializer.copy(row))
+    }
+  }
+
+  /**
+    * Collection inputFormat for testing.
+    */
+  class TestCollectionInputFormat[T](
+    val emitIntervalMs: Long,
+    val dataSet: java.util.Collection[T],
+    val serializer: TypeSerializer[T])
+    extends CollectionInputFormat[T](dataSet, serializer) {
+    @throws[IOException]
+    override def reachedEnd: Boolean = {
+      if (emitIntervalMs > 0) {
+        try
+          Thread.sleep(emitIntervalMs)
+        catch {
+          case _: InterruptedException =>
+        }
+      }
+      super.reachedEnd
+    }
+  }
+
+  /**
+    * Dimension table source fetcher.
+    */
+  class TemporalTableFetcher(
+    val dimData: JLinkedList[Row],
+    val keys: Array[Int]) extends TableFunction[Row] {
+
+    @throws[Exception]
+    def eval(values: Any*): Unit = {
+      for (data <- dimData) {
+        var matched = true
+        var idx = 0
+        while (matched && idx < keys.length) {
+          val dimField = data.getField(keys(idx))
+          val inputField = values(idx)
+          matched = dimField.equals(inputField)
+          idx += 1
+        }
+        if (matched) {
+          // copy the row data
+          val ret = new Row(data.getArity)
+          0 until data.getArity foreach { idx =>
+            ret.setField(idx, data.getField(idx))
+          }
+          collect(ret)
+        }
+      }
+    }
+  }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.sqlexec;
 
 import org.apache.flink.sql.parser.SqlProperty;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
@@ -31,6 +32,7 @@ import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.types.utils.TypeConversions;
 
 import org.apache.calcite.rel.RelRoot;
@@ -68,7 +70,7 @@ public class SqlToOperationConverter {
 
 	/**
 	 * This is the main entrance for executing all kinds of DDL/DML {@code SqlNode}s, different
-	 * SqlNode will have it's implementation in the #execute(type) method whose 'type' argument
+	 * SqlNode will have it's implementation in the #convert(type) method whose 'type' argument
 	 * is subclass of {@code SqlNode}.
 	 *
 	 * @param flinkPlanner     FlinkPlannerImpl to convert sql node to rel node
@@ -80,6 +82,8 @@ public class SqlToOperationConverter {
 		SqlToOperationConverter converter = new SqlToOperationConverter(flinkPlanner);
 		if (validated instanceof SqlCreateTable) {
 			return converter.convert((SqlCreateTable) validated);
+		} else if (validated instanceof SqlDropTable){
+			return converter.convert((SqlDropTable) validated);
 		} else {
 			return converter.convert(validated);
 		}
@@ -128,6 +132,11 @@ public class SqlToOperationConverter {
 			tableComment);
 		return new CreateTableOperation(sqlCreateTable.fullTableName(), catalogTable,
 			sqlCreateTable.isIfNotExists());
+	}
+
+	/** Convert DROP TABLE statement. */
+	private Operation convert(SqlDropTable sqlDropTable) {
+		return new DropTableOperation(sqlDropTable.fullTableName(), sqlDropTable.getIfExists());
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -477,7 +477,8 @@ abstract class TableEnvImpl(
         }
       case _ =>
         throw new TableException(
-          "Unsupported SQL query! sqlUpdate() only accepts SQL statements of type INSERT.")
+          "Unsupported SQL query! sqlUpdate() only accepts SQL statements of " +
+            "type INSERT, CREATE TABLE, DROP TABLE.")
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
@@ -440,6 +440,103 @@ class CatalogTableITCase(isStreaming: Boolean) {
     execJob("testJob")
     assertEquals(TestCollectionTableFactory.RESULT.sorted, sourceData.sorted)
   }
+
+  @Test
+  def testDropTableWithFullPath(): Unit = {
+    val ddl1 =
+      """
+        |create table t1(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  connector = 'COLLECTION'
+        |)
+      """.stripMargin
+    val ddl2 =
+      """
+        |create table t2(
+        |  a bigint,
+        |  b bigint
+        |) with (
+        |  connector = 'COLLECTION'
+        |)
+      """.stripMargin
+
+    tableEnv.sqlUpdate(ddl1)
+    tableEnv.sqlUpdate(ddl2)
+    assert(tableEnv.listTables().sameElements(Array[String]("t1", "t2")))
+    tableEnv.sqlUpdate("DROP TABLE default_catalog.default_database.t2")
+    assert(tableEnv.listTables().sameElements(Array("t1")))
+  }
+
+  @Test
+  def testDropTableWithPartialPath(): Unit = {
+    val ddl1 =
+      """
+        |create table t1(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  connector = 'COLLECTION'
+        |)
+      """.stripMargin
+    val ddl2 =
+      """
+        |create table t2(
+        |  a bigint,
+        |  b bigint
+        |) with (
+        |  connector = 'COLLECTION'
+        |)
+      """.stripMargin
+
+    tableEnv.sqlUpdate(ddl1)
+    tableEnv.sqlUpdate(ddl2)
+    assert(tableEnv.listTables().sameElements(Array[String]("t1", "t2")))
+    tableEnv.sqlUpdate("DROP TABLE default_database.t2")
+    tableEnv.sqlUpdate("DROP TABLE t1")
+    assert(tableEnv.listTables().isEmpty)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testDropTableWithInvalidPath(): Unit = {
+    val ddl1 =
+      """
+        |create table t1(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  connector = 'COLLECTION'
+        |)
+      """.stripMargin
+
+    tableEnv.sqlUpdate(ddl1)
+    assert(tableEnv.listTables().sameElements(Array[String]("t1")))
+    tableEnv.sqlUpdate("DROP TABLE catalog1.database1.t1")
+    assert(tableEnv.listTables().isEmpty)
+  }
+
+  @Test
+  def testDropTableWithInvalidPathIfExists(): Unit = {
+    val ddl1 =
+      """
+        |create table t1(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  connector = 'COLLECTION'
+        |)
+      """.stripMargin
+
+    tableEnv.sqlUpdate(ddl1)
+    assert(tableEnv.listTables().sameElements(Array[String]("t1")))
+    tableEnv.sqlUpdate("DROP TABLE IF EXISTS catalog1.database1.t1")
+    assert(tableEnv.listTables().sameElements(Array[String]("t1")))
+  }
 }
 
 object CatalogTableITCase {


### PR DESCRIPTION
## What is the purpose of the change

Add `DROP TABLE [IF EXISTS] ...` grammar for flink-planner TableEnvironment#sqlUpdate,
also add DDL support for blink planner.


## Brief change log

  - Add a new drop table operation
  - Add support in TableEnv


## Verifying this change

See tests in CatalogTableITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? no