### PR TITLE
[FLINK-13451][tests] Remove use of Unsafe.defineClass() from CommonTestUtils

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerClassLoadingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerClassLoadingTest.java
@@ -23,13 +23,10 @@ import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.core.testutils.CommonTestUtils;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.Serializable;
-import java.net.URL;
-import java.net.URLClassLoader;
 
 import static org.junit.Assert.fail;
 
@@ -39,13 +36,9 @@ import static org.junit.Assert.fail;
  */
 public class KryoSerializerClassLoadingTest extends SerializerTestBase<Object> {
 
-	/** Class loader for the object that is not in the test class path */
-	private static final ClassLoader CLASS_LOADER =
-			new URLClassLoader(new URL[0], KryoSerializerClassLoadingTest.class.getClassLoader());
-
-	/** An object that is not in the test class path */
-	private static final Serializable OBJECT_OUT_OF_CLASSPATH =
-			CommonTestUtils.createObjectForClassNotInClassPath(CLASS_LOADER);
+	/** Class loader and object that is not in the test class path. */
+	private static final CommonTestUtils.ObjectAndClassLoader OUTSIDE_CLASS_LOADING =
+			CommonTestUtils.createObjectFromNewClassLoader();
 
 	// ------------------------------------------------------------------------
 
@@ -54,7 +47,7 @@ public class KryoSerializerClassLoadingTest extends SerializerTestBase<Object> {
 	@Before
 	public void setupClassLoader() {
 		originalClassLoader = Thread.currentThread().getContextClassLoader();
-		Thread.currentThread().setContextClassLoader(CLASS_LOADER);
+		Thread.currentThread().setContextClassLoader(OUTSIDE_CLASS_LOADING.getClassLoader());
 	}
 
 	@After
@@ -67,7 +60,7 @@ public class KryoSerializerClassLoadingTest extends SerializerTestBase<Object> {
 	@Test
 	public void guardTestAssumptions() {
 		try {
-			Class.forName(OBJECT_OUT_OF_CLASSPATH.getClass().getName());
+			Class.forName(OUTSIDE_CLASS_LOADING.getObject().getClass().getName());
 			fail("This test's assumptions are broken");
 		}
 		catch (ClassNotFoundException ignored) {
@@ -98,11 +91,11 @@ public class KryoSerializerClassLoadingTest extends SerializerTestBase<Object> {
 				new Integer(7),
 
 				// an object whose class is not on the classpath
-				OBJECT_OUT_OF_CLASSPATH,
+				OUTSIDE_CLASS_LOADING.getObject(),
 
 				// an object whose class IS on the classpath with a nested object whose class
 				// is NOT on the classpath
-				new Tuple1<>(OBJECT_OUT_OF_CLASSPATH)
+				new Tuple1<>(OUTSIDE_CLASS_LOADING.getObject())
 		};
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -57,8 +57,6 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -75,8 +73,9 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
 
 	@Test
 	public void testDeserializationOfUserCodeWithUserClassLoader() throws Exception {
-		final ClassLoader classLoader = new URLClassLoader(new URL[0], getClass().getClassLoader());
-		final Serializable outOfClassPath = CommonTestUtils.createObjectForClassNotInClassPath(classLoader);
+		final CommonTestUtils.ObjectAndClassLoader outsideClassLoading = CommonTestUtils.createObjectFromNewClassLoader();
+		final ClassLoader classLoader = outsideClassLoading.getClassLoader();
+		final Serializable outOfClassPath = outsideClassLoading.getObject();
 
 		final MasterTriggerRestoreHook.Factory[] hooks = {
 				new TestFactory(outOfClassPath) };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ErrorInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ErrorInfoTest.java
@@ -23,8 +23,6 @@ import org.apache.flink.core.testutils.CommonTestUtils;
 import org.junit.Test;
 
 import java.io.Serializable;
-import java.net.URL;
-import java.net.URLClassLoader;
 
 import static org.junit.Assert.assertEquals;
 
@@ -50,10 +48,8 @@ public class ErrorInfoTest {
 
 		private static final long serialVersionUID = 42L;
 
-		private static final ClassLoader CUSTOM_LOADER = new URLClassLoader(new URL[0]);
-
 		@SuppressWarnings("unused")
-		private final Serializable outOfClassLoader = CommonTestUtils.createObjectForClassNotInClassPath(CUSTOM_LOADER);
+		private final Serializable outOfClassLoader = CommonTestUtils.createObjectFromNewClassLoader().getObject();
 
 		public ExceptionWithCustomClassLoader() {
 			super("tada");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerTest.java
@@ -29,8 +29,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.Serializable;
-import java.net.URL;
-import java.net.URLClassLoader;
 
 import static org.junit.Assert.*;
 
@@ -39,13 +37,9 @@ import static org.junit.Assert.*;
  */
 public class JavaSerializerTest extends SerializerTestBase<Serializable> {
 
-	/** Class loader for the object that is not in the test class path */
-	private static final ClassLoader CLASS_LOADER = 
-			new URLClassLoader(new URL[0], JavaSerializerTest.class.getClassLoader());
-
-	/** An object that is not in the test class path */
-	private static final Serializable OBJECT_OUT_OF_CLASSPATH = 
-			CommonTestUtils.createObjectForClassNotInClassPath(CLASS_LOADER);
+	/** Class loader and object that is not in the test class path. */
+	private static final CommonTestUtils.ObjectAndClassLoader OUTSIDE_CLASS_LOADING =
+		CommonTestUtils.createObjectFromNewClassLoader();
 
 	// ------------------------------------------------------------------------
 
@@ -54,7 +48,7 @@ public class JavaSerializerTest extends SerializerTestBase<Serializable> {
 	@Before
 	public void setupClassLoader() {
 		originalClassLoader = Thread.currentThread().getContextClassLoader();
-		Thread.currentThread().setContextClassLoader(CLASS_LOADER);
+		Thread.currentThread().setContextClassLoader(OUTSIDE_CLASS_LOADING.getClassLoader());
 	}
 
 	@After
@@ -68,7 +62,7 @@ public class JavaSerializerTest extends SerializerTestBase<Serializable> {
 	public void guardTest() {
 		// make sure that this test's assumptions hold
 		try {
-			Class.forName(OBJECT_OUT_OF_CLASSPATH.getClass().getName());
+			Class.forName(OUTSIDE_CLASS_LOADING.getObject().getClass().getName());
 			fail("Test ineffective: The test class that should not be on the classpath is actually on the classpath.");
 		} catch (ClassNotFoundException e) {
 			// expected
@@ -79,7 +73,7 @@ public class JavaSerializerTest extends SerializerTestBase<Serializable> {
 
 	@Override
 	protected TypeSerializer<Serializable> createSerializer() {
-		Thread.currentThread().setContextClassLoader(CLASS_LOADER);
+		Thread.currentThread().setContextClassLoader(OUTSIDE_CLASS_LOADING.getClassLoader());
 		return new JavaSerializer<>();
 	}
 
@@ -100,10 +94,10 @@ public class JavaSerializerTest extends SerializerTestBase<Serializable> {
 				new File("/some/path/that/I/made/up"),
 
 				// an object that is not in the classpath
-				OBJECT_OUT_OF_CLASSPATH,
+				OUTSIDE_CLASS_LOADING.getObject(),
 
 				// an object that is in the classpath with a nested object not in the classpath
-				new Tuple1<>(OBJECT_OUT_OF_CLASSPATH)
+				new Tuple1<>(OUTSIDE_CLASS_LOADING.getObject())
 		};
 	}
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/CommonTestUtilsTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/CommonTestUtilsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.testutils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link CommonTestUtils}.
+ */
+public class CommonTestUtilsTest {
+
+	@Test
+	public void testObjectFromNewClassLoaderObject() throws Exception {
+		final CommonTestUtils.ObjectAndClassLoader objectAndClassLoader = CommonTestUtils.createObjectFromNewClassLoader();
+		final Object o = objectAndClassLoader.getObject();
+
+		assertNotEquals(ClassLoader.getSystemClassLoader(), o.getClass().getClassLoader());
+
+		try {
+			Class.forName(o.getClass().getName());
+			fail("should not be able to load class from the system class loader");
+		}
+		catch (ClassNotFoundException ignored) {}
+	}
+
+	@Test
+	public void testObjectFromNewClassLoaderClassLoaders() throws Exception {
+		final CommonTestUtils.ObjectAndClassLoader objectAndClassLoader = CommonTestUtils.createObjectFromNewClassLoader();
+
+		assertNotEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader());
+		assertEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader().getParent());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The method `Unsafe.defineClass()` is removed in Java 11. To support Java 11, we rework the method
`CommonTestUtils.createClassNotInClassPath()` to use a different mechanism.

This commit now writes the class byte code out to a temporary file and create a new URLClassLoader that loads the class from that file. 

The solution is not a complete drop-in replacement, because it cannot add the class to an existing class loader, but can only create a new pair of (classloader & new-class-in-that-classloader).
Because of that, the commit also adjusts the existing tests to work with that new mechanism.

## Brief change log

  - Change `CommonTestUtils`:  `createObjectForClassNotInClassPath()` ==> `createObjectFromNewClassLoader()`
  - Adjust existing tests

## Verifying this change

There are two unit tests that validate the method of the new test utility.
Aside from that, this change is a refactoring of existing tests and thus needs no additional tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
