### PR TITLE
[FLINK-13321][table-planner-blink] Fix bug in Blink Planner, Join a udf with constant arguments or without argument in TableAPI query does not work now

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
@@ -396,6 +396,7 @@ object FlinkBatchRuleSets {
     BatchExecLookupJoinRule.SNAPSHOT_ON_TABLESCAN,
     BatchExecLookupJoinRule.SNAPSHOT_ON_CALC_TABLESCAN,
     // correlate
+    BatchExecConstantTableFunctionScanRule.INSTANCE,
     BatchExecCorrelateRule.INSTANCE,
     // sink
     BatchExecSinkRule.INSTANCE

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
@@ -378,6 +378,7 @@ object FlinkStreamRuleSets {
     // CEP
     StreamExecMatchRule.INSTANCE,
     // correlate
+    StreamExecConstantTableFunctionScanRule.INSTANCE,
     StreamExecCorrelateRule.INSTANCE,
     // sink
     StreamExecSinkRule.INSTANCE

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecConstantTableFunctionScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecConstantTableFunctionScanRule.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalTableFunctionScan
+import org.apache.flink.table.plan.nodes.physical.batch.{BatchExecCorrelate, BatchExecValues}
+
+import com.google.common.collect.ImmutableList
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.plan.RelOptRule._
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.{RexLiteral, RexUtil}
+
+/**
+  * Converts [[FlinkLogicalTableFunctionScan]] with constant RexCall to
+  * {{{
+  *                    [[BatchExecCorrelate]]
+  *                          /       \
+  * empty [[BatchExecValues]]  [[FlinkLogicalTableFunctionScan]]
+  * }}}
+  *
+  * Add the rule to support select from a UDF directly, such as the following SQL:
+  * SELECT * FROM LATERAL TABLE(func()) as T(c)
+  *
+  * Note: [[BatchExecCorrelateRule]] is responsible for converting a reasonable physical plan for
+  * the normal correlate query, such as the following SQL:
+  * example1: SELECT * FROM T, LATERAL TABLE(func()) as T(c)
+  * example2: SELECT a, c FROM T, LATERAL TABLE(func(a)) as T(c)
+  */
+class BatchExecConstantTableFunctionScanRule
+  extends RelOptRule(
+    operand(classOf[FlinkLogicalTableFunctionScan], any),
+    "BatchExecTableFunctionScanRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val scan: FlinkLogicalTableFunctionScan = call.rel(0)
+    RexUtil.isConstant(scan.getCall) && scan.getInputs.isEmpty
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val scan: FlinkLogicalTableFunctionScan = call.rel(0)
+
+    // create correlate left
+    val cluster = scan.getCluster
+    val traitSet = call.getPlanner.emptyTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+    val values = new BatchExecValues(
+      cluster,
+      traitSet,
+      ImmutableList.of(ImmutableList.of[RexLiteral]()),
+      cluster.getTypeFactory.createStructType(ImmutableList.of(), ImmutableList.of()))
+
+    val correlate = new BatchExecCorrelate(
+      cluster,
+      traitSet,
+      values,
+      scan,
+      None,
+      None,
+      scan.getRowType,
+      JoinRelType.INNER)
+    call.transformTo(correlate)
+  }
+
+}
+
+object BatchExecConstantTableFunctionScanRule {
+  val INSTANCE = new BatchExecConstantTableFunctionScanRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecConstantTableFunctionScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecConstantTableFunctionScanRule.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.stream
+
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalTableFunctionScan
+import org.apache.flink.table.plan.nodes.physical.stream.{StreamExecCorrelate, StreamExecValues}
+
+import com.google.common.collect.ImmutableList
+import org.apache.calcite.plan.RelOptRule._
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.{RexLiteral, RexUtil}
+
+/**
+  * Converts [[FlinkLogicalTableFunctionScan]] with constant RexCall to
+  * {{{
+  *                    [[StreamExecCorrelate]]
+  *                          /       \
+  * empty [[StreamExecValues]]  [[FlinkLogicalTableFunctionScan]]
+  * }}}
+  *
+  * Add the rule to support select from a UDF directly, such as the following SQL:
+  * SELECT * FROM LATERAL TABLE(func()) as T(c)
+  *
+  * Note: [[StreamExecCorrelateRule]] is responsible for converting a reasonable physical plan for
+  * the normal correlate query, such as the following SQL:
+  * example1: SELECT * FROM T, LATERAL TABLE(func()) as T(c)
+  * example2: SELECT a, c FROM T, LATERAL TABLE(func(a)) as T(c)
+  */
+class StreamExecConstantTableFunctionScanRule
+  extends RelOptRule(
+    operand(classOf[FlinkLogicalTableFunctionScan], any),
+    "StreamExecConstantTableFunctionScanRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val scan: FlinkLogicalTableFunctionScan = call.rel(0)
+    RexUtil.isConstant(scan.getCall) && scan.getInputs.isEmpty
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val scan: FlinkLogicalTableFunctionScan = call.rel(0)
+
+    // create correlate left
+    val cluster = scan.getCluster
+    val traitSet = call.getPlanner.emptyTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
+    val values = new StreamExecValues(
+      cluster,
+      traitSet,
+      ImmutableList.of(ImmutableList.of[RexLiteral]()),
+      cluster.getTypeFactory.createStructType(ImmutableList.of(), ImmutableList.of()))
+
+    val correlate = new StreamExecCorrelate(
+      cluster,
+      traitSet,
+      values,
+      None,
+      scan,
+      None,
+      scan.getRowType,
+      JoinRelType.INNER)
+    call.transformTo(correlate)
+  }
+
+}
+
+object StreamExecConstantTableFunctionScanRule {
+  val INSTANCE = new StreamExecConstantTableFunctionScanRule
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
@@ -24,11 +24,10 @@ import org.apache.flink.table.api.{DataTypes, Table, ValidationException}
 import org.apache.flink.table.expressions.utils.{Func1, Func18, FuncWithOpen, RichFunc2}
 import org.apache.flink.table.runtime.utils.JavaUserDefinedTableFunctions.JavaTableFunc0
 import org.apache.flink.table.runtime.utils.{BatchTableEnvUtil, BatchTestBase, CollectionBatchExecTable, UserDefinedFunctionTestUtils}
-import org.apache.flink.table.util.DateTimeTestUtil._
 import org.apache.flink.table.util._
 import org.apache.flink.test.util.TestBaseUtils
 
-import org.junit.{Assert, Ignore, Test}
+import org.junit.{Assert, Test}
 
 import java.sql.{Date, Timestamp}
 
@@ -289,8 +288,6 @@ class CorrelateITCase extends BatchTestBase {
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
-  // TODO
-  @Ignore("Add a rule to translate a Correlate without correlateSets to Join!")
   @Test
   def testTableFunctionWithVariableArguments(): Unit = {
     val varArgsFunc0 = new VarArgsFunc0

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/CorrelateITCase.scala
@@ -85,6 +85,30 @@ class CorrelateITCase extends StreamingTestBase {
   }
 
   @Test
+  def testConstantTableFunc(): Unit = {
+    tEnv.registerFunction("str_split", new StringSplit())
+    val query = "SELECT * FROM LATERAL TABLE(str_split()) as T0(d)"
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = List("a", "b", "c")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testConstantTableFunc2(): Unit = {
+    tEnv.registerFunction("str_split", new StringSplit())
+    val query = "SELECT * FROM LATERAL TABLE(str_split('Jack,John', ',')) as T0(d)"
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = List("Jack", "John")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
   def testUdfIsOpenedAfterUdtf(): Unit = {
     val data = List(
       (1, 2, "abc-bcd"),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
@@ -231,6 +231,37 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       "nosharp,2",
       "nosharp,nosharp")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
+
+    val result1 = testData(env)
+      .toTable(tEnv, 'a, 'b, 'c)
+      .select('c)
+      .joinLateral(varArgsFunc0("1", "2"))
+
+    val sink1 = new TestingAppendSink
+    result1.toAppendStream[Row].addSink(sink1)
+    env.execute()
+
+    val expected1 = mutable.MutableList(
+      "Anna#44,1",
+      "Anna#44,2",
+      "Jack#22,1",
+      "Jack#22,2",
+      "John#19,1",
+      "John#19,2",
+      "nosharp,1",
+      "nosharp,2")
+    assertEquals(expected1.sorted, sink1.getAppendResults.sorted)
+
+    // Test for empty cases
+    val result2 = testData(env)
+      .toTable(tEnv, 'a, 'b, 'c)
+      .select('c)
+      .joinLateral(varArgsFunc0())
+
+    val sink2 = new TestingAppendSink
+    result2.toAppendStream[Row].addSink(sink2)
+    env.execute()
+    assertTrue(sink2.getAppendResults.isEmpty)
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

In blink planner, Join a udf with constant arguments or without argument in TableAPI query does not work now. The root cause is the `FlinkLogicalTableFunctionScan`.CONVERTER translates a `TableFunctionScan` to a `Correlate`, it will translate the original `RelNode` tree to a `RelNode` with two Cascaded ·Correlate` (could be found in the above thrown message), which could not translate to Physical `RelNode`. The detail information could be get in https://issues.apache.org/jira/browse/FLINK-13321.

`FlinkLogicalTableFunctionScan`.CONVERTER is to deal with a special sql like 'SELECT * FROM LATERAL TABLE(FUNC()) as T(C1)'. The pr aims to fix above bug by updating `FlinkLogicalTableFunctionScan`.CONVERTER, and process the sql like 'SELECT * FROM LATERAL TABLE(FUNC()) as T(C1)' in the other solution.

## Brief change log

  - Update `FlinkLogicalTableFunctionScan`.CONVERTER to avoid rewrite `FlinkLogicalTableFunctionScan` node 
  - Add `BatchExecConstantTableFunctionScanRule` and `StreamExecConstantTableFunctionScanRule` to deal with sql like 'SELECT * FROM LATERAL TABLE(FUNC()) as T(C1)'.

## Verifying this change
ITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
