### PR TITLE
[FLINK-13258] Add tests for LongHashPartition, StringCallGen and EqualiserCodeGenerator

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/codegen/EqualiserCodeGeneratorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/codegen/EqualiserCodeGeneratorTest.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.codegen
+
+import org.apache.flink.table.dataformat.{BaseRow, BinaryRow, BinaryRowWriter, BinaryString, GenericRow}
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Test
+import java.lang.{Integer => JInt, Long => JLong}
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.table.api.DataTypes
+import org.apache.flink.table.types.logical.LogicalType
+import org.apache.flink.table.typeutils.BaseRowSerializer
+
+/**
+  * Test for [[EqualiserCodeGenerator]].
+  */
+class EqualiserCodeGeneratorTest {
+
+  @Test
+  def testEqualiser(): Unit = {
+    val types = Array[LogicalType](
+      DataTypes.INT.getLogicalType,
+      DataTypes.ROW(
+        DataTypes.FIELD("f0", DataTypes.INT),
+        DataTypes.FIELD("f1", DataTypes.STRING),
+        DataTypes.FIELD("f2", DataTypes.ROW(
+          DataTypes.FIELD("f20", DataTypes.STRING),
+          DataTypes.FIELD("f21", DataTypes.STRING)
+        ))).getLogicalType,
+      DataTypes.BIGINT.getLogicalType)
+    val generator = new EqualiserCodeGenerator(types)
+    val recordEqualiser = generator.generateRecordEqualiser("recordEqualiser")
+      .newInstance(Thread.currentThread().getContextClassLoader)
+
+    val rowLeft: GenericRow = GenericRow.of(
+      1: JInt,
+      GenericRow.of(
+        2: JInt,
+        BinaryString.fromString("3"),
+        GenericRow.of(
+          BinaryString.fromString("4"), BinaryString.fromString("5"))), 6L: JLong)
+    val rowRight: BaseRow = newBinaryRow(1: JInt, 2, "3", "4", "5", 6L)
+    assertTrue(recordEqualiser.equals(rowLeft, rowRight))
+
+    rowLeft.setHeader(1)
+    rowRight.setHeader(0)
+    assertFalse(recordEqualiser.equals(rowLeft, rowRight))
+    assertTrue(recordEqualiser.equalsWithoutHeader(rowLeft, rowRight))
+  }
+
+  def newBinaryRow(
+      c1: Int, c21: Int, c22: String, c231: String, c232: String, c3: Long): BinaryRow = {
+    val c23 = new BinaryRow(2)
+    var writer = new BinaryRowWriter(c23)
+    writer.writeString(0, BinaryString.fromString(c231))
+    writer.writeString(1, BinaryString.fromString(c232))
+    writer.complete()
+
+    val c2Row = new BinaryRow(2)
+    val c2Serializer = new BaseRowSerializer(
+      new ExecutionConfig(), DataTypes.STRING.getLogicalType, DataTypes.STRING.getLogicalType)
+    writer = new BinaryRowWriter(c2Row)
+    writer.writeInt(0, c21)
+    writer.writeString(1, BinaryString.fromString(c22))
+    writer.writeRow(2, c23, c2Serializer)
+    writer.complete()
+
+    val row = new BinaryRow(3)
+    writer = new BinaryRowWriter(row)
+    val serializer = new BaseRowSerializer(
+      new ExecutionConfig(),
+      DataTypes.INT.getLogicalType,
+      DataTypes.STRING.getLogicalType,
+      DataTypes.ROW(
+        DataTypes.FIELD("f20", DataTypes.STRING),
+        DataTypes.FIELD("f21", DataTypes.STRING)).getLogicalType)
+    writer.writeInt(0, c1)
+    writer.writeRow(1, c2Row, serializer)
+    writer.writeLong(2, c3)
+    writer.complete()
+    row
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/codegen/calls/StringCallGenTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/codegen/calls/StringCallGenTest.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codegen.calls
+
+import org.apache.calcite.sql.SqlOperator
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.sql.fun.SqlStdOperatorTable._
+import org.apache.flink.table.api.{DataTypes, TableConfig}
+import org.apache.flink.table.codegen.CodeGenUtils.{BINARY_STRING, newName}
+import org.apache.flink.table.codegen.ExprCodeGenerator.generateCallExpression
+import org.apache.flink.table.codegen.{CodeGeneratorContext, GeneratedExpression}
+import org.apache.flink.table.functions.sql.FlinkSqlOperatorTable
+import org.apache.flink.table.generated.CompileUtils.compile
+import org.apache.flink.table.types.logical.LogicalType
+import org.junit.Assert._
+import org.junit.Test
+
+class StringCallGenTest {
+
+  def invoke(operator: SqlOperator, operands: Seq[GeneratedExpression], tpe: LogicalType): Any = {
+    val config = new TableConfig()
+    val ctx = new CodeGeneratorContext(config)
+    val expr = generateCallExpression(ctx, operator, operands, tpe)
+    compileAndInvoke(ctx, expr)
+  }
+
+  def compileAndInvoke(ctx: CodeGeneratorContext, expr: GeneratedExpression): Any = {
+    val name = newName("StringCallGenTest")
+    val abstractClass = classOf[Func].getCanonicalName
+    val code =
+      s"""
+         |public class $name extends $abstractClass {
+         |
+         |  ${ctx.reuseMemberCode()}
+         |
+         |  @Override
+         |  public Object apply() {
+         |    ${ctx.reuseLocalVariableCode()}
+         |    ${expr.code}
+         |    if (${expr.nullTerm}) {
+         |      return null;
+         |    } else {
+         |      return ${expr.resultTerm};
+         |    }
+         |  }
+         |}
+          """.stripMargin
+    val func = compile(Thread.currentThread().getContextClassLoader, name, code)
+      .newInstance().asInstanceOf[Func]
+    func()
+  }
+
+  def toBinary(term: String): String = s"$BINARY_STRING.fromString($term)"
+
+  def str(term: String): GeneratedExpression =
+    newOperand(toBinary("\"" + term + "\""), DataTypes.STRING.getLogicalType)
+
+  def int(term: String): GeneratedExpression =
+    newOperand(term, DataTypes.INT.getLogicalType)
+
+  def newOperand(resultTerm: String, resultType: LogicalType): GeneratedExpression =
+    GeneratedExpression(resultTerm, "false", "", resultType)
+
+  @Test
+  def testEquals(): Unit = {
+    assertFalse(invoke(EQUALS, Seq(str("haha"), str("hehe")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+    assertTrue(invoke(EQUALS, Seq(str("haha"), str("haha")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+
+    assertTrue(invoke(NOT_EQUALS, Seq(str("haha"), str("hehe")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+    assertFalse(invoke(NOT_EQUALS, Seq(str("haha"), str("haha")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testLike(): Unit = {
+    assertFalse(invoke(SqlStdOperatorTable.LIKE, Seq(str("haha"), str("hehe")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+    assertTrue(invoke(SqlStdOperatorTable.LIKE, Seq(str("haha"), str("haha")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+
+    assertTrue(invoke(SqlStdOperatorTable.NOT_LIKE, Seq(str("haha"), str("hehe")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+    assertFalse(invoke(SqlStdOperatorTable.NOT_LIKE, Seq(str("haha"), str("haha")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testCharLength(): Unit = {
+    assertEquals(4, invoke(CHAR_LENGTH, Seq(str("haha")), DataTypes.INT.getLogicalType))
+    assertEquals(4, invoke(CHARACTER_LENGTH, Seq(str("haha")), DataTypes.INT.getLogicalType))
+  }
+
+  @Test
+  def testSqlTime(): Unit = {
+    assertEquals(1453438905L,
+      invoke(FlinkSqlOperatorTable.UNIX_TIMESTAMP,
+        Seq(str("2016-01-22 05:01:45")), DataTypes.TIMESTAMP.getLogicalType))
+
+    assertEquals(-120,
+      invoke(FlinkSqlOperatorTable.DATEDIFF,
+        Seq(str("2016-01-22"), str("2016-05-21")), DataTypes.DATE.getLogicalType))
+  }
+
+  @Test
+  def testSimilarTo(): Unit = {
+    assertFalse(invoke(SIMILAR_TO, Seq(str("haha"), str("hehe")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+    assertTrue(invoke(SIMILAR_TO, Seq(str("haha"), str("haha")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+
+    assertTrue(invoke(NOT_SIMILAR_TO, Seq(str("haha"), str("hehe")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+    assertFalse(invoke(NOT_SIMILAR_TO, Seq(str("haha"), str("haha")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testIsXxx(): Unit = {
+    assertTrue(invoke(FlinkSqlOperatorTable.IS_DECIMAL, Seq(str("1234134")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+    assertTrue(invoke(FlinkSqlOperatorTable.IS_DIGIT, Seq(str("1234134")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+    assertTrue(invoke(FlinkSqlOperatorTable.IS_ALPHA, Seq(str("adb")),
+      DataTypes.BOOLEAN.getLogicalType).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testPosition(): Unit = {
+    assertEquals(5,
+      invoke(POSITION, Seq(str("d"), str("aaaadfg")),
+      DataTypes.INT.getLogicalType))
+  }
+
+  @Test
+  def testHash(): Unit = {
+    assertEquals(1236857883,
+      invoke(FlinkSqlOperatorTable.HASH_CODE, Seq(str("aaaadfg")),
+      DataTypes.INT.getLogicalType))
+  }
+}
+
+abstract class Func {
+  def apply(): Any
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.hashtable;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.memory.SeekableDataInputView;
@@ -245,9 +246,10 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		return iterator;
 	}
 
-//	public MatchIterator get(long key) {
-//		return get(key, hashLong(key, recursionLevel));
-//	}
+	@VisibleForTesting
+	public MatchIterator get(long key) {
+		return get(key, hashLong(key, recursionLevel));
+	}
 
 	/**
 	 * Returns an iterator for all the values for the given key, or null if no value found.
@@ -651,6 +653,11 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 			longTable.returnAll(Arrays.asList(buckets));
 			buckets = null;
 		}
+	}
+
+	@VisibleForTesting
+	public void append(long key, BinaryRow row) throws IOException {
+		insertIntoTable(key, hashLong(key, recursionLevel), row);
 	}
 
 	// ------------------ PagedInputView for read end --------------------

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashPartitionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashPartitionTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file exceBinaryRow in compliance
+ * with the License.  You may oBinaryRowain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHBinaryRow WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.hashtable;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.api.ExecutionConfigOptions;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryRowWriter;
+import org.apache.flink.table.dataformat.BinaryString;
+import org.apache.flink.table.runtime.util.RowIterator;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.hashtable.LongHashPartition.INVALID_ADDRESS;
+
+/**
+ * Test for {@link LongHashPartition}.
+ */
+@RunWith(Parameterized.class)
+public class LongHashPartitionTest {
+
+	private static final int PAGE_SIZE = 32 * 1024;
+
+	private IOManager ioManager;
+	private BinaryRowSerializer buildSideSerializer;
+	private BinaryRowSerializer probeSideSerializer;
+	private MemoryManager memManager = new MemoryManager(50 * PAGE_SIZE, 1);
+
+	private boolean useCompress;
+	private Configuration conf;
+
+	private LongHashPartition partition;
+
+	public LongHashPartitionTest(boolean useCompress) {
+		this.useCompress = useCompress;
+	}
+
+	@Parameterized.Parameters(name = "useCompress-{0}")
+	public static List<Boolean> getVarSeg() {
+		return Arrays.asList(true, false);
+	}
+
+	@Before
+	public void init() {
+		TypeInformation[] types = new TypeInformation[]{Types.LONG, Types.STRING};
+		this.buildSideSerializer = new BinaryRowSerializer(types.length);
+		this.probeSideSerializer = new BinaryRowSerializer(types.length);
+		this.ioManager = new IOManagerAsync();
+
+		conf = new Configuration();
+		conf.setBoolean(ExecutionConfigOptions.SQL_EXEC_SPILL_COMPRESSION_ENABLED, useCompress);
+
+		LongHybridHashTable table = new MyHashTable(50 * PAGE_SIZE);
+		this.partition = new LongHashPartition(table, 1,
+			new BinaryRowSerializer(types.length), 15, 15, 0);
+	}
+
+	@Test
+	public void testAddressAndLen() {
+		int length = 5;
+		long addrAndLen = LongHashPartition.toAddrAndLen(INVALID_ADDRESS, length);
+		Assert.assertEquals(INVALID_ADDRESS, LongHashPartition.toAddress(addrAndLen));
+		Assert.assertEquals(length, LongHashPartition.toLength(addrAndLen));
+	}
+
+	@Test
+	public void testDenseLong() throws IOException {
+		partition.append(0, row(0, "hehe0"));
+		partition.append(0, row(0, "haha0"));
+		partition.append(5, row(5, "hehe5"));
+		partition.append(5, row(5, "haha5"));
+		partition.append(3, row(3, "hehe3"));
+		partition.append(3, row(3, "haha3"));
+		partition.append(128, row(128, "hehe128"));
+
+		partition.finalizeBuildPhase(null, null);
+
+		assertPartition(0, Arrays.asList("haha0", "hehe0"));
+		assertPartition(5, Arrays.asList("haha5", "hehe5"));
+		assertPartition(3, Arrays.asList("haha3", "hehe3"));
+		assertPartition(128, Collections.singletonList("hehe128"));
+	}
+
+	@Test
+	public void testNotDenseLong() throws IOException {
+		partition.append(5, row(5, "hehe5"));
+		partition.append(5, row(5, "haha5"));
+		partition.append(3222, row(3222, "hehe3222"));
+		partition.append(3, row(3, "haha3"));
+		partition.append(1284444, row(1284444, "hehe1284444"));
+
+		partition.finalizeBuildPhase(null, null);
+
+		assertPartition(5, Arrays.asList("haha5", "hehe5"));
+		assertPartition(3, Collections.singletonList("haha3"));
+		assertPartition(3222, Collections.singletonList("hehe3222"));
+		assertPartition(1284444, Collections.singletonList("hehe1284444"));
+	}
+
+	@Test
+	public void testMany() throws IOException {
+		for (int i = 0; i < 2500; i++) {
+			partition.append(i, row(i, "hehe" + i));
+		}
+
+		partition.append(10000000L, row(10000000L, "hehe" + 10000000L));
+
+		partition.finalizeBuildPhase(null, null);
+
+		for (int i = 0; i < 2500; i++) {
+			assertPartition(i, Collections.singletonList("hehe" + i));
+		}
+		assertPartition(10000000L, Collections.singletonList("hehe" + 10000000L));
+		Assert.assertFalse(partition.get(1010002020202L).advanceNext());
+	}
+
+	private void assertPartition(long k, List<String> values) {
+		RowIterator<BinaryRow> iterator = partition.get(k);
+		List<String> ret = new ArrayList<>();
+		while (iterator.advanceNext()) {
+			ret.add(iterator.getRow().getString(1).toString());
+		}
+		Assert.assertEquals(values, ret);
+	}
+
+	private BinaryRow row(long k, String v) {
+		BinaryRow row = new BinaryRow(2);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.writeLong(0, k);
+		writer.writeString(1, BinaryString.fromString(v));
+		writer.complete();
+		return row;
+	}
+
+	private class MyHashTable extends LongHybridHashTable {
+		MyHashTable(long memorySize) {
+			super(conf, LongHashPartitionTest.this, buildSideSerializer, probeSideSerializer, memManager, memorySize,
+				memorySize, 0, LongHashPartitionTest.this.ioManager,
+				24, 200000);
+		}
+
+		@Override
+		public long getBuildLongKey(BaseRow row) {
+			return row.getInt(0);
+		}
+
+		@Override
+		public long getProbeLongKey(BaseRow row) {
+			return row.getInt(0);
+		}
+
+		@Override
+		public BinaryRow probeToBinary(BaseRow row) {
+			return (BinaryRow) row;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds tests for `LongHashPartition`, `StringCallGen` and `EqualiserCodeGenerator` as these classes have no tests currently.

## Brief change log

 - Add tests for `LongHashPartition`
 - Add tests for `StringCallGen`
 - Add tests for `EqualiserCodeGenerator`

## Verifying this change

This change added tests and can be verified as follows: Run `LongHashPartitionTest`, `StringCallGenTest` and `EqualiserCodeGeneratorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
