### PR TITLE
[FLINK-12901][docs] Update Hadoop build instructions

### DIFF
--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -56,8 +56,6 @@ To speed up the build you can skip tests, QA plugins, and JavaDocs:
 mvn clean install -DskipTests -Dfast
 {% endhighlight %}
 
-The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink with HDFS and YARN.
-
 ## Build PyFlink
 
 If you want to build a PyFlink package that can be used for pip installation, you need to build Flink jars first, as described in [Build Flink](##Build Flink).

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -107,7 +107,7 @@ To build against Hadoop 2.4.1, 2.6.5, 2.7.5 or 2.8.3, it is sufficient to run (e
 mvn clean install -DskipTests -Dhadoop.version=2.6.5
 {% endhighlight %}
 
-To package a shaded pre-packaged hadoop jar into the distributions `/lib` directory, activate the `include-hadoop` profile`:
+To package a shaded pre-packaged Hadoop jar into the distributions `/lib` directory, activate the `include-hadoop` profile`:
 
 {% highlight bash %}
 mvn clean install -DskipTests -Pinclude-hadoop

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -97,34 +97,48 @@ mvn clean install
 
 ## Hadoop Versions
 
-{% info %} Most users do not need to do this manually. The [download page]({{ site.download_url }}) contains binary packages for common Hadoop versions.
+Flink has optional dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
 
-Flink has dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
+Flink can be built against any Hadoop version >= 2.4.0, but depending on the version it may be a 1 or 2 step process.
 
-Hadoop is only supported from version 2.4.0 upwards.
-You can also specify a specific Hadoop version to build against:
+### Pre-bundled versions
 
-{% highlight bash %}
-mvn clean install -DskipTests -Dhadoop.version=2.6.1
-{% endhighlight %}
-
-### Packaging Hadoop into the Flink distribution
-
-If you want to build a Flink distribution that has a shaded Hadoop pre-packaged in the lib folder you can use the `include-hadoop` profile to do so. You would build Flink as described above but include the profile:
+If you want to build against Hadoop 2.4.1, 2.6.5, 2.7.5 or 2.8.3, then it is sufficient to run:
 
 {% highlight bash %}
-mvn clean install -DskipTests -Pinclude-hadoop
+mvn clean install -DskipTests -Dhadoop.version=2.6.5
 {% endhighlight %}
 
-### Vendor-specific Versions
-To check the list of supported vendor versions, look in https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-hdfs?repo=cloudera
-To build Flink against a vendor specific Hadoop version, issue the following command:
+To further package a shaded pre-packaged hadoop jar into the distribution, additionally activate the `include-hadoop` profile`:
+
+{% highlight bash %}
+mvn clean install -DskipTests -Dhadoop.version=2.6.5 -Pinclude-hadoop
+{% endhighlight %}
+
+### Custom / Vendor-specific versions
+
+If you want to build against Hadoop version that is *NOT* 2.4.1, 2.6.5, 2.7.5 or 2.8.3,
+then it is first necessary to build [flink-shaded](https://github.com/apache/flink-shaded) against this version.
+You can find the source for this project in the `Additional Components` section of the [downloads page](http://flink.apache.org/downloads.html#additional-components).
+
+Run the following command to build and install `flink-shaded` against your desired Hadoop version:
+
+{% highlight bash %}
+mvn clean install -Dhadoop.version=2.6.5-custom
+{% endhighlight %}
+
+After this step is complete, follow the steps for [Pre-bundled versions](#pre-bundled-versions).
+
+To build Flink against a vendor specific Hadoop version, additionally activate -Pvendor-repos` profile when building
+`flink-shaded`.
 
 {% highlight bash %}
 mvn clean install -DskipTests -Pvendor-repos -Dhadoop.version=2.6.0-cdh5.16.1
 {% endhighlight %}
 
 The `-Pvendor-repos` activates a Maven [build profile](http://maven.apache.org/guides/introduction/introduction-to-profiles.html) that includes the repositories of popular Hadoop vendors such as Cloudera, Hortonworks, or MapR.
+
+The list of supported vendor versions can be checked [here](https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-hdfs?repo=cloudera).
 
 {% top %}
 

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -119,7 +119,7 @@ mvn clean install -DskipTests -Dhadoop.version=2.6.5 -Pinclude-hadoop
 
 If you want to build against Hadoop version that is *NOT* 2.4.1, 2.6.5, 2.7.5 or 2.8.3,
 then it is first necessary to build [flink-shaded](https://github.com/apache/flink-shaded) against this version.
-You can find the source for this project in the `Additional Components` section of the [downloads page](http://flink.apache.org/downloads.html#additional-components).
+You can find the source for this project in the [Additional Components]({{ site.download_url }}#additional-components) section of the download page.
 
 Run the following command to build and install `flink-shaded` against your desired Hadoop version:
 

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -97,7 +97,7 @@ mvn clean install
 
 ## Hadoop Versions
 
-Flink has optional dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
+Flink has optional dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using an incompatible combination of versions, exceptions may occur.
 
 Flink can be built against any Hadoop version >= 2.4.0, but depending on the version it may be a 1 or 2 step process.
 

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -103,16 +103,16 @@ Flink can be built against any Hadoop version >= 2.4.0, but depending on the ver
 
 ### Pre-bundled versions
 
-If you want to build against Hadoop 2.4.1, 2.6.5, 2.7.5 or 2.8.3, then it is sufficient to run:
+To build against Hadoop 2.4.1, 2.6.5, 2.7.5 or 2.8.3, it is sufficient to run (e.g., for version `2.6.5`):
 
 {% highlight bash %}
 mvn clean install -DskipTests -Dhadoop.version=2.6.5
 {% endhighlight %}
 
-To further package a shaded pre-packaged hadoop jar into the distribution, additionally activate the `include-hadoop` profile`:
+To package a shaded pre-packaged hadoop jar into the distributions `/lib` directory, activate the `include-hadoop` profile`:
 
 {% highlight bash %}
-mvn clean install -DskipTests -Dhadoop.version=2.6.5 -Pinclude-hadoop
+mvn clean install -DskipTests -Pinclude-hadoop
 {% endhighlight %}
 
 ### Custom / Vendor-specific versions
@@ -121,7 +121,7 @@ If you want to build against Hadoop version that is *NOT* 2.4.1, 2.6.5, 2.7.5 or
 then it is first necessary to build [flink-shaded](https://github.com/apache/flink-shaded) against this version.
 You can find the source for this project in the [Additional Components]({{ site.download_url }}#additional-components) section of the download page.
 
-Run the following command to build and install `flink-shaded` against your desired Hadoop version:
+Run the following command to build and install `flink-shaded` against your desired Hadoop version (e.g., for version `2.6.5-custom`):
 
 {% highlight bash %}
 mvn clean install -Dhadoop.version=2.6.5-custom

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -1,5 +1,5 @@
 ---
-title: 从源码构建 Flink
+title: Building Flink from Source
 nav-parent_id: flinkdev
 nav-pos: 20
 ---
@@ -97,34 +97,48 @@ mvn clean install
 
 ## Hadoop Versions
 
-{% info %} Most users do not need to do this manually. The [download page]({{ site.download_url }}) contains binary packages for common Hadoop versions.
+Flink has optional dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
 
-Flink has dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
+Flink can be built against any Hadoop version >= 2.4.0, but depending on the version it may be a 1 or 2 step process.
 
-Hadoop is only supported from version 2.4.0 upwards.
-You can also specify a specific Hadoop version to build against:
+### Pre-bundled versions
 
-{% highlight bash %}
-mvn clean install -DskipTests -Dhadoop.version=2.6.1
-{% endhighlight %}
-
-### Packaging Hadoop into the Flink distribution
-
-If you want to build a Flink distribution that has a shaded Hadoop pre-packaged in the lib folder you can use the `include-hadoop` profile to do so. You would build Flink as described above but include the profile:
+If you want to build against Hadoop 2.4.1, 2.6.5, 2.7.5 or 2.8.3, then it is sufficient to run:
 
 {% highlight bash %}
-mvn clean install -DskipTests -Pinclude-hadoop
+mvn clean install -DskipTests -Dhadoop.version=2.6.5
 {% endhighlight %}
 
-### Vendor-specific Versions
-To check the list of supported vendor versions, look in https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-hdfs?repo=cloudera
-To build Flink against a vendor specific Hadoop version, issue the following command:
+To further package a shaded pre-packaged hadoop jar into the distribution, additionally activate the `include-hadoop` profile`:
+
+{% highlight bash %}
+mvn clean install -DskipTests -Dhadoop.version=2.6.5 -Pinclude-hadoop
+{% endhighlight %}
+
+### Custom / Vendor-specific versions
+
+If you want to build against Hadoop version that is *NOT* 2.4.1, 2.6.5, 2.7.5 or 2.8.3,
+then it is first necessary to build [flink-shaded](https://github.com/apache/flink-shaded) against this version.
+You can find the source for this project in the `Additional Components` section of the [downloads page](http://flink.apache.org/downloads.html#additional-components).
+
+Run the following command to build and install `flink-shaded` against your desired Hadoop version:
+
+{% highlight bash %}
+mvn clean install -Dhadoop.version=2.6.5-custom
+{% endhighlight %}
+
+After this step is complete, follow the steps for [Pre-bundled versions](#pre-bundled-versions).
+
+To build Flink against a vendor specific Hadoop version, additionally activate -Pvendor-repos` profile when building
+`flink-shaded`.
 
 {% highlight bash %}
 mvn clean install -DskipTests -Pvendor-repos -Dhadoop.version=2.6.0-cdh5.16.1
 {% endhighlight %}
 
 The `-Pvendor-repos` activates a Maven [build profile](http://maven.apache.org/guides/introduction/introduction-to-profiles.html) that includes the repositories of popular Hadoop vendors such as Cloudera, Hortonworks, or MapR.
+
+The list of supported vendor versions can be checked [here](https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-hdfs?repo=cloudera).
 
 {% top %}
 

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -107,7 +107,7 @@ To build against Hadoop 2.4.1, 2.6.5, 2.7.5 or 2.8.3, it is sufficient to run (e
 mvn clean install -DskipTests -Dhadoop.version=2.6.5
 {% endhighlight %}
 
-To package a shaded pre-packaged hadoop jar into the distributions `/lib` directory, activate the `include-hadoop` profile`:
+To package a shaded pre-packaged Hadoop jar into the distributions `/lib` directory, activate the `include-hadoop` profile`:
 
 {% highlight bash %}
 mvn clean install -DskipTests -Pinclude-hadoop

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -119,7 +119,7 @@ mvn clean install -DskipTests -Dhadoop.version=2.6.5 -Pinclude-hadoop
 
 If you want to build against Hadoop version that is *NOT* 2.4.1, 2.6.5, 2.7.5 or 2.8.3,
 then it is first necessary to build [flink-shaded](https://github.com/apache/flink-shaded) against this version.
-You can find the source for this project in the `Additional Components` section of the [downloads page](http://flink.apache.org/downloads.html#additional-components).
+You can find the source for this project in the [Additional Components]({{ site.download_url }}#additional-components) section of the download page.
 
 Run the following command to build and install `flink-shaded` against your desired Hadoop version:
 

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -97,7 +97,7 @@ mvn clean install
 
 ## Hadoop Versions
 
-Flink has optional dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
+Flink has optional dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using an incompatible combination of versions, exceptions may occur.
 
 Flink can be built against any Hadoop version >= 2.4.0, but depending on the version it may be a 1 or 2 step process.
 

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -1,5 +1,5 @@
 ---
-title: Building Flink from Source
+title: 从源码构建 Flink
 nav-parent_id: flinkdev
 nav-pos: 20
 ---

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -103,16 +103,16 @@ Flink can be built against any Hadoop version >= 2.4.0, but depending on the ver
 
 ### Pre-bundled versions
 
-If you want to build against Hadoop 2.4.1, 2.6.5, 2.7.5 or 2.8.3, then it is sufficient to run:
+To build against Hadoop 2.4.1, 2.6.5, 2.7.5 or 2.8.3, it is sufficient to run (e.g., for version `2.6.5`):
 
 {% highlight bash %}
 mvn clean install -DskipTests -Dhadoop.version=2.6.5
 {% endhighlight %}
 
-To further package a shaded pre-packaged hadoop jar into the distribution, additionally activate the `include-hadoop` profile`:
+To package a shaded pre-packaged hadoop jar into the distributions `/lib` directory, activate the `include-hadoop` profile`:
 
 {% highlight bash %}
-mvn clean install -DskipTests -Dhadoop.version=2.6.5 -Pinclude-hadoop
+mvn clean install -DskipTests -Pinclude-hadoop
 {% endhighlight %}
 
 ### Custom / Vendor-specific versions
@@ -121,7 +121,7 @@ If you want to build against Hadoop version that is *NOT* 2.4.1, 2.6.5, 2.7.5 or
 then it is first necessary to build [flink-shaded](https://github.com/apache/flink-shaded) against this version.
 You can find the source for this project in the [Additional Components]({{ site.download_url }}#additional-components) section of the download page.
 
-Run the following command to build and install `flink-shaded` against your desired Hadoop version:
+Run the following command to build and install `flink-shaded` against your desired Hadoop version (e.g., for version `2.6.5-custom`):
 
 {% highlight bash %}
 mvn clean install -Dhadoop.version=2.6.5-custom

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -56,8 +56,6 @@ To speed up the build you can skip tests, QA plugins, and JavaDocs:
 mvn clean install -DskipTests -Dfast
 {% endhighlight %}
 
-The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink with HDFS and YARN.
-
 ## 构建PyFlink
 
 如果您想构建一个可用于pip安装的PyFlink包，您需要先构建Flink的Jar包，如[构建Flink](##Build Flink)中所述。

--- a/docs/getting-started/tutorials/local_setup.md
+++ b/docs/getting-started/tutorials/local_setup.md
@@ -51,7 +51,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)
 
 <div data-lang="Download and Unpack" markdown="1">
 1. Download a binary from the [downloads page](http://flink.apache.org/downloads.html). You can pick
-   any Scala variant you like. For certain features you may also have to download one of the pre-bundled hadoop jars
+   any Scala variant you like. For certain features you may also have to download one of the pre-bundled Hadoop jars
    and place them into the `/lib` directory.
 2. Go to the download directory.
 3. Unpack the downloaded archive.

--- a/docs/getting-started/tutorials/local_setup.md
+++ b/docs/getting-started/tutorials/local_setup.md
@@ -51,8 +51,8 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)
 
 <div data-lang="Download and Unpack" markdown="1">
 1. Download a binary from the [downloads page](http://flink.apache.org/downloads.html). You can pick
-   any Hadoop/Scala combination you like. If you plan to just use the local file system, any Hadoop
-   version will work fine.
+   any Scala variant you like. For certain features you may also have to download one of the pre-bundled hadoop jars
+   and place them into the `/lib` directory.
 2. Go to the download directory.
 3. Unpack the downloaded archive.
 

--- a/docs/getting-started/tutorials/local_setup.zh.md
+++ b/docs/getting-started/tutorials/local_setup.zh.md
@@ -51,7 +51,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)
 
 <div data-lang="Download and Unpack" markdown="1">
 1. Download a binary from the [downloads page](http://flink.apache.org/downloads.html). You can pick
-   any Scala variant you like. For certain features you may also have to download one of the pre-bundled hadoop jars
+   any Scala variant you like. For certain features you may also have to download one of the pre-bundled Hadoop jars
    and place them into the `/lib` directory.
 2. Go to the download directory.
 3. Unpack the downloaded archive.

--- a/docs/getting-started/tutorials/local_setup.zh.md
+++ b/docs/getting-started/tutorials/local_setup.zh.md
@@ -51,8 +51,8 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)
 
 <div data-lang="Download and Unpack" markdown="1">
 1. Download a binary from the [downloads page](http://flink.apache.org/downloads.html). You can pick
-   any Hadoop/Scala combination you like. If you plan to just use the local file system, any Hadoop
-   version will work fine.
+   any Scala variant you like. For certain features you may also have to download one of the pre-bundled hadoop jars
+   and place them into the `/lib` directory.
 2. Go to the download directory.
 3. Unpack the downloaded archive.
 


### PR DESCRIPTION
Updates the hadoop build instructions. With the migration to flink-shaded users now have to first build flink-shaded against the custom hadoop version.

![image](https://user-images.githubusercontent.com/5725237/61458264-5d646980-a96a-11e9-81e7-a5f453cb41c7.png)
