### PR TITLE
[FLINK-13293][state-processor-api][build] Add state processor api to opt/ directory in flink-dist

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -308,6 +308,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-state-processor-api_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-azure-fs-hadoop</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -75,6 +75,14 @@
 			<fileMode>0644</fileMode>
 		</file>
 
+		<!-- State Processor API -->
+		<file>
+			<source>../flink-libraries/flink-state-processing-api/target/flink-state-processor-api_${scala.binary.version}-${project.version}.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-state-processor-api_${scala.binary.version}-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
 		<!-- Metrics -->
 		<file>
 			<source>../flink-metrics/flink-metrics-graphite/target/flink-metrics-graphite-${project.version}.jar</source>


### PR DESCRIPTION
## What is the purpose of the change

Similarly to flinks other libraries (cep, gelly, etc) the state processor api should be bundled in the opt directory of flink dist


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage. Manually verified. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable