### PR TITLE
[FLINK-13453][build] Bump shade plugin to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -828,6 +828,11 @@ under the License.
 							<artifactId>build-helper-maven-plugin</artifactId>
 							<version>1.7</version>
 						</plugin>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-shade-plugin</artifactId>
+							<version>3.2.1</version>
+						</plugin>
 					</plugins>
 				</pluginManagement>
 


### PR DESCRIPTION
The shade-plugin only supports Java 11 since 3.2.1, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317921&version=12344059).