### PR TITLE
[FLINK-13206][sql client]replace `use database xxx` with `use xxx` in sql client parser

### DIFF
--- a/docs/dev/table/catalog.md
+++ b/docs/dev/table/catalog.md
@@ -63,7 +63,9 @@ select * from mydb2.myTable2
 
 `CatalogManager` always has a built-in `GenericInMemoryCatalog` named `default_catalog`, which has a built-in default database named `default_database`. If no other catalog and database are explicitly set, they will be the current catalog and current database by default. All temp meta-objects, such as those defined by `TableEnvironment#registerTable`  are registered to this catalog. 
 
-Users can set current catalog and database via `TableEnvironment.useCatalog(...)` and `TableEnvironment.useDatabase(...)` in Table API, or `USE CATALOG ...` and `USE ...` in Flink SQL.
+Users can set current catalog and database via `TableEnvironment.useCatalog(...)` and 
+`TableEnvironment.useDatabase(...)` in Table API, or `USE CATALOG ...` and `USE ...` in Flink SQL
+ Client.
 
 
 Catalog Types

--- a/docs/dev/table/catalog.md
+++ b/docs/dev/table/catalog.md
@@ -63,7 +63,7 @@ select * from mydb2.myTable2
 
 `CatalogManager` always has a built-in `GenericInMemoryCatalog` named `default_catalog`, which has a built-in default database named `default_database`. If no other catalog and database are explicitly set, they will be the current catalog and current database by default. All temp meta-objects, such as those defined by `TableEnvironment#registerTable`  are registered to this catalog. 
 
-Users can set current catalog and database via `TableEnvironment.useCatalog(...)` and `TableEnvironment.useDatabase(...)` in Table API, or `USE CATALOG ...` and `USE DATABASE ...` in Flink SQL.
+Users can set current catalog and database via `TableEnvironment.useCatalog(...)` and `TableEnvironment.useDatabase(...)` in Table API, or `USE CATALOG ...` and `USE ...` in Flink SQL.
 
 
 Catalog Types
@@ -337,7 +337,7 @@ default_catalog
 # ------ Set default catalog and database ------
 
 Flink SQL> use catalog myHive1;
-Flink SQL> use database myDb;
+Flink SQL> use myDb;
 
 # ------ Access Hive metadata ------
 

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -322,7 +322,7 @@ USE CATALOG mycatalog;
 {% endhighlight %}
             <p>Set current database of the current catalog for the session</p>
 {% highlight sql %}
-USE DATABASE mydatabase;
+USE mydatabase;
 {% endhighlight %}
       </td>
     </tr>

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -104,7 +104,7 @@ public final class SqlCommandParser {
 			SINGLE_OPERAND),
 
 		USE_DATABASE(
-			"USE\\s+DATABASE\\s+(.*)",
+			"USE\\s+(?!CATALOG)(.*)",
 			SINGLE_OPERAND),
 
 		DESCRIBE(

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -76,6 +76,7 @@ public class SqlCommandParserTest {
 		testInvalidSqlCommand("source"); // missing path
 		testValidSqlCommand("USE CATALOG default", new SqlCommandCall(SqlCommand.USE_CATALOG, new String[]{"default"}));
 		testValidSqlCommand("use default", new SqlCommandCall(SqlCommand.USE_DATABASE, new String[] {"default"}));
+		testInvalidSqlCommand("use catalog");
 	}
 
 	private void testInvalidSqlCommand(String stmt) {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -74,6 +74,8 @@ public class SqlCommandParserTest {
 		testValidSqlCommand("reset;", new SqlCommandCall(SqlCommand.RESET));
 		testValidSqlCommand("source /my/file", new SqlCommandCall(SqlCommand.SOURCE, new String[] {"/my/file"}));
 		testInvalidSqlCommand("source"); // missing path
+		testValidSqlCommand("USE CATALOG default", new SqlCommandCall(SqlCommand.USE_CATALOG, new String[]{"default"}));
+		testValidSqlCommand("use default", new SqlCommandCall(SqlCommand.USE_DATABASE, new String[] {"default"}));
 	}
 
 	private void testInvalidSqlCommand(String stmt) {


### PR DESCRIPTION
## What is the purpose of the change

Replace `use database xxx` with `use xxx` in sql client parser 


## Brief change log
  - *modify use database in sql client*


## Verifying this change
This change is already covered by existing tests, such as *SqlCommandParserTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
