### PR TITLE
[hotfix][connector] fix typo in filters of maven shade plguin

### DIFF
--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -74,7 +74,7 @@ under the License.
 											Cites a binary dependency on jersey, but this is neither reflected in the
 											dependency graph, nor are any jersey files bundled. -->
 										<exclude>NOTICE</exclude>
-										<execude>common/**</execude>
+										<exclude>common/**</exclude>
 									</excludes>
 								</filter>
 							</filters>


### PR DESCRIPTION
## What is the purpose of the change

Fix typo in filters of maven shade plugin.

## Brief change log
* Fix typo

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
