### PR TITLE
[FLINK-13440] Add test that fails job when in-flight sync savepoint is discarded.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -104,7 +104,7 @@ public class CheckpointFailureManager {
 
 		if (continuousFailureCounter.get() > tolerableCpFailureNumber) {
 			clearCount();
-			failureCallback.failJob();
+			failureCallback.failJob(new FlinkRuntimeException("Exceeded checkpoint tolerable failure threshold."));
 		}
 	}
 
@@ -128,7 +128,7 @@ public class CheckpointFailureManager {
 	 */
 	public interface FailJobCallback {
 
-		void failJob();
+		void failJob(final Throwable cause);
 
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -127,7 +127,7 @@ public class CheckpointFailureManager {
 	/**
 	 * Fails the whole job graph in case an in-progress synchronous savepoint is discarded.
 	 *
-	 * <p>If the checkpoint failure was cancelled at the checkpoint coordinator, i.e. before
+	 * <p>If the checkpoint was cancelled at the checkpoint coordinator, i.e. before
 	 * the synchronous savepoint barrier was sent to the tasks, then we do not cancel the job
 	 * as we do not risk having a deadlock.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -54,7 +54,7 @@ public enum CheckpointFailureReason {
 
 	CHECKPOINT_DECLINED_INPUT_END_OF_STREAM(false, "Checkpoint was declined because one input stream is finished"),
 
-	CHECKPOINT_COORDINATOR_SHUTDOWN(true, "CheckpointCoordinator shutdown."),
+	CHECKPOINT_COORDINATOR_SHUTDOWN(false, "CheckpointCoordinator shutdown."),
 
 	CHECKPOINT_COORDINATOR_SUSPEND(false, "Checkpoint Coordinator is suspending."),
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -23,60 +23,69 @@ package org.apache.flink.runtime.checkpoint;
  */
 public enum CheckpointFailureReason {
 
-	PERIODIC_SCHEDULER_SHUTDOWN("Periodic checkpoint scheduler is shut down."),
+	PERIODIC_SCHEDULER_SHUTDOWN(true, "Periodic checkpoint scheduler is shut down."),
 
-	ALREADY_QUEUED("Another checkpoint request has already been queued."),
+	ALREADY_QUEUED(true, "Another checkpoint request has already been queued."),
 
-	TOO_MANY_CONCURRENT_CHECKPOINTS("The maximum number of concurrent checkpoints is exceeded"),
+	TOO_MANY_CONCURRENT_CHECKPOINTS(true, "The maximum number of concurrent checkpoints is exceeded"),
 
-	MINIMUM_TIME_BETWEEN_CHECKPOINTS("The minimum time between checkpoints is still pending. " +
+	MINIMUM_TIME_BETWEEN_CHECKPOINTS(true, "The minimum time between checkpoints is still pending. " +
 			"Checkpoint will be triggered after the minimum time."),
 
-	NOT_ALL_REQUIRED_TASKS_RUNNING("Not all required tasks are currently running."),
+	NOT_ALL_REQUIRED_TASKS_RUNNING(true, "Not all required tasks are currently running."),
 
-	EXCEPTION("An Exception occurred while triggering the checkpoint."),
+	EXCEPTION(true, "An Exception occurred while triggering the checkpoint."),
 
-	CHECKPOINT_EXPIRED("Checkpoint expired before completing."),
+	CHECKPOINT_EXPIRED(false, "Checkpoint expired before completing."),
 
-	CHECKPOINT_SUBSUMED("Checkpoint has been subsumed."),
+	CHECKPOINT_SUBSUMED(false, "Checkpoint has been subsumed."),
 
-	CHECKPOINT_DECLINED("Checkpoint was declined."),
+	CHECKPOINT_DECLINED(false, "Checkpoint was declined."),
 
-	CHECKPOINT_DECLINED_TASK_NOT_READY("Checkpoint was declined (tasks not ready)"),
+	CHECKPOINT_DECLINED_TASK_NOT_READY(false, "Checkpoint was declined (tasks not ready)"),
 
-	CHECKPOINT_DECLINED_TASK_NOT_CHECKPOINTING("Task does not support checkpointing"),
+	CHECKPOINT_DECLINED_TASK_NOT_CHECKPOINTING(false, "Task does not support checkpointing"),
 
-	CHECKPOINT_DECLINED_SUBSUMED("Checkpoint was canceled because a barrier from newer checkpoint was received."),
+	CHECKPOINT_DECLINED_SUBSUMED(false, "Checkpoint was canceled because a barrier from newer checkpoint was received."),
 
-	CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER("Task received cancellation from one of its inputs"),
+	CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER(false, "Task received cancellation from one of its inputs"),
 
-	CHECKPOINT_DECLINED_ALIGNMENT_LIMIT_EXCEEDED("The checkpoint alignment phase needed to buffer more than the configured maximum bytes"),
+	CHECKPOINT_DECLINED_ALIGNMENT_LIMIT_EXCEEDED(false, "The checkpoint alignment phase needed to buffer more than the configured maximum bytes"),
 
-	CHECKPOINT_DECLINED_INPUT_END_OF_STREAM("Checkpoint was declined because one input stream is finished"),
+	CHECKPOINT_DECLINED_INPUT_END_OF_STREAM(false, "Checkpoint was declined because one input stream is finished"),
 
-	CHECKPOINT_COORDINATOR_SHUTDOWN("CheckpointCoordinator shutdown."),
+	CHECKPOINT_COORDINATOR_SHUTDOWN(true, "CheckpointCoordinator shutdown."),
 
-	CHECKPOINT_COORDINATOR_SUSPEND("Checkpoint Coordinator is suspending."),
+	CHECKPOINT_COORDINATOR_SUSPEND(false, "Checkpoint Coordinator is suspending."),
 
-	JOB_FAILURE("The job has failed."),
+	JOB_FAILURE(false, "The job has failed."),
 
-	JOB_FAILOVER_REGION("FailoverRegion is restarting."),
+	JOB_FAILOVER_REGION(false, "FailoverRegion is restarting."),
 
-	TASK_CHECKPOINT_FAILURE("Task local checkpoint failure."),
+	TASK_CHECKPOINT_FAILURE(false, "Task local checkpoint failure."),
 
-	FINALIZE_CHECKPOINT_FAILURE("Failure to finalize checkpoint."),
+	FINALIZE_CHECKPOINT_FAILURE(false, "Failure to finalize checkpoint."),
 
-	TRIGGER_CHECKPOINT_FAILURE("Trigger checkpoint failure.");
+	TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure.");
 
 	// ------------------------------------------------------------------------
 
+	private final boolean isPreFlight;
 	private final String message;
 
-	CheckpointFailureReason(String message) {
+	CheckpointFailureReason(boolean isPreFlight, String message) {
+		this.isPreFlight = isPreFlight;
 		this.message = message;
 	}
 
 	public String message() {
 		return message;
+	}
+
+	/**
+	 * @return true if this value indicates a failure reason happening before a checkpoint is passed to a job's tasks.
+	 */
+	public boolean isPreFlight() {
+		return isPreFlight;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -70,11 +70,11 @@ public enum CheckpointFailureReason {
 
 	// ------------------------------------------------------------------------
 
-	private final boolean isPreFlight;
+	private final boolean preFlight;
 	private final String message;
 
 	CheckpointFailureReason(boolean isPreFlight, String message) {
-		this.isPreFlight = isPreFlight;
+		this.preFlight = isPreFlight;
 		this.message = message;
 	}
 
@@ -86,6 +86,6 @@ public enum CheckpointFailureReason {
 	 * @return true if this value indicates a failure reason happening before a checkpoint is passed to a job's tasks.
 	 */
 	public boolean isPreFlight() {
-		return isPreFlight;
+		return preFlight;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1229,7 +1229,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		}
 	}
 
-	boolean switchToRunning() {
+	@VisibleForTesting
+	public boolean switchToRunning() {
 
 		if (transitionState(DEPLOYING, RUNNING)) {
 			sendPartitionInfos();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1229,8 +1229,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		}
 	}
 
-	@VisibleForTesting
-	public boolean switchToRunning() {
+	boolean switchToRunning() {
 
 		if (transitionState(DEPLOYING, RUNNING)) {
 			sendPartitionInfos();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -80,7 +80,6 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedThrowable;
@@ -581,10 +580,10 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 		checkpointStatsTracker = checkNotNull(statsTracker, "CheckpointStatsTracker");
 
-		CheckpointFailureManager failureManager = new CheckpointFailureManager(chkConfig.getTolerableCheckpointFailureNumber(), () ->
-			getJobMasterMainThreadExecutor().execute(() ->
-				failGlobal(new FlinkRuntimeException("Exceeded checkpoint tolerable failure threshold."))
-			));
+		CheckpointFailureManager failureManager = new CheckpointFailureManager(
+				chkConfig.getTolerableCheckpointFailureNumber(),
+				cause -> getJobMasterMainThreadExecutor().execute(() -> failGlobal(cause))
+		);
 
 		// create the coordinator that triggers and commits checkpoints and holds the state
 		checkpointCoordinator = new CheckpointCoordinator(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
@@ -75,6 +77,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.function.FunctionUtils;
@@ -618,6 +621,13 @@ public class LegacyScheduler implements SchedulerNG {
 			.handle((completedCheckpoint, throwable) -> {
 				if (throwable != null) {
 					log.info("Failed during stopping job {} with a savepoint. Reason: {}", jobGraph.getJobID(), throwable.getMessage());
+					// it's possible this failure hasn't triggered a task failure, but rather the savepoint was aborted
+					// "softly" (for example on checkpoints barriers alignment, due to buffer limits).
+					// such situation may leave other tasks of the job in a blocking state.
+					// to workaround this, we fail the whole job.
+					if (!isCheckpointPreFlightFailure(throwable)) {
+						executionGraph.failGlobal(throwable);
+					}
 					throw new CompletionException(throwable);
 				}
 				return completedCheckpoint.getExternalPointer();
@@ -648,5 +658,12 @@ public class LegacyScheduler implements SchedulerNG {
 			.map(Execution::getAssignedResourceLocation)
 			.map(TaskManagerLocation::toString)
 			.orElse("Unknown location");
+	}
+
+	private static boolean isCheckpointPreFlightFailure(Throwable throwable) {
+		return ExceptionUtils.findThrowable(throwable, CheckpointException.class)
+			.map(CheckpointException::getCheckpointFailureReason)
+			.map(CheckpointFailureReason::isPreFlight)
+			.orElse(false);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -66,7 +66,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 
 		final long triggerTimestamp = 1L;
 
-		CheckpointFailureManager failureManager = new CheckpointFailureManager(0, () -> {});
+		CheckpointFailureManager failureManager = new CheckpointFailureManager(0, throwable -> {});
 
 		// set up the coordinator and validate the initial state
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -442,7 +442,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY,
-				new CheckpointFailureManager(0, () -> {}));
+				new CheckpointFailureManager(0, throwable -> {}));
 	}
 
 	private static <T> T mockGeneric(Class<?> clazz) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -126,7 +126,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(0, () -> {});
+		failureManager = new CheckpointFailureManager(0, throwable -> {});
 	}
 
 	@Test
@@ -325,7 +325,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		final String errorMsg = "Exceeded checkpoint failure tolerance number!";
 
-		CheckpointFailureManager checkpointFailureManager = new CheckpointFailureManager(0, () -> {
+		CheckpointFailureManager checkpointFailureManager = new CheckpointFailureManager(0, throwable -> {
 			throw new RuntimeException(errorMsg);
 		});
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -105,7 +105,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		private int invokeCounter = 0;
 
 		@Override
-		public void failJob() {
+		public void failJob(final Throwable cause) {
 			invokeCounter++;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -67,7 +67,7 @@ public class CheckpointStateRestoreTest {
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(0, () -> {});
+		failureManager = new CheckpointFailureManager(0, throwable -> {});
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a test for the changes introduced in https://github.com/apache/flink/pull/9131. This PR is a follow-up of https://github.com/apache/flink/pull/9131 and also contains those commits.

## Verifying this change

This change added tests and can be verified by running the `CheckpointCoordinatorTest.jobFailsIfInFlightSynchronousSavepointIsDiscarded()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
