### PR TITLE
[FLINK-13279][table] Fallback to the builtin catalog when looking for registered tables.

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.table.delegation.Planner;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.sinks.TableSink;
 
 import javax.annotation.Nullable;
 
@@ -206,7 +208,14 @@ public class EnvironmentSettings {
 
 		/**
 		 * Specifies the name of the initial catalog to be created when instantiating
-		 * a {@link TableEnvironment}. Default: "default_catalog".
+		 * a {@link TableEnvironment}. This catalog will be used to store all
+		 * non-serializable objects such as tables and functions registered via e.g.
+		 * {@link TableEnvironment#registerTableSink(String, TableSink)} or
+		 * {@link TableEnvironment#registerFunction(String, ScalarFunction)}. This will
+		 * also be the initial value for the current catalog which can be altered via
+		 * {@link TableEnvironment#useCatalog(String)}.
+		 *
+		 * <p>Default: "default_catalog".
 		 */
 		public Builder withBuiltInCatalogName(String builtInCatalogName) {
 			this.builtInCatalogName = builtInCatalogName;
@@ -214,8 +223,15 @@ public class EnvironmentSettings {
 		}
 
 		/**
-		 * Specifies the name of the default database in the initial catalog to be created when instantiating
-		 * a {@link TableEnvironment}. Default: "default_database".
+		 * Specifies the name of the default database in the initial catalog to be
+		 * created when instantiating a {@link TableEnvironment}.This database will be
+		 * used to store all non-serializable objects such as tables and functions registered
+		 * via e.g. {@link TableEnvironment#registerTableSink(String, TableSink)} or
+		 * {@link TableEnvironment#registerFunction(String, ScalarFunction)}. This will
+		 * also be the initial value for the current database which can be altered via
+		 * {@link TableEnvironment#useDatabase(String)} (String)}.
+		 *
+		 * <p>Default: "default_database".
 		 */
 		public Builder withBuiltInDatabaseName(String builtInDatabaseName) {
 			this.builtInDatabaseName = builtInDatabaseName;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -830,7 +830,7 @@ public interface Table {
 
 	/**
 	 * Writes the {@link Table} to a {@link TableSink} that was registered under the specified name
-	 * in the initial default catalog.
+	 * in the builtin catalog.
 	 *
 	 * <p>A batch {@link Table} can only be written to a
 	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -106,10 +106,11 @@ public class TableEnvironmentImpl implements TableEnvironment {
 		this.execEnv = executor;
 
 		this.tableConfig = tableConfig;
+
 		// The current catalog and database are definitely builtin,
 		// see #create(EnvironmentSettings)
-		this.builtinCatalogName = catalogManager.getCurrentCatalog();
-		this.builtinDatabaseName = catalogManager.getCurrentDatabase();
+		this.builtinCatalogName = catalogManager.getBuiltinCatalogName();
+		this.builtinDatabaseName = catalogManager.getCatalog(builtinCatalogName).get().getDefaultDatabase();
 
 		this.functionCatalog = functionCatalog;
 		this.planner = planner;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -315,6 +315,7 @@ public class CatalogManager {
 	 * <ol>
 	 *     <li>{@code [current-catalog].[current-database].[tablePath]}</li>
 	 *     <li>{@code [current-catalog].[tablePath]}</li>
+	 *     <li>{@code [builtin-catalog].[default-database].[tablePath]}</li>
 	 *     <li>{@code [tablePath]}</li>
 	 * </ol>
 	 *
@@ -330,6 +331,7 @@ public class CatalogManager {
 		List<List<String>> prefixes = asList(
 			asList(currentCatalogName, currentDatabaseName),
 			singletonList(currentCatalogName),
+			asList(builtinCatalogName, catalogs.get(builtinCatalogName).getDefaultDatabase()),
 			emptyList()
 		);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -64,8 +64,8 @@ public class CatalogManager {
 
 	private String currentDatabaseName;
 
-	// The name of the default catalog
-	private final String defaultCatalogName;
+	// The name of the builtin catalog
+	private final String builtinCatalogName;
 
 	/**
 	 * Temporary solution to handle both {@link CatalogBaseTable} and
@@ -128,7 +128,9 @@ public class CatalogManager {
 		catalogs.put(defaultCatalogName, defaultCatalog);
 		this.currentCatalogName = defaultCatalogName;
 		this.currentDatabaseName = defaultCatalog.getDefaultDatabase();
-		this.defaultCatalogName = defaultCatalogName;
+
+		// right now the default catalog is always the builtin one
+		this.builtinCatalogName = defaultCatalogName;
 	}
 
 	/**
@@ -298,12 +300,13 @@ public class CatalogManager {
 	}
 
 	/**
-	 * Gets the default catalog name.
+	 * Gets the builtin catalog name. The built-in catalog is used for storing all non-serializable transient
+	 * meta-objects.
 	 *
-	 * @return the default catalog
+	 * @return the builtin catalog
 	 */
-	public String getDefaultCatalogName() {
-		return defaultCatalogName;
+	public String getBuiltinCatalogName() {
+		return builtinCatalogName;
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -150,9 +150,7 @@ public class FunctionCatalog implements FunctionLookup {
 				.map(FunctionDefinition::toString)
 				.collect(Collectors.toList()));
 
-		return result.stream()
-			.collect(Collectors.toList())
-			.toArray(new String[0]);
+		return result.toArray(new String[0]);
 	}
 
 	@Override
@@ -180,7 +178,7 @@ public class FunctionCatalog implements FunctionLookup {
 						userCandidate)
 				);
 			} else {
-				// TODO: should go thru function definition discover service
+				// TODO: should go through function definition discover service
 			}
 		} catch (FunctionNotExistException e) {
 			// Ignore
@@ -206,10 +204,13 @@ public class FunctionCatalog implements FunctionLookup {
 				.map(Function.identity());
 		}
 
-		String defaultCatalogName = catalogManager.getDefaultCatalogName();
+		String builtinCatalogName = catalogManager.getBuiltinCatalogName();
 
 		return foundDefinition.map(definition -> new FunctionLookup.Result(
-			ObjectIdentifier.of(defaultCatalogName, catalogManager.getCatalog(defaultCatalogName).get().getDefaultDatabase(), name),
+			ObjectIdentifier.of(
+				builtinCatalogName,
+				catalogManager.getCatalog(builtinCatalogName).get().getDefaultDatabase(),
+				name),
 			definition)
 		);
 	}

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
@@ -295,11 +295,11 @@ object BatchTableEnvironment {
           classOf[ExecutionEnvironment],
           classOf[TableConfig],
           classOf[CatalogManager])
-      val defaultCatalog = "default_catalog"
+      val builtinCatalog = "default_catalog"
       val catalogManager = new CatalogManager(
         "default_catalog",
         new GenericInMemoryCatalog(
-          defaultCatalog,
+          builtinCatalog,
           "default_database")
       )
       const.newInstance(executionEnvironment, tableConfig, catalogManager)

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/PlannerContext.java
@@ -74,13 +74,19 @@ public class PlannerContext {
 	private final FunctionCatalog functionCatalog;
 	private final FrameworkConfig frameworkConfig;
 	private final RelOptCluster cluster;
+	private final String builtinCatalog;
+	private final String builtinDatabase;
 
 	public PlannerContext(
 			TableConfig tableConfig,
 			FunctionCatalog functionCatalog,
 			CalciteSchema rootSchema,
-			List<RelTraitDef> traitDefs) {
+			List<RelTraitDef> traitDefs,
+			String builtinCatalog,
+			String builtinDatabase) {
 		this.tableConfig = tableConfig;
+		this.builtinCatalog = builtinCatalog;
+		this.builtinDatabase = builtinDatabase;
 		this.functionCatalog = functionCatalog;
 		this.frameworkConfig = createFrameworkConfig(rootSchema, traitDefs);
 
@@ -160,7 +166,8 @@ public class PlannerContext {
 				CalciteSchema.from(rootSchema),
 				asList(
 						asList(currentCatalog, currentDatabase),
-						singletonList(currentCatalog)
+						singletonList(currentCatalog),
+						asList(builtinCatalog, builtinDatabase)
 				),
 				typeFactory,
 				CalciteConfig$.MODULE$.connectionConfig(newSqlParserConfig));

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/PlannerBase.scala
@@ -83,7 +83,9 @@ abstract class PlannerBase(
       config,
       functionCatalog,
       asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),
-      getTraitDefs.toList
+      getTraitDefs.toList,
+      catalogManager.getBuiltinCatalogName,
+      catalogManager.getCatalog(catalogManager.getBuiltinCatalogName).get().getDefaultDatabase
     )
 
   /** Returns the [[FlinkRelBuilder]] of this TableEnvironment. */

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -89,7 +89,9 @@ class FlinkRelMdHandlerTestBase {
         ConventionTraitDef.INSTANCE,
         FlinkRelDistributionTraitDef.INSTANCE,
         RelCollationTraitDef.INSTANCE
-      )
+      ),
+      builtinCatalog,
+      builtinDatabase
     )
   val typeFactory: FlinkTypeFactory = plannerContext.getTypeFactory
   val mq: FlinkRelMetadataQuery = FlinkRelMetadataQuery.instance()

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -73,9 +73,10 @@ class FlinkRelMdHandlerTestBase {
   val tableConfig = new TableConfig()
   val rootSchema: SchemaPlus = MetadataTestUtil.initRootSchema()
 
-  val defaultCatalog = "default_catalog"
+  val builtinCatalog = "default_catalog"
+  val builtinDatabase = "default_database"
   val catalogManager = new CatalogManager(
-    defaultCatalog, new GenericInMemoryCatalog(defaultCatalog, "default_database"))
+    builtinCatalog, new GenericInMemoryCatalog(builtinCatalog, builtinDatabase))
 
   // TODO batch RelNode and stream RelNode should have different PlannerContext
   //  and RelOptCluster due to they have different trait definitions.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
@@ -77,19 +77,25 @@ public class PlanningConfigurationBuilder {
 	private final Context context;
 	private final TableConfig tableConfig;
 	private final FunctionCatalog functionCatalog;
+	private final String builtinCatalog;
+	private final String builtinDatabase;
 	private CalciteSchema rootSchema;
 
 	public PlanningConfigurationBuilder(
 			TableConfig tableConfig,
 			FunctionCatalog functionCatalog,
 			CalciteSchema rootSchema,
-			ExpressionBridge<PlannerExpression> expressionBridge) {
+			ExpressionBridge<PlannerExpression> expressionBridge,
+			String builtinCatalog,
+			String builtinDatabase) {
 		this.tableConfig = tableConfig;
 		this.functionCatalog = functionCatalog;
 
 		// the converter is needed when calling temporal table functions from SQL, because
 		// they reference a history table represented with a tree of table operations
 		this.context = Contexts.of(expressionBridge);
+		this.builtinCatalog = builtinCatalog;
+		this.builtinDatabase = builtinDatabase;
 
 		this.planner = new VolcanoPlanner(costFactory, context);
 		planner.setExecutor(new ExpressionReducer(tableConfig));
@@ -180,7 +186,8 @@ public class PlanningConfigurationBuilder {
 			rootSchema,
 			asList(
 				asList(currentCatalog, currentDatabase),
-				singletonList(currentCatalog)
+				singletonList(currentCatalog),
+				asList(builtinCatalog, builtinDatabase)
 			),
 			typeFactory,
 			CalciteConfig.connectionConfig(parserConfig));

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -93,7 +93,11 @@ abstract class TableEnvImpl(
       config,
       functionCatalog,
       asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),
-      expressionBridge)
+      expressionBridge,
+      catalogManager.getBuiltinCatalogName,
+      JavaScalaConversionUtil
+        .toScala(catalogManager.getCatalog(catalogManager.getBuiltinCatalogName))
+        .map(_.getDefaultDatabase).get)
 
   def getConfig: TableConfig = config
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -60,8 +60,9 @@ abstract class TableEnvImpl(
   extends TableEnvironment {
 
   // The current catalog and database are definitely builtin.
-  protected val builtinCatalogName: String = catalogManager.getCurrentCatalog
-  protected val builtinDatabaseName: String = catalogManager.getCurrentDatabase
+  protected val builtinCatalogName: String = catalogManager.getBuiltinCatalogName
+  protected val builtinDatabaseName: String = catalogManager.getCatalog(builtinCatalogName).get()
+    .getDefaultDatabase
 
   // Table API/SQL function catalog
   private[flink] val functionCatalog: FunctionCatalog = new FunctionCatalog(catalogManager)
@@ -358,7 +359,7 @@ abstract class TableEnvImpl(
           path,
           table,
           false)
-      case None => throw new TableException("The default catalog does not exist.")
+      case None => throw new TableException("The builtin catalog does not exist.")
     }
   }
 
@@ -371,7 +372,7 @@ abstract class TableEnvImpl(
           path,
           table,
           false)
-      case None => throw new TableException("The default catalog does not exist.")
+      case None => throw new TableException("The builtin catalog does not exist.")
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -86,7 +86,11 @@ class StreamPlanner(
       config,
       functionCatalog,
       internalSchema,
-      expressionBridge)
+      expressionBridge,
+      catalogManager.getBuiltinCatalogName,
+      JavaScalaConversionUtil
+        .toScala(catalogManager.getCatalog(catalogManager.getBuiltinCatalogName))
+        .map(_.getDefaultDatabase).get)
 
   @VisibleForTesting
   private[flink] val optimizer: StreamOptimizer = new StreamOptimizer(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/PathResolutionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/PathResolutionTest.java
@@ -122,7 +122,14 @@ public class PathResolutionTest {
 				.withCatalogManager(catalogWithSpecialCharacters())
 				.tableApiLookupPath("default db", "tab 1")
 				.sqlLookupPath("`default db`.`tab 1`")
-				.expectPath(BUILTIN_CATALOG_NAME, "default db", "tab 1")
+				.expectPath(BUILTIN_CATALOG_NAME, "default db", "tab 1"),
+
+			testSpec("fallBackToBuiltinCatalog")
+				.withCatalogManager(simpleCatalog())
+				.withDefaultPath("cat1", "db1")
+				.tableApiLookupPath("tab2")
+				.sqlLookupPath("tab2")
+				.expectPath(BUILTIN_CATALOG_NAME, "default", "tab2")
 		);
 	}
 
