### PR TITLE
[FLINK-13428][Connectors / FileSystem] allow part file names to be configurable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
@@ -38,7 +38,8 @@ interface BucketFactory<IN, BucketID> extends Serializable {
 			final Path bucketPath,
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
-			final RollingPolicy<IN, BucketID> rollingPolicy) throws IOException;
+			final RollingPolicy<IN, BucketID> rollingPolicy,
+			final PartFileConfig partFileConfig) throws IOException;
 
 	Bucket<IN, BucketID> restoreBucket(
 			final RecoverableWriter fsWriter,
@@ -46,5 +47,6 @@ interface BucketFactory<IN, BucketID> extends Serializable {
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
-			final BucketState<BucketID> bucketState) throws IOException;
+			final BucketState<BucketID> bucketState,
+			final PartFileConfig partFileConfig) throws IOException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -77,6 +77,8 @@ public class Buckets<IN, BucketID> {
 
 	private final RecoverableWriter fsWriter;
 
+	private final PartFileConfig partFileConfig;
+
 	// --------------------------- State Related Fields -----------------------------
 
 	private final BucketStateSerializer<BucketID> bucketStateSerializer;
@@ -96,7 +98,8 @@ public class Buckets<IN, BucketID> {
 			final BucketFactory<IN, BucketID> bucketFactory,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
-			final int subtaskIndex) throws IOException {
+			final int subtaskIndex,
+			final PartFileConfig partFileConfig) throws IOException {
 
 		this.basePath = Preconditions.checkNotNull(basePath);
 		this.bucketAssigner = Preconditions.checkNotNull(bucketAssigner);
@@ -104,6 +107,8 @@ public class Buckets<IN, BucketID> {
 		this.partFileWriterFactory = Preconditions.checkNotNull(partFileWriterFactory);
 		this.rollingPolicy = Preconditions.checkNotNull(rollingPolicy);
 		this.subtaskIndex = subtaskIndex;
+
+		this.partFileConfig = partFileConfig;
 
 		this.activeBuckets = new HashMap<>();
 		this.bucketerContext = new Buckets.BucketerContext();
@@ -180,7 +185,8 @@ public class Buckets<IN, BucketID> {
 						maxPartCounter,
 						partFileWriterFactory,
 						rollingPolicy,
-						recoveredState
+						recoveredState,
+						partFileConfig
 				);
 
 		updateActiveBucketId(bucketId, restoredBucket);
@@ -286,7 +292,8 @@ public class Buckets<IN, BucketID> {
 					bucketPath,
 					maxPartCounter,
 					partFileWriterFactory,
-					rollingPolicy);
+					rollingPolicy,
+					partFileConfig);
 			activeBuckets.put(bucketId, bucket);
 		}
 		return bucket;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
@@ -40,7 +40,8 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 			final Path bucketPath,
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
-			final RollingPolicy<IN, BucketID> rollingPolicy) {
+			final RollingPolicy<IN, BucketID> rollingPolicy,
+			final PartFileConfig partFileConfig) {
 
 		return Bucket.getNew(
 				fsWriter,
@@ -49,7 +50,8 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 				bucketPath,
 				initialPartCounter,
 				partFileWriterFactory,
-				rollingPolicy);
+				rollingPolicy,
+				partFileConfig);
 	}
 
 	@Override
@@ -59,7 +61,8 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
-			final BucketState<BucketID> bucketState) throws IOException {
+			final BucketState<BucketID> bucketState,
+			final PartFileConfig partFileConfig) throws IOException {
 
 		return Bucket.restore(
 				fsWriter,
@@ -67,6 +70,7 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 				initialPartCounter,
 				partFileWriterFactory,
 				rollingPolicy,
-				bucketState);
+				bucketState,
+				partFileConfig);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import org.apache.flink.util.Preconditions;
+
+public class PartFileConfig {
+
+	public static final String DEFAULT_PART_PREFIX = "part-";
+
+	public static final String DEFAULT_PART_SUFFIX = "";
+
+	private final String partPrefix;
+
+	private final String partSuffix;
+
+	public PartFileConfig() {
+		this(DEFAULT_PART_PREFIX, DEFAULT_PART_SUFFIX);
+	}
+
+	public PartFileConfig(final String partPrefix, final String partSuffix) {
+		this.partPrefix = Preconditions.checkNotNull(partPrefix);
+		this.partSuffix = Preconditions.checkNotNull(partSuffix);
+	}
+
+	public String getPartPrefix() {
+		return partPrefix;
+	}
+
+	public String getPartSuffix() {
+		return partSuffix;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
@@ -20,6 +20,10 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.util.Preconditions;
 
+/**
+ * Part file name configuration.
+ * This allow to define a prefix and a suffix to the part file name.
+ */
 public class PartFileConfig {
 
 	public static final String DEFAULT_PART_PREFIX = "part-";

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -197,8 +197,10 @@ public class StreamingFileSink<IN>
 
 		private final BucketFactory<IN, BucketID> bucketFactory;
 
+		private final PartFileConfig partFileConfig;
+
 		RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
-			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>());
+			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>(), new PartFileConfig());
 		}
 
 		private RowFormatBuilder(
@@ -207,29 +209,35 @@ public class StreamingFileSink<IN>
 				BucketAssigner<IN, BucketID> assigner,
 				RollingPolicy<IN, BucketID> policy,
 				long bucketCheckInterval,
-				BucketFactory<IN, BucketID> bucketFactory) {
+				BucketFactory<IN, BucketID> bucketFactory,
+				PartFileConfig partFileConfig) {
 			this.basePath = Preconditions.checkNotNull(basePath);
 			this.encoder = Preconditions.checkNotNull(encoder);
 			this.bucketAssigner = Preconditions.checkNotNull(assigner);
 			this.rollingPolicy = Preconditions.checkNotNull(policy);
 			this.bucketCheckInterval = bucketCheckInterval;
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
+			this.partFileConfig = Preconditions.checkNotNull(partFileConfig);
 		}
 
 		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketCheckInterval(final long interval) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, interval, bucketFactory);
