### PR TITLE
[FLINK-12249][table] Fix type equivalence check problems for Window Aggregates

### DIFF
--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -106,9 +106,7 @@ public class StreamSQLTestProgram {
 		String tumbleQuery = String.format(
 			"SELECT " +
 			"  key, " +
-			//TODO: The "WHEN -1 THEN NULL" part is a temporary workaround, to make the test pass, for
-			// https://issues.apache.org/jira/browse/FLINK-12249. We should remove it once the issue is fixed.
-			"  CASE SUM(cnt) / COUNT(*) WHEN 101 THEN 1 WHEN -1 THEN NULL ELSE 99 END AS correct, " +
+			"  CASE SUM(cnt) / COUNT(*) WHEN 101 THEN 1 ELSE 99 END AS correct, " +
 			"  TUMBLE_START(rowtime, INTERVAL '%d' SECOND) AS wStart, " +
 			"  TUMBLE_ROWTIME(rowtime, INTERVAL '%d' SECOND) AS rowtime " +
 			"FROM (%s) " +

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.xml
@@ -1409,4 +1409,111 @@ Calc(select=[w$end AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+    <TestCase name="testReturnTypeInferenceForWindowAgg[aggStrategy=AUTO]">
+        <Resource name="sql">
+            <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(b, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, b
+  FROM MyTable
+)
+GROUP BY TUMBLE(b, INTERVAL '15' MINUTE)
+      ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($1, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+Calc(select=[CAST(CASE(=($f1, 0), null:INTEGER, s)) AS s, CAST(/(CAST(CASE(=($f1, 0), null:INTEGER, s)), $f1)) AS a, w$start AS wStart])
++- HashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[Final_$SUM0(sum$0) AS s, Final_COUNT(count1$1) AS $f1])
+   +- Exchange(distribution=[single])
+      +- LocalHashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[Partial_$SUM0($f1) AS sum$0, Partial_COUNT(*) AS count1$1])
+         +- Calc(select=[b, CASE(=(a, 1), 1, 99) AS $f1])
+            +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testReturnTypeInferenceForWindowAgg[aggStrategy=ONE_PHASE]">
+        <Resource name="sql">
+            <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(b, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, b
+  FROM MyTable
+)
+GROUP BY TUMBLE(b, INTERVAL '15' MINUTE)
+      ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($1, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+Calc(select=[CAST(CASE(=($f1, 0), null:INTEGER, s)) AS s, CAST(/(CAST(CASE(=($f1, 0), null:INTEGER, s)), $f1)) AS a, w$start AS wStart])
++- HashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[$SUM0($f1) AS s, COUNT(*) AS $f1])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[b, CASE(=(a, 1), 1, 99) AS $f1])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testReturnTypeInferenceForWindowAgg[aggStrategy=TWO_PHASE]">
+        <Resource name="sql">
+            <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(b, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, b
+  FROM MyTable
+)
+GROUP BY TUMBLE(b, INTERVAL '15' MINUTE)
+      ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($1, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+Calc(select=[CAST(CASE(=($f1, 0), null:INTEGER, s)) AS s, CAST(/(CAST(CASE(=($f1, 0), null:INTEGER, s)), $f1)) AS a, w$start AS wStart])
++- HashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[Final_$SUM0(sum$0) AS s, Final_COUNT(count1$1) AS $f1])
+   +- Exchange(distribution=[single])
+      +- LocalHashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[Partial_$SUM0($f1) AS sum$0, Partial_COUNT(*) AS count1$1])
+         +- Calc(select=[b, CASE(=(a, 1), 1, 99) AS $f1])
+            +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+        </Resource>
+    </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -467,4 +467,39 @@ Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
 ]]>
     </Resource>
   </TestCase>
