### PR TITLE
[FLINK-13192][hive] Add tests for different Hive table formats

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -416,10 +416,6 @@ under the License.
 					<artifactId>tez-common</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>org.apache.tez</groupId>
-					<artifactId>tez-mapreduce</artifactId>
-				</exclusion>
-				<exclusion>
 					<!-- This dependency is no longer shipped with the JDK since Java 9.-->
 					<groupId>jdk.tools</groupId>
 					<artifactId>jdk.tools</artifactId>

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableOutputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableOutputFormat.java
@@ -259,9 +259,10 @@ public class HiveTableOutputFormat extends HadoopOutputFormatCommonBase<Row> imp
 	public void open(int taskNumber, int numTasks) throws IOException {
 		try {
 			StorageDescriptor sd = hiveTablePartition.getStorageDescriptor();
-			recordSerDe = (Serializer) Class.forName(sd.getSerdeInfo().getSerializationLib()).newInstance();
-			Preconditions.checkArgument(recordSerDe instanceof Deserializer,
-					"Expect to get a SerDe, but actually got " + recordSerDe.getClass().getName());
+			Object serdeLib = Class.forName(sd.getSerdeInfo().getSerializationLib()).newInstance();
+			Preconditions.checkArgument(serdeLib instanceof Serializer && serdeLib instanceof Deserializer,
+					"Expect a SerDe lib implementing both Serializer and Deserializer, but actually got " + serdeLib.getClass().getName());
+			recordSerDe = (Serializer) serdeLib;
 			ReflectionUtils.setConf(recordSerDe, jobConf);
 			// TODO: support partition properties, for now assume they're same as table properties
 			SerDeUtils.initializeSerDe((Deserializer) recordSerDe, jobConf, tableProperties, null);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
@@ -116,8 +116,14 @@ public class TableEnvHiveConnectorTest {
 		hiveShell.execute("create database db1");
 
 		// create source and dest tables
-		hiveShell.execute("create table db1.src (i int,s string) stored as " + format);
-		hiveShell.execute("create table db1.dest (i int,s string) stored as " + format);
+		String suffix;
+		if (format.equals("csv")) {
+			suffix = "row format serde 'org.apache.hadoop.hive.serde2.OpenCSVSerde'";
+		} else {
+			suffix = "stored as " + format;
+		}
+		hiveShell.execute("create table db1.src (i int,s string) " + suffix);
+		hiveShell.execute("create table db1.dest (i int,s string) " + suffix);
 
 		// prepare source data with Hive
 		hiveShell.execute("insert into db1.src values (1,'a'),(2,'b')");

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -100,10 +102,44 @@ public class TableEnvHiveConnectorTest {
 		hiveShell.execute("drop database db1 cascade");
 	}
 
+	@Test
+	public void testDifferentFormats() throws Exception {
+		String[] formats = new String[]{"orc", "parquet", "sequencefile"};
+		for (String format : formats) {
+			readWriteFormat(format);
+		}
+	}
+
+	private void readWriteFormat(String format) throws Exception {
+		TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
+
+		hiveShell.execute("create database db1");
+
+		// create source and dest tables
+		hiveShell.execute("create table db1.src (i int,s string) stored as " + format);
+		hiveShell.execute("create table db1.dest (i int,s string) stored as " + format);
+
+		// prepare source data with Hive
+		hiveShell.execute("insert into db1.src values (1,'a'),(2,'b')");
+
+		// populate dest table with source table
+		tableEnv.sqlUpdate("insert into db1.dest select * from db1.src");
+		tableEnv.execute("test_" + format);
+
+		// verify data on hive side
+		verifyHiveQueryResult("select * from db1.dest", Arrays.asList("1\ta", "2\tb"));
+
+		hiveShell.execute("drop database db1 cascade");
+	}
+
 	private TableEnvironment getTableEnvWithHiveCatalog() {
 		TableEnvironment tableEnv = HiveTestUtils.createTableEnv();
 		tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
 		tableEnv.useCatalog(hiveCatalog.getName());
 		return tableEnv;
+	}
+
+	private void verifyHiveQueryResult(String query, List<String> expected) {
+		assertEquals(new HashSet<>(expected), new HashSet<>(hiveShell.executeQuery(query)));
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
@@ -104,7 +104,7 @@ public class TableEnvHiveConnectorTest {
 
 	@Test
 	public void testDifferentFormats() throws Exception {
-		String[] formats = new String[]{"orc", "parquet", "sequencefile"};
+		String[] formats = new String[]{"orc", "parquet", "sequencefile", "csv"};
 		for (String format : formats) {
 			readWriteFormat(format);
 		}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

To add test for different table storage formats and fix issue with `HiveTableOutputFormat`.


## Brief change log

  - Make sure to use a common base class of the SerDe to support Hive 2.3.4 and 1.2.1.
  - Include some hadoop dependencies in test since hive runner needs to run MR job
  - Add tests for different table formats.


## Verifying this change

Added new test cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
