### PR TITLE
[FLINK-13469][state] Ensure resource used by StateMapSnapshot will be released if snapshot fails

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractStateTableSnapshot.java
@@ -88,13 +88,6 @@ abstract class AbstractStateTableSnapshot<K, N, S>
 	 */
 	protected abstract StateMapSnapshot<K, N, S, ? extends StateMap<K, N, S>> getStateMapSnapshotForKeyGroup(int keyGroup);
 
-	/**
-	 * Optional hook to release resources for this snapshot at the end of its lifecycle.
-	 */
-	@Override
-	public void release() {
-	}
-
 	@Nonnull
 	@Override
 	public StateMetaInfoSnapshot getMetaInfoSnapshot() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
@@ -38,6 +38,7 @@ import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -782,6 +783,11 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
 			"Cannot release snapshot which is owned by a different state map.");
 
 		releaseSnapshot(copyOnWriteStateMapSnapshot.getSnapshotVersion());
+	}
+
+	@VisibleForTesting
+	Set<Integer> getSnapshotVersions() {
+		return snapshotVersions;
 	}
 
 	// Meta data setter / getter and toString -----------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMapSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMapSnapshot.java
@@ -71,6 +71,11 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
 	private final int numberOfEntriesInSnapshotData;
 
 	/**
+	 * Whether this snapshot has been released.
+	 */
+	private boolean released;
+
+	/**
 	 * Creates a new {@link CopyOnWriteStateMapSnapshot}.
 	 *
 	 * @param owningStateMap the {@link CopyOnWriteStateMap} for which this object represents a snapshot.
@@ -81,11 +86,19 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
 		this.snapshotData = owningStateMap.snapshotMapArrays();
 		this.snapshotVersion = owningStateMap.getStateMapVersion();
 		this.numberOfEntriesInSnapshotData = owningStateMap.size();
+		this.released = false;
 	}
 
 	@Override
 	public void release() {
-		owningStateMap.releaseSnapshot(this);
+		if (!released) {
+			owningStateMap.releaseSnapshot(this);
+			released = true;
+		}
+	}
+
+	public boolean isReleased() {
+		return released;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -79,4 +79,13 @@ public class CopyOnWriteStateTableSnapshot<K, N, S> extends AbstractStateTableSn
 
 		return stateMapSnapshot;
 	}
+
+	@Override
+	public void release() {
+		for (CopyOnWriteStateMapSnapshot snapshot : stateMapSnapshots) {
+			if (!snapshot.isReleased()) {
+				snapshot.release();
+			}
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
@@ -95,5 +95,9 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 
 			return stateMap.stateSnapshot();
 		}
+
+		@Override
+		public void release() {
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
@@ -289,7 +289,7 @@ public abstract class StateTable<K, N, S>
 	}
 
 	@VisibleForTesting
-	protected StateMap<K, N, S> getMapForKeyGroup(int keyGroupIndex) {
+	StateMap<K, N, S> getMapForKeyGroup(int keyGroupIndex) {
 		final int pos = indexToOffset(keyGroupIndex);
 		if (pos >= 0 && pos < keyGroupedStateMaps.length) {
 			return keyGroupedStateMaps[pos];

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
@@ -19,14 +19,19 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.base.FloatSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.StateSnapshot;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Test for {@link CopyOnWriteStateTable}.
@@ -70,5 +75,88 @@ public class CopyOnWriteStateTableTest {
 		partitionedSnapshot.writeStateInKeyGroup(
 			new DataOutputViewStreamWrapper(
 				new ByteArrayOutputStreamWithPos(1024)), 0);
+	}
+
+	/**
+	 * This tests that resource can be released for a successful snapshot.
+	 */
+	@Test
+	public void testReleaseForSuccessfulSnapshot() throws IOException {
+		int numberOfKeyGroups = 10;
+		CopyOnWriteStateTable<Integer, Integer, Float> table = createStateTableForSnapshotRelease(numberOfKeyGroups);
+
+		ByteArrayOutputStreamWithPos byteArrayOutputStreamWithPos = new ByteArrayOutputStreamWithPos();
+		DataOutputView dataOutputView = new DataOutputViewStreamWrapper(byteArrayOutputStreamWithPos);
+
+		CopyOnWriteStateTableSnapshot<Integer, Integer, Float> snapshot = table.stateSnapshot();
+		for (int group = 0; group < numberOfKeyGroups; group++) {
+			snapshot.writeStateInKeyGroup(dataOutputView, group);
+			// resource used by one key group should be released after the snapshot is successful
+			Assert.assertTrue(isResourceReleasedForKeyGroup(table, group));
+		}
+		snapshot.release();
+		verifyResourceIsReleasedForAllKeyGroup(table, 1);
+	}
+
+	/**
+	 * This tests that resource can be released for a failed snapshot.
+	 */
+	@Test
+	public void testReleaseForFailedSnapshot() throws IOException {
+		int numberOfKeyGroups = 10;
+		CopyOnWriteStateTable<Integer, Integer, Float> table = createStateTableForSnapshotRelease(numberOfKeyGroups);
+
+		ByteArrayOutputStreamWithPos byteArrayOutputStreamWithPos = new ByteArrayOutputStreamWithPos();
+		DataOutputView dataOutputView = new DataOutputViewStreamWrapper(byteArrayOutputStreamWithPos);
+
+		CopyOnWriteStateTableSnapshot<Integer, Integer, Float> snapshot = table.stateSnapshot();
+		// only snapshot part of key groups to simulate a failed snapshot
+		for (int group = 0; group < numberOfKeyGroups / 2; group++) {
+			snapshot.writeStateInKeyGroup(dataOutputView, group);
+			Assert.assertTrue(isResourceReleasedForKeyGroup(table, group));
+		}
+		for (int group = numberOfKeyGroups / 2; group < numberOfKeyGroups; group++) {
+			Assert.assertFalse(isResourceReleasedForKeyGroup(table, group));
+		}
+		snapshot.release();
+		verifyResourceIsReleasedForAllKeyGroup(table, 2);
+	}
+
+	private CopyOnWriteStateTable<Integer, Integer, Float> createStateTableForSnapshotRelease(int numberOfKeyGroups) {
+		RegisteredKeyValueStateBackendMetaInfo<Integer, Float> metaInfo =
+			new RegisteredKeyValueStateBackendMetaInfo<>(
+				StateDescriptor.Type.VALUE,
+				"test",
+				IntSerializer.INSTANCE,
+				FloatSerializer.INSTANCE);
+
+		MockInternalKeyContext<Integer> mockKeyContext =
+			new MockInternalKeyContext<>(0, numberOfKeyGroups - 1, numberOfKeyGroups);
+		CopyOnWriteStateTable<Integer, Integer, Float> table =
+			new CopyOnWriteStateTable<>(mockKeyContext, metaInfo, IntSerializer.INSTANCE);
+
+		ThreadLocalRandom random = ThreadLocalRandom.current();
+		for (int i = 0; i < 1000; i++) {
+			mockKeyContext.setCurrentKeyAndKeyGroup(i);
+			table.put(random.nextInt(), random.nextFloat());
+		}
+
+		return table;
+	}
+
+	private void verifyResourceIsReleasedForAllKeyGroup(
+		CopyOnWriteStateTable table,
+		int snapshotVersion) {
+		StateMap[] stateMaps = table.getState();
+		for (StateMap map : stateMaps) {
+			Assert.assertFalse(((CopyOnWriteStateMap) map).getSnapshotVersions().contains(snapshotVersion));
+		}
+	}
+
+	private boolean isResourceReleasedForKeyGroup(
+		CopyOnWriteStateTable table,
+		int keyGroup) {
+		CopyOnWriteStateMap stateMap = (CopyOnWriteStateMap) table.getMapForKeyGroup(keyGroup);
+		return !stateMap.getSnapshotVersions().contains(1);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/MockInternalKeyContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/MockInternalKeyContext.java
@@ -19,18 +19,23 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 
 /**
  * Mock {@link InternalKeyContext}.
  */
 public class MockInternalKeyContext<K> extends InternalKeyContextImpl<K> {
+
 	MockInternalKeyContext() {
 		super(new KeyGroupRange(0, 0), 1);
 	}
 
-	@Override
-	public void setCurrentKey(K key) {
+	MockInternalKeyContext(int startKeyGroup, int endKeyGroup, int numberOfKeyGroups) {
+		super(new KeyGroupRange(startKeyGroup, endKeyGroup), numberOfKeyGroups);
+	}
+
+	public void setCurrentKeyAndKeyGroup(K key) {
 		super.setCurrentKey(key);
-		super.setCurrentKeyGroupIndex(0);
+		super.setCurrentKeyGroupIndex(KeyGroupRangeAssignment.assignToKeyGroup(key, getNumberOfKeyGroups()));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, resource used by `StateMapSnapshot` may not be released by `StateTableSnapshot` if snapshot fails. For example, If exception happens in `StateMapSnapshot#writeState`, resources used by current and left `StateMapSnapshot` can not be released. This PR will fix this problem.

## Brief change log
- make sure all resources are released in `StateTableSnapshot#release()`
    - `CopyOnWriteStateTableSnapshot` will check whether the resource is released for each `CopyOnWriteStateMapSnapshot` in `CopyOnWriteStateTableSnapshot#release()`, and release them if not
    -  `NestedMapsStateTableSnapshot` need do nothing in `NestedMapsStateTableSnapshot#release()`.  On the one hand, nested snapshot is synchronous, and doesn't hold all state map snapshots which will be used in async part like copy-on-write snapshot. State map snapshot for a key-group will not be created until it's turn to write state of this key group, so there is no resource  to need to release except for current state map snapshot. On the other hand, nested state map snapshot actually hold no resource. So `NestedMapsStateTableSnapshot` need do nothing for release.
- remove default implementation `AbstractStateTableSnapshot#release()`. The reasons are as follows:
    -  the way to release for the copy-on-write and the nested is very different, so there is no much meaning to provide default implementation
    - force subclass to think about the proper way to release, and make it more safety

## Verifying this change

This change added tests and can be verified as follows:
  - Added test `CopyOnWriteStateTableTest#testReleaseForSuccessfulSnapshot` and `CopyOnWriteStateTableTest#testReleaseForFailedSnapshot` to validates that resources can be released no matter snapshot is successful or failed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable