### PR TITLE
[FLINK-13449][core] Add ARM architecture to MemoryArchitecture

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/MemoryArchitecture.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MemoryArchitecture.java
@@ -60,7 +60,7 @@ public enum MemoryArchitecture {
 	private static MemoryArchitecture getInternal() {
 		// putting these into the method to avoid having objects on the heap that are not needed
 		// any more after initialization
-		final List<String> names64bit = Arrays.asList("amd64", "x86_64");
+		final List<String> names64bit = Arrays.asList("amd64", "x86_64", "aarch64");
 		final List<String> names32bit = Arrays.asList("x86", "i386", "i486", "i586", "i686");
 		final String arch = System.getProperty("os.arch");
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the `aarch64` for ARM64/AARCH64 to the known memory architectures.


## Brief change log

Previously, the `Memoryarchitecture` recognizes only various versions of `x86` and `amd64` / `ia64`, the `arm64` will not be recognized. 

This patch try to add `aarch64` for ARM64/AARCH64 to the known architectures.


## Verifying this change

This change is already covered by existing tests, such as the `testArchitectureNotUnknown` in *org.apache.flink.util.MemoryArchitectureTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no


## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
