### PR TITLE
[hotfix][table]Rename TableAggFunctionCallVisitor to TableAggFunctionCallResolver

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/factories/AggregateOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/factories/AggregateOperationFactory.java
@@ -518,11 +518,11 @@ public final class AggregateOperationFactory {
 	 * Extract a table aggregate Expression and it's aliases.
 	 */
 	public Tuple2<ResolvedExpression, List<String>> extractTableAggFunctionAndAliases(Expression callExpr) {
-		TableAggFunctionCallVisitor visitor = new TableAggFunctionCallVisitor();
+		TableAggFunctionCallResolver visitor = new TableAggFunctionCallResolver();
 		return Tuple2.of(callExpr.accept(visitor), visitor.getAlias());
 	}
 
-	private class TableAggFunctionCallVisitor extends ResolvedExpressionDefaultVisitor<ResolvedExpression> {
+	private class TableAggFunctionCallResolver extends ResolvedExpressionDefaultVisitor<ResolvedExpression> {
 
 		private List<String> alias = new LinkedList<>();
 


### PR DESCRIPTION
## What is the purpose of the change

Rename `TableAggFunctionCallVisitor` to `TableAggFunctionCallResolver` for class name more meaningful. i.e., `TableAggFunctionCallVisitor` have two liability:
* Resolve alias of TableAggregate Function.
* Resolve the TableAggregateFunction Expression.
So, I think It's better to improve the name of `TableAggFunctionCallVisitor` to `TableAggFunctionCallResolver`.

## Brief change log
  - Rename `TableAggFunctionCallVisitor` to `TableAggFunctionCallResolver `
 

## Verifying this change
This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
 