### PR TITLE
[FLINK-13367] Add support for writeReplace in nested ClosureCleaner.

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -165,6 +165,11 @@ public class ClosureCleaner {
 			return true;
 		} catch (NoSuchMethodException ignored) {}
 
+		try {
+			cls.getDeclaredMethod("writeReplace");
+			return true;
+		} catch (NoSuchMethodException ignored) {}
+
 		return Externalizable.class.isAssignableFrom(cls);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Support for writeReplace in ClosureCleaner for Apache Beam [Avro Coder](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java#L215).

## Brief change log

  - *Added failing test case*
  - *Make usesCustomSerialiazation method search for writeReplace method.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added failing test case that uses writeReplace method for serializing payload*
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