+			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, interval, bucketFactory, partFileConfig);
 		}
 
 		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketAssigner(final BucketAssigner<IN, BucketID> assigner) {
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), rollingPolicy, bucketCheckInterval, bucketFactory);
+			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), rollingPolicy, bucketCheckInterval, bucketFactory, partFileConfig);
 		}
 
 		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withRollingPolicy(final RollingPolicy<IN, BucketID> policy) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, Preconditions.checkNotNull(policy), bucketCheckInterval, bucketFactory);
+			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, Preconditions.checkNotNull(policy), bucketCheckInterval, bucketFactory, partFileConfig);
 		}
 
 		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID> withBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>());
+			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFileConfig);
+		}
+
+		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withPartFileConfig(PartFileConfig partFileConfig) {
+			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, bucketFactory, partFileConfig);
 		}
 
 		/** Creates the actual sink. */
@@ -245,12 +253,13 @@ public class StreamingFileSink<IN>
 					bucketFactory,
 					new RowWisePartWriter.Factory<>(encoder),
 					rollingPolicy,
-					subtaskIndex);
+					subtaskIndex,
+					partFileConfig);
 		}
 
 		@VisibleForTesting
 		StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, Preconditions.checkNotNull(factory));
+			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, Preconditions.checkNotNull(factory), partFileConfig);
 		}
 	}
 
@@ -272,8 +281,10 @@ public class StreamingFileSink<IN>
 
 		private final BucketFactory<IN, BucketID> bucketFactory;
 
+		private final PartFileConfig partFileConfig;
+
 		BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, BucketID> assigner) {
-			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>());
+			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>(), new PartFileConfig());
 		}
 
 		private BulkFormatBuilder(
@@ -281,25 +292,31 @@ public class StreamingFileSink<IN>
 				BulkWriter.Factory<IN> writerFactory,
 				BucketAssigner<IN, BucketID> assigner,
 				long bucketCheckInterval,
-				BucketFactory<IN, BucketID> bucketFactory) {
+				BucketFactory<IN, BucketID> bucketFactory,
+				PartFileConfig partFileConfig) {
 			this.basePath = Preconditions.checkNotNull(basePath);
 			this.writerFactory = writerFactory;
 			this.bucketAssigner = Preconditions.checkNotNull(assigner);
 			this.bucketCheckInterval = bucketCheckInterval;
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
+			this.partFileConfig = Preconditions.checkNotNull(partFileConfig);
 		}
 
 		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketCheckInterval(long interval) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, interval, bucketFactory);
+			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, interval, bucketFactory, partFileConfig);
 		}
 
 		public <ID> StreamingFileSink.BulkFormatBuilder<IN, ID> withBucketAssigner(BucketAssigner<IN, ID> assigner) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>());
+			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFileConfig);
+		}
+
+		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withPartFileConfig(PartFileConfig partFileConfig) {
+			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, bucketFactory, partFileConfig);
 		}
 
 		@VisibleForTesting
 		StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, Preconditions.checkNotNull(factory));
+			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, Preconditions.checkNotNull(factory), partFileConfig);
 		}
 
 		/** Creates the actual sink. */
@@ -315,7 +332,8 @@ public class StreamingFileSink<IN>
 					bucketFactory,
 					new BulkPartWriter.Factory<>(writerFactory),
 					OnCheckpointRollingPolicy.build(),
-					subtaskIndex);
+					subtaskIndex,
+					partFileConfig);
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
@@ -56,7 +56,8 @@ public class BucketAssignerITCases {
 			new DefaultBucketFactoryImpl<>(),
 			new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 			rollingPolicy,
-			0
+			0,
+			new PartFileConfig()
 		);
 
 		Bucket<String, String> bucket =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
