### PR TITLE
[FLINK-13338][table-api] Sql conformance is hard to config in TableConfig

### DIFF
--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -25,6 +25,7 @@ Important classes used by both Flink Streaming and Batch API:
 from pyflink.common.configuration import Configuration
 from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.execution_mode import ExecutionMode
+from pyflink.common.sql_dialect import SqlDialect
 from pyflink.common.input_dependency_constraint import InputDependencyConstraint
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
 
@@ -34,5 +35,6 @@ __all__ = [
     'ExecutionMode',
     'InputDependencyConstraint',
     'RestartStrategies',
-    'RestartStrategyConfiguration'
+    'RestartStrategyConfiguration',
+    'SqlDialect'
 ]

--- a/flink-python/pyflink/common/sql_dialect.py
+++ b/flink-python/pyflink/common/sql_dialect.py
@@ -24,11 +24,11 @@ class SqlDialect(object):
     """
     Enumeration of valid SQL compatibility modes.
 
-    For most of the cases, the built-in compatibility mode will suffice. For some features,
+    In most of the cases, the built-in compatibility mode will suffice. For some features,
     i.e. the "create partitionable table" grammar is only supported in Hive dialect, you may need
     to switch to the Hive dialect if that is your purpose.
 
-    There may introduce other sql dialects in the future.
+    We may introduce other sql dialects in the future.
 
     :data:`DEFAULT`:
 
@@ -36,7 +36,9 @@ class SqlDialect(object):
 
     :data:`HIVE`:
 
-    SQL dialect that allows some Apache HIVE specific grammar.
+    SQL dialect that allows some Apache Hive specific grammar.
+    Note: We might never support all of the Hive grammar.
+    See the documentation for supported features.
     """
 
     DEFAULT = 0

--- a/flink-python/pyflink/common/sql_dialect.py
+++ b/flink-python/pyflink/common/sql_dialect.py
@@ -1,0 +1,66 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.java_gateway import get_gateway
+
+__all__ = ['SqlDialect']
+
+
+class SqlDialect(object):
+    """
+    Enumeration of valid SQL compatibility modes.
+
+    For most of the cases, the built-in compatibility mode will suffice. For some features,
+    i.e. the "create partitionable table" grammar is only supported in Hive dialect, you may need
+    to switch to the Hive dialect if that is your purpose.
+
+    There may introduce other sql dialects in the future.
+
+    :data:`DEFAULT`:
+
+    Flink's default SQL behavior.
+
+    :data:`HIVE`:
+
+    SQL dialect that allows some Apache HIVE specific grammar.
+    """
+
+    DEFAULT = 0
+    HIVE = 1
+
+    @staticmethod
+    def _from_j_sql_dialect(j_sql_dialect):
+        gateway = get_gateway()
+        JSqlDialect = gateway.jvm.org.apache.flink.table.api.SqlDialect
+        if j_sql_dialect == JSqlDialect.DEFAULT:
+            return SqlDialect.DEFAULT
+        elif j_sql_dialect == JSqlDialect.HIVE:
+            return SqlDialect.HIVE
+        else:
+            raise Exception("Unsupported java sql dialect: %s" % j_sql_dialect)
+
+    @staticmethod
+    def _to_j_sql_dialect(sql_dialect):
+        gateway = get_gateway()
+        JSqlDialect = gateway.jvm.org.apache.flink.table.api.SqlDialect
+        if sql_dialect == SqlDialect.DEFAULT:
+            return JSqlDialect.DEFAULT
+        elif sql_dialect == SqlDialect.HIVE:
+            return JSqlDialect.HIVE
+        else:
+            raise TypeError("Unsupported sql dialect: %s, supported sql dialects are: "
+                            "SqlDialect.DEFAULT, SqlDialect.HIVE." % sql_dialect)

--- a/flink-python/pyflink/common/sql_dialect.py
+++ b/flink-python/pyflink/common/sql_dialect.py
@@ -25,8 +25,8 @@ class SqlDialect(object):
     Enumeration of valid SQL compatibility modes.
 
     In most of the cases, the built-in compatibility mode will suffice. For some features,
