### PR TITLE
[hotfix][docs] Fix loop redirection in https://ci.apache.org/projects/flink/flink-docs-master/dev/projectsetup/dependencies.html

### DIFF
--- a/docs/redirects/linking_with_optional_modules.md
+++ b/docs/redirects/linking_with_optional_modules.md
@@ -2,7 +2,7 @@
 title: "Linking with Optional Modules"
 layout: redirect
 redirect: /dev/projectsetup/dependencies.html
-permalink: /dev/projectsetup/dependencies.html
+permalink: /dev/linking.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed the loop redirection in https://ci.apache.org/projects/flink/flink-docs-master/dev/projectsetup/dependencies.html*


## Brief change log

  - *Set the value of `permalink` in `/docs/redirects/linking_with_optional_modules.md` to `/dev/linking.html`.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
