### PR TITLE
[FLINK-13283][FLINK-13490][jdbc] Fix JDBC connectors with DataTypes.DATE/TIME/TIMESTAMP support and null checking

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -66,12 +66,12 @@ public class JDBCTableSource implements
 		this.options = options;
 		this.readOptions = readOptions;
 		this.lookupOptions = lookupOptions;
-		this.schema = schema;
+		this.schema = JDBCUtils.toJDBCTableSchema(schema);
 
 		this.selectFields = selectFields;
 
-		final TypeInformation<?>[] schemaTypeInfos = schema.getFieldTypes();
-		final String[] schemaFieldNames = schema.getFieldNames();
+		final TypeInformation<?>[] schemaTypeInfos = this.schema.getFieldTypes();
+		final String[] schemaFieldNames = this.schema.getFieldNames();
 		if (selectFields != null) {
 			TypeInformation<?>[] typeInfos = new TypeInformation[selectFields.length];
 			String[] typeNames = new String[selectFields.length];

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertOutputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertOutputFormat.java
@@ -238,18 +238,18 @@ public class JDBCUpsertOutputFormat extends AbstractJDBCOutputFormat<Tuple2<Bool
 		}
 
 		/**
-		 * required, upsert unique keys.
-		 */
-		public Builder setKeyFields(String[] keyFields) {
-			this.keyFields = keyFields;
-			return this;
-		}
-
-		/**
 		 * required, field types of this jdbc sink.
 		 */
 		public Builder setFieldTypes(int[] fieldTypes) {
 			this.fieldTypes = fieldTypes;
+			return this;
+		}
+
+		/**
+		 * optional, upsert unique keys, no need for append mode.
+		 */
+		public Builder setKeyFields(String[] keyFields) {
+			this.keyFields = keyFields;
 			return this;
 		}
 
@@ -286,6 +286,7 @@ public class JDBCUpsertOutputFormat extends AbstractJDBCOutputFormat<Tuple2<Bool
 		public JDBCUpsertOutputFormat build() {
 			checkNotNull(options, "No options supplied.");
 			checkNotNull(fieldNames, "No fieldNames supplied.");
+			checkNotNull(fieldTypes, "No fieldTypes supplied.");
 			return new JDBCUpsertOutputFormat(
 				options, fieldNames, keyFields, fieldTypes, flushMaxSize, flushIntervalMills, maxRetryTimes);
 		}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
