### PR TITLE
[FLINK-13498][kafka] abort transactions in parallel

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -912,13 +912,20 @@ public class FlinkKafkaProducer011<IN>
 	// ----------------------------------- Utilities --------------------------
 
 	private void abortTransactions(Set<String> transactionalIds) {
-		for (String transactionalId : transactionalIds) {
+		transactionalIds.parallelStream().forEach(transactionalId -> {
+			// don't mess with the original configuration or any other properties of the
+			// original object
+			// -> create an internal kafka producer on our own and do not rely on
+			//    initTransactionalProducer().
+			final Properties myConfig = new Properties();
+			myConfig.putAll(producerConfig);
+			initTransactionalProducerConfig(myConfig, transactionalId);
 			try (FlinkKafkaProducer<byte[], byte[]> kafkaProducer =
-					initTransactionalProducer(transactionalId, false)) {
-				// it suffice to call initTransactions - this will abort any lingering transactions
+					new FlinkKafkaProducer<>(myConfig)) {
+				// it suffices to call initTransactions - this will abort any lingering transactions
 				kafkaProducer.initTransactions();
 			}
-		}
+		});
 	}
 
 	int getTransactionCoordinatorId() {
@@ -952,12 +959,16 @@ public class FlinkKafkaProducer011<IN>
 	}
 
 	private FlinkKafkaProducer<byte[], byte[]> initTransactionalProducer(String transactionalId, boolean registerMetrics) {
-		producerConfig.put("transactional.id", transactionalId);
+		initTransactionalProducerConfig(producerConfig, transactionalId);
 		return initProducer(registerMetrics);
 	}
 
+	private static void initTransactionalProducerConfig(Properties producerConfig, String transactionalId) {
+		producerConfig.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+	}
+
 	private FlinkKafkaProducer<byte[], byte[]> initNonTransactionalProducer(boolean registerMetrics) {
-		producerConfig.remove("transactional.id");
+		producerConfig.remove(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
 		return initProducer(registerMetrics);
 	}
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -386,7 +386,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	 */
 	@Test
 	public void testScaleUpAfterScalingDown() throws Exception {
-		String topic = "scale-down-before-first-checkpoint";
+		String topic = "scale-up-after-scaling-down";
 
 		final int parallelism1 = 4;
 		final int parallelism2 = 2;


### PR DESCRIPTION
## What is the purpose of the change

This makes `FlinkKafkaProducer` abort transactions, e.g. during a first startup, in parallel making use of lingering CPU resources (using at most `kafkaProducersPoolSize` producers at once each, just like during runtime).

Especially during that first startup (and thus also in tests), a lot of producers `(5*poolSize)` are being created at each sink instance to abort potentially existing previous transactions (in most cases, they don't exist).

With this change, Kafka test times (on my PC) change like this:
```
FlinkKafkaProducerMigrationTest        :  36.689s -> 29.438s
FlinkKafkaProducerMigrationOperatorTest:  33.288s -> 26.232s
------
FlinkKafkaProducerITCase               : 289.475s -> 228.469s
KafkaITCase                            : 139.7s   -> 127.595s
FlinkKafkaInternalProducerITCase       :  34.436s ->  35.391s
KafkaProducerAtLeastOnceITCase         : 391.627s -> 391.473s
KafkaProducerExactlyOnceITCase         :  84.366s ->  72.608s
```

## Brief change log

- change `FlinkKafkaProducer`:
  - abort transactions using a parallel stream
  - use a new thread pool with `size = kafkaProducersPoolSize`
  - do not use `#initTransactionalProducer()` but rather only instantiate the parts needed for aborting transactions, i.e. a `FlinkKafkaInternalProducer`
- do the same for `FlinkKafkaProducer011`

## Verifying this change

This change is already covered by existing tests, such as Kafka unit tests and ITCases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
