### PR TITLE
[FLINK-13190][hive]add test to verify partition pruning for HiveTableSource

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -229,7 +229,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 
 	@Override
 	public String explainSource() {
-		return super.explainSource() + String.format(" PartitionPruned: %s, partitionNums: %d",
-													partitionPruned, null == allHivePartitions ? 0 : allHivePartitions.size());
+		return super.explainSource() + String.format(" TablePath: %s, PartitionPruned: %s, PartitionNums: %d",
+													tablePath.getFullName(), partitionPruned, null == allHivePartitions ? 0 : allHivePartitions.size());
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -66,6 +66,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 	private List<Map<String, String>> partitionList = new ArrayList<>();
 	private Map<Map<String, String>, HiveTablePartition> partitionSpec2HiveTablePartition = new HashMap<>();
 	private boolean initAllPartitions;
+	private boolean applyPartitionPrunning;
 
 	public HiveTableSource(JobConf jobConf, ObjectPath tablePath, CatalogTable catalogTable) {
 		this.jobConf = Preconditions.checkNotNull(jobConf);
@@ -74,6 +75,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 		this.hiveVersion = Preconditions.checkNotNull(jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION),
 				"Hive version is not defined");
 		initAllPartitions = false;
+		applyPartitionPrunning = false;
 	}
 
 	private HiveTableSource(JobConf jobConf, ObjectPath tablePath, CatalogTable catalogTable,
@@ -87,6 +89,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 		this.hiveVersion = hiveVersion;
 		this.partitionList = partitionList;
 		this.initAllPartitions = true;
+		applyPartitionPrunning = true;
 	}
 
 	@Override
@@ -222,5 +225,11 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 		}
 		throw new FlinkHiveException(
 				new IllegalArgumentException(String.format("Can not convert %s to type %s for partition value", valStr, type)));
+	}
+
+	@Override
+	public String explainSource() {
+		return super.explainSource() + String.format(" PartitionPrunning: %s, partitionNums: %d",
+						applyPartitionPrunning, null == allHivePartitions ? 0 : allHivePartitions.size());
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -66,7 +66,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 	private List<Map<String, String>> partitionList = new ArrayList<>();
 	private Map<Map<String, String>, HiveTablePartition> partitionSpec2HiveTablePartition = new HashMap<>();
 	private boolean initAllPartitions;
-	private boolean applyPartitionPrunning;
+	private boolean partitionPruned;
 
 	public HiveTableSource(JobConf jobConf, ObjectPath tablePath, CatalogTable catalogTable) {
 		this.jobConf = Preconditions.checkNotNull(jobConf);
@@ -75,7 +75,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 		this.hiveVersion = Preconditions.checkNotNull(jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION),
 				"Hive version is not defined");
 		initAllPartitions = false;
-		applyPartitionPrunning = false;
+		partitionPruned = false;
 	}
 
 	private HiveTableSource(JobConf jobConf, ObjectPath tablePath, CatalogTable catalogTable,
@@ -89,7 +89,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 		this.hiveVersion = hiveVersion;
 		this.partitionList = partitionList;
 		this.initAllPartitions = true;
-		applyPartitionPrunning = true;
+		partitionPruned = true;
 	}
 
 	@Override
@@ -229,7 +229,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 
 	@Override
 	public String explainSource() {
-		return super.explainSource() + String.format(" PartitionPrunning: %s, partitionNums: %d",
-						applyPartitionPrunning, null == allHivePartitions ? 0 : allHivePartitions.size());
+		return super.explainSource() + String.format(" PartitionPruned: %s, partitionNums: %d",
+													partitionPruned, null == allHivePartitions ? 0 : allHivePartitions.size());
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -157,9 +157,9 @@ public class HiveTableSourceTest {
 		String abstractSyntaxTree = explain[1];
 		String optimizedLogicalPlan = explain[2];
 		String physicalExecutionPlan = explain[3];
-		assertTrue(abstractSyntaxTree.contains("HiveTableSource(year, value, pt) PartitionPruned: false, partitionNums: 2]"));
-		assertTrue(optimizedLogicalPlan.contains("HiveTableSource(year, value, pt) PartitionPruned: true, partitionNums: 1]"));
-		assertTrue(physicalExecutionPlan.contains("HiveTableSource(year, value, pt) PartitionPruned: true, partitionNums: 1]"));
+		assertTrue(abstractSyntaxTree.contains("HiveTableSource(year, value, pt) TablePath: source_db.test_table_pt_1, PartitionPruned: false, PartitionNums: 2]"));
+		assertTrue(optimizedLogicalPlan.contains("HiveTableSource(year, value, pt) TablePath: source_db.test_table_pt_1, PartitionPruned: true, PartitionNums: 1]"));
+		assertTrue(physicalExecutionPlan.contains("HiveTableSource(year, value, pt) TablePath: source_db.test_table_pt_1, PartitionPruned: true, PartitionNums: 1]"));
 		List<Row> rows = JavaConverters.seqAsJavaListConverter(TableUtil.collect((TableImpl) table)).asJava();
 		assertEquals(2, rows.size());
 		Object[] rowStrings = rows.stream().map(Row::toString).sorted().toArray();


### PR DESCRIPTION
## What is the purpose of the change

*add test to verify partition pruning for HiveTableSource*


## Brief change log
  - *add test to verify partition pruning for HiveTableSource*


## Verifying this change
This change added tests and can be verified as follows:

  - *Added integration tests HiveTableSource#testPartitionPrunning*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