@@ -60,7 +60,7 @@ public class JDBCUpsertTableSink implements UpsertStreamTableSink<Row> {
 		int flushMaxSize,
 		long flushIntervalMills,
 		int maxRetryTime) {
-		this.schema = schema;
+		this.schema = JDBCUtils.toJDBCTableSchema(schema);
 		this.options = options;
 		this.flushMaxSize = flushMaxSize;
 		this.flushIntervalMills = flushIntervalMills;
@@ -69,7 +69,8 @@ public class JDBCUpsertTableSink implements UpsertStreamTableSink<Row> {
 
 	private JDBCUpsertOutputFormat newFormat() {
 		if (!isAppendOnly && (keyFields == null || keyFields.length == 0)) {
-			throw new UnsupportedOperationException("JDBCUpsertTableSink can not support ");
+			throw new UnsupportedOperationException(
+				"Key fields must be specified when using JDBCUpsertTableSink in upsert mode");
 		}
 
 		// sql types

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUtils.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUtils.java
@@ -18,14 +18,20 @@
 
 package org.apache.flink.api.java.io.jdbc;
 
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
 
 /**
  * Utils for jdbc connectors.
@@ -230,5 +236,30 @@ public class JDBCUtils {
 		} else {
 			return ret;
 		}
+	}
+
+	public static TableSchema toJDBCTableSchema(TableSchema schema) {
+		TableSchema.Builder builder = TableSchema.builder();
+		DataType[] fieldDataTypes = schema.getFieldDataTypes();
+		String[] fieldNames = schema.getFieldNames();
+
+		for (int i = 0; i < fieldDataTypes.length; i++) {
+			switch (fieldDataTypes[i].getLogicalType().getTypeRoot()) {
+				case DATE:
+					builder.field(fieldNames[i], DataTypes.DATE().bridgedTo(Date.class));
+					break;
+				case TIME_WITHOUT_TIME_ZONE:
+					builder.field(fieldNames[i], DataTypes.TIME().bridgedTo(Time.class));
+					break;
+				case TIMESTAMP_WITHOUT_TIME_ZONE:
+					builder.field(fieldNames[i], DataTypes.TIMESTAMP(3).bridgedTo(Timestamp.class));
+					break;
+				default:
+					builder.field(fieldNames[i], fieldDataTypes[i]);
+					break;
+			}
+		}
+
+		return builder.build();
 	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
@@ -202,7 +202,7 @@ public class JDBCInputFormatTest extends JDBCTestBase {
 		Assert.assertEquals(1, jdbcInputFormat.createInputSplits(1).length);
 		jdbcInputFormat.openInputFormat();
 		jdbcInputFormat.open(null);
-		Row row =  new Row(5);
+		Row row =  new Row(8);
 		int recordCount = 0;
 		while (!jdbcInputFormat.reachedEnd()) {
 			Row next = jdbcInputFormat.nextRecord(row);
@@ -236,7 +236,7 @@ public class JDBCInputFormatTest extends JDBCTestBase {
 		//this query exploit parallelism (1 split for every id)
 		Assert.assertEquals(TEST_DATA.length, splits.length);
 		int recordCount = 0;
-		Row row =  new Row(5);
+		Row row =  new Row(8);
 		for (InputSplit split : splits) {
 			jdbcInputFormat.open(split);
 			while (!jdbcInputFormat.reachedEnd()) {
@@ -272,7 +272,7 @@ public class JDBCInputFormatTest extends JDBCTestBase {
 		//assert that a single split was generated
 		Assert.assertEquals(1, splits.length);
 		int recordCount = 0;
-		Row row =  new Row(5);
+		Row row =  new Row(8);
 		for (InputSplit split : splits) {
 			jdbcInputFormat.open(split);
 			while (!jdbcInputFormat.reachedEnd()) {
@@ -317,7 +317,7 @@ public class JDBCInputFormatTest extends JDBCTestBase {
 	private void verifySplit(InputSplit split, int expectedIDSum) throws IOException {
 		int sum = 0;
 
-		Row row =  new Row(5);
+		Row row =  new Row(8);
 		jdbcInputFormat.open(split);
 		while (!jdbcInputFormat.reachedEnd()) {
 			row = jdbcInputFormat.nextRecord(row);
@@ -357,6 +357,9 @@ public class JDBCInputFormatTest extends JDBCTestBase {
 		Assert.assertEquals(expected.author, actual.getField(2));
 		Assert.assertEquals(expected.price, actual.getField(3));
 		Assert.assertEquals(expected.qty, actual.getField(4));
+		Assert.assertEquals(expected.printDate, actual.getField(5));
+		Assert.assertEquals(expected.printTime, actual.getField(6));
+		Assert.assertEquals(expected.printTimestamp, actual.getField(7));
 	}
 
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 
 import org.junit.AfterClass;
@@ -28,9 +29,13 @@ import org.junit.rules.ExpectedException;
 
 import java.io.OutputStream;
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
 
 /**
  * Base test class for JDBC Input and Output formats.
@@ -45,25 +50,49 @@ public class JDBCTestBase {
 	public static final String INPUT_TABLE = "books";
 	public static final String OUTPUT_TABLE = "newbooks";
 	public static final String OUTPUT_TABLE_2 = "newbooks2";
+	public static final String[] FIELD_NAMES = new String[]{
+		"id", "title", "author", "price", "qty", "print_date", "print_time", "print_timestamp"};
+
 	public static final String SELECT_ALL_BOOKS = "select * from " + INPUT_TABLE;
 	public static final String SELECT_ALL_NEWBOOKS = "select * from " + OUTPUT_TABLE;
 	public static final String SELECT_ALL_NEWBOOKS_2 = "select * from " + OUTPUT_TABLE_2;
 	public static final String SELECT_EMPTY = "select * from books WHERE QTY < 0";
-	public static final String INSERT_TEMPLATE = "insert into %s (id, title, author, price, qty) values (?,?,?,?,?)";
+	public static final String INSERT_TEMPLATE =
+		"insert into %s (" + String.join(",", FIELD_NAMES) + ") values (?,?,?,?,?,?,?,?)";
 	public static final String SELECT_ALL_BOOKS_SPLIT_BY_ID = SELECT_ALL_BOOKS + " WHERE id BETWEEN ? AND ?";
 	public static final String SELECT_ALL_BOOKS_SPLIT_BY_AUTHOR = SELECT_ALL_BOOKS + " WHERE author = ?";
 
 	public static final TestEntry[] TEST_DATA = {
-			new TestEntry(1001, ("Java public for dummies"), ("Tan Ah Teck"), 11.11, 11),
-			new TestEntry(1002, ("More Java for dummies"), ("Tan Ah Teck"), 22.22, 22),
-			new TestEntry(1003, ("More Java for more dummies"), ("Mohammad Ali"), 33.33, 33),
-			new TestEntry(1004, ("A Cup of Java"), ("Kumar"), 44.44, 44),
-			new TestEntry(1005, ("A Teaspoon of Java"), ("Kevin Jones"), 55.55, 55),
-			new TestEntry(1006, ("A Teaspoon of Java 1.4"), ("Kevin Jones"), 66.66, 66),
-			new TestEntry(1007, ("A Teaspoon of Java 1.5"), ("Kevin Jones"), 77.77, 77),
-			new TestEntry(1008, ("A Teaspoon of Java 1.6"), ("Kevin Jones"), 88.88, 88),
-			new TestEntry(1009, ("A Teaspoon of Java 1.7"), ("Kevin Jones"), 99.99, 99),
-			new TestEntry(1010, ("A Teaspoon of Java 1.8"), ("Kevin Jones"), null, 1010)
+			new TestEntry(
+				1001, ("Java public for dummies"), ("Tan Ah Teck"), 11.11, 11,
+				Date.valueOf("2011-01-11"), Time.valueOf("01:11:11"), Timestamp.valueOf("2011-01-11 01:11:11")),
+			new TestEntry(
+				1002, ("More Java for dummies"), ("Tan Ah Teck"), 22.22, 22,
+				Date.valueOf("2012-02-12"), Time.valueOf("02:12:12"), Timestamp.valueOf("2012-02-12 02:12:12")),
+			new TestEntry(
+				1003, ("More Java for more dummies"), ("Mohammad Ali"), 33.33, 33,
+				Date.valueOf("2013-03-13"), Time.valueOf("03:13:13"), Timestamp.valueOf("2013-03-13 03:13:13")),
+			new TestEntry(
+				1004, ("A Cup of Java"), ("Kumar"), 44.44, 44,
+				Date.valueOf("2014-04-14"), Time.valueOf("04:14:14"), Timestamp.valueOf("2014-04-14 04:14:14")),
+			new TestEntry(
+				1005, ("A Teaspoon of Java"), ("Kevin Jones"), 55.55, 55,
+				Date.valueOf("2015-05-15"), Time.valueOf("05:15:15"), Timestamp.valueOf("2015-05-15 05:15:15")),
+			new TestEntry(
+				1006, ("A Teaspoon of Java 1.4"), ("Kevin Jones"), 66.66, 66,
+				Date.valueOf("2016-06-16"), Time.valueOf("06:16:16"), Timestamp.valueOf("2016-06-16 06:16:16")),
+			new TestEntry(
+				1007, ("A Teaspoon of Java 1.5"), ("Kevin Jones"), 77.77, 77,
+				Date.valueOf("2017-07-17"), Time.valueOf("07:17:17"), Timestamp.valueOf("2017-07-17 07:17:17")),
+			new TestEntry(
+				1008, ("A Teaspoon of Java 1.6"), ("Kevin Jones"), 88.88, 88,
+				Date.valueOf("2018-08-18"), Time.valueOf("08:18:18"), Timestamp.valueOf("2018-08-18 08:18:18")),
+			new TestEntry(
+				1009, ("A Teaspoon of Java 1.7"), ("Kevin Jones"), 99.99, 99,
+				Date.valueOf("2019-09-19"), Time.valueOf("09:19:19"), Timestamp.valueOf("2019-09-19 09:19:19")),
+			new TestEntry(
+				1010, ("A Teaspoon of Java 1.8"), ("Kevin Jones"), null, 1010,
+				Date.valueOf("2020-10-20"), null, Timestamp.valueOf("2020-10-20 10:20:20"))
 	};
 
 	static class TestEntry {
@@ -72,13 +101,21 @@ public class JDBCTestBase {
 		protected final String author;
 		protected final Double price;
 		protected final Integer qty;
+		protected final Date printDate;
+		protected final Time printTime;
+		protected final Timestamp printTimestamp;
 
-		private TestEntry(Integer id, String title, String author, Double price, Integer qty) {
+		private TestEntry(
+				Integer id, String title, String author, Double price, Integer qty,
+				Date printDate, Time printTime, Timestamp printTimestamp) {
 			this.id = id;
 			this.title = title;
 			this.author = author;
 			this.price = price;
 			this.qty = qty;
+			this.printDate = printDate;
+			this.printTime = printTime;
+			this.printTimestamp = printTimestamp;
 		}
 	}
 
@@ -87,7 +124,20 @@ public class JDBCTestBase {
 		BasicTypeInfo.STRING_TYPE_INFO,
 		BasicTypeInfo.STRING_TYPE_INFO,
 		BasicTypeInfo.DOUBLE_TYPE_INFO,
-		BasicTypeInfo.INT_TYPE_INFO);
+		BasicTypeInfo.INT_TYPE_INFO,
+		SqlTimeTypeInfo.DATE,
+		SqlTimeTypeInfo.TIME,
+		SqlTimeTypeInfo.TIMESTAMP);
+
+	public static final int[] SQL_TYPES = new int[] {
+		Types.INTEGER,
+		Types.VARCHAR,
+		Types.VARCHAR,
+		Types.DOUBLE,
+		Types.INTEGER,
+		Types.DATE,
+		Types.TIME,
+		Types.TIMESTAMP};
 
 	public static String getCreateQuery(String tableName) {
 		StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE ");
@@ -97,25 +147,48 @@ public class JDBCTestBase {
 		sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
 		sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
 		sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+		sqlQueryBuilder.append("print_date DATE DEFAULT NULL,");
+		sqlQueryBuilder.append("print_time TIME DEFAULT NULL,");
+		sqlQueryBuilder.append("print_timestamp TIMESTAMP DEFAULT NULL,");
 		sqlQueryBuilder.append("PRIMARY KEY (id))");
 		return sqlQueryBuilder.toString();
 	}
 
 	public static String getInsertQuery() {
-		StringBuilder sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
+		boolean[] surroundedByQuotes = new boolean[] {
+			false, true, true, false, false, true, true, true
+		};
+
+		StringBuilder sqlQueryBuilder = new StringBuilder(
+			"INSERT INTO books (" + String.join(", ", FIELD_NAMES) + ") VALUES ");
 		for (int i = 0; i < TEST_DATA.length; i++) {
-			sqlQueryBuilder.append("(")
-			.append(TEST_DATA[i].id).append(",'")
-			.append(TEST_DATA[i].title).append("','")
-			.append(TEST_DATA[i].author).append("',")
-			.append(TEST_DATA[i].price).append(",")
-			.append(TEST_DATA[i].qty).append(")");
+			sqlQueryBuilder.append("(");
+			Object[] objs = new Object[]{
+				TEST_DATA[i].id, TEST_DATA[i].title, TEST_DATA[i].author, TEST_DATA[i].price, TEST_DATA[i].qty,
+				TEST_DATA[i].printDate, TEST_DATA[i].printTime, TEST_DATA[i].printTimestamp
+			};
+			for (int j = 0; j < objs.length; j++) {
+				if (objs[j] == null) {
+					sqlQueryBuilder.append("null");
+				} else {
+					if (surroundedByQuotes[j]) {
+						sqlQueryBuilder.append("'");
+					}
+					sqlQueryBuilder.append(objs[j]);
+					if (surroundedByQuotes[j]) {
+						sqlQueryBuilder.append("'");
+					}
+				}
+				if (j < objs.length - 1) {
+					sqlQueryBuilder.append(", ");
+				}
+			}
+			sqlQueryBuilder.append(")");
 			if (i < TEST_DATA.length - 1) {
-				sqlQueryBuilder.append(",");
+				sqlQueryBuilder.append(", ");
 			}
 		}
-		String insertQuery = sqlQueryBuilder.toString();
-		return insertQuery;
+		return sqlQueryBuilder.toString();
 	}
 
 	public static final OutputStream DEV_NULL = new OutputStream() {

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertOutputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertOutputFormatTest.java
@@ -53,7 +53,7 @@ public class JDBCUpsertOutputFormatTest extends JDBCTestBase {
 
 	@Before
 	public void setup() {
-		fieldNames = new String[]{"id", "title", "author", "price", "qty"};
+		fieldNames = FIELD_NAMES;
 		keyFields = new String[]{"id"};
 	}
 
@@ -65,6 +65,7 @@ public class JDBCUpsertOutputFormatTest extends JDBCTestBase {
 						.setTableName(OUTPUT_TABLE)
 						.build())
 				.setFieldNames(fieldNames)
+				.setFieldTypes(SQL_TYPES)
 				.setKeyFields(keyFields)
 				.build();
 		RuntimeContext context = Mockito.mock(RuntimeContext.class);


### PR DESCRIPTION
## What is the purpose of the change

Currently JDBC connector does not support DataTypes.DATE/TIME/TIMESTAMP with their default conversion classes to be LocalDate/LocalTime/LocalDateTime. This PR fixes the support of these data types for JDBC connector.

<del>Also, the null checking in `JDBCUtils::getFieldFromResultSet` is incorrect. Under the current implementation, if one column is null in the result set, the following calls to this method using the same result set will always return null, no matter what the content of the column is.</del> merged

## Brief change log

 - Fix JDBC connector with DataTypes.DATE/TIME/TIMESTAMP support
 - <del>Fix null checking in `JDBCUtils::getFieldFromResultSet`</del> merged

## Verifying this change

This change is already covered by existing tests, such as the existing tests in the jdbc connector package. This PR updates these tests with some time data types and some null values.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
