### PR TITLE
[FLINK-13307] Fix SourceStreamTaskTest test instability.

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -59,6 +59,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.core.Is.isA;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -247,7 +248,7 @@ public class SourceStreamTaskTest {
 				BasicTypeInfo.STRING_TYPE_INFO);
 
 		final CompletableFuture<Void> operatorRunningWaitingFuture = new CompletableFuture<>();
-		ExceptionThrowingSource.setIsInRunLoop(operatorRunningWaitingFuture);
+		ExceptionThrowingSource.setIsInRunLoopFuture(operatorRunningWaitingFuture);
 
 		testHarness.setupOutputForSingletonOperatorChain();
 		StreamConfig streamConfig = testHarness.getStreamConfig();
@@ -281,7 +282,7 @@ public class SourceStreamTaskTest {
 				BasicTypeInfo.STRING_TYPE_INFO);
 
 		final CompletableFuture<Void> operatorRunningWaitingFuture = new CompletableFuture<>();
-		ExceptionThrowingSource.setIsInRunLoop(operatorRunningWaitingFuture);
+		ExceptionThrowingSource.setIsInRunLoopFuture(operatorRunningWaitingFuture);
 
 		testHarness.setupOutputForSingletonOperatorChain();
 		StreamConfig streamConfig = testHarness.getStreamConfig();
@@ -487,12 +488,14 @@ public class SourceStreamTaskTest {
 			}
 		}
 
-		public static void setIsInRunLoop(@Nonnull final CompletableFuture<Void> waitingLatch) {
+		public static void setIsInRunLoopFuture(@Nonnull final CompletableFuture<Void> waitingLatch) {
 			ExceptionThrowingSource.isInRunLoop = waitingLatch;
 		}
 
 		@Override
 		public void run(SourceContext<String> ctx) throws TestException {
+			checkState(isInRunLoop != null && !isInRunLoop.isDone());
+
 			while (running) {
 				if (!isInRunLoop.isDone()) {
 					isInRunLoop.complete(null);
@@ -505,7 +508,6 @@ public class SourceStreamTaskTest {
 
 		@Override
 		public void cancel() {
-			System.out.println("SETTING TO " + isInRunLoop);
 			running = false;
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -246,8 +246,8 @@ public class SourceStreamTaskTest {
 				SourceStreamTask::new,
 				BasicTypeInfo.STRING_TYPE_INFO);
 
-		final CompletableFuture<Void> waitingLatch = new CompletableFuture<>();
-		ExceptionThrowingSource.setIsInRunLoop(waitingLatch);
+		final CompletableFuture<Void> operatorRunningWaitingFuture = new CompletableFuture<>();
+		ExceptionThrowingSource.setIsInRunLoop(operatorRunningWaitingFuture);
 
 		testHarness.setupOutputForSingletonOperatorChain();
 		StreamConfig streamConfig = testHarness.getStreamConfig();
@@ -255,7 +255,7 @@ public class SourceStreamTaskTest {
 		streamConfig.setOperatorID(new OperatorID());
 
 		testHarness.invoke();
-		waitingLatch.get();
+		operatorRunningWaitingFuture.get();
 		testHarness.getTask().cancel();
 
 		Optional<ExceptionThrowingSource.TestException> testException = Optional.empty();
@@ -280,8 +280,8 @@ public class SourceStreamTaskTest {
 				SourceStreamTask::new,
 				BasicTypeInfo.STRING_TYPE_INFO);
 
-		final CompletableFuture<Void> waitingLatch = new CompletableFuture<>();
-		ExceptionThrowingSource.setIsInRunLoop(waitingLatch);
+		final CompletableFuture<Void> operatorRunningWaitingFuture = new CompletableFuture<>();
+		ExceptionThrowingSource.setIsInRunLoop(operatorRunningWaitingFuture);
 
 		testHarness.setupOutputForSingletonOperatorChain();
 		StreamConfig streamConfig = testHarness.getStreamConfig();
@@ -289,7 +289,7 @@ public class SourceStreamTaskTest {
 		streamConfig.setOperatorID(new OperatorID());
 
 		testHarness.invoke();
-		waitingLatch.get();
+		operatorRunningWaitingFuture.get();
 		testHarness.getTask().finishTask();
 
 		testHarness.waitForTaskCompletion();


### PR DESCRIPTION
## What is the purpose of the change

Fixes test instability that was due to synchronisation on a `static` variable used by different tests.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
