### PR TITLE
[hotfix] Fix the master build failure

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -100,40 +100,38 @@ These examples about how to submit a job in CLI.
 
 -   Run Python Table program:
 
-        ./bin/flink run -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar>
+        ./bin/flink run -py examples/python/table/batch/word_count.py
 
 -   Run Python Table program with pyFiles:
 
-        ./bin/flink run -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar> \
+        ./bin/flink run -py examples/python/table/batch/word_count.py \
                                 -pyfs file:///user.txt,hdfs:///$namenode_address/username.txt
 
 -   Run Python Table program with pyFiles and pyModule:
 
-        ./bin/flink run -pym batch.word_count -pyfs examples/python/table/batch -j <path/to/flink-table.jar>
+        ./bin/flink run -pym batch.word_count -pyfs examples/python/table/batch
 
 -   Run Python Table program with parallelism 16:
 
-        ./bin/flink run -p 16 -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar>
+        ./bin/flink run -p 16 -py examples/python/table/batch/word_count.py
 
 -   Run Python Table program with flink log output disabled:
 
-        ./bin/flink run -q -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar>
+        ./bin/flink run -q -py examples/python/table/batch/word_count.py
 
 -   Run Python Table program in detached mode:
 
-        ./bin/flink run -d -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar>
+        ./bin/flink run -d -py examples/python/table/batch/word_count.py
 
 -   Run Python Table program on a specific JobManager:
 
         ./bin/flink run -m myJMHost:8081 \
-                               -py examples/python/table/batch/word_count.py \
-                               -j <path/to/flink-table.jar>
+                               -py examples/python/table/batch/word_count.py
 
 -   Run Python Table program using a [per-job YARN cluster]({{site.baseurl}}/ops/deployment/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn) with 2 TaskManagers:
 
         ./bin/flink run -m yarn-cluster -yn 2 \
-                               -py examples/python/table/batch/word_count.py \
-                               -j <path/to/flink-table.jar>
+                               -py examples/python/table/batch/word_count.py
 </div>
 
 ### Job Management Examples

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -100,40 +100,38 @@ available.
 
 -   提交一个Python Table的作业:
 
-        ./bin/flink run -py WordCount.py -j <path/to/flink-table.jar>
+        ./bin/flink run -py WordCount.py
 
 -   提交一个有多个依赖的Python Table的作业:
 
-        ./bin/flink run -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar> \
+        ./bin/flink run -py examples/python/table/batch/word_count.py \
                                 -pyfs file:///user.txt,hdfs:///$namenode_address/username.txt
 
 -   提交一个有多个依赖的Python Table的作业，Python作业的主入口通过pym选项指定:
 
-        ./bin/flink run -pym batch.word_count -pyfs examples/python/table/batch -j <path/to/flink-table.jar>
+        ./bin/flink run -pym batch.word_count -pyfs examples/python/table/batch
 
 -   提交一个指定并发度为16的Python Table的作业:
 
-        ./bin/flink run -p 16 -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar>
+        ./bin/flink run -p 16 -py examples/python/table/batch/word_count.py
 
 -   提交一个关闭flink日志输出的Python Table的作业:
 
-        ./bin/flink run -q -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar>
+        ./bin/flink run -q -py examples/python/table/batch/word_count.py
 
 -   提交一个运行在detached模式下的Python Table的作业:
 
-        ./bin/flink run -d -py examples/python/table/batch/word_count.py -j <path/to/flink-table.jar>
+        ./bin/flink run -d -py examples/python/table/batch/word_count.py
 
 -   提交一个运行在指定JobManager上的Python Table的作业:
 
         ./bin/flink run -m myJMHost:8081 \
-                            -py examples/python/table/batch/word_count.py \
-                            -j <path/to/flink-table.jar>
+                            -py examples/python/table/batch/word_count.py
 
 -   提交一个运行在有两个TaskManager的[per-job YARN cluster]({{site.baseurl}}/ops/deployment/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn)的Python Table的作业:
 
         ./bin/flink run -m yarn-cluster -yn 2 \
-                                 -py examples/python/table/batch/word_count.py \
-                                 -j <path/to/flink-table.jar>
+                                 -py examples/python/table/batch/word_count.py
                                  
 </div>
 

--- a/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
@@ -50,7 +50,6 @@ done
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-python-$HOSTNAME.log
 log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-cli.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml)
 
-TABLE_JAR_PATH=`echo "$FLINK_HOME"/lib/flink-table*.jar`
 PYTHON_JAR_PATH=`echo "$FLINK_HOME"/opt/flink-python*.jar`
 
 FLINK_TEST_CLASSPATH=""
@@ -94,8 +93,8 @@ fi
 ARGS_COUNT=${#ARGS[@]}
 if [[ ${ARGS[0]} == "local" ]]; then
   ARGS=("${ARGS[@]:1:$ARGS_COUNT}")
-  exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -cp ${FLINK_CLASSPATH}:${TABLE_JAR_PATH}:${PYTHON_JAR_PATH}:${FLINK_TEST_CLASSPATH} ${DRIVER} ${ARGS[@]}
+  exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -cp ${FLINK_CLASSPATH}:${PYTHON_JAR_PATH}:${FLINK_TEST_CLASSPATH} ${DRIVER} ${ARGS[@]}
 else
   ARGS=("${ARGS[@]:1:$ARGS_COUNT}")
-  exec "$FLINK_BIN_DIR"/flink run ${ARGS[@]} -c ${DRIVER} -j ${TABLE_JAR_PATH}
+  exec "$FLINK_BIN_DIR"/flink run ${ARGS[@]} -c ${DRIVER}
 fi

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -146,7 +146,8 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
             ! -path "$CACHE_FLINK_DIR/flink-runtime/target/flink-runtime*tests.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-streaming-java/target/flink-streaming-java*tests.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-dist*.jar" \
-            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-table*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-table_*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-table-blink*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-python*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-elasticsearch-base/target/flink-*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-kafka-base/target/flink-*.jar" \


### PR DESCRIPTION

## What is the purpose of the change

* The [travis](https://travis-ci.org/apache/flink/builds/565619561?utm_source=github_status&utm_medium=notification) build fails in master. This issue is introduced in this [commit](https://github.com/apache/flink/commit/abc1e0a1ffbc907ffb1ce56c504dfbc6bf0357d6#diff-cdb60401f7e9c15a3f5f1b393ab76ad1). This PR will fix this issue.*

## Brief change log

  - *There is no need to add flink-table*.jar to the classpath any more*
  - *Updates the doc*

## Verifying this change

This change is a trivial rework without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
