### PR TITLE
[FLINK-13434][e2e] Add stop-with-savepoint end-to-end tests.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -531,14 +531,14 @@ public class CliFrontend {
 			activeCommandLine,
 			commandLine,
 			clusterClient -> {
+				final String savepointPath;
 				try {
-					clusterClient.stopWithSavepoint(jobId, advanceToEndOfEventTime, targetDirectory);
+					savepointPath = clusterClient.stopWithSavepoint(jobId, advanceToEndOfEventTime, targetDirectory);
 				} catch (Exception e) {
 					throw new FlinkException("Could not stop with a savepoint job \"" + jobId + "\".", e);
 				}
+				logAndSysout("Savepoint completed. Path: " + savepointPath);
 			});
-
-		logAndSysout((advanceToEndOfEventTime ? "Drained job " : "Suspended job ") + "\"" + jobId + "\" with a savepoint.");
 	}
 
 	/**

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -471,6 +471,10 @@ function wait_job_terminal_state {
   done
 }
 
+function stop_with_savepoint {
+  "$FLINK_DIR"/bin/flink stop -p $2 $1
+}
+
 function take_savepoint {
   "$FLINK_DIR"/bin/flink savepoint $1 $2
 }

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -85,10 +85,10 @@ wait_job_running $DATASTREAM_JOB
 wait_oper_metric_num_in_records SemanticsCheckMapper.0 200
 
 # take a savepoint of the state machine job
-SAVEPOINT_PATH=$(take_savepoint $DATASTREAM_JOB $TEST_DATA_DIR \
+SAVEPOINT_PATH=$(stop_with_savepoint $DATASTREAM_JOB $TEST_DATA_DIR \
   | grep "Savepoint completed. Path:" | sed 's/.* //g')
 
-cancel_job $DATASTREAM_JOB
+wait_job_terminal_state "${DATASTREAM_JOB}" "FINISHED"
 
 # Since it is not possible to differentiate reporter output between the first and second execution,
 # we remember the number of metrics sampled in the first execution so that they can be ignored in the following monitorings

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -90,6 +90,17 @@ SAVEPOINT_PATH=$(stop_with_savepoint $DATASTREAM_JOB $TEST_DATA_DIR \
 
 wait_job_terminal_state "${DATASTREAM_JOB}" "FINISHED"
 
+# isolate the path without the scheme ("file:") and do the necessary checks
+SAVEPOINT_DIR=${SAVEPOINT_PATH#"file:"}
+
+if [ -z "$SAVEPOINT_DIR" ]; then
+  echo "Savepoint location was empty. This may mean that the stop-with-savepoint failed."
+  exit 1
+elif [ ! -d "$SAVEPOINT_DIR" ]; then
+  echo "Savepoint $SAVEPOINT_PATH does not exist."
+  exit 1
+fi
+
 # Since it is not possible to differentiate reporter output between the first and second execution,
 # we remember the number of metrics sampled in the first execution so that they can be ignored in the following monitorings
 OLD_NUM_METRICS=$(get_num_metric_samples)

--- a/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
@@ -63,6 +63,17 @@ SAVEPOINT_PATH=$(stop_with_savepoint ${ORIGINAL_JOB} ${TEST_DATA_DIR} \
 
 wait_job_terminal_state "${ORIGINAL_JOB}" "FINISHED"
 
+# isolate the path without the scheme ("file:") and do the necessary checks
+SAVEPOINT_DIR=${SAVEPOINT_PATH#"file:"}
+
+if [ -z "$SAVEPOINT_DIR" ]; then
+  echo "Savepoint location was empty. This may mean that the stop-with-savepoint failed."
+  exit 1
+elif [ ! -d "$SAVEPOINT_DIR" ]; then
+  echo "Savepoint $SAVEPOINT_PATH does not exist."
+  exit 1
+fi
+
 JOB=$(job ${NEW_DOP})
 UPGRADED_JOB=$(${JOB} --test.job.variant upgraded \
   | grep "Job has been submitted with JobID" | sed 's/.* //g')

--- a/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
@@ -58,10 +58,10 @@ wait_job_running ${ORIGINAL_JOB}
 wait_oper_metric_num_in_records stateMap2.1 200
 
 # take a savepoint of the state machine job
-SAVEPOINT_PATH=$(take_savepoint ${ORIGINAL_JOB} ${TEST_DATA_DIR} \
+SAVEPOINT_PATH=$(stop_with_savepoint ${ORIGINAL_JOB} ${TEST_DATA_DIR} \
   | grep "Savepoint completed. Path:" | sed 's/.* //g')
 
-cancel_job ${ORIGINAL_JOB}
+wait_job_terminal_state "${ORIGINAL_JOB}" "FINISHED"
 
 JOB=$(job ${NEW_DOP})
 UPGRADED_JOB=$(${JOB} --test.job.variant upgraded \
@@ -71,5 +71,5 @@ wait_job_running ${UPGRADED_JOB}
 
 wait_oper_metric_num_in_records stateMap3.2 200
 
-# if state is errorneous and the state machine job produces alerting state transitions,
+# if state is erroneous and the state machine job produces alerting state transitions,
 # output would be non-empty and the test will not pass


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this PR is to add some end-to-end tests for the newly introduced `stop-with-savepoint` command. 

Instead of creating a new test (in bash), this PR modifies already existing tests to use the new feature. In the future, we should include an end-to-end test with a more complicated job that does some state manipulation at the `notifyCheckpointComplete`, as the exactly-once sinks do. This will *actually* test the new feature.

## Brief change log

This PR modifies the `test_stateful_stream_job_upgrad` and the `test_resume_savepoint`, without changing their logic.

## Verifying this change

This change is already covered by existing tests, which are the ones modified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
