### PR TITLE
[FLINK-13280][table-planner-blink] Revert blink changes in DateTimeUt…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -485,4 +485,9 @@ object BuiltInMethods {
     "convertTz",
     classOf[String], classOf[String], classOf[String], classOf[String])
 
+  val STRING_TO_DATE = Types.lookupMethod(
+    classOf[SqlDateTimeUtils], "dateStringToUnixDate", classOf[String])
+
+  val STRING_TO_TIME = Types.lookupMethod(
+    classOf[SqlDateTimeUtils], "timeStringToUnixDate", classOf[String])
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperatorGens.scala
@@ -892,7 +892,7 @@ object ScalarOperatorGens {
         operand,
         resultNullable = true) {
         operandTerm =>
-          s"${qualifyMethod(BuiltInMethod.STRING_TO_DATE.method)}($operandTerm.toString())"
+          s"${qualifyMethod(BuiltInMethods.STRING_TO_DATE)}($operandTerm.toString())"
       }
 
     // String -> Time
@@ -903,7 +903,7 @@ object ScalarOperatorGens {
         operand, 
         resultNullable = true) {
         operandTerm =>
-          s"${qualifyMethod(BuiltInMethod.STRING_TO_TIME.method)}($operandTerm.toString())"
+          s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString())"
       }
 
     // String -> Timestamp
@@ -2146,9 +2146,9 @@ object ScalarOperatorGens {
       operandTerm: String): String =
     targetType.getTypeRoot match {
       case DATE =>
-        s"${qualifyMethod(BuiltInMethod.STRING_TO_DATE.method)}($operandTerm.toString())"
+        s"${qualifyMethod(BuiltInMethods.STRING_TO_DATE)}($operandTerm.toString())"
       case TIME_WITHOUT_TIME_ZONE =>
-        s"${qualifyMethod(BuiltInMethod.STRING_TO_TIME.method)}($operandTerm.toString())"
+        s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString())"
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         s"""
            |${qualifyMethod(BuiltInMethods.STRING_TO_TIMESTAMP)}($operandTerm.toString())

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/codegen/calls/StringCallGen.scala
@@ -184,7 +184,7 @@ object StringCallGen {
       // Date/Time & BinaryString Converting -- start
 
       case TO_DATE if operands.size == 1 && isCharacterString(operands.head.resultType) =>
-        methodGen(BuiltInMethod.STRING_TO_DATE.method)
+        methodGen(BuiltInMethods.STRING_TO_DATE)
 
       case TO_DATE if operands.size == 2 &&
           isCharacterString(operands.head.resultType) &&


### PR DESCRIPTION
…ils, and keep it same as flink version

## What is the purpose of the change

revert blink changes in DateTimeUtils, and keep it same as flink version

## Brief change log

- revert DateTimeUtils
- move changes in **dateStringToUnixDate** and **timeStringToUnixDate** to **SqlDateTimeUtils** and fix test & codegen
- move **unixDateTimeToString** to **TestSinkUtil**

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
