### PR TITLE
[FLINK-13435] Remove ShuffleDescriptor.ReleaseType and make release semantics fixed per partition type

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -195,11 +195,6 @@ public class JobManagerOptions {
 			.defaultValue(true)
 			.withDescription("Controls whether partitions should already be released during the job execution.");
 
-	@Documentation.ExcludeFromDocumentation("dev use only; likely temporary")
-	public static final ConfigOption<Boolean> FORCE_PARTITION_RELEASE_ON_CONSUMPTION =
-			key("jobmanager.scheduler.partition.force-release-on-consumption")
-			.defaultValue(false);
-
 	// ---------------------------------------------------------------------------------------------
 
 	private JobManagerOptions() {

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -231,6 +231,11 @@ public class NettyShuffleEnvironmentOptions {
 
 	// ------------------------------------------------------------------------
 
+	@Documentation.ExcludeFromDocumentation("dev use only; likely temporary")
+	public static final ConfigOption<Boolean> FORCE_PARTITION_RELEASE_ON_CONSUMPTION =
+		key("taskmanager.network.partition.force-release-on-consumption")
+			.defaultValue(false);
+
 	/** Not intended to be instantiated. */
 	private NettyShuffleEnvironmentOptions() {}
 }

--- a/flink-end-to-end-tests/test-scripts/test_ha_dataset.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_dataset.sh
@@ -75,7 +75,6 @@ function setup_and_start_cluster() {
     create_ha_config
 
     set_config_key "jobmanager.execution.failover-strategy" "region"
-    set_config_key "jobmanager.scheduler.partition.force-release-on-consumption" "false"
     set_config_key "taskmanager.numberOfTaskSlots" "1"
 
     set_config_key "restart-strategy" "fixed-delay"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
@@ -18,22 +18,16 @@
 
 package org.apache.flink.runtime.deployment;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
-import org.apache.flink.runtime.shuffle.ShuffleDescriptor.ReleaseType;
-import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
-import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 
 import java.io.Serializable;
-import java.util.Collection;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -54,48 +48,16 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 	/** Flag whether the result partition should send scheduleOrUpdateConsumer messages. */
 	private final boolean sendScheduleOrUpdateConsumersMessage;
 
-	private final ReleaseType releaseType;
-
-	@VisibleForTesting
 	public ResultPartitionDeploymentDescriptor(
 			PartitionDescriptor partitionDescriptor,
 			ShuffleDescriptor shuffleDescriptor,
 			int maxParallelism,
 			boolean sendScheduleOrUpdateConsumersMessage) {
-		this(
-			checkNotNull(partitionDescriptor),
-			shuffleDescriptor,
-			maxParallelism,
-			sendScheduleOrUpdateConsumersMessage,
-			ReleaseType.AUTO);
-	}
-
-	public ResultPartitionDeploymentDescriptor(
-			PartitionDescriptor partitionDescriptor,
-			ShuffleDescriptor shuffleDescriptor,
-			int maxParallelism,
-			boolean sendScheduleOrUpdateConsumersMessage,
-			ReleaseType releaseType) {
-		checkReleaseOnConsumptionIsSupportedForPartition(shuffleDescriptor, releaseType);
 		this.partitionDescriptor = checkNotNull(partitionDescriptor);
 		this.shuffleDescriptor = checkNotNull(shuffleDescriptor);
 		KeyGroupRangeAssignment.checkParallelismPreconditions(maxParallelism);
 		this.maxParallelism = maxParallelism;
 		this.sendScheduleOrUpdateConsumersMessage = sendScheduleOrUpdateConsumersMessage;
-		this.releaseType = releaseType;
-	}
-
-	private static void checkReleaseOnConsumptionIsSupportedForPartition(
-			ShuffleDescriptor shuffleDescriptor,
-			ReleaseType releaseType) {
-		checkNotNull(shuffleDescriptor);
-		checkArgument(
-			shuffleDescriptor.getSupportedReleaseTypes().contains(releaseType),
-			"Release type %s is not supported by the shuffle service for this partition" +
-				"(id: %s), supported release types: %s",
-			releaseType,
-			shuffleDescriptor.getResultPartitionID(),
-			shuffleDescriptor.getSupportedReleaseTypes());
 	}
 
 	public IntermediateDataSetID getResultId() {
@@ -124,25 +86,6 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 
 	public boolean sendScheduleOrUpdateConsumersMessage() {
 		return sendScheduleOrUpdateConsumersMessage;
-	}
-
-	/**
-	 * Returns whether to release the partition after having been fully consumed once.
-	 *
-	 * <p>Indicates whether the shuffle service should automatically release all partition resources after
-	 * the first full consumption has been acknowledged. This kind of partition does not need to be explicitly released
-	 * by {@link ShuffleMaster#releasePartitionExternally(ShuffleDescriptor)}
-	 * and {@link ShuffleEnvironment#releasePartitionsLocally(Collection)}.
-	 *
-	 * <p>The partition has to support the corresponding {@link ReleaseType} in
-	 * {@link ShuffleDescriptor#getSupportedReleaseTypes()}:
-	 * {@link ReleaseType#AUTO} for {@code isReleasedOnConsumption()} to return {@code true} and
-	 * {@link ReleaseType#MANUAL} for {@code isReleasedOnConsumption()} to return {@code false}.
-	 *
-	 * @return whether to release the partition after having been fully consumed once.
-	 */
-	public boolean isReleasedOnConsumption() {
-		return releaseType == ReleaseType.AUTO;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -631,19 +631,12 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				.getShuffleMaster()
 				.registerPartitionWithProducer(partitionDescriptor, producerDescriptor);
 
-			final boolean releasePartitionOnConsumption =
-				vertex.getExecutionGraph().isForcePartitionReleaseOnConsumption()
-				|| !partitionDescriptor.getPartitionType().isBlocking();
-
 			CompletableFuture<ResultPartitionDeploymentDescriptor> partitionRegistration = shuffleDescriptorFuture
 				.thenApply(shuffleDescriptor -> new ResultPartitionDeploymentDescriptor(
 					partitionDescriptor,
 					shuffleDescriptor,
 					maxParallelism,
-					lazyScheduling,
-					releasePartitionOnConsumption
-						? ShuffleDescriptor.ReleaseType.AUTO
-						: ShuffleDescriptor.ReleaseType.MANUAL));
+					lazyScheduling));
 			partitionRegistrations.add(partitionRegistration);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -321,8 +321,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	/** Shuffle master to register partitions for task deployment. */
 	private final ShuffleMaster<?> shuffleMaster;
 
-	private boolean forcePartitionReleaseOnConsumption;
-
 	// --------------------------------------------------------------------------------------------
 	//   Constructors
 	// --------------------------------------------------------------------------------------------
@@ -426,7 +424,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			allocationTimeout,
 			new NotReleasingPartitionReleaseStrategy.Factory(),
 			NettyShuffleMaster.INSTANCE,
-			true,
 			new PartitionTrackerImpl(
 				jobInformation.getJobId(),
 				NettyShuffleMaster.INSTANCE,
@@ -449,7 +446,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			Time allocationTimeout,
 			PartitionReleaseStrategy.Factory partitionReleaseStrategyFactory,
 			ShuffleMaster<?> shuffleMaster,
-			boolean forcePartitionReleaseOnConsumption,
 			PartitionTracker partitionTracker,
 			ScheduleMode scheduleMode,
 			boolean allowQueuedScheduling) throws IOException {
@@ -511,8 +507,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 					"Call to ExecutionGraph.start(...) required.");
 
 		this.shuffleMaster = checkNotNull(shuffleMaster);
-
-		this.forcePartitionReleaseOnConsumption = forcePartitionReleaseOnConsumption;
 
 		this.partitionTracker = checkNotNull(partitionTracker);
 
@@ -736,10 +730,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	public long getNumberOfFullRestarts() {
 		// subtract one, because the version starts at one
 		return globalModVersion - 1;
-	}
-
-	boolean isForcePartitionReleaseOnConsumption() {
-		return forcePartitionReleaseOnConsumption;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -161,9 +161,6 @@ public class ExecutionGraphBuilder {
 		final PartitionReleaseStrategy.Factory partitionReleaseStrategyFactory =
 			PartitionReleaseStrategyFactoryLoader.loadPartitionReleaseStrategyFactory(jobManagerConfig);
 
-		final boolean forcePartitionReleaseOnConsumption =
-			jobManagerConfig.getBoolean(JobManagerOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION);
-
 		// create a new execution graph, if none exists so far
 		final ExecutionGraph executionGraph;
 		try {
@@ -182,7 +179,6 @@ public class ExecutionGraphBuilder {
 					allocationTimeout,
 					partitionReleaseStrategyFactory,
 					shuffleMaster,
-					forcePartitionReleaseOnConsumption,
 					partitionTracker,
 					jobGraph.getScheduleMode(),
 					jobGraph.getAllowQueuedScheduling());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -104,7 +104,8 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 			config.getBlockingSubpartitionType(),
 			config.networkBuffersPerChannel(),
 			config.floatingNetworkBuffersPerGate(),
-			config.networkBufferSize());
+			config.networkBufferSize(),
+			config.isForcePartitionReleaseOnConsumption());
 
 		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
 			taskExecutorResourceId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImpl.java
@@ -64,8 +64,8 @@ public class PartitionTrackerImpl implements PartitionTracker {
 		Preconditions.checkNotNull(producingTaskExecutorId);
 		Preconditions.checkNotNull(resultPartitionDeploymentDescriptor);
 
-		// if it is released on consumption we do not need to issue any release calls
-		if (resultPartitionDeploymentDescriptor.isReleasedOnConsumption()) {
+		// only blocking partitions require explicit release call
+		if (!resultPartitionDeploymentDescriptor.getPartitionType().isBlocking()) {
 			return;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -133,22 +133,17 @@ public class ResultPartitionFactory {
 			BoundedBlockingSubpartitionType blockingSubpartitionType,
 			ResultSubpartition[] subpartitions) {
 		// Create the subpartitions.
-		switch (type) {
-			case BLOCKING:
-			case BLOCKING_PERSISTENT:
-				initializeBoundedBlockingPartitions(subpartitions, partition, blockingSubpartitionType, networkBufferSize, channelManager);
-				break;
-
-			case PIPELINED:
-			case PIPELINED_BOUNDED:
-				for (int i = 0; i < subpartitions.length; i++) {
-					subpartitions[i] = new PipelinedSubpartition(i, partition);
-				}
-
-				break;
-
-			default:
-				throw new IllegalArgumentException("Unsupported result partition type.");
+		if (type.isBlocking()) {
+			initializeBoundedBlockingPartitions(
+				subpartitions,
+				partition,
+				blockingSubpartitionType,
+				networkBufferSize,
+				channelManager);
+		} else {
+			for (int i = 0; i < subpartitions.length; i++) {
+				subpartitions[i] = new PipelinedSubpartition(i, partition);
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleDescriptor.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
 import java.io.Serializable;
 import java.net.InetSocketAddress;
-import java.util.EnumSet;
 import java.util.Optional;
 
 /**
@@ -35,29 +34,19 @@ public class NettyShuffleDescriptor implements ShuffleDescriptor {
 
 	private static final long serialVersionUID = 852181945034989215L;
 
-	private static final EnumSet<ReleaseType> SUPPORTED_RELEASE_TYPES_FOR_BLOCKING_PARTITIONS =
-		EnumSet.of(ReleaseType.AUTO, ReleaseType.MANUAL);
-
-	private static final EnumSet<ReleaseType> SUPPORTED_RELEASE_TYPES_FOR_NON_BLOCKING_PARTITIONS =
-		EnumSet.of(ReleaseType.AUTO);
-
 	private final ResourceID producerLocation;
 
 	private final PartitionConnectionInfo partitionConnectionInfo;
 
 	private final ResultPartitionID resultPartitionID;
 
-	private final boolean isBlocking;
-
 	public NettyShuffleDescriptor(
 			ResourceID producerLocation,
 			PartitionConnectionInfo partitionConnectionInfo,
-			ResultPartitionID resultPartitionID,
-			boolean isBlocking) {
+			ResultPartitionID resultPartitionID) {
 		this.producerLocation = producerLocation;
 		this.partitionConnectionInfo = partitionConnectionInfo;
 		this.resultPartitionID = resultPartitionID;
-		this.isBlocking = isBlocking;
 	}
 
 	public ConnectionID getConnectionId() {
@@ -72,12 +61,6 @@ public class NettyShuffleDescriptor implements ShuffleDescriptor {
 	@Override
 	public Optional<ResourceID> storesLocalResourcesOn() {
 		return Optional.of(producerLocation);
-	}
-
-	@Override
-	public EnumSet<ReleaseType> getSupportedReleaseTypes() {
-		return isBlocking ?
-			SUPPORTED_RELEASE_TYPES_FOR_BLOCKING_PARTITIONS : SUPPORTED_RELEASE_TYPES_FOR_NON_BLOCKING_PARTITIONS;
 	}
 
 	public boolean isLocalTo(ResourceID consumerLocation) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleDescriptor.java
@@ -70,6 +70,7 @@ public class NettyShuffleDescriptor implements ShuffleDescriptor {
 	/**
 	 * Information for connection to partition producer for shuffle exchange.
 	 */
+	@FunctionalInterface
 	public interface PartitionConnectionInfo extends Serializable {
 		ConnectionID getConnectionId();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.shuffle;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.LocalExecutionPartitionConnectionInfo;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.NetworkPartitionConnectionInfo;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.PartitionConnectionInfo;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -51,7 +52,7 @@ public enum NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor> 
 	public void releasePartitionExternally(ShuffleDescriptor shuffleDescriptor) {
 	}
 
-	private static NettyShuffleDescriptor.PartitionConnectionInfo createConnectionInfo(
+	private static PartitionConnectionInfo createConnectionInfo(
 			ProducerDescriptor producerDescriptor,
 			int connectionIndex) {
 		return producerDescriptor.getDataPort() >= 0 ?

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -42,8 +42,7 @@ public enum NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor> 
 		NettyShuffleDescriptor shuffleDeploymentDescriptor = new NettyShuffleDescriptor(
 			producerDescriptor.getProducerLocation(),
 			createConnectionInfo(producerDescriptor, partitionDescriptor.getConnectionIndex()),
-			resultPartitionID,
-			partitionDescriptor.getPartitionType().isBlocking());
+			resultPartitionID);
 
 		return CompletableFuture.completedFuture(shuffleDeploymentDescriptor);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleDescriptor.java
@@ -41,14 +41,14 @@ public interface ShuffleDescriptor extends Serializable {
 	 * that the producer of the partition (consumer input channel) has not been scheduled
 	 * and its location and other relevant data is yet to be defined.
 	 * To proceed with the consumer deployment, currently unknown input channels have to be
-	 * marked with placeholders which are special implementation of {@link ShuffleDescriptor}:
+	 * marked with placeholders. The placeholder is a special implementation of the shuffle descriptor:
 	 * {@link UnknownShuffleDescriptor}.
 	 *
 	 * <p>Note: this method is not supposed to be overridden in concrete shuffle implementation.
 	 * The only class where it returns {@code true} is {@link UnknownShuffleDescriptor}.
 	 *
 	 * @return whether the partition producer has been ever deployed and
-	 * the corresponding {@link ShuffleDescriptor} is obtained from the {@link ShuffleMaster} implementation.
+	 * the corresponding shuffle descriptor is obtained from the {@link ShuffleMaster} implementation.
 	 */
 	default boolean isUnknown() {
 		return false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleDescriptor.java
@@ -19,12 +19,10 @@
 package org.apache.flink.runtime.shuffle;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.Optional;
 
 /**
@@ -61,39 +59,11 @@ public interface ShuffleDescriptor extends Serializable {
 	 *
 	 * <p>Indicates that this partition occupies local resources in the producing task executor. Such partition requires
 	 * that the task executor is running and being connected to be able to consume the produced data. This is mostly
-	 * relevant for the batch jobs and blocking result partitions which should outlive the producer lifetime and
-	 * be released externally: {@link ResultPartitionDeploymentDescriptor#isReleasedOnConsumption()} is {@code false}.
+	 * relevant for the batch jobs and blocking result partitions which can outlive the producer lifetime and
+	 * be released externally.
 	 * {@link ShuffleEnvironment#releasePartitionsLocally(Collection)} can be used to release such kind of partitions locally.
 	 *
 	 * @return the resource id of the producing task executor if the partition occupies local resources there
 	 */
 	Optional<ResourceID> storesLocalResourcesOn();
-
-	/**
-	 * Return release types supported by Shuffle Service for this partition.
-	 */
-	EnumSet<ReleaseType> getSupportedReleaseTypes();
-
-	/**
-	 * Partition release type.
-	 */
-	enum ReleaseType {
-		/**
-		 * Auto-release the partition after having been fully consumed once.
-		 *
-		 * <p>No additional actions required, like {@link ShuffleMaster#releasePartitionExternally(ShuffleDescriptor)}
-		 * or {@link ShuffleEnvironment#releasePartitionsLocally(Collection)}
-		 */
-		AUTO,
-
-		/**
-		 * Manually release the partition, the partition has to support consumption multiple times.
-		 *
-		 * <p>The partition requires manual release once all consumption is done:
-		 * {@link ShuffleMaster#releasePartitionExternally(ShuffleDescriptor)} and
-		 * if the partition occupies producer local resources ({@link #storesLocalResourcesOn()}) then also
-		 * {@link ShuffleEnvironment#releasePartitionsLocally(Collection)}.
-		 */
-		MANUAL
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.runtime.shuffle;
 
-import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.shuffle.ShuffleDescriptor.ReleaseType;
-
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
@@ -51,8 +48,6 @@ public interface ShuffleMaster<T extends ShuffleDescriptor> {
 	 *
 	 * <p>This call triggers release of any resources which are occupied by the given partition in the external systems
 	 * outside of the producer executor. This is mostly relevant for the batch jobs and blocking result partitions.
-	 * This method is not called if {@link ResultPartitionDeploymentDescriptor#isReleasedOnConsumption()} is {@code true}.
-	 * The partition has to support the {@link ReleaseType#MANUAL} in {@link ShuffleDescriptor#getSupportedReleaseTypes()}.
 	 * The producer local resources are managed by {@link ShuffleDescriptor#storesLocalResourcesOn()} and
 	 * {@link ShuffleEnvironment#releasePartitionsLocally(Collection)}.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/UnknownShuffleDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/UnknownShuffleDescriptor.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.shuffle;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
-import java.util.EnumSet;
 import java.util.Optional;
 
 /**
@@ -56,10 +55,5 @@ public final class UnknownShuffleDescriptor implements ShuffleDescriptor {
 	@Override
 	public Optional<ResourceID> storesLocalResourcesOn() {
 		return Optional.empty();
-	}
-
-	@Override
-	public EnumSet<ReleaseType> getSupportedReleaseTypes() {
-		return EnumSet.noneOf(ReleaseType.class);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -613,8 +613,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 	private void setupResultPartitionBookkeeping(TaskDeploymentDescriptor tdd, CompletableFuture<ExecutionState> terminationFuture) {
 		final List<ResultPartitionID> partitionsRequiringRelease = tdd.getProducedPartitions().stream()
-			// partitions that are released on consumption don't require any explicit release call
-			.filter(d -> !d.isReleasedOnConsumption())
+			// only blocking partitions require explicit release call
+			.filter(d -> d.getPartitionType().isBlocking())
 			.map(ResultPartitionDeploymentDescriptor::getShuffleDescriptor)
 			// partitions without local resources don't store anything on the TaskExecutor
 			.filter(d -> d.storesLocalResourcesOn().isPresent())

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -73,6 +73,8 @@ public class NettyShuffleEnvironmentConfiguration {
 
 	private final BoundedBlockingSubpartitionType blockingSubpartitionType;
 
+	private final boolean forcePartitionReleaseOnConsumption;
+
 	public NettyShuffleEnvironmentConfiguration(
 			int numNetworkBuffers,
 			int networkBufferSize,
@@ -85,7 +87,8 @@ public class NettyShuffleEnvironmentConfiguration {
 			boolean isNetworkDetailedMetrics,
 			@Nullable NettyConfig nettyConfig,
 			String[] tempDirs,
-			BoundedBlockingSubpartitionType blockingSubpartitionType) {
+			BoundedBlockingSubpartitionType blockingSubpartitionType,
+			boolean forcePartitionReleaseOnConsumption) {
 
 		this.numNetworkBuffers = numNetworkBuffers;
 		this.networkBufferSize = networkBufferSize;
@@ -99,6 +102,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		this.nettyConfig = nettyConfig;
 		this.tempDirs = Preconditions.checkNotNull(tempDirs);
 		this.blockingSubpartitionType = Preconditions.checkNotNull(blockingSubpartitionType);
+		this.forcePartitionReleaseOnConsumption = forcePartitionReleaseOnConsumption;
 	}
 
 	// ------------------------------------------------------------------------
@@ -151,6 +155,10 @@ public class NettyShuffleEnvironmentConfiguration {
 		return blockingSubpartitionType;
 	}
 
+	public boolean isForcePartitionReleaseOnConsumption() {
+		return forcePartitionReleaseOnConsumption;
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -194,6 +202,9 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		BoundedBlockingSubpartitionType blockingSubpartitionType = getBlockingSubpartitionType(configuration);
 
+		boolean forcePartitionReleaseOnConsumption =
+			configuration.getBoolean(NettyShuffleEnvironmentOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION);
+
 		return new NettyShuffleEnvironmentConfiguration(
 			numberOfNetworkBuffers,
 			pageSize,
@@ -206,7 +217,8 @@ public class NettyShuffleEnvironmentConfiguration {
 			isNetworkDetailedMetrics,
 			nettyConfig,
 			tempDirs,
-			blockingSubpartitionType);
+			blockingSubpartitionType,
+			forcePartitionReleaseOnConsumption);
 	}
 
 	/**
@@ -521,6 +533,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		result = 31 * result + (isCreditBased ? 1 : 0);
 		result = 31 * result + (nettyConfig != null ? nettyConfig.hashCode() : 0);
 		result = 31 * result + Arrays.hashCode(tempDirs);
+		result = 31 * result + (forcePartitionReleaseOnConsumption ? 1 : 0);
 		return result;
 	}
 
@@ -544,7 +557,8 @@ public class NettyShuffleEnvironmentConfiguration {
 					this.requestSegmentsTimeout.equals(that.requestSegmentsTimeout) &&
 					this.isCreditBased == that.isCreditBased &&
 					(nettyConfig != null ? nettyConfig.equals(that.nettyConfig) : that.nettyConfig == null) &&
-					Arrays.equals(this.tempDirs, that.tempDirs);
+					Arrays.equals(this.tempDirs, that.tempDirs) &&
+					this.forcePartitionReleaseOnConsumption == that.forcePartitionReleaseOnConsumption;
 		}
 	}
 
@@ -561,6 +575,7 @@ public class NettyShuffleEnvironmentConfiguration {
 				", isCreditBased=" + isCreditBased +
 				", nettyConfig=" + nettyConfig +
 				", tempDirs=" + Arrays.toString(tempDirs) +
+				", forcePartitionReleaseOnConsumption=" + forcePartitionReleaseOnConsumption +
 				'}';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -29,8 +29,8 @@ import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartitionType;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
-
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -30,9 +30,7 @@ import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.NetworkPartitionConnectionInfo;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
-import org.apache.flink.runtime.shuffle.ShuffleDescriptor.ReleaseType;
 import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
-import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -90,8 +88,7 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 		ShuffleDescriptor shuffleDescriptor = new NettyShuffleDescriptor(
 			producerLocation,
 			new NetworkPartitionConnectionInfo(connectionID),
-			resultPartitionID,
-			false);
+			resultPartitionID);
 
 		ResultPartitionDeploymentDescriptor copy =
 			createCopyAndVerifyResultPartitionDeploymentDescriptor(shuffleDescriptor);
@@ -102,16 +99,6 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 		assertThat(shuffleDescriptorCopy.isUnknown(), is(false));
 		assertThat(shuffleDescriptorCopy.isLocalTo(producerLocation), is(true));
 		assertThat(shuffleDescriptorCopy.getConnectionId(), is(connectionID));
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testIncompatibleReleaseTypeManual() {
-		new ResultPartitionDeploymentDescriptor(
-			partitionDescriptor,
-			NettyShuffleDescriptorBuilder.newBuilder().setBlocking(false).buildLocal(),
-			1,
-			true,
-			ReleaseType.MANUAL);
 	}
 
 	private static ResultPartitionDeploymentDescriptor createCopyAndVerifyResultPartitionDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -143,7 +143,8 @@ public class NettyShuffleEnvironmentBuilder {
 				isNetworkDetailedMetrics,
 				nettyConfig,
 				tempDirs,
-				BoundedBlockingSubpartitionType.AUTO),
+				BoundedBlockingSubpartitionType.AUTO,
+				false),
 			taskManagerLocation,
 			taskEventDispatcher,
 			metricGroup);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -33,37 +33,29 @@ import java.time.Duration;
  */
 public class NettyShuffleEnvironmentBuilder {
 
-	public static final int DEFAULT_NUM_NETWORK_BUFFERS = 1024;
+	private static final int DEFAULT_NETWORK_BUFFER_SIZE = 32 << 10;
+	private static final int DEFAULT_NUM_NETWORK_BUFFERS = 1024;
 
-	private static final String[] DEFAULT_TEMP_DIRS = new String[] {EnvironmentInformation.getTemporaryFileDirectory()};
+	private static final String[] DEFAULT_TEMP_DIRS = {EnvironmentInformation.getTemporaryFileDirectory()};
+	private static final Duration DEFAULT_REQUEST_SEGMENTS_TIMEOUT = Duration.ofMillis(30000L);
 
 	private int numNetworkBuffers = DEFAULT_NUM_NETWORK_BUFFERS;
 
-	private int networkBufferSize = 32 * 1024;
+	private int partitionRequestInitialBackoff;
 
-	private int partitionRequestInitialBackoff = 0;
-
-	private int partitionRequestMaxBackoff = 0;
+	private int partitionRequestMaxBackoff;
 
 	private int networkBuffersPerChannel = 2;
 
 	private int floatingNetworkBuffersPerGate = 8;
 
-	private Duration requestSegmentsTimeout = Duration.ofMillis(30000L);
-
 	private boolean isCreditBased = true;
-
-	private boolean isNetworkDetailedMetrics = false;
 
 	private ResourceID taskManagerLocation = ResourceID.generate();
 
 	private NettyConfig nettyConfig;
 
-	private TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
-
 	private MetricGroup metricGroup = UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup();
-
-	private String[] tempDirs = DEFAULT_TEMP_DIRS;
 
 	public NettyShuffleEnvironmentBuilder setTaskManagerLocation(ResourceID taskManagerLocation) {
 		this.taskManagerLocation = taskManagerLocation;
@@ -72,11 +64,6 @@ public class NettyShuffleEnvironmentBuilder {
 
 	public NettyShuffleEnvironmentBuilder setNumNetworkBuffers(int numNetworkBuffers) {
 		this.numNetworkBuffers = numNetworkBuffers;
-		return this;
-	}
-
-	public NettyShuffleEnvironmentBuilder setNetworkBufferSize(int networkBufferSize) {
-		this.networkBufferSize = networkBufferSize;
 		return this;
 	}
 
@@ -100,10 +87,6 @@ public class NettyShuffleEnvironmentBuilder {
 		return this;
 	}
 
-	public void setRequestSegmentsTimeout(Duration requestSegmentsTimeout) {
-		this.requestSegmentsTimeout = requestSegmentsTimeout;
-	}
-
 	public NettyShuffleEnvironmentBuilder setIsCreditBased(boolean isCreditBased) {
 		this.isCreditBased = isCreditBased;
 		return this;
@@ -114,18 +97,8 @@ public class NettyShuffleEnvironmentBuilder {
 		return this;
 	}
 
-	public NettyShuffleEnvironmentBuilder setTaskEventDispatcher(TaskEventDispatcher taskEventDispatcher) {
-		this.taskEventDispatcher = taskEventDispatcher;
-		return this;
-	}
-
 	public NettyShuffleEnvironmentBuilder setMetricGroup(MetricGroup metricGroup) {
 		this.metricGroup = metricGroup;
-		return this;
-	}
-
-	public NettyShuffleEnvironmentBuilder setTempDirs(String[] tempDirs) {
-		this.tempDirs = tempDirs;
 		return this;
 	}
 
@@ -133,20 +106,20 @@ public class NettyShuffleEnvironmentBuilder {
 		return NettyShuffleServiceFactory.createNettyShuffleEnvironment(
 			new NettyShuffleEnvironmentConfiguration(
 				numNetworkBuffers,
-				networkBufferSize,
+				DEFAULT_NETWORK_BUFFER_SIZE,
 				partitionRequestInitialBackoff,
 				partitionRequestMaxBackoff,
 				networkBuffersPerChannel,
 				floatingNetworkBuffersPerGate,
-				requestSegmentsTimeout,
+				DEFAULT_REQUEST_SEGMENTS_TIMEOUT,
 				isCreditBased,
-				isNetworkDetailedMetrics,
+				false,
 				nettyConfig,
-				tempDirs,
+				DEFAULT_TEMP_DIRS,
 				BoundedBlockingSubpartitionType.AUTO,
 				false),
 			taskManagerLocation,
-			taskEventDispatcher,
+			new TaskEventDispatcher(),
 			metricGroup);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
@@ -39,7 +40,8 @@ import static org.junit.Assert.fail;
  * While using Mockito internally (for now), the use of Mockito should not
  * leak out of this class.
  */
-public class PartitionTestUtils {
+public enum PartitionTestUtils {
+	;
 
 	public static ResultPartition createPartition() {
 		return createPartition(ResultPartitionType.PIPELINED_BOUNDED);
@@ -83,7 +85,7 @@ public class PartitionTestUtils {
 	}
 
 	static void verifyCreateSubpartitionViewThrowsException(
-			ResultPartitionManager partitionManager,
+			ResultPartitionProvider partitionManager,
 			ResultPartitionID partitionId) throws IOException {
 		try {
 			partitionManager.createSubpartitionView(partitionId, 0, new NoOpBufferAvailablityListener());
@@ -114,7 +116,10 @@ public class PartitionTestUtils {
 		return createPartitionDeploymentDescriptor(ResultPartitionType.BLOCKING);
 	}
 
-	public static void writeBuffers(ResultPartition partition, int numberOfBuffers, int bufferSize) throws IOException {
+	public static void writeBuffers(
+			ResultPartitionWriter partition,
+			int numberOfBuffers,
+			int bufferSize) throws IOException {
 		for (int i = 0; i < numberOfBuffers; i++) {
 			partition.addBufferConsumer(createFilledBufferConsumer(bufferSize, bufferSize), 0);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
@@ -30,8 +29,6 @@ import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
-import java.util.EnumSet;
-import java.util.Optional;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferConsumer;
 import static org.junit.Assert.assertThat;
@@ -97,8 +94,9 @@ public class PartitionTestUtils {
 		}
 	}
 
-	public static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(ResultPartitionType partitionType) {
-		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().setBlocking(partitionType.isBlocking()).buildLocal();
+	static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(
+		ResultPartitionType partitionType) {
+		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().buildLocal();
 		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
 			new IntermediateDataSetID(),
 			shuffleDescriptor.getResultPartitionID().getPartitionId(),
@@ -112,52 +110,8 @@ public class PartitionTestUtils {
 			true);
 	}
 
-	public static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(ShuffleDescriptor.ReleaseType releaseType) {
-		// set partition to blocking to support all release types
-		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().setBlocking(true).buildLocal();
-		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
-			new IntermediateDataSetID(),
-			shuffleDescriptor.getResultPartitionID().getPartitionId(),
-			ResultPartitionType.BLOCKING,
-			1,
-			0);
-		return new ResultPartitionDeploymentDescriptor(
-			partitionDescriptor,
-			shuffleDescriptor,
-			1,
-			true,
-			releaseType);
-	}
-
-	public static ResultPartitionDeploymentDescriptor createResultPartitionDeploymentDescriptor(ResultPartitionID resultPartitionId, ShuffleDescriptor.ReleaseType releaseType, boolean hasLocalResources) {
-		return new ResultPartitionDeploymentDescriptor(
-			new PartitionDescriptor(
-				new IntermediateDataSetID(),
-				resultPartitionId.getPartitionId(),
-				ResultPartitionType.BLOCKING,
-				1,
-				0),
-			new ShuffleDescriptor() {
-				@Override
-				public ResultPartitionID getResultPartitionID() {
-					return resultPartitionId;
-				}
-
-				@Override
-				public Optional<ResourceID> storesLocalResourcesOn() {
-					return hasLocalResources
-						? Optional.of(ResourceID.generate())
-						: Optional.empty();
-				}
-
-				@Override
-				public EnumSet<ReleaseType> getSupportedReleaseTypes() {
-					return EnumSet.of(releaseType);
-				}
-			},
-			1,
-			true,
-			releaseType);
+	public static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor() {
+		return createPartitionDeploymentDescriptor(ResultPartitionType.BLOCKING);
 	}
 
 	public static void writeBuffers(ResultPartition partition, int numberOfBuffers, int bufferSize) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTrackerImplTest.java
@@ -34,14 +34,12 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
@@ -53,15 +51,15 @@ public class PartitionTrackerImplTest extends TestLogger {
 
 	@Test
 	public void testReleasedOnConsumptionPartitionIsNotTracked() {
-		testReleaseOnConsumptionHandling(ShuffleDescriptor.ReleaseType.AUTO);
+		testReleaseOnConsumptionHandling(ResultPartitionType.PIPELINED);
 	}
 
 	@Test
 	public void testRetainedOnConsumptionPartitionIsTracked() {
-		testReleaseOnConsumptionHandling(ShuffleDescriptor.ReleaseType.MANUAL);
+		testReleaseOnConsumptionHandling(ResultPartitionType.BLOCKING);
 	}
 
-	private void testReleaseOnConsumptionHandling(ShuffleDescriptor.ReleaseType releaseType) {
+	private void testReleaseOnConsumptionHandling(ResultPartitionType resultPartitionType) {
 		final PartitionTracker partitionTracker = new PartitionTrackerImpl(
 			new JobID(),
 			new TestingShuffleMaster(),
@@ -74,10 +72,11 @@ public class PartitionTrackerImplTest extends TestLogger {
 			resourceId,
 			createResultPartitionDeploymentDescriptor(
 				resultPartitionId,
-				releaseType,
+				resultPartitionType,
 				false));
 
-		assertThat(partitionTracker.isTrackingPartitionsFor(resourceId), is(not(releaseType)));
+		final boolean isTrackingExpected = resultPartitionType == ResultPartitionType.BLOCKING;
+		assertThat(partitionTracker.isTrackingPartitionsFor(resourceId), is(isTrackingExpected));
 	}
 
 	@Test
@@ -97,7 +96,7 @@ public class PartitionTrackerImplTest extends TestLogger {
 
 		partitionTracker.startTrackingPartition(
 			executorWithTrackedPartition,
-			createResultPartitionDeploymentDescriptor(new ResultPartitionID(), ShuffleDescriptor.ReleaseType.MANUAL, true));
+			createResultPartitionDeploymentDescriptor(new ResultPartitionID(), true));
 
 		assertThat(partitionTracker.isTrackingPartitionsFor(executorWithTrackedPartition), is(true));
 		assertThat(partitionTracker.isTrackingPartitionsFor(executorWithoutTrackedPartition), is(false));
@@ -127,10 +126,10 @@ public class PartitionTrackerImplTest extends TestLogger {
 
 		partitionTracker.startTrackingPartition(
 			taskExecutorId1,
-			createResultPartitionDeploymentDescriptor(resultPartitionId1, ShuffleDescriptor.ReleaseType.MANUAL, true));
+			createResultPartitionDeploymentDescriptor(resultPartitionId1, true));
 		partitionTracker.startTrackingPartition(
 			taskExecutorId2,
-			createResultPartitionDeploymentDescriptor(resultPartitionId2, ShuffleDescriptor.ReleaseType.MANUAL, true));
+			createResultPartitionDeploymentDescriptor(resultPartitionId2, true));
 
 		{
 			partitionTracker.stopTrackingAndReleasePartitionsFor(taskExecutorId1);
@@ -183,10 +182,10 @@ public class PartitionTrackerImplTest extends TestLogger {
 
 		partitionTracker.startTrackingPartition(
 			taskExecutorId1,
-			createResultPartitionDeploymentDescriptor(resultPartitionId1, ShuffleDescriptor.ReleaseType.MANUAL, false));
+			createResultPartitionDeploymentDescriptor(resultPartitionId1, false));
 		partitionTracker.startTrackingPartition(
 			taskExecutorId2,
-			createResultPartitionDeploymentDescriptor(resultPartitionId2, ShuffleDescriptor.ReleaseType.MANUAL, false));
+			createResultPartitionDeploymentDescriptor(resultPartitionId2, false));
 
 		{
 			partitionTracker.stopTrackingAndReleasePartitionsFor(taskExecutorId1);
@@ -227,7 +226,7 @@ public class PartitionTrackerImplTest extends TestLogger {
 
 		partitionTracker.startTrackingPartition(
 			taskExecutorId1,
-			createResultPartitionDeploymentDescriptor(resultPartitionId1, ShuffleDescriptor.ReleaseType.MANUAL, true));
+			createResultPartitionDeploymentDescriptor(resultPartitionId1, true));
 
 		partitionTracker.stopTrackingPartitionsFor(taskExecutorId1);
 
@@ -236,15 +235,21 @@ public class PartitionTrackerImplTest extends TestLogger {
 	}
 
 	private static ResultPartitionDeploymentDescriptor createResultPartitionDeploymentDescriptor(
+			ResultPartitionID resultPartitionId,
+			boolean hasLocalResources) {
+		return createResultPartitionDeploymentDescriptor(resultPartitionId, ResultPartitionType.BLOCKING, hasLocalResources);
+	}
+
+	private static ResultPartitionDeploymentDescriptor createResultPartitionDeploymentDescriptor(
 		ResultPartitionID resultPartitionId,
-		ShuffleDescriptor.ReleaseType releaseType,
+		ResultPartitionType type,
 		boolean hasLocalResources) {
 
 		return new ResultPartitionDeploymentDescriptor(
 			new PartitionDescriptor(
 				new IntermediateDataSetID(),
 				resultPartitionId.getPartitionId(),
-				ResultPartitionType.BLOCKING,
+				type,
 				1,
 				0),
 			new ShuffleDescriptor() {
@@ -259,15 +264,9 @@ public class PartitionTrackerImplTest extends TestLogger {
 						? Optional.of(ResourceID.generate())
 						: Optional.empty();
 				}
-
-				@Override
-				public EnumSet<ReleaseType> getSupportedReleaseTypes() {
-					return EnumSet.of(releaseType);
-				}
 			},
 			1,
-			true,
-			releaseType);
+			true);
 	}
 
 	private static TaskExecutorGateway createTaskExecutorGateway(ResourceID taskExecutorId, Collection<Tuple3<ResourceID, JobID, Collection<ResultPartitionID>>> releaseCalls) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -113,7 +113,7 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
-	public ResultPartitionBuilder setNetworkBufferSize(int networkBufferSize) {
+	ResultPartitionBuilder setNetworkBufferSize(int networkBufferSize) {
 		this.networkBufferSize = networkBufferSize;
 		return this;
 	}
@@ -129,7 +129,8 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
-	public ResultPartitionBuilder setBoundedBlockingSubpartitionType(BoundedBlockingSubpartitionType blockingSubpartitionType) {
+	ResultPartitionBuilder setBoundedBlockingSubpartitionType(
+			@SuppressWarnings("SameParameterValue") BoundedBlockingSubpartitionType blockingSubpartitionType) {
 		this.blockingSubpartitionType = blockingSubpartitionType;
 		return this;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -142,7 +142,8 @@ public class ResultPartitionBuilder {
 			blockingSubpartitionType,
 			networkBuffersPerChannel,
 			floatingNetworkBuffersPerGate,
-			networkBufferSize);
+			networkBufferSize,
+			releasedOnConsumption);
 
 		FunctionWithException<BufferPoolOwner, BufferPool, IOException> factory = bufferPoolFactory.orElseGet(() ->
 			resultPartitionFactory.createBufferPoolFactory(numberOfSubpartitions, partitionType));
@@ -153,7 +154,6 @@ public class ResultPartitionBuilder {
 			partitionType,
 			numberOfSubpartitions,
 			numTargetKeyGroups,
-			releasedOnConsumption,
 			factory);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -39,9 +39,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Tests for the {@link ResultPartitionFactory}.
  */
+@SuppressWarnings("StaticVariableUsedBeforeInitialization")
 public class ResultPartitionFactoryTest extends TestLogger {
 
 	private static final String tempDir = EnvironmentInformation.getTemporaryFileDirectory();
+	private static final int SEGMENT_SIZE = 64;
 
 	private static FileChannelManager fileChannelManager;
 
@@ -79,11 +81,11 @@ public class ResultPartitionFactoryTest extends TestLogger {
 		ResultPartitionFactory factory = new ResultPartitionFactory(
 			new ResultPartitionManager(),
 			fileChannelManager,
-			new NetworkBufferPool(1, 64, 1),
+			new NetworkBufferPool(1, SEGMENT_SIZE, 1),
 			BoundedBlockingSubpartitionType.AUTO,
 			1,
 			1,
-			64,
+			SEGMENT_SIZE,
 			releasePartitionOnConsumption);
 
 		final ResultPartitionDeploymentDescriptor descriptor = new ResultPartitionDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -32,6 +32,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,6 +57,18 @@ public class ResultPartitionFactoryTest extends TestLogger {
 	@AfterClass
 	public static void shutdown() throws Exception {
 		fileChannelManager.close();
+	}
+
+	@Test
+	public void testBoundedBlockingSubpartitionsCreated() {
+		final ResultPartition resultPartition = createResultPartition(false, ResultPartitionType.BLOCKING);
+		Arrays.stream(resultPartition.subpartitions).forEach(sp -> assertThat(sp, instanceOf(BoundedBlockingSubpartition.class)));
+	}
+
+	@Test
+	public void testPipelinedSubpartitionsCreated() {
+		final ResultPartition resultPartition = createResultPartition(false, ResultPartitionType.PIPELINED);
+		Arrays.stream(resultPartition.subpartitions).forEach(sp -> assertThat(sp, instanceOf(PipelinedSubpartition.class)));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -56,7 +56,6 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
-import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.shuffle.ShuffleIOOwnerContext;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
@@ -216,7 +215,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 		boolean waitForRelease) throws Exception {
 
 		final ResultPartitionDeploymentDescriptor taskResultPartitionDescriptor =
-			PartitionTestUtils.createPartitionDeploymentDescriptor(ShuffleDescriptor.ReleaseType.MANUAL);
+			PartitionTestUtils.createPartitionDeploymentDescriptor();
 		final ExecutionAttemptID eid1 = taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID().getProducerId();
 
 		final TaskDeploymentDescriptor taskDeploymentDescriptor =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
@@ -38,8 +38,8 @@ public class NettyShuffleDescriptorBuilder {
 	private ResourceID producerLocation = ResourceID.generate();
 	private ResultPartitionID id = new ResultPartitionID();
 	private InetAddress address = InetAddress.getLoopbackAddress();
-	private int dataPort = 0;
-	private int connectionIndex = 0;
+	private int dataPort;
+	private int connectionIndex;
 	public NettyShuffleDescriptorBuilder setProducerLocation(ResourceID producerLocation) {
 		this.producerLocation = producerLocation;
 		return this;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
@@ -40,8 +40,6 @@ public class NettyShuffleDescriptorBuilder {
 	private InetAddress address = InetAddress.getLoopbackAddress();
 	private int dataPort = 0;
 	private int connectionIndex = 0;
-	private boolean isBlocking;
-
 	public NettyShuffleDescriptorBuilder setProducerLocation(ResourceID producerLocation) {
 		this.producerLocation = producerLocation;
 		return this;
@@ -74,26 +72,19 @@ public class NettyShuffleDescriptorBuilder {
 		return this;
 	}
 
-	public NettyShuffleDescriptorBuilder setBlocking(boolean isBlocking) {
-		this.isBlocking = isBlocking;
-		return this;
-	}
-
 	public NettyShuffleDescriptor buildRemote() {
 		ConnectionID connectionID = new ConnectionID(new InetSocketAddress(address, dataPort), connectionIndex);
 		return new NettyShuffleDescriptor(
 			producerLocation,
 			new NetworkPartitionConnectionInfo(connectionID),
-			id,
-			isBlocking);
+			id);
 	}
 
 	public NettyShuffleDescriptor buildLocal() {
 		return new NettyShuffleDescriptor(
 			producerLocation,
 			LocalExecutionPartitionConnectionInfo.INSTANCE,
-			id,
-			isBlocking);
+			id);
 	}
 
 	public static NettyShuffleDescriptorBuilder newBuilder() {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
-import static org.apache.flink.configuration.JobManagerOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION;
+import static org.apache.flink.configuration.NettyShuffleEnvironmentOptions.FORCE_PARTITION_RELEASE_ON_CONSUMPTION;
 import static org.apache.flink.runtime.executiongraph.failover.FailoverStrategyLoader.PIPELINED_REGION_RESTART_STRATEGY_NAME;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;


### PR DESCRIPTION
## What is the purpose of the change

In a long term we do not need auto-release semantics for blocking (persistent) partition. We expect them always to be released externally by JM and assume they can be consumed multiple times.

The pipelined partitions have always only one consumer and one consumption attempt. Afterwards they can be always released automatically.

`ShuffleDescriptor#ReleaseType` was introduced to make release semantics more flexible but it is not needed in a long term.

`FORCE_PARTITION_RELEASE_ON_CONSUMPTION` was introduced as a safety net to be able to fallback to 1.8 behaviour without the partition tracker and JM taking care about blocking partition release. We can make this option specific for `NettyShuffleEnvironment` which was the only existing shuffle service before. If it is activated then the blocking partition is also auto-released on a consumption attempt as it was before. The fine-grained recovery will just not find the partition after the job restart in this case and will restart the producer.

## Brief change log

  - Remove `ShuffleDescriptor#ReleaseType` and assume predefined release semantics for certain partition type
  - Adjust test and other involved code
  - Move `FORCE_PARTITION_RELEASE_ON_CONSUMPTION` from `JobManagerOptions` to `NettyShuffleEnvironmentOptions`
  - codestyle fixes


## Verifying this change

existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
