### PR TITLE
[FLINK-13331][table-planner-blink] Add CachedMiniCluster to share cluster between ITCases

### DIFF
--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -388,6 +388,27 @@ under the License.
 					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>integration-tests</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/*ITCase.*</include>
+							</includes>
+							<!-- Accelerate testing -->
+							<reuseForks>true</reuseForks>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/runtime/utils/CachedMiniClusterResource.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/runtime/utils/CachedMiniClusterResource.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.utils;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.rules.ExternalResource;
+
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Mini clusters cache to share cluster between Tests. This class use async thread to
+ * clean the expired cluster.
+ *
+ * <p>NOTE: Do not use {@link MiniClusterWithClientResource}, it will pollute thread local
+ * in {@link StreamExecutionEnvironment}.
+ */
+public class CachedMiniClusterResource extends ExternalResource {
+
+	public static final int DEFAULT_PARALLELISM = 4;
+	private static final Long CLEAN_INTERVAL_MILLS = 15 * 1000L;
+
+	private static final LinkedBlockingQueue<Tuple2<Long, MiniClusterResource>> CACHE = new LinkedBlockingQueue<>();
+	private static final ReadWriteLock LOCK = new ReentrantReadWriteLock();
+	private static final ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(
+			1, new ExecutorThreadFactory("CachedMiniClusterResource"));
+	static {
+		SCHEDULER.scheduleWithFixedDelay(
+				CachedMiniClusterResource::clean,
+				CLEAN_INTERVAL_MILLS, CLEAN_INTERVAL_MILLS, TimeUnit.MILLISECONDS);
+	}
+
+	private static MiniClusterResource loadCluster() throws Exception {
+		MiniClusterResource cluster = new MiniClusterResource(
+				new MiniClusterResourceConfiguration.Builder()
+						.setConfiguration(getConfiguration())
+						.setNumberTaskManagers(1)
+						.setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+						.build());
+
+		cluster.before();
+		return cluster;
+	}
+
+	private static Configuration getConfiguration() {
+		Configuration config = new Configuration();
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "100m");
+		return config;
+	}
+
+	private static void clean() {
+		try {
+			LOCK.writeLock().lock();
+			Iterator<Tuple2<Long, MiniClusterResource>> iter = CACHE.iterator();
+			while (iter.hasNext()) {
+				Tuple2<Long, MiniClusterResource> tuple2 = iter.next();
+				if (System.currentTimeMillis() - tuple2.f0 > CLEAN_INTERVAL_MILLS) {
+					tuple2.f1.after();
+					iter.remove();
+				}
+			}
+		} finally {
+			LOCK.writeLock().unlock();
+		}
+	}
+
+	private MiniClusterResource cluster;
+
+	@Override
+	protected void before() throws Throwable {
+		try {
+			LOCK.readLock().lock();
+			Tuple2<Long, MiniClusterResource> tuple2 = CACHE.poll();
+			cluster = tuple2 == null ? loadCluster() : tuple2.f1;
+		} finally {
+			LOCK.readLock().unlock();
+		}
+	}
+
+	@Override
+	protected void after() {
+		try {
+			LOCK.readLock().lock();
+			CACHE.add(new Tuple2<>(System.currentTimeMillis(), cluster));
+		} finally {
+			LOCK.readLock().unlock();
+		}
+	}
+
+	public MiniClusterResource getCluster() {
+		return cluster;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/runtime/utils/ITCaseBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/runtime/utils/ITCaseBase.java
@@ -18,37 +18,33 @@
 
 package org.apache.flink.table.runtime.utils;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
 
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
-
 /**
- * Batch test base to use {@link ClassRule}.
+ * Table test base to use {@link ClassRule}.
  */
-public class BatchAbstractTestBase {
+public abstract class ITCaseBase {
 
-	public static final int DEFAULT_PARALLELISM = 3;
+	public ITCaseBase() {
+		String name = getClass().getSimpleName();
+		if (!name.endsWith("ITCase")) {
+			throw new RuntimeException("ITCaseBase should only used in ITCase, now is: " + name);
+		}
+	}
 
 	@ClassRule
-	public static MiniClusterWithClientResource miniClusterResource = new MiniClusterWithClientResource(
-			new MiniClusterResourceConfiguration.Builder()
-					.setConfiguration(getConfiguration())
-					.setNumberTaskManagers(1)
-					.setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
-					.build());
+	public static CachedMiniClusterResource miniClusterResource = new CachedMiniClusterResource();
+
+	public static StreamExecutionEnvironment getExecutionEnvironment() {
+		return new TestStreamEnvironment(
+				miniClusterResource.getCluster().getMiniCluster(),
+				CachedMiniClusterResource.DEFAULT_PARALLELISM);
+	}
 
 	@ClassRule
 	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-
-	private static Configuration getConfiguration() {
-		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "100m");
-		return config;
-	}
-
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/Correlate2ITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/Correlate2ITCase.scala
@@ -29,7 +29,7 @@ import org.junit.{Before, Ignore, Test}
 
 import scala.collection.Seq
 
-class CorrelateITCase2 extends BatchTestBase {
+class Correlate2ITCase extends BatchTestBase {
 
   @Before
   override def before(): Unit = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/harness/AbstractTwoInputStreamOperatorWithTTLTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/harness/AbstractTwoInputStreamOperatorWithTTLTest.scala
@@ -28,12 +28,8 @@ import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.runtime.harness.HarnessTestBase.TestingBaseRowKeySelector
 import org.apache.flink.table.runtime.join.temporal.BaseTwoInputStreamOperatorWithStateRetention
 import org.apache.flink.table.runtime.util.StreamRecordUtils.record
-import org.apache.flink.table.runtime.utils.StreamingWithStateTestBase.HEAP_BACKEND
-import org.apache.flink.table.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.{Description, TypeSafeMatcher}
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import org.junit.{After, Before, Test}
 
 import java.lang.{Long => JLong}
@@ -45,8 +41,7 @@ import scala.collection.mutable.ArrayBuffer
   * Tests for the
   * [[org.apache.flink.table.runtime.join.temporal.BaseTwoInputStreamOperatorWithStateRetention]].
   */
-class AbstractTwoInputStreamOperatorWithTTLTest
-  extends HarnessTestBase(HEAP_BACKEND) {
+class AbstractTwoInputStreamOperatorWithTTLTest {
 
   @transient
   private var recordAForFirstKey: StreamRecord[BaseRow] = _

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/CorrelateITCase.scala
@@ -383,9 +383,6 @@ class CorrelateITCase extends StreamingTestBase {
 //      (1, 2, "2018-06-01"),
 //      (1, 2, "2018-06-02"))
 //
-//    val env = StreamExecutionEnvironment.getExecutionEnvironment
-//    val tEnv = TableEnvironment.getTableEnvironment(env)
-//
 //    val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
 //    tEnv.registerTable("T1", t1)
 //
@@ -404,9 +401,6 @@ class CorrelateITCase extends StreamingTestBase {
 //    val data = List(
 //      (1, 2, ""),
 //      (1, 3, ""))
-//
-//    val env = StreamExecutionEnvironment.getExecutionEnvironment
-//    val tEnv = TableEnvironment.getTableEnvironment(env)
 //
 //    val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
 //    tEnv.registerTable("T1", t1)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -46,9 +46,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testSimplePattern(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
-
     val data = new mutable.MutableList[(Int, String)]
     data.+=((1, "a"))
     data.+=((2, "z"))
@@ -92,9 +89,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testSimplePatternWithNulls(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
-
     val data = new mutable.MutableList[(Int, String, String)]
     data.+=((1, "a", null))
     data.+=((2, "b", null))
@@ -139,7 +133,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testCodeSplitsAreProperlyGenerated(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tableConfig = new TableConfig
     // TODO: this code is ported from flink-planner,
     //  However code split is not supported in blink-planner.
@@ -195,9 +188,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testEventsAreProperlyOrdered(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Left(2L, (12, 1, "a", 1)),
@@ -253,9 +244,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testMatchRecognizeAppliedToWindowedGrouping(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = StreamTableEnvironment.create(env)
 
     val data = new mutable.MutableList[(String, Long, Int, Int)]
     //first window
@@ -314,9 +303,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testWindowedGroupingAppliedToMatchRecognize(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = StreamTableEnvironment.create(env)
 
     val data = new mutable.MutableList[(String, Long, Int, Int)]
     //first window
@@ -369,9 +356,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testLogicalOffsets(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
-
     val data = new mutable.MutableList[(String, Long, Int, Int)]
     data.+=(("ACME", 1L, 19, 1))
     data.+=(("ACME", 2L, 17, 2))
@@ -418,9 +402,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testLogicalOffsetsWithStarVariable(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
-
     val data = new mutable.MutableList[(Int, String, Long, Int)]
     data.+=((1, "ACME", 1L, 20))
     data.+=((2, "ACME", 2L, 19))
@@ -478,9 +459,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testLogicalOffsetOutsideOfRangeInMeasures(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
-
     val data = new mutable.MutableList[(String, Long, Int, Int)]
     data.+=(("ACME", 1L, 19, 1))
     data.+=(("ACME", 2L, 17, 2))
@@ -529,8 +507,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
     */
   @Test
   def testAggregates(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
     tEnv.getConfig.setMaxGeneratedCodeLength(1)
 
     val data = new mutable.MutableList[(Int, String, Long, Double, Int)]
@@ -590,8 +566,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testAggregatesWithNullInputs(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
     tEnv.getConfig.setMaxGeneratedCodeLength(1)
 
     val data = new mutable.MutableList[Row]
@@ -645,9 +619,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testAccessingCurrentTime(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
-
     val data = new mutable.MutableList[(Int, String)]
     data.+=((1, "a"))
 
@@ -684,8 +655,6 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
 
   @Test
   def testUserDefinedFunctions(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
     tEnv.getConfig.setMaxGeneratedCodeLength(1)
 
     val data = new mutable.MutableList[(Int, String, Long)]

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/TemporalJoinITCase.scala
@@ -48,8 +48,6 @@ class TemporalJoinITCase(state: StateBackendMode)
     */
   @Test
   def testProcessTimeInnerJoin(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv: StreamTableEnvironment = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
 
@@ -97,8 +95,6 @@ class TemporalJoinITCase(state: StateBackendMode)
 
   @Test
   def testEventTimeInnerJoin(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv: StreamTableEnvironment = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamingTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamingTestBase.scala
@@ -25,12 +25,11 @@ import org.apache.flink.table.api.{EnvironmentSettings, Table, TableException}
 import org.apache.flink.table.operations.PlannerQueryOperation
 import org.apache.flink.table.plan.nodes.calcite.LogicalWatermarkAssigner
 import org.apache.flink.table.util.TableTestUtil
-import org.apache.flink.test.util.AbstractTestBase
 
 import org.junit.rules.{ExpectedException, TemporaryFolder}
 import org.junit.{Before, Rule}
 
-class StreamingTestBase extends AbstractTestBase {
+abstract class StreamingTestBase extends ITCaseBase {
 
   var env: StreamExecutionEnvironment = _
   var tEnv: StreamTableEnvironment = _
@@ -48,7 +47,7 @@ class StreamingTestBase extends AbstractTestBase {
   @Before
   def before(): Unit = {
     StreamTestSink.clear()
-    this.env = StreamExecutionEnvironment.getExecutionEnvironment
+    this.env = new StreamExecutionEnvironment(ITCaseBase.getExecutionEnvironment)
     env.setParallelism(4)
     this.env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     if (enableObjectReuse) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamingWithAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamingWithAggTestBase.scala
@@ -30,7 +30,7 @@ import org.junit.runners.Parameterized
 
 import scala.collection.JavaConversions._
 
-class StreamingWithAggTestBase(
+abstract class StreamingWithAggTestBase(
   aggMode: AggMode,
   miniBatch: MiniBatchMode,
   backend: StateBackendMode) extends StreamingWithMiniBatchTestBase(miniBatch, backend) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/utils/StreamingWithStateTestBase.scala
@@ -44,7 +44,7 @@ import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestBase {
+abstract class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestBase {
 
   enableObjectReuse = state match {
     case HEAP_BACKEND => false // TODO heap statebackend not support obj reuse now.


### PR DESCRIPTION

## What is the purpose of the change

Add CachedMiniClusterWithClientResource to share cluster between ITCases.
This should reduce a lot of test time.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
