### PR TITLE
[FLINK-13307][tests] Fix SourceStreamTaskTest test instability. (master)

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -242,8 +242,8 @@ public class SourceStreamTaskTest {
 				SourceStreamTask::new,
 				BasicTypeInfo.STRING_TYPE_INFO);
 
-		final CompletableFuture<Void> waitingLatch = new CompletableFuture<>();
-		ExceptionThrowingSource.setIsInRunLoop(waitingLatch);
+		final CompletableFuture<Void> operatorRunningWaitingFuture = new CompletableFuture<>();
+		ExceptionThrowingSource.setIsInRunLoop(operatorRunningWaitingFuture);
 
 		testHarness.setupOutputForSingletonOperatorChain();
 		StreamConfig streamConfig = testHarness.getStreamConfig();
@@ -251,7 +251,7 @@ public class SourceStreamTaskTest {
 		streamConfig.setOperatorID(new OperatorID());
 
 		testHarness.invoke();
-		waitingLatch.get();
+		operatorRunningWaitingFuture.get();
 		testHarness.getTask().finishTask();
 
 		testHarness.waitForTaskCompletion();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -42,6 +42,8 @@ import org.apache.flink.util.ExceptionUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
@@ -240,13 +242,16 @@ public class SourceStreamTaskTest {
 				SourceStreamTask::new,
 				BasicTypeInfo.STRING_TYPE_INFO);
 
+		final CompletableFuture<Void> waitingLatch = new CompletableFuture<>();
+		ExceptionThrowingSource.setIsInRunLoop(waitingLatch);
+
 		testHarness.setupOutputForSingletonOperatorChain();
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 		streamConfig.setStreamOperator(new StreamSource<>(new ExceptionThrowingSource()));
 		streamConfig.setOperatorID(new OperatorID());
 
 		testHarness.invoke();
-		ExceptionThrowingSource.isInRunLoop.get();
+		waitingLatch.get();
 		testHarness.getTask().finishTask();
 
 		testHarness.waitForTaskCompletion();
@@ -434,13 +439,18 @@ public class SourceStreamTaskTest {
 	 */
 	private static class ExceptionThrowingSource implements SourceFunction<String> {
 
+		private static volatile CompletableFuture<Void> isInRunLoop;
+
 		private volatile boolean running = true;
-		static CompletableFuture<Void> isInRunLoop = new CompletableFuture<>();
 
 		public static class TestException extends RuntimeException {
 			public TestException(String message) {
 				super(message);
 			}
+		}
+
+		public static void setIsInRunLoop(@Nonnull final CompletableFuture<Void> waitingLatch) {
+			ExceptionThrowingSource.isInRunLoop = waitingLatch;
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

Fixes test instability that was due to synchronisation on a `static` variable used by different tests.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
