### PR TITLE
 [FLINK-13504][table] Fixed shading issues in table modules. 

### DIFF
--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -60,6 +60,7 @@ run_test "Modern Kafka end-to-end test" "$END_TO_END_DIR/test-scripts/test_strea
 run_test "Kinesis end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_kinesis.sh"
 run_test "class loading end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_classloader.sh"
 run_test "Distributed cache end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh"
+run_test "Dependency shading of table module test" "$END_TO_END_DIR/test-scripts/test_table_shaded_dependencies.sh"
 
 printf "\n[PASS] All tests passed\n"
 exit 0

--- a/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
+++ b/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+function checkDependencies {
+  JAR=$1
+  CONTENTS_FILE=$TEST_DATA_DIR/contentsInJar.txt
+  jdeps $JAR > $CONTENTS_FILE
+  if [[ `grep -c "(?<!org.apache.flink.calcite.shaded.)com.google" $CONTENTS_FILE` -eq '0' && \
+      `grep -c "(?<!org.apache.flink.calcite.shaded.)com.jayway" $CONTENTS_FILE` -eq '0' && \
+      `grep -c "(?<!org.apache.flink.calcite.shaded.)org.apache.commons.codec" $CONTENTS_FILE` -eq '0' && \
+      `grep -c "(?<!org.apache.flink.table.shaded.)org.joda.time" $CONTENTS_FILE` -eq '0' && \
+      `grep -c "(?<!org.apache.flink.table.shaded.)net.jpountz" $CONTENTS_FILE` -eq '0' && \
+      `grep -c "(?<!org.apache.flink.calcite.shaded.)com.fasterxml" $CONTENTS_FILE` -eq '0' ]]; then
+
+      echo "Success: There are no unwanted dependencies in the ${JAR} jar."
+  else
+      echo "Failure: There are unwanted dependencies in the ${JAR} jar."
+      exit 1
+  fi
+}
+
+checkDependencies "${END_TO_END_DIR}/../flink-table/flink-table-planner/target/flink-table-planner_*.jar"
+checkDependencies "${END_TO_END_DIR}/../flink-table/flink-table-planner-blink/target/flink-table-planner-blink_*.jar"
+checkDependencies "${END_TO_END_DIR}/../flink-table/flink-table-runtime-blink/target/flink-table-runtime-blink_*.jar"
+checkDependencies "${FLINK_DIR}/lib/flink-table-blink.jar"
+checkDependencies "${FLINK_DIR}/lib/flink-table.jar"

--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -40,11 +40,6 @@ under the License.
 
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-guava</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
 			<!-- When updating the Calcite version, make sure to update the dependency exclusions -->

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateView.java
@@ -21,8 +21,6 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.flink.sql.parser.ExtendedSqlNode;
 import org.apache.flink.sql.parser.error.SqlParseException;
 
