### PR TITLE
[FLINK-13433][table-planner-blink]  Do not fetch data from LookupableTableSource if the JoinKey in left side of LookupJoin contains null value.

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonLookupJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonLookupJoin.scala
@@ -560,7 +560,7 @@ abstract class CommonLookupJoin(
       joinType: JoinRelType): Unit = {
 
     // check join on all fields of PRIMARY KEY or (UNIQUE) INDEX
-    if (allLookupKeys.isEmpty || allLookupKeys.isEmpty) {
+    if (allLookupKeys.isEmpty) {
       throw new TableException(
         "Temporal table join requires an equality condition on fields of " +
           s"table [${tableSource.explainSource()}].")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
@@ -86,6 +86,28 @@ class LookupJoinTest extends TableTestBase {
   }
 
   @Test
+  def testNotDistinctFromInJoinCondition(): Unit = {
+
+    // does not support join condition contains `IS NOT DISTINCT`
+    expectExceptionThrown(
+      "SELECT * FROM MyTable AS T LEFT JOIN temporalTest " +
+        "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a IS NOT  DISTINCT FROM D.id",
+      "LookupJoin doesn't support join condition contains 'a IS NOT DISTINCT FROM b' (or " +
+        "alternative '(a = b) or (a IS NULL AND b IS NULL)')",
+      classOf[TableException]
+    )
+
+    // does not support join condition contains `IS NOT  DISTINCT` and similar syntax
+    expectExceptionThrown(
+      "SELECT * FROM MyTable AS T LEFT JOIN temporalTest " +
+        "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id OR (T.a IS NULL AND D.id IS NULL)",
+      "LookupJoin doesn't support join condition contains 'a IS NOT DISTINCT FROM b' (or " +
+        "alternative '(a = b) or (a IS NULL AND b IS NULL)')",
+      classOf[TableException]
+    )
+  }
+
+  @Test
   def testLogicalPlan(): Unit = {
     val sql1 =
       """

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/LookupJoinITCase.scala
@@ -22,15 +22,29 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.planner.runtime.utils.{BatchTableEnvUtil, BatchTestBase, InMemoryLookupableTableSource}
 
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import org.junit.{Before, Test}
 
-class LookupJoinITCase extends BatchTestBase {
+import java.lang.Boolean
+import java.util
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[Parameterized])
+class LookupJoinITCase(isAsyncMode: Boolean) extends BatchTestBase {
 
   val data = List(
     BatchTestBase.row(1L, 12L, "Julian"),
     BatchTestBase.row(2L, 15L, "Hello"),
     BatchTestBase.row(3L, 15L, "Fabian"),
     BatchTestBase.row(8L, 11L, "Hello world"),
+    BatchTestBase.row(9L, 12L, "Hello world!"))
+
+  val dataWithNull = List(
+    BatchTestBase.row(null, 15L, "Hello"),
+    BatchTestBase.row(3L, 15L, "Fabian"),
+    BatchTestBase.row(null, 11L, "Hello world"),
     BatchTestBase.row(9L, 12L, "Hello world!"))
 
   val typeInfo = new RowTypeInfo(LONG_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO)
@@ -55,142 +69,57 @@ class LookupJoinITCase extends BatchTestBase {
     .enableAsync()
     .build()
 
+  val userDataWithNull = List(
+    (11, 1L, "Julian"),
+    (22, null, "Hello"),
+    (33, 3L, "Fabian"),
+    (44, null, "Hello world"))
+
+  val userWithNullDataTableSource = InMemoryLookupableTableSource.builder()
+    .data(userDataWithNull)
+    .field("age", Types.INT)
+    .field("id", Types.LONG)
+    .field("name", Types.STRING)
+    .build()
+
+  val userAsyncWithNullDataTableSource = InMemoryLookupableTableSource.builder()
+    .data(userDataWithNull)
+    .field("age", Types.INT)
+    .field("id", Types.LONG)
+    .field("name", Types.STRING)
+    .enableAsync()
+    .build()
+
+  var userTable: String = _
+  var userTableWithNull: String = _
+
   @Before
   override def before() {
     super.before()
     BatchTableEnvUtil.registerCollection(tEnv, "T0", data, typeInfo, "id, len, content")
     val myTable = tEnv.sqlQuery("SELECT *, PROCTIME() as proctime  FROM T0")
     tEnv.registerTable("T", myTable)
+
+    BatchTableEnvUtil.registerCollection(
+      tEnv, "T1", dataWithNull, typeInfo, "id, len, content")
+    val myTable1 = tEnv.sqlQuery("SELECT *, PROCTIME() as proctime  FROM T1")
+    tEnv.registerTable("nullableT", myTable1)
+
     tEnv.registerTableSource("userTable", userTableSource)
     tEnv.registerTableSource("userAsyncTable", userAsyncTableSource)
-  }
+    userTable = if (isAsyncMode) "userAsyncTable" else "userTable"
 
-  @Test
-  def testJoinTemporalTable(): Unit = {
-    val sql = "SELECT T.id, T.len, T.content, D.name FROM T JOIN userTable " +
-      "for system_time as of T.proctime AS D ON T.id = D.id"
+    tEnv.registerTableSource("userWithNullDataTable", userWithNullDataTableSource)
+    tEnv.registerTableSource("userWithNullDataAsyncTable", userAsyncWithNullDataTableSource)
+    userTableWithNull = if (isAsyncMode) "userWithNullDataAsyncTable" else "userWithNullDataTable"
 
-    val expected = Seq(
-      BatchTestBase.row(1, 12, "Julian", "Julian"),
-      BatchTestBase.row(2, 15, "Hello", "Jark"),
-      BatchTestBase.row(3, 15, "Fabian", "Fabian"))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testJoinTemporalTableWithPushDown(): Unit = {
-    val sql = "SELECT T.id, T.len, T.content, D.name FROM T JOIN userTable " +
-      "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20"
-
-    val expected = Seq(
-      BatchTestBase.row(2, 15, "Hello", "Jark"),
-      BatchTestBase.row(3, 15, "Fabian", "Fabian"))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testJoinTemporalTableWithNonEqualFilter(): Unit = {
-    val sql = "SELECT T.id, T.len, T.content, D.name, D.age FROM T JOIN userTable " +
-      "for system_time as of T.proctime AS D ON T.id = D.id WHERE T.len <= D.age"
-
-    val expected = Seq(
-      BatchTestBase.row(2, 15, "Hello", "Jark", 22),
-      BatchTestBase.row(3, 15, "Fabian", "Fabian", 33))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testJoinTemporalTableOnMultiFields(): Unit = {
-    val sql = "SELECT T.id, T.len, D.name FROM T JOIN userTable " +
-      "for system_time as of T.proctime AS D ON T.id = D.id AND T.content = D.name"
-
-    val expected = Seq(
-      BatchTestBase.row(1, 12, "Julian"),
-      BatchTestBase.row(3, 15, "Fabian"))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testJoinTemporalTableOnMultiFieldsWithUdf(): Unit = {
-    val sql = "SELECT T.id, T.len, D.name FROM T JOIN userTable " +
-      "for system_time as of T.proctime AS D ON mod(T.id, 4) = D.id AND T.content = D.name"
-
-    val expected = Seq(
-      BatchTestBase.row(1, 12, "Julian"),
-      BatchTestBase.row(3, 15, "Fabian"))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testJoinTemporalTableOnMultiKeyFields(): Unit = {
-    val sql = "SELECT T.id, T.len, D.name FROM T JOIN userTable " +
-      "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
-
-    val expected = Seq(
-      BatchTestBase.row(1, 12, "Julian"),
-      BatchTestBase.row(3, 15, "Fabian"))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testLeftJoinTemporalTable(): Unit = {
-    val sql = "SELECT T.id, T.len, D.name, D.age FROM T LEFT JOIN userTable " +
-      "for system_time as of T.proctime AS D ON T.id = D.id"
-
-    val expected = Seq(
-      BatchTestBase.row(1, 12, "Julian", 11),
-      BatchTestBase.row(2, 15, "Jark", 22),
-      BatchTestBase.row(3, 15, "Fabian", 33),
-      BatchTestBase.row(8, 11, null, null),
-      BatchTestBase.row(9, 12, null, null))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testAsyncJoinTemporalTable(): Unit = {
     // TODO: enable object reuse until [FLINK-12351] is fixed.
     env.getConfig.disableObjectReuse()
-    val sql = "SELECT T.id, T.len, T.content, D.name FROM T JOIN userAsyncTable " +
-      "for system_time as of T.proctime AS D ON T.id = D.id"
-
-    val expected = Seq(
-      BatchTestBase.row(1, 12, "Julian", "Julian"),
-      BatchTestBase.row(2, 15, "Hello", "Jark"),
-      BatchTestBase.row(3, 15, "Fabian", "Fabian"))
-    checkResult(sql, expected, false)
   }
 
   @Test
-  def testAsyncJoinTemporalTableWithPushDown(): Unit = {
-    // TODO: enable object reuse until [FLINK-12351] is fixed.
-    env.getConfig.disableObjectReuse()
-    val sql = "SELECT T.id, T.len, T.content, D.name FROM T JOIN userAsyncTable " +
-      "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20"
-
-    val expected = Seq(
-      BatchTestBase.row(2, 15, "Hello", "Jark"),
-      BatchTestBase.row(3, 15, "Fabian", "Fabian"))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testAsyncJoinTemporalTableWithNonEqualFilter(): Unit = {
-    // TODO: enable object reuse until [FLINK-12351] is fixed.
-    env.getConfig.disableObjectReuse()
-    val sql = "SELECT T.id, T.len, T.content, D.name, D.age FROM T JOIN userAsyncTable " +
-      "for system_time as of T.proctime AS D ON T.id = D.id WHERE T.len <= D.age"
-
-    val expected = Seq(
-      BatchTestBase.row(2, 15, "Hello", "Jark", 22),
-      BatchTestBase.row(3, 15, "Fabian", "Fabian", 33))
-    checkResult(sql, expected, false)
-  }
-
-  @Test
-  def testAsyncLeftJoinTemporalTableWithLocalPredicate(): Unit = {
-    // TODO: enable object reuse until [FLINK-12351] is fixed.
-    env.getConfig.disableObjectReuse()
-    val sql = "SELECT T.id, T.len, T.content, D.name, D.age FROM T LEFT JOIN userAsyncTable " +
+  def testLeftJoinTemporalTableWithLocalPredicate(): Unit = {
+    val sql = s"SELECT T.id, T.len, T.content, D.name, D.age FROM T LEFT JOIN $userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id " +
       "AND T.len > 1 AND D.age > 20 AND D.name = 'Fabian' " +
       "WHERE T.id > 1"
@@ -204,10 +133,42 @@ class LookupJoinITCase extends BatchTestBase {
   }
 
   @Test
-  def testAsyncJoinTemporalTableOnMultiFields(): Unit = {
-    // TODO: enable object reuse until [FLINK-12351] is fixed.
-    env.getConfig.disableObjectReuse()
-    val sql = "SELECT T.id, T.len, D.name FROM T JOIN userAsyncTable " +
+  def testJoinTemporalTable(): Unit = {
+    val sql = s"SELECT T.id, T.len, T.content, D.name FROM T JOIN $userTable " +
+      "for system_time as of T.proctime AS D ON T.id = D.id"
+
+    val expected = Seq(
+      BatchTestBase.row(1, 12, "Julian", "Julian"),
+      BatchTestBase.row(2, 15, "Hello", "Jark"),
+      BatchTestBase.row(3, 15, "Fabian", "Fabian"))
+    checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testJoinTemporalTableWithPushDown(): Unit = {
+    val sql = s"SELECT T.id, T.len, T.content, D.name FROM T JOIN $userTable " +
+      "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20"
+
+    val expected = Seq(
+      BatchTestBase.row(2, 15, "Hello", "Jark"),
+      BatchTestBase.row(3, 15, "Fabian", "Fabian"))
+    checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testJoinTemporalTableWithNonEqualFilter(): Unit = {
+    val sql = s"SELECT T.id, T.len, T.content, D.name, D.age FROM T JOIN $userTable " +
+      "for system_time as of T.proctime AS D ON T.id = D.id WHERE T.len <= D.age"
+
+    val expected = Seq(
+      BatchTestBase.row(2, 15, "Hello", "Jark", 22),
+      BatchTestBase.row(3, 15, "Fabian", "Fabian", 33))
+    checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testJoinTemporalTableOnMultiFields(): Unit = {
+    val sql = s"SELECT T.id, T.len, D.name FROM T JOIN $userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id AND T.content = D.name"
 
     val expected = Seq(
@@ -217,10 +178,30 @@ class LookupJoinITCase extends BatchTestBase {
   }
 
   @Test
-  def testAsyncLeftJoinTemporalTable(): Unit = {
-    // TODO: enable object reuse until [FLINK-12351] is fixed.
-    env.getConfig.disableObjectReuse()
-    val sql = "SELECT T.id, T.len, D.name, D.age FROM T LEFT JOIN userAsyncTable " +
+  def testJoinTemporalTableOnMultiFieldsWithUdf(): Unit = {
+    val sql = s"SELECT T.id, T.len, D.name FROM T JOIN $userTable " +
+      "for system_time as of T.proctime AS D ON mod(T.id, 4) = D.id AND T.content = D.name"
+
+    val expected = Seq(
+      BatchTestBase.row(1, 12, "Julian"),
+      BatchTestBase.row(3, 15, "Fabian"))
+    checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testJoinTemporalTableOnMultiKeyFields(): Unit = {
+    val sql = s"SELECT T.id, T.len, D.name FROM T JOIN $userTable " +
+      "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
+
+    val expected = Seq(
+      BatchTestBase.row(1, 12, "Julian"),
+      BatchTestBase.row(3, 15, "Fabian"))
+    checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testLeftJoinTemporalTable(): Unit = {
+    val sql = s"SELECT T.id, T.len, D.name, D.age FROM T LEFT JOIN $userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val expected = Seq(
@@ -230,5 +211,53 @@ class LookupJoinITCase extends BatchTestBase {
       BatchTestBase.row(8, 11, null, null),
       BatchTestBase.row(9, 12, null, null))
     checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
+    val sql = s"SELECT T.id, T.len, D.name FROM nullableT T JOIN $userTableWithNull " +
+      "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
+
+    val expected = Seq(
+      BatchTestBase.row(3,15,"Fabian"))
+    checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testLeftJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
+    val sql = s"SELECT D.id, T.len, D.name FROM nullableT T LEFT JOIN $userTableWithNull " +
+      "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
+    val expected = Seq(
+      BatchTestBase.row(null,15,null),
+      BatchTestBase.row(3,15,"Fabian"),
+      BatchTestBase.row(null,11,null),
+      BatchTestBase.row(null,12,null))
+    checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testJoinTemporalTableOnNullConstantKey(): Unit = {
+    val sql = s"SELECT T.id, T.len, T.content FROM T JOIN $userTable " +
+      "for system_time as of T.proctime AS D ON D.id = null"
+    val expected = Seq()
+    checkResult(sql, expected, false)
+  }
+
+  @Test
+  def testJoinTemporalTableOnMultiKeyFieldsWithNullConstantKey(): Unit = {
+    val sql = s"SELECT T.id, T.len, D.name FROM T JOIN $userTable " +
+      "for system_time as of T.proctime AS D ON T.content = D.name AND null = D.id"
+    val expected = Seq()
+    checkResult(sql, expected, false)
+  }
+}
+
+object LookupJoinITCase {
+
+  @Parameterized.Parameters(name = "isAsyncMode = {0}")
+  def parameters(): util.Collection[Array[java.lang.Object]] = {
+    Seq[Array[AnyRef]](
+      Array(Boolean.TRUE), Array(Boolean.FALSE)
+    )
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils
 import org.apache.flink.table.planner.runtime.utils.{InMemoryLookupableTableSource, StreamingTestBase, TestingAppendSink}
 import org.apache.flink.types.Row
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
 import java.lang.{Integer => JInt, Long => JLong}
@@ -46,6 +46,11 @@ class LookupJoinITCase extends StreamingTestBase {
     Row.of(null, new JInt(11), "Hello world"),
     Row.of(new JLong(9), new JInt(12), "Hello world!"))
 
+  val dataRowType:TypeInformation[Row] = new RowTypeInfo(
+    BasicTypeInfo.LONG_TYPE_INFO,
+    BasicTypeInfo.INT_TYPE_INFO,
+    BasicTypeInfo.STRING_TYPE_INFO)
+
   val userData = List(
     (11, 1L, "Julian"),
     (22, 2L, "Jark"),
@@ -60,6 +65,20 @@ class LookupJoinITCase extends StreamingTestBase {
 
   val userTableSourceWith2Keys = InMemoryLookupableTableSource.builder()
     .data(userData)
+    .field("age", Types.INT)
+    .field("id", Types.LONG)
+    .field("name", Types.STRING)
+    .build()
+
+  val userDataWithNull = List(
+    (11, 1L, "Julian"),
+    (22, null, "Hello"),
+    (33, 3L, "Fabian"),
+    (44, null, "Hello world")
+  )
+
+  val userWithNullDataTableSourceWith2Keys = InMemoryLookupableTableSource.builder()
+    .data(userDataWithNull)
     .field("age", Types.INT)
     .field("id", Types.LONG)
     .field("name", Types.STRING)
@@ -137,11 +156,7 @@ class LookupJoinITCase extends StreamingTestBase {
 
   @Test
   def testJoinTemporalTableOnNullableKey(): Unit = {
-
-    implicit val tpe: TypeInformation[Row] = new RowTypeInfo(
-      BasicTypeInfo.LONG_TYPE_INFO,
-      BasicTypeInfo.INT_TYPE_INFO,
-      BasicTypeInfo.STRING_TYPE_INFO)
+    implicit val tpe: TypeInformation[Row] = dataRowType
     val streamTable = env.fromCollection(dataWithNull)
       .toTable(tEnv, 'id, 'len, 'content, 'proctime.proctime)
     tEnv.registerTable("T", streamTable)
@@ -366,11 +381,7 @@ class LookupJoinITCase extends StreamingTestBase {
 
   @Test
   def testLeftJoinTemporalTableOnNullableKey(): Unit = {
-
-    implicit val tpe: TypeInformation[Row] = new RowTypeInfo(
-      BasicTypeInfo.LONG_TYPE_INFO,
-      BasicTypeInfo.INT_TYPE_INFO,
-      BasicTypeInfo.STRING_TYPE_INFO)
+    implicit val tpe: TypeInformation[Row] = dataRowType
     val streamTable = env.fromCollection(dataWithNull)
       .toTable(tEnv, 'id, 'len, 'content, 'proctime.proctime)
     tEnv.registerTable("T", streamTable)
@@ -416,6 +427,92 @@ class LookupJoinITCase extends StreamingTestBase {
       "9,12,null,null")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
     assertEquals(0, userTableSource.getResourceCounter)
+  }
+
+  @Test
+  def testJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
+    implicit val tpe: TypeInformation[Row] = dataRowType
+    val streamTable = env.fromCollection(dataWithNull)
+      .toTable(tEnv, 'id, 'len, 'content, 'proctime.proctime)
+    tEnv.registerTable("T", streamTable)
+
+    tEnv.registerTableSource("userTable", userWithNullDataTableSourceWith2Keys)
+
+    val sql = "SELECT T.id, T.len, D.name FROM T JOIN userTable " +
+      "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "3,15,Fabian")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+    assertEquals(0, userTableSourceWith2Keys.getResourceCounter)
+  }
+
+  @Test
+  def testLeftJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
+    implicit val tpe: TypeInformation[Row] = dataRowType
+    val streamTable = env.fromCollection(dataWithNull)
+      .toTable(tEnv, 'id, 'len, 'content, 'proctime.proctime)
+    tEnv.registerTable("T", streamTable)
+
+    tEnv.registerTableSource("userTable", userWithNullDataTableSourceWith2Keys)
+
+    val sql = "SELECT D.id, T.len, D.name FROM T LEFT JOIN userTable " +
+      "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "null,15,null",
+      "3,15,Fabian",
+      "null,11,null",
+      "null,12,null")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+    assertEquals(0, userTableSourceWith2Keys.getResourceCounter)
+  }
+
+  @Test
+  def testJoinTemporalTableOnNullConstantKey(): Unit = {
+    implicit val tpe: TypeInformation[Row] = dataRowType
+    val streamTable = env.fromCollection(dataWithNull)
+      .toTable(tEnv, 'id, 'len, 'content, 'proctime.proctime)
+    tEnv.registerTable("T", streamTable)
+
+    tEnv.registerTableSource("userTable", userWithNullDataTableSourceWith2Keys)
+
+    val sql = "SELECT T.id, T.len, T.content FROM T JOIN userTable " +
+      "for system_time as of T.proctime AS D ON D.id = null"
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    assertTrue(sink.getAppendResults.isEmpty)
+    assertEquals(0, userTableSource.getResourceCounter)
+  }
+
+  @Test
+  def testJoinTemporalTableOnMultiKeyFieldsWithNullConstantKey(): Unit = {
+    val streamTable = env.fromCollection(data)
+      .toTable(tEnv, 'id, 'len, 'content, 'proctime.proctime)
+    tEnv.registerTable("T", streamTable)
+
+    tEnv.registerTableSource("userTable", userTableSourceWith2Keys)
+
+    val sql = "SELECT T.id, T.len, D.name FROM T JOIN userTable " +
+      "for system_time as of T.proctime AS D ON T.content = D.name AND null = D.id"
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    assertTrue(sink.getAppendResults.isEmpty)
+    assertEquals(0, userTableSourceWith2Keys.getResourceCounter)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/InMemoryLookupableTableSource.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/InMemoryLookupableTableSource.scala
@@ -205,6 +205,8 @@ object InMemoryLookupableTableSource {
     @varargs
     def eval(inputs: AnyRef*): Unit = {
       val key = Row.of(inputs: _*)
+      Preconditions.checkArgument(!inputs.contains(null),
+        s"Lookup key %s contains null value, which would not happen.", key)
       data.get(key) match {
         case Some(list) => list.foreach(result => collect(result))
         case None => // do nothing
@@ -236,8 +238,11 @@ object InMemoryLookupableTableSource {
 
     @varargs
     def eval(resultFuture: CompletableFuture[util.Collection[Row]], inputs: AnyRef*): Unit = {
+      val key = Row.of(inputs: _*)
+      Preconditions.checkArgument(!inputs.contains(null),
+        s"Lookup key %s contains null value, which would not happen.", key)
       CompletableFuture
-        .supplyAsync(new CollectionSupplier(data, Row.of(inputs: _*)), executor)
+        .supplyAsync(new CollectionSupplier(data, key), executor)
         .thenAccept(new CollectionConsumer(resultFuture))
     }
 


### PR DESCRIPTION
## What is the purpose of the change

For LookupJoin, if joinKey in left side of a LeftOuterJoin/InnerJoin contains null values, there is no need to fetch data from `LookupableTableSource`. 
However, we don't shortcut the fetch function under the case at present, the correctness of results depends on the `TableFunction` implementation of each `LookupableTableSource`.

## Brief change log

  - correct the behavior of `LookupJoin` where lookupKeys contains null.
  - Add more testcases.

## Verifying this change
testcases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
