### PR TITLE
[FLINK-13825][e2e] Restore original plugins dir in flink distribution after test run

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -78,29 +78,26 @@ function print_mem_use {
     fi
 }
 
+BACKUP_FLINK_DIRS="conf lib plugins"
+
 function backup_flink_dir() {
     mkdir -p "${TEST_DATA_DIR}/tmp/backup"
     # Note: not copying all directory tree, as it may take some time on some file systems.
-    cp -r "${FLINK_DIR}/conf" "${TEST_DATA_DIR}/tmp/backup/"
-    cp -r "${FLINK_DIR}/lib" "${TEST_DATA_DIR}/tmp/backup/"
+    for dirname in ${BACKUP_FLINK_DIRS}; do
+        cp -r "${FLINK_DIR}/${dirname}" "${TEST_DATA_DIR}/tmp/backup/"
+    done
 }
 
 function revert_flink_dir() {
 
-    if [ -d "${TEST_DATA_DIR}/tmp/backup/conf" ]; then
-        rm -rf "${FLINK_DIR}/conf"
-        mv "${TEST_DATA_DIR}/tmp/backup/conf" "${FLINK_DIR}/"
-    fi
-
-    if [ -d "${TEST_DATA_DIR}/tmp/backup/lib" ]; then
-        rm -rf "${FLINK_DIR}/lib"
-        mv "${TEST_DATA_DIR}/tmp/backup/lib" "${FLINK_DIR}/"
-    fi
+    for dirname in ${BACKUP_FLINK_DIRS}; do
+        if [ -d "${TEST_DATA_DIR}/tmp/backup/${dirname}" ]; then
+            rm -rf "${FLINK_DIR}/${dirname}"
+            mv "${TEST_DATA_DIR}/tmp/backup/${dirname}" "${FLINK_DIR}/"
+        fi
+    done
 
     rm -r "${TEST_DATA_DIR}/tmp/backup"
-
-    # By default, the plugins dir doesn't exist. Some tests may have created it.
-    rm -r "${FLINK_DIR}/plugins"
 
     REST_PROTOCOL="http"
     CURL_SSL_ARGS=""


### PR DESCRIPTION
## What is the purpose of the change

Keep the Flink distribution directory as original one after running tests in `flink-end-to-end-tests/test-scripts`.

## Brief change log

  - `backup_flink_dir/revert_flink_dir` have been modified to backup and copy back the original `plugins` directory of Flink distribution dir

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. Can be verified by running some e2e test and checked manually that the `plugins` dir in the Flink distribution dir contains `README.txt`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
