### PR TITLE
[FLINK-13402] [table] Copy RelOptCluster to flink planner to fix "RelOptCluster's constructor can not be accessed when connector depends on both planners"

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/plan/RelOptCluster.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/plan/RelOptCluster.java
@@ -1,12 +1,13 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * This class is copied from Calcite's {@link org.apache.calcite.plan.RelOptCluster},
  * can be removed after https://issues.apache.org/jira/browse/CALCITE-2855 is accepted.
- * NOTES: please make sure to synchronize with RelDecorrelator in flink planner when changing this class.
+ * NOTES: please make sure to synchronize with RelDecorrelator in blink planner when changing this class.
  *
  * Modification:
  * - Make non-deprecated constructor public


### PR DESCRIPTION


## What is the purpose of the change

*Copy RelOptCluster to flink planner to fix "RelOptCluster's constructor can not be accessed when connector depends on both planners"*


## Brief change log

  - *Copy RelOptCluster from blink planner to flink planner*


## Verifying this change

all tests should pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
