### PR TITLE
[FLINK-13390] Clarify the exact meaning of state size when executing incremental checkpoint

### DIFF
--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -36,7 +36,7 @@
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Some state backends may not support incremental checkpoints and ignore this option.</td>
+            <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Once enabled, the state size shown in web UI or fetched from rest API only represents the delta checkpoint size instead of full checkpoint size. Some state backends may not support incremental checkpoints and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.backend.local-recovery</h5></td>

--- a/docs/_includes/generated/common_state_backends_section.html
+++ b/docs/_includes/generated/common_state_backends_section.html
@@ -30,7 +30,7 @@
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Some state backends may not support incremental checkpoints and ignore this option.</td>
+            <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Once enabled, the state size shown in web UI or fetched from rest API only represents the delta checkpoint size instead of full checkpoint size. Some state backends may not support incremental checkpoints and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.backend.local-recovery</h5></td>

--- a/docs/monitoring/checkpoint_monitoring.md
+++ b/docs/monitoring/checkpoint_monitoring.md
@@ -61,7 +61,7 @@ The checkpoint history keeps statistics about recently triggered checkpoints, in
 - **Trigger Time**: The time when the checkpoint was triggered at the JobManager.
 - **Latest Acknowledgement**: The time when the latest acknowledged for any subtask was received at the JobManager (or n/a if no acknowledgement received yet).
 - **End to End Duration**: The duration from the trigger timestamp until the latest acknowledgement (or n/a if no acknowledgement received yet). This end to end duration for a complete checkpoint is determined by the last subtask that acknowledges the checkpoint. This time is usually larger than single subtasks need to actually checkpoint the state.
-- **State Size**: The state size over all acknowledged subtasks.
+- **Checkpointed Data Size**: The checkpointed data size over all acknowledged subtasks. This value would be the delta delta checkpointed data if incremetnal checkpoint is on.
 - **Buffered During Alignment**: The number of bytes buffered during alignment over all acknowledged subtasks. This is only > 0 if a stream alignment takes place during checkpointing. If the checkpointing mode is `AT_LEAST_ONCE` this will always be zero as at least once mode does not require stream alignment.
 
 #### History Size Configuration
@@ -75,7 +75,7 @@ web.checkpoints.history: 15
 
 ### Summary Tab
 
