### PR TITLE
[FLINK-13281] Fix the verify logic of AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
@@ -97,7 +97,10 @@ public class AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest 
 		// the failover strategy should then cancel all pending checkpoints on restart
 		checkpointCoordinator.receiveAcknowledgeMessage(acknowledgeCheckpoint, "Unknown location");
 		assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+
 		failVertex(firstExecutionVertex);
+		assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+		manualMainThreadExecutor.triggerScheduledTasks();
 
 		assertNoPendingCheckpoints(checkpointCoordinator);
 	}
@@ -114,7 +117,6 @@ public class AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest 
 	private void failVertex(final ExecutionVertex onlyExecutionVertex) {
 		onlyExecutionVertex.getCurrentExecutionAttempt().fail(new Exception("Test Exception"));
 		manualMainThreadExecutor.triggerAll();
-		manualMainThreadExecutor.triggerScheduledTasks();
 	}
 
 	private static JobGraph createStreamingJobGraph() {


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-13060](https://issues.apache.org/jira/browse/FLINK-13060) ensure FailoverStrategies should respect restart constraints. However, this change did not cover the `AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest` which should also set as `FixedDelayRestartStrategy`. Currently, as the pending checkpoint would still be discarded due to `failUnacknowledgedPendingCheckpoints` within `CheckpointCoordinator`, `AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest` could pass the test.

This is actually not what we want the test did, we should actually verify that when region failover, pending checkpoints would be discarded.

## Brief change log

* Fix the verify logic of `AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest`

## Verifying this change

This change modify previous test `AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
