### PR TITLE
[FLINK-13223][dist] Enable fine-grained recovery by default in distribution

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -186,7 +186,7 @@ public class JobManagerOptions {
 	@Documentation.ExcludeFromDocumentation("dev use only; likely temporary")
 	public static final ConfigOption<Boolean> FORCE_PARTITION_RELEASE_ON_CONSUMPTION =
 			key("jobmanager.scheduler.partition.force-release-on-consumption")
-			.defaultValue(true);
+			.defaultValue(false);
 
 	// ---------------------------------------------------------------------------------------------
 

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -120,6 +120,12 @@ parallelism.default: 1
 #
 # state.backend.incremental: false
 
+# The failover strategy, i.e., how the job computation recovers from task failures.
+# Only restart tasks that may have been affected by the task failure, which typically includes
+# downstream tasks and potentially upstream tasks if their produced data is no longer available for consumption.
+
+jobmanager.execution.failover-strategy: region
+
 #==============================================================================
 # Rest & web frontend
 #==============================================================================

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -29,6 +29,8 @@ echo "Executing test with ${OPENSSL_LINKAGE} openSSL linkage (random selection b
 s3_setup hadoop
 set_conf_ssl "mutual" "OPENSSL" "${OPENSSL_LINKAGE}"
 set_config_key "metrics.fetcher.update-interval" "2000"
+# this test relies on global failovers
+set_config_key "jobmanager.execution.failover-strategy", "full"
 
 OUT=temp/test_streaming_file_sink-$(uuidgen)
 OUTPUT_PATH="$TEST_DATA_DIR/$OUT"

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -30,7 +30,7 @@ s3_setup hadoop
 set_conf_ssl "mutual" "OPENSSL" "${OPENSSL_LINKAGE}"
 set_config_key "metrics.fetcher.update-interval" "2000"
 # this test relies on global failovers
-set_config_key "jobmanager.execution.failover-strategy", "full"
+set_config_key "jobmanager.execution.failover-strategy" "full"
 
 OUT=temp/test_streaming_file_sink-$(uuidgen)
 OUTPUT_PATH="$TEST_DATA_DIR/$OUT"


### PR DESCRIPTION
Enables fine-grained recovery by default in the flink distribution. We don't enable it by default for all tests since too many tests make implicit assumptions about the failover behavior, that is they rely on every task being restarted on failure.

Change log:
* disables `FORCE_PARTITION_RELEASE_ON_CONSUMPTION` as otherwise fine-grained recovery cannot really work; this change should be safe for tests
* sets the failover strategy to "region" in the flink-conf.yaml contained in the distribution
* disables fine-grained recovery in the StreamingFileSink E2E test since it relies on global failovers to occur

@KurtYoung @tzulitai I would like to include this in 1.9, as otherwise I fear this feature will go largely unnoticed by new users and during testing.