### PR TITLE
[FLINK-13446][table-runtime-blink] Fix assign logic for row count sliding window

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowITCase.scala
@@ -82,7 +82,8 @@ class GroupWindowITCase(mode: StateBackendMode)
     windowedTable.toAppendStream[Row].addSink(sink)
     env.execute()
 
-    val expected = Seq(s"Hello world,2,${6.0/2},12,3,2", s"Hello,2,${4.0/2},3,2,2")
+    val expected = Seq(s"Hello world,1,3.0,8,3,1", s"Hello world,2,3.0,12,3,2", "Hello,1,2.0,2,2,1",
+      "Hello,2,2.0,3,2,2", "Hi,1,1.0,1,1,1")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 
@@ -174,7 +175,7 @@ class GroupWindowITCase(mode: StateBackendMode)
     windowedTable.toAppendStream[Row].addSink(sink)
     env.execute()
 
-    val expected = Seq("12,2", "3,2")
+    val expected = Seq("12,2", "8,1", "2,1", "3,2", "1,1")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/CountWindow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/CountWindow.java
@@ -30,14 +30,18 @@ import java.io.IOException;
 /**
  * A {@link Window} that represents a count window. For each count window, we will assign a unique
  * id. Thus this CountWindow can act as namespace part in state. We can attach data to each
- * different CountWindow.
+ * different CountWindow. Each CountWindow contains a triggerSize which indicates the max row count
+ * in the window.
  */
 public class CountWindow extends Window {
 
 	private final long id;
 
-	public CountWindow(long id) {
+	private final long triggerSize;
+
+	public CountWindow(long id, long triggerSize) {
 		this.id = id;
+		this.triggerSize = triggerSize;
 	}
 
 	/**
@@ -45,6 +49,10 @@ public class CountWindow extends Window {
 	 */
 	public long getId() {
 		return id;
+	}
+
+	public long getTriggerSize() {
+		return triggerSize;
 	}
 
 	@Override
@@ -63,6 +71,7 @@ public class CountWindow extends Window {
 
 		CountWindow window = (CountWindow) o;
 
+		// only compare id, we treat id as the key of a window.
 		return id == window.id;
 	}
 
@@ -73,8 +82,7 @@ public class CountWindow extends Window {
 
 	@Override
 	public String toString() {
-		return "CountWindow{" +
-			"id=" + id + '}';
+		return String.format("CountWindow{id=%s, triggerSize=%s}", id, triggerSize);
 	}
 
 	@Override
@@ -121,11 +129,12 @@ public class CountWindow extends Window {
 		@Override
 		public void serialize(CountWindow record, DataOutputView target) throws IOException {
 			target.writeLong(record.id);
+			target.writeLong(record.triggerSize);
 		}
 
 		@Override
 		public CountWindow deserialize(DataInputView source) throws IOException {
-			return new CountWindow(source.readLong());
+			return new CountWindow(source.readLong(), source.readLong());
 		}
 
 		@Override
@@ -135,6 +144,7 @@ public class CountWindow extends Window {
 
 		@Override
 		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			target.writeLong(source.readLong());
 			target.writeLong(source.readLong());
 		}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/assigners/CountSlidingWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/assigners/CountSlidingWindowAssigner.java
@@ -67,17 +67,19 @@ public class CountSlidingWindowAssigner extends WindowAssigner<CountWindow> {
 		Long countValue = count.value();
 		long currentCount = countValue == null ? 0L : countValue;
 		count.update(currentCount + 1);
-		long lastId = currentCount / windowSlide;
-		long lastStart = lastId * windowSlide;
-		long lastEnd = lastStart + windowSize - 1;
+		long windowId = currentCount / windowSlide;
+		long windowEnd = windowId * windowSlide + windowSlide - 1;
+		long windowStart = windowEnd - windowSize + 1;
 		List<CountWindow> windows = new ArrayList<>();
-		while (lastId >= 0 && lastStart <= currentCount && currentCount <= lastEnd) {
-			if (lastStart <= currentCount && currentCount <= lastEnd) {
-				windows.add(new CountWindow(lastId));
+		while ((windowStart <= currentCount) && (currentCount <= windowEnd)) {
+			if (0 > windowStart) {
+				windows.add(new CountWindow(windowId, windowSize + windowStart));
+			} else {
+				windows.add(new CountWindow(windowId, windowSize));
 			}
-			lastId--;
-			lastStart -= windowSlide;
-			lastEnd -= windowSlide;
+			windowId++;
+			windowStart += windowSlide;
+			windowEnd += windowSlide;
 		}
 		return windows;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/assigners/CountTumblingWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/assigners/CountTumblingWindowAssigner.java
@@ -61,7 +61,7 @@ public class CountTumblingWindowAssigner extends WindowAssigner<CountWindow> {
 		long currentCount = countValue == null ? 0L : countValue;
 		long id = currentCount / size;
 		count.update(currentCount + 1);
-		return Collections.singleton(new CountWindow(id));
+		return Collections.singleton(new CountWindow(id, size));
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
@@ -1045,7 +1045,7 @@ public class WindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(12000));
 		testHarness.setProcessingTime(12000L);
-		expectedOutput.add(record("key2", 15L, 5L, 0L));
+		expectedOutput.add(record("key2", 6L, 3L, 0L));
 		expectedOutput.add(new Watermark(12000));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -1062,14 +1062,15 @@ public class WindowOperatorTest {
 		testHarness.processElement(record("key1", 3, 2500L));
 		testHarness.processElement(record("key1", 4, 2500L));
 		testHarness.processElement(record("key1", 5, 2500L));
-		expectedOutput.add(record("key1", 15L, 5L, 0L));
+		expectedOutput.add(record("key1", 6L, 3L, 0L));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processElement(record("key2", 6, 6000L));
 		testHarness.processElement(record("key2", 7, 6000L));
 		testHarness.processElement(record("key2", 8, 6050L));
 		testHarness.processElement(record("key2", 9, 6050L));
-		expectedOutput.add(record("key2", 30L, 5L, 1L));
+		expectedOutput.add(record("key2", 20L, 5L, 1L));
+		expectedOutput.add(record("key2", 35L, 5L, 2L));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processElement(record("key1", 6, 4000L));
@@ -1077,8 +1078,7 @@ public class WindowOperatorTest {
 		testHarness.processElement(record("key1", 8, 4000L));
 		testHarness.processElement(record("key2", 10, 15000L));
 		testHarness.processElement(record("key2", 11, 15000L));
-		expectedOutput.add(record("key1", 30L, 5L, 1L));
-		expectedOutput.add(record("key2", 45L, 5L, 2L));
+		expectedOutput.add(record("key1", 20L, 5L, 1L));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.close();


### PR DESCRIPTION

## What is the purpose of the change

For blink planner, the Row count sliding window outputs incorrectly. The window assigner assigns less window than what expected. This means the window outputs fewer data. 

This pull request fixes the window assigner and trigger logic, i.e., correct the window start and end calculation. 


## Brief change log

  - Add trigger size property to `CountWindow`, because in some cases, the count window fires with a trigger size less than the window size.
  - Correct the window start and end calculation in `CountSlidingWindowAssigner`. 
  - Correct existing test cases.


## Verifying this change

This change is already covered by existing tests, such as GroupWindowITCase and WindowOperatorTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
