### PR TITLE
[FLINK-13466][table-common] Uncouple batch factories from new source/sink stack

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSinkFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.table.sinks.BatchTableSink;
-import org.apache.flink.table.sinks.TableSink;
 
 import java.util.Map;
 
@@ -29,7 +28,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory consumes
  */
-public interface BatchTableSinkFactory<T> extends TableSinkFactory<T> {
+public interface BatchTableSinkFactory<T> extends TableFactory {
 
 	/**
 	 * Creates and configures a {@link BatchTableSink} using the given properties.
@@ -38,12 +37,4 @@ public interface BatchTableSinkFactory<T> extends TableSinkFactory<T> {
 	 * @return the configured table sink.
 	 */
 	BatchTableSink<T> createBatchTableSink(Map<String, String> properties);
-
-	/**
-	 * Only create batch table sink.
-	 */
-	@Override
-	default TableSink<T> createTableSink(Map<String, String> properties) {
-		return createBatchTableSink(properties);
-	}
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSourceFactory.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.sources.BatchTableSource;
-import org.apache.flink.table.sources.TableSource;
 
 import java.util.Map;
 
@@ -29,7 +29,8 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory produces
  */
-public interface BatchTableSourceFactory<T> extends TableSourceFactory<T> {
+@PublicEvolving
+public interface BatchTableSourceFactory<T> extends TableFactory {
 
 	/**
 	 * Creates and configures a {@link BatchTableSource} using the given properties.
@@ -38,12 +39,4 @@ public interface BatchTableSourceFactory<T> extends TableSourceFactory<T> {
 	 * @return the configured batch table source.
 	 */
 	BatchTableSource<T> createBatchTableSource(Map<String, String> properties);
-
-	/**
-	 * Only create batch table source.
-	 */
-	@Override
-	default TableSource<T> createTableSource(Map<String, String> properties) {
-		return createBatchTableSource(properties);
-	}
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSinkFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.sinks.StreamTableSink;
 import org.apache.flink.table.sinks.TableSink;
 
@@ -29,6 +30,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory consumes
  */
+@PublicEvolving
 public interface StreamTableSinkFactory<T> extends TableSinkFactory<T> {
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSourceFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 
@@ -29,6 +30,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory produces
  */
+@PublicEvolving
 public interface StreamTableSourceFactory<T> extends TableSourceFactory<T> {
 
 	/**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sinks/CsvBatchTableSinkFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sinks/CsvBatchTableSinkFactory.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.sinks
 
 import java.util
 
-import org.apache.flink.table.factories.BatchTableSinkFactory
+import org.apache.flink.table.factories.{BatchTableSinkFactory, StreamTableSinkFactory}
 import org.apache.flink.types.Row
 
 /**
@@ -28,11 +28,18 @@ import org.apache.flink.types.Row
   */
 class CsvBatchTableSinkFactory
   extends CsvTableSinkFactoryBase
-  with BatchTableSinkFactory[Row] {
+  with BatchTableSinkFactory[Row]
+  with StreamTableSinkFactory[Row] {
 
   override def createBatchTableSink(
       properties: util.Map[String, String])
     : BatchTableSink[Row] = {
+    createTableSink(isStreaming = false, properties)
+  }
+
+  override def createStreamTableSink(
+      properties: util.Map[String, String])
+    : StreamTableSink[Row] = {
     createTableSink(isStreaming = false, properties)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sources/CsvBatchTableSourceFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sources/CsvBatchTableSourceFactory.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.sources
 
 import java.util
 
-import org.apache.flink.table.factories.BatchTableSourceFactory
+import org.apache.flink.table.factories.{BatchTableSourceFactory, StreamTableSourceFactory}
 import org.apache.flink.types.Row
 
 /**
@@ -28,11 +28,18 @@ import org.apache.flink.types.Row
   */
 class CsvBatchTableSourceFactory
   extends CsvTableSourceFactoryBase
-  with BatchTableSourceFactory[Row] {
+  with BatchTableSourceFactory[Row]
+  with StreamTableSourceFactory[Row]{
 
   override def createBatchTableSource(
       properties: util.Map[String, String])
     : BatchTableSource[Row] = {
+    createTableSource(isStreaming = false, properties)
+  }
+
+  override def createStreamTableSource(
+      properties: util.Map[String, String])
+    : StreamTableSource[Row] = {
     createTableSource(isStreaming = false, properties)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

This allows to implement a factory for both batch and streaming sources for both planners. It also updates the CSV factories to test the functionality.

## Brief change log

See commit messages.

## Verifying this change

This change is already covered by existing tests, such as `TableDescriptorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
