### PR TITLE
[FLINK-13184][yarn] Support launching task executors with multi-thread on YARN.

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -54,7 +54,7 @@
         </tr>
         <tr>
             <td><h5>yarn.max-container-launcher-number</h5></td>
-            <td style="word-wrap: break-word;">100</td>
+            <td style="word-wrap: break-word;">10</td>
             <td>The max number of threads for starting yarn containers in yarn resource manager.</td>
         </tr>
         <tr>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -53,6 +53,11 @@
             <td>Time between heartbeats with the ResourceManager in seconds.</td>
         </tr>
         <tr>
+            <td><h5>yarn.max-container-launcher-number</h5></td>
+            <td style="word-wrap: break-word;">100</td>
+            <td>The max number of threads for starting yarn containers in yarn resource manager.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.maximum-failed-containers</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Maximum number of containers the system is going to reallocate in case of a failure.</td>

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -140,7 +140,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	/**
 	 * Executor for starting new yarn containers.
 	 */
-	private final Executor startContainerExecutor;
+	private final ThreadPoolExecutor startContainerExecutor;
 
 	public YarnResourceManager(
 			RpcService rpcService,
@@ -289,6 +289,14 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 		if (nodeManagerClient != null) {
 			try {
 				nodeManagerClient.stop();
+			} catch (Throwable t) {
+				firstException = ExceptionUtils.firstOrSuppressed(t, firstException);
+			}
+		}
+
+		if (startContainerExecutor != null) {
+			try {
+				startContainerExecutor.shutdownNow();
 			} catch (Throwable t) {
 				firstException = ExceptionUtils.firstOrSuppressed(t, firstException);
 			}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -599,4 +599,9 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 				.put(ENV_FLINK_NODE_ID, host);
 		return taskExecutorLaunchContext;
 	}
+
+	@VisibleForTesting
+	Executor getStartContainerExecutor() {
+		return startContainerExecutor;
+	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -196,7 +196,9 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 		this.resource = Resource.newInstance(defaultTaskManagerMemoryMB, defaultCpus);
 
 		this.slotsPerWorker = createWorkerSlotProfiles(flinkConfig);
-		this.startContainerExecutor = new ThreadPoolExecutor(0, flinkConfig.getInteger(YarnConfigOptions.CONTAINER_LAUNCHER_NUM_MAX),
+
+		final int containerLauncherNum = flinkConfig.getInteger(YarnConfigOptions.CONTAINER_LAUNCHER_NUM_MAX);
+		this.startContainerExecutor = new ThreadPoolExecutor(containerLauncherNum, containerLauncherNum,
 			60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new ThreadFactoryBuilder()
 			.setNameFormat("ContainerLauncher #%d")
 			.build());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -193,7 +193,7 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<Integer> CONTAINER_LAUNCHER_NUM_MAX =
 		key("yarn.max-container-launcher-number")
-			.defaultValue(100)
+			.defaultValue(10)
 			.withDescription("The max number of threads for starting yarn containers in yarn resource manager.");
 
 	// ------------------------------------------------------------------------

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -188,6 +188,14 @@ public class YarnConfigOptions {
 		.defaultValue("")
 		.withDescription("A comma-separated list of tags to apply to the Flink YARN application.");
 
+	/**
+	 * The max number of threads for starting yarn containers in yarn resource manager.
+	 */
+	public static final ConfigOption<Integer> CONTAINER_LAUNCHER_NUM_MAX =
+		key("yarn.max-container-launcher-number")
+			.defaultValue(100)
+			.withDescription("The max number of threads for starting yarn containers in yarn resource manager.");
+
 	// ------------------------------------------------------------------------
 
 	/** This class is not meant to be instantiated. */


### PR DESCRIPTION
## What is the purpose of the change

This pull request support starting new TaskExecutors with multi-thread in YarnResourceManager, so when starting a large amount of TaskExecutors it won't the block main thread on RM from responding to other RPC messages (TE registration, heartbeats, etc.).

## Brief change log

- b2ed97d0e6dd506602888aacf6146238fbcdfd48: Introduce a config option for the max number of threads on RM used for starting new TaskExecutors. 
- 06c7209af04f49ca69a263f57fc713f3b9c55c87: Introduce a thread pool in YarnResourceManager and start new TaskExecutors with multi-thread. 
- 25fc95f30720209e19bd010cdd517ff5e3c685d8: Update relevant test cases to wait for threads starting new TaskExecutors to finish.

## Verifying this change

  - Updated YarnResourceManagerTest to verify that YarnResourceManager starts new TaskExecutors properly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
