### PR TITLE
[FLINK-13454][build] Bump japicmp jaxb dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -833,6 +833,32 @@ under the License.
 							<artifactId>maven-shade-plugin</artifactId>
 							<version>3.2.1</version>
 						</plugin>
+						<plugin>
+							<groupId>com.github.siom79.japicmp</groupId>
+							<artifactId>japicmp-maven-plugin</artifactId>
+							<dependencies>
+								<dependency>
+									<groupId>javax.xml.bind</groupId>
+									<artifactId>jaxb-api</artifactId>
+									<version>2.3.0</version>
+								</dependency>
+								<dependency>
+									<groupId>com.sun.xml.bind</groupId>
+									<artifactId>jaxb-impl</artifactId>
+									<version>2.3.0</version>
+								</dependency>
+								<dependency>
+									<groupId>com.sun.xml.bind</groupId>
+									<artifactId>jaxb-core</artifactId>
+									<version>2.3.0</version>
+								</dependency>
+								<dependency>
+									<groupId>javax.activation</groupId>
+									<artifactId>activation</artifactId>
+									<version>1.1.1</version>
+								</dependency>
+							</dependencies>
+						</plugin>
 					</plugins>
 				</pluginManagement>
 


### PR DESCRIPTION
Bumps the jaxb dependencies of the `japicmp` plugin when running on Java 11, as it fails otherwise.

see https://github.com/siom79/japicmp/issues/183