+    <TestCase name="testReturnTypeInferenceForWindowAgg">
+        <Resource name="sql">
+            <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(rowtime, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, rowtime
+  FROM MyTable
+)
+GROUP BY TUMBLE(rowtime, INTERVAL '15' MINUTE)
+      ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($4, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+Calc(select=[CAST(CASE(=($f1, 0), null:INTEGER, s)) AS s, CAST(/(CAST(CASE(=($f1, 0), null:INTEGER, s)), $f1)) AS a, w$start AS wStart])
++- GroupWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime, w$proctime], select=[$SUM0($f1) AS s, COUNT(*) AS $f1, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[rowtime, CASE(=(a, 1), 1, 99) AS $f1])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+        </Resource>
+    </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.scala
@@ -300,6 +300,28 @@ class WindowAggregateTest(aggStrategy: AggregatePhaseStrategy) extends TableTest
       """.stripMargin
     util.verifyPlan(sql)
   }
+
+  @Test
+  def testReturnTypeInferenceForWindowAgg() = {
+
+    val sql =
+      """
+        |SELECT
+        |  SUM(correct) AS s,
+        |  AVG(correct) AS a,
+        |  TUMBLE_START(b, INTERVAL '15' MINUTE) AS wStart
+        |FROM (
+        |  SELECT CASE a
+        |      WHEN 1 THEN 1
+        |      ELSE 99
+        |    END AS correct, b
+        |  FROM MyTable
+        |)
+        |GROUP BY TUMBLE(b, INTERVAL '15' MINUTE)
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
 }
 
 object WindowAggregateTest {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
@@ -295,4 +295,25 @@ class WindowAggregateTest extends TableTestBase {
     util.verifyPlan(sql)
   }
 
+  @Test
+  def testReturnTypeInferenceForWindowAgg() = {
+
+    val sql =
+      """
+        |SELECT
+        |  SUM(correct) AS s,
+        |  AVG(correct) AS a,
+        |  TUMBLE_START(rowtime, INTERVAL '15' MINUTE) AS wStart
+        |FROM (
+        |  SELECT CASE a
+        |      WHEN 1 THEN 1
+        |      ELSE 99
+        |    END AS correct, rowtime
+        |  FROM MyTable
+        |)
+        |GROUP BY TUMBLE(rowtime, INTERVAL '15' MINUTE)
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/common/LogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/common/LogicalWindowAggregateRule.scala
@@ -21,8 +21,10 @@ import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan._
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
 import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
 import org.apache.calcite.rex._
+import org.apache.calcite.sql.`type`.SqlTypeUtil
 import org.apache.calcite.util.ImmutableBitSet
 import org.apache.flink.table.api._
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
@@ -78,13 +80,20 @@ abstract class LogicalWindowAggregateRule(ruleName: String)
       .project(project.getChildExps.updated(windowExprIdx, inAggGroupExpression))
       .build()
 
+    // Currently, this rule removes the window group by field which may lead to the changes of
+    // AggCall's type which brings fails on type checks.
+    // To solve the problem, we can change the types to the inferred types in the Aggregate and then
+    // cast back in the project after Aggregate.
+    val indexAndTypes = getIndexAndInferredTypesForInvalidAggCalls(agg)
+    val finalCalls = replaceAggCalls(indexAndTypes, agg)
+
     // we don't use the builder here because it uses RelMetadataQuery which affects the plan
     val newAgg = LogicalAggregate.create(
       newProject,
       agg.indicator,
       newGroupSet,
       ImmutableList.of(newGroupSet),
-      agg.getAggCallList)
+      finalCalls)
 
     // create an additional project to conform with types
     val outAggGroupExpression = getOutAggregateGroupExpression(rexBuilder, windowExpr)
@@ -93,9 +102,72 @@ abstract class LogicalWindowAggregateRule(ruleName: String)
       window,
       Seq[NamedWindowProperty](),
       newAgg))
-      .project(transformed.fields().patch(windowExprIdx, Seq(outAggGroupExpression), 0))
+      .project(transformed
+        .fields()
+        .patch(windowExprIdx, Seq(outAggGroupExpression), 0)
+        .zipWithIndex.map { rexNodeAndIndex =>
+        val aggCallIndex = rexNodeAndIndex._2 - agg.getGroupCount
+        if (indexAndTypes.containsKey(aggCallIndex)) {
+          rexBuilder.makeCast(agg.getAggCallList.get(aggCallIndex).`type`, rexNodeAndIndex._1, true)
+        } else {
+          rexNodeAndIndex._1
+        }
+      })
 
     call.transformTo(transformed.build())
+  }
+
+  /**
+    * Change the types of [[AggregateCall]] to the corresponding inferred types.
+    */
+  private def replaceAggCalls(
+    indexAndTypes: Map[Int, RelDataType], agg: LogicalAggregate): Seq[AggregateCall] = {
+
+    agg.getAggCallList.zipWithIndex.map { aggCallAndIndex =>
+      if (indexAndTypes.containsKey(aggCallAndIndex._2)) {
+        val aggCall = aggCallAndIndex._1
+        AggregateCall.create(
+          aggCall.getAggregation,
+          aggCall.isDistinct,
+          aggCall.isApproximate,
+          aggCall.ignoreNulls(),
+          aggCall.getArgList,
+          aggCall.filterArg,
+          aggCall.collation,
+          agg.getGroupCount,
+          agg.getInput,
+          indexAndTypes(aggCallAndIndex._2),
+          aggCall.name)
+      } else {
+        aggCallAndIndex._1
+      }
+    }
+  }
+
+  /**
+    * Check if there are any types of [[AggregateCall]] that need to be changed. Return the
+    * [[AggregateCall]] indexes and the corresponding inferred types.
+    */
+  private def getIndexAndInferredTypesForInvalidAggCalls(
+    agg: LogicalAggregate): Map[Int, RelDataType] = {
+
+    agg.getAggCallList.zipWithIndex.map { aggCallAndIndex =>
+      val aggCall = aggCallAndIndex._1
+      val origType = aggCall.`type`
+      val aggCallBinding = new Aggregate.AggCallBinding(
+        agg.getCluster.getTypeFactory,
+        aggCall.getAggregation,
+        SqlTypeUtil.projectTypes(agg.getInput.getRowType, aggCall.getArgList),
+        0,
+        aggCall.hasFilter)
+      val inferredType = aggCall.getAggregation.inferReturnType(aggCallBinding)
+
+      if (origType != inferredType && agg.getGroupCount == 1) {
+        (aggCallAndIndex._2, inferredType)
+      } else {
+        (-1, null)
+      }
+    }.filter(_._1 != -1).toMap
   }
 
   private[table] def getWindowExpressions(agg: LogicalAggregate): Seq[(RexCall, Int)] = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/common/LogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/common/LogicalWindowAggregateRule.scala
@@ -95,26 +95,34 @@ abstract class LogicalWindowAggregateRule(ruleName: String)
       ImmutableList.of(newGroupSet),
       finalCalls)
 
-    // create an additional project to conform with types
-    val outAggGroupExpression = getOutAggregateGroupExpression(rexBuilder, windowExpr)
     val transformed = call.builder()
-    transformed.push(LogicalWindowAggregate.create(
+    val windowAgg = LogicalWindowAggregate.create(
       window,
       Seq[NamedWindowProperty](),
-      newAgg))
-      .project(transformed
-        .fields()
-        .patch(windowExprIdx, Seq(outAggGroupExpression), 0)
-        .zipWithIndex.map { rexNodeAndIndex =>
-        val aggCallIndex = rexNodeAndIndex._2 - agg.getGroupCount
-        if (indexAndTypes.containsKey(aggCallIndex)) {
-          rexBuilder.makeCast(agg.getAggCallList.get(aggCallIndex).`type`, rexNodeAndIndex._1, true)
-        } else {
-          rexNodeAndIndex._1
-        }
-      })
+      newAgg)
+    transformed.push(windowAgg)
 
-    call.transformTo(transformed.build())
+    // The transformation adds an additional LogicalProject at the top to ensure
+    // that the types are equivalent.
+    // 1. ensure group key types, create an additional project to conform with types
+    val outAggGroupExpression = getOutAggregateGroupExpression(rexBuilder, windowExpr)
+    val projectsEnsureGroupKeyTypes =
+    transformed.fields.patch(windowExprIdx, Seq(outAggGroupExpression), 0)
+    // 2. ensure aggCall types
+    val projectsEnsureAggCallTypes =
+      projectsEnsureGroupKeyTypes.zipWithIndex.map {
+        case (aggCall, index) =>
+          val aggCallIndex = index - agg.getGroupCount
+          if (indexAndTypes.containsKey(aggCallIndex)) {
+            rexBuilder.makeCast(agg.getAggCallList.get(aggCallIndex).`type`, aggCall, true)
+          } else {
+            aggCall
+          }
+      }
+    transformed.project(projectsEnsureAggCallTypes)
+
+    val result = transformed.build()
+    call.transformTo(result)
   }
 
   /**
@@ -123,24 +131,24 @@ abstract class LogicalWindowAggregateRule(ruleName: String)
   private def replaceAggCalls(
     indexAndTypes: Map[Int, RelDataType], agg: LogicalAggregate): Seq[AggregateCall] = {
 
-    agg.getAggCallList.zipWithIndex.map { aggCallAndIndex =>
-      if (indexAndTypes.containsKey(aggCallAndIndex._2)) {
-        val aggCall = aggCallAndIndex._1
-        AggregateCall.create(
-          aggCall.getAggregation,
-          aggCall.isDistinct,
-          aggCall.isApproximate,
-          aggCall.ignoreNulls(),
-          aggCall.getArgList,
-          aggCall.filterArg,
-          aggCall.collation,
-          agg.getGroupCount,
-          agg.getInput,
-          indexAndTypes(aggCallAndIndex._2),
-          aggCall.name)
-      } else {
-        aggCallAndIndex._1
-      }
+    agg.getAggCallList.zipWithIndex.map {
+      case (aggCall, index) =>
+        if (indexAndTypes.containsKey(index)) {
+          AggregateCall.create(
+            aggCall.getAggregation,
+            aggCall.isDistinct,
+            aggCall.isApproximate,
+            aggCall.ignoreNulls(),
+            aggCall.getArgList,
+            aggCall.filterArg,
+            aggCall.collation,
+            agg.getGroupCount,
+            agg.getInput,
+            indexAndTypes(index),
+            aggCall.name)
+        } else {
+          aggCall
+        }
     }
   }
 
@@ -151,22 +159,22 @@ abstract class LogicalWindowAggregateRule(ruleName: String)
   private def getIndexAndInferredTypesForInvalidAggCalls(
     agg: LogicalAggregate): Map[Int, RelDataType] = {
 
-    agg.getAggCallList.zipWithIndex.map { aggCallAndIndex =>
-      val aggCall = aggCallAndIndex._1
-      val origType = aggCall.`type`
-      val aggCallBinding = new Aggregate.AggCallBinding(
-        agg.getCluster.getTypeFactory,
-        aggCall.getAggregation,
-        SqlTypeUtil.projectTypes(agg.getInput.getRowType, aggCall.getArgList),
-        0,
-        aggCall.hasFilter)
-      val inferredType = aggCall.getAggregation.inferReturnType(aggCallBinding)
+    agg.getAggCallList.zipWithIndex.map {
+      case (aggCall, index) =>
+        val origType = aggCall.`type`
+        val aggCallBinding = new Aggregate.AggCallBinding(
+          agg.getCluster.getTypeFactory,
+          aggCall.getAggregation,
+          SqlTypeUtil.projectTypes(agg.getInput.getRowType, aggCall.getArgList),
+          0,
+          aggCall.hasFilter)
+        val inferredType = aggCall.getAggregation.inferReturnType(aggCallBinding)
 
-      if (origType != inferredType && agg.getGroupCount == 1) {
-        (aggCallAndIndex._2, inferredType)
-      } else {
-        (-1, null)
-      }
+        if (origType != inferredType && agg.getGroupCount == 1) {
+          (index, inferredType)
+        } else {
+          (-1, null)
+        }
     }.filter(_._1 != -1).toMap
   }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes type equivalence check problems for Window Aggregates

### background

Creating Aggregate node fails in rules: LogicalWindowAggregateRule and ExtendedAggregateExtractProjectRule if the only grouping expression is a window and
we compute aggregation on NON NULLABLE field.

The root cause for that, is how return type inference strategies in calcite work and how we handle window aggregates. Take org.apache.calcite.sql.type.ReturnTypes#AGG_SUM as an example, based on groupCount it adjusts type nullability based on groupCount.

### analysis
There is no problem for non-window aggregate that return type turn to nullable if the call occurs within a "GROUP BY ()" query, e.g. in "select sum(x) as s from empty", s may be null. 
This is also the behavior of common databases, such as mysql. The result of query "select sum(x) as s from empty" is a null output.

However, for window aggregate, there is no way to output null, as we don't know which window the null belongs to, so the result should be an empty result which means the result type is also not null.

### solution
To fix this problem we can replace the current sum/avg SqlAggFunction to a self-defined one which avoids turning the "not null" to "nullable" for window aggregate. We can simply use a Rule to archive this.

## Brief change log

  - Add a self-defined sum and avg SqlAggFunction which will not change return type to nullable even if the call occurs within a "GROUP BY ()" for window aggregates.
  - Add a Rule(`ReplaceWindowAggregateFunctionRule`) to change the sum/avg to the self-defined sum/avg(`SqlWindowAvgAggFunction` and `SqlWindowSumAggFunction`).
  - Add `getSqlAggFunctionString` in `CommonAggregate`. This method makes sure that the new self-defined sum/avg returns same string with sum/agg.
  - Add tests.

## Verifying this change

This change added tests and can be verified as follows:

  - Added plan tests for flink, blink.
  - Added plan tests for batch, streaming.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
