### PR TITLE
[FLINK-13245][network] Fix the bug of resource leak while releasing partition and view reader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -138,9 +138,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 		}
 
 		for (NetworkSequenceViewReader reader : allReaders.values()) {
-			reader.notifySubpartitionConsumed();
-			reader.releaseAllResources();
-			markAsReleased(reader.getReceiverId());
+			releaseViewReader(reader, true);
 		}
 		allReaders.clear();
 	}
@@ -307,8 +305,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 	private void releaseAllResources() throws IOException {
 		// note: this is only ever executed by one thread: the Netty IO thread!
 		for (NetworkSequenceViewReader reader : allReaders.values()) {
-			reader.releaseAllResources();
-			markAsReleased(reader.getReceiverId());
+			releaseViewReader(reader, false);
 		}
 
 		availableReaders.clear();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.io.network.partition.ProducerFailedException;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 
-import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFutureListener;
@@ -40,7 +39,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -61,8 +59,6 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 
 	/** All the readers created for the consumers' partition requests. */
 	private final ConcurrentMap<InputChannelID, NetworkSequenceViewReader> allReaders = new ConcurrentHashMap<>();
-
-	private final Set<InputChannelID> released = Sets.newHashSet();
 
 	private boolean fatalError;
 
@@ -175,9 +171,6 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 		} else if (msg.getClass() == InputChannelID.class) {
 			// Release partition view that get a cancel request.
 			InputChannelID toCancel = (InputChannelID) msg;
-			if (released.contains(toCancel)) {
-				return;
-			}
 
 			// remove reader from queue of available readers
 			availableReaders.removeIf(reader -> reader.getReceiverId().equals(toCancel));
@@ -222,7 +215,6 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 					if (!reader.isReleased()) {
 						continue;
 					}
-					markAsReleased(reader.getReceiverId());
 
 					Throwable cause = reader.getFailureCause();
 					if (cause != null) {
@@ -317,14 +309,6 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 
 		reader.setRegisteredAsAvailable(false);
 		reader.releaseAllResources();
-		markAsReleased(reader.getReceiverId());
-	}
-
-	/**
-	 * Marks a receiver as released.
-	 */
-	private void markAsReleased(InputChannelID receiverId) {
-		released.add(receiverId);
 	}
 
 	// This listener is called after an element of the current nonEmptyReader has been

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -134,7 +134,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 		}
 
 		for (NetworkSequenceViewReader reader : allReaders.values()) {
-			releaseViewReader(reader, true);
+			releaseViewReader(reader);
 		}
 		allReaders.clear();
 	}
@@ -178,7 +178,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 			// remove reader from queue of all readers and release its resource
 			final NetworkSequenceViewReader toRelease = allReaders.remove(toCancel);
 			if (toRelease != null) {
-				releaseViewReader(toRelease, true);
+				releaseViewReader(toRelease);
 			}
 		} else {
 			ctx.fireUserEventTriggered(msg);
@@ -293,20 +293,15 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 	private void releaseAllResources() throws IOException {
 		// note: this is only ever executed by one thread: the Netty IO thread!
 		for (NetworkSequenceViewReader reader : allReaders.values()) {
-			releaseViewReader(reader, false);
+			releaseViewReader(reader);
 		}
 
 		availableReaders.clear();
 		allReaders.clear();
 	}
 
-	private void releaseViewReader(
-			NetworkSequenceViewReader reader,
-			boolean shouldNotifyConsumed) throws IOException {
-		if (shouldNotifyConsumed) {
-			reader.notifySubpartitionConsumed();
-		}
-
+	private void releaseViewReader(NetworkSequenceViewReader reader) throws IOException {
+		reader.notifySubpartitionConsumed();
 		reader.setRegisteredAsAvailable(false);
 		reader.releaseAllResources();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -109,7 +109,7 @@ public class CancelPartitionRequestTest {
 			}
 
 			verify(view, times(1)).releaseAllResources();
-			verify(view, times(0)).notifySubpartitionConsumed();
+			verify(view, times(1)).notifySubpartitionConsumed();
 		}
 		finally {
 			shutdown(serverAndClient);
@@ -168,7 +168,7 @@ public class CancelPartitionRequestTest {
 			NettyTestUtil.awaitClose(ch);
 
 			verify(view, times(1)).releaseAllResources();
-			verify(view, times(0)).notifySubpartitionConsumed();
+			verify(view, times(1)).notifySubpartitionConsumed();
 		}
 		finally {
 			shutdown(serverAndClient);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Optional;
 
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferConsumer;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -157,5 +158,12 @@ public class PartitionTestUtils {
 			1,
 			true,
 			releaseType);
+	}
+
+	public static void writeBuffers(ResultPartition partition, int numberOfBuffers, int bufferSize) throws IOException {
+		for (int i = 0; i < numberOfBuffers; i++) {
+			partition.addBufferConsumer(createFilledBufferConsumer(bufferSize, bufferSize), 0);
+		}
+		partition.finish();
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*The view reader release and the relevant partition release based on reference counter in `ReleaseOnConsumptionResultPartition` do not work correctly within expection, which would result in resource leak. In order to fix this issue we need to adjust the following parts:*

*1. On producer side the netty stack handles the `CancelPartitionRequest` via finding the proper view from available queue atm. But the corresponding view might not always be available, so it is reasonable to trace it from all readers queue instead.*

*2. We could always call `NetworkSequenceViewReader#notifySubpartitionConsumed` along with `NetworkSequenceViewReader#releaseAllResources` in any cases. Then the reference counter based release could work correctly in `ReleaseOnConsumptionResultPartition` and the logic is simple in netty stack.*

*3. In the implementation of `ReleaseOnConsumptionResultPartition#onConsumedSubpartition`, if one subpartition is consumed multiple times, the reference counter is also decreased multiple times. Then it would cause the whole result partition released after only partial subpartitions consumed multiple times. A boolean tag is added for indicating the state of every subpartition.*

## Brief change log

  - *Fix the logic in handling `CancelPartitionRequest` in `PartitionRequestQueue`*
  - *Always calling `notifySubpartitionConsumed` while calling `releaseAllResources`*
  - *Remove redundant bookkeeping for already canceled input channel IDs*
  - *Add the boolean tag for every subpartition to avoid decrease reference counter multiple times for one subpartition in `ReleaseOnConsumptionResultPartition`.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for verifying the partition and view are both released while receiving `CancelPartitionRequest` for the case of available/unavailable view.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)