### PR TITLE
[FLINK-13055] [runtime] Leverage JM tracked partitions to find out unavailable partitions in …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -516,7 +516,9 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 		this.partitionTracker = checkNotNull(partitionTracker);
 
-		this.resultPartitionAvailabilityChecker = new ExecutionGraphResultPartitionAvailabilityChecker(this);
+		this.resultPartitionAvailabilityChecker = new ExecutionGraphResultPartitionAvailabilityChecker(
+			this::createResultPartitionId,
+			partitionTracker);
 
 		LOG.info("Job recovers via failover strategy: {}", failoverStrategy.getStrategyName());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.failover.adapter.DefaultFailoverTopology;
+import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.NotReleasingPartitionReleaseStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionReleaseStrategy;
 import org.apache.flink.runtime.executiongraph.restart.ExecutionGraphRestartCallback;
@@ -297,6 +298,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	private final PartitionTracker partitionTracker;
 
+	private final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker;
+
 	/**
 	 * Future for an ongoing or completed scheduling action.
 	 */
@@ -512,6 +515,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		this.forcePartitionReleaseOnConsumption = forcePartitionReleaseOnConsumption;
 
 		this.partitionTracker = checkNotNull(partitionTracker);
+
+		this.resultPartitionAvailabilityChecker = new ExecutionGraphResultPartitionAvailabilityChecker(this);
 
 		LOG.info("Job recovers via failover strategy: {}", failoverStrategy.getStrategyName());
 	}
@@ -1567,7 +1572,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		}
 	}
 
