### PR TITLE
[FLINK-13508][tests] CommonTestUtils#waitUntilCondition() may attempt to sleep with negative time

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -2867,12 +2867,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 				Collection<OperatorStateHandle> managedOperatorState = opState.getManagedOperatorState();
 				assertEquals(1, managedOperatorState.size());
-				assertTrue(CommonTestUtils.isSteamContentEqual(expectedManagedOpState.openInputStream(),
+				assertTrue(CommonTestUtils.isStreamContentEqual(expectedManagedOpState.openInputStream(),
 					managedOperatorState.iterator().next().openInputStream()));
 
 				Collection<OperatorStateHandle> rawOperatorState = opState.getRawOperatorState();
 				assertEquals(1, rawOperatorState.size());
-				assertTrue(CommonTestUtils.isSteamContentEqual(expectedRawOpState.openInputStream(),
+				assertTrue(CommonTestUtils.isStreamContentEqual(expectedRawOpState.openInputStream(),
 					rawOperatorState.iterator().next().openInputStream()));
 			}
 			// operator2
@@ -2888,12 +2888,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 				Collection<OperatorStateHandle> managedOperatorState = opState.getManagedOperatorState();
 				assertEquals(1, managedOperatorState.size());
-				assertTrue(CommonTestUtils.isSteamContentEqual(expectedManagedOpState.openInputStream(),
+				assertTrue(CommonTestUtils.isStreamContentEqual(expectedManagedOpState.openInputStream(),
 					managedOperatorState.iterator().next().openInputStream()));
 
 				Collection<OperatorStateHandle> rawOperatorState = opState.getRawOperatorState();
 				assertEquals(1, rawOperatorState.size());
-				assertTrue(CommonTestUtils.isSteamContentEqual(expectedRawOpState.openInputStream(),
+				assertTrue(CommonTestUtils.isStreamContentEqual(expectedRawOpState.openInputStream(),
 					rawOperatorState.iterator().next().openInputStream()));
 			}
 		}
@@ -3290,7 +3290,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ChainedStateHandle<OperatorStateHandle> expectedOpStateBackend =
 					generateChainedPartitionableStateHandle(jobVertexID, i, 2, 8, false);
 
-			assertTrue(CommonTestUtils.isSteamContentEqual(
+			assertTrue(CommonTestUtils.isStreamContentEqual(
 					expectedOpStateBackend.get(0).openInputStream(),
 					operatorState.getManagedOperatorState().iterator().next().openInputStream()));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/DuplicatingCheckpointOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/DuplicatingCheckpointOutputStreamTest.java
@@ -71,11 +71,11 @@ public class DuplicatingCheckpointOutputStreamTest extends TestLogger {
 		StreamStateHandle primaryStateHandle = duplicatingStream.closeAndGetPrimaryHandle();
 		StreamStateHandle secondaryStateHandle = duplicatingStream.closeAndGetSecondaryHandle();
 
-		Assert.assertTrue(CommonTestUtils.isSteamContentEqual(
+		Assert.assertTrue(CommonTestUtils.isStreamContentEqual(
 			refStateHandle.openInputStream(),
 			primaryStateHandle.openInputStream()));
 
-		Assert.assertTrue(CommonTestUtils.isSteamContentEqual(
+		Assert.assertTrue(CommonTestUtils.isStreamContentEqual(
 			refStateHandle.openInputStream(),
 			secondaryStateHandle.openInputStream()));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -157,7 +157,7 @@ public class CommonTestUtils {
 		}
 	}
 
-	public static boolean isSteamContentEqual(InputStream input1, InputStream input2) throws IOException {
+	public static boolean isStreamContentEqual(InputStream input1, InputStream input2) throws IOException {
 
 		if (!(input1 instanceof BufferedInputStream)) {
 			input1 = new BufferedInputStream(input1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -120,27 +120,6 @@ public class CommonTestUtils {
 		return null;
 	}
 
-	/**
-	 * Checks whether a process is still alive. Utility method for JVM versions before 1.8,
-	 * where no direct method to check that is available.
-	 *
-	 * @param process The process to check.
-	 * @return True, if the process is alive, false otherwise.
-	 */
-	public static boolean isProcessAlive(Process process) {
-		if (process == null) {
-			return false;
-
-		}
-		try {
-			process.exitValue();
-			return false;
-		}
-		catch(IllegalThreadStateException e) {
-			return true;
-		}
-	}
-
 	public static void printLog4jDebugConfig(File file) throws IOException {
 		try (PrintWriter writer = new PrintWriter(new FileWriter(file))) {
 			writer.println("log4j.rootLogger=DEBUG, console");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -117,7 +117,8 @@ public class CommonTestUtils {
 
 	public static void waitUntilCondition(SupplierWithException<Boolean, Exception> condition, Deadline timeout, long retryIntervalMillis) throws Exception {
 		while (timeout.hasTimeLeft() && !condition.get()) {
-			Thread.sleep(Math.min(retryIntervalMillis, timeout.timeLeft().toMillis()));
+			final long timeLeft = Math.max(0, timeout.timeLeft().toMillis());
+			Thread.sleep(Math.min(retryIntervalMillis, timeLeft));
 		}
 
 		if (!timeout.hasTimeLeft()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -41,28 +41,6 @@ public class CommonTestUtils {
 	private static final long RETRY_INTERVAL = 100L;
 
 	/**
-	 * Sleeps for a given set of milliseconds, uninterruptibly. If interrupt is called,
-	 * the sleep will continue nonetheless.
-	 *
-	 * @param msecs The number of milliseconds to sleep.
-	 */
-	public static void sleepUninterruptibly(long msecs) {
-		
-		long now = System.currentTimeMillis();
-		long sleepUntil = now + msecs;
-		long remaining;
-		
-		while ((remaining = sleepUntil - now) > 0) {
-			try {
-				Thread.sleep(remaining);
-			}
-			catch (InterruptedException ignored) {}
-			
-			now = System.currentTimeMillis();
-		}
-	}
-
-	/**
 	 * Gets the classpath with which the current JVM was started.
 	 *
 	 * @return The classpath with which the current JVM was started.


### PR DESCRIPTION
## What is the purpose of the change

*This fixes that `CommonTestUtils#waitUntilCondition()` may invoke `Thread.sleep()` with a negative argument.*


## Brief change log

  - *See commits*

## Verifying this change

This change is already covered by existing tests, such as *tests using this method*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
