### PR TITLE
[FLINK-13075][table-planner-blink] Project pushdown rule shouldn't require the TableSource return a modified schema in blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecTableSourceScan.scala
@@ -102,7 +102,7 @@ class BatchExecTableSourceScan(
     val fieldIndexes = TableSourceUtil.computeIndexMapping(
       tableSource,
       isStreamTable = false,
-      None)
+      tableSourceTable.selectedFields)
 
     val inputDataType = fromLegacyInfoToDataType(inputTransform.getOutputType)
     val producedDataType = tableSource.getProducedDataType
@@ -118,7 +118,7 @@ class BatchExecTableSourceScan(
     // get expression to extract rowtime attribute
     val rowtimeExpression: Option[RexNode] = TableSourceUtil.getRowtimeExtractionExpression(
       tableSource,
-      None,
+      tableSourceTable.selectedFields,
       cluster,
       planner.getRelBuilder
     )
@@ -144,7 +144,7 @@ class BatchExecTableSourceScan(
     val fieldIndexes = TableSourceUtil.computeIndexMapping(
       tableSource,
       isStreamTable = false,
-      None)
+      tableSourceTable.selectedFields)
     ScanUtil.hasTimeAttributeField(fieldIndexes) ||
       ScanUtil.needsConversion(
         tableSource.getProducedDataType,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -114,7 +114,7 @@ class StreamExecTableSourceScan(
     val fieldIndexes = TableSourceUtil.computeIndexMapping(
       tableSource,
       isStreamTable = true,
-      None)
+      tableSourceTable.selectedFields)
 
     val inputDataType = fromLegacyInfoToDataType(inputTransform.getOutputType)
     val producedDataType = tableSource.getProducedDataType
@@ -130,7 +130,7 @@ class StreamExecTableSourceScan(
     // get expression to extract rowtime attribute
     val rowtimeExpression: Option[RexNode] = TableSourceUtil.getRowtimeExtractionExpression(
       tableSource,
-      None,
+      tableSourceTable.selectedFields,
       cluster,
       planner.getRelBuilder
     )
@@ -166,7 +166,7 @@ class StreamExecTableSourceScan(
 
     // generate watermarks for rowtime indicator
     val rowtimeDesc: Option[RowtimeAttributeDescriptor] =
-      TableSourceUtil.getRowtimeAttributeDescriptor(tableSource, None)
+      TableSourceUtil.getRowtimeAttributeDescriptor(tableSource, tableSourceTable.selectedFields)
 
     val withWatermarks = if (rowtimeDesc.isDefined) {
       val rowtimeFieldIdx = getRowType.getFieldNames.indexOf(rowtimeDesc.get.getAttributeName)
@@ -195,7 +195,7 @@ class StreamExecTableSourceScan(
     val fieldIndexes = TableSourceUtil.computeIndexMapping(
       tableSource,
       isStreamTable = true,
-      None)
+      tableSourceTable.selectedFields)
     ScanUtil.hasTimeAttributeField(fieldIndexes) ||
       ScanUtil.needsConversion(
         tableSource.getProducedDataType,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
@@ -362,7 +362,7 @@ object FlinkBatchRuleSets {
     FlinkExpandConversionRule.BATCH_INSTANCE,
     // source
     BatchExecBoundedStreamScanRule.INSTANCE,
-    BatchExecScanTableSourceRule.INSTANCE,
+    BatchExecTableSourceScanRule.INSTANCE,
     BatchExecIntermediateTableScanRule.INSTANCE,
     BatchExecValuesRule.INSTANCE,
     // calc

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecTableSourceScanRule.scala
@@ -31,7 +31,7 @@ import org.apache.flink.table.sources.StreamTableSource
 /**
   * Rule that converts [[FlinkLogicalTableSourceScan]] to [[BatchExecTableSourceScan]].
   */
-class BatchExecScanTableSourceRule
+class BatchExecTableSourceScanRule
   extends ConverterRule(
     classOf[FlinkLogicalTableSourceScan],
     FlinkConventions.LOGICAL,
@@ -63,6 +63,6 @@ class BatchExecScanTableSourceRule
   }
 }
 
-object BatchExecScanTableSourceRule {
-  val INSTANCE: RelOptRule = new BatchExecScanTableSourceRule
+object BatchExecTableSourceScanRule {
+  val INSTANCE: RelOptRule = new BatchExecTableSourceScanRule
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/TableSourceTable.scala
@@ -34,8 +34,13 @@ import org.apache.flink.table.sources.{TableSource, TableSourceUtil}
 class TableSourceTable[T](
     val tableSource: TableSource[T],
     val isStreamingMode: Boolean,
-    val statistic: FlinkStatistic)
+    val statistic: FlinkStatistic,
+    val selectedFields: Option[Array[Int]])
   extends FlinkTable {
+
+  def this(tableSource: TableSource[T], isStreamingMode: Boolean, statistic: FlinkStatistic) {
+    this(tableSource, isStreamingMode, statistic, None)
+  }
 
   // TODO implements this
   // TableSourceUtil.validateTableSource(tableSource)
@@ -43,7 +48,7 @@ class TableSourceTable[T](
   override def getRowType(typeFactory: RelDataTypeFactory): RelDataType = {
     TableSourceUtil.getRelDataType(
       tableSource,
-      None,
+      selectedFields,
       streaming = isStreamingMode,
       typeFactory.asInstanceOf[FlinkTypeFactory])
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
@@ -179,8 +179,6 @@ class TableSourceITCase extends BatchTestBase {
     )
   }
 
-  @Ignore("[FLINK-13075] Project pushdown rule shouldn't require" +
-    " the TableSource return a modified schema in blink planner")
   @Test
   def testLookupJoinCsvTemporalTable(): Unit = {
     val orders = TestTableSources.getOrdersCsvTableSource

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/util/testTableSources.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/util/testTableSources.scala
@@ -244,9 +244,6 @@ class TestProjectableTableSource(
       projectedTypes.asInstanceOf[Array[TypeInformation[_]]],
       projectedNames)
 
-    val projectedDataTypes = fields.map(tableSchema.getFieldDataTypes.apply(_))
-    val newTableSchema = TableSchema.builder().fields(projectedNames, projectedDataTypes).build()
-
     val projectedValues = values.map { fromRow =>
       val pRow = new Row(fields.length)
       fields.zipWithIndex.foreach{ case (from, to) => pRow.setField(to, fromRow.getField(from)) }
@@ -255,7 +252,7 @@ class TestProjectableTableSource(
 
     new TestProjectableTableSource(
       isBounded,
-      newTableSchema,
+      tableSchema,
       projectedReturnType,
       projectedValues,
       rowtime,
@@ -304,9 +301,6 @@ class TestNestedProjectableTableSource(
     val newReadNestedFields = projectedNames.zip(nestedFields)
       .flatMap(f => f._2.map(n => s"${f._1}.$n"))
 
-    val projectedDataTypes = fields.map(tableSchema.getFieldDataTypes.apply(_))
-    val newTableSchema = TableSchema.builder().fields(projectedNames, projectedDataTypes).build()
-
     val projectedValues = values.map { fromRow =>
       val pRow = new Row(fields.length)
       fields.zipWithIndex.foreach{ case (from, to) => pRow.setField(to, fromRow.getField(from)) }
@@ -315,7 +309,7 @@ class TestNestedProjectableTableSource(
 
     val copy = new TestNestedProjectableTableSource(
       isBounded,
-      newTableSchema,
+      tableSchema,
       projectedReturnType,
       projectedValues,
       rowtime,


### PR DESCRIPTION
## What is the purpose of the change

As the javadoc of `org.apache.flink.table.sources.ProjectableTableSource#projectFields` said, the table schema of the `TableSource` copy must not be modified by this method. However, `PushProjectIntoTableSourceScanRule` in blink planner requires the returning a table source with the modified table schema. This conflict with the javadoc and result in the `TableSource` works for flink planner can't work for blink planner.

This PR fixes `PushProjectIntoTableSourceScanRule` and related class to make it work for blink planner.

## Brief change log

 - Fix `PushProjectIntoTableSourceScanRule` so that the schema of the newly created table source is the same with the original one.

## Verifying this change

This change is already covered by existing tests, such as `TableSourceItCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
