### PR TITLE
[FLINK-13034] Introduce isEmpty method for MapState

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -115,6 +115,7 @@ added using `add(T)` are folded into an aggregate using a specified `FoldFunctio
 retrieve an `Iterable` over all currently stored mappings. Mappings are added using `put(UK, UV)` or
 `putAll(Map<UK, UV>)`. The value associated with a user key can be retrieved using `get(UK)`. The iterable
 views for mappings, keys and values can be retrieved using `entries()`, `keys()` and `values()` respectively.
+You can also use `isEmpty()` to check whether this map contains any key-value mappings.
 
 All types of state also have a method `clear()` that clears the state for the currently
 active key, i.e. the key of the input element.

--- a/docs/dev/stream/state/state.zh.md
+++ b/docs/dev/stream/state/state.zh.md
@@ -87,7 +87,7 @@ managed keyed state 接口提供不同类型状态的访问接口，这些状态
 接口与 `ListState` 类似，但使用`add（T）`添加的元素会用指定的 `FoldFunction` 折叠成聚合值。
 
 * `MapState<UK, UV>`: 维护了一个映射列表。 你可以添加键值对到状态中，也可以获得反映当前所有映射的迭代器。使用 `put(UK，UV)` 或者 `putAll(Map<UK，UV>)` 添加映射。
- 使用 `get(UK)` 检索特定 key。 使用 `entries()`，`keys()` 和 `values()` 分别检索映射、键和值的可迭代视图。
+ 使用 `get(UK)` 检索特定 key。 使用 `entries()`，`keys()` 和 `values()` 分别检索映射、键和值的可迭代视图。你还可以通过 `isEmpty()` 来判断是否包含任何键值对。
 
 所有类型的状态还有一个`clear()` 方法，清除当前 key 下的状态数据，也就是当前输入元素的 key。
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/MapState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/MapState.java
@@ -124,4 +124,13 @@ public interface MapState<UK, UV> extends State {
 	 * @throws Exception Thrown if the system cannot access the state.
 	 */
 	Iterator<Map.Entry<UK, UV>> iterator() throws Exception;
+
+	/**
+	 * Returns true if this state contains no key-value mappings, otherwise false.
+	 *
+	 * @return True if this state contains no key-value mappings, otherwise false.
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	boolean isEmpty() throws Exception;
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -535,7 +535,7 @@ public class CepOperator<IN, KEY, OUT>
 	@VisibleForTesting
 	boolean hasNonEmptyPQ(KEY key) throws Exception {
 		setCurrentKey(key);
-		return elementQueueState.keys().iterator().hasNext();
+		return !elementQueueState.isEmpty();
 	}
 
 	@VisibleForTesting

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
@@ -220,6 +220,15 @@ public class TestSharedBuffer<V> extends SharedBuffer<V> {
 				}
 
 				@Override
+				public boolean isEmpty() throws Exception {
+					if (values == null) {
+						return false;
+					}
+
+					return values.isEmpty();
+				}
+
+				@Override
 				public void clear() {
 					stateWrites++;
 					this.values = null;

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
@@ -222,7 +222,7 @@ public class TestSharedBuffer<V> extends SharedBuffer<V> {
 				@Override
 				public boolean isEmpty() throws Exception {
 					if (values == null) {
-						return false;
+						return true;
 					}
 
 					return values.isEmpty();

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableMapState.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableMapState.java
@@ -114,6 +114,11 @@ public final class ImmutableMapState<K, V> extends ImmutableState implements Map
 	}
 
 	@Override
+	public boolean isEmpty() {
+		return state.isEmpty();
+	}
+
+	@Override
 	public void clear() {
 		throw MODIFICATION_ATTEMPT_ERROR;
 	}

--- a/flink-queryable-state/flink-queryable-state-client-java/src/test/java/org/apache/flink/queryablestate/client/state/ImmutableMapStateTest.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/test/java/org/apache/flink/queryablestate/client/state/ImmutableMapStateTest.java
@@ -68,7 +68,6 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testPut() throws Exception {
-		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -82,7 +81,6 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testPutAll() throws Exception {
-		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -100,7 +98,6 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testUpdate() throws Exception {
-		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -114,7 +111,6 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testIterator() throws Exception {
-		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -131,7 +127,6 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testIterable() throws Exception {
-		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -150,7 +145,6 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testKeys() throws Exception {
-		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -167,7 +161,6 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testValues() throws Exception {
-		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -184,7 +177,6 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testClear() throws Exception {
-		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -194,5 +186,10 @@ public class ImmutableMapStateTest {
 		assertEquals(5L, value);
 
 		mapState.clear();
+	}
+
+	@Test
+	public void testIsEmpty() throws Exception {
+		assertFalse(mapState.isEmpty());
 	}
 }

--- a/flink-queryable-state/flink-queryable-state-client-java/src/test/java/org/apache/flink/queryablestate/client/state/ImmutableMapStateTest.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/test/java/org/apache/flink/queryablestate/client/state/ImmutableMapStateTest.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -67,6 +68,7 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testPut() throws Exception {
+		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -80,6 +82,7 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testPutAll() throws Exception {
+		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -97,6 +100,7 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testUpdate() throws Exception {
+		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -110,6 +114,7 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testIterator() throws Exception {
+		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -126,6 +131,7 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testIterable() throws Exception {
+		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -144,6 +150,7 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testKeys() throws Exception {
+		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -160,6 +167,7 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testValues() throws Exception {
+		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);
@@ -176,6 +184,7 @@ public class ImmutableMapStateTest {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testClear() throws Exception {
+		assertFalse(mapState.isEmpty());
 		assertTrue(mapState.contains(1L));
 		long value = mapState.get(1L);
 		assertEquals(5L, value);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingMapState.java
@@ -95,4 +95,9 @@ class UserFacingMapState<K, V> implements MapState<K, V> {
 		Iterator<Map.Entry<K, V>> original = originalState.iterator();
 		return original != null ? original : emptyState.entrySet().iterator();
 	}
+
+	@Override
+	public boolean isEmpty() throws Exception {
+		return originalState.isEmpty();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -162,6 +162,12 @@ class HeapMapState<K, N, UK, UV>
 	}
 
 	@Override
+	public boolean isEmpty() {
+		Map<UK, UV> userMap = stateTable.get(currentNamespace);
+		return userMap == null || userMap.isEmpty();
+	}
+
+	@Override
 	public byte[] getSerializedValue(
 			final byte[] serializedKeyAndNamespace,
 			final TypeSerializer<K> safeKeySerializer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
@@ -121,6 +121,12 @@ class TtlMapState<K, N, UK, UV>
 		return entries().iterator();
 	}
 
+	@Override
+	public boolean isEmpty() throws Exception {
+		accessCallback.run();
+		return original.isEmpty();
+	}
+
 	@Nullable
 	@Override
 	public Map<UK, TtlValue<UV>> getUnexpiredOrNull(@Nonnull Map<UK, TtlValue<UV>> ttlValue) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -2511,10 +2511,12 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 		// some modifications to the state
 		backend.setCurrentKey("1");
+		assertTrue(state.isEmpty());
 		assertNull(state.get(1));
 		assertNull(getSerializedMap(kvState, "1", keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, userKeySerializer, userValueSerializer));
 		state.put(1, "1");
 		backend.setCurrentKey("2");
+		assertTrue(state.isEmpty());
 		assertNull(state.get(2));
 		assertNull(getSerializedMap(kvState, "2", keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, userKeySerializer, userValueSerializer));
 		state.put(2, "2");
@@ -2524,6 +2526,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		state.put(11, "11");
 
 		backend.setCurrentKey("1");
+		assertFalse(state.isEmpty());
 		assertTrue(state.contains(1));
 		assertEquals("1", state.get(1));
 		assertEquals(new HashMap<Integer, String>() {{ put (1, "1"); }},
@@ -2561,6 +2564,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		assertEquals(new HashMap<Integer, String>() {{ put(2, "2"); put(102, "102"); }},
 				getSerializedMap(kvState, "2", keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, userKeySerializer, userValueSerializer));
 		backend.setCurrentKey("3");
+		assertFalse(state.isEmpty());
 		assertTrue(state.contains(103));
 		assertEquals("103", state.get(103));
 		assertEquals(new HashMap<Integer, String>() {{ put(103, "103"); put(1031, "1031"); put(1032, "1032"); }},
@@ -2603,9 +2607,12 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 		// validate the state
 		backend.setCurrentKey("1");
+		assertTrue(state.isEmpty());
 		backend.setCurrentKey("2");
+		assertFalse(state.isEmpty());
 		assertFalse(state.contains(102));
 		backend.setCurrentKey("3");
+		assertFalse(state.isEmpty());
 		for (Map.Entry<Integer, String> entry : state.entries()) {
 			assertEquals(4 + updateSuffix.length(), entry.getValue().length());
 			assertTrue(entry.getValue().endsWith(updateSuffix));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMapState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMapState.java
@@ -86,6 +86,11 @@ public class MockInternalMapState<K, N, UK, UV>
 		return entries().iterator();
 	}
 
+	@Override
+	public boolean isEmpty() {
+		return getInternal().isEmpty();
+	}
+
 	@SuppressWarnings({"unchecked", "unused"})
 	static <N, T, S extends State, IS extends S> IS createState(
 		TypeSerializer<N> namespaceSerializer,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -240,6 +240,18 @@ class RocksDBMapState<K, N, UK, UV>
 	}
 
 	@Override
+	public boolean isEmpty() {
+		final byte[] prefixBytes = serializeCurrentKeyWithGroupAndNamespace();
+
+		try (RocksIteratorWrapper iterator = RocksDBOperationUtils.getRocksIterator(backend.db, columnFamily)) {
+
+			iterator.seek(prefixBytes);
+
+			return !iterator.isValid() || !startWithKeyPrefix(prefixBytes, iterator.key());
+		}
+	}
+
+	@Override
 	public void clear() {
 		try {
 			try (RocksIteratorWrapper iterator = RocksDBOperationUtils.getRocksIterator(backend.db, columnFamily);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/dataview/MapView.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/dataview/MapView.java
@@ -204,6 +204,17 @@ public class MapView<K, V> implements DataView {
 	}
 
 	/**
+	 * Returns true if the map view contains no key-value mappings, otherwise false.
+	 *
+	 * @return True if the map view contains no key-value mappings, otherwise false.
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	public boolean isEmpty() throws Exception {
+		return map.isEmpty();
+	}
+
+	/**
 	 * Removes all entries of this map.
 	 */
 	@Override

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/dataview/StateMapView.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/dataview/StateMapView.scala
@@ -50,5 +50,7 @@ class StateMapView[K, V](state: MapState[K, V]) extends MapView[K, V] {
 
   override def iterator: util.Iterator[util.Map.Entry[K, V]] = state.iterator()
 
+  override def isEmpty(): Boolean = state.isEmpty
+
   override def clear(): Unit = state.clear()
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/join/TemporalRowtimeJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/join/TemporalRowtimeJoin.scala
@@ -169,7 +169,7 @@ class TemporalRowtimeJoin(
 
     // if we have more state at any side, then update the timer, else clean it up.
     if (stateCleaningEnabled) {
-      if (lastUnprocessedTime < Long.MaxValue || rightState.iterator().hasNext) {
+      if (lastUnprocessedTime < Long.MaxValue || !rightState.isEmpty) {
         registerProcessingCleanUpTimer()
       } else {
         cleanUpLastTimer()

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/dataview/StateMapView.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/dataview/StateMapView.java
@@ -108,6 +108,11 @@ public abstract class StateMapView<N, MK, MV> extends MapView<MK, MV> implements
 		}
 
 		@Override
+		public boolean isEmpty() throws Exception {
+			return getMapState().isEmpty();
+		}
+
+		@Override
 		public void clear() {
 			getMapState().clear();
 		}
@@ -189,6 +194,11 @@ public abstract class StateMapView<N, MK, MV> extends MapView<MK, MV> implements
 		@Override
 		public Iterator<Map.Entry<MK, MV>> iterator() throws Exception {
 			return new NullAwareMapIterator<>(getMapState().iterator(), new NullMapEntryImpl());
+		}
+
+		@Override
+		public boolean isEmpty() throws Exception {
+			return getMapState().isEmpty() && getNullState().value() == null;
 		}
 
 		@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
@@ -189,7 +189,7 @@ public class TemporalRowTimeJoinOperator
 
 		// if we have more state at any side, then update the timer, else clean it up.
 		if (stateCleaningEnabled) {
-			if (lastUnprocessedTime < Long.MAX_VALUE || rightState.iterator().hasNext()) {
+			if (lastUnprocessedTime < Long.MAX_VALUE || !rightState.isEmpty()) {
 				registerProcessingCleanupTimer();
 			} else {
 				cleanupLastTimer();

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
@@ -157,8 +157,7 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 			if (stateCleaningEnabled) {
 
 				// we check whether there are still records which have not been processed yet
-				boolean noRecordsToProcess = !inputState.keys().iterator().hasNext();
-				if (noRecordsToProcess) {
+				if (inputState.isEmpty()) {
 					// we clean the state
 					cleanupState(inputState, accState);
 					function.cleanup();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/MergingWindowSetTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/MergingWindowSetTest.java
@@ -418,6 +418,11 @@ public class MergingWindowSetTest {
 		}
 
 		@Override
+		public boolean isEmpty() throws Exception {
+			return map.isEmpty();
+		}
+
+		@Override
 		public void clear() {
 			map.clear();
 		}
@@ -586,6 +591,11 @@ public class MergingWindowSetTest {
 		@Override
 		public Iterator<Map.Entry<UK, UV>> iterator() throws Exception {
 			return internalMap.entrySet().iterator();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return internalMap.isEmpty();
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

Introduce `#isEmpty()` method for `MapState`, this aims to improve the performance when we use `MapState.iterator().hasNext()` to judge whether the map is empty for RocksDB.


## Brief change log

  - Introduce `#isEmpty()` method for `MapState`.
  - Introduce `#isEmpty()` method for `MapView`.
  - Replace previous usage of `MapState.iterator().hasNext()` to `MapState.isEmpty()`.


## Verifying this change

This change added tests and can be verified as follows:

  - Add test for `StateBackendTestBase#testMapState()`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes, improve**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ** no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **JavaDocs**
