### PR TITLE
[FLINK-13456][build] Bump lombok to 1.16.22

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -123,7 +123,7 @@ under the License.
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.20</version>
+			<version>1.16.22</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Bumps lombok from 1.16.20 to 1.16.22, as the latter works properly on Java 11.

see https://github.com/rzwitserloot/lombok/issues/1651#issuecomment-394351798.