### PR TITLE
[FLINK-13502] move CatalogTableStatisticsConverter & TreeNode to correct package

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -42,7 +42,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static java.lang.String.format;
-import static org.apache.flink.table.util.CatalogTableStatisticsConverter.convertToTableStats;
+import static org.apache.flink.table.planner.utils.CatalogTableStatisticsConverter.convertToTableStats;
 
 /**
  * A mapping between Flink catalog's database and Calcite's schema.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.util;
+package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpression.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpression.scala
@@ -19,7 +19,6 @@ package org.apache.flink.table.planner.expressions
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.expressions.{Expression, ExpressionVisitor}
-import org.apache.flink.table.planner.plan.TreeNode
 import org.apache.flink.table.planner.validate.{ValidationResult, ValidationSuccess}
 
 import java.util

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/TreeNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/TreeNode.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.planner.plan
+package org.apache.flink.table.planner.expressions
 
 import org.apache.flink.table.planner.typeutils.TypeInfoCheckUtils
 


### PR DESCRIPTION
## What is the purpose of the change

*move CatalogTableStatisticsConverter & TreeNode to correct package*


## Brief change log

  - *move CatalogTableStatisticsConverter to planner.utils*
  - *move TreeNode to planner.expressions*


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
