### PR TITLE
[FLINK-13236][table-runtime-blink] Fix bug and improve performance in TopNBuffer

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/rank/TopNBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/rank/TopNBuffer.java
@@ -75,6 +75,10 @@ class TopNBuffer implements Serializable {
 	 * @param values record lists to be associated with the specified key
 	 */
 	void putAll(BaseRow sortKey, Collection<BaseRow> values) {
+		Collection<BaseRow> oldValues = treeMap.get(sortKey);
+		if (oldValues != null) {
+			currentTopNum -= oldValues.size();
+		}
 		treeMap.put(sortKey, values);
 		currentTopNum += values.size();
 	}
@@ -145,18 +149,18 @@ class TopNBuffer implements Serializable {
 	 */
 	BaseRow getElement(int rank) {
 		int curRank = 0;
-		Iterator<Map.Entry<BaseRow, Collection<BaseRow>>> iter = treeMap.entrySet().iterator();
-		while (iter.hasNext()) {
-			Map.Entry<BaseRow, Collection<BaseRow>> entry = iter.next();
+		for (Map.Entry<BaseRow, Collection<BaseRow>> entry : treeMap.entrySet()) {
 			Collection<BaseRow> list = entry.getValue();
 
-			Iterator<BaseRow> listIter = list.iterator();
-			while (listIter.hasNext()) {
-				BaseRow elem = listIter.next();
-				curRank += 1;
-				if (curRank == rank) {
-					return elem;
+			if (curRank + list.size() >= rank) {
+				for (BaseRow elem : list) {
+					curRank += 1;
+					if (curRank == rank) {
+						return elem;
+					}
 				}
+			} else {
+				curRank += list.size();
 			}
 		}
 		return null;


### PR DESCRIPTION
## What is the purpose of the change

The value of `currentTopNum` will be incorrectly calculated in the `putAll` method of `TopNBuffer` when the given `sortKey` exists in `treeMap`.

Also, the inner loop of `getElement` method can be removed to improve performance.

See [jira page](https://issues.apache.org/jira/browse/FLINK-13236) for detailed description.

## Brief change log

 - Fix `putAll` method in `TopNBuffer`
 - Improve performance of `getElement` method in `TopNBuffer`

## Verifying this change

This change is a trivial bug fix / improvement without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
