### PR TITLE
[FLINK-13429][table-common] Fix BoundedOutOfOrderTimestamps watermark strategy

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/wmstrategies/BoundedOutOfOrderTimestamps.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/wmstrategies/BoundedOutOfOrderTimestamps.java
@@ -36,13 +36,14 @@ public final class BoundedOutOfOrderTimestamps extends PeriodicWatermarkAssigner
 	private static final long serialVersionUID = 1L;
 
 	private final long delay;
-	private long maxTimestamp = Long.MIN_VALUE + 1;
+	private long maxTimestamp;
 
 	/**
 	 * @param delay The delay by which watermarks are behind the maximum observed timestamp.
 	 */
 	public BoundedOutOfOrderTimestamps(long delay) {
 		this.delay = delay;
+		maxTimestamp = Long.MIN_VALUE + delay;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Fixes a bug that was introduced with FLINK-13315 in de1a8a0444c231df6c57a70cefb689aa7126a502 while porting watermark strategies to Java. This ensures the old behavior and is also in sync with the DataStream API timestamp extractor.

## Brief change log

BoundedOutOfOrderTimestamps updated.

## Verifying this change

This change is already covered by existing tests, such as SQL Client e2e test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
