### PR TITLE
[FLINK-13259] Fix typo about "access"

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparator.java
@@ -180,7 +180,7 @@ public final class PojoComparator<T> extends CompositeTypeComparator<T> implemen
 		} catch (NullPointerException npex) {
 			throw new NullKeyFieldException("Unable to access field "+field+" on object "+object);
 		} catch (IllegalAccessException iaex) {
-			throw new RuntimeException("This should not happen since we call setAccesssible(true) in PojoTypeInfo."
+			throw new RuntimeException("This should not happen since we call setAccessible(true) in PojoTypeInfo."
 			+ " fields: " + field + " obj: " + object);
 		}
 		return object;
@@ -195,7 +195,7 @@ public final class PojoComparator<T> extends CompositeTypeComparator<T> implemen
 			try {
 				code += this.comparators[i].hash(accessField(keyFields[i], value));
 			}catch(NullPointerException npe) {
-				throw new RuntimeException("A NullPointerException occured while accessing a key field in a POJO. " +
+				throw new RuntimeException("A NullPointerException occurred while accessing a key field in a POJO. " +
 						"Most likely, the value grouped/joined on is null. Field name: "+keyFields[i].getName(), npe);
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
@@ -64,14 +64,14 @@ public class HashTableITCase extends TestLogger {
 	private MemoryManager memManager;
 	private IOManager ioManager;
 	
-	private TypeSerializer<Record> recordBuildSideAccesssor;
-	private TypeSerializer<Record> recordProbeSideAccesssor;
+	private TypeSerializer<Record> recordBuildSideAccessor;
+	private TypeSerializer<Record> recordProbeSideAccessor;
 	private TypeComparator<Record> recordBuildSideComparator;
 	private TypeComparator<Record> recordProbeSideComparator;
 	private TypePairComparator<Record, Record> pactRecordComparator;
 	
-	private TypeSerializer<IntPair> pairBuildSideAccesssor;
-	private TypeSerializer<IntPair> pairProbeSideAccesssor;
+	private TypeSerializer<IntPair> pairBuildSideAccessor;
+	private TypeSerializer<IntPair> pairProbeSideAccessor;
 	private TypeComparator<IntPair> pairBuildSideComparator;
 	private TypeComparator<IntPair> pairProbeSideComparator;
 	private TypePairComparator<IntPair, IntPair> pairComparator;
@@ -83,14 +83,14 @@ public class HashTableITCase extends TestLogger {
 		@SuppressWarnings("unchecked")
 		final Class<? extends Value>[] keyType = (Class<? extends Value>[]) new Class[] { IntValue.class };
 		
-		this.recordBuildSideAccesssor = RecordSerializer.get();
-		this.recordProbeSideAccesssor = RecordSerializer.get();
+		this.recordBuildSideAccessor = RecordSerializer.get();
+		this.recordProbeSideAccessor = RecordSerializer.get();
 		this.recordBuildSideComparator = new RecordComparator(keyPos, keyType);
 		this.recordProbeSideComparator = new RecordComparator(keyPos, keyType);
 		this.pactRecordComparator = new RecordPairComparatorFirstInt();
 		
-		this.pairBuildSideAccesssor = new IntPairSerializer();
-		this.pairProbeSideAccesssor = new IntPairSerializer();
+		this.pairBuildSideAccessor = new IntPairSerializer();
+		this.pairProbeSideAccessor = new IntPairSerializer();
 		this.pairBuildSideComparator = new IntPairComparator();
 		this.pairProbeSideComparator = new IntPairComparator();
 		this.pairComparator = new IntPairPairComparator();
@@ -159,7 +159,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-			this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+			this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 			this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 			memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -210,7 +210,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -262,7 +262,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -374,7 +374,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -487,7 +487,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -596,7 +596,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -651,7 +651,7 @@ public class HashTableITCase extends TestLogger {
 		}
 
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		join.open(buildInput, new UniformRecordGenerator(NUM_PROBE_KEYS, NUM_PROBE_VALS, true));
@@ -701,7 +701,7 @@ public class HashTableITCase extends TestLogger {
 		}
 
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor,
+				this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		join.open(buildInput, new UniformRecordGenerator(NUM_PROBE_KEYS, NUM_PROBE_VALS, true), true);
@@ -750,7 +750,7 @@ public class HashTableITCase extends TestLogger {
 		}		
 				
 		final MutableHashTable<Record, Record> join = new MutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		join.open(buildInput, new UniformRecordGenerator(NUM_PROBE_KEYS, NUM_PROBE_VALS, true));
@@ -805,7 +805,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-			this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+			this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 			this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 			memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -854,7 +854,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -906,7 +906,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -1018,7 +1018,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -1130,7 +1130,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -1238,7 +1238,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -1293,7 +1293,7 @@ public class HashTableITCase extends TestLogger {
 		}
 
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 				memSegments, ioManager);
 		join.open(buildInput, new UniformIntPairGenerator(NUM_PROBE_KEYS, NUM_PROBE_VALS, true));
@@ -1342,7 +1342,7 @@ public class HashTableITCase extends TestLogger {
 		}
 				
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 				memSegments, ioManager);
 		join.open(buildInput, new UniformIntPairGenerator(NUM_PROBE_KEYS, NUM_PROBE_VALS, true));
@@ -1392,7 +1392,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 			memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -1468,7 +1468,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-				this.pairBuildSideAccesssor, this.pairProbeSideAccesssor,
+				this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 				this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 				memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -1553,7 +1553,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-			this.pairBuildSideAccesssor, this.pairProbeSideAccesssor,
+			this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 			this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 			memSegments, ioManager);
 		join.open(buildInput, probeInput);
@@ -1599,7 +1599,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-			this.pairBuildSideAccesssor, this.pairProbeSideAccesssor,
+			this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 			this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 			memSegments, ioManager);
 		join.open(buildInput, probeInput, true);
@@ -1648,7 +1648,7 @@ public class HashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 		
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
-			this.pairBuildSideAccesssor, this.pairProbeSideAccesssor,
+			this.pairBuildSideAccessor, this.pairProbeSideAccessor,
 			this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
 			memSegments, ioManager);
 		join.open(buildInput, probeInput, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReOpenableHashTableITCase.java
@@ -61,8 +61,8 @@ public class ReOpenableHashTableITCase extends TestLogger {
 	private MemoryManager memoryManager;
 
 	private static final AbstractInvokable MEM_OWNER = new DummyInvokable();
-	private TypeSerializer<Tuple2<Integer, Integer>> recordBuildSideAccesssor;
-	private TypeSerializer<Tuple2<Integer, Integer>> recordProbeSideAccesssor;
+	private TypeSerializer<Tuple2<Integer, Integer>> recordBuildSideAccessor;
+	private TypeSerializer<Tuple2<Integer, Integer>> recordProbeSideAccessor;
 	private TypeComparator<Tuple2<Integer, Integer>> recordBuildSideComparator;
 	private TypeComparator<Tuple2<Integer, Integer>> recordProbeSideComparator;
 	private TypePairComparator<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> pactRecordComparator;
@@ -70,8 +70,8 @@ public class ReOpenableHashTableITCase extends TestLogger {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Before
 	public void beforeTest() {
-		this.recordBuildSideAccesssor = TestData.getIntIntTupleSerializer();
-		this.recordProbeSideAccesssor = TestData.getIntIntTupleSerializer();
+		this.recordBuildSideAccessor = TestData.getIntIntTupleSerializer();
+		this.recordProbeSideAccessor = TestData.getIntIntTupleSerializer();
 		this.recordBuildSideComparator = TestData.getIntIntTupleComparator();
 		this.recordProbeSideComparator = TestData.getIntIntTupleComparator();
 		this.pactRecordComparator = new GenericPairComparator(this.recordBuildSideComparator, this.recordProbeSideComparator);
@@ -150,7 +150,7 @@ public class ReOpenableHashTableITCase extends TestLogger {
 		// ----------------------------------------------------------------------------------------
 
 		final ReOpenableMutableHashTable<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> join = new ReOpenableMutableHashTable<>(
-			this.recordBuildSideAccesssor, this.recordProbeSideAccesssor,
+			this.recordBuildSideAccessor, this.recordProbeSideAccessor,
 			this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 			memSegments, ioManager, true);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReOpenableHashTableTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReOpenableHashTableTestBase.java
@@ -66,8 +66,8 @@ public abstract class ReOpenableHashTableTestBase extends TestLogger {
 	protected TypeComparator<Tuple2<Integer, String>> record2Comparator;
 	protected TypePairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>> recordPairComparator;
 
-	protected TypeSerializer<Tuple2<Integer, Integer>> recordBuildSideAccesssor;
-	protected TypeSerializer<Tuple2<Integer, Integer>> recordProbeSideAccesssor;
+	protected TypeSerializer<Tuple2<Integer, Integer>> recordBuildSideAccessor;
+	protected TypeSerializer<Tuple2<Integer, Integer>> recordProbeSideAccessor;
 	protected TypeComparator<Tuple2<Integer, Integer>> recordBuildSideComparator;
 	protected TypeComparator<Tuple2<Integer, Integer>> recordProbeSideComparator;
 	protected TypePairComparator<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> pactRecordComparator;
@@ -81,8 +81,8 @@ public abstract class ReOpenableHashTableTestBase extends TestLogger {
 		this.record2Comparator = TestData.getIntStringTupleComparator();
 		this.recordPairComparator = new GenericPairComparator(this.record1Comparator, this.record2Comparator);
 
-		this.recordBuildSideAccesssor = TestData.getIntIntTupleSerializer();
-		this.recordProbeSideAccesssor = TestData.getIntIntTupleSerializer();
+		this.recordBuildSideAccessor = TestData.getIntIntTupleSerializer();
+		this.recordProbeSideAccessor = TestData.getIntIntTupleSerializer();
 		this.recordBuildSideComparator = TestData.getIntIntTupleComparator();
 		this.recordProbeSideComparator = TestData.getIntIntTupleComparator();
 		this.pactRecordComparator = new GenericPairComparator(this.recordBuildSideComparator, this.recordProbeSideComparator);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
@@ -252,7 +252,7 @@ public abstract class FieldAccessor<T, F> implements Serializable {
 				return innerAccessor.get(inner);
 			} catch (IllegalAccessException iaex) {
 				// The Field class is transient and when deserializing its value we also make it accessible
-				throw new RuntimeException("This should not happen since we call setAccesssible(true) in readObject."
+				throw new RuntimeException("This should not happen since we call setAccessible(true) in readObject."
 						+ " fields: " + field + " obj: " + pojo);
 			}
 		}
@@ -266,7 +266,7 @@ public abstract class FieldAccessor<T, F> implements Serializable {
 				return pojo;
 			} catch (IllegalAccessException iaex) {
 				// The Field class is transient and when deserializing its value we also make it accessible
-				throw new RuntimeException("This should not happen since we call setAccesssible(true) in readObject."
+				throw new RuntimeException("This should not happen since we call setAccessible(true) in readObject."
 						+ " fields: " + field + " obj: " + pojo);
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes some typos about "access".

## Brief change log

 - Fix typos about "access".


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable