### PR TITLE
[FLINK-10052][coordination] Tolerate temporarily suspended ZooKeeper connections

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
@@ -410,8 +410,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 				LOG.debug("Connected to ZooKeeper quorum. Leader election can start.");
 				break;
 			case SUSPENDED:
-				LOG.warn("Connection to ZooKeeper suspended. The contender " + leaderContender.getDescription()
-					+ " no longer participates in the leader election.");
+				LOG.warn("Connection to ZooKeeper suspended, waiting for reconnection.");
 				break;
 			case RECONNECTED:
 				LOG.info("Connection to ZooKeeper was reconnected. Leader election can be restarted.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
@@ -191,8 +191,7 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 				LOG.debug("Connected to ZooKeeper quorum. Leader retrieval can start.");
 				break;
 			case SUSPENDED:
-				LOG.warn("Connection to ZooKeeper suspended. Can no longer retrieve the leader from " +
-					"ZooKeeper.");
+				LOG.warn("Connection to ZooKeeper suspended, waiting for reconnection.");
 				break;
 			case RECONNECTED:
 				LOG.info("Connection to ZooKeeper was reconnected. Leader retrieval can be restarted.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -44,6 +44,7 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.imps.DefaultACLProvider;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.state.SessionConnectionStateErrorPolicy;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
@@ -129,6 +130,7 @@ public class ZooKeeperUtils {
 				.sessionTimeoutMs(sessionTimeout)
 				.connectionTimeoutMs(connectionTimeout)
 				.retryPolicy(new ExponentialBackoffRetry(retryWait, maxRetryAttempts))
+			    .connectionStateErrorPolicy(new SessionConnectionStateErrorPolicy())
 				// Curator prepends a '/' manually and throws an Exception if the
 				// namespace starts with a '/'.
 				.namespace(rootWithNamespace.startsWith("/") ? rootWithNamespace.substring(1) : rootWithNamespace)


### PR DESCRIPTION
## What is the purpose of the change
### Desc
The `ZooKeeperLeaderElectionService` uses the LeaderLatch Curator recipe for leader election. The leader latch revokes leadership in case of a suspended ZooKeeper connection. This can be premature in case that the system can reconnect to ZooKeeper before its session expires. The effect of the lost leadership is that all jobs will be canceled and directly restarted after regaining the leadership. When more and more tasks deployed in cluster, the situation will get worse and worse.

### Aims
- Fix the impact of zookeeper network disconnect temporarily on flink long running jobs.
- Improve the stability of the flink longrunning jobs.

### Detail
Click here for more jira detail [FLINK-10052](https://issues.apache.org/jira/browse/FLINK-10052).

<br />

## Brief change log

  - upgrage curator-recipes dependency to 4.2.0
  - use `SessionConnectionStateErrorPolicy` as the error connect policy when build `CuratorFramework`

## Verifying this change

This change is already covered by existing tests, such as *ZooKeeperLeaderElectionITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
