### PR TITLE
[FLINK-13378][table-planner-blink] Fix bug: Blink-planner not support SingleValueAggFunction

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/ExpressionBuilder.java
@@ -140,6 +140,6 @@ public class ExpressionBuilder {
 	}
 
 	public static Expression throwException(String msg, DataType type) {
-		return call(THROW_EXCEPTION, typeLiteral(type));
+		return call(THROW_EXCEPTION, literal(msg), typeLiteral(type));
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/RexNodeConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/RexNodeConverter.java
@@ -49,8 +49,11 @@ import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.RexAggLocalVariable;
 import org.apache.flink.table.planner.calcite.RexDistinctKeyVariable;
+import org.apache.flink.table.planner.functions.InternalFunctionDefinitions;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+import org.apache.flink.table.planner.functions.sql.SqlThrowExceptionFunction;
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -305,6 +308,14 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 		conversionsOfBuiltInFunc.put(BuiltInFunctionDefinitions.SHA1, exprs -> convert(FlinkSqlOperatorTable.SHA1, exprs));
 		conversionsOfBuiltInFunc.put(BuiltInFunctionDefinitions.STREAM_RECORD_TIMESTAMP,
 				exprs -> convert(FlinkSqlOperatorTable.STREAMRECORD_TIMESTAMP, exprs));
+
+		// blink expression
+		conversionsOfBuiltInFunc.put(InternalFunctionDefinitions.THROW_EXCEPTION, exprs -> {
+			DataType type = ((TypeLiteralExpression) exprs.get(1)).getOutputDataType();
+			return convert(new SqlThrowExceptionFunction(
+					typeFactory.createFieldTypeFromLogicalType(fromDataTypeToLogicalType(type))),
+					exprs.subList(0, 1));
+		});
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SingleValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SingleValueAggFunction.java
@@ -76,7 +76,7 @@ public abstract class SingleValueAggFunction extends DeclarativeAggregateFunctio
 	@Override
 	public Expression[] accumulateExpressions() {
 		return new Expression[] {
-			/* value = count == 0 ? exception : operand(0) */
+			/* value = count > 0 ? exception : operand(0) */
 			ifThenElse(greaterThan(count, ZERO),
 				throwException(ERROR_MSG, getResultType()),
 				operand(0)),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -955,11 +955,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	 */
 	public static final SqlIncrSumAggFunction INCR_SUM = new SqlIncrSumAggFunction();
 
-	/**
-	 * <code>THROW_EXCEPTION</code> scalar function. Only internal used.
-	 */
-	public static final SqlFunction THROW_EXCEPTION = new SqlThrowExceptionFunction();
-
 	// -----------------------------------------------------------------------------
 	// Window SQL functions
 	// -----------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/SqlThrowExceptionFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/SqlThrowExceptionFunction.java
@@ -18,24 +18,23 @@
 
 package org.apache.flink.table.planner.functions.sql;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.OperandTypes;
-import org.apache.calcite.sql.type.ReturnTypes;
-import org.apache.calcite.sql.type.SqlTypeFamily;
 
 /**
  * Function used to throw an exception, only used internally.
  */
 public class SqlThrowExceptionFunction extends SqlFunction {
-	public SqlThrowExceptionFunction() {
+	public SqlThrowExceptionFunction(RelDataType returnType) {
 		super(
 			"THROW_EXCEPTION",
 			SqlKind.OTHER_FUNCTION,
-			ReturnTypes.ARG0_NULLABLE,
+			opBinding -> returnType,
 			null,
-			OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.ANY),
+			OperandTypes.STRING,
 			SqlFunctionCategory.USER_DEFINED_FUNCTION);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -24,9 +24,11 @@ import org.apache.flink.table.expressions.{ApiExpressionVisitor, CallExpression,
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions._
 import org.apache.flink.table.functions._
 import org.apache.flink.table.planner.expressions.{E => PlannerE, UUID => PlannerUUID}
+import org.apache.flink.table.planner.functions.InternalFunctionDefinitions.THROW_EXCEPTION
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
 import org.apache.flink.table.types.logical.LogicalTypeRoot.{CHAR, DECIMAL, SYMBOL, TIMESTAMP_WITHOUT_TIME_ZONE}
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks._
+import org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo
 
 import _root_.scala.collection.JavaConverters._
 
@@ -84,6 +86,13 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
         assert(children.size == 1)
         val windowReference = translateWindowReference(children.head)
         return RowtimeAttribute(windowReference)
+
+      case THROW_EXCEPTION =>
+        assert(children.size == 2)
+        return ThrowException(
+          children.head.accept(this),
+          fromDataTypeToLegacyInfo(
+            children(1).asInstanceOf[TypeLiteralExpression].getOutputDataType))
 
       case _ =>
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/call.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/call.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.table.planner.expressions
 
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation, Types}
 import org.apache.flink.table.functions._
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
@@ -220,4 +220,22 @@ case class PlannerTableFunctionCall(
 
   override def toString =
     s"${tableFunction.getClass.getCanonicalName}(${parameters.mkString(", ")})"
+}
+
+case class ThrowException(msg: PlannerExpression, tp: TypeInformation[_]) extends UnaryExpression {
+
+  override private[flink] def resultType = tp
+
+  override private[flink] def child = msg
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (child.resultType == Types.STRING) {
+      ValidationSuccess
+    } else {
+      ValidationFailure(s"ThrowException operator requires String input, " +
+          s"but $child is of type ${child.resultType}")
+    }
+  }
+
+  override def toString: String = s"ThrowException($msg)"
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/ScalarQueryITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/ScalarQueryITCase.scala
@@ -20,6 +20,9 @@ package org.apache.flink.table.planner.runtime.batch.sql.join
 
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.planner.runtime.utils.TestData._
+
+import org.junit.{Before, Test}
 
 import scala.collection.Seq
 
@@ -46,6 +49,18 @@ class ScalarQueryITCase extends BatchTestBase {
     row(6, null)
   )
 
-}
+  @Before
+  override def before(): Unit = {
+    super.before()
+    registerCollection("l", l, INT_DOUBLE, "a, b")
+    registerCollection("r", r, INT_DOUBLE, "c, d")
+  }
 
+  @Test
+  def testScalarQuery(): Unit = {
+    checkResult(
+      "SELECT * FROM l WHERE a = (SELECT c FROM r where c = 3)",
+      Seq(row(3, 3.0)))
+  }
+}
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/ScalarQueryITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/ScalarQueryITCase.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql.join
 
+import org.apache.flink.runtime.client.JobExecutionException
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
@@ -57,9 +58,16 @@ class ScalarQueryITCase extends BatchTestBase {
   }
 
   @Test
-  def testScalarQuery(): Unit = {
+  def testScalarSubQuery(): Unit = {
     checkResult(
       "SELECT * FROM l WHERE a = (SELECT c FROM r where c = 3)",
+      Seq(row(3, 3.0)))
+  }
+
+  @Test(expected = classOf[JobExecutionException])
+  def testScalarSubQueryException(): Unit = {
+    checkResult(
+      "SELECT * FROM l WHERE a = (SELECT c FROM r)",
       Seq(row(3, 3.0)))
   }
 }


### PR DESCRIPTION

## What is the purpose of the change

There some problem in SingleValueAggFunction:
1.The comment in the method is "value = count == 0 ? exception : operand(0)", but actually it need to be "value = count > 0 ? exception : operand(0)" according to the code and logic.
2.The throwException expression should call(THROW_EXCEPTION, literal(msg), typeLiteral(type)).

And there are some bugs to support it in blink-planner:
1.RexNodeConverter lack converter for THROW_EXCEPTION
2.PlannerExpressions lack expr to support type inference for THROW_EXCEPTION

## Verifying this change

ScalarQueryITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no