### PR TITLE
[FLINK-13442][network] Remove unnecessary notifySubpartitionConsumed method from view reader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
@@ -61,8 +61,6 @@ public interface NetworkSequenceViewReader {
 	 */
 	void setRegisteredAsAvailable(boolean isRegisteredAvailable);
 
-	void notifySubpartitionConsumed() throws IOException;
-
 	boolean isReleased();
 
 	void releaseAllResources() throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -173,11 +173,6 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() throws IOException {
-		subpartitionView.notifySubpartitionConsumed();
-	}
-
-	@Override
 	public boolean isReleased() {
 		return subpartitionView.isReleased();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -301,7 +301,6 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 	}
 
 	private void releaseViewReader(NetworkSequenceViewReader reader) throws IOException {
-		reader.notifySubpartitionConsumed();
 		reader.setRegisteredAsAvailable(false);
 		reader.releaseAllResources();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
@@ -118,11 +118,6 @@ class SequenceNumberingViewReader implements BufferAvailabilityListener, Network
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() throws IOException {
-		subpartitionView.notifySubpartitionConsumed();
-	}
-
-	@Override
 	public boolean isReleased() {
 		return subpartitionView.isReleased();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -206,6 +206,8 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 	}
 
 	void releaseReaderReference(BoundedBlockingSubpartitionReader reader) throws IOException {
+		onConsumedSubpartition();
+
 		synchronized (lock) {
 			if (readers.remove(reader) && isReleased) {
 				checkReaderReferencesAndDispose();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -124,11 +124,6 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() throws IOException {
-		parent.onConsumedSubpartition();
-	}
-
-	@Override
 	public void releaseAllResources() throws IOException {
 		// it is not a problem if this method executes multiple times
 		isReleased = true;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -39,10 +39,6 @@ public class NoOpResultSubpartitionView implements ResultSubpartitionView {
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() {
-	}
-
-	@Override
 	public boolean isReleased() {
 		return true;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -57,11 +57,6 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() {
-		releaseAllResources();
-	}
-
-	@Override
 	public void releaseAllResources() {
 		if (isReleased.compareAndSet(false, true)) {
 			// The view doesn't hold any resources and the parent cannot be restarted. Therefore,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -48,8 +48,6 @@ public interface ResultSubpartitionView {
 
 	void releaseAllResources() throws IOException;
 
-	void notifySubpartitionConsumed() throws IOException;
-
 	boolean isReleased();
 
 	Throwable getFailureCause();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -164,8 +164,6 @@ public abstract class InputChannel {
 
 	abstract boolean isReleased();
 
-	abstract void notifySubpartitionConsumed() throws IOException;
-
 	/**
 	 * Releases all resources of the channel.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -237,13 +237,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		return isReleased;
 	}
 
-	@Override
-	void notifySubpartitionConsumed() throws IOException {
-		if (subpartitionView != null) {
-			subpartitionView.notifySubpartitionConsumed();
-		}
-	}
-
 	/**
 	 * Releases the partition reader.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -229,11 +229,6 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		return isReleased.get();
 	}
 
-	@Override
-	void notifySubpartitionConsumed() {
-		// Nothing to do
-	}
-
 	/**
 	 * Releases all exclusive and floating buffers, closes the partition request client.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -559,7 +559,6 @@ public class SingleInputGate extends InputGate {
 					markAvailable();
 				}
 
-				currentChannel.notifySubpartitionConsumed();
 				currentChannel.releaseAllResources();
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -108,10 +108,6 @@ class UnknownInputChannel extends InputChannel {
 	}
 
 	@Override
-	public void notifySubpartitionConsumed() {
-	}
-
-	@Override
 	public void releaseAllResources() throws IOException {
 		// Nothing to do here
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -109,7 +109,6 @@ public class CancelPartitionRequestTest {
 			}
 
 			verify(view, times(1)).releaseAllResources();
-			verify(view, times(1)).notifySubpartitionConsumed();
 		}
 		finally {
 			shutdown(serverAndClient);
@@ -168,7 +167,6 @@ public class CancelPartitionRequestTest {
 			NettyTestUtil.awaitClose(ch);
 
 			verify(view, times(1)).releaseAllResources();
-			verify(view, times(1)).notifySubpartitionConsumed();
 		}
 		finally {
 			shutdown(serverAndClient);
@@ -203,10 +201,6 @@ public class CancelPartitionRequestTest {
 		@Override
 		public void releaseAllResources() throws IOException {
 			sync.countDown();
-		}
-
-		@Override
-		public void notifySubpartitionConsumed() throws IOException {
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -137,7 +137,7 @@ public class ResultPartitionTest {
 		// a blocking partition that is not released on consumption should be consumable multiple times
 		for (int x = 0; x < 2; x++) {
 			ResultSubpartitionView subpartitionView1 = partition.createSubpartitionView(0, () -> {});
-			subpartitionView1.notifySubpartitionConsumed();
+			subpartitionView1.releaseAllResources();
 
 			// partition should not be released on consumption
 			assertThat(manager.getUnreleasedPartitions(), contains(partition.getPartitionId()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
@@ -146,10 +146,6 @@ public class InputChannelTest {
 		}
 
 		@Override
-		void notifySubpartitionConsumed() throws IOException {
-		}
-
-		@Override
 		void releaseAllResources() throws IOException {
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -155,11 +155,6 @@ public class TestInputChannel extends InputChannel {
 	}
 
 	@Override
-	void notifySubpartitionConsumed() throws IOException {
-
-	}
-
-	@Override
 	void releaseAllResources() throws IOException {
 
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionConsumer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionConsumer.java
@@ -112,7 +112,7 @@ public class TestSubpartitionConsumer implements Callable<Boolean>, BufferAvaila
 						bufferAndBacklog.buffer().recycleBuffer();
 
 						if (event.getClass() == EndOfPartitionEvent.class) {
-							subpartitionView.notifySubpartitionConsumed();
+							subpartitionView.releaseAllResources();
 
 							return true;
 						}


### PR DESCRIPTION
## What is the purpose of the change

*Currently the methods of `NetworkSequenceViewReader#notifySubpartitionConsumed` and `NetworkSequenceViewReader#releaseAllResources` would be called meanwhile in netty stack during releasing resources.*

*As confirmed in FLINK-13245, in order to make this release logic simple and clean, we could remove the redundant `notifySubpartitionConsumed` from `NetworkSequenceViewReader` side, and also remove it from `ResultSubpartitionView` side. In the implementation of `ResultSubpartitionView#releaseAllResources` it would further notify the parent subpartition of consumed state via `ResultSubpartition#notifySubpartitionConsumed` which further feedback to parent `ResultPartition` layer via `onConsumedSubpartition`. Finally `ResultPartition` could decide whether to release itself or not.*

*E.g. for the case of `ReleaseOnConsumptionResultPartition` which is mainly used for pipelined partition, it would release partition after reference counter decreased to
0. For the case of `ResultPartition` which would be generated for blocking partition by default, it would never be released after notifying consumed. And the JM/scheduler
would decide when to release partition properly. In addition, `InputChannel#notifySubpartitionConsumed` could also be removed as a result of above.*

## Brief change log

  - *Remove `notifySubpartitionConsumed` from `NetworkSequenceViewReader`*
  - *Remove `notifySubpartitionConsumed` from `ResultSubpartitionView`*
  - *Remove `notifySubpartitionConsumed` from `InputChannel`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
