### PR TITLE
[FLINK-13216][FLINK-13153][table-planner-blink] Fix Max_Retract and Min_Retract may produce incorrect result

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/MaxWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/MaxWithRetractAggFunction.java
@@ -135,6 +135,8 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 		// when both of them are expired.
 		if (!hasMax) {
 			acc.mapSize = 0L;
+			// we should also override max value, because it may have an old value.
+			acc.max = null;
 		}
 	}
 
@@ -142,7 +144,7 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 		boolean needUpdateMax = false;
 		for (MaxWithRetractAccumulator<T> a : its) {
 			// set max element
-			if (acc.mapSize == 0 || (a.max != null && acc.max.compareTo(a.max) < 0)) {
+			if (acc.mapSize == 0 || (a.mapSize > 0 && a.max != null && acc.max.compareTo(a.max) < 0)) {
 				acc.max = a.max;
 			}
 			// merge the count for each key
@@ -195,7 +197,7 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 
 	@Override
 	public T getValue(MaxWithRetractAccumulator<T> acc) {
-		if (acc.mapSize != 0) {
+		if (acc.mapSize > 0) {
 			return acc.max;
 		} else {
 			return null;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/MinWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/aggfunctions/MinWithRetractAggFunction.java
@@ -135,6 +135,8 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 		// when both of them are expired.
 		if (!hasMin) {
 			acc.mapSize = 0L;
+			// we should also override min value, because it may have an old value.
+			acc.min = null;
 		}
 	}
 
@@ -142,7 +144,7 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 		boolean needUpdateMin = false;
 		for (MinWithRetractAccumulator<T> a : its) {
 			// set min element
-			if (acc.mapSize == 0 || (a.min != null && acc.min.compareTo(a.min) > 0)) {
+			if (acc.mapSize == 0 || (a.mapSize > 0 && a.min != null && acc.min.compareTo(a.min) > 0)) {
 				acc.min = a.min;
 			}
 			// merge the count for each key
@@ -195,7 +197,7 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 
 	@Override
 	public T getValue(MinWithRetractAccumulator<T> acc) {
-		if (acc.mapSize != 0) {
+		if (acc.mapSize > 0) {
 			return acc.min;
 		} else {
 			return null;


### PR DESCRIPTION



<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix unstable tests failed on travis, including `AggregateITCase.testNestedGroupByAgg` and `SplitAggregateITCase.testMinMaxWithRetraction`.


## Brief change log


The reason is we didn't set null to acc.max/min which may have an old value when we need to get a new max/min from an empty MapView. And the old value will be output to downstream instead of a null value. This influences the final result. 

This causes many unstable cases, which all contains max/min with retract, including:
- AggregateITCase.testNestedGroupByAgg
- SplitAggregateITCase.testMinMaxWithRetraction


## Verifying this change

The situation is not reproduced 100%. I tested in my local machine, for example, `AggregateITCase.testNestedGroupByAgg` can reproduce this problem every 100 times. After fix this problem, I didn't reproduce this problem after running 1000 times.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
