### PR TITLE
[FLINK-13504][table] Fixed shading issues in table modules.

### DIFF
--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -25,6 +25,7 @@ under the License.
 		<artifactId>flink-table</artifactId>
 		<groupId>org.apache.flink</groupId>
 		<version>1.10-SNAPSHOT</version>
+		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>flink-sql-parser</artifactId>
@@ -35,7 +36,6 @@ under the License.
 	<properties>
 		<!-- override parent pom -->
 		<test.excludedGroups/>
-		<calcite.version>1.20.0</calcite.version>
 	</properties>
 
 	<dependencies>
@@ -47,100 +47,10 @@ under the License.
 		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
-			<!-- When updating the Calcite version, make sure to update the dependency exclusions -->
-			<version>${calcite.version}</version>
-			<exclusions>
-				<!--
-				"mvn dependency:tree" as of Calcite 1.20:
-
-				[INFO] +- org.apache.calcite:calcite-core:jar:1.20.0:compile
-				[INFO] |  +- org.apache.calcite.avatica:avatica-core:jar:1.15.0:compile
-				[INFO] |  \- com.google.guava:guava:jar:19.0:compile
-
-				Dependencies that are not needed for how we use Calcite right now.
-				-->
-				<exclusion>
-					<groupId>org.apache.calcite.avatica</groupId>
-					<artifactId>avatica-metrics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-java</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-dbcp2</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.esri.geometry</groupId>
-					<artifactId>esri-geometry-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.dataformat</groupId>
-					<artifactId>jackson-dataformat-yaml</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.yahoo.datasketches</groupId>
-					<artifactId>sketches-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>net.hydromatic</groupId>
-					<artifactId>aggdesigner-algorithm</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-annotations</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.jayway.jsonpath</groupId>
-					<artifactId>json-path</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>joda-time</groupId>
-					<artifactId>joda-time</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.calcite</groupId>
-					<artifactId>calcite-linq4j</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.janino</groupId>
-					<artifactId>janino</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.janino</groupId>
-					<artifactId>commons-compiler</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.code.findbugs</groupId>
-					<artifactId>jsr305</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-lang3</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>commons-codec</artifactId>
-				</exclusion>
-			</exclusions>
+			<!--This fixes dependency convergence in modules that depend on flink-table-planner* explicitly-->
+			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
@@ -274,6 +184,16 @@ under the License.
 					<forkCount>1</forkCount>
 					<reuseForks>false</reuseForks>
 				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -39,45 +39,6 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<dependencyManagement>
