### PR TITLE
[MINOR][docs] Doc fix for cluster_setup.md

### DIFF
--- a/docs/ops/deployment/cluster_setup.md
+++ b/docs/ops/deployment/cluster_setup.md
@@ -109,7 +109,6 @@ In particular,
  * the amount of available memory per JobManager (`jobmanager.heap.size`),
  * the amount of available memory per TaskManager (`taskmanager.heap.size`),
  * the number of available CPUs per machine (`taskmanager.numberOfTaskSlots`),
- * the total number of CPUs in the cluster (`parallelism.default`) and
  * the temporary directories (`io.tmp.dirs`)
 
 are very important configuration values.


### PR DESCRIPTION

## What is the purpose of the change

This is a trivial PR to update the doc `cluster_setup.md`

## Brief change log

IIUC, `parallelism.default` is job level configuration instead of cluster configuration, so I remove it from `cluster_setup.md`