-import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
-
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlCreate;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -34,6 +32,7 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -63,7 +62,7 @@ public class SqlCreateView extends SqlCreate implements ExtendedSqlNode {
 
 	@Override
 	public List<SqlNode> getOperandList() {
-		List<SqlNode> ops = Lists.newArrayList();
+		List<SqlNode> ops = new ArrayList<>();
 		ops.add(viewName);
 		ops.add(fieldList);
 		ops.add(query);

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -336,7 +336,7 @@ under the License.
 									<include>commons-codec:commons-codec</include>
 
 									<!-- flink-table-planner-blink dependencies -->
-									<include>org.apache.flink.sql.parser:*</include>
+									<include>org.apache.flink:flink-sql-parser</include>
 
 									<!-- flink-table-runtime-blink dependencies -->
 									<include>org.codehaus.janino:*</include>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -339,7 +339,7 @@ under the License.
 									<include>commons-codec:commons-codec</include>
 
 									<!-- flink-table-planner dependencies -->
-									<include>org.apache.flink.sql.parser:*</include>
+									<include>org.apache.flink:flink-sql-parser</include>
 									<include>org.codehaus.janino:*</include>
 									<include>joda-time:*</include>
 								</includes>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -342,6 +342,7 @@ under the License.
 									<include>org.apache.flink:flink-sql-parser</include>
 									<include>org.codehaus.janino:*</include>
 									<include>joda-time:*</include>
+									<include>joda-convert:*</include>
 								</includes>
 							</artifactSet>
 							<relocations>
@@ -371,8 +372,8 @@ under the License.
 
 								<!-- flink-table-planner dependencies -->
 								<relocation>
-									<pattern>org.joda.time</pattern>
-									<shadedPattern>org.apache.flink.table.shaded.org.joda.time</shadedPattern>
+									<pattern>org.joda</pattern>
+									<shadedPattern>org.apache.flink.table.shaded.org.joda</shadedPattern>
 								</relocation>
 								<!-- not relocated for now, because we need to change the contents of the properties field otherwise -->
 								<!--<relocation>

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -102,9 +102,8 @@ under the License.
 						<configuration>
 							<artifactSet>
 								<includes combine.children="append">
-									<include>org.apache.flink:flink-table-common</include>
 									<!--Sql parser is included in planners-->
-									<!--<include>org.apache.flink:flink-sql-parser</include>-->
+									<include>org.apache.flink:flink-table-common</include>
 									<include>org.apache.flink:flink-table-api-java</include>
 									<include>org.apache.flink:flink-table-api-scala_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -103,7 +103,8 @@ under the License.
 							<artifactSet>
 								<includes combine.children="append">
 									<include>org.apache.flink:flink-table-common</include>
-									<include>org.apache.flink:flink-sql-parser</include>
+									<!--Sql parser is included in planners-->
+									<!--<include>org.apache.flink:flink-sql-parser</include>-->
 									<include>org.apache.flink:flink-table-api-java</include>
 									<include>org.apache.flink:flink-table-api-scala_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>

--- a/flink-table/flink-table-uber/pom.xml
+++ b/flink-table/flink-table-uber/pom.xml
@@ -95,9 +95,8 @@ under the License.
 						<configuration>
 							<artifactSet>
 								<includes combine.children="append">
-									<include>org.apache.flink:flink-table-common</include>
 									<!--Sql parser is included in planners-->
-									<!--<include>org.apache.flink:flink-sql-parser</include>-->
+									<include>org.apache.flink:flink-table-common</include>
 									<include>org.apache.flink:flink-table-api-java</include>
 									<include>org.apache.flink:flink-table-api-scala_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>

--- a/flink-table/flink-table-uber/pom.xml
+++ b/flink-table/flink-table-uber/pom.xml
@@ -86,7 +86,6 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
-					<!-- Exclude all flink-dist files and only include flink-table-* -->
 					<execution>
 						<id>shade-flink</id>
 						<phase>package</phase>
@@ -97,7 +96,8 @@ under the License.
 							<artifactSet>
 								<includes combine.children="append">
 									<include>org.apache.flink:flink-table-common</include>
-									<include>org.apache.flink:flink-sql-parser</include>
+									<!--Sql parser is included in planners-->
+									<!--<include>org.apache.flink:flink-sql-parser</include>-->
 									<include>org.apache.flink:flink-table-api-java</include>
 									<include>org.apache.flink:flink-table-api-scala_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>


### PR DESCRIPTION
## What is the purpose of the change

This PR properly includes the flink-sql-parser into flink-planner* modules shaded
jars. It also removes the flink-sql-parser module from flink-table-uber* jars as
it is already included in the flink-planner* modules.


## Brief change log

  - Fixed shading of `flink-sql-parser`
  - Removed unnecessary dependency on guava in `flink-sql-parser`

Verifying this change

  * For verification of sql-parser module e.g. run the query attached to jira issue.
  * Verify contents of flink-table-planner, flink-table-planner-blink, flink-table-runtime-blink, flink-sql-parser, flink-table-uber, flink-table-uber-blink do not contain unwanted classes.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
