### PR TITLE
 [FLINK-13399][table] Create two separate table uber jars for old and blink planners

### DIFF
--- a/docs/dev/table/index.md
+++ b/docs/dev/table/index.md
@@ -34,7 +34,11 @@ The Table API and the SQL interfaces are tightly integrated with each other as w
 Dependency Structure
 --------------------
 
-All Table API and SQL components are bundled in the `flink-table` Maven artifact.
+Starting from Flink 1.9 the Table API provides two different planners: Blink planner and the old one available before. Planners are responsible for
+translating the relational operators into an executable, optimized plan. Both of the planners come with different optimization rules and runtime classes.
+They may also differ in a set of supported features. For a production use cases we recommend the old before Flink 1.9 planner.
+
+All Table API and SQL components are bundled in the `flink-table` or `flink-table-blink` Maven artifacts.
 
 The following dependencies are relevant for most projects:
 
@@ -43,11 +47,11 @@ The following dependencies are relevant for most projects:
 * `flink-table-api-scala`: The Table & SQL API for pure table programs using the Scala programming language (in early development stage, not recommended!).
 * `flink-table-api-java-bridge`: The Table & SQL API with DataStream/DataSet API support using the Java programming language.
 * `flink-table-api-scala-bridge`: The Table & SQL API with DataStream/DataSet API support using the Scala programming language.
-* `flink-table-planner`: The table program planner and runtime.
-* `flink-table-planner-blink`: The table program blink planner.
-* `flink-table-runtime-blink`: The table program blink runtime.
-* `flink-table-uber`: Packages the common modules above plus the current planner into a distribution for most Table & SQL API use cases. The uber JAR file `flink-table*.jar` is by default located in the `/lib` directory of a Flink release.
-* `flink-table-uber-blink`: Packages the common modules above plus the blink specific modules into a distribution for most Table & SQL API use cases. The uber JAR file `flink-table-blink*.jar` is by default located in the `/lib` directory of a Flink release.
+* `flink-table-planner`: The table program planner and runtime. This is the only planner of Flink before 1.9. It is still the recommended one.
+* `flink-table-planner-blink`: The table program Blink planner.
+* `flink-table-runtime-blink`: The table program Blink runtime.
+* `flink-table-uber`: Packages the API modules above plus the old planner into a distribution for most Table & SQL API use cases. The uber JAR file `flink-table-{{site.version}}.jar` is by default located in the `/lib` directory of a Flink release.
+* `flink-table-uber-blink`: Packages the API modules above plus the Blink specific modules into a distribution for most Table & SQL API use cases. The uber JAR file `flink-table-blink-{{site.version}}.jar` is by default located in the `/lib` directory of a Flink release.
 
 ### Table Program Dependencies
 
@@ -71,21 +75,16 @@ Depending on the target programming language, you need to add the Java or Scala 
 Additionally, if you want to run the Table API & SQL programs locally you must add one of the
 following set of modules, depending which planner you want to use:
 {% highlight xml %}
-<!-- Either... -->
+<!-- Either for the old Flink planner before Flink 1.9 -->
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-table-planner{{ site.scala_version_suffix }}</artifactId>
   <version>{{site.version}}</version>
 </dependency>
-<!-- or... -->
+<!-- or for the new Blink planner... -->
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-table-planner-blink{{ site.scala_version_suffix }}</artifactId>
-  <version>{{site.version}}</version>
-</dependency>
-<dependency>
-  <groupId>org.apache.flink</groupId>
-  <artifactId>flink-table-runtime-blink{{ site.scala_version_suffix }}</artifactId>
   <version>{{site.version}}</version>
 </dependency>
 {% endhighlight %}

--- a/docs/dev/table/index.md
+++ b/docs/dev/table/index.md
@@ -44,21 +44,14 @@ The following dependencies are relevant for most projects:
 * `flink-table-api-java-bridge`: The Table & SQL API with DataStream/DataSet API support using the Java programming language.
 * `flink-table-api-scala-bridge`: The Table & SQL API with DataStream/DataSet API support using the Scala programming language.
 * `flink-table-planner`: The table program planner and runtime.
