### PR TITLE
[FLINK-13330][table-planner-blink] Remove unnecessary to reduce testing time in blink

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/InnerJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/join/InnerJoinITCase.scala
@@ -153,6 +153,10 @@ class InnerJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
 
   @Test
   def testBigForSpill(): Unit = {
+    // ignore nested loop join because it is too slow.
+    if (expectedJoinType == NestedLoopJoin) {
+      return
+    }
 
     conf.getConfiguration.setInteger(ExecutionConfigOptions.SQL_RESOURCE_SORT_BUFFER_MEM, 1)
     conf.getConfiguration.setInteger(ExecutionConfigOptions.SQL_RESOURCE_HASH_JOIN_TABLE_MEM, 2)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamingWithAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamingWithAggTestBase.scala
@@ -63,9 +63,11 @@ object StreamingWithAggTestBase {
 
   @Parameterized.Parameters(name = "LocalGlobal={0}, {1}, StateBackend={2}")
   def parameters(): util.Collection[Array[java.lang.Object]] = {
+    // To avoid too long testing time, we not test all HEAP_BACKEND.
+    // If HEAP_BACKEND has changed, please open it manually for testing.
     Seq[Array[AnyRef]](
-      Array(LocalGlobalOff, MiniBatchOff, HEAP_BACKEND),
-      Array(LocalGlobalOff, MiniBatchOn, HEAP_BACKEND),
+//      Array(LocalGlobalOff, MiniBatchOff, HEAP_BACKEND),
+//      Array(LocalGlobalOff, MiniBatchOn, HEAP_BACKEND),
       Array(LocalGlobalOn, MiniBatchOn, HEAP_BACKEND),
       Array(LocalGlobalOff, MiniBatchOff, ROCKSDB_BACKEND),
       Array(LocalGlobalOff, MiniBatchOn, ROCKSDB_BACKEND),

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
@@ -49,7 +49,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +77,10 @@ public class BinaryHashTableTest {
 
 	@Parameterized.Parameters(name = "useCompress-{0}")
 	public static List<Boolean> getVarSeg() {
-		return Arrays.asList(true, false);
+		// To avoid too long testing time, we only tested the default configuration.
+		// If BinaryHashTable has changed, please open it manually for testing.
+//		return Arrays.asList(true, false);
+		return Collections.singletonList(true);
 	}
 
 	@Before

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
@@ -42,7 +42,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,7 +71,10 @@ public class LongHashTableTest {
 
 	@Parameterized.Parameters(name = "useCompress-{0}")
 	public static List<Boolean> getVarSeg() {
-		return Arrays.asList(true, false);
+		// To avoid too long testing time, we only tested the default configuration.
+		// If LongHashTable has changed, please open it manually for testing.
+//		return Arrays.asList(true, false);
+		return Collections.singletonList(true);
 	}
 
 	@Before

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/sort/BinaryExternalSorterTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/sort/BinaryExternalSorterTest.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -76,11 +75,14 @@ public class BinaryExternalSorterTest {
 
 	@Parameterized.Parameters(name = "spillCompress-{0} asyncMerge-{1}")
 	public static Collection<Boolean[]> parameters() {
-		return Arrays.asList(
-				new Boolean[]{false, false},
-				new Boolean[]{false, true},
-				new Boolean[]{true, false},
-				new Boolean[]{true, true});
+		// To avoid too long testing time, we only tested the default configuration.
+		// If BinaryExternalSorter has changed, please open it manually for testing.
+//		return Arrays.asList(
+//				new Boolean[]{false, false},
+//				new Boolean[]{false, true},
+//				new Boolean[]{true, false},
+//				new Boolean[]{true, true});
+		return Collections.singletonList(new Boolean[]{true, true});
 	}
 
 	private static String getString(int count) {


### PR DESCRIPTION

## What is the purpose of the change

Some tests are unnecessary.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no