### PR TITLE
[FLINK-12858][checkpointing] Stop-with-savepoint, workaround: fail whole job when savepoint is declined by a task

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -23,60 +23,69 @@ package org.apache.flink.runtime.checkpoint;
  */
 public enum CheckpointFailureReason {
 
-	PERIODIC_SCHEDULER_SHUTDOWN("Periodic checkpoint scheduler is shut down."),
+	PERIODIC_SCHEDULER_SHUTDOWN(true, "Periodic checkpoint scheduler is shut down."),
 
-	ALREADY_QUEUED("Another checkpoint request has already been queued."),
+	ALREADY_QUEUED(true, "Another checkpoint request has already been queued."),
 
-	TOO_MANY_CONCURRENT_CHECKPOINTS("The maximum number of concurrent checkpoints is exceeded"),
+	TOO_MANY_CONCURRENT_CHECKPOINTS(true, "The maximum number of concurrent checkpoints is exceeded"),
 
-	MINIMUM_TIME_BETWEEN_CHECKPOINTS("The minimum time between checkpoints is still pending. " +
+	MINIMUM_TIME_BETWEEN_CHECKPOINTS(true, "The minimum time between checkpoints is still pending. " +
 			"Checkpoint will be triggered after the minimum time."),
 
-	NOT_ALL_REQUIRED_TASKS_RUNNING("Not all required tasks are currently running."),
+	NOT_ALL_REQUIRED_TASKS_RUNNING(true, "Not all required tasks are currently running."),
 
-	EXCEPTION("An Exception occurred while triggering the checkpoint."),
+	EXCEPTION(true, "An Exception occurred while triggering the checkpoint."),
 
-	CHECKPOINT_EXPIRED("Checkpoint expired before completing."),
+	CHECKPOINT_EXPIRED(false, "Checkpoint expired before completing."),
 
-	CHECKPOINT_SUBSUMED("Checkpoint has been subsumed."),
+	CHECKPOINT_SUBSUMED(false, "Checkpoint has been subsumed."),
 
-	CHECKPOINT_DECLINED("Checkpoint was declined."),
+	CHECKPOINT_DECLINED(false, "Checkpoint was declined."),
 
-	CHECKPOINT_DECLINED_TASK_NOT_READY("Checkpoint was declined (tasks not ready)"),
+	CHECKPOINT_DECLINED_TASK_NOT_READY(false, "Checkpoint was declined (tasks not ready)"),
 
-	CHECKPOINT_DECLINED_TASK_NOT_CHECKPOINTING("Task does not support checkpointing"),
+	CHECKPOINT_DECLINED_TASK_NOT_CHECKPOINTING(false, "Task does not support checkpointing"),
 
-	CHECKPOINT_DECLINED_SUBSUMED("Checkpoint was canceled because a barrier from newer checkpoint was received."),
+	CHECKPOINT_DECLINED_SUBSUMED(false, "Checkpoint was canceled because a barrier from newer checkpoint was received."),
 
-	CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER("Task received cancellation from one of its inputs"),
+	CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER(false, "Task received cancellation from one of its inputs"),
 
-	CHECKPOINT_DECLINED_ALIGNMENT_LIMIT_EXCEEDED("The checkpoint alignment phase needed to buffer more than the configured maximum bytes"),
+	CHECKPOINT_DECLINED_ALIGNMENT_LIMIT_EXCEEDED(false, "The checkpoint alignment phase needed to buffer more than the configured maximum bytes"),
 
-	CHECKPOINT_DECLINED_INPUT_END_OF_STREAM("Checkpoint was declined because one input stream is finished"),
+	CHECKPOINT_DECLINED_INPUT_END_OF_STREAM(false, "Checkpoint was declined because one input stream is finished"),
 
-	CHECKPOINT_COORDINATOR_SHUTDOWN("CheckpointCoordinator shutdown."),
+	CHECKPOINT_COORDINATOR_SHUTDOWN(true, "CheckpointCoordinator shutdown."),
 
-	CHECKPOINT_COORDINATOR_SUSPEND("Checkpoint Coordinator is suspending."),
+	CHECKPOINT_COORDINATOR_SUSPEND(false, "Checkpoint Coordinator is suspending."),
 
-	JOB_FAILURE("The job has failed."),
+	JOB_FAILURE(false, "The job has failed."),
 
-	JOB_FAILOVER_REGION("FailoverRegion is restarting."),
+	JOB_FAILOVER_REGION(false, "FailoverRegion is restarting."),
 
-	TASK_CHECKPOINT_FAILURE("Task local checkpoint failure."),
+	TASK_CHECKPOINT_FAILURE(false, "Task local checkpoint failure."),
 
-	FINALIZE_CHECKPOINT_FAILURE("Failure to finalize checkpoint."),
+	FINALIZE_CHECKPOINT_FAILURE(false, "Failure to finalize checkpoint."),
 
-	TRIGGER_CHECKPOINT_FAILURE("Trigger checkpoint failure.");
+	TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure.");
 
 	// ------------------------------------------------------------------------
 
+	private final boolean isPreFlight;
 	private final String message;
 
-	CheckpointFailureReason(String message) {
+	CheckpointFailureReason(boolean isPreFlight, String message) {
+		this.isPreFlight = isPreFlight;
 		this.message = message;
 	}
 
 	public String message() {
 		return message;
+	}
+
+	/**
+	 * @return true if this value indicates a failure reason happening before a checkpoint is passed to a job's tasks.
+	 */
+	public boolean isPreFlight() {
+		return isPreFlight;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
@@ -75,6 +77,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.function.FunctionUtils;
@@ -618,6 +621,13 @@ public class LegacyScheduler implements SchedulerNG {
 			.handle((completedCheckpoint, throwable) -> {
 				if (throwable != null) {
 					log.info("Failed during stopping job {} with a savepoint. Reason: {}", jobGraph.getJobID(), throwable.getMessage());
+					// it's possible this failure hasn't triggered a task failure, but rather the savepoint was aborted
+					// "softly" (for example on checkpoints barriers alignment, due to buffer limits).
+					// such situation may leave other tasks of the job in a blocking state.
+					// to workaround this, we fail the whole job.
+					if (!isCheckpointPreFlightFailure(throwable)) {
+						executionGraph.failGlobal(throwable);
+					}
 					throw new CompletionException(throwable);
 				}
 				return completedCheckpoint.getExternalPointer();
@@ -648,5 +658,12 @@ public class LegacyScheduler implements SchedulerNG {
 			.map(Execution::getAssignedResourceLocation)
 			.map(TaskManagerLocation::toString)
 			.orElse("Unknown location");
+	}
+
+	private static boolean isCheckpointPreFlightFailure(Throwable throwable) {
+		return ExceptionUtils.findThrowable(throwable, CheckpointException.class)
+			.map(CheckpointException::getCheckpointFailureReason)
+			.map(CheckpointFailureReason::isPreFlight)
+			.orElse(false);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request is an attempt to address hanging Flink job when stop-with-savepoint fails due to decline of the savepoint by job's task. In such cases, the job manager would fail the whole execution graph (which may trigger a job restart).

## Brief change log

  - The `LegacyScheduler` is modified to track `CheckpointException`s in `stopWithSavepoint()` that originate from tasks and fails the execution graph for such exceptions.

## Verifying this change

This change was partially tested by manual e2e test:
 * configured Flink cluster with savepoints/checkpoints setup and `task.checkpoint.alignment.max-size: 64` set;
 * a test Flink job with two congested sources (joined in `map-1`) and events that exceed the configured limit (see execution graph below).

In the test job, the `map-1` with high probability rejects checkpoint/savepoints due to `checkpointSizeLimitExceeded`.

![job-graph](https://user-images.githubusercontent.com/488251/61300624-9b368600-a7e2-11e9-8d9c-62e936689a79.png)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
