### PR TITLE
[FLINK-13376][datastream] ContinuousFileReaderOperator should respect…

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamingJobGraphGeneratorNodeHashTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamingJobGraphGeneratorNodeHashTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamNode;
@@ -94,7 +93,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 
 		src0.map(new NoOpMapFunction())
 				.union(src1, src2)
-				.addSink(new NoOpSinkFunction()).name("sink");
+				.addSink(new DiscardingSink<>()).name("sink");
 
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
@@ -121,7 +120,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 
 		src0.map(new NoOpMapFunction())
 				.union(src1, src2)
-				.addSink(new NoOpSinkFunction()).name("sink");
+				.addSink(new DiscardingSink<>()).name("sink");
 
 		jobGraph = env.getStreamGraph().getJobGraph();
 
@@ -146,7 +145,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 		DataStream<String> src0 = env.addSource(new NoOpSourceFunction());
 		DataStream<String> src1 = env.addSource(new NoOpSourceFunction());
 
-		src0.union(src1).addSink(new NoOpSinkFunction());
+		src0.union(src1).addSink(new DiscardingSink<>());
 
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
@@ -178,7 +177,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 		env.addSource(new NoOpSourceFunction())
 				.map(new NoOpMapFunction())
 				.filter(new NoOpFilterFunction())
-				.addSink(new NoOpSinkFunction());
+				.addSink(new DiscardingSink<>());
 
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
@@ -192,7 +191,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 				.map(new NoOpMapFunction())
 				.startNewChain()
 				.filter(new NoOpFilterFunction())
-				.addSink(new NoOpSinkFunction());
+				.addSink(new DiscardingSink<>());
 
 		jobGraph = env.getStreamGraph().getJobGraph();
 
@@ -221,7 +220,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 				.map(new NoOpMapFunction()).name("map")
 				.startNewChain()
 				.filter(new NoOpFilterFunction())
-				.addSink(new NoOpSinkFunction());
+				.addSink(new DiscardingSink<>());
 
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
@@ -237,7 +236,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 				.startNewChain()
 				.filter(new NoOpFilterFunction())
 				.startNewChain()
-				.addSink(new NoOpSinkFunction());
+				.addSink(new DiscardingSink<>());
 
 		jobGraph = env.getStreamGraph().getJobGraph();
 
@@ -266,9 +265,9 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 
 		DataStream<String> src = env.addSource(new NoOpSourceFunction());
 
-		src.map(new NoOpMapFunction()).addSink(new NoOpSinkFunction());
+		src.map(new NoOpMapFunction()).addSink(new DiscardingSink<>());
 
-		src.map(new NoOpMapFunction()).addSink(new NoOpSinkFunction());
+		src.map(new NoOpMapFunction()).addSink(new DiscardingSink<>());
 
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 		Set<JobVertexID> vertexIds = new HashSet<>();
@@ -326,11 +325,11 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 				.name("source").uid("source");
 
 		src.map(new NoOpMapFunction())
-				.addSink(new NoOpSinkFunction())
+				.addSink(new DiscardingSink<>())
 				.name("sink0").uid("sink0");
 
 		src.map(new NoOpMapFunction())
-				.addSink(new NoOpSinkFunction())
+				.addSink(new DiscardingSink<>())
 				.name("sink1").uid("sink1");
 
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
@@ -352,13 +351,13 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 		src.map(new NoOpMapFunction())
 				.keyBy(new NoOpKeySelector())
 				.reduce(new NoOpReduceFunction())
-				.addSink(new NoOpSinkFunction())
+				.addSink(new DiscardingSink<>())
 				.name("sink0").uid("sink0");
 
 		src.map(new NoOpMapFunction())
 				.keyBy(new NoOpKeySelector())
 				.reduce(new NoOpReduceFunction())
-				.addSink(new NoOpSinkFunction())
+				.addSink(new DiscardingSink<>())
 				.name("sink1").uid("sink1");
 
 		JobGraph newJobGraph = env.getStreamGraph().getJobGraph();
@@ -386,7 +385,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 
 		env.addSource(new NoOpSourceFunction()).uid("source")
 				.map(new NoOpMapFunction()).uid("source") // Collision
-				.addSink(new NoOpSinkFunction());
+				.addSink(new DiscardingSink<>());
 
 		// This call is necessary to generate the job graph
 		env.getStreamGraph().getJobGraph();
