### PR TITLE
[hotfix] fix a typo

### DIFF
--- a/docs/dev/api_concepts.md
+++ b/docs/dev/api_concepts.md
@@ -758,7 +758,7 @@ Restrictions apply to classes containing fields that cannot be serialized, like 
 resources. Classes that follow the Java Beans conventions work well in general.
 
 All classes that are not identified as POJO types (see POJO requirements above) are handled by Flink as general class types.
-Flink treats these data types as black boxes and is not able to access their content (i.e., for efficient sorting). General types are de/serialized using the serialization framework [Kryo](https://github.com/EsotericSoftware/kryo).
+Flink treats these data types as black boxes and is not able to access their content (e.g., for efficient sorting). General types are de/serialized using the serialization framework [Kryo](https://github.com/EsotericSoftware/kryo).
 
 #### Values
 


### PR DESCRIPTION
@aljoscha
Just change a "i.e." to "e.g.".