### PR TITLE
[FLINK-13477][core] Add `memory-overhead-ratio` conf for containers

### DIFF
--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -18,6 +18,11 @@
             <td>Percentage of heap space to remove from containers (YARN / Mesos), to compensate for other JVM memory usage.</td>
         </tr>
         <tr>
+            <td><h5>containerized.memory-overhead-ratio</h5></td>
+            <td style="word-wrap: break-word;">0.0</td>
+            <td>Percentage of the container memory (YARN / Mesos) to keep unallocated (not used for JVM heap memory or JVM off-heap direct memory).</td>
+        </tr>
+        <tr>
             <td><h5>local.number-resourcemanager</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>The number of resource managers start.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -56,6 +56,16 @@ public class ResourceManagerOptions {
 			" Its not possible to use this configuration key to define port ranges.");
 
 	/**
+	 * Percentage of the container memory (YARN / Mesos) to keep unallocated (not used for JVM heap memory
+	 * or JVM off-heap direct memory).
+	 */
+	public static final ConfigOption<Float> CONTAINERIZED_MEMORY_OVERHEAD_RATIO = ConfigOptions
+		.key("containerized.memory-overhead-ratio")
+		.defaultValue(0f)
+		.withDescription("Percentage of the container memory (YARN / Mesos) to keep unallocated (not used for" +
+			" JVM heap memory or JVM off-heap direct memory).");
+
+	/**
 	 * Percentage of heap space to remove from containers (YARN / Mesos), to compensate
 	 * for other JVM memory usage.
 	 */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParametersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParametersTest.java
@@ -71,6 +71,22 @@ public class ContaineredTaskManagerParametersTest extends TestLogger {
 	}
 
 	/**
+	 * This tests that the memory allocate honors the required memory overhead.
+	 */
+	@Test
+	public void testUsableMemory() {
+		Configuration conf = new Configuration();
+		conf.setFloat(ResourceManagerOptions.CONTAINERIZED_MEMORY_OVERHEAD_RATIO, 0.1f);
+
+		ContaineredTaskManagerParameters params =
+			ContaineredTaskManagerParameters.create(conf, CONTAINER_MEMORY, 1);
+
+		assertEquals(params.taskManagerTotalMemoryMB(), CONTAINER_MEMORY);
+		assertEquals(params.taskManagerHeapSizeMB() + params.taskManagerDirectMemoryLimitMB(),
+			0.9f * params.taskManagerTotalMemoryMB(), 1f);
+	}
+
+	/**
 	 * This tests that when using off-heap memory the sum of on and off heap memory does not exceed the container
 	 * maximum.
 	 */


### PR DESCRIPTION
## What is the purpose of the change

Currently, the `-XX:MaxDirectMemorySize` parameter is set as:
`MaxDirectMemorySize = containerMemoryMB - heapSizeMB`

However as explained at
https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html,
`MaxDirectMemorySize` only sets the maximum amount of memory that can be
used for direct buffers, thus the amount of off-heap memory used can be
greater than that value, leading to the sum of heap + off-heap memory used being
higher than the allocated container memory and the container being killed by Yarn
or Mesos for that reason.

In addition, users might want to allocate off-heap memory through native
code, in which case they will want to keep some of the container memory
free and unallocated by Flink.

This PR introduces the `containerized.memory-overhead-ratio` config to allow keeping some of the container memory free. With this change, the heap and direct memory sizes are computed as fractions of the usable memory, with `usableMemoryMB = containerMemoryMB * (1 - overheadRatio)` instead of on the full container memory. The overhead ratio default value is 0 to keep the current behavior.

## Brief change log

  - *Add `containerized.memory-overhead-ratio` config to allow keeping some of the container memory free (default is 0 to keep the current behavior)*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added `testUsableMemory` unit test to ensure memory-overhead-ratio is honored in `ContainerTaskManagerParametersTest.java`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs 
