### PR TITLE
[FLINK-13385][hive]Align Hive data type mapping with FLIP-37

### DIFF
--- a/docs/dev/table/catalog.md
+++ b/docs/dev/table/catalog.md
@@ -157,19 +157,19 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
 
 |  Flink Data Type  |  Hive Data Type  |
 |---|---|
-| CHAR(p)       |  char(p)* |
-| VARCHAR(p)    |  varchar(p)** |
-| STRING        |  string |
-| BOOLEAN       |  boolean |
-| TINYINT       |  tinyint |
-| SMALLINT      |  smallint |
-| INT           |  int |
-| BIGINT        |  long |
-| FLOAT         |  float |
-| DOUBLE        |  double |
-| DECIMAL(p, s) |  decimal(p, s) |
-| DATE          |  date |
-| TIMESTAMP_WITHOUT_TIME_ZONE |  Timestamp |
+| CHAR(p)       |  CHAR(p)* |
+| VARCHAR(p)    |  VARCHAR(p)** |
+| STRING        |  STRING |
+| BOOLEAN       |  BOOLEAN |
+| TINYINT       |  TINYINT |
+| SMALLINT      |  SMALLINT |
+| INT           |  INT |
+| BIGINT        |  LONG |
+| FLOAT         |  FLOAT |
+| DOUBLE        |  DOUBLE |
+| DECIMAL(p, s) |  DECIMAL(p, s) |
+| DATE          |  DATE |
+| TIMESTAMP_WITHOUT_TIME_ZONE |  timestamp |
 | TIMESTAMP_WITH_TIME_ZONE |  N/A |
 | TIMESTAMP_WITH_LOCAL_TIME_ZONE |  N/A |
 | INTERVAL      |   N/A*** |
@@ -177,8 +177,8 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
 | VARBINARY(p)  |   N/A |
 | BYTES         |   BINARY |
 | ARRAY\<E>     |  ARRAY\<E> |
-| MAP<K, V>     |  map<K, V> ****|
-| ROW           |  struct |
+| MAP<K, V>     |  MAP<K, V> ****|
+| ROW           |  STRUCT |
 | MULTISET      |  N/A |
 
 
@@ -190,13 +190,13 @@ The following limitations in Hive's data types impact the mapping between Flink 
 
 \** maximum length is 65535
 
-## User-configured Catalog
-
-Catalogs are pluggable. Users can develop custom catalogs by implementing the `Catalog` interface, which defines a set of APIs for reading and writing catalog meta-objects such as database, tables, partitions, views, and functions.
-
 \*** `INTERVAL` type can not be mapped to hive `INTERVAL` for now.
 
 \**** Hive map key type only allows primitive types, while Flink map key can be any data type.
+
+## User-configured Catalog
+
+Catalogs are pluggable. Users can develop custom catalogs by implementing the `Catalog` interface, which defines a set of APIs for reading and writing catalog meta-objects such as database, tables, partitions, views, and functions.
 
 Catalog Registration
 --------------------

--- a/docs/dev/table/catalog.md
+++ b/docs/dev/table/catalog.md
@@ -161,8 +161,8 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
 | VARCHAR(p)    |  varchar(p)** |
 | STRING        |  string |
 | BOOLEAN       |  boolean |
-| BYTE          |  tinyint |
-| SHORT         |  smallint |
+| TINYINT       |  tinyint |
+| SMALLINT      |  smallint |
 | INT           |  int |
 | BIGINT        |  long |
 | FLOAT         |  float |
@@ -172,10 +172,11 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
 | TIMESTAMP_WITHOUT_TIME_ZONE |  Timestamp |
 | TIMESTAMP_WITH_TIME_ZONE |  N/A |
 | TIMESTAMP_WITH_LOCAL_TIME_ZONE |  N/A |
-| INTERVAL |  N/A |
-| BINARY        |  binary |
-| VARBINARY(p)  |  binary |
-| ARRAY\<E>     |  list\<E> |
+| INTERVAL      |   N/A*** |
+| BINARY        |   N/A |
+| VARBINARY(p)  |   N/A |
+| BYTES         |   BINARY |
+| ARRAY\<E>     |  ARRAY\<E> |
 | MAP<K, V>     |  map<K, V> |
 | ROW           |  struct |
 | MULTISET      |  N/A |
