### PR TITLE
[HOTFIX][mvn] upgrade frontend-maven-plugin version to 1.7.5

### DIFF
--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -220,7 +220,7 @@ under the License.
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>1.6</version>
+				<version>1.7.5</version>
 				<executions>
 					<execution>
 						<id>install node and npm</id>


### PR DESCRIPTION
## What is the purpose of the change

When package module `flink-runtime-web`, we met below error and we found it's `frontend-maven-plugin`'s bug, see more detail, please click [frontend-maven-plugin-bug](https://github.com/eirslett/frontend-maven-plugin/issues/783)

```
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.6:install-node-and-npm (install node and npm) on project flink-runtime-web_2.11: Execution install node and npm of goal com.github.eirslett:frontend-maven-plugin:1.6:install-node-and-npm failed: A required class was missing while executing com.github.eirslett:frontend-maven-plugin:1.6:install-node-and-npm: org/apache/http/protocol/HttpContext
```

## Brief change log

upgrade frontend-maven-plugin version to 1.7.5

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no
