### PR TITLE
[FLINK-13465][build] Bump javassist to 3.24.0-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,7 +449,7 @@ under the License.
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.19.0-GA</version>
+				<version>3.24.0-GA</version>
 			</dependency>
 
 			<!-- joda time is pulled in different versions by different transitive dependencies-->


### PR DESCRIPTION
Bumps javassist to 3.24.0, which added Java 11 support.