### PR TITLE
[FLINK-13264][table] Let the planner supply its type inference util

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionLookup.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionLookup.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.delegation.PlannerTypeInferenceUtil;
 import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.functions.FunctionDefinition;
 
@@ -48,6 +49,11 @@ public interface FunctionLookup {
 				)
 			);
 	}
+
+	/**
+	 * Temporary utility until the new type inference is fully functional.
+	 */
+	PlannerTypeInferenceUtil getPlannerTypeInferenceUtil();
 
 	/**
 	 * Result of a function lookup.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/PlannerTypeInferenceUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/PlannerTypeInferenceUtil.java
@@ -19,14 +19,12 @@
 package org.apache.flink.table.delegation;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeInferenceUtil;
 
-import java.lang.reflect.Constructor;
 import java.util.List;
 
 /**
@@ -36,40 +34,10 @@ import java.util.List;
 @Internal
 public interface PlannerTypeInferenceUtil {
 
-	static PlannerTypeInferenceUtil create() {
-		return SingletonPlannerTypeInferenceUtil.getPlannerTypeInferenceUtil();
-	}
-
 	/**
 	 * Same behavior as {@link TypeInferenceUtil#runTypeInference(TypeInference, CallContext)}.
 	 */
 	TypeInferenceUtil.Result runTypeInference(
 		UnresolvedCallExpression unresolvedCall,
 		List<ResolvedExpression> resolvedArgs);
