### PR TITLE
[FLINK-13396] Deprecate the BucketingSink.

### DIFF
--- a/docs/dev/connectors/filesystem_sink.md
+++ b/docs/dev/connectors/filesystem_sink.md
@@ -23,6 +23,10 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<div class="alert alert-info">
+The BucketingSink has been deprecated since Flink 1.9 and will be removed in subsequent releases. Please use the StreamingFileSink instead.
+</div>
+
 This connector provides a Sink that writes partitioned files to any filesystem supported by
 [Hadoop FileSystem](http://hadoop.apache.org). To use this connector, add the
 following dependency to your project:

--- a/docs/dev/connectors/filesystem_sink.md
+++ b/docs/dev/connectors/filesystem_sink.md
@@ -23,8 +23,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<div class="alert alert-info">
-The BucketingSink has been deprecated since Flink 1.9 and will be removed in subsequent releases. Please use the StreamingFileSink instead.
+<div class="alert alert-info" markdown="span">
+The `BucketingSink` has been **deprecated since Flink 1.9** and will be removed in subsequent releases.
+Please use the [__StreamingFileSink__]({{site.baseurl}}/dev/connectors/streamfile_sink.html) instead.
 </div>
 
 This connector provides a Sink that writes partitioned files to any filesystem supported by

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/AvroKeyValueSinkWriter.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/AvroKeyValueSinkWriter.java
@@ -64,6 +64,7 @@ Usage:
 }
 </pre>
 */
+@Deprecated
 public class AvroKeyValueSinkWriter<K, V> extends StreamWriterBase<Tuple2<K, V>> implements Writer<Tuple2<K, V>>, InputTypeConfigurable {
 	private static final long serialVersionUID = 1L;
 	public static final String CONF_OUTPUT_KEY_SCHEMA = "avro.schema.output.key";

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Clock.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Clock.java
@@ -24,6 +24,7 @@ package org.apache.flink.streaming.connectors.fs;
  *
  * <p>Normally this would be system time, but for testing a custom {@code Clock} can be provided.
  */
+@Deprecated
 public interface Clock {
 
 	/**

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SequenceFileWriter.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SequenceFileWriter.java
@@ -44,6 +44,7 @@ import java.io.IOException;
  * @param <K> The type of the first tuple field.
  * @param <V> The type of the second tuple field.
  */
+@Deprecated
 public class SequenceFileWriter<K extends Writable, V extends Writable> extends StreamWriterBase<Tuple2<K, V>> implements InputTypeConfigurable {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StreamWriterBase.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StreamWriterBase.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 /**
  * Base class for {@link Writer Writers} that write to a {@link FSDataOutputStream}.
  */
+@Deprecated
 public abstract class StreamWriterBase<T> implements Writer<T> {
 
 	private static final long serialVersionUID = 2L;

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
@@ -33,6 +33,7 @@ import java.nio.charset.UnsupportedCharsetException;
  *
  * @param <T> The type of the elements that are being written by the sink.
  */
+@Deprecated
 public class StringWriter<T> extends StreamWriterBase<T> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SystemClock.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SystemClock.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.connectors.fs;
 /**
  * A {@link Clock} that uses {@code System.currentTimeMillis()} to determine the system time.
  */
+@Deprecated
 public class SystemClock implements Clock {
 	@Override
 	public long currentTimeMillis() {

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Writer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Writer.java
@@ -33,6 +33,7 @@ import java.io.Serializable;
  *
  * @param <T> The type of the elements that are being written by the sink.
  */
+@Deprecated
 public interface Writer<T> extends Serializable {
 
 	/**

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BasePathBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BasePathBucketer.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path;
  * A {@link Bucketer} that does not perform any
  * bucketing of files. All files are written to the base path.
  */
+@Deprecated
 public class BasePathBucketer<T> implements Bucketer<T> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/Bucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/Bucketer.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
  * path the element should fall in. The {@code Bucketer} can, for example, determine buckets based on
  * system time.
  */
+@Deprecated
 public interface Bucketer<T> extends Serializable {
 	/**
 	 * Returns the {@link Path} of a bucket file.

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -160,6 +160,7 @@ import java.util.UUID;
  *
  * @param <T> Type of the elements emitted by this sink
  */
+@Deprecated
 public class BucketingSink<T>
 		extends RichSinkFunction<T>
 		implements InputTypeConfigurable, CheckpointedFunction, CheckpointListener, ProcessingTimeCallback {

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -159,6 +159,11 @@ import java.util.UUID;
  * @see SequenceFileWriter
  *
  * @param <T> Type of the elements emitted by this sink
+ *
+ * @deprecated Please use the
+ * {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
+ * instead.
+ *
  */
 @Deprecated
 public class BucketingSink<T>

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketer.java
@@ -56,6 +56,7 @@ import java.time.format.DateTimeFormatter;
  * {@code /base/1976-12-31-14/}
  *
  */
+@Deprecated
 public class DateTimeBucketer<T> implements Bucketer<T> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunction.java
@@ -38,7 +38,8 @@ import java.io.IOException;
  *
  * @param <IN> Input type
  *
- * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
+ * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
+ * for writing to files from a streaming program.
  */
 @PublicEvolving
 @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormat.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormat.java
@@ -29,7 +29,8 @@ import java.util.ArrayList;
  * @param <IN>
  *            Input tuple type
  *
- * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
+ * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
+ * for writing to files from a streaming program.
  */
 @PublicEvolving
 @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormatAsCsv.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormatAsCsv.java
@@ -31,7 +31,8 @@ import java.util.ArrayList;
  * @param <IN>
  *            Input tuple type
  *
- * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
+ * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
+ * for writing to files from a streaming program.
  */
 @PublicEvolving
 @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormatAsText.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormatAsText.java
@@ -31,7 +31,8 @@ import java.util.ArrayList;
  * @param <IN>
  *            Input tuple type
  *
- * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
+ * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
+ * for writing to files from a streaming program.
  */
 @PublicEvolving
 @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteSinkFunction.java
@@ -32,7 +32,8 @@ import java.util.ArrayList;
  * @param <IN>
  *            Input tuple type
  *
- * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
+ * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
+ * for writing to files from a streaming program.
  */
 @PublicEvolving
 @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteSinkFunctionByMillis.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteSinkFunctionByMillis.java
@@ -26,7 +26,8 @@ import org.apache.flink.annotation.PublicEvolving;
  * @param <IN>
  *            Input tuple type
  *
- * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
+ * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
+ * for writing to files from a streaming program.
  */
 @PublicEvolving
 @Deprecated


### PR DESCRIPTION
## What is the purpose of the change

It marks the `BucketingSink` as deprecated in favour of the `StreamingFileSink` and updates the documentation accordingly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