-    i.e. the "create partitionable table" grammar is only supported in Hive dialect, you may need
-    to switch to the Hive dialect if that is your purpose.
+    i.e. the "insert into T partition(a='xxx') ..." grammar is only supported in Hive dialect,
+    you may need to switch to the Hive dialect if that is your purpose.
 
     We may introduce other sql dialects in the future.
 

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -19,7 +19,7 @@ import sys
 
 from py4j.compat import long
 
-from pyflink.common import Configuration
+from pyflink.common import Configuration, SqlDialect
 from pyflink.java_gateway import get_gateway
 
 __all__ = ['TableConfig']
@@ -246,6 +246,23 @@ class TableConfig(object):
         :type configuration: Configuration
         """
         self._j_table_config.addConfiguration(configuration._j_configuration)
+
+    def get_sql_dialect(self):
+        """
+        Returns the current sql dialect.
+
+        :rtype: SqlDialect
+        """
+        return SqlDialect._from_j_sql_dialect(self._j_table_config.getSqlDialect())
+
+    def set_sql_dialect(self, sql_dialect):
+        """
+        Setup the current sql dialect to parse the sql query.
+
+        :param sql_dialect: The given sql dialect.
+        :type sql_dialect: SqlDialect
+        """
+        self._j_table_config.setSqlDialect(SqlDialect._to_j_sql_dialect(sql_dialect))
 
     @staticmethod
     def get_default():

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlDialect.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlDialect.java
@@ -24,8 +24,8 @@ import org.apache.flink.annotation.PublicEvolving;
  * Enumeration of valid SQL compatibility modes.
  *
  * <p>In most of the cases, the built-in compatibility mode will suffice. For some features,
- * i.e. the "create partitionable table" grammar is only supported in Hive dialect, you may need
- * to switch to the Hive dialect if required.
+ * i.e. the "insert into T partition(a='xxx') ..." grammar is only supported in Hive dialect,
+ * you may need to switch to the Hive dialect if required.
  *
  * <p>We may introduce other sql dialects in the future.
  */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlDialect.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlDialect.java
@@ -23,12 +23,11 @@ import org.apache.flink.annotation.PublicEvolving;
 /**
  * Enumeration of valid SQL compatibility modes.
  *
- * <p>For most of the cases, the built-in compatibility mode will suffice. For some features,
- * i.e. the "insert into t partition(...) ..." grammar is only supported in Hive dialect,
- * you may need
- * to switch to the Hive dialect if that is your purpose.
+ * <p>In most of the cases, the built-in compatibility mode will suffice. For some features,
+ * i.e. the "create partitionable table" grammar is only supported in Hive dialect, you may need
+ * to switch to the Hive dialect if required.
  *
- * <p>There may introduce other sql dialects in the future.
+ * <p>We may introduce other sql dialects in the future.
  */
 @PublicEvolving
 public enum SqlDialect {
@@ -37,7 +36,9 @@ public enum SqlDialect {
 	 */
 	DEFAULT,
 	/**
-	 * SQL dialect that allows some Apache HIVE specific grammar.
+	 * SQL dialect that allows some Apache Hive specific grammar.
+	 * Note: We might never support all of the Hive grammar.
+	 * See the documentation for supported features.
 	 */
 	HIVE
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlDialect.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlDialect.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Enumeration of valid SQL compatibility modes.
+ *
+ * <p>For most of the cases, the built-in compatibility mode will suffice. For some features,
+ * i.e. the "insert into t partition(...) ..." grammar is only supported in Hive dialect,
+ * you may need
+ * to switch to the Hive dialect if that is your purpose.
+ *
+ * <p>There may introduce other sql dialects in the future.
+ */
+@PublicEvolving
+public enum SqlDialect {
+	/**
+	 * Flink's default SQL behavior.
+	 */
+	DEFAULT,
+	/**
+	 * SQL dialect that allows some Apache HIVE specific grammar.
+	 */
+	HIVE
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -77,6 +77,12 @@ public class TableConfig {
 	private Configuration configuration = new Configuration();
 
 	/**
+	 * The sql dialect defines how to parse a sql query, different
+	 * sql dialect may support different sql grammar.
+	 */
+	private SqlDialect sqlDialect = SqlDialect.DEFAULT;
+
+	/**
 	 * Returns all key/value configuration.
 	 */
 	public Configuration getConfiguration() {
@@ -91,6 +97,20 @@ public class TableConfig {
 	public void addConfiguration(Configuration configuration) {
 		Preconditions.checkNotNull(configuration);
 		this.configuration.addAll(configuration);
+	}
+
+	/**
+	 * Returns the current sql dialect.
+	 */
+	public SqlDialect getSqlDialect() {
+		return this.sqlDialect;
+	}
+
+	/**
+	 * Setup the current sql dialect to parse the sql query.
+	 */
+	public void setSqlDialect(SqlDialect sqlDialect) {
+		this.sqlDialect = sqlDialect;
 	}
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
 import org.apache.flink.table.planner.calcite.CalciteConfig$;
@@ -212,7 +213,7 @@ public class PlannerContext {
 		case DEFAULT:
 			return FlinkSqlConformance.DEFAULT;
 		default:
-			return FlinkSqlConformance.DEFAULT;
+			throw new TableException("Unsupported sql dialect " + sqlDialect + ".");
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.delegation;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
+import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
@@ -41,6 +42,7 @@ import org.apache.flink.table.planner.utils.TableConfigUtils;
 
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitDef;
@@ -72,8 +74,10 @@ public class PlannerContext {
 	private final FlinkTypeFactory typeFactory = new FlinkTypeFactory(typeSystem);
 	private final TableConfig tableConfig;
 	private final FunctionCatalog functionCatalog;
-	private final FrameworkConfig frameworkConfig;
 	private final RelOptCluster cluster;
+	private final Context context;
+	private final CalciteSchema rootSchema;
+	private final List<RelTraitDef> traitDefs;
 
 	public PlannerContext(
 			TableConfig tableConfig,
@@ -82,7 +86,13 @@ public class PlannerContext {
 			List<RelTraitDef> traitDefs) {
 		this.tableConfig = tableConfig;
 		this.functionCatalog = functionCatalog;
-		this.frameworkConfig = createFrameworkConfig(rootSchema, traitDefs);
+		this.context = new FlinkContextImpl(tableConfig, functionCatalog);
+		this.rootSchema = rootSchema;
+		this.traitDefs = traitDefs;
+		// Make a framework config to initialize the RelOptCluster instance,
+		// caution that we can only use the attributes that can not be overwrite/configured
+		// by user.
+		final FrameworkConfig frameworkConfig = createFrameworkConfig();
 
 		RelOptPlanner planner = new VolcanoPlanner(frameworkConfig.getCostFactory(), frameworkConfig.getContext());
 		planner.setExecutor(frameworkConfig.getExecutor());
@@ -92,19 +102,19 @@ public class PlannerContext {
 		this.cluster = FlinkRelOptClusterFactory.create(planner, new RexBuilder(typeFactory));
 	}
 
-	private FrameworkConfig createFrameworkConfig(CalciteSchema rootSchema, List<RelTraitDef> traitDefs) {
+	private FrameworkConfig createFrameworkConfig() {
 		return Frameworks.newConfigBuilder()
-				.defaultSchema(rootSchema.plus())
-				.parserConfig(getSqlParserConfig())
-				.costFactory(new FlinkCostFactory())
-				.typeSystem(typeSystem)
-				.sqlToRelConverterConfig(getSqlToRelConverterConfig(getCalciteConfig(tableConfig)))
-				.operatorTable(getSqlOperatorTable(getCalciteConfig(tableConfig), functionCatalog))
-				// set the executor to evaluate constant expressions
-				.executor(new ExpressionReducer(tableConfig, false))
-				.context(new FlinkContextImpl(tableConfig, functionCatalog))
-				.traitDefs(traitDefs)
-				.build();
+			.defaultSchema(rootSchema.plus())
+			.parserConfig(getSqlParserConfig())
+			.costFactory(new FlinkCostFactory())
+			.typeSystem(typeSystem)
+			.sqlToRelConverterConfig(getSqlToRelConverterConfig(getCalciteConfig(tableConfig)))
+			.operatorTable(getSqlOperatorTable(getCalciteConfig(tableConfig), functionCatalog))
+			// set the executor to evaluate constant expressions
+			.executor(new ExpressionReducer(tableConfig, false))
+			.context(context)
+			.traitDefs(traitDefs)
+			.build();
 	}
 
 	/** Returns the {@link FlinkTypeFactory} that will be used. */
@@ -121,7 +131,7 @@ public class PlannerContext {
 	 */
 	public FlinkRelBuilder createRelBuilder(String currentCatalog, String currentDatabase) {
 		FlinkCalciteCatalogReader relOptSchema = createCatalogReader(false, currentCatalog, currentDatabase);
-		return new FlinkRelBuilder(frameworkConfig.getContext(), cluster, relOptSchema);
+		return new FlinkRelBuilder(this.context, cluster, relOptSchema);
 	}
 
 	/**
@@ -133,7 +143,7 @@ public class PlannerContext {
 	 */
 	public FlinkPlannerImpl createFlinkPlanner(String currentCatalog, String currentDatabase) {
 		return new FlinkPlannerImpl(
-				frameworkConfig,
+				createFrameworkConfig(),
 				isLenient -> createCatalogReader(isLenient, currentCatalog, currentDatabase),
 				typeFactory,
 				cluster);
@@ -143,7 +153,7 @@ public class PlannerContext {
 			boolean lenientCaseSensitivity,
 			String currentCatalog,
 			String currentDatabase) {
-		SqlParser.Config sqlParserConfig = frameworkConfig.getParserConfig();
+		SqlParser.Config sqlParserConfig = getSqlParserConfig();
 		final boolean caseSensitive;
 		if (lenientCaseSensitivity) {
 			caseSensitive = false;
@@ -155,7 +165,7 @@ public class PlannerContext {
 				.setCaseSensitive(caseSensitive)
 				.build();
 
-		SchemaPlus rootSchema = getRootSchema(frameworkConfig.getDefaultSchema());
+		SchemaPlus rootSchema = getRootSchema(this.rootSchema.plus());
 		return new FlinkCalciteCatalogReader(
 				CalciteSchema.from(rootSchema),
 				asList(
@@ -188,10 +198,22 @@ public class PlannerContext {
 				() -> SqlParser
 						.configBuilder()
 						.setParserFactory(FlinkSqlParserImpl.FACTORY)
-						.setConformance(FlinkSqlConformance.DEFAULT)
+						.setConformance(getSqlConformance())
 						.setLex(Lex.JAVA)
 						.setIdentifierMaxLength(256)
 						.build());
+	}
+
+	private FlinkSqlConformance getSqlConformance() {
+		SqlDialect sqlDialect = tableConfig.getSqlDialect();
+		switch (sqlDialect) {
+		case HIVE:
+			return FlinkSqlConformance.HIVE;
+		case DEFAULT:
+			return FlinkSqlConformance.DEFAULT;
+		default:
+			return FlinkSqlConformance.DEFAULT;
+		}
 	}
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -22,13 +22,10 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl
-import org.apache.flink.sql.parser.validate.FlinkSqlConformance
 import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.table.api.config.ExecutionConfigOptions
-import org.apache.flink.table.api.{TableConfig, TableSchema, ValidationException}
-import org.apache.flink.table.planner.calcite.CalciteConfig
+import org.apache.flink.table.api.{SqlDialect, TableSchema, ValidationException}
 import org.apache.flink.table.planner.runtime.batch.sql.PartitionableSinkITCase._
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
@@ -37,8 +34,6 @@ import org.apache.flink.table.sinks.{PartitionableTableSink, StreamTableSink, Ta
 import org.apache.flink.table.types.logical.{BigIntType, IntType, VarCharType}
 import org.apache.flink.types.Row
 
-import org.apache.calcite.config.Lex
-import org.apache.calcite.sql.parser.SqlParser
 import org.junit.Assert._
 import org.junit.rules.ExpectedException
 import org.junit.{Before, Rule, Test}
@@ -66,22 +61,10 @@ class PartitionableSinkITCase extends BatchTestBase {
     tEnv.getConfig
       .getConfiguration
       .setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 3)
+    tEnv.getConfig.setSqlDialect(SqlDialect.HIVE)
     registerCollection("nonSortTable", testData, type3, "a, b, c", dataNullables)
     registerCollection("sortTable", testData1, type3, "a, b, c", dataNullables)
     PartitionableSinkITCase.init()
-  }
-
-  override def getTableConfig: TableConfig = {
-    val parserConfig = SqlParser.configBuilder
-      .setParserFactory(FlinkSqlParserImpl.FACTORY)
-      .setConformance(FlinkSqlConformance.HIVE) // set up hive dialect
-      .setLex(Lex.JAVA)
-      .setIdentifierMaxLength(256).build
-    val plannerConfig = CalciteConfig.createBuilder(CalciteConfig.DEFAULT)
-      .replaceSqlParserConfig(parserConfig)
-    val tableConfig = new TableConfig
-    tableConfig.setPlannerConfig(plannerConfig.build())
-    tableConfig
   }
 
   @Test
@@ -181,7 +164,7 @@ class PartitionableSinkITCase extends BatchTestBase {
     expectedEx.expect(classOf[ValidationException])
     expectedEx.expectMessage("Static partition column b "
       + "should appear before dynamic partition a")
-    registerTableSink(grouping = true, partitionColumns = Array("a", "b"))
+    registerTableSink(partitionColumns = Array("a", "b"))
     tEnv.sqlUpdate("insert into sinkTable partition(b=1) select a, c from sortTable")
     tEnv.execute("testJob")
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
@@ -56,7 +56,7 @@ class BatchTestBase extends BatchAbstractTestBase {
 
   private val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build()
   private val testingTableEnv: TestingTableEnvironment = TestingTableEnvironment
-    .create(settings, catalogManager = None, getTableConfig)
+    .create(settings, catalogManager = None, new TableConfig)
   val tEnv: TableEnvironment = testingTableEnv
   private val planner = tEnv.asInstanceOf[TableEnvironmentImpl].getPlanner.asInstanceOf[PlannerBase]
   val env: StreamExecutionEnvironment = planner.getExecEnv
@@ -66,14 +66,6 @@ class BatchTestBase extends BatchAbstractTestBase {
   val LINE_COL_PATTERN: Pattern = Pattern.compile("At line ([0-9]+), column ([0-9]+)")
   val LINE_COL_TWICE_PATTERN: Pattern = Pattern.compile("(?s)From line ([0-9]+),"
     + " column ([0-9]+) to line ([0-9]+), column ([0-9]+): (.*)")
-
-  // TODO: [FLINK-13338] will expose dialect option to TableConfig to
-  //  avoid override CalciteConfig by users
-  /**
-    * Subclass should overwrite this method if we want to overwrite configuration during
-    * sql parse to sql to rel conversion phrase.
-    */
-  protected def getTableConfig: TableConfig = new TableConfig
 
   @Before
   def before(): Unit = {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
+import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.calcite.CalciteConfig;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
@@ -155,9 +156,21 @@ public class PlanningConfigurationBuilder {
 			SqlParser
 				.configBuilder()
 				.setParserFactory(FlinkSqlParserImpl.FACTORY)
-				.setConformance(FlinkSqlConformance.DEFAULT)
+				.setConformance(getSqlConformance())
 				.setLex(Lex.JAVA)
 				.build());
+	}
+
+	private FlinkSqlConformance getSqlConformance() {
+		SqlDialect sqlDialect = tableConfig.getSqlDialect();
+		switch (sqlDialect) {
+		case HIVE:
+			return FlinkSqlConformance.HIVE;
+		case DEFAULT:
+			return FlinkSqlConformance.DEFAULT;
+		default:
+			return FlinkSqlConformance.DEFAULT;
+		}
 	}
 
 	private CatalogReader createCatalogReader(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/PlanningConfigurationBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.calcite.CalciteConfig;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.calcite.FlinkRelBuilder;
@@ -169,7 +170,7 @@ public class PlanningConfigurationBuilder {
 		case DEFAULT:
 			return FlinkSqlConformance.DEFAULT;
 		default:
-			return FlinkSqlConformance.DEFAULT;
+			throw new TableException("Unsupported sql dialect " + sqlDialect + ".");
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This patch adds an interface `TableConfig#setSqlDialect(SqlDialect)` to make the sql dialect configuration more user friendly.


## Brief change log

  - Add new class `SqlDialect` to enumerate the sql dialects Flink supports now
  - Add configuration interface for sql dialect in `TableConfig`


## Verifying this change

See tests in SqlToOperationConverterTest, PartitionableSinkITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