@@ -193,6 +194,7 @@ The following limitations in Hive's data types impact the mapping between Flink 
 
 Catalogs are pluggable. Users can develop custom catalogs by implementing the `Catalog` interface, which defines a set of APIs for reading and writing catalog meta-objects such as database, tables, partitions, views, and functions.
 
+\*** `INTERVAL` type can not be mapped to hive `INTERVAL` for now.
 
 Catalog Registration
 --------------------

--- a/docs/dev/table/catalog.md
+++ b/docs/dev/table/catalog.md
@@ -177,7 +177,7 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
 | VARBINARY(p)  |   N/A |
 | BYTES         |   BINARY |
 | ARRAY\<E>     |  ARRAY\<E> |
-| MAP<K, V>     |  map<K, V> |
+| MAP<K, V>     |  map<K, V> ****|
 | ROW           |  struct |
 | MULTISET      |  N/A |
 
@@ -195,6 +195,8 @@ The following limitations in Hive's data types impact the mapping between Flink 
 Catalogs are pluggable. Users can develop custom catalogs by implementing the `Catalog` interface, which defines a set of APIs for reading and writing catalog meta-objects such as database, tables, partitions, views, and functions.
 
 \*** `INTERVAL` type can not be mapped to hive `INTERVAL` for now.
+
+\**** Hive map key type only allows primitive types, while Flink map key can be any data type.
 
 Catalog Registration
 --------------------

--- a/docs/dev/table/catalog.md
+++ b/docs/dev/table/catalog.md
@@ -169,7 +169,7 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
 | DOUBLE        |  DOUBLE |
 | DECIMAL(p, s) |  DECIMAL(p, s) |
 | DATE          |  DATE |
