### PR TITLE
[hotfix][python] Change "flink-python-" to "flink-python" for the change  of artifact of flink-python module

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -485,7 +485,7 @@ public class PackagedProgram {
 					@Override
 					public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 						FileVisitResult result = super.visitFile(file, attrs);
-						if (file.getFileName().toString().startsWith("flink-python-")) {
+						if (file.getFileName().toString().startsWith("flink-python")) {
 							pythonJarPath.add(file);
 						}
 						return result;


### PR DESCRIPTION
## What is the purpose of the change

*Because the artifact of flink-python has changed, the code in PackagedProgram can't find the flink-python_*jar. *


## Brief change log

  - *Changes "flink-python-" to "flink-python" in PackagedProgram*


## Verifying this change

This change is already covered by existing tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