-The summary computes a simple min/average/maximum statistics over all completed checkpoints for the End to End Duration, State Size, and Bytes Buffered During Alignment (see [History](#history) for details about what these mean).
+The summary computes a simple min/average/maximum statistics over all completed checkpoints for the End to End Duration, Checkpointed Data Size, and Bytes Buffered During Alignment (see [History](#history) for details about what these mean).
 
 <center>
   <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-summary.png" width="700px" alt="Checkpoint Monitoring: Summary">

--- a/docs/monitoring/checkpoint_monitoring.zh.md
+++ b/docs/monitoring/checkpoint_monitoring.zh.md
@@ -61,7 +61,7 @@ The checkpoint history keeps statistics about recently triggered checkpoints, in
 - **Trigger Time**: The time when the checkpoint was triggered at the JobManager.
 - **Latest Acknowledgement**: The time when the latest acknowledged for any subtask was received at the JobManager (or n/a if no acknowledgement received yet).
 - **End to End Duration**: The duration from the trigger timestamp until the latest acknowledgement (or n/a if no acknowledgement received yet). This end to end duration for a complete checkpoint is determined by the last subtask that acknowledges the checkpoint. This time is usually larger than single subtasks need to actually checkpoint the state.
-- **State Size**: The state size over all acknowledged subtasks.
+- **Checkpointed Data Size**: The state size over all acknowledged subtasks.
 - **Buffered During Alignment**: The number of bytes buffered during alignment over all acknowledged subtasks. This is only > 0 if a stream alignment takes place during checkpointing. If the checkpointing mode is `AT_LEAST_ONCE` this will always be zero as at least once mode does not require stream alignment.
 
 #### History Size Configuration
@@ -75,7 +75,7 @@ web.checkpoints.history: 15
 
 ### Summary Tab
 
-The summary computes a simple min/average/maximum statistics over all completed checkpoints for the End to End Duration, State Size, and Bytes Buffered During Alignment (see [History](#history) for details about what these mean).
+The summary computes a simple min/average/maximum statistics over all completed checkpoints for the End to End Duration, Checkpointed Data Size, and Bytes Buffered During Alignment (see [History](#history) for details about what these mean).
 
 <center>
   <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-summary.png" width="700px" alt="Checkpoint Monitoring: Summary">

--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -213,6 +213,9 @@ While we encourage the use of incremental checkpoints for large state, you need 
   - Setting a default in your `flink-conf.yaml`: `state.backend.incremental: true` will enable incremental checkpoints, unless the application overrides this setting in the code.
   - You can alternatively configure this directly in the code (overrides the config default): `RocksDBStateBackend backend = new RocksDBStateBackend(checkpointDirURI, true);`
 
+Notice that once incremental checkpoont is enabled, the `Checkpointed Data Size` showed in web UI only represents the 
+delta checkpointed data size of that checkpoint instead of full state size.
+
 ### Memory Management
 
 Flink aims to control the total process memory consumption to make sure that the Flink TaskManagers have a well-behaved memory footprint. That means staying within the limits enforced by the environment (Docker/Kubernetes, Yarn, etc) to not get killed for consuming too much memory, but also to not under-utilize memory (unnecessary spilling to disk, wasted caching opportunities, reduced performance).

--- a/docs/ops/state/state_backends.zh.md
+++ b/docs/ops/state/state_backends.zh.md
@@ -206,6 +206,8 @@ RocksDBStateBackend 支持*增量快照*。不同于产生一个包含所有数�
   - 在 `flink-conf.yaml` 中设置：`state.backend.incremental: true` 或者
   - 在代码中按照右侧方式配置（来覆盖默认配置）：`RocksDBStateBackend backend = new RocksDBStateBackend(filebackend, true);`
 
+需要注意的是，一旦启用了增量快照，网页上展示的 `Checkpointed Data Size` 只代表增量上传的数据量，而不是一次快照的完整数据量。
+
 ### 内存管理
 
 Flink 致力于控制整个进程的内存消耗，以确保 Flink 任务管理器（TaskManager）有良好的内存使用，从而既不会在容器（Docker/Kubernetes, Yarn等）环境中由于内存超用被杀掉，也不会因为内存利用率过低导致不必要的数据落盘或是缓存命中率下降，致使性能下降。

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -63,6 +63,9 @@ public class CheckpointingOptions {
 	 * if possible. For an incremental checkpoint, only a diff from the previous
 	 * checkpoint is stored, rather than the complete checkpoint state.
 	 *
+	 * <p>Once enabled, the state size shown in web UI or fetched from rest API only represents the delta checkpoint size
+	 * instead of full checkpoint size.
+	 *
 	 * <p>Some state backends may not support incremental checkpoints and ignore
 	 * this option.*/
 	@Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
@@ -71,8 +74,9 @@ public class CheckpointingOptions {
 			.defaultValue(false)
 			.withDescription("Option whether the state backend should create incremental checkpoints, if possible. For" +
 				" an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the" +
-				" complete checkpoint state. Some state backends may not support incremental checkpoints and ignore" +
-				" this option.");
+				" complete checkpoint state. Once enabled, the state size shown in web UI or fetched from rest API" +
+				" only represents the delta checkpoint size instead of full checkpoint size." +
+				" Some state backends may not support incremental checkpoints and ignore this option.");
 
 	/**
 	 * This option configures local recovery for this state backend. By default, local recovery is deactivated.

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/detail/job-checkpoints-detail.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/detail/job-checkpoints-detail.component.html
@@ -43,7 +43,7 @@
         <th><strong>Acknowledged</strong></th>
         <th><strong>Latest Acknowledgment</strong></th>
         <th><strong>End to End Duration</strong></th>
-        <th><strong>State Size</strong></th>
+        <th><strong>Checkpointed Data Size</strong></th>
         <th><strong>Buffered During Alignment</strong></th>
       </tr>
     </thead>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
@@ -49,7 +49,7 @@
               <nz-divider nzType="vertical"></nz-divider>
               <span><strong>End to End Duration: </strong> {{ checkPointStats['latest']['completed']['end_to_end_duration'] | humanizeDuration}}</span>
               <nz-divider nzType="vertical"></nz-divider>
-              <span><strong>State Size: </strong> {{ checkPointStats['latest']['completed']['state_size'] | humanizeBytes }}</span>
+              <span><strong>Checkpointed Data Size: </strong> {{ checkPointStats['latest']['completed']['checkpointed_data_size'] | humanizeBytes }}</span>
             </td>
             <td *ngIf="!checkPointStats['latest']['completed']">None</td>
           </tr>
@@ -82,7 +82,7 @@
               <nz-divider nzType="vertical"></nz-divider>
               <span><strong>Completion Time: </strong> {{ checkPointStats['latest']['savepoint']['latest_ack_timestamp'] | date:'HH:mm:ss' }}</span>
               <nz-divider nzType="vertical"></nz-divider>
-              <span><strong>State Size: </strong> {{ checkPointStats['latest']['savepoint']['state_size'] | humanizeBytes }}</span>
+              <span><strong>Checkpointed Data Size: </strong> {{ checkPointStats['latest']['savepoint']['state_size'] | humanizeBytes }}</span>
               <nz-divider nzType="vertical"></nz-divider>
               <span><strong>Path: </strong> {{ checkPointStats['latest']['savepoint']['external_path'] }}</span>
             </td>
@@ -127,7 +127,7 @@
           <th><strong>Trigger Time</strong></th>
           <th><strong>Latest Acknowledgement</strong></th>
           <th><strong>End to End Duration</strong></th>
-          <th><strong>State Size</strong></th>
+          <th><strong>Checkpointed Data Size</strong></th>
           <th><strong>Buffered During Alignment</strong></th>
         </tr>
       </thead>
@@ -175,7 +175,7 @@
         <tr>
           <th></th>
           <th><strong>End to End Duration</strong></th>
-          <th><strong>State Size</strong></th>
+          <th><strong>Checkpointed Data Size</strong></th>
           <th><strong>Buffered During Alignment</strong></th>
         </tr>
       </thead>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
@@ -29,7 +29,7 @@
       <tr>
         <th></th>
         <th><strong>End to End Duration</strong></th>
-        <th><strong>State Size</strong></th>
+        <th><strong>Checkpointed Data Size</strong></th>
         <th><strong>Sync Duration</strong></th>
         <th><strong>Async Duration</strong></th>
         <th><strong>Alignment Buffered</strong></th>
@@ -85,7 +85,7 @@
         <th><strong>ID</strong></th>
         <th nzSortKey="ack_timestamp" nzShowSort><strong>Acknowledged</strong></th>
         <th nzSortKey="end_to_end_duration" nzShowSort><strong>End to End Duration</strong></th>
-        <th nzSortKey="state_size" nzShowSort><strong>State Size</strong></th>
+        <th nzSortKey="state_size" nzShowSort><strong>Checkpointed Data Size</strong></th>
         <th nzSortKey="checkpoint.sync" nzShowSort><strong>Sync Duration</strong></th>
         <th nzSortKey="checkpoint.async" nzShowSort><strong>Async Duration</strong></th>
         <th nzSortKey="alignment.buffered" nzShowSort><strong>Alignment Buffered</strong></th>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatistics.java
@@ -65,6 +65,12 @@ public class CheckpointStatistics implements ResponseBody {
 
 	public static final String FIELD_NAME_LATEST_ACK_TIMESTAMP = "latest_ack_timestamp";
 
+	/**
+	 * The accurate name of this field should be 'checkpointed_data_size',
+	 * keep it as before to not break backwards compatibility for old web UI.
+	 *
+	 * @see <a href="https://issues.apache.org/jira/browse/FLINK-13390">FLINK-13390</a>
+	 */
 	public static final String FIELD_NAME_STATE_SIZE = "state_size";
 
 	public static final String FIELD_NAME_DURATION = "end_to_end_duration";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatistics.java
@@ -199,6 +199,12 @@ public class CheckpointingStatistics implements ResponseBody {
 	 */
 	public static final class Summary {
 
+		/**
+		 * The accurate name of this field should be 'checkpointed_data_size',
+		 * keep it as before to not break backwards compatibility for old web UI.
+		 *
+		 * @see <a href="https://issues.apache.org/jira/browse/FLINK-13390">FLINK-13390</a>
+		 */
 		public static final String FIELD_NAME_STATE_SIZE = "state_size";
 
 		public static final String FIELD_NAME_DURATION = "end_to_end_duration";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
@@ -91,6 +91,12 @@ public class SubtaskCheckpointStatistics {
 
 		public static final String FIELD_NAME_DURATION = "end_to_end_duration";
 
+		/**
+		 * The accurate name of this field should be 'checkpointed_data_size',
+		 * keep it as before to not break backwards compatibility for old web UI.
+		 *
+		 * @see <a href="https://issues.apache.org/jira/browse/FLINK-13390">FLINK-13390</a>
+		 */
 		public static final String FIELD_NAME_STATE_SIZE = "state_size";
 
 		public static final String FIELD_NAME_CHECKPOINT_DURATION = "checkpoint";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatistics.java
@@ -38,6 +38,12 @@ public class TaskCheckpointStatistics implements ResponseBody {
 
 	public static final String FIELD_NAME_LATEST_ACK_TIMESTAMP = "latest_ack_timestamp";
 
+	/**
+	 * The accurate name of this field should be 'checkpointed_data_size',
+	 * keep it as before to not break backwards compatibility for old web UI.
+	 *
+	 * @see <a href="https://issues.apache.org/jira/browse/FLINK-13390">FLINK-13390</a>
+	 */
 	public static final String FIELD_NAME_STATE_SIZE = "state_size";
 
 	public static final String FIELD_NAME_DURATION = "end_to_end_duration";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
@@ -107,6 +107,12 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
 	 */
 	public static final class Summary {
 
+		/**
+		 * The accurate name of this field should be 'checkpointed_data_size',
+		 * keep it as before to not break backwards compatibility for old web UI.
+		 *
+		 * @see <a href="https://issues.apache.org/jira/browse/FLINK-13390">FLINK-13390</a>
+		 */
 		public static final String FIELD_NAME_STATE_SIZE = "state_size";
 
 		public static final String FIELD_NAME_DURATION = "end_to_end_duration";


### PR DESCRIPTION
## What is the purpose of the change

This issue is inspired from [a user mail](https://lists.apache.org/thread.html/56069ce869afbfca66179e89788c05d3b092e3fe363f3540dcdeb7a1@%3Cuser.flink.apache.org%3E) which confused about the state size meaning.
This PR changes the description of state size and add some notices on documentation could help this.

## Brief change log

  - Update web UI description.
  - Update documentation of incremental checkpoints to notice the change of meaning.


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