@@ -403,7 +402,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 		env.addSource(new NoOpSourceFunction())
 				// Intermediate chained node
 				.map(new NoOpMapFunction()).uid("map")
-				.addSink(new NoOpSinkFunction());
+				.addSink(new DiscardingSink<>());
 
 		env.getStreamGraph().getJobGraph();
 	}
@@ -418,7 +417,7 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 
 		env.addSource(new NoOpSourceFunction()).uid("source")
 				.map(new NoOpMapFunction())
-				.addSink(new NoOpSinkFunction());
+				.addSink(new DiscardingSink<>());
 
 		env.getStreamGraph().getJobGraph();
 	}
@@ -544,15 +543,6 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 
 		@Override
 		public void cancel() {
-		}
-	}
-
-	private static class NoOpSinkFunction implements SinkFunction<String> {
-
-		private static final long serialVersionUID = -5654199886203297279L;
-
-		@Override
-		public void invoke(String value) throws Exception {
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointedStreamingProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointedStreamingProgram.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
 import java.util.Collections;
@@ -48,7 +48,7 @@ public class CheckpointedStreamingProgram {
 		env.disableOperatorChaining();
 
 		DataStream<String> text = env.addSource(new SimpleStringGenerator());
-		text.map(new StatefulMapper()).addSink(new NoOpSink());
+		text.map(new StatefulMapper()).addSink(new DiscardingSink<>());
 		env.setParallelism(1);
 		env.execute("Checkpointed Streaming Program");
 	}
@@ -132,11 +132,5 @@ public class CheckpointedStreamingProgram {
 	 */
 	private static class SuccessException extends Exception {
 
-	}
-
-	private static class NoOpSink implements SinkFunction<String>{
-		@Override
-		public void invoke(String value) throws Exception {
-		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
@@ -31,7 +31,7 @@ import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -60,7 +60,7 @@ public class StreamingCustomInputSplitProgram {
 			public Tuple2<Integer, Double> map(Integer value) throws Exception {
 				return new Tuple2<Integer, Double>(value, value * 0.5);
 			}
-		}).addSink(new NoOpSink());
+		}).addSink(new DiscardingSink<>());
 
 		env.execute();
 	}
@@ -165,12 +165,6 @@ public class StreamingCustomInputSplitProgram {
 					remainingSplits.add((CustomInputSplit) split);
 				}
 			}
