### PR TITLE
[FLINK-13452] Ensure to fail global when exception happens during reseting tasks of regions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
@@ -54,6 +54,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -108,16 +109,18 @@ public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 
 		FutureUtils.assertNoException(
 			cancelTasks(verticesToRestart)
-				.thenRunAsync(resetAndRescheduleTasks(globalModVersion, vertexVersions), executionGraph.getJobMasterMainThreadExecutor())
+				.thenComposeAsync(resetAndRescheduleTasks(globalModVersion, vertexVersions), executionGraph.getJobMasterMainThreadExecutor())
 				.handle(failGlobalOnError()));
 	}
 
-	private Runnable resetAndRescheduleTasks(final long globalModVersion, final Set<ExecutionVertexVersion> vertexVersions) {
-		final RestartStrategy restartStrategy = executionGraph.getRestartStrategy();
-		return () -> restartStrategy.restart(
-			createResetAndRescheduleTasksCallback(globalModVersion, vertexVersions),
-			executionGraph.getJobMasterMainThreadExecutor()
-		);
+	private Function<Object, CompletableFuture<Void>> resetAndRescheduleTasks(final long globalModVersion, final Set<ExecutionVertexVersion> vertexVersions) {
+		return (ignored) -> {
+			final RestartStrategy restartStrategy = executionGraph.getRestartStrategy();
+			return restartStrategy.restart(
+				createResetAndRescheduleTasksCallback(globalModVersion, vertexVersions),
+				executionGraph.getJobMasterMainThreadExecutor()
+			);
+		};
 	}
 
 	private RestartCallback createResetAndRescheduleTasksCallback(final long globalModVersion, final Set<ExecutionVertexVersion> vertexVersions) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
@@ -22,14 +22,16 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
 
-import scala.concurrent.duration.Duration;
-
 import java.util.ArrayDeque;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+
+import scala.concurrent.duration.Duration;
 
 /**
  * Restart strategy which tries to restart the given {@link ExecutionGraph} when failure rate exceeded
@@ -68,18 +70,12 @@ public class FailureRateRestartStrategy implements RestartStrategy {
 	}
 
 	@Override
-	public void restart(final RestartCallback restarter, ScheduledExecutor executor) {
+	public CompletableFuture<Void> restart(final RestartCallback restarter, ScheduledExecutor executor) {
 		if (isRestartTimestampsQueueFull()) {
 			restartTimestampsDeque.remove();
 		}
 		restartTimestampsDeque.add(System.currentTimeMillis());
-
-		executor.schedule(new Runnable() {
-			@Override
-			public void run() {
-				restarter.triggerFullRecovery();
-			}
-		}, delayInterval.getSize(), delayInterval.getUnit());
+		return FutureUtils.scheduleWithDelay(restarter::triggerFullRecovery, delayInterval, executor);
 	}
 
 	private boolean isRestartTimestampsQueueFull() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -18,13 +18,15 @@
 
 package org.apache.flink.runtime.executiongraph.restart;
 
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
 
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
 
 import scala.concurrent.duration.Duration;
 
@@ -60,9 +62,9 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 	}
 
 	@Override
-	public void restart(final RestartCallback restarter, ScheduledExecutor executor) {
+	public CompletableFuture<Void> restart(final RestartCallback restarter, ScheduledExecutor executor) {
 		currentRestartAttempt++;
-		executor.schedule(restarter::triggerFullRecovery, delayBetweenRestartAttempts, TimeUnit.MILLISECONDS);
+		return FutureUtils.scheduleWithDelay(restarter::triggerFullRecovery, Time.milliseconds(delayBetweenRestartAttempts), executor);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/NoRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/NoRestartStrategy.java
@@ -22,6 +22,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Restart strategy which does not restart an {@link ExecutionGraph}.
  */
@@ -33,7 +35,7 @@ public class NoRestartStrategy implements RestartStrategy {
 	}
 
 	@Override
-	public void restart(RestartCallback restarter, ScheduledExecutor executor) {
+	public CompletableFuture<Void> restart(RestartCallback restarter, ScheduledExecutor executor) {
 		throw new UnsupportedOperationException("NoRestartStrategy does not support restart.");
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategy.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.executiongraph.restart;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Strategy for {@link ExecutionGraph} restarts.
  */
@@ -42,6 +44,7 @@ public interface RestartStrategy {
 	 *
 	 * @param restarter The hook to restart the ExecutionGraph
 	 * @param executor An scheduled executor to delay the restart
+	 * @return A {@link CompletableFuture} that will be completed when the restarting process is done.
 	 */
-	void restart(RestartCallback restarter, ScheduledExecutor executor);
+	CompletableFuture<Void> restart(RestartCallback restarter, ScheduledExecutor executor);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/ThrowingRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/ThrowingRestartStrategy.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.executiongraph.restart;
 
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 
+import java.util.concurrent.CompletableFuture;
+
 
 /**
  * A restart strategy that validates that it is not in use by throwing {@link IllegalStateException}
@@ -34,7 +36,7 @@ public class ThrowingRestartStrategy implements RestartStrategy {
 	}
 
 	@Override
-	public void restart(final RestartCallback restarter, final ScheduledExecutor executor) {
+	public CompletableFuture<Void> restart(final RestartCallback restarter, final ScheduledExecutor executor) {
 		throw new IllegalStateException("Unexpected restart() call");
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGFailoverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGFailoverTest.java
@@ -19,20 +19,17 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.AdaptedRestartPipelinedRegionStrategyNG;
+import org.apache.flink.runtime.executiongraph.restart.FailingRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
-import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.io.network.partition.PartitionTracker;
 import org.apache.flink.runtime.io.network.partition.PartitionTrackerImpl;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -44,10 +41,6 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
-import org.apache.flink.runtime.jobmaster.LogicalSlot;
-import org.apache.flink.runtime.jobmaster.SlotRequestId;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.util.TestLogger;
@@ -55,17 +48,13 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeoutException;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -80,15 +69,12 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 
 	private ComponentMainThreadExecutor componentMainThreadExecutor;
 
-	private FailingSlotProviderDecorator slotProvider;
-
 	private ManuallyTriggeredScheduledExecutor manualMainThreadExecutor;
 
 	@Before
 	public void setUp() {
 		manualMainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
 		componentMainThreadExecutor = new ComponentMainThreadExecutorServiceAdapter(manualMainThreadExecutor, Thread.currentThread());
-		slotProvider = new FailingSlotProviderDecorator(new SimpleSlotProvider(TEST_JOB_ID, 14));
 	}
 
 	/**
@@ -285,9 +271,9 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 	}
 
 	@Test
-	public void testFailGlobalIfErrorOnRestartingTasks() throws Exception {
+	public void testFailGlobalIfErrorOnRestartTasks() throws Exception {
 		final JobGraph jobGraph = createStreamingJobGraph();
-		final ExecutionGraph eg = createExecutionGraph(jobGraph);
+		final ExecutionGraph eg = createExecutionGraph(jobGraph, new FailingRestartStrategy(1));
 
 		final Iterator<ExecutionVertex> vertexIterator = eg.getAllExecutionVertices().iterator();
 		final ExecutionVertex ev11 = vertexIterator.next();
@@ -297,7 +283,6 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 
 		final long globalModVersionBeforeFailure = eg.getGlobalModVersion();
 
-		slotProvider.setFailSlotAllocation(true);
 		ev11.fail(new Exception("Test Exception"));
 		completeCancelling(ev11, ev12, ev21, ev22);
 
@@ -391,7 +376,6 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobGraph)
 			.setRestartStrategy(restartStrategy)
 			.setFailoverStrategyFactory(TestAdaptedRestartPipelinedRegionStrategyNG::new)
-			.setSlotProvider(slotProvider)
 			.setPartitionTracker(partitionTracker)
 			.build();
 
@@ -452,51 +436,6 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 
 		Set<ExecutionVertexID> getLastTasksToCancel() {
 			return lastTasksToRestart;
-		}
-	}
-
-	private static class FailingSlotProviderDecorator implements SlotProvider {
-
-		private final SlotProvider delegate;
-
-		private boolean failSlotAllocation = false;
-
-		FailingSlotProviderDecorator(final SlotProvider delegate) {
-			this.delegate = checkNotNull(delegate);
-		}
-
-		@Override
-		public CompletableFuture<LogicalSlot> allocateBatchSlot(
-			final SlotRequestId slotRequestId,
-			final ScheduledUnit scheduledUnit,
-			final SlotProfile slotProfile,
-			final boolean allowQueuedScheduling) {
-			return allocateSlot(slotRequestId, scheduledUnit, slotProfile, allowQueuedScheduling, null);
-		}
-
-		@Override
-		public CompletableFuture<LogicalSlot> allocateSlot(
-				final SlotRequestId slotRequestId,
-				final ScheduledUnit scheduledUnit,
-				final SlotProfile slotProfile,
-				final boolean allowQueuedScheduling,
-				final Time allocationTimeout) {
-			if (failSlotAllocation) {
-				return FutureUtils.completedExceptionally(new TimeoutException("Expected"));
-			}
-			return delegate.allocateSlot(slotRequestId, scheduledUnit, slotProfile, allowQueuedScheduling, allocationTimeout);
-		}
-
-		@Override
-		public void cancelSlotRequest(
-				final SlotRequestId slotRequestId,
-				@Nullable final SlotSharingGroupId slotSharingGroupId,
-				final Throwable cause) {
-			delegate.cancelSlotRequest(slotRequestId, slotSharingGroupId, cause);
-		}
-
-		public void setFailSlotAllocation(final boolean failSlotAllocation) {
-			this.failSlotAllocation = failSlotAllocation;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestRestartStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestRestartStrategy.java
@@ -72,7 +72,7 @@ public class TestRestartStrategy implements RestartStrategy {
 	}
 
 	@Override
-	public void restart(RestartCallback restarter, ScheduledExecutor executor) {
+	public CompletableFuture<Void> restart(RestartCallback restarter, ScheduledExecutor executor) {
 
 		++restartAttempts;
 		ExecutorAction executorAction = new ExecutorAction(restarter::triggerFullRecovery, executor);
@@ -80,8 +80,9 @@ public class TestRestartStrategy implements RestartStrategy {
 			synchronized (actionsQueue) {
 				actionsQueue.add(executorAction);
 			}
+			return new CompletableFuture<>();
 		} else {
-			executorAction.trigger();
+			return executorAction.trigger();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/FailingRestartStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/FailingRestartStrategy.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.restart;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnegative;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A restart strategy which fails a predefined amount of times.
+ */
+public class FailingRestartStrategy implements RestartStrategy {
+
+	public static final ConfigOption<Integer> NUM_FAILURES_CONFIG_OPTION = ConfigOptions
+		.key("restart-strategy.failing.failures")
+		.defaultValue(1);
+
+	private final int numberOfFailures;
+
+	private int restartedTimes;
+
+	public FailingRestartStrategy(@Nonnegative int numberOfFailures) {
+		this.numberOfFailures = numberOfFailures;
+	}
+
+	@Override
+	public boolean canRestart() {
+		return true;
+	}
+
+	@Override
+	public CompletableFuture<Void> restart(RestartCallback restarter, ScheduledExecutor executor) {
+		++restartedTimes;
+
+		if (restartedTimes <= numberOfFailures) {
+			return FutureUtils.completedExceptionally(new FlinkRuntimeException("Fail to restart for " + restartedTimes + " time(s)."));
+		} else {
+			return FutureUtils.scheduleWithDelay(restarter::triggerFullRecovery, Time.milliseconds(0L), executor);
+		}
+	}
+
+	/**
+	 * Creates a {@link FailingRestartStrategyFactory} from the given Configuration.
+	 */
+	public static FailingRestartStrategyFactory createFactory(Configuration configuration) {
+		int numberOfFailures = configuration.getInteger(NUM_FAILURES_CONFIG_OPTION);
+		return new FailingRestartStrategyFactory(numberOfFailures);
+	}
+
+	/**
+	 * Factory for {@link FailingRestartStrategy}.
+	 */
+	public static class FailingRestartStrategyFactory extends RestartStrategyFactory {
+		private static final long serialVersionUID = 1L;
+
+		private final int numberOfFailures;
+
+		public FailingRestartStrategyFactory(int numberOfFailures) {
+			this.numberOfFailures = numberOfFailures;
+		}
+
+		@Override
+		public RestartStrategy createRestartStrategy() {
+			return new FailingRestartStrategy(numberOfFailures);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/InfiniteDelayRestartStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/InfiniteDelayRestartStrategy.java
@@ -20,8 +20,11 @@ package org.apache.flink.runtime.executiongraph.restart;
 
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Testing restart strategy which promise to restart {@link ExecutionGraph} after the infinite time delay.
@@ -49,11 +52,12 @@ public class InfiniteDelayRestartStrategy implements RestartStrategy {
 	}
 
 	@Override
-	public void restart(RestartCallback restarter, ScheduledExecutor executor) {
+	public CompletableFuture<Void> restart(RestartCallback restarter, ScheduledExecutor executor) {
 		LOG.info("Delaying retry of job execution forever");
 
 		if (maxRestartAttempts >= 0) {
 			restartAttemptCounter++;
 		}
+		return new CompletableFuture<>();
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

After [FLINK-13060](https://issues.apache.org/jira/browse/FLINK-13060), we would run `createResetAndRescheduleTasksCallback` within another runnable `resetAndRescheduleTasks`. Unfortunately, any exception happened in `createResetAndRescheduleTasksCallback` would cause the thread terminated silently but record the exception in `outcome` of `FutureTask`. We should change the code back to previously that would `failGlobal` within the `createResetAndRescheduleTasksCallback` runnable.


## Brief change log

  - [59b1a6d5](https://github.com/apache/flink/pull/9268/commits/59b1a6d50b025925afd14a09b2b95a507889800a) :
    - Let runnable `createResetAndRescheduleTasksCallback` fail global if come across any exception.
    - Refine `RegionFailoverITCase` to mock the exception that checkpoint store would failed when recover from checkpoint for the 1st time.

  - [b732229](https://github.com/apache/flink/pull/9268/commits/b732229f0644a896b51245096fc0c7b7e19f0b02) :  Refactor interface of `RestartStrategy#restart` and add UT to verify `failGlobalIfErrorOnResetTasks`

 - [073d815](https://github.com/apache/flink/pull/9268/commits/073d8158a43ed8ac9ed44a3e563c5e8aca8c574a) 
    - Refactor the return value of RestartStrategy#restart to CompletableFuture<Void>
    - Refatcor return valud of method ExecutionGraph#allVerticesInTerminalState to align with new RestartStrategy#restart
    - Simplify AdaptedRestartPipelinedRegionStrategyNGFailoverTest with FailureMultiTimesRestartStrategy to throw exception directly
    - Refactor RegionFailoverITCase with FailureMultiTimesRestartStrategy
    - Add unit tests for FutureUtils#scheduleAsync

## Verifying this change

This change added tests and can be verified as follows:

  - Refine `RegionFailoverITCase` to mock the exception that checkpoint store would failed when recover from checkpoint for the 1st time.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