-
-	/**
-	 * A singleton pattern utility for avoiding creating many {@link PlannerTypeInferenceUtil}.
-	 */
-	class SingletonPlannerTypeInferenceUtil {
-
-		private static PlannerTypeInferenceUtil plannerTypeInferenceUtil;
-
-		public static PlannerTypeInferenceUtil getPlannerTypeInferenceUtil() {
-			if (plannerTypeInferenceUtil == null) {
-				try {
-					final Class<?> clazz =
-						Class.forName("org.apache.flink.table.expressions.PlannerTypeInferenceUtilImpl");
-					final Constructor<?> con = clazz.getConstructor();
-					plannerTypeInferenceUtil = (PlannerTypeInferenceUtil) con.newInstance();
-				} catch (Throwable t) {
-					throw new TableException("Instantiation of PlannerTypeInferenceUtil failed.", t);
-				}
-			}
-			return plannerTypeInferenceUtil;
-		}
-
-		private SingletonPlannerTypeInferenceUtil() {
-			// no instantiation
-		}
-	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
@@ -162,7 +162,7 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 				UnresolvedCallExpression unresolvedCall,
 				List<ResolvedExpression> resolvedArgs) {
 
-			final PlannerTypeInferenceUtil util = PlannerTypeInferenceUtil.create();
+			final PlannerTypeInferenceUtil util = resolutionContext.functionLookup().getPlannerTypeInferenceUtil();
 
 			final TypeInferenceUtil.Result inferenceResult = util.runTypeInference(
 				unresolvedCall,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/PlannerTypeInferenceUtilImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/PlannerTypeInferenceUtilImpl.java
@@ -43,6 +43,8 @@ import static org.apache.flink.table.util.JavaScalaConversionUtil.toJava;
 @Internal
 public final class PlannerTypeInferenceUtilImpl implements PlannerTypeInferenceUtil {
 
+	public static final PlannerTypeInferenceUtil INSTANCE = new PlannerTypeInferenceUtilImpl();
+
 	private static final PlannerExpressionConverter CONVERTER = PlannerExpressionConverter.INSTANCE();
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/PlannerBase.scala
@@ -40,15 +40,15 @@ import org.apache.flink.table.sinks.{DataStreamTableSink, TableSink, TableSinkUt
 import org.apache.flink.table.sqlexec.SqlToOperationConverter
 import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter
 import org.apache.flink.table.util.JavaScalaConversionUtil
-
 import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.plan.{RelTrait, RelTraitDef}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.sql.{SqlIdentifier, SqlInsert, SqlKind}
 import org.apache.calcite.tools.FrameworkConfig
-
 import _root_.java.util.{List => JList}
 import java.util
+
+import org.apache.flink.table.expressions.PlannerTypeInferenceUtilImpl
 
 import _root_.scala.collection.JavaConversions._
 
@@ -70,6 +70,9 @@ abstract class PlannerBase(
     val functionCatalog: FunctionCatalog,
     catalogManager: CatalogManager)
   extends Planner {
+
+  // temporary utility until we don't use planner expressions anymore
+  functionCatalog.setPlannerTypeInferenceUtil(PlannerTypeInferenceUtilImpl.INSTANCE)
 
   executor.asInstanceOf[ExecutorBase].setTableConfig(config)
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/PlannerTypeInferenceUtilImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/PlannerTypeInferenceUtilImpl.java
@@ -42,6 +42,8 @@ import static org.apache.flink.table.util.JavaScalaConversionUtil.toJava;
 @Internal
 public final class PlannerTypeInferenceUtilImpl implements PlannerTypeInferenceUtil {
 
+	public static final PlannerTypeInferenceUtil INSTANCE = new PlannerTypeInferenceUtilImpl();
+
 	private static final PlannerExpressionConverter CONVERTER = PlannerExpressionConverter.INSTANCE();
 
 	@Override

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -67,6 +67,8 @@ abstract class TableEnvImpl(
   private[flink] val functionCatalog: FunctionCatalog = new FunctionCatalog(
     builtinCatalogName,
     builtinDatabaseName)
+  // temporary utility until we don't use planner expressions anymore
+  functionCatalog.setPlannerTypeInferenceUtil(PlannerTypeInferenceUtilImpl.INSTANCE)
 
   // temporary bridge between API and planner
   private[flink] val expressionBridge: ExpressionBridge[PlannerExpression] =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.catalog.{CatalogManager, CatalogManagerCalciteSche
 import org.apache.flink.table.delegation.{Executor, Planner}
 import org.apache.flink.table.executor.StreamExecutor
 import org.apache.flink.table.explain.PlanJsonParser
-import org.apache.flink.table.expressions.{ExpressionBridge, PlannerExpression, PlannerExpressionConverter}
+import org.apache.flink.table.expressions.{ExpressionBridge, PlannerExpression, PlannerExpressionConverter, PlannerTypeInferenceUtilImpl}
 import org.apache.flink.table.factories.{TableFactoryService, TableFactoryUtil, TableSinkFactory}
 import org.apache.flink.table.operations.OutputConversionModifyOperation.UpdateMode
 import org.apache.flink.table.operations._
@@ -41,13 +41,11 @@ import org.apache.flink.table.sinks._
 import org.apache.flink.table.sqlexec.SqlToOperationConverter
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.table.util.JavaScalaConversionUtil
-
 import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.sql.{SqlIdentifier, SqlInsert, SqlKind}
-
 import _root_.java.lang.{Boolean => JBool}
 import _root_.java.util
 import _root_.java.util.{Objects, List => JList}
@@ -71,7 +69,10 @@ class StreamPlanner(
     config: TableConfig,
     functionCatalog: FunctionCatalog,
     catalogManager: CatalogManager)
-  extends Planner{
+  extends Planner {
+
+  // temporary utility until we don't use planner expressions anymore
+  functionCatalog.setPlannerTypeInferenceUtil(PlannerTypeInferenceUtilImpl.INSTANCE)
 
   private val internalSchema: CalciteSchema =
     asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false))


### PR DESCRIPTION
## What is the purpose of the change

This PR makes it possible that `org.apache.flink.table.expressions.PlannerTypeInferenceUtilImpl` can be relocated in each planner module while the API does not need to perform any reflection-based lookup.

## Brief change log

Planner supplies its type inference util.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
