### PR TITLE
[FLINK-13347] [table-planner] should handle SEMI/ANTI JoinRelType in switch case

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
@@ -100,7 +100,7 @@ trait CommonCorrelate {
            |}
            |""".stripMargin
     } else if (joinType != JoinRelType.INNER) {
-      throw new TableException(s"Unsupported SemiJoinType: $joinType for correlate join.")
+      throw new TableException(s"Unsupported JoinRelType: $joinType for correlate join.")
     }
 
     functionGenerator.generateFunction(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonJoin.scala
@@ -45,6 +45,8 @@ trait CommonJoin {
       case JoinRelType.LEFT=> "LeftOuterJoin"
       case JoinRelType.RIGHT => "RightOuterJoin"
       case JoinRelType.FULL => "FullOuterJoin"
+      case JoinRelType.SEMI => "SemiJoin"
+      case JoinRelType.ANTI => "AntiJoin"
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
@@ -199,6 +199,7 @@ class DataSetJoin(
           rightKeys.toArray,
           returnType,
           config)
+      case _ => throw new TableException(s"$joinType is not supported.")
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamJoinToCoProcessTranslator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamJoinToCoProcessTranslator.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.functions.FlatJoinFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator
 import org.apache.flink.streaming.api.operators.co.LegacyKeyedCoProcessOperator
-import org.apache.flink.table.api.{StreamQueryConfig, TableConfig}
+import org.apache.flink.table.api.{StreamQueryConfig, TableConfig, TableException}
 import org.apache.flink.table.codegen.{FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.CRowKeySelector
@@ -145,6 +145,7 @@ class DataStreamJoinToCoProcessTranslator(
           genFunction.name,
           genFunction.code,
           queryConfig)
+      case _ => throw new TableException(s"$joinType is not supported.")
     }
     new LegacyKeyedCoProcessOperator(joinFunction)
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamJoinToCoProcessTranslator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamJoinToCoProcessTranslator.scala
@@ -18,19 +18,20 @@
 
 package org.apache.flink.table.plan.nodes.datastream
 
-import org.apache.calcite.rel.core.{JoinInfo, JoinRelType}
-import org.apache.calcite.rex.{RexBuilder, RexNode}
 import org.apache.flink.api.common.functions.FlatJoinFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator
 import org.apache.flink.streaming.api.operators.co.LegacyKeyedCoProcessOperator
-import org.apache.flink.table.api.{StreamQueryConfig, TableConfig, TableException}
+import org.apache.flink.table.api.{StreamQueryConfig, TableConfig, ValidationException}
 import org.apache.flink.table.codegen.{FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.CRowKeySelector
 import org.apache.flink.table.runtime.join._
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.types.Row
+
+import org.apache.calcite.rel.core.{JoinInfo, JoinRelType}
+import org.apache.calcite.rex.{RexBuilder, RexNode}
 
 class DataStreamJoinToCoProcessTranslator(
     config: TableConfig,
@@ -145,7 +146,7 @@ class DataStreamJoinToCoProcessTranslator(
           genFunction.name,
           genFunction.code,
           queryConfig)
-      case _ => throw new TableException(s"$joinType is not supported.")
+      case _ => throw new ValidationException(s"$joinType is not supported.")
     }
     new LegacyKeyedCoProcessOperator(joinFunction)
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
@@ -150,6 +150,7 @@ class DataStreamWindowJoin(
       case JoinRelType.FULL => JoinType.FULL_OUTER
       case JoinRelType.LEFT => JoinType.LEFT_OUTER
       case JoinRelType.RIGHT => JoinType.RIGHT_OUTER
+      case _ => throw new TableException(s"$joinType is not supported.")
     }
 
     if (relativeWindowSize < 0) {
@@ -232,6 +233,7 @@ class DataStreamWindowJoin(
       case JoinType.FULL_OUTER =>
         leftDataStream.map(leftPadder).name("Full Outer Join").setParallelism(leftP)
           .union(rightDataStream.map(rightPadder).name("Full Outer Join").setParallelism(rightP))
+      case _ => throw new TableException(s"$joinType is not supported.")
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/join/WindowJoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/join/WindowJoinUtil.scala
@@ -18,7 +18,6 @@
 package org.apache.flink.table.runtime.join
 
 import java.util
-
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.JoinRelType
@@ -27,7 +26,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.{SqlKind, SqlOperatorTable}
 import org.apache.flink.api.common.functions.FlatJoinFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.calcite.{FlinkTypeFactory, RelTimeIndicatorConverter}
 import org.apache.flink.table.codegen.{ExpressionReducer, FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.functions.sql.ProctimeSqlFunction
@@ -444,6 +443,7 @@ object WindowJoinUtil {
       case JoinRelType.LEFT => true
       case JoinRelType.RIGHT => true
       case JoinRelType.FULL => true
+      case _ => throw new TableException(s"$joinType is not supported.")
     }
 
     // generate other non-equi function code


### PR DESCRIPTION


## What is the purpose of the change

*should handle SEMI/ANTI JoinRelType in switch case*


## Brief change log

  - *handle SEMI/ANTI JoinRelType in switch case*

## Verifying this change

all tests should pass


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not **documented)**
