### PR TITLE
[hotfix][client] Fix PreviewPlanEnvironment missing set up field "plan"

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
@@ -49,7 +49,7 @@ public final class PreviewPlanEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan plan = createProgramPlan("unused");
+		this.plan = createProgramPlan("unused");
 		this.previewPlan = Optimizer.createPreOptimizedPlan(plan);
 
 		// do not go on with anything now!


### PR DESCRIPTION
## What is the purpose of the change

Fix PreviewPlanEnvironment missing set up field "plan".

## Brief change log

`PreviewPlanEnvironment` should have set `this.plan = ...`. However, it happens to use a local variable and leave the field to be `null`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol @dawidwys 
