### PR TITLE
[FLINK-13460][tests] Rework SerializedThrowableTest to not use Unsafe#defineClass()

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerClassLoadingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerClassLoadingTest.java
@@ -28,6 +28,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.Serializable;
+
 import static org.junit.Assert.fail;
 
 /**
@@ -37,8 +39,8 @@ import static org.junit.Assert.fail;
 public class KryoSerializerClassLoadingTest extends SerializerTestBase<Object> {
 
 	/** Class loader and object that is not in the test class path. */
-	private static final CommonTestUtils.ObjectAndClassLoader OUTSIDE_CLASS_LOADING =
-			CommonTestUtils.createObjectFromNewClassLoader();
+	private static final CommonTestUtils.ObjectAndClassLoader<Serializable> OUTSIDE_CLASS_LOADING =
+			CommonTestUtils.createSerializableObjectFromNewClassLoader();
 
 	// ------------------------------------------------------------------------
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSnapshotTest.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isCompatibleAsIs;
 import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isCompatibleWithReconfiguredSerializer;
@@ -127,7 +128,7 @@ public class KryoSerializerSnapshotTest {
 	private static byte[] unLoadableSnapshotBytes() throws IOException {
 		final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
 
-		final CommonTestUtils.ObjectAndClassLoader outsideClassLoading = CommonTestUtils.createObjectFromNewClassLoader();
+		final CommonTestUtils.ObjectAndClassLoader<Serializable> outsideClassLoading = CommonTestUtils.createSerializableObjectFromNewClassLoader();
 
 		try {
 			Thread.currentThread().setContextClassLoader(outsideClassLoading.getClassLoader());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -73,7 +73,7 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
 
 	@Test
 	public void testDeserializationOfUserCodeWithUserClassLoader() throws Exception {
-		final CommonTestUtils.ObjectAndClassLoader outsideClassLoading = CommonTestUtils.createObjectFromNewClassLoader();
+		final CommonTestUtils.ObjectAndClassLoader<Serializable> outsideClassLoading = CommonTestUtils.createSerializableObjectFromNewClassLoader();
 		final ClassLoader classLoader = outsideClassLoading.getClassLoader();
 		final Serializable outOfClassPath = outsideClassLoading.getObject();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ErrorInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ErrorInfoTest.java
@@ -49,7 +49,7 @@ public class ErrorInfoTest {
 		private static final long serialVersionUID = 42L;
 
 		@SuppressWarnings("unused")
-		private final Serializable outOfClassLoader = CommonTestUtils.createObjectFromNewClassLoader().getObject();
+		private final Serializable outOfClassLoader = CommonTestUtils.createSerializableObjectFromNewClassLoader().getObject();
 
 		public ExceptionWithCustomClassLoader() {
 			super("tada");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerTest.java
@@ -38,8 +38,8 @@ import static org.junit.Assert.*;
 public class JavaSerializerTest extends SerializerTestBase<Serializable> {
 
 	/** Class loader and object that is not in the test class path. */
-	private static final CommonTestUtils.ObjectAndClassLoader OUTSIDE_CLASS_LOADING =
-		CommonTestUtils.createObjectFromNewClassLoader();
+	private static final CommonTestUtils.ObjectAndClassLoader<Serializable> OUTSIDE_CLASS_LOADING =
+		CommonTestUtils.createSerializableObjectFromNewClassLoader();
 
 	// ------------------------------------------------------------------------
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.util;
 
-import org.apache.flink.core.memory.MemoryUtils;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.InstantiationUtil;
@@ -26,14 +25,10 @@ import org.apache.flink.util.SerializedThrowable;
 
 import org.junit.Test;
 
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.security.CodeSource;
-import java.security.Permissions;
-import java.security.ProtectionDomain;
-import java.security.cert.Certificate;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public class SerializedThrowableTest {
 	
@@ -61,48 +56,11 @@ public class SerializedThrowableTest {
 	public void testSerialization() {
 		try {
 			// We need an exception whose class is not in the core class loader
-			// we solve that by defining an exception class dynamically
-			
-			// an exception class, as bytes 
-			final byte[] classData = {
-					-54, -2, -70, -66, 0, 0, 0, 51, 0, 21, 10, 0, 3, 0, 18, 7, 0, 19, 7, 0, 20, 1,
-					0, 16, 115, 101, 114, 105, 97, 108, 86, 101, 114, 115, 105, 111, 110, 85, 73,
-					68, 1, 0, 1, 74, 1, 0, 13, 67, 111, 110, 115, 116, 97, 110, 116, 86, 97, 108,
-					117, 101, 5, -103, -52, 22, -41, -23, -36, -25, 47, 1, 0, 6, 60, 105, 110, 105,
-					116, 62, 1, 0, 3, 40, 41, 86, 1, 0, 4, 67, 111, 100, 101, 1, 0, 15, 76, 105,
-					110, 101, 78, 117, 109, 98, 101, 114, 84, 97, 98, 108, 101, 1, 0, 18, 76, 111,
-					99, 97, 108, 86, 97, 114, 105, 97, 98, 108, 101, 84, 97, 98, 108, 101, 1, 0, 4,
-					116, 104, 105, 115, 1, 0, 61, 76, 111, 114, 103, 47, 97, 112, 97, 99, 104, 101,
-					47, 102, 108, 105, 110, 107, 47, 114, 117, 110, 116, 105, 109, 101, 47, 117,
-					116, 105, 108, 47, 84, 101, 115, 116, 69, 120, 99, 101, 112, 116, 105, 111,
-					110, 70, 111, 114, 83, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111,
-					110, 59, 1, 0, 10, 83, 111, 117, 114, 99, 101, 70, 105, 108, 101, 1, 0, 34, 84,
-					101, 115, 116, 69, 120, 99, 101, 112, 116, 105, 111, 110, 70, 111, 114, 83,
-					101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 46, 106, 97, 118, 97,
-					12, 0, 9, 0, 10, 1, 0, 59, 111, 114, 103, 47, 97, 112, 97, 99, 104, 101, 47,
-					102, 108, 105, 110, 107, 47, 114, 117, 110, 116, 105, 109, 101, 47, 117, 116,
-					105, 108, 47, 84, 101, 115, 116, 69, 120, 99, 101, 112, 116, 105, 111, 110, 70,
-					111, 114, 83, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 1, 0,
-					19, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 69, 120, 99, 101, 112, 116,
-					105, 111, 110, 0, 33, 0, 2, 0, 3, 0, 0, 0, 1, 0, 26, 0, 4, 0, 5, 0, 1, 0, 6, 0,
-					0, 0, 2, 0, 7, 0, 1, 0, 1, 0, 9, 0, 10, 0, 1, 0, 11, 0, 0, 0, 47, 0, 1, 0, 1, 0,
-					0, 0, 5, 42, -73, 0, 1, -79, 0, 0, 0, 2, 0, 12, 0, 0, 0, 6, 0, 1, 0, 0, 0, 21,
-					0, 13, 0, 0, 0, 12, 0, 1, 0, 0, 0, 5, 0, 14, 0, 15, 0, 0, 0, 1, 0, 16, 0, 0, 0,
-					2, 0, 17};
+			final CommonTestUtils.ObjectAndClassLoader<Exception> outsideClassLoading = CommonTestUtils.createExceptionObjectFromNewClassLoader();
+			ClassLoader loader = outsideClassLoading.getClassLoader();
+			Exception userException = outsideClassLoading.getObject();
+			Class<?> clazz = userException.getClass();
 
-			// dummy class loader that has no access to any classes
-			ClassLoader loader = new URLClassLoader(new URL[0]);
-
-			// define a class into the classloader
-			Class<?> clazz = MemoryUtils.UNSAFE.defineClass(
-					"org.apache.flink.runtime.util.TestExceptionForSerialization",
-					classData, 0, classData.length,
-					loader,
-					new ProtectionDomain(new CodeSource(null, (Certificate[]) null), new Permissions()));
-			
-			// create an instance of the exception (no message, no cause)
-			Exception userException = clazz.asSubclass(Exception.class).newInstance();
-			
 			// check that we cannot simply copy the exception
 			try {
 				byte[] serialized = InstantiationUtil.serializeObject(userException);

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -159,7 +159,8 @@ public class CommonTestUtils {
 
 	/**
 	 * A new object and the corresponding ClassLoader for that object, as returned by
-	 * {@link #createSerializableObjectFromNewClassLoader(ClassLoader)}.
+	 * {@link #createSerializableObjectFromNewClassLoader(ClassLoader)} or
+	 * {@link #createExceptionObjectFromNewClassLoader(ClassLoader)}.
 	 */
 	public static final class ObjectAndClassLoader<T> {
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -159,14 +159,14 @@ public class CommonTestUtils {
 
 	/**
 	 * A new object and the corresponding ClassLoader for that object, as returned by
-	 * {@link #createObjectFromNewClassLoader(ClassLoader)}.
+	 * {@link #createSerializableObjectFromNewClassLoader(ClassLoader)}.
 	 */
-	public static final class ObjectAndClassLoader {
+	public static final class ObjectAndClassLoader<T> {
 
-		private final Serializable object;
+		private final T object;
 		private final ClassLoader classLoader;
 
-		private ObjectAndClassLoader(Serializable object, ClassLoader classLoader) {
+		private ObjectAndClassLoader(T object, ClassLoader classLoader) {
 			this.object = object;
 			this.classLoader = classLoader;
 		}
@@ -175,7 +175,7 @@ public class CommonTestUtils {
 			return classLoader;
 		}
 
-		public Serializable getObject() {
+		public T getObject() {
 			return object;
 		}
 	}
@@ -185,14 +185,25 @@ public class CommonTestUtils {
 	 * This is useful when unit testing the class loading behavior of code, and needing a class that
 	 * is outside the system class path.
 	 *
-	 * <p>This method behaves like {@code createObjectFromNewClassLoader(ClassLoader.getSystemClassLoader())}.
+	 * <p>This method behaves like {@code createSerializableObjectFromNewClassLoader(ClassLoader.getSystemClassLoader())}.
 	 */
-	public static ObjectAndClassLoader createObjectFromNewClassLoader() {
-		return createObjectFromNewClassLoader(ClassLoader.getSystemClassLoader());
+	public static ObjectAndClassLoader<Serializable> createSerializableObjectFromNewClassLoader() {
+		return createSerializableObjectFromNewClassLoader(ClassLoader.getSystemClassLoader());
 	}
 
 	/**
 	 * Creates a new ClassLoader and a new class inside that ClassLoader.
+	 * This is useful when unit testing the class loading behavior of code, and needing a class that
+	 * is outside the system class path.
+	 *
+	 * <p>This method behaves like {@code createExceptionObjectFromNewClassLoader(ClassLoader.getSystemClassLoader())}.
+	 */
+	public static ObjectAndClassLoader<Exception> createExceptionObjectFromNewClassLoader() {
+		return createExceptionObjectFromNewClassLoader(ClassLoader.getSystemClassLoader());
+	}
+
+	/**
+	 * Creates a new ClassLoader and a new {@link Serializable} class inside that ClassLoader.
 	 * This is useful when unit testing the class loading behavior of code, and needing a class that
 	 * is outside the system class path.
 	 *
@@ -203,8 +214,123 @@ public class CommonTestUtils {
 	 *
 	 * @param parentClassLoader The parent class loader used for the newly created class loader.
 	 */
-	public static ObjectAndClassLoader createObjectFromNewClassLoader(@Nullable ClassLoader parentClassLoader) {
-		final String testClassName = "org.apache.flink.TestSerializable";
+	public static ObjectAndClassLoader<Serializable> createSerializableObjectFromNewClassLoader(@Nullable ClassLoader parentClassLoader) {
+		// this is the byte code of the following simple class:
+		// ----------------------------------------------------------------------
+		// package org.apache.flink;
+		//
+		// public class TestSerializable implements java.io.Serializable {}
+		// ----------------------------------------------------------------------
+
+		final byte[] classData = {-54, -2, -70, -66, 0, 0, 0, 51, 0, 65, 10, 0, 15, 0, 43, 7, 0, 44,
+			10, 0, 2, 0, 43, 10, 0, 2, 0, 45, 9, 0, 7, 0, 46, 10, 0, 15, 0, 47, 7, 0, 48, 7, 0,
+			49, 10, 0, 8, 0, 43, 8, 0, 50, 10, 0, 8, 0, 51, 10, 0, 8, 0, 52, 10, 0, 8, 0, 53, 10,
+			0, 8, 0, 54, 7, 0, 55, 7, 0, 56, 1, 0, 16, 115, 101, 114, 105, 97, 108, 86, 101, 114,
+			115, 105, 111, 110, 85, 73, 68, 1, 0, 1, 74, 1, 0, 13, 67, 111, 110, 115, 116, 97, 110,
+			116, 86, 97, 108, 117, 101, 5, -1, -1, -1, -1, -1, -1, -1, -3, 1, 0, 6, 114, 97, 110,
+			100, 111, 109, 1, 0, 6, 60, 105, 110, 105, 116, 62, 1, 0, 3, 40, 41, 86, 1, 0, 4, 67,
+			111, 100, 101, 1, 0, 15, 76, 105, 110, 101, 78, 117, 109, 98, 101, 114, 84, 97, 98, 108,
+			101, 1, 0, 18, 76, 111, 99, 97, 108, 86, 97, 114, 105, 97, 98, 108, 101, 84, 97, 98,
+			108, 101, 1, 0, 4, 116, 104, 105, 115, 1, 0, 35, 76, 111, 114, 103, 47, 97, 112, 97, 99,
+			104, 101, 47, 102, 108, 105, 110, 107, 47, 84, 101, 115, 116, 83, 101, 114, 105, 97, 108,
+			105, 122, 97, 98, 108, 101, 59, 1, 0, 6, 101, 113, 117, 97, 108, 115, 1, 0, 21, 40, 76,
+			106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 79, 98, 106, 101, 99, 116, 59, 41, 90, 1, 0,
+			1, 111, 1, 0, 18, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 79, 98, 106, 101, 99,
+			116, 59, 1, 0, 4, 116, 104, 97, 116, 1, 0, 13, 83, 116, 97, 99, 107, 77, 97, 112, 84, 97,
+			98, 108, 101, 7, 0, 48, 1, 0, 8, 104, 97, 115, 104, 67, 111, 100, 101, 1, 0, 3, 40, 41,
+			73, 1, 0, 8, 116, 111, 83, 116, 114, 105, 110, 103, 1, 0, 20, 40, 41, 76, 106, 97, 118, 97,
+			47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110, 103, 59, 1, 0, 10, 83, 111, 117, 114,
+			99, 101, 70, 105, 108, 101, 1, 0, 21, 84, 101, 115, 116, 83, 101, 114, 105, 97, 108, 105,
+			122, 97, 98, 108, 101, 46, 106, 97, 118, 97, 12, 0, 23, 0, 24, 1, 0, 16, 106, 97, 118, 97,
+			47, 117, 116, 105, 108, 47, 82, 97, 110, 100, 111, 109, 12, 0, 57, 0, 58, 12, 0, 22, 0, 18,
+			12, 0, 59, 0, 60, 1, 0, 33, 111, 114, 103, 47, 97, 112, 97, 99, 104, 101, 47, 102, 108, 105,
+			110, 107, 47, 84, 101, 115, 116, 83, 101, 114, 105, 97, 108, 105, 122, 97, 98, 108, 101, 1,
+			0, 23, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110, 103, 66, 117,
+			105, 108, 100, 101, 114, 1, 0, 24, 84, 101, 115, 116, 83, 101, 114, 105, 97, 108, 105, 122,
+			97, 98, 108, 101, 123, 114, 97, 110, 100, 111, 109, 61, 12, 0, 61, 0, 62, 12, 0, 61, 0, 63,
+			12, 0, 61, 0, 64, 12, 0, 39, 0, 40, 1, 0, 16, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47,
+			79, 98, 106, 101, 99, 116, 1, 0, 20, 106, 97, 118, 97, 47, 105, 111, 47, 83, 101, 114, 105,
+			97, 108, 105, 122, 97, 98, 108, 101, 1, 0, 8, 110, 101, 120, 116, 76, 111, 110, 103, 1, 0,
+			3, 40, 41, 74, 1, 0, 8, 103, 101, 116, 67, 108, 97, 115, 115, 1, 0, 19, 40, 41, 76, 106, 97,
+			118, 97, 47, 108, 97, 110, 103, 47, 67, 108, 97, 115, 115, 59, 1, 0, 6, 97, 112, 112, 101,
+			110, 100, 1, 0, 45, 40, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105,
+			110, 103, 59, 41, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110,
+			103, 66, 117, 105, 108, 100, 101, 114, 59, 1, 0, 28, 40, 74, 41, 76, 106, 97, 118, 97, 47,
+			108, 97, 110, 103, 47, 83, 116, 114, 105, 110, 103, 66, 117, 105, 108, 100, 101, 114, 59, 1,
+			0, 28, 40, 67, 41, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110,
+			103, 66, 117, 105, 108, 100, 101, 114, 59, 0, 33, 0, 7, 0, 15, 0, 1, 0, 16, 0, 2, 0, 26, 0,
+			17, 0, 18, 0, 1, 0, 19, 0, 0, 0, 2, 0, 20, 0, 18, 0, 22, 0, 18, 0, 0, 0, 4, 0, 1, 0, 23, 0,
+			24, 0, 1, 0, 25, 0, 0, 0, 69, 0, 3, 0, 1, 0, 0, 0, 19, 42, -73, 0, 1, 42, -69, 0, 2, 89, -73,
+			0, 3, -74, 0, 4, -75, 0, 5, -79, 0, 0, 0, 2, 0, 26, 0, 0, 0, 14, 0, 3, 0, 0, 0, 30, 0, 4, 0,
+			31, 0, 18, 0, 32, 0, 27, 0, 0, 0, 12, 0, 1, 0, 0, 0, 19, 0, 28, 0, 29, 0, 0, 0, 1, 0, 30, 0,
+			31, 0, 1, 0, 25, 0, 0, 0, -116, 0, 4, 0, 3, 0, 0, 0, 47, 42, 43, -90, 0, 5, 4, -84, 43, -58,
+			0, 14, 42, -74, 0, 6, 43, -74, 0, 6, -91, 0, 5, 3, -84, 43, -64, 0, 7, 77, 42, -76, 0, 5, 44,
+			-76, 0, 5, -108, -102, 0, 7, 4, -89, 0, 4, 3, -84, 0, 0, 0, 3, 0, 26, 0, 0, 0, 18, 0, 4, 0, 0,
+			0, 36, 0, 7, 0, 37, 0, 24, 0, 39, 0, 29, 0, 40, 0, 27, 0, 0, 0, 32, 0, 3, 0, 0, 0, 47, 0, 28,
+			0, 29, 0, 0, 0, 0, 0, 47, 0, 32, 0, 33, 0, 1, 0, 29, 0, 18, 0, 34, 0, 29, 0, 2, 0, 35, 0, 0,
+			0, 13, 0, 5, 7, 14, 1, -4, 0, 20, 7, 0, 36, 64, 1, 0, 1, 0, 37, 0, 38, 0, 1, 0, 25, 0, 0, 0,
+			56, 0, 5, 0, 1, 0, 0, 0, 14, 42, -76, 0, 5, 42, -76, 0, 5, 16, 32, 125, -125, -120, -84, 0, 0,
+			0, 2, 0, 26, 0, 0, 0, 6, 0, 1, 0, 0, 0, 46, 0, 27, 0, 0, 0, 12, 0, 1, 0, 0, 0, 14, 0, 28, 0,
+			29, 0, 0, 0, 1, 0, 39, 0, 40, 0, 1, 0, 25, 0, 0, 0, 70, 0, 3, 0, 1, 0, 0, 0, 28, -69, 0, 8,
+			89, -73, 0, 9, 18, 10, -74, 0, 11, 42, -76, 0, 5, -74, 0, 12, 16, 125, -74, 0, 13, -74, 0, 14,
+			-80, 0, 0, 0, 2, 0, 26, 0, 0, 0, 6, 0, 1, 0, 0, 0, 51, 0, 27, 0, 0, 0, 12, 0, 1, 0, 0, 0, 28,
+			0, 28, 0, 29, 0, 0, 0, 1, 0, 41, 0, 0, 0, 2, 0, 42};
+
+		return createObjectFromNewClassLoader(
+			"org.apache.flink.TestSerializable",
+			Serializable.class,
+			classData,
+			parentClassLoader);
+	}
+
+	/**
+	 * Creates a new ClassLoader and a new {@link Exception} class inside that ClassLoader.
+	 * This is useful when unit testing the class loading behavior of code, and needing a class that
+	 * is outside the system class path.
+	 *
+	 * <p>NOTE: Even though this method may throw IOExceptions, we do not declare those and rather
+	 * wrap them in Runtime Exceptions. While this is generally discouraged, we do this here because it
+	 * is merely a test utility and not production code, and it makes it easier to use this method
+	 * during the initialization of variables and especially static variables.
+	 *
+	 * @param parentClassLoader The parent class loader used for the newly created class loader.
+	 */
+	public static ObjectAndClassLoader<Exception> createExceptionObjectFromNewClassLoader(@Nullable ClassLoader parentClassLoader) {
+		// an exception class, as bytes
+		final byte[] classData = {
+			-54, -2, -70, -66, 0, 0, 0, 51, 0, 21, 10, 0, 3, 0, 18, 7, 0, 19, 7, 0, 20, 1,
+			0, 16, 115, 101, 114, 105, 97, 108, 86, 101, 114, 115, 105, 111, 110, 85, 73,
+			68, 1, 0, 1, 74, 1, 0, 13, 67, 111, 110, 115, 116, 97, 110, 116, 86, 97, 108,
+			117, 101, 5, -103, -52, 22, -41, -23, -36, -25, 47, 1, 0, 6, 60, 105, 110, 105,
+			116, 62, 1, 0, 3, 40, 41, 86, 1, 0, 4, 67, 111, 100, 101, 1, 0, 15, 76, 105,
+			110, 101, 78, 117, 109, 98, 101, 114, 84, 97, 98, 108, 101, 1, 0, 18, 76, 111,
+			99, 97, 108, 86, 97, 114, 105, 97, 98, 108, 101, 84, 97, 98, 108, 101, 1, 0, 4,
+			116, 104, 105, 115, 1, 0, 61, 76, 111, 114, 103, 47, 97, 112, 97, 99, 104, 101,
+			47, 102, 108, 105, 110, 107, 47, 114, 117, 110, 116, 105, 109, 101, 47, 117,
+			116, 105, 108, 47, 84, 101, 115, 116, 69, 120, 99, 101, 112, 116, 105, 111,
+			110, 70, 111, 114, 83, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111,
+			110, 59, 1, 0, 10, 83, 111, 117, 114, 99, 101, 70, 105, 108, 101, 1, 0, 34, 84,
+			101, 115, 116, 69, 120, 99, 101, 112, 116, 105, 111, 110, 70, 111, 114, 83,
+			101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 46, 106, 97, 118, 97,
+			12, 0, 9, 0, 10, 1, 0, 59, 111, 114, 103, 47, 97, 112, 97, 99, 104, 101, 47,
+			102, 108, 105, 110, 107, 47, 114, 117, 110, 116, 105, 109, 101, 47, 117, 116,
+			105, 108, 47, 84, 101, 115, 116, 69, 120, 99, 101, 112, 116, 105, 111, 110, 70,
+			111, 114, 83, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 1, 0,
+			19, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 69, 120, 99, 101, 112, 116,
+			105, 111, 110, 0, 33, 0, 2, 0, 3, 0, 0, 0, 1, 0, 26, 0, 4, 0, 5, 0, 1, 0, 6, 0,
+			0, 0, 2, 0, 7, 0, 1, 0, 1, 0, 9, 0, 10, 0, 1, 0, 11, 0, 0, 0, 47, 0, 1, 0, 1, 0,
+			0, 0, 5, 42, -73, 0, 1, -79, 0, 0, 0, 2, 0, 12, 0, 0, 0, 6, 0, 1, 0, 0, 0, 21,
+			0, 13, 0, 0, 0, 12, 0, 1, 0, 0, 0, 5, 0, 14, 0, 15, 0, 0, 0, 1, 0, 16, 0, 0, 0,
+			2, 0, 17};
+
+		return createObjectFromNewClassLoader(
+			"org.apache.flink.runtime.util.TestExceptionForSerialization",
+			Exception.class,
+			classData,
+			parentClassLoader);
+	}
+
+	private static <T> ObjectAndClassLoader<T> createObjectFromNewClassLoader(String testClassName, Class<T> testClass, byte[] classData, @Nullable ClassLoader parentClassLoader) {
 		final String testClassFile = testClassName.replace('.', '/') + ".class";
 
 		final Path classDirPath = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString()).toPath();
@@ -213,7 +339,7 @@ public class CommonTestUtils {
 		URLClassLoader classLoader = null;
 		try {
 			Files.createDirectories(classFilePath.getParent());
-			writeClassFile(classFilePath);
+			writeClassFile(classFilePath, classData);
 
 			final URL[] classPath = new URL[] {classDirPath.toUri().toURL()};
 			classLoader = parentClassLoader == null ?
@@ -221,9 +347,9 @@ public class CommonTestUtils {
 				new URLClassLoader(classPath, parentClassLoader);
 
 			final Class<?> clazz = classLoader.loadClass(testClassName);
-			final Serializable object = clazz.asSubclass(Serializable.class).newInstance();
+			final T object = clazz.asSubclass(testClass).newInstance();
 
-			return new ObjectAndClassLoader(object, classLoader);
+			return new ObjectAndClassLoader<>(object, classLoader);
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Cannot create test class outside system class path", e);
@@ -236,68 +362,7 @@ public class CommonTestUtils {
 		}
 	}
 
-	private static void writeClassFile(Path path) throws IOException {
-		// this is the byte code of the following simple class:
-		// ----------------------------------------------------------------------
-		// package org.apache.flink;
-		//
-		// public class TestSerializable implements java.io.Serializable {}
-		// ----------------------------------------------------------------------
-
-		final byte[] classData = {-54, -2, -70, -66, 0, 0, 0, 51, 0, 65, 10, 0, 15, 0, 43, 7, 0, 44,
-				10, 0, 2, 0, 43, 10, 0, 2, 0, 45, 9, 0, 7, 0, 46, 10, 0, 15, 0, 47, 7, 0, 48, 7, 0,
-				49, 10, 0, 8, 0, 43, 8, 0, 50, 10, 0, 8, 0, 51, 10, 0, 8, 0, 52, 10, 0, 8, 0, 53, 10,
-				0, 8, 0, 54, 7, 0, 55, 7, 0, 56, 1, 0, 16, 115, 101, 114, 105, 97, 108, 86, 101, 114,
-				115, 105, 111, 110, 85, 73, 68, 1, 0, 1, 74, 1, 0, 13, 67, 111, 110, 115, 116, 97, 110,
-				116, 86, 97, 108, 117, 101, 5, -1, -1, -1, -1, -1, -1, -1, -3, 1, 0, 6, 114, 97, 110,
-				100, 111, 109, 1, 0, 6, 60, 105, 110, 105, 116, 62, 1, 0, 3, 40, 41, 86, 1, 0, 4, 67,
-				111, 100, 101, 1, 0, 15, 76, 105, 110, 101, 78, 117, 109, 98, 101, 114, 84, 97, 98, 108,
-				101, 1, 0, 18, 76, 111, 99, 97, 108, 86, 97, 114, 105, 97, 98, 108, 101, 84, 97, 98,
-				108, 101, 1, 0, 4, 116, 104, 105, 115, 1, 0, 35, 76, 111, 114, 103, 47, 97, 112, 97, 99,
-				104, 101, 47, 102, 108, 105, 110, 107, 47, 84, 101, 115, 116, 83, 101, 114, 105, 97, 108,
-				105, 122, 97, 98, 108, 101, 59, 1, 0, 6, 101, 113, 117, 97, 108, 115, 1, 0, 21, 40, 76,
-				106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 79, 98, 106, 101, 99, 116, 59, 41, 90, 1, 0,
-				1, 111, 1, 0, 18, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 79, 98, 106, 101, 99,
-				116, 59, 1, 0, 4, 116, 104, 97, 116, 1, 0, 13, 83, 116, 97, 99, 107, 77, 97, 112, 84, 97,
-				98, 108, 101, 7, 0, 48, 1, 0, 8, 104, 97, 115, 104, 67, 111, 100, 101, 1, 0, 3, 40, 41,
-				73, 1, 0, 8, 116, 111, 83, 116, 114, 105, 110, 103, 1, 0, 20, 40, 41, 76, 106, 97, 118, 97,
-				47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110, 103, 59, 1, 0, 10, 83, 111, 117, 114,
-				99, 101, 70, 105, 108, 101, 1, 0, 21, 84, 101, 115, 116, 83, 101, 114, 105, 97, 108, 105,
-				122, 97, 98, 108, 101, 46, 106, 97, 118, 97, 12, 0, 23, 0, 24, 1, 0, 16, 106, 97, 118, 97,
-				47, 117, 116, 105, 108, 47, 82, 97, 110, 100, 111, 109, 12, 0, 57, 0, 58, 12, 0, 22, 0, 18,
-				12, 0, 59, 0, 60, 1, 0, 33, 111, 114, 103, 47, 97, 112, 97, 99, 104, 101, 47, 102, 108, 105,
-				110, 107, 47, 84, 101, 115, 116, 83, 101, 114, 105, 97, 108, 105, 122, 97, 98, 108, 101, 1,
-				0, 23, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110, 103, 66, 117,
-				105, 108, 100, 101, 114, 1, 0, 24, 84, 101, 115, 116, 83, 101, 114, 105, 97, 108, 105, 122,
-				97, 98, 108, 101, 123, 114, 97, 110, 100, 111, 109, 61, 12, 0, 61, 0, 62, 12, 0, 61, 0, 63,
-				12, 0, 61, 0, 64, 12, 0, 39, 0, 40, 1, 0, 16, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47,
-				79, 98, 106, 101, 99, 116, 1, 0, 20, 106, 97, 118, 97, 47, 105, 111, 47, 83, 101, 114, 105,
-				97, 108, 105, 122, 97, 98, 108, 101, 1, 0, 8, 110, 101, 120, 116, 76, 111, 110, 103, 1, 0,
-				3, 40, 41, 74, 1, 0, 8, 103, 101, 116, 67, 108, 97, 115, 115, 1, 0, 19, 40, 41, 76, 106, 97,
-				118, 97, 47, 108, 97, 110, 103, 47, 67, 108, 97, 115, 115, 59, 1, 0, 6, 97, 112, 112, 101,
-				110, 100, 1, 0, 45, 40, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105,
-				110, 103, 59, 41, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110,
-				103, 66, 117, 105, 108, 100, 101, 114, 59, 1, 0, 28, 40, 74, 41, 76, 106, 97, 118, 97, 47,
-				108, 97, 110, 103, 47, 83, 116, 114, 105, 110, 103, 66, 117, 105, 108, 100, 101, 114, 59, 1,
-				0, 28, 40, 67, 41, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110,
-				103, 66, 117, 105, 108, 100, 101, 114, 59, 0, 33, 0, 7, 0, 15, 0, 1, 0, 16, 0, 2, 0, 26, 0,
-				17, 0, 18, 0, 1, 0, 19, 0, 0, 0, 2, 0, 20, 0, 18, 0, 22, 0, 18, 0, 0, 0, 4, 0, 1, 0, 23, 0,
-				24, 0, 1, 0, 25, 0, 0, 0, 69, 0, 3, 0, 1, 0, 0, 0, 19, 42, -73, 0, 1, 42, -69, 0, 2, 89, -73,
-				0, 3, -74, 0, 4, -75, 0, 5, -79, 0, 0, 0, 2, 0, 26, 0, 0, 0, 14, 0, 3, 0, 0, 0, 30, 0, 4, 0,
-				31, 0, 18, 0, 32, 0, 27, 0, 0, 0, 12, 0, 1, 0, 0, 0, 19, 0, 28, 0, 29, 0, 0, 0, 1, 0, 30, 0,
-				31, 0, 1, 0, 25, 0, 0, 0, -116, 0, 4, 0, 3, 0, 0, 0, 47, 42, 43, -90, 0, 5, 4, -84, 43, -58,
-				0, 14, 42, -74, 0, 6, 43, -74, 0, 6, -91, 0, 5, 3, -84, 43, -64, 0, 7, 77, 42, -76, 0, 5, 44,
-				-76, 0, 5, -108, -102, 0, 7, 4, -89, 0, 4, 3, -84, 0, 0, 0, 3, 0, 26, 0, 0, 0, 18, 0, 4, 0, 0,
-				0, 36, 0, 7, 0, 37, 0, 24, 0, 39, 0, 29, 0, 40, 0, 27, 0, 0, 0, 32, 0, 3, 0, 0, 0, 47, 0, 28,
-				0, 29, 0, 0, 0, 0, 0, 47, 0, 32, 0, 33, 0, 1, 0, 29, 0, 18, 0, 34, 0, 29, 0, 2, 0, 35, 0, 0,
-				0, 13, 0, 5, 7, 14, 1, -4, 0, 20, 7, 0, 36, 64, 1, 0, 1, 0, 37, 0, 38, 0, 1, 0, 25, 0, 0, 0,
-				56, 0, 5, 0, 1, 0, 0, 0, 14, 42, -76, 0, 5, 42, -76, 0, 5, 16, 32, 125, -125, -120, -84, 0, 0,
-				0, 2, 0, 26, 0, 0, 0, 6, 0, 1, 0, 0, 0, 46, 0, 27, 0, 0, 0, 12, 0, 1, 0, 0, 0, 14, 0, 28, 0,
-				29, 0, 0, 0, 1, 0, 39, 0, 40, 0, 1, 0, 25, 0, 0, 0, 70, 0, 3, 0, 1, 0, 0, 0, 28, -69, 0, 8,
-				89, -73, 0, 9, 18, 10, -74, 0, 11, 42, -76, 0, 5, -74, 0, 12, 16, 125, -74, 0, 13, -74, 0, 14,
-				-80, 0, 0, 0, 2, 0, 26, 0, 0, 0, 6, 0, 1, 0, 0, 0, 51, 0, 27, 0, 0, 0, 12, 0, 1, 0, 0, 0, 28,
-				0, 28, 0, 29, 0, 0, 0, 1, 0, 41, 0, 0, 0, 2, 0, 42};
-
+	private static void writeClassFile(Path path, byte[] classData) throws IOException {
 		try (OutputStream out = Files.newOutputStream(path, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
 			out.write(classData);
 		}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/CommonTestUtilsTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/CommonTestUtilsTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.core.testutils;
 
 import org.junit.Test;
 
+import java.io.Serializable;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -31,7 +33,7 @@ public class CommonTestUtilsTest {
 
 	@Test
 	public void testObjectFromNewClassLoaderObject() throws Exception {
-		final CommonTestUtils.ObjectAndClassLoader objectAndClassLoader = CommonTestUtils.createObjectFromNewClassLoader();
+		final CommonTestUtils.ObjectAndClassLoader<Serializable> objectAndClassLoader = CommonTestUtils.createSerializableObjectFromNewClassLoader();
 		final Object o = objectAndClassLoader.getObject();
 
 		assertNotEquals(ClassLoader.getSystemClassLoader(), o.getClass().getClassLoader());
@@ -45,7 +47,29 @@ public class CommonTestUtilsTest {
 
 	@Test
 	public void testObjectFromNewClassLoaderClassLoaders() throws Exception {
-		final CommonTestUtils.ObjectAndClassLoader objectAndClassLoader = CommonTestUtils.createObjectFromNewClassLoader();
+		final CommonTestUtils.ObjectAndClassLoader<Serializable> objectAndClassLoader = CommonTestUtils.createSerializableObjectFromNewClassLoader();
+
+		assertNotEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader());
+		assertEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader().getParent());
+	}
+
+	@Test
+	public void testExceptionObjectFromNewClassLoaderObject() throws Exception {
+		final CommonTestUtils.ObjectAndClassLoader<Exception> objectAndClassLoader = CommonTestUtils.createExceptionObjectFromNewClassLoader();
+		final Object o = objectAndClassLoader.getObject();
+
+		assertNotEquals(ClassLoader.getSystemClassLoader(), o.getClass().getClassLoader());
+
+		try {
+			Class.forName(o.getClass().getName());
+			fail("should not be able to load class from the system class loader");
+		}
+		catch (ClassNotFoundException ignored) {}
+	}
+
+	@Test
+	public void testExceptionObjectFromNewClassLoaderClassLoaders() throws Exception {
+		final CommonTestUtils.ObjectAndClassLoader<Exception> objectAndClassLoader = CommonTestUtils.createExceptionObjectFromNewClassLoader();
 
 		assertNotEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader());
 		assertEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader().getParent());

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/CommonTestUtilsTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/CommonTestUtilsTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.core.testutils;
 
 import org.junit.Test;
 
-import java.io.Serializable;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -33,29 +33,26 @@ public class CommonTestUtilsTest {
 
 	@Test
 	public void testObjectFromNewClassLoaderObject() throws Exception {
-		final CommonTestUtils.ObjectAndClassLoader<Serializable> objectAndClassLoader = CommonTestUtils.createSerializableObjectFromNewClassLoader();
-		final Object o = objectAndClassLoader.getObject();
-
-		assertNotEquals(ClassLoader.getSystemClassLoader(), o.getClass().getClassLoader());
-
-		try {
-			Class.forName(o.getClass().getName());
-			fail("should not be able to load class from the system class loader");
-		}
-		catch (ClassNotFoundException ignored) {}
+		testObjectFromNewClassLoaderObject(CommonTestUtils::createSerializableObjectFromNewClassLoader);
 	}
 
 	@Test
 	public void testObjectFromNewClassLoaderClassLoaders() throws Exception {
-		final CommonTestUtils.ObjectAndClassLoader<Serializable> objectAndClassLoader = CommonTestUtils.createSerializableObjectFromNewClassLoader();
-
-		assertNotEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader());
-		assertEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader().getParent());
+		testObjectFromNewClassLoaderClassLoaders(CommonTestUtils::createSerializableObjectFromNewClassLoader);
 	}
 
 	@Test
 	public void testExceptionObjectFromNewClassLoaderObject() throws Exception {
-		final CommonTestUtils.ObjectAndClassLoader<Exception> objectAndClassLoader = CommonTestUtils.createExceptionObjectFromNewClassLoader();
+		testObjectFromNewClassLoaderObject(CommonTestUtils::createExceptionObjectFromNewClassLoader);
+	}
+
+	@Test
+	public void testExceptionObjectFromNewClassLoaderClassLoaders() throws Exception {
+		testObjectFromNewClassLoaderClassLoaders(CommonTestUtils::createExceptionObjectFromNewClassLoader);
+	}
+
+	private static <X> void testObjectFromNewClassLoaderObject(Supplier<CommonTestUtils.ObjectAndClassLoader<X>> supplier) {
+		final CommonTestUtils.ObjectAndClassLoader<X> objectAndClassLoader = supplier.get();
 		final Object o = objectAndClassLoader.getObject();
 
 		assertNotEquals(ClassLoader.getSystemClassLoader(), o.getClass().getClassLoader());
@@ -67,9 +64,8 @@ public class CommonTestUtilsTest {
 		catch (ClassNotFoundException ignored) {}
 	}
 
-	@Test
-	public void testExceptionObjectFromNewClassLoaderClassLoaders() throws Exception {
-		final CommonTestUtils.ObjectAndClassLoader<Exception> objectAndClassLoader = CommonTestUtils.createExceptionObjectFromNewClassLoader();
+	private static <X> void testObjectFromNewClassLoaderClassLoaders(Supplier<CommonTestUtils.ObjectAndClassLoader<X>> supplier) {
+		final CommonTestUtils.ObjectAndClassLoader<X> objectAndClassLoader = supplier.get();
 
 		assertNotEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader());
 		assertEquals(ClassLoader.getSystemClassLoader(), objectAndClassLoader.getClassLoader().getParent());


### PR DESCRIPTION
Follow-up to #9251.

Uses the same mechanism to migrate away from `Unsafe#defineClass` used in #9251. Extends it to support an `Exception` class that isn't on the classpath.