### PR TITLE
[FLINK-11631][test] Harden TaskExecutorITCase

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.minicluster;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.MemoryArchivedExecutionGraphStore;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent;
@@ -28,6 +29,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 
 import javax.annotation.Nonnull;
@@ -35,6 +37,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -49,6 +52,10 @@ public class TestingMiniCluster extends MiniCluster {
 
 	private final boolean localCommunication;
 
+	private final List<ResourceID> taskManagersInOrder;
+
+	private final Object manipulationLock;
+
 	@Nullable
 	private final Supplier<HighAvailabilityServices> highAvailabilityServicesSupplier;
 
@@ -59,6 +66,8 @@ public class TestingMiniCluster extends MiniCluster {
 		this.numberDispatcherResourceManagerComponents = miniClusterConfiguration.getNumberDispatcherResourceManagerComponents();
 		this.highAvailabilityServicesSupplier = highAvailabilityServicesSupplier;
 		this.localCommunication = miniClusterConfiguration.isLocalCommunication();
+		this.taskManagersInOrder = new LinkedList<>();
+		this.manipulationLock = getManipulationLock();
 	}
 
 	public TestingMiniCluster(TestingMiniClusterConfiguration miniClusterConfiguration) {
@@ -71,15 +80,24 @@ public class TestingMiniCluster extends MiniCluster {
 		return super.getDispatcherResourceManagerComponents();
 	}
 
-	@Nonnull
-	@Override
-	public CompletableFuture<Void> terminateTaskExecutor(int index) {
-		return super.terminateTaskExecutor(index);
+	public CompletableFuture<Void> terminateAndRemoveTaskExecutor(int index) {
+		synchronized (manipulationLock) {
+			final ResourceID taskManagerId = taskManagersInOrder.remove(index);
+			final TaskExecutor taskExecutor = getTaskManagers().remove(taskManagerId);
+			if (taskExecutor == null) {
+				throw new RuntimeException("Task manager with index " + index + " has been shut down");
+			}
+			return taskExecutor.closeAsync();
+		}
 	}
 
 	@Override
-	public void startTaskExecutor() throws Exception {
-		super.startTaskExecutor();
+	public ResourceID startTaskExecutor() throws Exception {
+		synchronized (manipulationLock) {
+			final ResourceID taskManagerId = super.startTaskExecutor();
+			taskManagersInOrder.add(taskManagerId);
+			return taskManagerId;
+		}
 	}
 
 	@Override
@@ -130,6 +148,13 @@ public class TestingMiniCluster extends MiniCluster {
 	@Override
 	public CompletableFuture<DispatcherGateway> getDispatcherGatewayFuture() {
 		return super.getDispatcherGatewayFuture();
+	}
+
+	protected Collection<? extends CompletableFuture<Void>> terminateTaskExecutors() {
+		synchronized (manipulationLock) {
+			taskManagersInOrder.clear();
+			return super.terminateTaskExecutors();
+		}
 	}
 
 	private SessionDispatcherResourceManagerComponentFactory createTestingDispatcherResourceManagerComponentFactory() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -95,7 +95,7 @@ public class TaskExecutorITCase extends TestLogger {
 		final CompletableFuture<JobResult> jobResultFuture = submitJobAndWaitUntilRunning(jobGraph);
 
 		// kill one TaskExecutor which should fail the job execution
-		miniCluster.terminateTaskExecutor(0);
+		miniCluster.terminateAndRemoveTaskExecutor(0);
 
 		final JobResult jobResult = jobResultFuture.get();
 
@@ -122,7 +122,7 @@ public class TaskExecutorITCase extends TestLogger {
 		// start an additional TaskExecutor
 		miniCluster.startTaskExecutor();
 
-		miniCluster.terminateTaskExecutor(0).get(); // this should fail the job
+		miniCluster.terminateAndRemoveTaskExecutor(0).get(); // this should fail the job
 
 		BlockingOperator.unblock();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -122,7 +123,12 @@ public class TaskExecutorITCase extends TestLogger {
 		// start an additional TaskExecutor
 		miniCluster.startTaskExecutor();
 
-		miniCluster.terminateAndRemoveTaskExecutor(0).get(); // this should fail the job
+		try {
+			miniCluster.terminateAndRemoveTaskExecutor(0).get(); // this should fail the job
+		} catch (ExecutionException e) {
+			// we need this catching till FLINK-11630 has been resolved
+			log.info("Terminate task executor randomly caused an exception, just ignore it", e);
+		}
 
 		BlockingOperator.unblock();
 


### PR DESCRIPTION
## What is the purpose of the change

* The corrupt `TaskExecutor` might fail `MiniCluster` when shutting down, we should avoid this scenario
* Harden `TaskExecutorITCase#testJobReExecutionAfterTaskExecutorTermination`
* Harden `TastExecutorITCase#testJobRecoveryWithFailingTaskExecutor`

## Brief change log

* Improve `MiniCluster` by clearing terminated components. Use a map to keep task managers in `MiniCluster` instead of a list since the task managers might be mutable in some test cases
* `MiniCluster` exposes more components to `TestingMiniCluster` for enriching testing and Keep all testing codes in `TestingMiniCluster`
* Add a try-catch for `TastExecutorITCase#testJobRecoveryWithFailingTaskExecutor` to avoid unexpected exception caused by corrupt task executor

## Verifying this change

* This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
