### PR TITLE
[FLINK-13094][state-processor-api] Provide an easy way to read timers using the State Processor API

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/KeyedStateReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/KeyedStateReaderFunction.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 
+import java.util.Set;
+
 /**
  * A function that processes keys from a restored operator
  *
@@ -79,6 +81,16 @@ public abstract class KeyedStateReaderFunction<K, OUT> extends AbstractRichFunct
 	 * afterwards!
 	 */
 	public interface Context {
+
+		/**
+		 * @return All registered event time timers for the current key.
+		 */
+		Set<Long> registeredEventTimeTimers() throws Exception;
+
+		/**
+		 * @return All registered processing time timers for the current key.
+		 */
+		Set<Long> registeredProcessingTimeTimers() throws Exception;
 	}
 }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.function.BiConsumerWithException;
 
 /**
  * Interface for working with time and timers.
@@ -58,4 +59,16 @@ public interface InternalTimerService<N> {
 	 * Deletes the timer for the given key and namespace.
 	 */
 	void deleteEventTimeTimer(N namespace, long time);
+
+	/**
+	 * Performs an action for each registered timer. The timer service will
+	 * set the key context for the timers key before invoking the action.
+	 */
+	void forEachEventTimeTimer(BiConsumerWithException<N, Long, Exception> consumer) throws Exception;
+
+	/**
+	 * Performs an action for each registered timer. The timer service will
+	 * set the key context for the timers key before invoking the action.
+	 */
+	void forEachProcessingTimeTimer(BiConsumerWithException<N, Long, Exception> consumer) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializer.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -39,6 +40,7 @@ import java.util.Objects;
  * @param <K> type of the timer key.
  * @param <N> type of the timer namespace.
  */
+@Internal
 public class TimerSerializer<K, N> extends TypeSerializer<TimerHeapInternalTimer<K, N>> {
 
 	private static final long serialVersionUID = 1L;
@@ -60,7 +62,7 @@ public class TimerSerializer<K, N> extends TypeSerializer<TimerHeapInternalTimer
 	/** True iff the serialized type (and composite objects) are immutable. */
 	private final boolean immutableType;
 
-	TimerSerializer(
+	public TimerSerializer(
 		@Nonnull TypeSerializer<K> keySerializer,
 		@Nonnull TypeSerializer<N> namespaceSerializer) {
 		this(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImplTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.operators;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -558,6 +559,84 @@ public class InternalTimerServiceImplTest {
 		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
+	}
+
+	/**
+	 * This also verifies that we iterate over all timers and set the key context on each element.
+	 */
+	@Test
+	public void testForEachEventTimeTimers() throws Exception {
+		@SuppressWarnings("unchecked")
+		Triggerable<Integer, String> mockTriggerable = mock(Triggerable.class);
+
+		TestKeyContext keyContext = new TestKeyContext();
+		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+		InternalTimerServiceImpl<Integer, String> timerService =
+			createAndStartInternalTimerService(mockTriggerable, keyContext, processingTimeService, testKeyGroupRange, createQueueFactory());
+
+		// get two different keys
+		int key1 = getKeyInKeyGroupRange(testKeyGroupRange, maxParallelism);
+		int key2 = getKeyInKeyGroupRange(testKeyGroupRange, maxParallelism);
+		while (key2 == key1) {
+			key2 = getKeyInKeyGroupRange(testKeyGroupRange, maxParallelism);
+		}
+
+		Set<Tuple3<Integer, String, Long>> timers = new HashSet<>();
+		timers.add(Tuple3.of(key1, "ciao", 10L));
+		timers.add(Tuple3.of(key1, "hello", 10L));
+		timers.add(Tuple3.of(key2, "ciao", 10L));
+		timers.add(Tuple3.of(key2, "hello", 10L));
+
+		for (Tuple3<Integer, String, Long> timer : timers) {
+			keyContext.setCurrentKey(timer.f0);
+			timerService.registerEventTimeTimer(timer.f1, timer.f2);
+		}
+
+		Set<Tuple3<Integer, String, Long>> results = new HashSet<>();
+		timerService.forEachEventTimeTimer((namespace, timer) -> {
+			results.add(Tuple3.of((Integer) keyContext.getCurrentKey(), namespace, timer));
+		});
+
+		Assert.assertEquals(timers, results);
+	}
+
+	/**
+	 * This also verifies that we iterate over all timers and set the key context on each element.
+	 */
+	@Test
+	public void testForEachProcessingTimeTimers() throws Exception {
+		@SuppressWarnings("unchecked")
+		Triggerable<Integer, String> mockTriggerable = mock(Triggerable.class);
+
+		TestKeyContext keyContext = new TestKeyContext();
+		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+		InternalTimerServiceImpl<Integer, String> timerService =
+			createAndStartInternalTimerService(mockTriggerable, keyContext, processingTimeService, testKeyGroupRange, createQueueFactory());
+
+		// get two different keys
+		int key1 = getKeyInKeyGroupRange(testKeyGroupRange, maxParallelism);
+		int key2 = getKeyInKeyGroupRange(testKeyGroupRange, maxParallelism);
+		while (key2 == key1) {
+			key2 = getKeyInKeyGroupRange(testKeyGroupRange, maxParallelism);
+		}
+
+		Set<Tuple3<Integer, String, Long>> timers = new HashSet<>();
+		timers.add(Tuple3.of(key1, "ciao", 10L));
+		timers.add(Tuple3.of(key1, "hello", 10L));
+		timers.add(Tuple3.of(key2, "ciao", 10L));
+		timers.add(Tuple3.of(key2, "hello", 10L));
+
+		for (Tuple3<Integer, String, Long> timer : timers) {
+			keyContext.setCurrentKey(timer.f0);
+			timerService.registerProcessingTimeTimer(timer.f1, timer.f2);
+		}
+
+		Set<Tuple3<Integer, String, Long>> results = new HashSet<>();
+		timerService.forEachProcessingTimeTimer((namespace, timer) -> {
+			results.add(Tuple3.of((Integer) keyContext.getCurrentKey(), namespace, timer));
+		});
+
+		Assert.assertEquals(timers, results);
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/TestInternalTimerService.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/TestInternalTimerService.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.function.BiConsumerWithException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -105,6 +106,22 @@ public class TestInternalTimerService<K, N> implements InternalTimerService<N> {
 		Timer<K, N> timer = new Timer<>(time, (K) keyContext.getCurrentKey(), namespace);
 		if (watermarkTimers.remove(timer)) {
 			watermarkTimersQueue.remove(timer);
+		}
+	}
+
+	@Override
+	public void forEachEventTimeTimer(BiConsumerWithException<N, Long, Exception> consumer) throws Exception {
+		for (Timer<K, N> timer : watermarkTimers) {
+			keyContext.setCurrentKey(timer.getKey());
+			consumer.accept(timer.getNamespace(), timer.getTimestamp());
+		}
+	}
+
+	@Override
+	public void forEachProcessingTimeTimer(BiConsumerWithException<N, Long, Exception> consumer) throws Exception {
+		for (Timer<K, N> timer : processingTimeTimers) {
+			keyContext.setCurrentKey(timer.getKey());
+			consumer.accept(timer.getNamespace(), timer.getTimestamp());
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Update the state processor api to be able to read registered timers from state.


## Brief change log

cddbea2  Adds the ability to iterate over all registered timers in an internal state backend

90313e4 Update the state processor api to restore and read registered timers


## Verifying this change

UT & IT test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? javadoc
