### PR TITLE
 [FLINK-13273][sql-client] Allow switching planners in SQL Client

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -199,9 +199,24 @@ functions:
       - 7.6
       - false
 
+# Define available catalogs
+
+catalogs:
+   - name: catalog_1
+     type: hive
+     property-version: 1
+     hive-conf-dir: ...
+   - name: catalog_2
+     type: hive
+     property-version: 1
+     default-database: mydb2
+     hive-conf-dir: ...
+     hive-version: 1.2.1
+
 # Execution properties allow for changing the behavior of a table program.
 
 execution:
+  planner: old                      # optional: either 'old' (default) or 'blink'
   type: streaming                   # required: execution mode either 'batch' or 'streaming'
   result-mode: table                # required: either 'table' or 'changelog'
   max-table-result-rows: 1000000    # optional: maximum number of maintained rows in
@@ -212,29 +227,16 @@ execution:
   max-parallelism: 16               # optional: Flink's maximum parallelism (128 by default)
   min-idle-state-retention: 0       # optional: table program's minimum idle state time
   max-idle-state-retention: 0       # optional: table program's maximum idle state time
+  current-catalog: catalog_1        # optional: name of the current catalog of the session ('default_catalog' by default)
+  current-database: mydb1           # optional: name of the current database of the current catalog
+                                    #   (default database of the current catalog by default)
   restart-strategy:                 # optional: restart strategy
     type: fallback                  #   "fallback" to global restart strategy by default
-  current-catalog: catalog_1        # optional: name of the current catalog of the session ("default_catalog" by default)
-  current-database: mydb1           # optional: name of the current database of the current catalog (default value is the default database name of the current catalog)
 
 # Deployment properties allow for describing the cluster to which table programs are submitted to.
 
 deployment:
   response-timeout: 5000
-
-# Catalogs
-
-catalogs:
-   - name: catalog_1
-     type: hive
-     property-version: 1
-     hive-conf-dir: ...
-   - name: catalog_2
-     type: hive
-     property-version: 1
-     default-database: mydb2        # optional: name of default database of this catalog
-     hive-conf-dir: ...             # optional: path of Hive conf directory. (Default value is created by HiveConf)
-     hive-version: 1.2.1            # optional: version of Hive (2.3.4 by default)
 {% endhighlight %}
 
 This configuration:
@@ -242,11 +244,10 @@ This configuration:
 - defines an environment with a table source `MyTableSource` that reads from a CSV file,
 - defines a view `MyCustomView` that declares a virtual table using a SQL query,
 - defines a user-defined function `myUDF` that can be instantiated using the class name and two constructor parameters,
+- connects to two Hive catalogs and uses `catalog_1` as the current catalog with `mydb1` as the current database of the catalog,
 - specifies a parallelism of 1 for queries executed in this streaming environment,
 - specifies an event-time characteristic, and
 - runs queries in the `table` result mode.
-- creates two `HiveCatalog` (type: hive) named with their own default databases and specified Hive conf directory. Hive version of the first `HiveCatalog` is `2.3.4` by default and that of the second one is specified as `1.2.1`.
-- use `catalog_1` as the current catalog of the environment upon start, and `mydb1` as the current database of the catalog.
 
 Depending on the use case, a configuration can be split into multiple files. Therefore, environment files can be created for general purposes (*defaults environment file* using `--defaults`) as well as on a per-session basis (*session environment file* using `--environment`). Every CLI session is initialized with the default properties followed by the session properties. For example, the defaults environment file could specify all table sources that should be available for querying in every session whereas the session environment file only declares a specific state retention time and parallelism. Both default and session environment files can be passed when starting the CLI application. If no default environment file has been specified, the SQL Client searches for `./conf/sql-client-defaults.yaml` in Flink's configuration directory.
 
@@ -431,16 +432,11 @@ This process can be recursively performed until all the constructor parameters a
 Catalogs
 --------
 
-Catalogs can be defined as a set of yaml properties and are automatically registered to the environment upon starting SQL Client.
+Catalogs can be defined as a set of YAML properties and are automatically registered to the environment upon starting SQL Client.
 
-Users can specify in section `execution` that which catalog they want to use as the current catalog in SQL CLI, and which database of the catalog they want to use as the current database. 
+Users can specify which catalog they want to use as the current catalog in SQL CLI, and which database of the catalog they want to use as the current database.
 
 {% highlight yaml %}
-execution:
-   ...
-   current-catalog: catalog_1
-   current-database: mydb1
-
 catalogs:
    - name: catalog_1
      type: hive
@@ -452,9 +448,12 @@ catalogs:
      type: hive
      property-version: 1
      hive-conf-dir: <path of Hive conf directory>
-{% endhighlight %}
 
-Currently Flink supports two types of catalog - `FlinkInMemoryCatalog` and `HiveCatalog`.
+execution:
+   ...
+   current-catalog: catalog_1
+   current-database: mydb1
+{% endhighlight %}
 
 For more information about catalog, see [Catalogs]({{ site.baseurl }}/dev/table/catalog.html).
 

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -143,7 +143,8 @@ run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_D
 run_test "State TTL Heap backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh file"
 run_test "State TTL RocksDb backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh rocks"
 