@@ -317,7 +317,8 @@ public class BucketsTest {
 				new DefaultBucketFactoryImpl<>(),
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				DefaultRollingPolicy.create().build(),
-				2
+				2,
+				new PartFileConfig()
 		);
 
 		buckets.onElement(
@@ -369,9 +370,22 @@ public class BucketsTest {
 	// ------------------------------- Utility Methods --------------------------------
 
 	private static Buckets<String, String> createBuckets(
+		final Path basePath,
+		final RollingPolicy<String, String> rollingPolicy,
+		final int subtaskIdx
+	) throws IOException {
+		return createBuckets(
+				basePath,
+				rollingPolicy,
+				subtaskIdx,
+				new PartFileConfig());
+	}
+
+	private static Buckets<String, String> createBuckets(
 			final Path basePath,
 			final RollingPolicy<String, String> rollingPolicy,
-			final int subtaskIdx
+			final int subtaskIdx,
+			final PartFileConfig partFileConfig
 	) throws IOException {
 
 		return new Buckets<>(
@@ -380,8 +394,25 @@ public class BucketsTest {
 				new DefaultBucketFactoryImpl<>(),
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				rollingPolicy,
-				subtaskIdx
+				subtaskIdx,
+				partFileConfig
 		);
+	}
+
+	private static Buckets<String, String> restoreBuckets(
+		final Path basePath,
+		final RollingPolicy<String, String> rollingPolicy,
+		final int subtaskIdx,
+		final ListState<byte[]> bucketState,
+		final ListState<Long> partCounterState
+	) throws Exception {
+		return restoreBuckets(
+				basePath,
+				rollingPolicy,
+				subtaskIdx,
+				bucketState,
+				partCounterState,
+				new PartFileConfig());
 	}
 
 	private static Buckets<String, String> restoreBuckets(
@@ -389,10 +420,11 @@ public class BucketsTest {
 			final RollingPolicy<String, String> rollingPolicy,
 			final int subtaskIdx,
 			final ListState<byte[]> bucketState,
-			final ListState<Long> partCounterState
+			final ListState<Long> partCounterState,
+			final PartFileConfig partFileConfig
 	) throws Exception {
 
-		final Buckets<String, String> restoredBuckets = createBuckets(basePath, rollingPolicy, subtaskIdx);
+		final Buckets<String, String> restoredBuckets = createBuckets(basePath, rollingPolicy, subtaskIdx, partFileConfig);
 		restoredBuckets.initializeState(bucketState, partCounterState);
 		return restoredBuckets;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
@@ -80,7 +80,7 @@ public class BulkWriterTest extends TestLogger {
 					new TestUtils.TupleToStringBucketer(),
 					new TestBulkWriterFactory(),
 					new DefaultBucketFactoryImpl<>(),
-					new PartFileConfig("prefix-",".ext"))
+					new PartFileConfig("prefix-", ".ext"))
 		) {
 			testPartFiles(testHarness, outDir, ".prefix-0-0.ext.inprogress", ".prefix-0-1.ext.inprogress");
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
@@ -190,7 +190,8 @@ public class RollingPolicyTest {
 				new DefaultBucketFactoryImpl<>(),
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				rollingPolicyToTest,
-				0
+				0,
+				new PartFileConfig()
 		);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -116,12 +116,26 @@ public class TestUtils {
 			final BulkWriter.Factory<Tuple2<String, Integer>> writer,
 			final BucketFactory<Tuple2<String, Integer>, String> bucketFactory) throws Exception {
 
+		return createTestSinkWithBulkEncoder(outDir, totalParallelism, taskIdx, bucketCheckInterval, bucketer, writer, bucketFactory, new PartFileConfig());
+	}
+
+	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithBulkEncoder(
+		final File outDir,
+		final int totalParallelism,
+		final int taskIdx,
+		final long bucketCheckInterval,
+		final BucketAssigner<Tuple2<String, Integer>, String> bucketer,
+		final BulkWriter.Factory<Tuple2<String, Integer>> writer,
+		final BucketFactory<Tuple2<String, Integer>, String> bucketFactory,
+		final PartFileConfig partFileConfig) throws Exception {
+
 		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
-				.forBulkFormat(new Path(outDir.toURI()), writer)
-				.withBucketAssigner(bucketer)
-				.withBucketCheckInterval(bucketCheckInterval)
-				.withBucketFactory(bucketFactory)
-				.build();
+			.forBulkFormat(new Path(outDir.toURI()), writer)
+			.withBucketAssigner(bucketer)
+			.withBucketCheckInterval(bucketCheckInterval)
+			.withBucketFactory(bucketFactory)
+			.withPartFileConfig(partFileConfig)
+			.build();
 
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
 	}


### PR DESCRIPTION
## What is the purpose of the change
Allow part file name to be configurable


## Brief change log
- Bucket have part name prefix and suffix

## Verifying this change
This change added tests to BulkWritterTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
