### PR TITLE
[FLINK-12038] [test] fix YARNITCase random fail

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -117,10 +117,6 @@ public class YARNITCase extends YarnTestBase {
 					if (clusterClient != null) {
 						clusterClient.shutdown();
 					}
-
-					if (applicationId != null) {
-						yarnClusterDescriptor.killCluster(applicationId);
-					}
 				}
 			}
 		});

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -113,9 +113,15 @@ public class YARNITCase extends YarnTestBase {
 
 					assertThat(jobResult, is(notNullValue()));
 					assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
+
+					waitUntilApplicationFinished(applicationId, 10);
 				} finally {
 					if (clusterClient != null) {
 						clusterClient.shutdown();
+					}
+
+					if (applicationId != null) {
+						yarnClusterDescriptor.killCluster(applicationId);
 					}
 				}
 			}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -37,6 +37,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
@@ -49,6 +50,8 @@ import static org.junit.Assert.assertThat;
  * Test cases for the deployment of Yarn Flink clusters.
  */
 public class YARNITCase extends YarnTestBase {
+
+	private final Duration yarnAppTerminateTimeout = Duration.ofSeconds(10);
 
 	@BeforeClass
 	public static void setup() {
@@ -114,7 +117,7 @@ public class YARNITCase extends YarnTestBase {
 					assertThat(jobResult, is(notNullValue()));
 					assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
 
-					waitUntilApplicationFinished(applicationId, 10);
+					waitUntilApplicationFinished(applicationId, yarnAppTerminateTimeout);
 				} finally {
 					if (clusterClient != null) {
 						clusterClient.shutdown();

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -137,19 +137,20 @@ public class YARNITCase extends YarnTestBase {
 			Duration timeout,
 			YarnClusterDescriptor yarnClusterDescriptor) throws Exception {
 		Deadline deadline = Deadline.now().plus(timeout);
-		YarnApplicationState state = yarnClient.getApplicationReport(applicationId).getYarnApplicationState();
+		YarnApplicationState state = getYarnClient().getApplicationReport(applicationId).getYarnApplicationState();
 
 		while (state != YarnApplicationState.FINISHED) {
 			if (state == YarnApplicationState.FAILED || state == YarnApplicationState.KILLED) {
 				Assert.fail("Application became FAILED or KILLED while expecting FINISHED");
-			} else {
-				sleep(sleepIntervalInMS);
 			}
+
 			if (deadline.isOverdue()) {
 				yarnClusterDescriptor.killCluster(applicationId);
 				Assert.fail("Application didn't finish before timeout");
 			}
-			state = yarnClient.getApplicationReport(applicationId).getYarnApplicationState();
+
+			sleep(sleepIntervalInMS);
+			state = getYarnClient().getApplicationReport(applicationId).getYarnApplicationState();
 		}
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -160,7 +160,7 @@ public abstract class YarnTestBase extends TestLogger {
 
 	protected static File yarnSiteXML = null;
 
-	protected YarnClient yarnClient = null;
+	private YarnClient yarnClient = null;
 
 	private static org.apache.flink.configuration.Configuration globalConfiguration;
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.service.Service;
-import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
@@ -135,8 +134,6 @@ public abstract class YarnTestBase extends TestLogger {
 		"lost the leadership."
 	};
 
-	private final int sleepIntervalInMS = 100;
-
 	// Temp directory which is deleted after the unit test.
 	@ClassRule
 	public static TemporaryFolder tmp = new TemporaryFolder();
@@ -163,7 +160,7 @@ public abstract class YarnTestBase extends TestLogger {
 
 	protected static File yarnSiteXML = null;
 
-	private YarnClient yarnClient = null;
+	protected YarnClient yarnClient = null;
 
 	private static org.apache.flink.configuration.Configuration globalConfiguration;
 
@@ -574,23 +571,6 @@ public abstract class YarnTestBase extends TestLogger {
 			count += containers.size();
 		}
 		return count;
-	}
-
-	void waitUntilApplicationFinished(ApplicationId applicationId, Duration timeout) throws Exception {
-		Deadline deadline = Deadline.now().plus(timeout);
-		while (true) {
-			YarnApplicationState state = yarnClient.getApplicationReport(applicationId).getYarnApplicationState();
-			if (state == YarnApplicationState.FINISHED) {
-				break;
-			} else if (state == YarnApplicationState.FAILED || state == YarnApplicationState.KILLED) {
-				Assert.fail("Application became FAILED or KILLED while expecting FINISHED");
-			} else {
-				sleep(sleepIntervalInMS);
-			}
-			if (deadline.isOverdue()) {
-				Assert.fail("Application didn't finish before timeout");
-			}
-		}
 	}
 
 	public static void startYARNSecureMode(YarnConfiguration conf, String principal, String keytab) {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.service.Service;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
@@ -571,6 +572,20 @@ public abstract class YarnTestBase extends TestLogger {
 			count += containers.size();
 		}
 		return count;
+	}
+
+	public void waitUntilApplicationFinished(ApplicationId applicationId, int timeout) throws Exception {
+		Deadline deadline = Deadline.now().plus(Duration.ofSeconds(timeout));
+		while (deadline.hasTimeLeft()) {
+			YarnApplicationState state = yarnClient.getApplicationReport(applicationId).getYarnApplicationState();
+			if (state == YarnApplicationState.FINISHED ||
+					state == YarnApplicationState.FAILED ||
+					state == YarnApplicationState.KILLED) {
+				break;
+			} else {
+				sleep(500);
+			}
+		}
 	}
 
 	public static void startYARNSecureMode(YarnConfiguration conf, String principal, String keytab) {


### PR DESCRIPTION
## What is the purpose of the change

This pr fix that the YARNITCase may random fail due to [YARN-2853](https://issues.apache.org/jira/browse/YARN-2853). 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
