### PR TITLE
[FLINK-9526][e2e] Fix unstable BucketingSink end-to-end test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
@@ -22,7 +22,9 @@ source "$(dirname "$0")"/common.sh
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-bucketing-sink-test/target/BucketingSinkTestProgram.jar
 
 # enable DEBUG logging level to retrieve truncate length later
-sed -i -e 's/#log4j.logger.org.apache.flink=INFO/log4j.logger.org.apache.flink=DEBUG/g' $FLINK_DIR/conf/log4j.properties
+# make sure it would always start a new line
+echo "" >> $FLINK_DIR/conf/log4j.properties
+echo "log4j.logger.org.apache.flink.streaming.connectors.fs.bucketing.BucketingSink=DEBUG" >> $FLINK_DIR/conf/log4j.properties
 
 set_conf_ssl
 start_cluster


### PR DESCRIPTION
## What is the purpose of the change

* Fix unstable end-to-end test for `BucketingSink`
* The root cause of this unstable case is an unexpected debug log involved. This case sets the log level to `DEBUG` for checking the truncating log. However it sets the global log level. There might be a debug log "Responding with error: ..." in `PartitionRequestServerHandler` if a `PartitionNotFound` occurred. This error would fail the error checking due to there is a word "error" in this log.

## Brief change log

* Shrink the `DEBUG` log level to `BucketingSink` only, not global anymore

## Verifying this change

* This is a test case fixing. And I have tested locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
