### PR TITLE
[FLINK-13326] Support asynchronous writing to raw operator (and raw keyed) state	

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateCheckpointOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateCheckpointOutputStream.java
@@ -102,7 +102,7 @@ public final class KeyedStateCheckpointOutputStream extends NonClosingCheckpoint
 
 	@Override
 	KeyGroupsStateHandle closeAndGetHandle() throws IOException {
-		StreamStateHandle streamStateHandle = delegate.closeAndGetHandle();
+		StreamStateHandle streamStateHandle = super.closeAndGetHandleAfterLeasesReleased();
 		return streamStateHandle != null ? new KeyGroupsStateHandle(keyGroupRangeOffsets, streamStateHandle) : null;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateCheckpointOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateCheckpointOutputStream.java
@@ -56,7 +56,7 @@ public final class OperatorStateCheckpointOutputStream
 	 */
 	@Override
 	OperatorStateHandle closeAndGetHandle() throws IOException {
-		StreamStateHandle streamStateHandle = delegate.closeAndGetHandle();
+		StreamStateHandle streamStateHandle = super.closeAndGetHandleAfterLeasesReleased();
 
 		if (null == streamStateHandle) {
 			return null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotContextSynchronousImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotContextSynchronousImpl.java
@@ -20,34 +20,35 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.state.AsyncSnapshotCallable.AsyncSnapshotTask;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.RunnableFuture;
 
 /**
  * This class is a default implementation for StateSnapshotContext.
  */
-public class StateSnapshotContextSynchronousImpl implements StateSnapshotContext, Closeable {
+public class StateSnapshotContextSynchronousImpl implements StateSnapshotContext {
 
 	/** Checkpoint id of the snapshot. */
 	private final long checkpointId;
 
 	/** Checkpoint timestamp of the snapshot. */
 	private final long checkpointTimestamp;
-	
-	/** Factory for the checkpointing stream */
+
+	/** Factory for the checkpointing stream. */
 	private final CheckpointStreamFactory streamFactory;
-	
-	/** Key group range for the operator that created this context. Only for keyed operators */
+
+	/** Key group range for the operator that created this context. Only for keyed operators. */
 	private final KeyGroupRange keyGroupRange;
 
 	/**
-	 * Registry for opened streams to participate in the lifecycle of the stream task. Hence, this registry should be 
+	 * Registry for opened streams to participate in the lifecycle of the stream task. Hence, this registry should be
 	 * obtained from and managed by the stream task.
 	 */
 	private final CloseableRegistry closableRegistry;
@@ -58,15 +59,17 @@ public class StateSnapshotContextSynchronousImpl implements StateSnapshotContext
 	/** Output stream for the raw operator state. */
 	private OperatorStateCheckpointOutputStream operatorStateCheckpointOutputStream;
 
+	private RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateCheckpointClosingFuture;
+	private RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateCheckpointClosingFuture;
+
 	@VisibleForTesting
 	public StateSnapshotContextSynchronousImpl(long checkpointId, long checkpointTimestamp) {
 		this.checkpointId = checkpointId;
 		this.checkpointTimestamp = checkpointTimestamp;
 		this.streamFactory = null;
 		this.keyGroupRange = KeyGroupRange.EMPTY_KEY_GROUP_RANGE;
-		this.closableRegistry = null;
+		this.closableRegistry = new CloseableRegistry();
 	}
-
 
 	public StateSnapshotContextSynchronousImpl(
 			long checkpointId,
@@ -119,31 +122,26 @@ public class StateSnapshotContextSynchronousImpl implements StateSnapshotContext
 
 	@Nonnull
 	public RunnableFuture<SnapshotResult<KeyedStateHandle>> getKeyedStateStreamFuture() throws IOException {
-		KeyedStateHandle keyGroupsStateHandle =
-			closeAndUnregisterStreamToObtainStateHandle(keyedStateCheckpointOutputStream);
-		return toDoneFutureOfSnapshotResult(keyGroupsStateHandle);
+		if (null == keyedStateCheckpointClosingFuture) {
+			StreamCloserCallable<KeyGroupsStateHandle> callable = new StreamCloserCallable<>(closableRegistry, keyedStateCheckpointOutputStream);
+			AsyncSnapshotTask asyncSnapshotTask = callable.toAsyncSnapshotFutureTask(closableRegistry);
+			keyedStateCheckpointClosingFuture = castAsKeyedStateHandle(asyncSnapshotTask);
+		}
+		return keyedStateCheckpointClosingFuture;
 	}
 
 	@Nonnull
 	public RunnableFuture<SnapshotResult<OperatorStateHandle>> getOperatorStateStreamFuture() throws IOException {
-		OperatorStateHandle operatorStateHandle =
-			closeAndUnregisterStreamToObtainStateHandle(operatorStateCheckpointOutputStream);
-		return toDoneFutureOfSnapshotResult(operatorStateHandle);
-	}
-
-	private <T extends StateObject> RunnableFuture<SnapshotResult<T>> toDoneFutureOfSnapshotResult(T handle) {
-		SnapshotResult<T> snapshotResult = SnapshotResult.of(handle);
-		return DoneFuture.of(snapshotResult);
-	}
-
-	private <T extends StreamStateHandle> T closeAndUnregisterStreamToObtainStateHandle(
-		NonClosingCheckpointOutputStream<T> stream) throws IOException {
-
-		if (stream != null && closableRegistry.unregisterCloseable(stream.getDelegate())) {
-			return stream.closeAndGetHandle();
-		} else {
-			return null;
+		if (null == operatorStateCheckpointClosingFuture) {
+			StreamCloserCallable<OperatorStateHandle> callable = new StreamCloserCallable<>(closableRegistry, operatorStateCheckpointOutputStream);
+			operatorStateCheckpointClosingFuture = callable.toAsyncSnapshotFutureTask(closableRegistry);
 		}
+		return operatorStateCheckpointClosingFuture;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static RunnableFuture<SnapshotResult<KeyedStateHandle>> castAsKeyedStateHandle(RunnableFuture<?> asyncSnapshotTask) {
+		return (RunnableFuture<SnapshotResult<KeyedStateHandle>>) asyncSnapshotTask;
 	}
 
 	private <T extends StreamStateHandle> void closeAndUnregisterStream(
@@ -158,30 +156,70 @@ public class StateSnapshotContextSynchronousImpl implements StateSnapshotContext
 		}
 	}
 
-	@Override
-	public void close() throws IOException {
+	public void closeExceptionally() throws IOException {
 		IOException exception = null;
-
 		if (keyedStateCheckpointOutputStream != null) {
 			try {
 				closeAndUnregisterStream(keyedStateCheckpointOutputStream);
-			} catch (IOException e) {
+			}
+			catch (IOException e) {
 				exception = new IOException("Could not close the raw keyed state checkpoint output stream.", e);
 			}
 		}
-
 		if (operatorStateCheckpointOutputStream != null) {
 			try {
 				closeAndUnregisterStream(operatorStateCheckpointOutputStream);
-			} catch (IOException e) {
+			}
+			catch (IOException e) {
 				exception = ExceptionUtils.firstOrSuppressed(
 					new IOException("Could not close the raw operator state checkpoint output stream.", e),
 					exception);
 			}
 		}
-
+		if (keyedStateCheckpointClosingFuture != null) {
+			keyedStateCheckpointClosingFuture.cancel(true);
+		}
+		if (operatorStateCheckpointClosingFuture != null) {
+			operatorStateCheckpointClosingFuture.cancel(true);
+		}
 		if (exception != null) {
 			throw exception;
+		}
+	}
+
+	private static final class StreamCloserCallable<T extends StreamStateHandle> extends AsyncSnapshotCallable<SnapshotResult<T>> {
+
+		@Nullable
+		private final NonClosingCheckpointOutputStream<T> stream;
+		private final CloseableRegistry closableRegistry;
+
+		StreamCloserCallable(CloseableRegistry closableRegistry, @Nullable NonClosingCheckpointOutputStream<T> stream) {
+			this.closableRegistry = Preconditions.checkNotNull(closableRegistry);
+			this.stream = stream;
+		}
+
+		@Override
+		protected SnapshotResult<T> callInternal() throws Exception {
+			if (stream == null) {
+				return SnapshotResult.of(null);
+			}
+			if (!closableRegistry.unregisterCloseable(stream.getDelegate())) {
+				throw new IOException("Stream delegate appears to be closed, because it is no longer registered.");
+			}
+			T closed = stream.closeAndGetHandle();
+			return SnapshotResult.of(closed);
+		}
+
+		@Override
+		protected void cleanupProvidedResources() {
+			try {
+				if (stream != null && closableRegistry.unregisterCloseable(stream.getDelegate())) {
+					stream.closeAndGetHandle();
+				}
+			}
+			catch (IOException e) {
+				throw new IllegalStateException("Unable to cleanup a stream.", e);
+			}
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -521,7 +521,6 @@ public class AbstractStreamOperatorTest {
 				CheckpointOptions.forCheckpointWithDefaultLocation(),
 				new MemCheckpointStreamFactory(Integer.MAX_VALUE));
 
-		verify(context).close();
 	}
 
 	/**
@@ -561,8 +560,6 @@ public class AbstractStreamOperatorTest {
 		} catch (Exception e) {
 			assertEquals(failingException, e.getCause());
 		}
-
-		verify(context).close();
 	}
 
 	/**
@@ -644,7 +641,6 @@ public class AbstractStreamOperatorTest {
 
 		// verify that the context has been closed, the operator snapshot result has been cancelled
 		// and that all futures have been cancelled.
-		verify(context).close();
 		verify(operatorSnapshotResult).cancel();
 
 		verify(futureKeyedStateHandle).cancel(anyBoolean());


### PR DESCRIPTION
## What is the purpose of the change

Currently, the users of the `AbstractStreamOperator` class, are expected to complete the writing of `rawKeyedOperatorState` and `rawOperatorState` in the synchronous part of a snapshot (before the completion of `snapshotState` method)
But sometimes it is desirable to snapshot a custom data structure asynchronously (i.e. out side of the snapshotState method) in a similar way that the other state backends allow.

This PR adds the ability to suspend the closing of the raw states streams in `snapshotState` outside of the snapshotState method, and hence effectively support async snapshots for raw states.

Flink snapshotting logic already supports splitting the snapshot to sync and async parts for the various state backends, therefore the changes introduced in this PR mainly reuse that logic.


## Brief change log

  - Add an interruptible close method to `ResourceGuard` (the default is still unInterruptible).
  - Add and use a ResourceGuard in `NonClosingCheckpointOutputStream`.
  - modify the `StateSnapshotContextSynchronousImpl#getRaw*OperatorStateOutput`   to return a future that completes after all the leases were released.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