-| TIMESTAMP_WITHOUT_TIME_ZONE |  timestamp |
+| TIMESTAMP_WITHOUT_TIME_ZONE |  TIMESTAMP |
 | TIMESTAMP_WITH_TIME_ZONE |  N/A |
 | TIMESTAMP_WITH_LOCAL_TIME_ZONE |  N/A |
 | INTERVAL      |   N/A*** |

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -103,9 +103,6 @@ public class HiveTypeUtil {
 				return TypeInfoFactory.dateTypeInfo;
 			} else if (type.equals(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
 				return TypeInfoFactory.timestampTypeInfo;
-			} else if (type.equals(LogicalTypeRoot.BINARY) || type.equals(LogicalTypeRoot.VARBINARY)) {
-				// Hive doesn't support variable-length binary string
-				return TypeInfoFactory.binaryTypeInfo;
 			} else if (type.equals(LogicalTypeRoot.CHAR)) {
 				CharType charType = (CharType) dataType.getLogicalType();
 
@@ -144,6 +141,11 @@ public class HiveTypeUtil {
 			}
 
 			// Flink's primitive types that Hive 2.3.4 doesn't support: Time, TIMESTAMP_WITH_LOCAL_TIME_ZONE
+		}
+
+		if (dataType.equals(DataTypes.BYTES())) {
+			// Hive doesn't support variable-length binary string
+			return TypeInfoFactory.binaryTypeInfo;
 		}
 
 		if (dataType instanceof CollectionDataType) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -144,7 +144,6 @@ public class HiveTypeUtil {
 		}
 
 		if (dataType.equals(DataTypes.BYTES())) {
-			// Hive doesn't support variable-length binary string
 			return TypeInfoFactory.binaryTypeInfo;
 		}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -22,36 +22,24 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.AnyType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
-import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
-import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeVisitor;
 import org.apache.flink.table.types.logical.MapType;
-import org.apache.flink.table.types.logical.MultisetType;
-import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
-import org.apache.flink.table.types.logical.StructuredType;
-import org.apache.flink.table.types.logical.SymbolType;
-import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
-import org.apache.flink.table.types.logical.YearMonthIntervalType;
-import org.apache.flink.table.types.logical.ZonedTimestampType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -101,16 +89,8 @@ public class HiveTypeUtil {
 	 */
 	public static TypeInfo toHiveTypeInfo(DataType dataType) {
 		checkNotNull(dataType, "type cannot be null");
-
-//		LogicalTypeRoot type = dataType.getLogicalType().getTypeRoot();
 		LogicalType logicalType = dataType.getLogicalType();
-		TypeInfo typeInfo = logicalType.accept(new TypeInfoLogicalTypeVisitor());
-		if (null == typeInfo) {
-			throw new UnsupportedOperationException(
-					String.format("Flink doesn't support converting type %s to Hive type yet.", dataType.toString()));
-		} else {
-			return typeInfo;
-		}
+		return logicalType.accept(new TypeInfoLogicalTypeVisitor(dataType));
 	}
 
 	/**
@@ -199,7 +179,13 @@ public class HiveTypeUtil {
 		}
 	}
 
-	private static class TypeInfoLogicalTypeVisitor implements LogicalTypeVisitor<TypeInfo> {
+	private static class TypeInfoLogicalTypeVisitor extends LogicalTypeDefaultVisitor<TypeInfo> {
+		private final DataType dataType;
+
+		public TypeInfoLogicalTypeVisitor(DataType dataType) {
+			this.dataType = dataType;
+		}
+
 		@Override
 		public TypeInfo visit(CharType charType) {
 			if (charType.getLength() > HiveChar.MAX_CHAR_LENGTH) {
@@ -234,11 +220,6 @@ public class HiveTypeUtil {
 		}
 
 		@Override
-		public TypeInfo visit(BinaryType binaryType) {
-			return null;
-		}
-
-		@Override
 		public TypeInfo visit(VarBinaryType varBinaryType) {
 			// Flink's BytesType is defined as VARBINARY(Integer.MAX_VALUE)
 			// We don't have more information in LogicalTypeRoot to distinguish BytesType and a VARBINARY(Integer.MAX_VALUE) instance
@@ -246,7 +227,7 @@ public class HiveTypeUtil {
 			if (varBinaryType.getLength() == VarBinaryType.MAX_LENGTH) {
 				return TypeInfoFactory.binaryTypeInfo;
 			}
-			return null;
+			return defaultMethod(varBinaryType);
 		}
 
 		@Override
@@ -292,59 +273,29 @@ public class HiveTypeUtil {
 		}
 
 		@Override
-		public TypeInfo visit(TimeType timeType) {
-			return null;
-		}
-
-		@Override
 		public TypeInfo visit(TimestampType timestampType) {
 			return TypeInfoFactory.timestampTypeInfo;
 		}
 
 		@Override
-		public TypeInfo visit(ZonedTimestampType zonedTimestampType) {
-			return null;
-		}
-
-		@Override
-		public TypeInfo visit(LocalZonedTimestampType localZonedTimestampType) {
-			return null;
-		}
-
-		@Override
-		public TypeInfo visit(YearMonthIntervalType yearMonthIntervalType) {
-			return null;
-		}
-
-		@Override
-		public TypeInfo visit(DayTimeIntervalType dayTimeIntervalType) {
-			return null;
-		}
-
-		@Override
 		public TypeInfo visit(ArrayType arrayType) {
 			LogicalType elementType = arrayType.getElementType();
-			TypeInfo elementTypeInfo = elementType.accept(new TypeInfoLogicalTypeVisitor());
+			TypeInfo elementTypeInfo = elementType.accept(new TypeInfoLogicalTypeVisitor(dataType));
 			if (null != elementTypeInfo) {
 				return TypeInfoFactory.getListTypeInfo(elementTypeInfo);
 			} else {
-				return null;
+				return defaultMethod(arrayType);
 			}
-		}
-
-		@Override
-		public TypeInfo visit(MultisetType multisetType) {
-			return null;
 		}
 
 		@Override
 		public TypeInfo visit(MapType mapType) {
 			LogicalType keyType  = mapType.getKeyType();
 			LogicalType valueType = mapType.getValueType();
-			TypeInfo keyTypeInfo = keyType.accept(new TypeInfoLogicalTypeVisitor());
-			TypeInfo valueTypeInfo = valueType.accept(new TypeInfoLogicalTypeVisitor());
+			TypeInfo keyTypeInfo = keyType.accept(new TypeInfoLogicalTypeVisitor(dataType));
+			TypeInfo valueTypeInfo = valueType.accept(new TypeInfoLogicalTypeVisitor(dataType));
 			if (null == keyTypeInfo || null == valueTypeInfo) {
-				return null;
+				return defaultMethod(mapType);
 			} else {
 				return TypeInfoFactory.getMapTypeInfo(keyTypeInfo, valueTypeInfo);
 			}
@@ -356,44 +307,20 @@ public class HiveTypeUtil {
 			List<TypeInfo> typeInfos = new ArrayList<>(names.size());
 			for (String name : names) {
 				TypeInfo typeInfo =
-						rowType.getTypeAt(rowType.getFieldIndex(name)).accept(new TypeInfoLogicalTypeVisitor());
+						rowType.getTypeAt(rowType.getFieldIndex(name)).accept(new TypeInfoLogicalTypeVisitor(dataType));
 				if (null != typeInfo) {
 					typeInfos.add(typeInfo);
 				} else {
-					return null;
+					return defaultMethod(rowType);
 				}
 			}
 			return TypeInfoFactory.getStructTypeInfo(names, typeInfos);
 		}
 
 		@Override
-		public TypeInfo visit(DistinctType distinctType) {
-			return null;
-		}
-
-		@Override
-		public TypeInfo visit(StructuredType structuredType) {
-			return null;
-		}
-
-		@Override
-		public TypeInfo visit(NullType nullType) {
-			return null;
-		}
-
-		@Override
-		public TypeInfo visit(AnyType<?> anyType) {
-			return null;
-		}
-
-		@Override
-		public TypeInfo visit(SymbolType<?> symbolType) {
-			return null;
-		}
-
-		@Override
-		public TypeInfo visit(LogicalType other) {
-			return null;
+		protected TypeInfo defaultMethod(LogicalType logicalType) {
+			throw new UnsupportedOperationException(
+					String.format("Flink doesn't support converting type %s to Hive type yet.", dataType.toString()));
 		}
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -118,7 +118,7 @@ public class HiveTypeUtil {
 				case VARCHAR: {
 					VarCharType varCharType = (VarCharType) dataType.getLogicalType();
 					// Flink's StringType is defined as VARCHAR(Integer.MAX_VALUE)
-					// We don't have more information in LogicalTypeRoot to distringuish StringType and a VARCHAR(Integer.MAX_VALUE) instance
+					// We don't have more information in LogicalTypeRoot to distinguish StringType and a VARCHAR(Integer.MAX_VALUE) instance
 					// Thus always treat VARCHAR(Integer.MAX_VALUE) as StringType
 					if (varCharType.getLength() == Integer.MAX_VALUE) {
 						return TypeInfoFactory.stringTypeInfo;
@@ -138,6 +138,9 @@ public class HiveTypeUtil {
 					return TypeInfoFactory.getDecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale());
 				}
 				case VARBINARY: {
+					// Flink's BytesType is defined as VARBINARY(Integer.MAX_VALUE)
+					// We don't have more information in LogicalTypeRoot to distinguish BytesType and a VARBINARY(Integer.MAX_VALUE) instance
+					// Thus always treat VARBINARY(Integer.MAX_VALUE) as BytesType
 					VarBinaryType varBinaryType = (VarBinaryType) dataType.getLogicalType();
 					if (varBinaryType.getLength() == VarBinaryType.MAX_LENGTH) {
 						return TypeInfoFactory.binaryTypeInfo;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
@@ -136,14 +137,17 @@ public class HiveTypeUtil {
 					// Flink already validates the type so we don't need to validate again here
 					return TypeInfoFactory.getDecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale());
 				}
+				case VARBINARY: {
+					VarBinaryType varBinaryType = (VarBinaryType) dataType.getLogicalType();
+					if (varBinaryType.getLength() == VarBinaryType.MAX_LENGTH) {
+						return TypeInfoFactory.binaryTypeInfo;
+					}
+					break;
+				}
 				// Flink's primitive types that Hive 2.3.4 doesn't support: Time, TIMESTAMP_WITH_LOCAL_TIME_ZONE
 				default:
 					break;
 			}
-		}
-
-		if (dataType.equals(DataTypes.BYTES())) {
-			return TypeInfoFactory.binaryTypeInfo;
 		}
 
 		if (dataType instanceof CollectionDataType) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.BinaryType;
-import org.apache.flink.table.types.logical.VarBinaryType;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -124,8 +122,8 @@ public class HiveCatalogDataTypeTest {
 	@Test
 	public void testNonExactlyMatchedDataTypes() throws Exception {
 		DataType[] types = new DataType[] {
-			DataTypes.BINARY(BinaryType.MAX_LENGTH),
-			DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH)
+			DataTypes.BYTES(),
+			DataTypes.BYTES()
 		};
 
 		CatalogTable table = createCatalogTable(types);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
@@ -28,6 +28,8 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -38,7 +40,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Arrays;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -120,20 +121,18 @@ public class HiveCatalogDataTypeTest {
 	}
 
 	@Test
-	public void testNonExactlyMatchedDataTypes() throws Exception {
+	public void testNonSupportedBinaryDataTypes() throws Exception {
 		DataType[] types = new DataType[] {
-			DataTypes.BYTES(),
-			DataTypes.BYTES()
+				DataTypes.BINARY(BinaryType.MAX_LENGTH),
+				DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH)
 		};
 
 		CatalogTable table = createCatalogTable(types);
 
 		catalog.createDatabase(db1, createDb(), false);
-		catalog.createTable(path1, table, false);
 
-		Arrays.equals(
-			new DataType[] {DataTypes.BYTES(), DataTypes.BYTES()},
-			catalog.getTable(path1).getSchema().getFieldDataTypes());
+		exception.expect(UnsupportedOperationException.class);
+		catalog.createTable(path1, table, false);
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BinaryType;
-import org.apache.flink.table.types.logical.VarBinaryType;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -123,8 +122,21 @@ public class HiveCatalogDataTypeTest {
 	@Test
 	public void testNonSupportedBinaryDataTypes() throws Exception {
 		DataType[] types = new DataType[] {
-				DataTypes.BINARY(BinaryType.MAX_LENGTH),
-				DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH)
+				DataTypes.BINARY(BinaryType.MAX_LENGTH)
+		};
+
+		CatalogTable table = createCatalogTable(types);
+
+		catalog.createDatabase(db1, createDb(), false);
+
+		exception.expect(UnsupportedOperationException.class);
+		catalog.createTable(path1, table, false);
+	}
+
+	@Test
+	public void testNonSupportedVarBinaryDataTypes() throws Exception {
+		DataType[] types = new DataType[] {
+				DataTypes.VARBINARY(20)
 		};
 
 		CatalogTable table = createCatalogTable(types);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -88,7 +88,7 @@ public class HiveCatalogHiveMetadataTest extends CatalogTestBase {
 											.field("fourth", DataTypes.DATE())
 											.field("fifth", DataTypes.DOUBLE())
 											.field("sixth", DataTypes.BIGINT())
-											.field("seventh", DataTypes.VARBINARY(200))
+											.field("seventh", DataTypes.BYTES())
 											.build();
 		CatalogTable catalogTable = new CatalogTableImpl(tableSchema, getBatchTableProperties(), TEST_COMMENT);
 		catalog.createTable(path1, catalogTable, false);


### PR DESCRIPTION
## What is the purpose of the change
Align Hive data type mapping with FLIP-37. 


## Brief change log
  - *Align Hive data type mapping with FLIP-37*
  - *Not support interval type mapping for now. It's not type mapping related only, also related to data converting, maybe we can do it in the future.*


## Verifying this change

This change is already covered by existing tests, such as *HiveCatalogDataTypeTest.java*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
