### PR TITLE
[FLINK-13512][kinesis][build] Add jaxb-api dependency on Java 11

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -182,6 +182,8 @@ under the License.
 									<include>com.amazonaws:*</include>
 									<include>com.google.protobuf:*</include>
 									<include>org.apache.httpcomponents:*</include>
+									<!-- Java 11 specific inclusion; should be a no-op for other versions -->
+									<include>javax.xml.bind:jaxb-api</include>
 								</includes>
 							</artifactSet>
 							<relocations combine.children="override">
@@ -205,4 +207,21 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>java11</id>
+			<activation>
+				<jdk>11</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<!-- KPL requires jaxb-api for javax.xml.bind.DatatypeConverter -->
+					<groupId>javax.xml.bind</groupId>
+					<artifactId>jaxb-api</artifactId>
+					<version>2.3.0</version>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
KPL relies on `javax.xml.bind.DatatypeConverter` (contained in jaxb-api), but relies on it being on the classpath by default, which no longer holds on Java 11.
Hence we add an explicit dependency when compiling on Java 11, and also bundle it in the jar.