-* `flink-table-uber`: Packages the modules above into a distribution for most Table & SQL API use cases. The uber JAR file `flink-table*.jar` is located in the `/opt` directory of a Flink release and can be moved to `/lib` if desired.
+* `flink-table-planner-blink`: The table program blink planner.
+* `flink-table-runtime-blink`: The table program blink runtime.
+* `flink-table-uber`: Packages the common modules above plus the current planner into a distribution for most Table & SQL API use cases. The uber JAR file `flink-table*.jar` is by default located in the `/lib` directory of a Flink release.
+* `flink-table-uber-blink`: Packages the common modules above plus the blink specific modules into a distribution for most Table & SQL API use cases. The uber JAR file `flink-table-blink*.jar` is by default located in the `/lib` directory of a Flink release.
 
 ### Table Program Dependencies
 
-The following dependencies must be added to a project in order to use the Table API & SQL for defining pipelines:
-
-{% highlight xml %}
-<dependency>
-  <groupId>org.apache.flink</groupId>
-  <artifactId>flink-table-planner{{ site.scala_version_suffix }}</artifactId>
-  <version>{{site.version}}</version>
-</dependency>
-{% endhighlight %}
-
-Additionally, depending on the target programming language, you need to add the Java or Scala API.
+Depending on the target programming language, you need to add the Java or Scala API to a project in order to use the Table API & SQL for defining pipelines:
 
 {% highlight xml %}
 <!-- Either... -->
@@ -71,6 +64,28 @@ Additionally, depending on the target programming language, you need to add the 
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-table-api-scala-bridge{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version}}</version>
+</dependency>
+{% endhighlight %}
+
+Additionally, if you want to run the Table API & SQL programs locally you must add one of the
+following set of modules, depending which planner you want to use:
+{% highlight xml %}
+<!-- Either... -->
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-table-planner{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version}}</version>
+</dependency>
+<!-- or... -->
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-table-planner-blink{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version}}</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-table-runtime-blink{{ site.scala_version_suffix }}</artifactId>
   <version>{{site.version}}</version>
 </dependency>
 {% endhighlight %}

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -301,6 +301,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-uber-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-client_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -52,6 +52,21 @@ under the License.
 			<fileMode>0644</fileMode>
 		</file>
 
+		<!-- Table/SQL Uber JAR -->
+		<file>
+			<source>../flink-table/flink-table-uber/target/flink-table-uber_${scala.binary.version}-${project.version}.jar</source>
+			<outputDirectory>lib/</outputDirectory>
+			<destName>flink-table_${scala.binary.version}-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-table/flink-table-uber-blink/target/flink-table-uber-blink_${scala.binary.version}-${project.version}.jar</source>
+			<outputDirectory>lib/</outputDirectory>
+			<destName>flink-table-blink_${scala.binary.version}-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
 		<!-- copy the config file -->
 		<file>
 			<source>src/main/resources/flink-conf.yaml</source>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -59,14 +59,6 @@
 			<fileMode>0644</fileMode>
 		</file>
 
-		<!-- Table/SQL Uber JAR -->
-		<file>
-			<source>../flink-table/flink-table-uber/target/flink-table-uber_${scala.binary.version}-${project.version}.jar</source>
-			<outputDirectory>opt/</outputDirectory>
-			<destName>flink-table_${scala.binary.version}-${project.version}.jar</destName>
-			<fileMode>0644</fileMode>
-		</file>
-
 		<!-- SQL Client -->
 		<file>
 			<source>../flink-table/flink-sql-client/target/flink-sql-client_${scala.binary.version}-${project.version}.jar</source>

--- a/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
@@ -50,7 +50,7 @@ done
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-python-$HOSTNAME.log
 log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-cli.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml)
 
-TABLE_JAR_PATH=`echo "$FLINK_HOME"/opt/flink-table*.jar`
+TABLE_JAR_PATH=`echo "$FLINK_HOME"/lib/flink-table*.jar`
 PYTHON_JAR_PATH=`echo "$FLINK_HOME"/opt/flink-python*.jar`
 
 FLINK_TEST_CLASSPATH=""

--- a/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
@@ -49,12 +49,6 @@
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-scala-shell/start-script/start-scala-shell.sh
+++ b/flink-scala-shell/start-script/start-scala-shell.sh
@@ -52,13 +52,6 @@ bin=`cd "$bin"; pwd`
 
 FLINK_CLASSPATH=`constructFlinkClassPath`
 