-		<dependencies>
-			<!-- Common dependency of calcite-core and flink-* -->
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>19.0</version>
-			</dependency>
-			<!-- Common dependency of calcite-core and flink-table-runtime-blink -->
-			<dependency>
-				<groupId>org.codehaus.janino</groupId>
-				<artifactId>commons-compiler</artifactId>
-				<version>${janino.version}</version>
-			</dependency>
-			<!-- Common dependency of calcite-core and flink-table-runtime-blink -->
-			<dependency>
-				<groupId>org.codehaus.janino</groupId>
-				<artifactId>janino</artifactId>
-				<version>${janino.version}</version>
-			</dependency>
-			<!-- Common dependencies within calcite-core -->
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -161,61 +122,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
-			<!-- When updating the Calcite version, make sure to update the dependency exclusions -->
-			<version>1.20.0</version>
-			<exclusions>
-				<!--
-				"mvn dependency:tree" as of Calcite 1.20:
-
-				[INFO] +- org.apache.calcite:calcite-core:jar:1.20.0:compile
-				[INFO] |  +- commons-codec:commons-codec:jar:1.10:compile
-				[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.20.0:compile
-				[INFO] |  +- org.apache.commons:commons-lang3:jar:3.3.2:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.6:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.6:compile
-				[INFO] |  +- com.google.guava:guava:jar:19.0:compile
-				[INFO] |  \- com.jayway.jsonpath:json-path:jar:2.4.0:compile
-
-				Dependencies that are not needed for how we use Calcite right now.
-				-->
-				<exclusion>
-					<groupId>org.apache.calcite.avatica</groupId>
-					<artifactId>avatica-metrics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-java</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-dbcp2</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.esri.geometry</groupId>
-					<artifactId>esri-geometry-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.dataformat</groupId>
-					<artifactId>jackson-dataformat-yaml</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.yahoo.datasketches</groupId>
-					<artifactId>sketches-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>net.hydromatic</groupId>
-					<artifactId>aggdesigner-algorithm</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- test dependencies -->
@@ -304,24 +210,6 @@ under the License.
 					<execution>
 						<id>shade-flink</id>
 						<configuration>
-							<shadeTestJar>false</shadeTestJar>
-							<filters>
-								<filter>
-									<artifact>*:*</artifact>
-									<excludes>
-										<!-- Excluded all these files for a clean flink-table-planner-blink JAR -->
-										<exclude>org-apache-calcite-jdbc.properties</exclude>
-										<exclude>common.proto</exclude>
-										<exclude>requests.proto</exclude>
-										<exclude>responses.proto</exclude>
-										<exclude>codegen/**</exclude>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-										<exclude>META-INF/services/java.sql.Driver</exclude>
-									</excludes>
-								</filter>
-							</filters>
 							<artifactSet>
 								<includes combine.children="append">
 									<include>org.apache.calcite:*</include>
@@ -335,46 +223,10 @@ under the License.
 									<include>com.fasterxml.jackson.core:jackson-annotations</include>
 									<include>commons-codec:commons-codec</include>
 
-									<!-- flink-table-planner-blink dependencies -->
-									<include>org.apache.flink.sql.parser:*</include>
-
 									<!-- flink-table-runtime-blink dependencies -->
 									<include>org.codehaus.janino:*</include>
 								</includes>
 							</artifactSet>
-							<relocations>
-								<!-- Calcite is not relocated for now, because we expose it at some locations such as CalciteConfig -->
-								<!--<relocation>
-									<pattern>org.apache.calcite</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.org.apache.calcite</shadedPattern>
-								</relocation>-->
-
-								<!-- Calcite's dependencies -->
-								<relocation>
-									<pattern>com.google</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.com.google</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.jayway</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.com.jayway</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.fasterxml</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.com.fasterxml</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>org.apache.commons.codec</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.org.apache.commons.codec</shadedPattern>
-								</relocation>
-
-								<!-- flink-table-planner dependencies -->
-								<!-- not relocated for now, because we need to change the contents of the properties field otherwise -->
-								<!--<relocation>
-									<pattern>org.codehaus</pattern>
-									<shadedPattern>org.apache.flink.table.shaded.org.codehaus</shadedPattern>
-								</relocation>-->
-
-							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -37,45 +37,6 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<dependencyManagement>
-		<dependencies>
-			<!-- Common dependency of calcite-core and flink-test-utils -->
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>19.0</version>
-			</dependency>
-			<!-- Common dependency of calcite-core and janino -->
-			<dependency>
-				<groupId>org.codehaus.janino</groupId>
-				<artifactId>commons-compiler</artifactId>
-				<version>${janino.version}</version>
-			</dependency>
-			<!-- Common dependency of calcite-core and flink-table-planner -->
-			<dependency>
-				<groupId>org.codehaus.janino</groupId>
-				<artifactId>janino</artifactId>
-				<version>${janino.version}</version>
-			</dependency>
-			<!-- Common dependencies within calcite-core -->
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -102,12 +63,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-parser</artifactId>
 			<version>${project.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.calcite</groupId>
-					<artifactId>calcite-core</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -147,62 +102,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
-			<!-- When updating the Calcite version, make sure to update the dependency exclusions -->
-			<version>1.20.0</version>
-			<exclusions>
-				<!--
-				"mvn dependency:tree" as of Calcite 1.20:
-
-				[INFO] +- org.apache.calcite:calcite-core:jar:1.20.0:compile
-				[INFO] |  +- commons-codec:commons-codec:jar:1.10:compile
-				[INFO] |  +- org.apache.calcite.avatica:avatica-core:jar:1.15.0:compile
-				[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.20.0:compile
-				[INFO] |  +- org.apache.commons:commons-lang3:jar:3.3.2:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.6:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.6:compile
-				[INFO] |  +- com.google.guava:guava:jar:19.0:compile
-				[INFO] |  \- com.jayway.jsonpath:json-path:jar:2.4.0:compile
-
-				Dependencies that are not needed for how we use Calcite right now.
-				-->
-				<exclusion>
-					<groupId>org.apache.calcite.avatica</groupId>
-					<artifactId>avatica-metrics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-java</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-dbcp2</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.esri.geometry</groupId>
-					<artifactId>esri-geometry-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.dataformat</groupId>
-					<artifactId>jackson-dataformat-yaml</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.yahoo.datasketches</groupId>
-					<artifactId>sketches-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>net.hydromatic</groupId>
-					<artifactId>aggdesigner-algorithm</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- Used for date/time formatting -->
@@ -305,26 +204,6 @@ under the License.
 					<execution>
 						<id>shade-flink</id>
 						<configuration>
-							<shadeTestJar>false</shadeTestJar>
-							<filters>
-								<filter>
-									<artifact>*:*</artifact>
-									<excludes>
-										<!-- excluded all these files for a clean flink-table-planner jar -->
-										<exclude>org-apache-calcite-jdbc.properties</exclude>
-										<exclude>common.proto</exclude>
-										<exclude>requests.proto</exclude>
-										<exclude>responses.proto</exclude>
-										<exclude>codegen/**</exclude>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-										<exclude>META-INF/services/java.sql.Driver</exclude>
-										<!-- not relocated for now, because it is needed by Calcite -->
-										<!--<exclude>org.codehaus.commons.compiler.properties</exclude>-->
-									</excludes>
-								</filter>
-							</filters>
 							<artifactSet>
 								<includes combine.children="append">
 									<include>org.apache.calcite:*</include>
@@ -339,47 +218,10 @@ under the License.
 									<include>commons-codec:commons-codec</include>
 
 									<!-- flink-table-planner dependencies -->
-									<include>org.apache.flink.sql.parser:*</include>
 									<include>org.codehaus.janino:*</include>
 									<include>joda-time:*</include>
 								</includes>
 							</artifactSet>
-							<relocations>
-								<!-- Calcite is not relocated for now, because we expose it at some locations such as CalciteConfig -->
-								<!--<relocation>
-									<pattern>org.apache.calcite</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.org.apache.calcite</shadedPattern>
-								</relocation>-->
-
-								<!-- Calcite's dependencies -->
-								<relocation>
-									<pattern>com.google</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.com.google</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.jayway</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.com.jayway</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.fasterxml</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.com.fasterxml</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>org.apache.commons.codec</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.org.apache.commons.codec</shadedPattern>
-								</relocation>
-
-								<!-- flink-table-planner dependencies -->
-								<relocation>
-									<pattern>org.joda.time</pattern>
-									<shadedPattern>org.apache.flink.table.shaded.org.joda.time</shadedPattern>
-								</relocation>
-								<!-- not relocated for now, because we need to change the contents of the properties field otherwise -->
-								<!--<relocation>
-									<pattern>org.codehaus</pattern>
-									<shadedPattern>org.apache.flink.table.shaded.org.codehaus</shadedPattern>
-								</relocation>-->
-							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -77,50 +77,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.calcite.avatica</groupId>
 			<artifactId>avatica-core</artifactId>
-			<!-- When updating the Calcite version, make sure to update the version and dependency exclusions -->
-			<version>1.15.0</version>
-			<exclusions>
-				<!--
-
-				Dependencies that are not needed for how we use Avatica right now.
-
-				We exclude all the dependencies of Avatica because currently we only use
-				TimeUnit, TimeUnitRange and SqlDateTimeUtils which only dependent JDK.
-
-				"mvn dependency:tree" as of Avatica 1.15:
-
-				[INFO] +- org.apache.calcite.avatica:avatica-core:jar:1.15.0:compile
-
-				-->
-				<exclusion>
-					<groupId>org.apache.calcite.avatica</groupId>
-					<artifactId>avatica-metrics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-java</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-annotations</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- Lz4 compression library -->

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -50,5 +50,228 @@ under the License.
 	<properties>
 		<!-- When updating Janino, make sure that Calcite supports it as well. -->
 		<janino.version>3.0.9</janino.version>
+		<calcite.version>1.20.0</calcite.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Used for translation of table programs -->
+			<dependency>
+				<groupId>org.apache.calcite</groupId>
+				<artifactId>calcite-core</artifactId>
+				<!-- When updating the Calcite version, make sure to update the dependency exclusions -->
+				<version>${calcite.version}</version>
+				<exclusions>
+					<!--
+					"mvn dependency:tree" as of Calcite 1.20:
+
+					[INFO] +- org.apache.calcite:calcite-core:jar:1.20.0:compile
+					[INFO] |  +- commons-codec:commons-codec:jar:1.10:compile
+					[INFO] |  +- org.apache.calcite.avatica:avatica-core:jar:1.15.0:compile
+					[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.20.0:compile
+					[INFO] |  +- org.apache.commons:commons-lang3:jar:3.3.2:compile
+					[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
+					[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.6:compile
+					[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.6:compile
+					[INFO] |  +- com.google.guava:guava:jar:19.0:compile
+					[INFO] |  \- com.jayway.jsonpath:json-path:jar:2.4.0:compile
+
+					Dependencies that are not needed for how we use Calcite right now.
+					-->
+					<exclusion>
+						<groupId>org.apache.calcite.avatica</groupId>
+						<artifactId>avatica-metrics</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.google.protobuf</groupId>
+						<artifactId>protobuf-java</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpclient</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpcore</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.commons</groupId>
+						<artifactId>commons-dbcp2</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.esri.geometry</groupId>
+						<artifactId>esri-geometry-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.dataformat</groupId>
+						<artifactId>jackson-dataformat-yaml</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.yahoo.datasketches</groupId>
+						<artifactId>sketches-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>net.hydromatic</groupId>
+						<artifactId>aggdesigner-algorithm</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.calcite.avatica</groupId>
+				<artifactId>avatica-core</artifactId>
+				<!-- When updating the Calcite version, make sure to update the version and dependency exclusions -->
+				<version>1.15.0</version>
+				<exclusions>
+					<!--
+
+					Dependencies that are not needed for how we use Avatica right now.
+
+					We exclude all the dependencies of Avatica because currently we only use
+					TimeUnit, TimeUnitRange and SqlDateTimeUtils which only dependent JDK.
+
+					"mvn dependency:tree" as of Avatica 1.15:
+
+					[INFO] +- org.apache.calcite.avatica:avatica-core:jar:1.15.0:compile
+
+					-->
+					<exclusion>
+						<groupId>org.apache.calcite.avatica</groupId>
+						<artifactId>avatica-metrics</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.google.protobuf</groupId>
+						<artifactId>protobuf-java</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpclient</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpcore</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<!-- Common dependency of calcite-core and flink-test-utils -->
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>19.0</version>
+			</dependency>
+			<!-- Common dependency of calcite-core and janino -->
+			<dependency>
+				<groupId>org.codehaus.janino</groupId>
+				<artifactId>commons-compiler</artifactId>
+				<version>${janino.version}</version>
+			</dependency>
+			<!-- Common dependency of calcite-core and flink-table-planner -->
+			<dependency>
+				<groupId>org.codehaus.janino</groupId>
+				<artifactId>janino</artifactId>
+				<version>${janino.version}</version>
+			</dependency>
+			<!-- Common dependencies within calcite-core -->
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.9.6</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.9.6</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.9.6</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-shade-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>shade-flink</id>
+							<configuration>
+								<shadeTestJar>false</shadeTestJar>
+								<filters>
+									<filter>
+										<artifact>*:*</artifact>
+										<excludes>
+											<!-- Excluded all these files for a clean flink-table-planner-blink JAR -->
+											<exclude>org-apache-calcite-jdbc.properties</exclude>
+											<exclude>common.proto</exclude>
+											<exclude>requests.proto</exclude>
+											<exclude>responses.proto</exclude>
+											<exclude>codegen/**</exclude>
+											<exclude>META-INF/*.SF</exclude>
+											<exclude>META-INF/*.DSA</exclude>
+											<exclude>META-INF/*.RSA</exclude>
+											<exclude>META-INF/services/java.sql.Driver</exclude>
+										</excludes>
+									</filter>
+								</filters>
+								<relocations>
+									<!-- Calcite is not relocated for now, because we expose it at some locations such as CalciteConfig -->
+									<!--<relocation>
+										<pattern>org.apache.calcite</pattern>
+										<shadedPattern>org.apache.flink.calcite.shaded.org.apache.calcite</shadedPattern>
+									</relocation>-->
+
+									<!-- Calcite's dependencies -->
+									<relocation>
+										<pattern>com.google</pattern>
+										<shadedPattern>org.apache.flink.calcite.shaded.com.google</shadedPattern>
+									</relocation>
+									<relocation>
+										<pattern>com.jayway</pattern>
+										<shadedPattern>org.apache.flink.calcite.shaded.com.jayway</shadedPattern>
+									</relocation>
+									<relocation>
+										<pattern>com.fasterxml</pattern>
+										<shadedPattern>org.apache.flink.calcite.shaded.com.fasterxml</shadedPattern>
+									</relocation>
+									<relocation>
+										<pattern>org.apache.commons.codec</pattern>
+										<shadedPattern>org.apache.flink.calcite.shaded.org.apache.commons.codec</shadedPattern>
+									</relocation>
+
+									<!-- flink-table-planner dependencies -->
+									<relocation>
+										<pattern>org.joda.time</pattern>
+										<shadedPattern>org.apache.flink.table.shaded.org.joda.time</shadedPattern>
+									</relocation>
+
+									<!-- not relocated for now, because we need to change the contents of the properties field otherwise -->
+									<!--<relocation>
+										<pattern>org.codehaus</pattern>
+										<shadedPattern>org.apache.flink.table.shaded.org.codehaus</shadedPattern>
+									</relocation>-->
+
+								</relocations>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 </project>


### PR DESCRIPTION
## What is the purpose of the change

Moved the common calcite specific dependencies configuration to
flink-table in order to have them unified across flink-table-planner,
flink-table-planner-blink, flink-table-runtime-blink & flink-sql-parser.

Shading configuration is also done in the table parent pom so that all
modules have common relocation policies.

Enabled shading for flink-sql-parser.

## Verifying this change

* For verification of sql-parser module e.g. run the query attached to jira issue.
* Verify contents of flink-table-planner, flink-table-planner-blink, flink-table-runtime-blink, flink-sql-parser, flink-table-uber, flink-table-uber-blink do not contain unwanted classes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no /** don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