-	private ResultPartitionID createResultPartitionId(final IntermediateResultPartitionID resultPartitionId) {
+	ResultPartitionID createResultPartitionId(final IntermediateResultPartitionID resultPartitionId) {
 		final SchedulingResultPartition schedulingResultPartition = schedulingTopology.getResultPartitionOrThrow(resultPartitionId);
 		final SchedulingExecutionVertex producer = schedulingResultPartition.getProducer();
 		final ExecutionVertexID producerId = producer.getId();
@@ -1741,6 +1746,10 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	public PartitionTracker getPartitionTracker() {
 		return partitionTracker;
+	}
+
+	public ResultPartitionAvailabilityChecker getResultPartitionAvailabilityChecker() {
+		return resultPartitionAvailabilityChecker;
 	}
 
 	PartitionReleaseStrategy getPartitionReleaseStrategy() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphResultPartitionAvailabilityChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphResultPartitionAvailabilityChecker.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link ResultPartitionAvailabilityChecker} which decides the intermediate result partition availability
+ * based on whether the corresponding result partition in the execution graph is tracked.
+ */
+public class ExecutionGraphResultPartitionAvailabilityChecker implements ResultPartitionAvailabilityChecker {
+
+	/** The execution graph that hosts the result partitions. */
+	private final ExecutionGraph executionGraph;
+
+	/** The tracker that tracks all available result partitions. */
+	private final PartitionTracker partitionTracker;
+
+	ExecutionGraphResultPartitionAvailabilityChecker(final ExecutionGraph executionGraph) {
+		this.executionGraph = checkNotNull(executionGraph);
+		this.partitionTracker = executionGraph.getPartitionTracker();
+	}
+
+	@Override
+	public boolean isAvailable(final IntermediateResultPartitionID resultPartitionID) {
+		return partitionTracker.isPartitionTracked(executionGraph.createResultPartitionId(resultPartitionID));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
@@ -290,7 +290,7 @@ public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 		// currently it's safe to add it here, as this method is invoked only once in production code.
 		checkState(restartPipelinedRegionStrategy == null, "notifyNewVertices() must be called only once");
 		this.restartPipelinedRegionStrategy = new RestartPipelinedRegionStrategy(
-			new DefaultFailoverTopology(executionGraph));
+			new DefaultFailoverTopology(executionGraph), executionGraph.getResultPartitionAvailabilityChecker());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ResultPartitionAvailabilityChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ResultPartitionAvailabilityChecker.java
@@ -22,7 +22,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 /**
  * This checker helps to query result partition availability.
  */
-interface ResultPartitionAvailabilityChecker {
+public interface ResultPartitionAvailabilityChecker {
 
 	/**
 	 * Returns whether the given partition is available.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTracker.java
@@ -54,4 +54,9 @@ public interface PartitionTracker {
 	 * Returns whether any partition is being tracked for the given task executor ID.
 	 */
 	boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId);
+
+	/**
+	 * Returns whether the given partition is being tracked.
+	 */
+	boolean isPartitionTracked(ResultPartitionID resultPartitionID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImpl.java
@@ -122,6 +122,13 @@ public class PartitionTrackerImpl implements PartitionTracker {
 		return partitionTable.hasTrackedPartitions(producingTaskExecutorId);
 	}
 
+	@Override
+	public boolean isPartitionTracked(final ResultPartitionID resultPartitionID) {
+		Preconditions.checkNotNull(resultPartitionID);
+
+		return partitionInfos.containsKey(resultPartitionID);
+	}
+
 	private Optional<PartitionInfo> internalStopTrackingPartition(ResultPartitionID resultPartitionId) {
 		final PartitionInfo partitionInfo = partitionInfos.remove(resultPartitionId);
 		if (partitionInfo == null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
@@ -267,24 +265,20 @@ public class AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest exten
 
 		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(TEST_JOB_ID, DEFAULT_PARALLELISM);
 
-		final Configuration jmConfig = new Configuration();
-		jmConfig.setBoolean(JobManagerOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION, false);
-
 		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
 			jg.getJobID(),
 			NettyShuffleMaster.INSTANCE,
 			ignored -> Optional.empty());
 
-		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jg)
+		final ExecutionGraph graph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jg)
 			.setRestartStrategy(manuallyTriggeredRestartStrategy)
 			.setFailoverStrategyFactory(TestAdaptedRestartPipelinedRegionStrategyNG::new)
 			.setSlotProvider(slotProvider)
-			.setJobMasterConfig(jmConfig)
 			.setPartitionTracker(partitionTracker)
 			.build();
 
-		eg.start(componentMainThreadExecutor);
+		graph.start(componentMainThreadExecutor);
 
-		return eg;
+		return graph;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.VoidBlobWriter;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
@@ -29,12 +29,14 @@ import org.apache.flink.runtime.executiongraph.AdaptedRestartPipelinedRegionStra
 import org.apache.flink.runtime.executiongraph.failover.AdaptedRestartPipelinedRegionStrategyNG;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
+import org.apache.flink.runtime.io.network.partition.PartitionTrackerImpl;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
 
@@ -42,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertEquals;
@@ -250,37 +253,38 @@ public class AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest exten
 	 */
 	private ExecutionGraph createExecutionGraph() throws Exception {
 
-		final JobInformation jobInformation = new DummyJobInformation(TEST_JOB_ID, "test job");
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(TEST_JOB_ID, DEFAULT_PARALLELISM);
-
-		final Time timeout = Time.seconds(10L);
-		final ExecutionGraph graph = new ExecutionGraph(
-			jobInformation,
-			TestingUtils.defaultExecutor(),
-			TestingUtils.defaultExecutor(),
-			timeout,
-			manuallyTriggeredRestartStrategy,
-			TestAdaptedRestartPipelinedRegionStrategyNG::new,
-			slotProvider,
-			getClass().getClassLoader(),
-			VoidBlobWriter.getInstance(),
-			timeout);
-
-		JobVertex v1 = new JobVertex("vertex1");
+		final JobVertex v1 = new JobVertex("vertex1");
 		v1.setInvokableClass(NoOpInvokable.class);
 		v1.setParallelism(DEFAULT_PARALLELISM);
 
-		JobVertex v2 = new JobVertex("vertex2");
+		final JobVertex v2 = new JobVertex("vertex2");
 		v2.setInvokableClass(NoOpInvokable.class);
 		v2.setParallelism(DEFAULT_PARALLELISM);
 
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
 
-		JobGraph jg = new JobGraph(TEST_JOB_ID, "testjob", v1, v2);
-		graph.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
+		final JobGraph jg = new JobGraph(TEST_JOB_ID, "testjob", v1, v2);
 
-		graph.start(componentMainThreadExecutor);
+		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(TEST_JOB_ID, DEFAULT_PARALLELISM);
 
-		return graph;
+		final Configuration jmConfig = new Configuration();
+		jmConfig.setBoolean(JobManagerOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION, false);
+
+		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
+			jg.getJobID(),
+			NettyShuffleMaster.INSTANCE,
+			ignored -> Optional.empty());
+
+		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jg)
+			.setRestartStrategy(manuallyTriggeredRestartStrategy)
+			.setFailoverStrategyFactory(TestAdaptedRestartPipelinedRegionStrategyNG::new)
+			.setSlotProvider(slotProvider)
+			.setJobMasterConfig(jmConfig)
+			.setPartitionTracker(partitionTracker)
+			.build();
+
+		eg.start(componentMainThreadExecutor);
+
+		return eg;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGFailoverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGFailoverTest.java
@@ -20,8 +20,6 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
@@ -385,9 +383,6 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 			final JobGraph jobGraph,
 			final RestartStrategy restartStrategy) throws Exception {
 
-		final Configuration jmConfig = new Configuration();
-		jmConfig.setBoolean(JobManagerOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION, false);
-
 		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
 			jobGraph.getJobID(),
 			NettyShuffleMaster.INSTANCE,
@@ -397,7 +392,6 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 			.setRestartStrategy(restartStrategy)
 			.setFailoverStrategyFactory(TestAdaptedRestartPipelinedRegionStrategyNG::new)
 			.setSlotProvider(slotProvider)
-			.setJobMasterConfig(jmConfig)
 			.setPartitionTracker(partitionTracker)
 			.build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphResultPartitionAvailabilityCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphResultPartitionAvailabilityCheckerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
+import org.apache.flink.runtime.io.network.partition.PartitionTracker;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.TestingPartitionTracker;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ExecutionGraphResultPartitionAvailabilityChecker}.
+ */
+public class ExecutionGraphResultPartitionAvailabilityCheckerTest extends TestLogger {
+
+	@Test
+	public void testPartitionAvailabilityCheck() throws Exception {
+
+		final TestingPartitionTracker partitionTracker = new TestingPartitionTracker();
+		final ExecutionGraph eg = createExecutionGraph(partitionTracker);
+		final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker = eg.getResultPartitionAvailabilityChecker();
+
+		final Iterator<ExecutionVertex> vertexIterator = eg.getAllExecutionVertices().iterator();
+		final ExecutionVertex ev11 = vertexIterator.next();
+		final ExecutionVertex ev12 = vertexIterator.next();
+
+		final IntermediateResultPartitionID irp1ID = ev11.getProducedPartitions().keySet().iterator().next();
+		final IntermediateResultPartitionID irp2ID = ev12.getProducedPartitions().keySet().iterator().next();
+
+		final Map<IntermediateResultPartitionID, Boolean> expectedAvailability =
+			new HashMap<IntermediateResultPartitionID, Boolean>() {{
+				put(irp1ID, true);
+				put(irp2ID, false);
+			}};
+
+		// let the partition tracker respect the expected availability result
+		partitionTracker.setIsPartitionTrackedFunction(rpID -> expectedAvailability.get(rpID.getPartitionId()));
+
+		for (IntermediateResultPartitionID irpID : expectedAvailability.keySet()) {
+			assertEquals(expectedAvailability.get(irpID), resultPartitionAvailabilityChecker.isAvailable(irpID));
+		}
+	}
+
+	// ------------------------------- Test Utils -----------------------------------------
+
+	/**
+	 * Creating an execution graph as below.
+	 * <pre>
+	 *     (v11) -+-> (v21)
+	 *            x
+	 *     (v12) -+-> (v22)
+	 *
+	 *            ^
+	 *            |
+	 *        (blocking)
+	 * </pre>
+	 */
+	private ExecutionGraph createExecutionGraph(final PartitionTracker partitionTracker) throws Exception {
+
+		final JobVertex v1 = new JobVertex("vertex1");
+		v1.setInvokableClass(NoOpInvokable.class);
+		v1.setParallelism(2);
+
+		final JobVertex v2 = new JobVertex("vertex2");
+		v2.setInvokableClass(NoOpInvokable.class);
+		v2.setParallelism(2);
+
+		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+		final JobGraph jobGraph = new JobGraph(new JobID(), "testjob", v1, v2);
+
+		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobGraph)
+			.setPartitionTracker(partitionTracker)
+			.build();
+
+		return eg;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphResultPartitionAvailabilityCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphResultPartitionAvailabilityCheckerTest.java
@@ -18,23 +18,17 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
-import org.apache.flink.runtime.io.network.partition.PartitionTracker;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.TestingPartitionTracker;
-import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 
@@ -44,65 +38,34 @@ import static org.junit.Assert.assertEquals;
 public class ExecutionGraphResultPartitionAvailabilityCheckerTest extends TestLogger {
 
 	@Test
-	public void testPartitionAvailabilityCheck() throws Exception {
+	public void testPartitionAvailabilityCheck() {
 
-		final TestingPartitionTracker partitionTracker = new TestingPartitionTracker();
-		final ExecutionGraph eg = createExecutionGraph(partitionTracker);
-		final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker = eg.getResultPartitionAvailabilityChecker();
-
-		final Iterator<ExecutionVertex> vertexIterator = eg.getAllExecutionVertices().iterator();
-		final ExecutionVertex ev11 = vertexIterator.next();
-		final ExecutionVertex ev12 = vertexIterator.next();
-
-		final IntermediateResultPartitionID irp1ID = ev11.getProducedPartitions().keySet().iterator().next();
-		final IntermediateResultPartitionID irp2ID = ev12.getProducedPartitions().keySet().iterator().next();
+		final IntermediateResultPartitionID irp1ID = new IntermediateResultPartitionID();
+		final IntermediateResultPartitionID irp2ID = new IntermediateResultPartitionID();
+		final IntermediateResultPartitionID irp3ID = new IntermediateResultPartitionID();
+		final IntermediateResultPartitionID irp4ID = new IntermediateResultPartitionID();
 
 		final Map<IntermediateResultPartitionID, Boolean> expectedAvailability =
 			new HashMap<IntermediateResultPartitionID, Boolean>() {{
 				put(irp1ID, true);
 				put(irp2ID, false);
+				put(irp3ID, false);
+				put(irp4ID, true);
 			}};
 
 		// let the partition tracker respect the expected availability result
+		final TestingPartitionTracker partitionTracker = new TestingPartitionTracker();
 		partitionTracker.setIsPartitionTrackedFunction(rpID -> expectedAvailability.get(rpID.getPartitionId()));
+
+		// the execution attempt ID should make no difference in this case
+		final Function<IntermediateResultPartitionID, ResultPartitionID> partitionIDMapper =
+			intermediateResultPartitionID -> new ResultPartitionID(intermediateResultPartitionID, new ExecutionAttemptID());
+
+		final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker =
+			new ExecutionGraphResultPartitionAvailabilityChecker(partitionIDMapper, partitionTracker);
 
 		for (IntermediateResultPartitionID irpID : expectedAvailability.keySet()) {
 			assertEquals(expectedAvailability.get(irpID), resultPartitionAvailabilityChecker.isAvailable(irpID));
 		}
-	}
-
-	// ------------------------------- Test Utils -----------------------------------------
-
-	/**
-	 * Creating an execution graph as below.
-	 * <pre>
-	 *     (v11) -+-> (v21)
-	 *            x
-	 *     (v12) -+-> (v22)
-	 *
-	 *            ^
-	 *            |
-	 *        (blocking)
-	 * </pre>
-	 */
-	private ExecutionGraph createExecutionGraph(final PartitionTracker partitionTracker) throws Exception {
-
-		final JobVertex v1 = new JobVertex("vertex1");
-		v1.setInvokableClass(NoOpInvokable.class);
-		v1.setParallelism(2);
-
-		final JobVertex v2 = new JobVertex("vertex2");
-		v2.setInvokableClass(NoOpInvokable.class);
-		v2.setParallelism(2);
-
-		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
-
-		final JobGraph jobGraph = new JobGraph(new JobID(), "testjob", v1, v2);
-
-		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobGraph)
-			.setPartitionTracker(partitionTracker)
-			.build();
-
-		return eg;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpPartitionTracker.java
@@ -50,4 +50,9 @@ public enum NoOpPartitionTracker implements PartitionTracker {
 	public boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
 		return false;
 	}
+
+	@Override
+	public boolean isPartitionTracked(final ResultPartitionID resultPartitionID) {
+		return false;
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingPartitionTracker.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 public class TestingPartitionTracker implements PartitionTracker {
 
 	private Function<ResourceID, Boolean> isTrackingPartitionsForFunction = ignored -> false;
+	private Function<ResultPartitionID, Boolean> isPartitionTrackedFunction = ignored -> false;
 	private Consumer<ResourceID> stopTrackingAllPartitionsConsumer = ignored -> {};
 	private Consumer<ResourceID> stopTrackingAndReleaseAllPartitionsConsumer = ignored -> {};
 	private BiConsumer<ResourceID, ResultPartitionDeploymentDescriptor> startTrackingPartitionsConsumer = (ignoredA, ignoredB) -> {};
@@ -42,6 +43,10 @@ public class TestingPartitionTracker implements PartitionTracker {
 
 	public void setIsTrackingPartitionsForFunction(Function<ResourceID, Boolean> isTrackingPartitionsForFunction) {
 		this.isTrackingPartitionsForFunction = isTrackingPartitionsForFunction;
+	}
+
+	public void setIsPartitionTrackedFunction(Function<ResultPartitionID, Boolean> isPartitionTrackedFunction) {
+		this.isPartitionTrackedFunction = isPartitionTrackedFunction;
 	}
 
 	public void setStopTrackingAllPartitionsConsumer(Consumer<ResourceID> stopTrackingAllPartitionsConsumer) {
@@ -79,5 +84,10 @@ public class TestingPartitionTracker implements PartitionTracker {
 	@Override
 	public boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
 		return isTrackingPartitionsForFunction.apply(producingTaskExecutorId);
+	}
+
+	@Override
+	public boolean isPartitionTracked(final ResultPartitionID resultPartitionID) {
+		return isPartitionTrackedFunction.apply(resultPartitionID);
 	}
 }


### PR DESCRIPTION
…time

## What is the purpose of the change

*In current region failover process, most of the input result partition states are unknown. Even though the failure cause is a PartitionException, only one unhealthy partition can be identified.*

*The may lead to multiple unsuccessful failovers before all the unhealthy but needed partitions are identified and their producers are involved in the failover as well. (unsuccessful failover here means the recovered tasks get failed again soon due to some missing input partitions.)*

*This PR leverages JM side tracked partition states to help the region failover to identify unhealthy(missing) partitions earlier, thus to improve the failover experience.*


## Brief change log

  - *Implemented ExecutionGraphResultPartitionAvailabilityChecker*
  - *Let ExecutionGraph build its ExecutionGraphResultPartitionAvailabilityChecker and use it to generate region failover strategy*
  - *Enabled PartitionTracker to support querying whether a given partition is tracked*



## Verifying this change

  - *Added UT for ExecutionGraphResultPartitionAvailabilityChecker*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