-# Append flink-table jar into class path
-opt=`dirname "$0"`
-opt=`cd "$opt"/../opt; pwd`
-FLINK_TABLE_LIB_PATH=$opt/`ls $opt|grep flink-table_*`
-FLINK_CLASSPATH=$FLINK_CLASSPATH:$FLINK_TABLE_LIB_PATH
-
-
 # https://issues.scala-lang.org/browse/SI-6502, cant load external jars interactively
 # in scala shell since 2.10, has to be done at startup
 # checks arguments for additional classpath and adds it to the "standard classpath"

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -59,12 +59,6 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-cep_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- Table ecosystem -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -515,12 +509,6 @@ under the License.
 						<configuration>
 							<artifactSet>
 								<includes combine.children="append">
-									<include>org.apache.flink:flink-table-common</include>
-									<include>org.apache.flink:flink-table-api-java</include>
-									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>
-									<include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
-									<include>org.apache.flink:flink-cep_${scala.binary.version}</include>
-									<include>org.apache.flink:flink-sql-parser</include>
 									<include>org.jline:*</include>
 								</includes>
 							</artifactSet>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -130,7 +130,6 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- Used for code generation -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-cep_${scala.binary.version}</artifactId>
@@ -138,6 +137,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- Used for code generation -->
 		<dependency>
 			<groupId>org.codehaus.janino</groupId>
 			<artifactId>janino</artifactId>

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -170,6 +170,12 @@ under the License.
 									<include>org.lz4:lz4-java</include>
 								</includes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>net.jpountz</pattern>
+									<shadedPattern>org.apache.flink.table.shaded.net.jpountz</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -172,6 +172,7 @@ under the License.
 							</artifactSet>
 							<relocations>
 								<relocation>
+									<!-- Relocate org.lz4:lz4-java -->
 									<pattern>net.jpountz</pattern>
 									<shadedPattern>org.apache.flink.table.shaded.net.jpountz</shadedPattern>
 								</relocation>

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -31,8 +31,9 @@ under the License.
 	<name>flink-table-uber-blink</name>
 	<description>
 		This module contains the entire Table/SQL distribution for writing table programs
-		within the table ecosystem or between other Flink APIs. This module uses the blink planner.
-		Users can either use the Scala or Java programming language.
+		within the table ecosystem or between other Flink APIs. This module uses the Blink planner
+		for generating optimized runnable plan from relational query. Users can either use the
+		Scala or Java programming language.
 	</description>
 
 	<packaging>jar</packaging>

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -27,12 +27,12 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-table-uber_${scala.binary.version}</artifactId>
-	<name>flink-table-uber</name>
+	<artifactId>flink-table-uber-blink_${scala.binary.version}</artifactId>
+	<name>flink-table-uber-blink</name>
 	<description>
 		This module contains the entire Table/SQL distribution for writing table programs
-		within the table ecosystem or between other Flink APIs. Users can either use the
-		Scala or Java programming language.
+		within the table ecosystem or between other Flink APIs. This module uses the blink planner.
+		Users can either use the Scala or Java programming language.
 	</description>
 
 	<packaging>jar</packaging>
@@ -70,7 +70,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
@@ -102,7 +107,8 @@ under the License.
 									<include>org.apache.flink:flink-table-api-scala_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-api-scala-bridge_${scala.binary.version}</include>
-									<include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-table-planner-blink_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-table-runtime-blink_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-cep_${scala.binary.version}</include>
 								</includes>
 							</artifactSet>

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -42,6 +42,7 @@ under the License.
 		<module>flink-table-planner-blink</module>
 		<module>flink-table-runtime-blink</module>
 		<module>flink-table-uber</module>
+		<module>flink-table-uber-blink</module>
 		<module>flink-sql-client</module>
 		<module>flink-sql-parser</module>
 	</modules>

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -146,7 +146,7 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
             ! -path "$CACHE_FLINK_DIR/flink-runtime/target/flink-runtime*tests.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-streaming-java/target/flink-streaming-java*tests.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-dist*.jar" \
-            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-table*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-table*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-python*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-elasticsearch-base/target/flink-*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-kafka-base/target/flink-*.jar" \


### PR DESCRIPTION
## What is the purpose of the change

This PRs creates two table api uber jars bundling two different planners (the current one and the blink planner). Also for a user convenience both are placed in the lib directory. The current planner should be enabled by default (#9249)

## Verifying this change

The `test_streaming_sql.sh` and `test_sql_client.sh` should run (with the legacy planner)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