-run_test "SQL Client end-to-end test" "$END_TO_END_DIR/test-scripts/test_sql_client.sh"
+run_test "SQL Client end-to-end test (Old planner)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh old"
+run_test "SQL Client end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh blink"
 run_test "SQL Client end-to-end test for Kafka 0.10" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka010.sh"
 run_test "SQL Client end-to-end test for Kafka 0.11" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka011.sh"
 run_test "SQL Client end-to-end test for modern Kafka" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka.sh"

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -60,6 +60,8 @@ run_test "Modern Kafka end-to-end test" "$END_TO_END_DIR/test-scripts/test_strea
 run_test "Kinesis end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_kinesis.sh"
 run_test "class loading end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_classloader.sh"
 run_test "Distributed cache end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh"
+run_test "SQL Client end-to-end test (Old planner)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh old"
+run_test "SQL Client end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh blink"
 
 printf "\n[PASS] All tests passed\n"
 exit 0

--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -92,8 +92,8 @@ function verify_result_hash {
     echo "Result verification attempt $i..."
     curl "localhost:9200/${index}/_search?q=*&pretty" > $TEST_DATA_DIR/es_output || true
 
-    # remove meta information
-    sed '2,9d' $TEST_DATA_DIR/es_output > $TEST_DATA_DIR/es_content
+    # remove meta information and sort for determinism
+    sed '2,9d' $TEST_DATA_DIR/es_output | sort > $TEST_DATA_DIR/es_content
 
     check_result_hash_no_exit "$name" $TEST_DATA_DIR/es_content "$expectedHash" || error_code=$?
 

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -19,6 +19,8 @@
 
 set -Eeuo pipefail
 
+PLANNER="${1:-old}"
+
 KAFKA_VERSION="2.2.0"
 CONFLUENT_VERSION="5.0.0"
 CONFLUENT_MAJOR_VERSION="5.0"
@@ -185,6 +187,9 @@ functions:
   - name: RegReplace
     from: class
     class: org.apache.flink.table.toolbox.StringRegexReplaceFunction
+
+execution:
+  planner: "$PLANNER"
 EOF
 
 # submit SQL statements
@@ -208,7 +213,7 @@ JOB_ID=$($FLINK_DIR/bin/sql-client.sh embedded \
 
 wait_job_terminal_state "$JOB_ID" "FINISHED"
 
-verify_result_hash "SQL Client Elasticsearch Upsert" "$ELASTICSEARCH_INDEX" 3 "982cb32908def9801e781381c1b8a8db"
+verify_result_hash "SQL Client Elasticsearch Upsert" "$ELASTICSEARCH_INDEX" 3 "f16e8da8e0f379b6af01dcdc00cff4e1"
 
 echo "Executing SQL: Values -> Elasticsearch (append, no key)"
 

--- a/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
@@ -50,6 +50,7 @@ tables: [] # empty list
 #   time-attribute: ...
 #   primary-key: ...
 
+
 #==============================================================================
 # User-defined functions
 #==============================================================================
@@ -63,6 +64,21 @@ functions: [] # empty list
 #   class: ...
 #   constructor: ...
 
+
+#==============================================================================
+# Catalogs
+#==============================================================================
+
+# Define catalogs here.
+
+catalogs: [] # empty list
+# A typical catalog definition looks like:
+#  - name: myhive
+#    type: hive
+#    hive-conf-dir: /opt/hive_conf/
+#    default-database: ...
+
+
 #==============================================================================
 # Execution properties
 #==============================================================================
@@ -70,6 +86,9 @@ functions: [] # empty list
 # Execution properties allow for changing the behavior of a table program.
 
 execution:
+  # select the implementation responsible for planning table programs
+  # possible values are 'old' (used by default) or 'blink'
+  planner: old
   # 'batch' or 'streaming' execution
   type: streaming
   # allow 'event-time' or only 'processing-time' in sources
@@ -88,15 +107,15 @@ execution:
   min-idle-state-retention: 0
   # maximum idle state retention in ms
   max-idle-state-retention: 0
+  # current catalog ('default_catalog' by default)
+  current-catalog: default_catalog
+  # current database of the current catalog (default database of the catalog by default)
+  current-database: default_database
   # controls how table programs are restarted in case of a failures
   restart-strategy:
     # strategy type
     # possible values are "fixed-delay", "failure-rate", "none", or "fallback" (default)
     type: fallback
-  # current catalog of SQL Client
-#  current-catalog: ...
-  # current database of the current catalog
-#  current-database: ...
 
 
 #==============================================================================
@@ -113,16 +132,3 @@ deployment:
   gateway-address: ""
   # (optional) port from cluster to gateway
   gateway-port: 0
-
-
-#==============================================================================
-# Catalogs
-#==============================================================================
-
-# Define catalogs here.
-
-catalogs: [] # empty list
-#  - name: myhive
-#    type: hive
-#    hive-conf-dir: /opt/hive_conf/
-#    default-database: ...

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -90,6 +90,18 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- logging utilities -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -518,9 +530,11 @@ under the License.
 									<include>org.apache.flink:flink-table-common</include>
 									<include>org.apache.flink:flink-table-api-java</include>
 									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>
-									<include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
-									<include>org.apache.flink:flink-cep_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-sql-parser</include>
+									<include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-table-planner-blink_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-table-runtime-blink_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-cep_${scala.binary.version}</include>
 									<include>org.jline:*</include>
 								</includes>
 							</artifactSet>

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ExecutionEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ExecutionEntry.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.client.config.entries;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.client.config.ConfigUtil;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.descriptors.DescriptorProperties;
@@ -48,6 +49,12 @@ public class ExecutionEntry extends ConfigEntry {
 
 	public static final ExecutionEntry DEFAULT_INSTANCE =
 		new ExecutionEntry(new DescriptorProperties(true));
+
+	private static final String EXECUTION_PLANNER = "planner";
+
+	public static final String EXECUTION_PLANNER_VALUE_OLD = "old";
+
+	public static final String EXECUTION_PLANNER_VALUE_BLINK = "blink";
 
 	private static final String EXECUTION_TYPE = "type";
 
@@ -97,9 +104,9 @@ public class ExecutionEntry extends ConfigEntry {
 
 	private static final String EXECUTION_RESTART_STRATEGY_MAX_FAILURES_PER_INTERVAL = "restart-strategy.max-failures-per-interval";
 
-	public static final String EXECUTION_CURRNET_CATALOG = "current-catalog";
+	public static final String EXECUTION_CURRENT_CATALOG = "current-catalog";
 
-	public static final String EXECUTION_CURRNET_DATABASE = "current-database";
+	public static final String EXECUTION_CURRENT_DATABASE = "current-database";
 
 	private ExecutionEntry(DescriptorProperties properties) {
 		super(properties);
@@ -107,6 +114,12 @@ public class ExecutionEntry extends ConfigEntry {
 
 	@Override
 	protected void validate(DescriptorProperties properties) {
+		properties.validateEnumValues(
+			EXECUTION_PLANNER,
+			true,
+			Arrays.asList(
+				EXECUTION_PLANNER_VALUE_OLD,
+				EXECUTION_PLANNER_VALUE_BLINK));
 		properties.validateEnumValues(
 			EXECUTION_TYPE,
 			true,
@@ -137,20 +150,73 @@ public class ExecutionEntry extends ConfigEntry {
 		properties.validateLong(EXECUTION_RESTART_STRATEGY_DELAY, true, 0);
 		properties.validateLong(EXECUTION_RESTART_STRATEGY_FAILURE_RATE_INTERVAL, true, 1);
 		properties.validateInt(EXECUTION_RESTART_STRATEGY_MAX_FAILURES_PER_INTERVAL, true, 1);
-		properties.validateString(EXECUTION_CURRNET_CATALOG, true, 1);
-		properties.validateString(EXECUTION_CURRNET_DATABASE, true, 1);
+		properties.validateString(EXECUTION_CURRENT_CATALOG, true, 1);
+		properties.validateString(EXECUTION_CURRENT_DATABASE, true, 1);
 	}
 
-	public boolean isStreamingExecution() {
-		return properties.getOptionalString(EXECUTION_TYPE)
-			.map((v) -> v.equals(EXECUTION_TYPE_VALUE_STREAMING))
-			.orElse(false);
+	public EnvironmentSettings getEnvironmentSettings() {
+		final EnvironmentSettings.Builder builder = EnvironmentSettings.newInstance();
+
+		if (inStreamingMode()) {
+			builder.inStreamingMode();
+		} else if (inBatchMode()) {
+			builder.inBatchMode();
+		}
+
+		final String planner = properties.getOptionalString(EXECUTION_PLANNER)
+			.orElse(EXECUTION_PLANNER_VALUE_OLD);
+
+		if (planner.equals(EXECUTION_PLANNER_VALUE_OLD)) {
+			builder.useOldPlanner();
+		} else if (planner.equals(EXECUTION_PLANNER_VALUE_BLINK)) {
+			builder.useBlinkPlanner();
+		}
+
+		return builder.build();
 	}
 
-	public boolean isBatchExecution() {
+	public boolean inStreamingMode() {
 		return properties.getOptionalString(EXECUTION_TYPE)
-			.map((v) -> v.equals(EXECUTION_TYPE_VALUE_BATCH))
-			.orElse(false);
+				.map((v) -> v.equals(EXECUTION_TYPE_VALUE_STREAMING))
+				.orElse(false);
+	}
+
+	public boolean inBatchMode() {
+		return properties.getOptionalString(EXECUTION_TYPE)
+				.map((v) -> v.equals(EXECUTION_TYPE_VALUE_BATCH))
+				.orElse(false);
+	}
+
+	public boolean isStreamingPlanner() {
+		final String planner = properties.getOptionalString(EXECUTION_PLANNER)
+			.orElse(EXECUTION_PLANNER_VALUE_OLD);
+
+		// Blink planner is a streaming planner
+		if (planner.equals(EXECUTION_PLANNER_VALUE_BLINK)) {
+			return true;
+		}
+		// Old planner can be a streaming or batch planner
+		else if (planner.equals(EXECUTION_PLANNER_VALUE_OLD)) {
+			return inStreamingMode();
+		}
+
+		return false;
+	}
+
+	public boolean isBatchPlanner() {
+		final String planner = properties.getOptionalString(EXECUTION_PLANNER)
+			.orElse(EXECUTION_PLANNER_VALUE_OLD);
+
+		// Blink planner is not a batch planner
+		if (planner.equals(EXECUTION_PLANNER_VALUE_BLINK)) {
+			return false;
+		}
+		// Old planner can be a streaming or batch planner
+		else if (planner.equals(EXECUTION_PLANNER_VALUE_OLD)) {
+			return inBatchMode();
+		}
+
+		return false;
 	}
 
 	public TimeCharacteristic getTimeCharacteristic() {
@@ -237,11 +303,11 @@ public class ExecutionEntry extends ConfigEntry {
 	}
 
 	public Optional<String> getCurrentCatalog() {
-		return properties.getOptionalString(EXECUTION_CURRNET_CATALOG);
+		return properties.getOptionalString(EXECUTION_CURRENT_CATALOG);
 	}
 
 	public Optional<String> getCurrentDatabase() {
-		return properties.getOptionalString(EXECUTION_CURRNET_DATABASE);
+		return properties.getOptionalString(EXECUTION_CURRENT_DATABASE);
 	}
 
 	public boolean isChangelogMode() {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
@@ -79,23 +79,23 @@ public class SessionContext {
 	}
 
 	public Optional<String> getCurrentCatalog() {
-		return Optional.ofNullable(sessionProperties.get(ExecutionEntry.EXECUTION_CURRNET_CATALOG));
+		return Optional.ofNullable(sessionProperties.get(ExecutionEntry.EXECUTION_CURRENT_CATALOG));
 	}
 
 	public void setCurrentCatalog(String currentCatalog) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(currentCatalog));
 
-		sessionProperties.put(ExecutionEntry.EXECUTION_CURRNET_CATALOG, currentCatalog);
+		sessionProperties.put(ExecutionEntry.EXECUTION_CURRENT_CATALOG, currentCatalog);
 	}
 
 	public Optional<String> getCurrentDatabase() {
-		return Optional.ofNullable(sessionProperties.get(ExecutionEntry.EXECUTION_CURRNET_DATABASE));
+		return Optional.ofNullable(sessionProperties.get(ExecutionEntry.EXECUTION_CURRENT_DATABASE));
 	}
 
 	public void setCurrentDatabase(String currentDatabase) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(currentDatabase));
 
-		sessionProperties.put(ExecutionEntry.EXECUTION_CURRNET_DATABASE, currentDatabase);
+		sessionProperties.put(ExecutionEntry.EXECUTION_CURRENT_DATABASE, currentDatabase);
 	}
 
 	public Environment getEnvironment() {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
@@ -18,18 +18,20 @@
 
 package org.apache.flink.table.client.gateway.local;
 
+import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.table.sinks.BatchTableSink;
+import org.apache.flink.table.sinks.OutputFormatTableSink;
 import org.apache.flink.types.Row;
 
 /**
  * Table sink for collecting the results locally all at once using accumulators.
  */
-public class CollectBatchTableSink implements BatchTableSink<Row> {
+public class CollectBatchTableSink extends OutputFormatTableSink<Row> implements BatchTableSink<Row> {
 
 	private final String accumulatorName;
 	private final TypeSerializer<Row> serializer;
@@ -40,6 +42,13 @@ public class CollectBatchTableSink implements BatchTableSink<Row> {
 	public CollectBatchTableSink(String accumulatorName, TypeSerializer<Row> serializer) {
 		this.accumulatorName = accumulatorName;
 		this.serializer = serializer;
+	}
+
+	/**
+	 * Returns the serializer for deserializing the collected result.
+	 */
+	public TypeSerializer<Row> getSerializer() {
+		return serializer;
 	}
 
 	@Override
@@ -72,10 +81,8 @@ public class CollectBatchTableSink implements BatchTableSink<Row> {
 			.name("SQL Client Batch Collect Sink");
 	}
 
-	/**
-	 * Returns the serializer for deserializing the collected result.
-	 */
-	public TypeSerializer<Row> getSerializer() {
-		return serializer;
+	@Override
+	public OutputFormat<Row> getOutputFormat() {
+		return new Utils.CollectHelper<>(accumulatorName, serializer);
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.experimental.CollectSink;
 import org.apache.flink.table.sinks.RetractStreamTableSink;
 import org.apache.flink.types.Row;
@@ -73,8 +74,13 @@ public class CollectStreamTableSink implements RetractStreamTableSink<Row> {
 
 	@Override
 	public void emitDataStream(DataStream<Tuple2<Boolean, Row>> stream) {
+		consumeDataStream(stream);
+	}
+
+	@Override
+	public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, Row>> stream) {
 		// add sink
-		stream
+		return stream
 			.addSink(new CollectSink<>(targetAddress, targetPort, serializer))
 			.name("SQL Client Stream Collect Sink")
 			.setParallelism(1);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -39,13 +39,20 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.BatchQueryConfig;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.QueryConfig;
 import org.apache.flink.table.api.StreamQueryConfig;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.api.java.internal.StreamTableEnvironmentImpl;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.DeploymentEntry;
 import org.apache.flink.table.client.config.entries.ExecutionEntry;
@@ -56,17 +63,23 @@ import org.apache.flink.table.client.config.entries.TemporalTableEntry;
 import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.delegation.Executor;
+import org.apache.flink.table.delegation.ExecutorFactory;
+import org.apache.flink.table.delegation.Planner;
+import org.apache.flink.table.delegation.PlannerFactory;
 import org.apache.flink.table.factories.BatchTableSinkFactory;
 import org.apache.flink.table.factories.BatchTableSourceFactory;
 import org.apache.flink.table.factories.CatalogFactory;
-import org.apache.flink.table.factories.StreamTableSinkFactory;
-import org.apache.flink.table.factories.StreamTableSourceFactory;
+import org.apache.flink.table.factories.ComponentFactoryService;
 import org.apache.flink.table.factories.TableFactoryService;
+import org.apache.flink.table.factories.TableSinkFactory;
+import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.FunctionService;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.planner.delegation.ExecutorBase;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.util.FlinkException;
@@ -74,6 +87,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -246,11 +260,11 @@ public class ExecutionContext<T> {
 	}
 
 	private static TableSource<?> createTableSource(ExecutionEntry execution, Map<String, String> sourceProperties, ClassLoader classLoader) {
-		if (execution.isStreamingExecution()) {
-			final StreamTableSourceFactory<?> factory = (StreamTableSourceFactory<?>)
-				TableFactoryService.find(StreamTableSourceFactory.class, sourceProperties, classLoader);
-			return factory.createStreamTableSource(sourceProperties);
-		} else if (execution.isBatchExecution()) {
+		if (execution.isStreamingPlanner()) {
+			final TableSourceFactory<?> factory = (TableSourceFactory<?>)
+				TableFactoryService.find(TableSourceFactory.class, sourceProperties, classLoader);
+			return factory.createTableSource(sourceProperties);
+		} else if (execution.isBatchPlanner()) {
 			final BatchTableSourceFactory<?> factory = (BatchTableSourceFactory<?>)
 				TableFactoryService.find(BatchTableSourceFactory.class, sourceProperties, classLoader);
 			return factory.createBatchTableSource(sourceProperties);
@@ -259,16 +273,63 @@ public class ExecutionContext<T> {
 	}
 
 	private static TableSink<?> createTableSink(ExecutionEntry execution, Map<String, String> sinkProperties, ClassLoader classLoader) {
-		if (execution.isStreamingExecution()) {
-			final StreamTableSinkFactory<?> factory = (StreamTableSinkFactory<?>)
-				TableFactoryService.find(StreamTableSinkFactory.class, sinkProperties, classLoader);
-			return factory.createStreamTableSink(sinkProperties);
-		} else if (execution.isBatchExecution()) {
+		if (execution.isStreamingPlanner()) {
+			final TableSinkFactory<?> factory = (TableSinkFactory<?>)
+				TableFactoryService.find(TableSinkFactory.class, sinkProperties, classLoader);
+			return factory.createTableSink(sinkProperties);
+		} else if (execution.isBatchPlanner()) {
 			final BatchTableSinkFactory<?> factory = (BatchTableSinkFactory<?>)
 				TableFactoryService.find(BatchTableSinkFactory.class, sinkProperties, classLoader);
 			return factory.createBatchTableSink(sinkProperties);
 		}
 		throw new SqlExecutionException("Unsupported execution type for sinks.");
+	}
+
+	private static TableEnvironment createStreamTableEnvironment(
+			StreamExecutionEnvironment env,
+			EnvironmentSettings settings,
+			Executor executor) {
+
+		final TableConfig config = TableConfig.getDefault();
+
+		final CatalogManager catalogManager = new CatalogManager(
+			settings.getBuiltInCatalogName(),
+			new GenericInMemoryCatalog(settings.getBuiltInCatalogName(), settings.getBuiltInDatabaseName()));
+
+		final FunctionCatalog functionCatalog = new FunctionCatalog(catalogManager);
+
+		final Map<String, String> plannerProperties = settings.toPlannerProperties();
+		final Planner planner = ComponentFactoryService.find(PlannerFactory.class, plannerProperties)
+			.create(plannerProperties, executor, config, functionCatalog, catalogManager);
+
+		return new StreamTableEnvironmentImpl(
+			catalogManager,
+			functionCatalog,
+			config,
+			env,
+			planner,
+			executor,
+			settings.isStreamingMode()
+		);
+	}
+
+	private static Executor lookupExecutor(
+			Map<String, String> executorProperties,
+			StreamExecutionEnvironment executionEnvironment) {
+		try {
+			ExecutorFactory executorFactory = ComponentFactoryService.find(ExecutorFactory.class, executorProperties);
+			Method createMethod = executorFactory.getClass()
+				.getMethod("create", Map.class, StreamExecutionEnvironment.class);
+
+			return (Executor) createMethod.invoke(
+				executorFactory,
+				executorProperties,
+				executionEnvironment);
+		} catch (Exception e) {
+			throw new TableException(
+				"Could not instantiate the executor. Make sure a planner module is on the classpath",
+				e);
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -283,17 +344,25 @@ public class ExecutionContext<T> {
 		private final QueryConfig queryConfig;
 		private final ExecutionEnvironment execEnv;
 		private final StreamExecutionEnvironment streamExecEnv;
+		private final Executor executor;
 		private final TableEnvironment tableEnv;
 
 		private EnvironmentInstance() {
+			// create settings
+			final EnvironmentSettings settings = mergedEnv.getExecution().getEnvironmentSettings();
+
 			// create environments
-			if (mergedEnv.getExecution().isStreamingExecution()) {
+			if (mergedEnv.getExecution().isStreamingPlanner()) {
 				streamExecEnv = createStreamExecutionEnvironment();
 				execEnv = null;
-				tableEnv = StreamTableEnvironment.create(streamExecEnv);
-			} else if (mergedEnv.getExecution().isBatchExecution()) {
+
+				final Map<String, String> executorProperties = settings.toExecutorProperties();
+				executor = lookupExecutor(executorProperties, streamExecEnv);
+				tableEnv = createStreamTableEnvironment(streamExecEnv, settings, executor);
+			} else if (mergedEnv.getExecution().isBatchPlanner()) {
 				streamExecEnv = null;
 				execEnv = createExecutionEnvironment();
+				executor = null;
 				tableEnv = BatchTableEnvironment.create(execEnv);
 			} else {
 				throw new SqlExecutionException("Unsupported execution type specified.");
@@ -378,6 +447,11 @@ public class ExecutionContext<T> {
 
 		private FlinkPlan createPlan(String name, Configuration flinkConfig) {
 			if (streamExecEnv != null) {
+				// special case for Blink planner to apply batch optimizations
+				// note: it also modifies the ExecutionConfig!
+				if (executor instanceof ExecutorBase) {
+					return ((ExecutorBase) executor).generateStreamGraph(name);
+				}
 				return streamExecEnv.getStreamGraph(name);
 			} else {
 				final int parallelism = execEnv.getParallelism();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -39,7 +39,6 @@ import org.apache.flink.table.api.StreamQueryConfig;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.internal.TableEnvImpl;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.calcite.FlinkTypeFactory;
 import org.apache.flink.table.client.SqlClientException;
@@ -301,7 +300,7 @@ public class LocalExecutor implements Executor {
 
 		try {
 			return context.wrapClassLoader(() ->
-				Arrays.asList(((TableEnvImpl) tableEnv).getCompletionHints(statement, position)));
+				Arrays.asList(tableEnv.getCompletionHints(statement, position)));
 		} catch (Throwable t) {
 			// catch everything such that the query does not crash the executor
 			if (LOG.isDebugEnabled()) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -61,7 +61,7 @@ public class ResultStore {
 
 		final RowTypeInfo outputType = new RowTypeInfo(schema.getFieldTypes(), schema.getFieldNames());
 
-		if (env.getExecution().isStreamingExecution()) {
+		if (env.getExecution().inStreamingMode()) {
 			// determine gateway address (and port if possible)
 			final InetAddress gatewayAddress = getGatewayAddress(env.getDeployment());
 			final int gatewayPort = getGatewayPort(env.getDeployment());

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
@@ -51,6 +51,7 @@ public class EnvironmentTest {
 	@Test
 	public void testMerging() throws Exception {
 		final Map<String, String> replaceVars1 = new HashMap<>();
+		replaceVars1.put("$VAR_PLANNER", "old");
 		replaceVars1.put("$VAR_EXECUTION_TYPE", "batch");
 		replaceVars1.put("$VAR_RESULT_MODE", "table");
 		replaceVars1.put("$VAR_UPDATE_MODE", "");
@@ -76,7 +77,7 @@ public class EnvironmentTest {
 		tables.add("TestView2");
 
 		assertEquals(tables, merged.getTables().keySet());
-		assertTrue(merged.getExecution().isStreamingExecution());
+		assertTrue(merged.getExecution().inStreamingMode());
 		assertEquals(16, merged.getExecution().getMaxParallelism());
 	}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -247,6 +247,7 @@ public class ExecutionContextTest {
 
 	private <T> ExecutionContext<T> createDefaultExecutionContext() throws Exception {
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", "old");
 		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
 		replaceVars.put("$VAR_RESULT_MODE", "changelog");
 		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
@@ -256,6 +257,7 @@ public class ExecutionContextTest {
 
 	private <T> ExecutionContext<T> createCatalogExecutionContext() throws Exception {
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", "old");
 		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
 		replaceVars.put("$VAR_RESULT_MODE", "changelog");
 		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.config.entries.ExecutionEntry;
 import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
@@ -51,6 +52,10 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.io.File;
 import java.io.IOException;
@@ -73,7 +78,15 @@ import static org.junit.Assert.fail;
 /**
  * Contains basic tests for the {@link LocalExecutor}.
  */
+@RunWith(Parameterized.class)
 public class LocalExecutorITCase extends TestLogger {
+
+	@Parameters(name = "Planner: {0}")
+	public static List<String> planner() {
+		return Arrays.asList(
+			ExecutionEntry.EXECUTION_PLANNER_VALUE_OLD,
+			ExecutionEntry.EXECUTION_PLANNER_VALUE_BLINK);
+	}
 
 	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-client-defaults.yaml";
 	private static final String CATALOGS_ENVIRONMENT_FILE = "test-sql-client-catalogs.yaml";
@@ -107,6 +120,9 @@ public class LocalExecutorITCase extends TestLogger {
 		config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
 		return config;
 	}
+
+	@Parameter
+	public String planner;
 
 	@Test
 	public void testValidateSession() throws Exception {
@@ -171,7 +187,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final List<String> actualDatabases = executor.listDatabases(session);
 
-		final List<String> expectedDatabases = Arrays.asList("default_database");
+		final List<String> expectedDatabases = Collections.singletonList("default_database");
 		assertEquals(expectedDatabases, actualDatabases);
 	}
 
@@ -217,6 +233,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final Map<String, String> actualProperties = executor.getSessionProperties(session);
 
 		final Map<String, String> expectedProperties = new HashMap<>();
+		expectedProperties.put("execution.planner", planner);
 		expectedProperties.put("execution.type", "batch");
 		expectedProperties.put("execution.time-characteristic", "event-time");
 		expectedProperties.put("execution.periodic-watermarks-interval", "99");
@@ -272,6 +289,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
 		Objects.requireNonNull(url);
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
 		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
 		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
 		replaceVars.put("$VAR_RESULT_MODE", "changelog");
@@ -312,6 +330,7 @@ public class LocalExecutorITCase extends TestLogger {
 		Objects.requireNonNull(url);
 
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
 		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
 		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
 		replaceVars.put("$VAR_RESULT_MODE", "table");
@@ -337,6 +356,7 @@ public class LocalExecutorITCase extends TestLogger {
 		Objects.requireNonNull(url);
 
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
 		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
 		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
 		replaceVars.put("$VAR_RESULT_MODE", "table");
@@ -356,6 +376,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
 		Objects.requireNonNull(url);
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
 		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
 		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
 		replaceVars.put("$VAR_RESULT_MODE", "table");
@@ -392,6 +413,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
 		Objects.requireNonNull(url);
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
 		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
 		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
 		replaceVars.put("$VAR_SOURCE_SINK_PATH", csvOutputPath);
@@ -435,6 +457,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
 		Objects.requireNonNull(url);
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
 		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
 		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
 		replaceVars.put("$VAR_SOURCE_SINK_PATH", csvOutputPath);
@@ -500,6 +523,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 	private <T> LocalExecutor createDefaultExecutor(ClusterClient<T> clusterClient) throws Exception {
 		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
 		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
 		replaceVars.put("$VAR_UPDATE_MODE", "");
 		replaceVars.put("$VAR_MAX_ROWS", "100");

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -115,7 +115,12 @@ functions:
       - type: LONG
         value: 5
 
+catalogs:
+  - name: catalog1
+    type: DependencyTest
+
 execution:
+  planner: "$VAR_PLANNER"
   type: "$VAR_EXECUTION_TYPE"
   time-characteristic: event-time
   periodic-watermarks-interval: 99
@@ -133,7 +138,3 @@ execution:
 
 deployment:
   response-timeout: 5000
-
-catalogs:
-  - name: catalog1
-    type: DependencyTest

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.api.java.internal;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
@@ -79,7 +78,6 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl imple
 
 	private final StreamExecutionEnvironment executionEnvironment;
 
-	@VisibleForTesting
 	public StreamTableEnvironmentImpl(
 			CatalogManager catalogManager,
 			FunctionCatalog functionCatalog,
@@ -90,17 +88,17 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl imple
 			boolean isStreamingMode) {
 		super(catalogManager, tableConfig, executor, functionCatalog, planner, isStreamingMode);
 		this.executionEnvironment = executionEnvironment;
-
-		if (!isStreamingMode) {
-			throw new TableException(
-				"StreamTableEnvironment is not supported in batch mode now, please use TableEnvironment.");
-		}
 	}
 
 	public static StreamTableEnvironment create(
 			StreamExecutionEnvironment executionEnvironment,
 			EnvironmentSettings settings,
 			TableConfig tableConfig) {
+
+		if (!settings.isStreamingMode()) {
+			throw new TableException(
+				"StreamTableEnvironment can not run in batch mode for now, please use TableEnvironment.");
+		}
 
 		CatalogManager catalogManager = new CatalogManager(
 			settings.getBuiltInCatalogName(),

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSinkFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.sinks.BatchTableSink;
 import org.apache.flink.table.sinks.TableSink;
 
@@ -29,6 +30,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory consumes
  */
+@PublicEvolving
 public interface BatchTableSinkFactory<T> extends TableSinkFactory<T> {
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSourceFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.sources.BatchTableSource;
 import org.apache.flink.table.sources.TableSource;
 
@@ -29,6 +30,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory produces
  */
+@PublicEvolving
 public interface BatchTableSourceFactory<T> extends TableSourceFactory<T> {
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSinkFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.sinks.StreamTableSink;
 import org.apache.flink.table.sinks.TableSink;
 
@@ -29,6 +30,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory consumes
  */
+@PublicEvolving
 public interface StreamTableSinkFactory<T> extends TableSinkFactory<T> {
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSourceFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 
@@ -29,6 +30,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory produces
  */
+@PublicEvolving
 public interface StreamTableSourceFactory<T> extends TableSourceFactory<T> {
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
@@ -51,7 +51,7 @@ public class BatchExecutor extends ExecutorBase {
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		StreamExecutionEnvironment execEnv = getExecutionEnvironment();
-		StreamGraph streamGraph = generateStreamGraph(transformations, jobName);
+		StreamGraph streamGraph = generateStreamGraph(jobName);
 		return execEnv.execute(streamGraph);
 	}
 
@@ -69,9 +69,7 @@ public class BatchExecutor extends ExecutorBase {
 		}
 	}
 
-	/**
-	 * Translates transformationList to streamGraph.
-	 */
+	@Override
 	public StreamGraph generateStreamGraph(List<Transformation<?>> transformations, String jobName) {
 		StreamExecutionEnvironment execEnv = getExecutionEnvironment();
 		setBatchProperties(execEnv);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
@@ -58,9 +58,17 @@ public abstract class ExecutorBase implements Executor {
 		return executionEnvironment;
 	}
 
-	public abstract StreamGraph generateStreamGraph(
-			List<Transformation<?>> transformations,
-			String jobName) throws Exception;
+	/**
+	 * Translates the applied transformations to a stream graph.
+	 */
+	public StreamGraph generateStreamGraph(String jobName) {
+		return generateStreamGraph(transformations, jobName);
+	}
+
+	/**
+	 * Translates the given transformations to a stream graph.
+	 */
+	public abstract StreamGraph generateStreamGraph(List<Transformation<?>> transformations, String jobName);
 
 	protected String getNonEmptyJobName(String jobName) {
 		if (StringUtils.isNullOrWhitespaceOnly(jobName)) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/StreamExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/StreamExecutor.java
@@ -46,9 +46,8 @@ public class StreamExecutor extends ExecutorBase {
 		return execEnv.execute(generateStreamGraph(transformations, jobName));
 	}
 
-	public StreamGraph generateStreamGraph(
-			List<Transformation<?>> transformations,
-			String jobName) throws Exception {
+	@Override
+	public StreamGraph generateStreamGraph(List<Transformation<?>> transformations, String jobName) {
 		transformations.forEach(getExecutionEnvironment()::addOperator);
 		return getExecutionEnvironment().getStreamGraph(getNonEmptyJobName(jobName));
 	}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -78,7 +78,7 @@ class FlinkPlannerImpl(
       catalogReaderSupplier.apply(true), // ignore cases for lenient completion
       typeFactory,
       config.getParserConfig.conformance())
-    val advisor = new SqlAdvisor(advisorValidator)
+    val advisor = new SqlAdvisor(advisorValidator, config.getParserConfig)
     val replaced = Array[String](null)
     val hints = advisor.getCompletionHints(sql, cursor, replaced)
       .map(item => item.toIdentifier.toString)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -96,7 +96,7 @@ class ExpressionReducer(
       resultType,
       EMPTY_ROW_TYPE)
 
-    val function = generatedFunction.newInstance(getClass.getClassLoader)
+    val function = generatedFunction.newInstance(Thread.currentThread().getContextClassLoader)
     val richMapFunction = function match {
       case r: RichMapFunction[GenericRow, GenericRow] => r
       case _ => throw new TableException("RichMapFunction[GenericRow, GenericRow] required here")

--- a/tools/travis/splits/split_misc.sh
+++ b/tools/travis/splits/split_misc.sh
@@ -67,7 +67,8 @@ run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_D
 run_test "State TTL Heap backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh file"
 run_test "State TTL RocksDb backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh rocks"
 
-run_test "SQL Client end-to-end test" "$END_TO_END_DIR/test-scripts/test_sql_client.sh"
+run_test "SQL Client end-to-end test (Old planner)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh old"
+run_test "SQL Client end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh blink"
 run_test "SQL Client end-to-end test for Kafka 0.10" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka010.sh"
 run_test "SQL Client end-to-end test for Kafka 0.11" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka011.sh"
 run_test "SQL Client end-to-end test for modern Kafka" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka.sh"


### PR DESCRIPTION
## What is the purpose of the change

This allows to switch planners in SQL Client. A user can specify `execution.planner=blink` to activate it. The SQL Client E2E tests as well as integration tests have been updated for verifying the behavior.

This PR is based on #9263.

## Brief change log

See commit messages.

## Verifying this change

This change is already covered by existing tests, such as `LocalExecutorITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
