### PR TITLE
[FLINK-13491][datastream] AsyncWaitOperator supports BoundedOneInput

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -223,6 +223,30 @@ public class AsyncWaitOperatorTest extends TestLogger {
 	}
 
 	/**
+	 * AsyncFunction supports a specific delay(ms) before async invocation.
+	 */
+	private static class DelayedAsyncFunction extends MyAsyncFunction {
+
+		private final long delayed;
+
+		public DelayedAsyncFunction(long delayed) {
+			this.delayed = delayed;
+		}
+
+		@Override
+		public void asyncInvoke(final Integer input, final ResultFuture<Integer> resultFuture) throws Exception {
+			executorService.submit(() -> {
+				try {
+					Thread.sleep(delayed);
+				} catch (InterruptedException e) {
+					resultFuture.completeExceptionally(e);
+				}
+				resultFuture.complete(Collections.singletonList(input * 2));
+			});
+		}
+	}
+
+	/**
 	 * A special {@link LazyAsyncFunction} for timeout handling.
 	 * Complete the result future with 3 times the input when the timeout occurred.
 	 */
@@ -1175,5 +1199,49 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		operator.setChainingStrategy(ChainingStrategy.ALWAYS);
 
 		return in.transform("async wait operator", outTypeInfo, operator);
+	}
+
+	/**
+	 * Delay a while before async invocation to check whether end input waits for all elements finished or not.
+	 */
+	@Test
+	public void testEndInput() throws Exception {
+		final AsyncWaitOperator<Integer, Integer> operator = new AsyncWaitOperator<>(
+			new DelayedAsyncFunction(10),
+			-1,
+			2,
+			AsyncDataStream.OutputMode.ORDERED);
+
+		final OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+			new OneInputStreamOperatorTestHarness<>(operator, IntSerializer.INSTANCE);
+
+		final long initialTime = 0L;
+		final ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+		expectedOutput.add(new StreamRecord<>(2, initialTime + 1));
+		expectedOutput.add(new StreamRecord<>(4, initialTime + 2));
+		expectedOutput.add(new Watermark(initialTime + 2));
+		expectedOutput.add(new StreamRecord<>(6, initialTime + 3));
+
+		testHarness.open();
+
+		try {
+			synchronized (testHarness.getCheckpointLock()) {
+				testHarness.processElement(new StreamRecord<>(1, initialTime + 1));
+				testHarness.processElement(new StreamRecord<>(2, initialTime + 2));
+				testHarness.processWatermark(new Watermark(initialTime + 2));
+				testHarness.processElement(new StreamRecord<>(3, initialTime + 3));
+			}
+
+			// wait until all async collectors in the buffer have been emitted out.
+			synchronized (testHarness.getCheckpointLock()) {
+				testHarness.endInput();
+			}
+
+			TestHarnessUtil.assertOutputEquals("Output with watermark was not correct.", expectedOutput, testHarness.getOutput());
+		} finally {
+			synchronized (testHarness.getCheckpointLock()) {
+				testHarness.close();
+			}
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -129,5 +130,13 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 
 	public long getCurrentWatermark() {
 		return currentWatermark;
+	}
+
+	public void endInput() throws Exception {
+		if (oneInputOperator instanceof BoundedOneInput) {
+			((BoundedOneInput) oneInputOperator).endInput();
+		} else {
+			throw new UnsupportedOperationException("The operator is not BoundedOneInput");
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

* `AsyncWaitOperator` should respect semantics of `BoundedOneInput`

## Brief change log

* `AsyncWaitOperator` supports `BoundedOneInput`
* Wait the in-flight inputs in `AsyncWaitOperator`.`endInput`
* I keep this waiting operation a bit redundant both in `endInput` and `close` because we probably re-think the `endInput` semantics in the near future
* BTW, I think the resource releasing of `AsyncWaitOperator`(endInput/close/dispose) is a bit messy. However I would like to discuss it in another thread.

## Verifying this change

* This change added tests in `AsyncWaitOperatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
