### PR TITLE
[FLINK-13228][tests][filesystems] Harden HadoopRecoverableWriterTest

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.core.fs;
 
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -122,7 +123,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 				Assert.assertEquals(testData1, fileContents.getValue());
 			}
 		} finally {
-			closeStreamSilently(stream);
+			IOUtils.closeQuietly(stream);
 		}
 	}
 
@@ -148,7 +149,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 				Assert.assertEquals(testData1 + testData2, fileContents.getValue());
 			}
 		} finally {
-			closeStreamSilently(stream);
+			IOUtils.closeQuietly(stream);
 		}
 	}
 
@@ -217,7 +218,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 
 			recoverables.put(FINAL_WITH_EXTRA_STATE, stream.persist());
 		} finally {
-			closeStreamSilently(stream);
+			IOUtils.closeQuietly(stream);
 		}
 
 		final SimpleVersionedSerializer<RecoverableWriter.ResumeRecoverable> serializer = initWriter.getResumeRecoverableSerializer();
@@ -253,7 +254,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 				Assert.assertEquals(expectedFinalContents, fileContents.getValue());
 			}
 		} finally {
-			closeStreamSilently(recoveredStream);
+			IOUtils.closeQuietly(recoveredStream);
 		}
 	}
 
@@ -278,7 +279,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 
 			recoverable = stream.closeForCommit().getRecoverable();
 		} finally {
-			closeStreamSilently(stream);
+			IOUtils.closeQuietly(stream);
 		}
 
 		final byte[] serializedRecoverable = initWriter.getCommitRecoverableSerializer().serialize(recoverable);
@@ -318,7 +319,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 			stream.write(testData2.getBytes(StandardCharsets.UTF_8));
 			fail();
 		} finally {
-			closeStreamSilently(stream);
+			IOUtils.closeQuietly(stream);
 		}
 	}
 
@@ -340,7 +341,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 
 			stream.closeForCommit().commit();
 		} finally {
-			closeStreamSilently(stream);
+			IOUtils.closeQuietly(stream);
 		}
 
 		// this should throw an exception as the file is already committed
@@ -371,7 +372,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 			recoverable2 = stream.persist();
 			stream.write(testData3.getBytes(StandardCharsets.UTF_8));
 		} finally {
-			closeStreamSilently(stream);
+			IOUtils.closeQuietly(stream);
 		}
 
 		try (RecoverableFsDataOutputStream ignored = writer.recover(recoverable1)) {
@@ -408,17 +409,5 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 
 	private static String randomName() {
 		return StringUtils.getRandomString(RND, 16, 16, 'a', 'z');
-	}
-
-	private void closeStreamSilently(RecoverableFsDataOutputStream stream) {
-		if (stream == null) {
-			return;
-		}
-		try {
-			stream.close();
-		} catch (IOException e) {
-			// log and ignore the exception
-			log.debug("Exception observed and ignored while trying to close the stream", e);
-		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
@@ -332,7 +332,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 
 		RecoverableWriter.ResumeRecoverable recoverable;
 		RecoverableFsDataOutputStream stream = null;
-		try{
+		try {
 			stream = writer.open(path);
 			stream.write(testData1.getBytes(StandardCharsets.UTF_8));
 


### PR DESCRIPTION
## What is the purpose of the change
Currently test cases will fail when trying to close the output stream if all data written but `ClosedByInterruptException` occurs at the ending phase. This PR proposes to close the stream silently if the test case logic passed properly.

## Brief change log
Close the output stream silently in `HadoopRecoverableWriterTest` if the test case logic passed properly.


## Verifying this change
This change is on the test cases and verified by sanity test through modifying hadoop source code to simulate the rarely happening situation that triggers the issue.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
