### PR TITLE
[FLINK-13369] Add failing test case for cleaning circular dependencie…

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -37,6 +37,9 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 
 /**
  * The closure cleaner is a utility that tries to truncate the closure (enclosing instance)
@@ -65,7 +68,15 @@ public class ClosureCleaner {
 	 *                          be loaded, in order to process during the closure cleaning.
 	 */
 	public static void clean(Object func, ExecutionConfig.ClosureCleanerLevel level, boolean checkSerializable) {
+		clean(func, level, checkSerializable, Collections.newSetFromMap(new IdentityHashMap<>()));
+	}
+
+	private static void clean(Object func, ExecutionConfig.ClosureCleanerLevel level, boolean checkSerializable, Set<Object> visited) {
 		if (func == null) {
+			return;
+		}
+
+		if (!visited.add(func)) {
 			return;
 		}
 
@@ -112,7 +123,7 @@ public class ClosureCleaner {
 						LOG.debug("Dig to clean the {}", fieldObject.getClass().getName());
 					}
 
-					clean(fieldObject, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+					clean(fieldObject, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true, visited);
 				}
 			}
 		}

--- a/flink-java/src/test/java/org/apache/flink/api/java/functions/ClosureCleanerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/functions/ClosureCleanerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.functions;
 
+import java.util.function.Supplier;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.MapFunction;
@@ -131,6 +132,12 @@ public class ClosureCleanerTest {
 		int result = complexMap.map(3);
 
 		Assert.assertEquals(result, 4);
+	}
+
+	@Test
+	public void testSelfReferencingClean() throws Exception {
+		final NestedSelfReferencing selfReferencing = new NestedSelfReferencing();
+		ClosureCleaner.clean(selfReferencing, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	class InnerCustomMap implements MapFunction<Integer, Integer> {
@@ -418,6 +425,15 @@ class OuterMapCreator implements MapCreator {
 	@Override
 	public MapFunction<Integer, Integer> getMap() {
 		return new OuterStaticClass().getMap();
+	}
+}
+
+class NestedSelfReferencing implements Serializable {
+
+	private final Supplier<NestedSelfReferencing> cycle;
+
+	NestedSelfReferencing() {
+		this.cycle = () -> this;
 	}
 }
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/functions/ClosureCleanerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/functions/ClosureCleanerTest.java
@@ -135,7 +135,7 @@ public class ClosureCleanerTest {
 	}
 
 	@Test
-	public void testSelfReferencingClean() throws Exception {
+	public void testSelfReferencingClean() {
 		final NestedSelfReferencing selfReferencing = new NestedSelfReferencing();
 		ClosureCleaner.clean(selfReferencing, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
@@ -428,12 +428,21 @@ class OuterMapCreator implements MapCreator {
 	}
 }
 
+@FunctionalInterface
+interface SerializableSupplier<T> extends Supplier<T>, Serializable {
+
+}
+
 class NestedSelfReferencing implements Serializable {
 
-	private final Supplier<NestedSelfReferencing> cycle;
+	private final SerializableSupplier<NestedSelfReferencing> cycle;
 
 	NestedSelfReferencing() {
 		this.cycle = () -> this;
+	}
+
+	public SerializableSupplier<NestedSelfReferencing> getCycle() {
+		return cycle;
 	}
 }
 


### PR DESCRIPTION
…s using ClosureCleaner

## What is the purpose of the change

Another issue I've run into while cleaning Beam's [AvroCoder](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java). In case of [circular dependency](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java#L271), cleaner ends up with StackOverflow.

Providing a failing test case. Patch needs to track references of already accessed object before descending.

## Brief change log

  - *Added failing test case*


## Verifying this change

This change added tests and can be verified as follows:
 
- *Added test that tries to clean self-referencing closure

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
