### PR TITLE
[FLINK-13464][build] Bump powermock to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ under the License.
 		<avro.version>1.8.2</avro.version>
 		<junit.version>4.12</junit.version>
 		<mockito.version>2.21.0</mockito.version>
-		<powermock.version>2.0.0-RC.4</powermock.version>
+		<powermock.version>2.0.2</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<py4j.version>0.10.8.1</py4j.version>
 		<japicmp.skip>false</japicmp.skip>


### PR DESCRIPTION
Bumps powermock to 2.0.2, which properly handles private constructors on Java 11.

see https://github.com/powermock/powermock/issues/958