-		}
-	}
-
-	private static class NoOpSink implements SinkFunction<Tuple2<Integer, Double>> {
-		@Override
-		public void invoke(Tuple2<Integer, Double> value) throws Exception {
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingProgram.java
@@ -21,7 +21,7 @@ package org.apache.flink.test.classloading.jar;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.util.Collector;
 
@@ -42,7 +42,7 @@ public class StreamingProgram {
 		DataStream<Word> counts =
 				text.flatMap(new Tokenizer()).keyBy("word").sum("frequency");
 
-		counts.addSink(new NoOpSink());
+		counts.addSink(new DiscardingSink<>());
 
 		env.execute();
 	}
@@ -93,12 +93,6 @@ public class StreamingProgram {
 			while (tokenizer.hasMoreTokens()){
 				out.collect(new Word(tokenizer.nextToken(), 1));
 			}
-		}
-	}
-
-	private static class NoOpSink implements SinkFunction<Word>{
-		@Override
-		public void invoke(Word value) throws Exception {
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/ContinuousFileReaderOperatorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/ContinuousFileReaderOperatorITCase.java
@@ -21,7 +21,7 @@ package org.apache.flink.test.streaming.api;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
@@ -61,7 +61,7 @@ public class ContinuousFileReaderOperatorITCase extends AbstractTestBase {
 		TestBoundedOneInputStreamOperator checkingOperator = new TestBoundedOneInputStreamOperator(elementCount);
 		DataStream<String> endInputChecking = source.transform("EndInputChecking", STRING_TYPE_INFO, checkingOperator);
 
-		endInputChecking.addSink(new NoOpSink());
+		endInputChecking.addSink(new DiscardingSink<>());
 
 		env.execute("ContinuousFileReaderOperatorITCase.testEndInput");
 	}
@@ -95,6 +95,4 @@ public class ContinuousFileReaderOperatorITCase extends AbstractTestBase {
 			processedElementCount++;
 		}
 	}
-
-	private static class NoOpSink implements SinkFunction<String> {}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/ContinuousFileReaderOperatorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/ContinuousFileReaderOperatorITCase.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.api;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Integration tests for {@link org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperator}.
+ */
+public class ContinuousFileReaderOperatorITCase extends AbstractTestBase {
+
+	@Test
+	public void testEndInput() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		final File sourceFile = TEMPORARY_FOLDER.newFile();
+		final int elementCount = 10000;
+		try (PrintWriter printWriter = new PrintWriter(sourceFile)) {
+			for (int i = 0; i < elementCount; i++) {
+				printWriter.println(i);
+			}
+		}
+
+		DataStreamSource<String> source = env.readTextFile(sourceFile.getAbsolutePath());
+
+		// check the endInput is invoked at the right time
+		TestBoundedOneInputStreamOperator checkingOperator = new TestBoundedOneInputStreamOperator(elementCount);
+		DataStream<String> endInputChecking = source.transform("EndInputChecking", STRING_TYPE_INFO, checkingOperator);
+
+		endInputChecking.addSink(new NoOpSink());
+
+		env.execute("ContinuousFileReaderOperatorITCase.testEndInput");
+	}
+
+	private static class TestBoundedOneInputStreamOperator extends AbstractStreamOperator<String>
+		implements OneInputStreamOperator<String, String>, BoundedOneInput {
+
+		private final int expectedProcessedElementCount;
+
+		private boolean hasEnded = false;
+
+		private int processedElementCount = 0;
+
+		TestBoundedOneInputStreamOperator(int expectedProcessedElementCount) {
+			// this operator must be chained with ContinuousFileReaderOperator
+			// that way, this end input would be triggered after ContinuousFileReaderOperator
+			chainingStrategy = ChainingStrategy.ALWAYS;
+			this.expectedProcessedElementCount = expectedProcessedElementCount;
+		}
+
+		@Override
+		public void endInput() throws Exception {
+			assertEquals(expectedProcessedElementCount, processedElementCount);
+			hasEnded = true;
+		}
+
+		@Override
+		public void processElement(StreamRecord<String> element) throws Exception {
+			assertFalse(hasEnded);
+			output.collect(element);
+			processedElementCount++;
+		}
+	}
+
+	private static class NoOpSink implements SinkFunction<String> {}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/GlobalAggregateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/GlobalAggregateITCase.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -45,7 +45,7 @@ public class GlobalAggregateITCase extends AbstractTestBase {
 
 		streamExecutionEnvironment
 			.addSource(new TestSourceFunction(new IntegerAggregateFunction(), false))
-			.addSink(new NoOpSinkFunction());
+			.addSink(new DiscardingSink<>());
 
 		streamExecutionEnvironment.execute();
 	}
@@ -56,7 +56,7 @@ public class GlobalAggregateITCase extends AbstractTestBase {
 
 		streamExecutionEnvironment
 			.addSource(new TestSourceFunction(new ExceptionThrowingAggregateFunction(), true))
-			.addSink(new NoOpSinkFunction());
+			.addSink(new DiscardingSink<>());
 
 		streamExecutionEnvironment.execute();
 	}
@@ -164,17 +164,6 @@ public class GlobalAggregateITCase extends AbstractTestBase {
 		@Override
 		public Integer merge(Integer accumulatorA, Integer accumulatorB) {
 			return add(accumulatorA, accumulatorB);
-		}
-	}
-
-	/**
-	 * Sink function that does nothing.
-	 */
-	private static class NoOpSinkFunction implements SinkFunction<Integer> {
-
-		@Override
-		public void invoke(Integer value, Context context) throws Exception {
-
 		}
 	}
 }


### PR DESCRIPTION
… semantics of BoundedOneInput

## What is the purpose of the change

* Currently `ContinuousFileReaderOperator` does not respect the semantics of `BoundedOneInput`
* If there are some operators chained with `ContinuousFileReaderOperator`, the `endInput` of these operators might be triggered before all datum finishing

## Brief change log

* Make `ContinuousFileReaderOperator` implementing `BoundedOneInput`
* Make `ContinuousFileReaderOperator` blocking in `endInput` instead of `close`
* Leave the blocking logic in `close` due to compatibility (I think the `BoundedOneInput.endInput` might be unstable)

## Verifying this change

* This change added an integration test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
