### PR TITLE
[Flink-12164][tests] Harden JobMasterTest.testJobFailureWhenTaskExecutorHeartbeatTimeout

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
@@ -18,12 +18,140 @@
 
 package org.apache.flink.runtime.heartbeat;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * A {@link HeartbeatServices} implementation for testing purposes.
  */
 public class TestingHeartbeatServices extends HeartbeatServices {
 
+	private final long heartbeatInterval;
+
+	private final long heartbeatTimeout;
+
+	private final ConcurrentHashMap<ResourceID, TestHeartbeatManager> heartbeatManagers = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<ResourceID, TestHeartbeatManager> heartbeatManagerSenders = new ConcurrentHashMap<>();
+
 	public TestingHeartbeatServices() {
-		super(1000L, 10000L);
+		this(Long.MAX_VALUE, Long.MAX_VALUE);
+	}
+
+	public TestingHeartbeatServices(long heartbeatInterval, long heartbeatTimeout) {
+		super(heartbeatInterval, heartbeatTimeout);
+
+		this.heartbeatInterval = heartbeatInterval;
+		this.heartbeatTimeout = heartbeatTimeout;
+	}
+
+	@Override
+	public <I, O> HeartbeatManager<I, O> createHeartbeatManager(
+		ResourceID resourceId,
+		HeartbeatListener<I, O> heartbeatListener,
+		ScheduledExecutor mainThreadExecutor,
+		Logger log) {
+
+		TestHeartbeatManager<I, O> heartbeatManager = new TestHeartbeatManager<>(
+			heartbeatInterval,
+			resourceId,
+			heartbeatListener,
+			mainThreadExecutor,
+			log);
+
+		heartbeatManagers.put(resourceId, heartbeatManager);
+		return heartbeatManager;
+	}
+
+	@Override
+	public <I, O> HeartbeatManager<I, O> createHeartbeatManagerSender(
+		ResourceID resourceId,
+		HeartbeatListener<I, O> heartbeatListener,
+		ScheduledExecutor mainThreadExecutor,
+		Logger log) {
+
+		TestHeartbeatManager<I, O> heartbeatManager = new TestHeartbeatManager<>(
+			heartbeatInterval,
+			resourceId,
+			heartbeatListener,
+			mainThreadExecutor,
+			log);
+
+		heartbeatManagerSenders.put(resourceId, heartbeatManager);
+		return heartbeatManager;
+	}
+
+	public void triggerHeartbeatTimeout(ResourceID managerResourceId, ResourceID targetResourceId) {
+		heartbeatManagers.get(managerResourceId).triggerHeartbeatTimeout(targetResourceId);
+	}
+
+	public void triggerHeartbeatSenderTimeout(ResourceID managerResourceId, ResourceID targetResourceId) {
+		heartbeatManagerSenders.get(managerResourceId).triggerHeartbeatTimeout(targetResourceId);
+	}
+
+	private static class TestHeartbeatManager<I, O> implements HeartbeatManager<I, O> {
+
+		private final long heartbeatTimeoutIntervalMs;
+		private final ResourceID ownResourceID;
+		private final HeartbeatListener<I, O> heartbeatListener;
+		private final ScheduledExecutor mainThreadExecutor;
+		private final ConcurrentHashMap<ResourceID, HeartbeatTarget<O>> monitoringTargets = new ConcurrentHashMap<>();
+		private volatile boolean stopped;
+
+		public TestHeartbeatManager(
+			long heartbeatTimeoutIntervalMs,
+			ResourceID ownResourceID,
+			HeartbeatListener<I, O> heartbeatListener,
+			ScheduledExecutor mainThreadExecutor,
+			Logger log) {
+
+			this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
+			this.ownResourceID = ownResourceID;
+			this.heartbeatListener = heartbeatListener;
+			this.mainThreadExecutor = mainThreadExecutor;
+		}
+
+		@Override
+		public void monitorTarget(ResourceID resourceID, HeartbeatTarget<O> heartbeatTarget) {
+			if (!stopped) {
+				monitoringTargets.put(resourceID, heartbeatTarget);
+			}
+		}
+
+		@Override
+		public void unmonitorTarget(ResourceID resourceID) {
+			if (!stopped) {
+				monitoringTargets.remove(resourceID);
+			}
+		}
+
+		@Override
+		public void stop() {
+			stopped = true;
+			monitoringTargets.clear();
+		}
+
+		@Override
+		public long getLastHeartbeatFrom(ResourceID resourceId) {
+			return 0;
+		}
+
+		@Override
+		public void receiveHeartbeat(ResourceID heartbeatOrigin, I heartbeatPayload) {
+
+		}
+
+		@Override
+		public void requestHeartbeat(ResourceID requestOrigin, I heartbeatPayload) {
+
+		}
+
+		public void triggerHeartbeatTimeout(ResourceID targetResourceId) {
+			mainThreadExecutor.execute(() -> heartbeatListener.notifyHeartbeatTimeout(targetResourceId));
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1779,7 +1779,7 @@ public class JobMasterTest extends TestLogger {
 	}
 
 	/**
-	 * Tests the updateGlobalAggregate functionality
+	 * Tests the updateGlobalAggregate functionality.
 	 */
 	@Test
 	public void testJobMasterAggregatesValuesCorrectly() throws Exception {
@@ -1837,9 +1837,7 @@ public class JobMasterTest extends TestLogger {
 
 			@Override
 			public Integer add(Integer value, Integer accumulator) {
-				Integer _acc = (Integer) accumulator;
-				Integer _value = (Integer) value;
-				return _acc + _value;
+				return accumulator + value;
 			}
 
 			@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -62,6 +62,7 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategyLoader;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.SimpleSlotContext;
@@ -220,6 +221,8 @@ public class JobMasterTest extends TestLogger {
 
 	private static HeartbeatServices heartbeatServices;
 
+	private static TestingHeartbeatServices testingHeartbeatService;
+
 	private Configuration configuration;
 
 	private ResourceID jmResourceId;
@@ -238,6 +241,7 @@ public class JobMasterTest extends TestLogger {
 
 		fastHeartbeatServices = new HeartbeatServices(fastHeartbeatInterval, fastHeartbeatTimeout);
 		heartbeatServices = new HeartbeatServices(heartbeatInterval, heartbeatTimeout);
+		testingHeartbeatService = new TestingHeartbeatServices();
 	}
 
 	@Before
@@ -1969,14 +1973,11 @@ public class JobMasterTest extends TestLogger {
 
 	@Test
 	public void testJobFailureWhenTaskExecutorHeartbeatTimeout() throws Exception {
-		final AtomicBoolean respondToHeartbeats = new AtomicBoolean(true);
 		runJobFailureWhenTaskExecutorTerminatesTest(
-			fastHeartbeatServices,
-			(localTaskManagerLocation, jobMasterGateway) -> respondToHeartbeats.set(false),
+			testingHeartbeatService,
+			(localTaskManagerLocation, jobMasterGateway) -> testingHeartbeatService.triggerHeartbeatSenderTimeout(jmResourceId, localTaskManagerLocation.getResourceID()),
 			(jobMasterGateway, taskManagerResourceId) -> (resourceId, ignored) -> {
-				if (respondToHeartbeats.get()) {
-					jobMasterGateway.heartbeatFromTaskManager(taskManagerResourceId, new AccumulatorReport(Collections.emptyList()));
-				}
+				jobMasterGateway.heartbeatFromTaskManager(taskManagerResourceId, new AccumulatorReport(Collections.emptyList()));
 			}
 		);
 	}


### PR DESCRIPTION
## What is the purpose of the change

* Harden unstable case, `JobMasterTest`.`testJobFailureWhenTaskExecutorHeartbeatTimeout`

## Brief change log

* Enrich `TestingHeartbeatServices`, support manually trigger timeout for testing 
* Make `JobMasterTest`.`testJobFailureWhenTaskExecutorHeartbeatTimeout` not relying on timeout anymore
* Correct invalid format of `JobMasterTest`

## Verifying this change

* This change is already covered by existing tests, such as `JobMasterTest`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
