### PR TITLE
[FLINK-13124] Don't forward exceptions when finishing SourceStreamTask

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -56,6 +57,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.hamcrest.core.Is.isA;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -231,6 +234,59 @@ public class SourceStreamTaskTest {
 			testHarness.getOutput());
 	}
 
+	/**
+	 * Cancelling should not swallow exceptions in the Invokable. They will eventually be ignored
+	 * because the bubble up into the Task thread, where they go nowhere.
+	 */
+	@Test
+	public void cancellingForwardsExceptions() throws Exception {
+		final StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(
+				SourceStreamTask::new,
+				BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness.setupOutputForSingletonOperatorChain();
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setStreamOperator(new StreamSource<>(new ExceptionThrowingSource()));
+		streamConfig.setOperatorID(new OperatorID());
+
+		testHarness.invoke();
+		ExceptionThrowingSource.isInRunLoop.get();
+		testHarness.getTask().cancel();
+
+		Optional<ExceptionThrowingSource.TestException> testException = Optional.empty();
+		try {
+			testHarness.waitForTaskCompletion();
+		} catch (Throwable t) {
+			testException = ExceptionUtils.findThrowable(
+					t,
+					ExceptionThrowingSource.TestException.class);
+		}
+
+		assertTrue(testException.isPresent());
+		assertThat(testException.get(), isA(ExceptionThrowingSource.TestException.class));
+	}
+
+	/**
+	 * If finishing a task doesn't swallow exceptions this test would fail with an exception.
+	 */
+	@Test
+	public void finishingIgnoresExceptions() throws Exception {
+		final StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(
+				SourceStreamTask::new,
+				BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness.setupOutputForSingletonOperatorChain();
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setStreamOperator(new StreamSource<>(new ExceptionThrowingSource()));
+		streamConfig.setOperatorID(new OperatorID());
+
+		testHarness.invoke();
+		ExceptionThrowingSource.isInRunLoop.get();
+		testHarness.getTask().finishTask();
+
+		testHarness.waitForTaskCompletion();
+	}
+
 	private static class MockSource implements SourceFunction<Tuple2<Long, Integer>>, ListCheckpointed<Serializable> {
 		private static final long serialVersionUID = 1;
 
@@ -404,6 +460,39 @@ public class SourceStreamTaskTest {
 
 		public static CompletableFuture<Void> getDataProcessing() {
 			return dataProcessing;
+		}
+	}
+
+	/**
+	 * A {@link SourceFunction} that throws an exception from {@link #run(SourceContext)} when it is
+	 * cancelled via {@link #cancel()}.
+	 */
+	private static class ExceptionThrowingSource implements SourceFunction<String> {
+
+		private volatile boolean running = true;
+		static CompletableFuture<Void> isInRunLoop = new CompletableFuture<>();
+
+		public static class TestException extends RuntimeException {
+			public TestException(String message) {
+				super(message);
+			}
+		}
+
+		@Override
+		public void run(SourceContext<String> ctx) throws TestException {
+			while (running) {
+				if (!isInRunLoop.isDone()) {
+					isInRunLoop.complete(null);
+				}
+				ctx.collect("hello");
+			}
+
+			throw new TestException("Oh no, we're failing.");
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Before, exceptions that occurred after cancelling a source (as the
KafkaConsumer did, for example) would make a job fail when attempting a
"stop-with-savepoint". Now we ignore those exceptions.

## Brief change log

- add a `isFinished` flag in `SourceStreamTask`
- check this flag before re-throwing exceptions

## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests in `SourceStreamTaskTest`

## Does this pull request potentially affect one of the following parts:

  - Checkpointing, yes, because it fixes stop-with-savepoint

## Documentation

  - Does this pull request introduce a new feature? no