@@ -131,11 +138,13 @@ public class PathResolutionTest {
 			.builtin(
 				database(
 					"default",
-					table("tab1")
+					table("tab1"),
+					table("tab2")
 				),
 				database(
 					"db1",
-					table("tab1")
+					table("tab1"),
+					table("tab2")
 				)
 			)
 			.catalog(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSinkITCase.scala
@@ -24,12 +24,14 @@ import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.api.scala.{ExecutionEnvironment, _}
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.catalog.GenericInMemoryCatalog
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.table.sinks.CsvTableSink
 import org.apache.flink.table.utils.MemoryTableSourceSinkUtil
 import org.apache.flink.table.utils.MemoryTableSourceSinkUtil.UnsafeMemoryOutputFormatTableSink
 import org.apache.flink.test.util.TestBaseUtils
+
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -60,7 +62,7 @@ class TableSinkITCase(
     val input = CollectionDataSets.get3TupleDataSet(env)
       .map(x => x).setParallelism(4) // increase DOP to 4
 
-    val results = input.toTable(tEnv, 'a, 'b, 'c)
+    input.toTable(tEnv, 'a, 'b, 'c)
       .where('a < 5 || 'a > 17)
       .select('c, 'b)
       .insertInto("testSink")
@@ -99,6 +101,34 @@ class TableSinkITCase(
     val expected = Seq(
       "Hi,1", "Hello,2", "Hello world,2", "Hello world, how are you?,3",
       "Comment#12,6", "Comment#13,6", "Comment#14,6", "Comment#15,6").mkString("\n")
+
+    TestBaseUtils.compareResultAsText(results, expected)
+  }
+
+  @Test
+  def testSinkWithNonDefaultCurrentCatalog(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = BatchTableEnvironment.create(env, config)
+    MemoryTableSourceSinkUtil.clear()
+    tEnv.registerCatalog("other", new GenericInMemoryCatalog("other", "default"))
+    tEnv.useCatalog("other")
+
+    val fieldNames = Array("c", "b")
+    val fieldTypes: Array[TypeInformation[_]] = Array(Types.STRING, Types.LONG)
+    val sink = new UnsafeMemoryOutputFormatTableSink
+    tEnv.registerTableSink("testSink", sink.configure(fieldNames, fieldTypes))
+
+    val input = CollectionDataSets.get3TupleDataSet(env)
+
+    input.toTable(tEnv, 'a, 'b, 'c)
+      .where('b === 2)
+      .select('c, 'b)
+      .insertInto("testSink")
+
+    env.execute()
+
+    val results = MemoryTableSourceSinkUtil.tableDataStrings.asJava
+    val expected = Seq("Hello world,2", "Hello,2").mkString("\n")
 
     TestBaseUtils.compareResultAsText(results, expected)
   }


### PR DESCRIPTION
## What is the purpose of the change

Makes the builtin catalog a fallback catalog. If the name is not found in the current catalog it will be looked up in the builtin catalog, before trying to resolve it as a full path.

## Verifying this change

This change added tests and can be verified as follows:
 - TableSinkItCase#testSinkWithNonDefaultCurrentCatalog
 - case in PathResolutionTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
