### PR TITLE
FLINK-13302][table-planner] DateTimeUtils.unixDateCeil returns the same value as unixDateFloor does

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
@@ -835,7 +835,7 @@ public class DateTimeUtils {
 	}
 
 	public static long unixDateCeil(TimeUnitRange range, long date) {
-		return julianDateFloor(range, (int) date + EPOCH_JULIAN, true);
+		return julianDateFloor(range, (int) date + EPOCH_JULIAN, false);
 	}
 
 	private static int julianDateFloor(TimeUnitRange range, int julian,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -2447,7 +2447,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       'f16.ceil(TimeIntervalUnit.YEAR),
       "f16.ceil(YEAR)",
       "CEIL(f16 TO YEAR)",
-      "1996-01-01")
+      "1997-01-01")
 
     testAllApis(
       'f16.ceil(TimeIntervalUnit.MONTH),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -2453,7 +2453,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       'f16.ceil(TimeIntervalUnit.MONTH),
       "f16.ceil(MONTH)",
       "CEIL(f16 TO MONTH)",
-      "1996-11-01")
+      "1996-12-01")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change
Fix a bug in DateTimeUtils.unixDateCeil & keep sync with calcite

## Brief change log
- Fix unixDateCeil
- Fix related unit test cases


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
