### PR TITLE
[FLINK-13232][table-planner-blink] Correct CURRENT_DATE test to avoid timezone error

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/expressions/TemporalTypesTest.scala
@@ -523,7 +523,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2017-11-29 18:58:58.998")
 
     val sdf = new SimpleDateFormat("yyyy-MM-dd")
-    sdf.setTimeZone(TimeZone.getTimeZone(config.getLocalTimeZone))
+    sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
     val currMillis = System.currentTimeMillis()
     val ts = new Timestamp(currMillis)
     val currDateStr = sdf.format(ts)


### PR DESCRIPTION

## What is the purpose of the change

CURRENT_DATE return UTC date, if user want to return local date, user should use LOCALTIMESTAMP to get date.

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no