### PR TITLE
[FLINK-13304][FLINK-13322][FLINK-13323][table-runtime-blink] Fix implementation of getString and getBinary method in NestedRow, fix serializer restore in BaseArray/Map serializer and add tests for complex data formats

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
@@ -25,8 +25,12 @@ import static org.apache.flink.table.dataformat.BinaryRow.calculateBitSetWidthIn
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
- * Its memory storage structure and {@link BinaryRow} exactly the same, the only different is it supports
- * all bytes in variable MemorySegments.
+ * Its memory storage structure is exactly the same with {@link BinaryRow}.
+ * The only different is that, as {@link NestedRow} is used
+ * to store row value in the variable-length part of {@link BinaryRow},
+ * every field (including both fixed-length part and variable-length part) of {@link NestedRow}
+ * has a possibility to cross the boundary of a segment, while the fixed-length part of {@link BinaryRow}
+ * must fit into its first memory segment.
  */
 public final class NestedRow extends BinaryFormat implements BaseRow {
 
@@ -219,7 +223,7 @@ public final class NestedRow extends BinaryFormat implements BaseRow {
 	public BinaryString getString(int pos) {
 		assertIndexIsValid(pos);
 		int fieldOffset = getFieldOffset(pos);
-		final long offsetAndLen = segments[0].getLong(fieldOffset);
+		final long offsetAndLen = SegmentsUtil.getLong(segments, fieldOffset);
 		return BinaryString.readBinaryStringFieldFromSegments(segments, offset, fieldOffset, offsetAndLen);
 	}
 
@@ -247,7 +251,7 @@ public final class NestedRow extends BinaryFormat implements BaseRow {
 	public byte[] getBinary(int pos) {
 		assertIndexIsValid(pos);
 		int fieldOffset = getFieldOffset(pos);
-		final long offsetAndLen = segments[0].getLong(fieldOffset);
+		final long offsetAndLen = SegmentsUtil.getLong(segments, fieldOffset);
 		return readBinaryFieldFromSegments(segments, offset, fieldOffset, offsetAndLen);
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/types/InternalSerializers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/types/InternalSerializers.java
@@ -80,9 +80,9 @@ public class InternalSerializers {
 				return new BaseArraySerializer(((ArrayType) type).getElementType(), config);
 			case MAP:
 				MapType mapType = (MapType) type;
-				return new BaseMapSerializer(mapType.getKeyType(), mapType.getValueType());
+				return new BaseMapSerializer(mapType.getKeyType(), mapType.getValueType(), config);
 			case MULTISET:
-				return new BaseMapSerializer(((MultisetType) type).getElementType(), new IntType());
+				return new BaseMapSerializer(((MultisetType) type).getElementType(), new IntType(), config);
 			case ROW:
 				RowType rowType = (RowType) type;
 				return new BaseRowSerializer(config, rowType);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BaseRowTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BaseRowTest.java
@@ -102,7 +102,8 @@ public class BaseRowTest {
 		writer.writeDecimal(10, decimal1, 5);
 		writer.writeDecimal(11, decimal2, 20);
 		writer.writeArray(12, array, new BaseArraySerializer(DataTypes.INT().getLogicalType(), null));
-		writer.writeMap(13, map, new BaseMapSerializer(DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType()));
+		writer.writeMap(13, map, new BaseMapSerializer(
+			DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType(), null));
 		writer.writeRow(14, underRow, new BaseRowSerializer(null, RowType.of(new IntType(), new IntType())));
 		writer.writeBinary(15, bytes);
 		return row;

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryArrayTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryArrayTest.java
@@ -325,7 +325,7 @@ public class BinaryArrayTest {
 			BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
 			writer.setNullAt(0);
 			writer.writeMap(1, BinaryMap.valueOf(subArray, subArray),
-					new BaseMapSerializer(DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType()));
+					new BaseMapSerializer(DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType(), null));
 			writer.complete();
 
 			assertTrue(array.isNullAt(0));
@@ -358,7 +358,7 @@ public class BinaryArrayTest {
 		BinaryRow row = new BinaryRow(1);
 		BinaryRowWriter rowWriter = new BinaryRowWriter(row);
 		rowWriter.writeMap(0, binaryMap,
-				new BaseMapSerializer(DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType()));
+				new BaseMapSerializer(DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType(), null));
 		rowWriter.complete();
 
 		BinaryMap map = (BinaryMap) row.getMap(0);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryRowTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryRowTest.java
@@ -18,31 +18,60 @@
 
 package org.apache.flink.table.dataformat;
 
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LocalDateSerializer;
+import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
+import org.apache.flink.api.common.typeutils.base.LocalTimeSerializer;
+import org.apache.flink.api.common.typeutils.base.SqlDateSerializer;
+import org.apache.flink.api.common.typeutils.base.SqlTimeSerializer;
+import org.apache.flink.api.common.typeutils.base.SqlTimestampSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.disk.RandomAccessInputView;
 import org.apache.flink.runtime.io.disk.RandomAccessOutputView;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.typeutils.BaseArraySerializer;
+import org.apache.flink.table.typeutils.BaseMapSerializer;
 import org.apache.flink.table.typeutils.BaseRowSerializer;
 import org.apache.flink.table.typeutils.BinaryRowSerializer;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
 import static org.apache.flink.table.dataformat.BinaryString.fromBytes;
 import static org.apache.flink.table.dataformat.BinaryString.fromString;
+import static org.apache.flink.table.dataformat.DataFormatTestUtil.MyObj;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -61,7 +90,7 @@ public class BinaryRowTest {
 		MemorySegment segment = MemorySegmentFactory.wrap(new byte[100]);
 		BinaryRow row = new BinaryRow(2);
 		row.pointTo(segment, 10, 48);
-		assertTrue(row.getSegments()[0] == segment);
+		assertSame(row.getSegments()[0], segment);
 		row.setInt(0, 5);
 		row.setDouble(1, 5.8D);
 	}
@@ -85,7 +114,7 @@ public class BinaryRowTest {
 		assertTrue(row.isNullAt(0));
 		assertEquals(55, row.getShort(5));
 		assertEquals(22, row.getLong(2));
-		assertEquals(true, row.getBoolean(4));
+		assertTrue(row.getBoolean(4));
 		assertEquals((byte) 66, row.getByte(6));
 		assertEquals(77f, row.getFloat(7), 0);
 	}
@@ -131,7 +160,7 @@ public class BinaryRowTest {
 	}
 
 	@Test
-	public void testWriteString() throws IOException {
+	public void testWriteString() {
 		{
 			// litter byte[]
 			BinaryRow row = new BinaryRow(1);
@@ -242,7 +271,7 @@ public class BinaryRowTest {
 		assertEquals((byte) 99, row.getByte(2));
 		assertEquals(87.1d, row.getDouble(6), 0);
 		assertEquals(26.1f, row.getFloat(7), 0);
-		assertEquals(true, row.getBoolean(1));
+		assertTrue(row.getBoolean(1));
 		assertEquals("1234567", row.getString(3).toString());
 		assertEquals("12345678", row.getString(5).toString());
 		assertEquals("啦啦啦啦啦我是快乐的粉刷匠", row.getString(9).toString());
@@ -269,7 +298,7 @@ public class BinaryRowTest {
 	}
 
 	@Test
-	public void anyNullTest() throws IOException {
+	public void anyNullTest() {
 		{
 			BinaryRow row = new BinaryRow(3);
 			BinaryRowWriter writer = new BinaryRowWriter(row);
@@ -302,7 +331,7 @@ public class BinaryRowTest {
 	}
 
 	@Test
-	public void testSingleSegmentBinaryRowHashCode() throws IOException {
+	public void testSingleSegmentBinaryRowHashCode() {
 		final Random rnd = new Random(System.currentTimeMillis());
 		// test hash stabilization
 		BinaryRow row = new BinaryRow(13);
@@ -347,7 +376,7 @@ public class BinaryRowTest {
 	}
 
 	@Test
-	public void testHeaderSize() throws IOException {
+	public void testHeaderSize() {
 		assertEquals(8, BinaryRow.calculateBitSetWidthInBytes(56));
 		assertEquals(16, BinaryRow.calculateBitSetWidthInBytes(57));
 		assertEquals(16, BinaryRow.calculateBitSetWidthInBytes(120));
@@ -355,7 +384,7 @@ public class BinaryRowTest {
 	}
 
 	@Test
-	public void testHeader() throws IOException {
+	public void testHeader() {
 		BinaryRow row = new BinaryRow(2);
 		BinaryRowWriter writer = new BinaryRowWriter(row);
 
@@ -455,5 +484,499 @@ public class BinaryRowTest {
 
 		Assert.assertArrayEquals(bytes1, row.getBinary(0));
 		Assert.assertArrayEquals(bytes2, row.getBinary(1));
+	}
+
+	@Test
+	public void testBinaryArray() {
+		// 1. array test
+		BinaryArray array = new BinaryArray();
+		BinaryArrayWriter arrayWriter = new BinaryArrayWriter(
+			array, 3, BinaryArray.calculateFixLengthPartSize(DataTypes.INT().getLogicalType()));
+
+		arrayWriter.writeInt(0, 6);
+		arrayWriter.setNullInt(1);
+		arrayWriter.writeInt(2, 666);
+		arrayWriter.complete();
+
+		assertEquals(array.getInt(0), 6);
+		assertTrue(array.isNullAt(1));
+		assertEquals(array.getInt(2), 666);
+
+		// 2. test write array to binary row
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter rowWriter = new BinaryRowWriter(row);
+		BaseArraySerializer serializer = new BaseArraySerializer(
+			DataTypes.INT().getLogicalType(), new ExecutionConfig());
+		rowWriter.writeArray(0, array, serializer);
+		rowWriter.complete();
+
+		BinaryArray array2 = (BinaryArray) row.getArray(0);
+		assertEquals(array, array2);
+		assertEquals(6, array2.getInt(0));
+		assertTrue(array2.isNullAt(1));
+		assertEquals(666, array2.getInt(2));
+	}
+
+	@Test
+	public void testGenericArray() {
+		// 1. array test
+		Integer[] javaArray = {6, null, 666};
+		GenericArray array = new GenericArray(javaArray, 3, false);
+
+		assertEquals(array.getInt(0), 6);
+		assertTrue(array.isNullAt(1));
+		assertEquals(array.getInt(2), 666);
+
+		// 2. test write array to binary row
+		BinaryRow row2 = new BinaryRow(1);
+		BinaryRowWriter writer2 = new BinaryRowWriter(row2);
+		BaseArraySerializer serializer = new BaseArraySerializer(
+			DataTypes.INT().getLogicalType(), new ExecutionConfig());
+		writer2.writeArray(0, array, serializer);
+		writer2.complete();
+
+		BaseArray array2 = row2.getArray(0);
+		assertEquals(6, array2.getInt(0));
+		assertTrue(array2.isNullAt(1));
+		assertEquals(666, array2.getInt(2));
+	}
+
+	@Test
+	public void testBinaryMap() {
+		BinaryArray array1 = new BinaryArray();
+		BinaryArrayWriter writer1 = new BinaryArrayWriter(
+			array1, 4, BinaryArray.calculateFixLengthPartSize(DataTypes.INT().getLogicalType()));
+		writer1.writeInt(0, 6);
+		writer1.writeInt(1, 5);
+		writer1.writeInt(2, 666);
+		writer1.writeInt(3, 0);
+		writer1.complete();
+
+		BinaryArray array2 = new BinaryArray();
+		BinaryArrayWriter writer2 = new BinaryArrayWriter(
+			array2, 4, BinaryArray.calculateFixLengthPartSize(DataTypes.STRING().getLogicalType()));
+		writer2.writeString(0, BinaryString.fromString("6"));
+		writer2.writeString(1, BinaryString.fromString("5"));
+		writer2.writeString(2, BinaryString.fromString("666"));
+		writer2.setNullAt(3, DataTypes.STRING().getLogicalType());
+		writer2.complete();
+
+		BinaryMap binaryMap = BinaryMap.valueOf(array1, array2);
+
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter rowWriter = new BinaryRowWriter(row);
+		BaseMapSerializer serializer = new BaseMapSerializer(
+			DataTypes.STRING().getLogicalType(),
+			DataTypes.INT().getLogicalType(),
+			new ExecutionConfig());
+		rowWriter.writeMap(0, binaryMap, serializer);
+		rowWriter.complete();
+
+		BinaryMap map = (BinaryMap) row.getMap(0);
+		BinaryArray key = map.keyArray();
+		BinaryArray value = map.valueArray();
+
+		assertEquals(binaryMap, map);
+		assertEquals(array1, key);
+		assertEquals(array2, value);
+
+		assertEquals(5, key.getInt(1));
+		assertEquals(BinaryString.fromString("5"), value.getString(1));
+		assertEquals(0, key.getInt(3));
+		assertTrue(value.isNullAt(3));
+	}
+
+	@Test
+	public void testGenericMap() {
+		Map javaMap = new HashMap();
+		javaMap.put(6, BinaryString.fromString("6"));
+		javaMap.put(5, BinaryString.fromString("5"));
+		javaMap.put(666, BinaryString.fromString("666"));
+		javaMap.put(0, null);
+
+		GenericMap genericMap = new GenericMap(javaMap);
+
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter rowWriter = new BinaryRowWriter(row);
+		BaseMapSerializer serializer = new BaseMapSerializer(
+			DataTypes.INT().getLogicalType(),
+			DataTypes.STRING().getLogicalType(),
+			new ExecutionConfig());
+		rowWriter.writeMap(0, genericMap, serializer);
+		rowWriter.complete();
+
+		Map map = row.getMap(0).toJavaMap(DataTypes.INT().getLogicalType(), DataTypes.STRING().getLogicalType());
+		assertEquals(BinaryString.fromString("6"), map.get(6));
+		assertEquals(BinaryString.fromString("5"), map.get(5));
+		assertEquals(BinaryString.fromString("666"), map.get(666));
+		assertTrue(map.containsKey(0));
+		assertNull(map.get(0));
+	}
+
+	@Test
+	public void testGenericObject() throws Exception {
+
+		GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
+		TypeSerializer<MyObj> genericSerializer = info.createSerializer(new ExecutionConfig());
+
+		BinaryRow row = new BinaryRow(4);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.writeInt(0, 0);
+
+		BinaryGeneric<MyObj> myObj1 = new BinaryGeneric<>(new MyObj(0, 1), genericSerializer);
+		writer.writeGeneric(1, myObj1);
+		BinaryGeneric<MyObj> myObj2 = new BinaryGeneric<>(new MyObj(123, 5.0), genericSerializer);
+		myObj2.ensureMaterialized();
+		writer.writeGeneric(2, myObj2);
+		BinaryGeneric<MyObj> myObj3 = new BinaryGeneric<>(new MyObj(1, 1), genericSerializer);
+		writer.writeGeneric(3, myObj3);
+		writer.complete();
+
+		assertTestGenericObjectRow(row, genericSerializer);
+
+		// getBytes from var-length memorySegments.
+		BinaryRowSerializer serializer = new BinaryRowSerializer(4);
+		MemorySegment[] memorySegments = new MemorySegment[3];
+		ArrayList<MemorySegment> memorySegmentList = new ArrayList<>();
+		for (int i = 0; i < 3; i++) {
+			memorySegments[i] = MemorySegmentFactory.wrap(new byte[64]);
+			memorySegmentList.add(memorySegments[i]);
+		}
+		RandomAccessOutputView out = new RandomAccessOutputView(memorySegments, 64);
+		serializer.serializeToPages(row, out);
+
+		BinaryRow mapRow = serializer.mapFromPages(new RandomAccessInputView(memorySegmentList, 64));
+		assertTestGenericObjectRow(mapRow, genericSerializer);
+	}
+
+	private void assertTestGenericObjectRow(BinaryRow row, TypeSerializer<MyObj> serializer) {
+		assertEquals(0, row.getInt(0));
+		BinaryGeneric<MyObj> binaryGeneric1 = row.getGeneric(1);
+		BinaryGeneric<MyObj> binaryGeneric2 = row.getGeneric(2);
+		BinaryGeneric<MyObj> binaryGeneric3 = row.getGeneric(3);
+		assertEquals(new MyObj(0, 1), BinaryGeneric.getJavaObjectFromBinaryGeneric(binaryGeneric1, serializer));
+		assertEquals(new MyObj(123, 5.0), BinaryGeneric.getJavaObjectFromBinaryGeneric(binaryGeneric2, serializer));
+		assertEquals(new MyObj(1, 1), BinaryGeneric.getJavaObjectFromBinaryGeneric(binaryGeneric3, serializer));
+	}
+
+	@Test
+	public void testDateAndTimeAsGenericObject() {
+		BinaryRow row = new BinaryRow(7);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+
+		LocalDate localDate = LocalDate.of(2019, 7, 16);
+		LocalTime localTime = LocalTime.of(17, 31);
+		LocalDateTime localDateTime = LocalDateTime.of(localDate, localTime);
+
+		writer.writeInt(0, 0);
+		writer.writeGeneric(1, new BinaryGeneric<>(new Date(123), SqlDateSerializer.INSTANCE));
+		writer.writeGeneric(2, new BinaryGeneric<>(new Time(456), SqlTimeSerializer.INSTANCE));
+		writer.writeGeneric(3, new BinaryGeneric<>(new Timestamp(789), SqlTimestampSerializer.INSTANCE));
+		writer.writeGeneric(4, new BinaryGeneric<>(localDate, LocalDateSerializer.INSTANCE));
+		writer.writeGeneric(5, new BinaryGeneric<>(localTime, LocalTimeSerializer.INSTANCE));
+		writer.writeGeneric(6, new BinaryGeneric<>(localDateTime, LocalDateTimeSerializer.INSTANCE));
+		writer.complete();
+
+		assertEquals(new Date(123), BinaryGeneric.getJavaObjectFromBinaryGeneric(
+			row.getGeneric(1), SqlDateSerializer.INSTANCE));
+		assertEquals(new Time(456), BinaryGeneric.getJavaObjectFromBinaryGeneric(
+			row.getGeneric(2), SqlTimeSerializer.INSTANCE));
+		assertEquals(new Timestamp(789), BinaryGeneric.getJavaObjectFromBinaryGeneric(
+			row.getGeneric(3), SqlTimestampSerializer.INSTANCE));
+		assertEquals(localDate, BinaryGeneric.getJavaObjectFromBinaryGeneric(
+			row.getGeneric(4), LocalDateSerializer.INSTANCE));
+		assertEquals(localTime, BinaryGeneric.getJavaObjectFromBinaryGeneric(
+			row.getGeneric(5), LocalTimeSerializer.INSTANCE));
+		assertEquals(localDateTime, BinaryGeneric.getJavaObjectFromBinaryGeneric(
+			row.getGeneric(6), LocalDateTimeSerializer.INSTANCE));
+	}
+
+	@Test
+	public void testSerializeVariousSize() throws IOException {
+		// in this test, we are going to start serializing from the i-th byte (i in 0...`segSize`)
+		// and the size of the row we're going to serialize is j bytes
+		// (j in `rowFixLength` to the maximum length we can write)
+
+		int segSize = 64;
+		int segTotalNumber = 3;
+
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		Random random = new Random();
+		byte[] bytes = new byte[1024];
+		random.nextBytes(bytes);
+		writer.writeBinary(0, bytes);
+		writer.complete();
+
+		MemorySegment[] memorySegments = new MemorySegment[segTotalNumber];
+		Map<MemorySegment, Integer> msIndex = new HashMap<>();
+		for (int i = 0; i < segTotalNumber; i++) {
+			memorySegments[i] = MemorySegmentFactory.wrap(new byte[segSize]);
+			msIndex.put(memorySegments[i], i);
+		}
+
+		BinaryRowSerializer serializer = new BinaryRowSerializer(1);
+
+		int rowSizeInt = 4;
+		// note that as there is only one field in the row, the fixed-length part is 16 bytes (header + 1 field)
+		int rowFixLength = 16;
+		for (int i = 0; i < segSize; i++) {
+			// this is the maximum row size we can serialize
+			// if we are going to serialize from the i-th byte of the input view
+			int maxRowSize = (segSize * segTotalNumber) - i - rowSizeInt;
+			if (segSize - i < rowFixLength + rowSizeInt) {
+				// oops, we can't write the whole fixed-length part in the first segment
+				// because the remaining space is too small, so we have to start serializing from the second segment.
+				// when serializing, we need to first write the length of the row,
+				// then write the fixed-length part of the row.
+				maxRowSize -= segSize - i;
+			}
+			for (int j = rowFixLength; j < maxRowSize; j++) {
+				// ok, now we're going to serialize a row of j bytes
+				testSerialize(row, memorySegments, msIndex, serializer, i, j);
+			}
+		}
+	}
+
+	private void testSerialize(
+		BinaryRow row, MemorySegment[] memorySegments,
+		Map<MemorySegment, Integer> msIndex, BinaryRowSerializer serializer, int position,
+		int rowSize) throws IOException {
+		RandomAccessOutputView out = new RandomAccessOutputView(memorySegments, 64);
+		out.skipBytesToWrite(position);
+		row.setTotalSize(rowSize);
+
+		// this `row` contains random bytes, and now we're going to serialize `rowSize` bytes
+		// (not including the row header) of the contents
+		serializer.serializeToPages(row, out);
+
+		// let's see how many segments we have written
+		int segNumber = msIndex.get(out.getCurrentSegment()) + 1;
+		int lastSegSize = out.getCurrentPositionInSegment();
+
+		// now deserialize from the written segments
+		ArrayList<MemorySegment> segments = new ArrayList<>(Arrays.asList(memorySegments).subList(0, segNumber));
+		RandomAccessInputView input = new RandomAccessInputView(segments, 64, lastSegSize);
+		input.skipBytesToRead(position);
+		BinaryRow mapRow = serializer.mapFromPages(input);
+
+		assertEquals(row, mapRow);
+	}
+
+	@Test
+	public void testZeroOutPaddingGeneric() {
+
+		GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
+		TypeSerializer<MyObj> genericSerializer = info.createSerializer(new ExecutionConfig());
+
+		Random random = new Random();
+		byte[] bytes = new byte[1024];
+
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+
+		// let's random the bytes
+		writer.reset();
+		random.nextBytes(bytes);
+		writer.writeBinary(0, bytes);
+		writer.reset();
+		writer.writeGeneric(0, new BinaryGeneric<>(new MyObj(0, 1), genericSerializer));
+		writer.complete();
+		int hash1 = row.hashCode();
+
+		writer.reset();
+		random.nextBytes(bytes);
+		writer.writeBinary(0, bytes);
+		writer.reset();
+		writer.writeGeneric(0, new BinaryGeneric<>(new MyObj(0, 1), genericSerializer));
+		writer.complete();
+		int hash2 = row.hashCode();
+
+		assertEquals(hash1, hash2);
+	}
+
+	@Test
+	public void testZeroOutPaddingString() {
+
+		Random random = new Random();
+		byte[] bytes = new byte[1024];
+
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+
+		writer.reset();
+		random.nextBytes(bytes);
+		writer.writeBinary(0, bytes);
+		writer.reset();
+		writer.writeString(0, BinaryString.fromString("wahahah"));
+		writer.complete();
+		int hash1 = row.hashCode();
+
+		writer.reset();
+		random.nextBytes(bytes);
+		writer.writeBinary(0, bytes);
+		writer.reset();
+		writer.writeString(0, BinaryString.fromString("wahahah"));
+		writer.complete();
+		int hash2 = row.hashCode();
+
+		assertEquals(hash1, hash2);
+	}
+
+	@Test
+	public void testHashAndCopy() throws IOException {
+		MemorySegment[] segments = new MemorySegment[3];
+		for (int i = 0; i < 3; i++) {
+			segments[i] = MemorySegmentFactory.wrap(new byte[64]);
+		}
+		RandomAccessOutputView out = new RandomAccessOutputView(segments, 64);
+		BinaryRowSerializer serializer = new BinaryRowSerializer(2);
+
+		BinaryRow row = new BinaryRow(2);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.writeString(0, BinaryString.fromString("hahahahahahahahahahahahahahahahahahahhahahahahahahahahah"));
+		writer.writeString(1, BinaryString.fromString("hahahahahahahahahahahahahahahahahahahhahahahahahahahahaa"));
+		writer.complete();
+		serializer.serializeToPages(row, out);
+
+		ArrayList<MemorySegment> segmentList = new ArrayList<>(Arrays.asList(segments));
+		RandomAccessInputView input = new RandomAccessInputView(segmentList, 64, 64);
+
+		BinaryRow mapRow = serializer.mapFromPages(input);
+		assertEquals(row, mapRow);
+		assertEquals(row.getString(0), mapRow.getString(0));
+		assertEquals(row.getString(1), mapRow.getString(1));
+		assertNotEquals(row.getString(0), mapRow.getString(1));
+
+		// test if the hash code before and after serialization are the same
+		assertEquals(row.hashCode(), mapRow.hashCode());
+		assertEquals(row.getString(0).hashCode(), mapRow.getString(0).hashCode());
+		assertEquals(row.getString(1).hashCode(), mapRow.getString(1).hashCode());
+
+		// test if the copy method produce a row with the same contents
+		assertEquals(row.copy(), mapRow.copy());
+		assertEquals(row.getString(0).copy(), mapRow.getString(0).copy());
+		assertEquals(row.getString(1).copy(), mapRow.getString(1).copy());
+	}
+
+	@Test
+	public void testSerStringToKryo() throws IOException {
+		KryoSerializer<BinaryString> serializer = new KryoSerializer<>(
+			BinaryString.class, new ExecutionConfig());
+
+		BinaryString string = BinaryString.fromString("hahahahaha");
+		RandomAccessOutputView out = new RandomAccessOutputView(
+			new MemorySegment[]{MemorySegmentFactory.wrap(new byte[1024])}, 64);
+		serializer.serialize(string, out);
+
+		RandomAccessInputView input = new RandomAccessInputView(
+			new ArrayList<>(Collections.singletonList(out.getCurrentSegment())), 64, 64);
+		BinaryString newStr = serializer.deserialize(input);
+
+		assertEquals(string, newStr);
+	}
+
+	@Test
+	public void testSerializerPages() throws IOException {
+		// Boundary tests
+		BinaryRow row24 = DataFormatTestUtil.get24BytesBinaryRow();
+		BinaryRow row160 = DataFormatTestUtil.get160BytesBinaryRow();
+		testSerializerPagesInternal(row24, row160);
+		testSerializerPagesInternal(row24, DataFormatTestUtil.getMultiSeg160BytesBinaryRow(row160));
+	}
+
+	private void testSerializerPagesInternal(BinaryRow row24, BinaryRow row160) throws IOException {
+		BinaryRowSerializer serializer = new BinaryRowSerializer(2);
+
+		// 1. test middle row with just on the edge1
+		{
+			MemorySegment[] segments = new MemorySegment[4];
+			for (int i = 0; i < segments.length; i++) {
+				segments[i] = MemorySegmentFactory.wrap(new byte[64]);
+			}
+			RandomAccessOutputView out = new RandomAccessOutputView(segments, segments[0].size());
+			serializer.serializeToPages(row24, out);
+			serializer.serializeToPages(row160, out);
+			serializer.serializeToPages(row24, out);
+
+			RandomAccessInputView in = new RandomAccessInputView(
+				new ArrayList<>(Arrays.asList(segments)),
+				segments[0].size(),
+				out.getCurrentPositionInSegment());
+
+			BinaryRow retRow = new BinaryRow(2);
+			List<BinaryRow> rets = new ArrayList<>();
+			while (true) {
+				try {
+					retRow = serializer.mapFromPages(retRow, in);
+				} catch (EOFException e) {
+					break;
+				}
+				rets.add(retRow.copy());
+			}
+			assertEquals(row24, rets.get(0));
+			assertEquals(row160, rets.get(1));
+			assertEquals(row24, rets.get(2));
+		}
+
+		// 2. test middle row with just on the edge2
+		{
+			MemorySegment[] segments = new MemorySegment[7];
+			for (int i = 0; i < segments.length; i++) {
+				segments[i] = MemorySegmentFactory.wrap(new byte[64]);
+			}
+			RandomAccessOutputView out = new RandomAccessOutputView(segments, segments[0].size());
+			serializer.serializeToPages(row24, out);
+			serializer.serializeToPages(row160, out);
+			serializer.serializeToPages(row160, out);
+
+			RandomAccessInputView in = new RandomAccessInputView(
+				new ArrayList<>(Arrays.asList(segments)),
+				segments[0].size(),
+				out.getCurrentPositionInSegment());
+
+			BinaryRow retRow = new BinaryRow(2);
+			List<BinaryRow> rets = new ArrayList<>();
+			while (true) {
+				try {
+					retRow = serializer.mapFromPages(retRow, in);
+				} catch (EOFException e) {
+					break;
+				}
+				rets.add(retRow.copy());
+			}
+			assertEquals(row24, rets.get(0));
+			assertEquals(row160, rets.get(1));
+			assertEquals(row160, rets.get(2));
+		}
+
+		// 3. test last row with just on the edge
+		{
+			MemorySegment[] segments = new MemorySegment[3];
+			for (int i = 0; i < segments.length; i++) {
+				segments[i] = MemorySegmentFactory.wrap(new byte[64]);
+			}
+			RandomAccessOutputView out = new RandomAccessOutputView(segments, segments[0].size());
+			serializer.serializeToPages(row24, out);
+			serializer.serializeToPages(row160, out);
+
+			RandomAccessInputView in = new RandomAccessInputView(
+				new ArrayList<>(Arrays.asList(segments)),
+				segments[0].size(),
+				out.getCurrentPositionInSegment());
+
+			BinaryRow retRow = new BinaryRow(2);
+			List<BinaryRow> rets = new ArrayList<>();
+			while (true) {
+				try {
+					retRow = serializer.mapFromPages(retRow, in);
+				} catch (EOFException e) {
+					break;
+				}
+				rets.add(retRow.copy());
+			}
+			assertEquals(row24, rets.get(0));
+			assertEquals(row160, rets.get(1));
+		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DataFormatTestUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DataFormatTestUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.	See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+
+/**
+ * Utils for testing data formats.
+ */
+class DataFormatTestUtil {
+
+	/**
+	 * Split the given byte array into two memory segments.
+	 */
+	static MemorySegment[] splitBytes(byte[] bytes, int baseOffset) {
+		int newSize = (bytes.length + 1) / 2 + baseOffset;
+		MemorySegment[] ret = new MemorySegment[2];
+		ret[0] = MemorySegmentFactory.wrap(new byte[newSize]);
+		ret[1] = MemorySegmentFactory.wrap(new byte[newSize]);
+
+		ret[0].put(baseOffset, bytes, 0, newSize - baseOffset);
+		ret[1].put(0, bytes, newSize - baseOffset, bytes.length - (newSize - baseOffset));
+		return ret;
+	}
+
+	/**
+	 * A simple class for testing generic type getting / setting on data formats.
+	 */
+	static class MyObj {
+		public int i;
+		public double j;
+
+		MyObj(int i, double j) {
+			this.i = i;
+			this.j = j;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			MyObj myObj = (MyObj) o;
+
+			return i == myObj.i && Double.compare(myObj.j, j) == 0;
+		}
+
+		@Override
+		public String toString() {
+			return "MyObj{" + "i=" + i + ", j=" + j + '}';
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DecimalTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DecimalTest.java
@@ -114,4 +114,12 @@ public class DecimalTest {
 		Assert.assertEquals(0, Decimal.zero(20, 2).toBigDecimal().intValue());
 		Assert.assertEquals(0, Decimal.zero(20, 2).toBigDecimal().intValue());
 	}
+
+	@Test
+	public void testToString() {
+		String val = "0.0000000000000000001";
+		Assert.assertEquals(val, Decimal.castFrom(val, 39, val.length() - 2).toString());
+		val = "123456789012345678901234567890123456789";
+		Assert.assertEquals(val, Decimal.castFrom(val, 39, 0).toString());
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/NestedRowTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/NestedRowTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.	See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.typeutils.BaseRowSerializer;
+
+import org.junit.Test;
+
+import static org.apache.flink.table.dataformat.DataFormatTestUtil.MyObj;
+import static org.apache.flink.table.dataformat.DataFormatTestUtil.splitBytes;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link NestedRow}s.
+ */
+public class NestedRowTest {
+
+	@Test
+	public void testNestedRowWithOneSegment() {
+		BinaryRow row = getBinaryRow();
+		GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
+		TypeSerializer<MyObj> genericSerializer = info.createSerializer(new ExecutionConfig());
+
+		BaseRow nestedRow = row.getRow(0, 5);
+		assertEquals(nestedRow.getInt(0), 1);
+		assertEquals(nestedRow.getLong(1), 5L);
+		assertEquals(nestedRow.getString(2), BinaryString.fromString("12345678"));
+		assertTrue(nestedRow.isNullAt(3));
+		assertEquals(new MyObj(15, 5),
+			BinaryGeneric.getJavaObjectFromBinaryGeneric(nestedRow.getGeneric(4), genericSerializer));
+	}
+
+	@Test
+	public void testNestedRowWithMultipleSegments() {
+		BinaryRow row = getBinaryRow();
+		GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
+		TypeSerializer<MyObj> genericSerializer = info.createSerializer(new ExecutionConfig());
+
+		MemorySegment[] segments = splitBytes(row.getSegments()[0].getHeapMemory(), 3);
+		row.pointTo(segments, 3, row.getSizeInBytes());
+		{
+			BaseRow nestedRow = row.getRow(0, 5);
+			assertEquals(nestedRow.getInt(0), 1);
+			assertEquals(nestedRow.getLong(1), 5L);
+			assertEquals(nestedRow.getString(2), BinaryString.fromString("12345678"));
+			assertTrue(nestedRow.isNullAt(3));
+			assertEquals(new MyObj(15, 5),
+				BinaryGeneric.getJavaObjectFromBinaryGeneric(nestedRow.getGeneric(4), genericSerializer));
+		}
+	}
+
+	@Test
+	public void testNestInNestedRow() {
+		// layer1
+		GenericRow gRow = new GenericRow(4);
+		gRow.setField(0, 1);
+		gRow.setField(1, 5L);
+		gRow.setField(2, BinaryString.fromString("12345678"));
+		gRow.setField(3, null);
+
+		// layer2
+		BaseRowSerializer serializer = new BaseRowSerializer(
+			new LogicalType[]{
+				DataTypes.INT().getLogicalType(),
+				DataTypes.BIGINT().getLogicalType(),
+				DataTypes.STRING().getLogicalType(),
+				DataTypes.STRING().getLogicalType()
+			},
+			new TypeSerializer[]{
+				IntSerializer.INSTANCE,
+				LongSerializer.INSTANCE,
+				StringSerializer.INSTANCE,
+				StringSerializer.INSTANCE
+			});
+		BinaryRow row = new BinaryRow(2);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.writeString(0, BinaryString.fromString("hahahahafff"));
+		writer.writeRow(1, gRow, serializer);
+		writer.complete();
+
+		// layer3
+		BinaryRow row2 = new BinaryRow(1);
+		BinaryRowWriter writer2 = new BinaryRowWriter(row2);
+		writer2.writeRow(0, row, null);
+		writer2.complete();
+
+		// verify
+		{
+			NestedRow nestedRow = (NestedRow) row2.getRow(0, 2);
+			BinaryRow binaryRow = new BinaryRow(2);
+			binaryRow.pointTo(nestedRow.getSegments(), nestedRow.getOffset(),
+				nestedRow.getSizeInBytes());
+			assertEquals(binaryRow, row);
+		}
+
+		assertEquals(row2.getRow(0, 2).getString(0), BinaryString.fromString("hahahahafff"));
+		BaseRow nestedRow = row2.getRow(0, 2).getRow(1, 4);
+		assertEquals(nestedRow.getInt(0), 1);
+		assertEquals(nestedRow.getLong(1), 5L);
+		assertEquals(nestedRow.getString(2), BinaryString.fromString("12345678"));
+		assertTrue(nestedRow.isNullAt(3));
+	}
+
+	private BinaryRow getBinaryRow() {
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+
+		GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
+		TypeSerializer<MyObj> genericSerializer = info.createSerializer(new ExecutionConfig());
+		GenericRow gRow = new GenericRow(5);
+		gRow.setField(0, 1);
+		gRow.setField(1, 5L);
+		gRow.setField(2, BinaryString.fromString("12345678"));
+		gRow.setField(3, null);
+		gRow.setField(4, new BinaryGeneric<>(new MyObj(15, 5), genericSerializer));
+
+		BaseRowSerializer serializer = new BaseRowSerializer(
+			new LogicalType[]{
+				DataTypes.INT().getLogicalType(),
+				DataTypes.BIGINT().getLogicalType(),
+				DataTypes.STRING().getLogicalType(),
+				DataTypes.STRING().getLogicalType(),
+				DataTypes.ANY(info).getLogicalType()
+			},
+			new TypeSerializer[]{
+				IntSerializer.INSTANCE,
+				LongSerializer.INSTANCE,
+				StringSerializer.INSTANCE,
+				StringSerializer.INSTANCE,
+				genericSerializer
+			});
+		writer.writeRow(0, gRow, serializer);
+		writer.complete();
+
+		return row;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/typeutils/BaseArraySerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/typeutils/BaseArraySerializerTest.java
@@ -19,14 +19,30 @@
 package org.apache.flink.table.typeutils;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.dataformat.BaseArray;
 import org.apache.flink.table.dataformat.BinaryArray;
 import org.apache.flink.table.dataformat.BinaryArrayWriter;
+import org.apache.flink.table.dataformat.BinaryGeneric;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.GenericArray;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.apache.flink.table.typeutils.SerializerTestUtil.MyObj;
+import static org.apache.flink.table.typeutils.SerializerTestUtil.MyObjSerializer;
+import static org.apache.flink.table.typeutils.SerializerTestUtil.snapshotAndReconfigure;
+import static org.junit.Assert.assertEquals;
 
 /**
  * A test for the {@link BaseArraySerializer}.
@@ -56,6 +72,47 @@ public class BaseArraySerializerTest extends SerializerTestBase<BaseArray> {
 					return true;
 				}
 		));
+	}
+
+	@Test
+	public void testExecutionConfigWithKryo() throws Exception {
+		// serialize base array
+		ExecutionConfig config = new ExecutionConfig();
+		config.enableForceKryo();
+		config.registerTypeWithKryoSerializer(MyObj.class, new MyObjSerializer());
+		final BaseArraySerializer serializer = createSerializerWithConfig(config);
+
+		MyObj inputObj = new MyObj(114514, 1919810);
+		BaseArray inputArray = new GenericArray(new BinaryGeneric[] {
+			new BinaryGeneric<>(inputObj, new KryoSerializer<>(MyObj.class, config))
+		}, 1);
+
+		byte[] serialized;
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			serializer.serialize(inputArray, new DataOutputViewStreamWrapper(out));
+			serialized = out.toByteArray();
+		}
+
+		// deserialize base array using restored serializer
+		final BaseArraySerializer restoreSerializer =
+			(BaseArraySerializer) snapshotAndReconfigure(serializer, () -> createSerializerWithConfig(config));
+
+		BaseArray outputArray;
+		try (ByteArrayInputStream in = new ByteArrayInputStream(serialized)) {
+			outputArray = restoreSerializer.deserialize(new DataInputViewStreamWrapper(in));
+		}
+
+		TypeSerializer restoreEleSer = restoreSerializer.getEleSer();
+		assertEquals(serializer.getEleSer(), restoreEleSer);
+
+		MyObj outputObj = BinaryGeneric.getJavaObjectFromBinaryGeneric(
+			outputArray.getGeneric(0), new KryoSerializer<>(MyObj.class, config));
+		assertEquals(inputObj, outputObj);
+	}
+
+	private BaseArraySerializer createSerializerWithConfig(ExecutionConfig config) {
+		return new BaseArraySerializer(
+			DataTypes.ANY(TypeInformation.of(MyObj.class)).getLogicalType(), config);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/typeutils/BaseMapSerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/typeutils/BaseMapSerializerTest.java
@@ -18,19 +18,35 @@
 
 package org.apache.flink.table.typeutils;
 
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.dataformat.BaseMap;
 import org.apache.flink.table.dataformat.BinaryArray;
 import org.apache.flink.table.dataformat.BinaryArrayWriter;
+import org.apache.flink.table.dataformat.BinaryGeneric;
 import org.apache.flink.table.dataformat.BinaryMap;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.GenericMap;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.apache.flink.table.typeutils.SerializerTestUtil.MyObj;
+import static org.apache.flink.table.typeutils.SerializerTestUtil.MyObjSerializer;
+import static org.apache.flink.table.typeutils.SerializerTestUtil.snapshotAndReconfigure;
+import static org.junit.Assert.assertEquals;
 
 /**
  * A test for the {@link BaseMapSerializer}.
@@ -55,8 +71,56 @@ public class BaseMapSerializerTest extends SerializerTestBase<BaseMap> {
 		));
 	}
 
+	@Test
+	public void testExecutionConfigWithKryo() throws Exception {
+		// serialize base array
+		ExecutionConfig config = new ExecutionConfig();
+		config.enableForceKryo();
+		config.registerTypeWithKryoSerializer(MyObj.class, new MyObjSerializer());
+		final BaseMapSerializer serializer = createSerializerWithConfig(config);
+
+		int inputKey = 998244353;
+		MyObj inputObj = new MyObj(114514, 1919810);
+		Map<Object, Object> javaMap = new HashMap<>();
+		javaMap.put(inputKey, new BinaryGeneric<>(inputObj, new KryoSerializer<>(MyObj.class, config)));
+		BaseMap inputMap = new GenericMap(javaMap);
+
+		byte[] serialized;
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			serializer.serialize(inputMap, new DataOutputViewStreamWrapper(out));
+			serialized = out.toByteArray();
+		}
+
+		// deserialize base array using restored serializer
+		final BaseMapSerializer restoreSerializer =
+			(BaseMapSerializer) snapshotAndReconfigure(serializer, () -> createSerializerWithConfig(config));
+
+		BaseMap outputMap;
+		try (ByteArrayInputStream in = new ByteArrayInputStream(serialized)) {
+			outputMap = restoreSerializer.deserialize(new DataInputViewStreamWrapper(in));
+		}
+
+		TypeSerializer restoreKeySer = restoreSerializer.getKeySerializer();
+		TypeSerializer restoreValueSer = restoreSerializer.getValueSerializer();
+		assertEquals(serializer.getKeySerializer(), restoreKeySer);
+		assertEquals(serializer.getValueSerializer(), restoreValueSer);
+
+		MyObj outputObj = BinaryGeneric.getJavaObjectFromBinaryGeneric(
+			(BinaryGeneric) outputMap.toJavaMap(
+				DataTypes.INT().getLogicalType(), DataTypes.ANY(TypeInformation.of(MyObj.class)).getLogicalType())
+				.get(inputKey), new KryoSerializer<>(MyObj.class, config));
+		assertEquals(inputObj, outputObj);
+	}
+
+	private BaseMapSerializer createSerializerWithConfig(ExecutionConfig config) {
+		return new BaseMapSerializer(
+			DataTypes.INT().getLogicalType(),
+			DataTypes.ANY(TypeInformation.of(MyObj.class)).getLogicalType(),
+			config);
+	}
+
 	private static BaseMapSerializer newSer() {
-		return new BaseMapSerializer(INT, STRING);
+		return new BaseMapSerializer(INT, STRING, new ExecutionConfig());
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/typeutils/SerializerTestUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/typeutils/SerializerTestUtil.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.typeutils;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshotSerializationUtil;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Utils for testing serializers.
+ */
+public class SerializerTestUtil {
+
+	/**
+	 * Snapshot and restore the given serializer. Returns the restored serializer.
+	 */
+	public static <T> TypeSerializer<T> snapshotAndReconfigure(
+		TypeSerializer<T> serializer, SerializerGetter<T> serializerGetter) throws IOException {
+		TypeSerializerSnapshot<T> configSnapshot = serializer.snapshotConfiguration();
+
+		byte[] serializedConfig;
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			TypeSerializerSnapshotSerializationUtil.writeSerializerSnapshot(
+				new DataOutputViewStreamWrapper(out), configSnapshot, serializer);
+			serializedConfig = out.toByteArray();
+		}
+
+		TypeSerializerSnapshot<T> restoredConfig;
+		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
+			restoredConfig = TypeSerializerSnapshotSerializationUtil.readSerializerSnapshot(
+				new DataInputViewStreamWrapper(in),
+				Thread.currentThread().getContextClassLoader(),
+				serializerGetter.getSerializer());
+		}
+
+		TypeSerializerSchemaCompatibility<T> strategy =
+			restoredConfig.resolveSchemaCompatibility(serializerGetter.getSerializer());
+		final TypeSerializer<T> restoredSerializer;
+		if (strategy.isCompatibleAsIs()) {
+			restoredSerializer = restoredConfig.restoreSerializer();
+		}
+		else if (strategy.isCompatibleWithReconfiguredSerializer()) {
+			restoredSerializer = strategy.getReconfiguredSerializer();
+		}
+		else {
+			throw new AssertionError("Unable to restore serializer with " + strategy);
+		}
+		assertEquals(serializer.getClass(), restoredSerializer.getClass());
+
+		return restoredSerializer;
+	}
+
+	/**
+	 * Used for snapshotAndReconfigure method to provide serializers when restoring.
+	 */
+	public interface SerializerGetter<T> {
+		TypeSerializer<T> getSerializer();
+	}
+
+	/**
+	 * A simple POJO.
+	 */
+	public static class MyObj {
+		private int a;
+		private int b;
+
+		MyObj(int a, int b) {
+			this.a = a;
+			this.b = b;
+		}
+
+		int getA() {
+			return a;
+		}
+
+		int getB() {
+			return b;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			return o instanceof MyObj && ((MyObj) o).a == a && ((MyObj) o).b == b;
+		}
+	}
+
+	/**
+	 * Kryo serializer for POJO.
+	 */
+	public static class MyObjSerializer extends Serializer<MyObj> implements Serializable {
+
+		private static final long serialVersionUID = 1L;
+		private static final int delta = 7;
+
+		@Override
+		public void write(Kryo kryo, Output output, MyObj myObj) {
+			output.writeInt(myObj.getA() + delta);
+			output.writeInt(myObj.getB() + delta);
+		}
+
+		@Override
+		public MyObj read(Kryo kryo, Input input, Class<MyObj> aClass) {
+			int a = input.readInt() - delta;
+			int b = input.readInt() - delta;
+			return new MyObj(a, b);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			return o instanceof MyObjSerializer;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The `getString` and `getBinary` methods are not implemented correctly in `NestedRow`. This PR fixes the implementation and adds test cases for complex data formats.

Also, the config snapshot of BaseArray/Map serializer is not implemented correctly. When user specifies his custom kryo serializer as the element/key/value serializer and later restore the serializers from the snapshot, the element/key/value serializer may change. This PR also fixes this issue.

(This PR ought to be split into 3 PRs... I discover this problem after @wuchong reviewed this, so I'll keep this PR and let @wuchong continues his review. Sorry for the inconvenience caused)

## Brief change log

 - Fix implementation of `getString` and `getBinary` in `NestedRow`.
 - Fix serializer restoring in BaseArray/Map serializer.
 - Add tests for complex data formats.

## Verifying this change

This change added tests and can be verified as follows: run the newly added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
