### PR TITLE
[FLINK-13257][table-planner-blink] blink runner should avoid stream operator implementing BoundedOneInput

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -63,9 +63,7 @@ object CalcCodeGenerator {
         ctx,
         opName,
         processCode,
-        "",
         inputType,
-        config,
         inputTerm = inputTerm,
         lazyInputUnboxingCode = true)
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -68,11 +68,6 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   private val reusableCloseStatements: mutable.LinkedHashSet[String] =
     mutable.LinkedHashSet[String]()
 
-  // set of endInput statements for StreamOperator that will be added only once
-  // we use a LinkedHashSet to keep the insertion order
-  private val reusableEndInputStatements: mutable.LinkedHashSet[String] =
-    mutable.LinkedHashSet[String]()
-
   // set of statements for cleanup dataview that will be added only once
   // we use a LinkedHashSet to keep the insertion order
   private val reusableCleanupStatements = mutable.LinkedHashSet[String]()
@@ -249,14 +244,6 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   }
 
   /**
-    * @return code block of statements that need to be placed in the endInput() method
-    *         (StreamOperator)
-    */
-  def reuseEndInputCode(): String = {
-    reusableEndInputStatements.mkString("\n")
-  }
-
-  /**
     * @return code block of statements that need to be placed in the cleanup() method of
     *         [AggregationsFunction]
     */
@@ -343,11 +330,6 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     * Adds a reusable close statement
     */
   def addReusableCloseStatement(s: String): Unit = reusableCloseStatements.add(s)
-
-  /**
-    * Adds a reusable endInput statement
-    */
-  def addReusableEndInputStatement(s: String): Unit = reusableEndInputStatements.add(s)
 
   /**
     * Adds a reusable cleanup statement

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
@@ -273,12 +273,7 @@ object CorrelateCodeGenerator {
     }
 
     val genOperator = OperatorCodeGenerator.generateOneInputStreamOperator[BaseRow, BaseRow](
-      ctx,
-      ruleDescription,
-      body,
-      "",
-      inputType,
-      config)
+      ctx, ruleDescription, body, inputType)
     new CodeGenOperatorFactory(genOperator)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpandCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpandCodeGenerator.scala
@@ -65,9 +65,7 @@ object ExpandCodeGenerator {
       ctx,
       opName,
       processCode,
-      "",
       inputType,
-      config,
       inputTerm = inputTerm,
       lazyInputUnboxingCode = false)
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
@@ -323,11 +323,6 @@ object LongHashJoinGenerator {
          |}
        """.stripMargin,
       s"""
-         |LOG.info("Finish build phase.");
-         |table.endBuild();
-         |$buildEnd = true;
-       """.stripMargin,
-      s"""
          |$BASE_ROW row = ($BASE_ROW) element.getValue();
          |$nullCheckProbeCode
          |if (!$nullCheckProbeTerm) {
@@ -337,22 +332,30 @@ object LongHashJoinGenerator {
          |}
          |$nullOuterJoin
        """.stripMargin,
-      s"""
-         |LOG.info("Finish probe phase.");
-         |while (this.table.nextMatching()) {
-         |  joinWithNextKey();
-         |}
-         |LOG.info("Finish rebuild phase.");
-       """.stripMargin,
-      s"""
-         |if ($buildEnd) {
-         |  return $INPUT_SELECTION.SECOND;
-         |} else {
-         |  return $INPUT_SELECTION.FIRST;
-         |}
-       """.stripMargin,
       buildType,
-      probeType)
+      probeType,
+      nextSelectionCode = Some(
+        s"""
+           |if ($buildEnd) {
+           |  return $INPUT_SELECTION.SECOND;
+           |} else {
+           |  return $INPUT_SELECTION.FIRST;
+           |}
+         """.stripMargin),
+      endInputCode1 = Some(
+        s"""
+           |LOG.info("Finish build phase.");
+           |table.endBuild();
+           |$buildEnd = true;
+       """.stripMargin),
+      endInputCode2 = Some(
+        s"""
+           |LOG.info("Finish probe phase.");
+           |while (this.table.nextMatching()) {
+           |  joinWithNextKey();
+           |}
+           |LOG.info("Finish rebuild phase.");
+         """.stripMargin))
 
     new CodeGenOperatorFactory[BaseRow](genOp)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/NestedLoopJoinCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/NestedLoopJoinCodeGenerator.scala
@@ -133,18 +133,19 @@ class NestedLoopJoinCodeGenerator(
       ctx,
       "BatchNestedLoopJoin",
       processCode1,
-      endInputCode1,
       processCode2,
-      endInputCode2,
-      s"""
-         |if ($buildEnd) {
-         |  return $INPUT_SELECTION.${if (leftIsBuild) "SECOND" else "FIRST"};
-         |} else {
-         |  return $INPUT_SELECTION.${if (leftIsBuild) "FIRST" else "SECOND"};
-         |}
-       """.stripMargin,
       leftType,
-      rightType)
+      rightType,
+      nextSelectionCode = Some(
+        s"""
+           |if ($buildEnd) {
+           |  return $INPUT_SELECTION.${if (leftIsBuild) "SECOND" else "FIRST"};
+           |} else {
+           |  return $INPUT_SELECTION.${if (leftIsBuild) "FIRST" else "SECOND"};
+           |}
+         """.stripMargin),
+      endInputCode1 = Some(endInputCode1),
+      endInputCode2 = Some(endInputCode2))
     new CodeGenOperatorFactory[BaseRow](genOp)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/SinkCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/SinkCodeGenerator.scala
@@ -175,7 +175,6 @@ object SinkCodeGenerator {
           """.stripMargin
     }
 
-    val endInputCode = ""
     val generated = OperatorCodeGenerator.generateOneInputStreamOperator[BaseRow, OUT](
       ctx,
       operatorName,
@@ -183,9 +182,7 @@ object SinkCodeGenerator {
          |$fieldIndexProcessCode
          |$retractProcessCode
          |""".stripMargin,
-      endInputCode,
-      fromTypeInfoToLogicalType(inputTypeInfo),
-      config)
+      fromTypeInfoToLogicalType(inputTypeInfo))
     (new CodeGenOperatorFactory[OUT](generated), outputTypeInfo.asInstanceOf[TypeInformation[OUT]])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -709,9 +709,8 @@ object AggCodeGenHelper {
       ctx,
       name,
       processCode,
-      endInputCode,
       inputType,
-      ctx.tableConfig,
+      endInputCode = Some(endInputCode),
       lazyInputUnboxingCode = true)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
@@ -109,9 +109,7 @@ object ScanUtil {
       ctx,
       convertName,
       processCode,
-      "",
       outputRowType,
-      config,
       converter = inputTermConverter)
 
     val substituteStreamOperator = new CodeGenOperatorFactory[BaseRow](generatedOperator)

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperatorTest.java
@@ -76,7 +76,6 @@ public class StreamSortOperatorTest {
 
 		// do a snapshot, data could be recovered from state
 		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
-		operator.endInput();
 		testHarness.close();
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 
@@ -88,7 +87,6 @@ public class StreamSortOperatorTest {
 		testHarness.open();
 		testHarness.processElement(record("abc", 1));
 		testHarness.processElement(record("aa", 1));
-		operator.endInput();
 		testHarness.close();
 
 		expectedOutput.add(record("aa", 1));


### PR DESCRIPTION

## What is the purpose of the change

According to https://issues.apache.org/jira/browse/FLINK-11879 , BoundedOneInput should not coexist with checkpoint, so we can not use BoundedOneInput in streaming mode.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no