### PR TITLE
[FLINK-12704][python] Enable the configuration of using blink planner.

### DIFF
--- a/flink-python/pyflink/table/__init__.py
+++ b/flink-python/pyflink/table/__init__.py
@@ -27,6 +27,8 @@ Important classes of Flink Table API:
     - :class:`pyflink.table.TableConfig`
       A config to define the runtime behavior of the Table API.
       It is necessary when creating :class:`TableEnvironment`.
+    - :class:`pyflink.table.EnvironmentSettings`
+      Defines all parameters that initialize a table environment.
     - :class:`pyflink.table.StreamQueryConfig` and :class:`pyflink.table.BatchQueryConfig`
       A query config holds parameters to configure the behavior of queries.
     - :class:`pyflink.table.TableSource`
@@ -53,6 +55,7 @@ Important classes of Flink Table API:
 """
 from __future__ import absolute_import
 
+from pyflink.table.environment_settings import EnvironmentSettings
 from pyflink.table.table import Table, GroupedTable, GroupWindowedTable, OverWindowedTable, \
     WindowGroupedTable
 from pyflink.table.table_config import TableConfig
@@ -67,6 +70,7 @@ __all__ = [
     'TableEnvironment',
     'StreamTableEnvironment',
     'BatchTableEnvironment',
+    'EnvironmentSettings',
     'Table',
     'GroupedTable',
     'GroupWindowedTable',

--- a/flink-python/pyflink/table/environment_settings.py
+++ b/flink-python/pyflink/table/environment_settings.py
@@ -39,7 +39,7 @@ class EnvironmentSettings(object):
 
     class Builder(object):
         """
-        A builder for :class:`EnvironmentSettingss`.
+        A builder for :class:`EnvironmentSettings`.
         """
 
         def __init__(self):
@@ -152,8 +152,8 @@ class EnvironmentSettings(object):
             """
             return EnvironmentSettings(self._j_builder.build())
 
-    def __init__(self, j_envrionment_settings):
-        self._j_environment_settings = j_envrionment_settings
+    def __init__(self, j_environment_settings):
+        self._j_environment_settings = j_environment_settings
 
     def get_built_in_catalog_name(self):
         """

--- a/flink-python/pyflink/table/environment_settings.py
+++ b/flink-python/pyflink/table/environment_settings.py
@@ -188,12 +188,12 @@ class EnvironmentSettings(object):
     @staticmethod
     def new_instance():
         """
-        Creates a builder for creating an instance of EnvironmentSettingss.
+        Creates a builder for creating an instance of EnvironmentSettings.
 
         By default, it does not specify a required planner and will use the one that is available
         on the classpath via discovery.
 
-        :return: A builder of EnvironmentSettingss.
+        :return: A builder of EnvironmentSettings.
         :rtype: EnvironmentSettings.Builder
         """
         return EnvironmentSettings.Builder()

--- a/flink-python/pyflink/table/environment_settings.py
+++ b/flink-python/pyflink/table/environment_settings.py
@@ -1,0 +1,199 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.java_gateway import get_gateway
+
+__all__ = ['EnvironmentSettings']
+
+
+class EnvironmentSettings(object):
+    """
+    Defines all parameters that initialize a table environment. Those parameters are used only
+    during instantiation of a :class:`~pyflink.table.TableEnvironment` and cannot be changed
+    afterwards.
+
+    Example:
+    ::
+
+        >>> EnvironmentSettings.new_instance() \\
+        ...     .use_old_planner() \\
+        ...     .in_streaming_mode() \\
+        ...     .with_built_in_catalog_name("my_catalog") \\
+        ...     .with_built_in_database_name("my_database") \\
+        ...     .build()
+    """
+
+    class Builder(object):
+        """
+        A builder for :class:`EnvironmentSettingss`.
+        """
+
+        def __init__(self):
+            gateway = get_gateway()
+            self._j_builder = gateway.jvm.EnvironmentSettings.Builder()
+
+        def use_old_planner(self):
+            """
+            Sets the old Flink planner as the required module.
+
+            This is the default behavior.
+
+            :return: This object.
+            :rtype: EnvironmentSettings.Builder
+            """
+            self._j_builder = self._j_builder.useOldPlanner()
+            return self
+
+        def use_blink_planner(self):
+            """
+            Sets the Blink planner as the required module. By default, :func:`use_old_planner` is
+            enabled.
+
+            :return: This object.
+            :rtype: EnvironmentSettings.Builder
+            """
+            self._j_builder = self._j_builder.useBlinkPlanner()
+            return self
+
+        def use_any_planner(self):
+            """
+            Does not set a planner requirement explicitly.
+
+            A planner will be discovered automatically, if there is only one planner available.
+
+            By default, :func:`use_old_planner` is enabled.
+
+            :return: This object.
+            :rtype: EnvironmentSettings.Builder
+            """
+            self._j_builder = self._j_builder.useAnyPlanner()
+            return self
+
+        def in_batch_mode(self):
+            """
+            Sets that the components should work in a batch mode. Streaming mode by default.
+
+            :return: This object.
+            :rtype: EnvironmentSettings.Builder
+            """
+            self._j_builder = self._j_builder.inBatchMode()
+            return self
+
+        def in_streaming_mode(self):
+            """
+            Sets that the components should work in a streaming mode. Enabled by default.
+
+            :return: This object.
+            :rtype: EnvironmentSettings.Builder
+            """
+            self._j_builder = self._j_builder.inStreamingMode()
+            return self
+
+        def with_built_in_catalog_name(self, built_in_catalog_name):
+            """
+            Specifies the name of the initial catalog to be created when instantiating
+            a :class:`~pyflink.table.TableEnvironment`. This catalog will be used to store all
+            non-serializable objects such as tables and functions registered via e.g.
+            :func:`~pyflink.table.TableEnvironment.register_table_sink` or
+            :func:`~pyflink.table.TableEnvironment.register_java_function`. It will also be the
+            initial value for the current catalog which can be altered via
+            :func:`~pyflink.table.TableEnvironment.use_catalog`.
+
+            Default: "default_catalog".
+
+            :param built_in_catalog_name: The specified built-in catalog name.
+            :type built_in_catalog_name: str
+            :return: This object.
+            :rtype: EnvironmentSettings.Builder
+            """
+            self._j_builder = self._j_builder.withBuiltInCatalogName(built_in_catalog_name)
+            return self
+
+        def with_built_in_database_name(self, built_in_database_name):
+            """
+            Specifies the name of the default database in the initial catalog to be
+            created when instantiating a :class:`~pyflink.table.TableEnvironment`. The database
+            will be used to store all non-serializable objects such as tables and functions
+            registered via e.g. :func:`~pyflink.table.TableEnvironment.register_table_sink` or
+            :func:`~pyflink.table.TableEnvironment.register_java_function`. It will also be the
+            initial value for the current database which can be altered via
+            :func:`~pyflink.table.TableEnvironment.use_database`.
+
+            Default: "default_database".
+
+            :param built_in_database_name: The specified built-in database name.
+            :type built_in_database_name: str
+            :return: This object.
+            :rtype: EnvironmentSettings.Builder
+            """
+            self._j_builder = self._j_builder.withBuiltInDatabaseName(built_in_database_name)
+            return self
+
+        def build(self):
+            """
+            Returns an immutable instance of EnvironmentSettings.
+
+            :return: an immutable instance of EnvironmentSettings.
+            :rtype: EnvironmentSettings
+            """
+            return EnvironmentSettings(self._j_builder.build())
+
+    def __init__(self, j_envrionment_settings):
+        self._j_environment_settings = j_envrionment_settings
+
+    def get_built_in_catalog_name(self):
+        """
+        Gets the specified name of the initial catalog to be created when instantiating a
+        :class:`~pyflink.table.TableEnvironment`.
+
+        :return: The specified name of the initial catalog to be created.
+        :rtype: str
+        """
+        return self._j_environment_settings.getBuiltInCatalogName()
+
+    def get_built_in_database_name(self):
+        """
+        Gets the specified name of the default database in the initial catalog to be created when
+        instantiating a :class:`~pyflink.table.TableEnvironment`.
+
+        :return: The specified name of the default database in the initial catalog to be created.
+        :rtype: str
+        """
+        return self._j_environment_settings.getBuiltInDatabaseName()
+
+    def is_streaming_mode(self):
+        """
+        Tells if the :class:`~pyflink.table.TableEnvironment` should work in a batch or streaming
+        mode.
+
+        :return: True if the TableEnvironment should work in a streaming mode, false otherwise.
+        :rtype: bool
+        """
+        return self._j_environment_settings.isStreamingMode()
+
+    @staticmethod
+    def new_instance():
+        """
+        Creates a builder for creating an instance of EnvironmentSettingss.
+
+        By default, it does not specify a required planner and will use the one that is available
+        on the classpath via discovery.
+
+        :return: A builder of EnvironmentSettingss.
+        :rtype: EnvironmentSettings.Builder
+        """
+        return EnvironmentSettings.Builder()

--- a/flink-python/pyflink/table/tests/test_environment_settings.py
+++ b/flink-python/pyflink/table/tests/test_environment_settings.py
@@ -1,0 +1,133 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.java_gateway import get_gateway
+
+from pyflink.table import EnvironmentSettings
+from pyflink.testing.test_case_utils import PyFlinkTestCase, get_private_field
+
+
+class EnvironmentSettingsTests(PyFlinkTestCase):
+
+    def test_planner_selection(self):
+
+        gateway = get_gateway()
+
+        CLASS_NAME = gateway.jvm.EnvironmentSettings.CLASS_NAME
+
+        builder = EnvironmentSettings.new_instance()
+
+        OLD_PLANNER_FACTORY = get_private_field(builder._j_builder, "OLD_PLANNER_FACTORY")
+        OLD_EXECUTOR_FACTORY = get_private_field(builder._j_builder, "OLD_EXECUTOR_FACTORY")
+        BLINK_PLANNER_FACTORY = get_private_field(builder._j_builder, "BLINK_PLANNER_FACTORY")
+        BLINK_EXECUTOR_FACTORY = get_private_field(builder._j_builder, "BLINK_EXECUTOR_FACTORY")
+
+        # test the default behaviour to make sure it is consistent with the python doc
+        envrionment_settings = builder.build()
+
+        self.assertEqual(
+            envrionment_settings._j_environment_settings.toPlannerProperties()[CLASS_NAME],
+            OLD_PLANNER_FACTORY)
+
+        self.assertEqual(
+            envrionment_settings._j_environment_settings.toExecutorProperties()[CLASS_NAME],
+            OLD_EXECUTOR_FACTORY)
+
+        # test use_old_planner
+        envrionment_settings = builder.use_old_planner().build()
+
+        self.assertEqual(
+            envrionment_settings._j_environment_settings.toPlannerProperties()[CLASS_NAME],
+            OLD_PLANNER_FACTORY)
+
+        self.assertEqual(
+            envrionment_settings._j_environment_settings.toExecutorProperties()[CLASS_NAME],
+            OLD_EXECUTOR_FACTORY)
+
+        # test use_blink_planner
+        envrionment_settings = builder.use_blink_planner().build()
+
+        self.assertEqual(
+            envrionment_settings._j_environment_settings.toPlannerProperties()[CLASS_NAME],
+            BLINK_PLANNER_FACTORY)
+
+        self.assertEqual(
+            envrionment_settings._j_environment_settings.toExecutorProperties()[CLASS_NAME],
+            BLINK_EXECUTOR_FACTORY)
+
+        # test use_any_planner
+        envrionment_settings = builder.use_any_planner().build()
+
+        self.assertTrue(
+            CLASS_NAME not in envrionment_settings._j_environment_settings.toPlannerProperties())
+
+        self.assertTrue(
+            CLASS_NAME not in envrionment_settings._j_environment_settings.toExecutorProperties())
+
+    def test_mode_selection(self):
+
+        builder = EnvironmentSettings.new_instance()
+
+        # test the default behaviour to make sure it is consistent with the python doc
+        envrionment_settings = builder.build()
+
+        self.assertTrue(envrionment_settings.is_streaming_mode())
+
+        # test in_streaming_mode
+        envrionment_settings = builder.in_streaming_mode().build()
+
+        self.assertTrue(envrionment_settings.is_streaming_mode())
+
+        # test in_batch_mode
+        envrionment_settings = builder.in_batch_mode().build()
+
+        self.assertFalse(envrionment_settings.is_streaming_mode())
+
+    def test_with_built_in_catalog_name(self):
+
+        gateway = get_gateway()
+
+        DEFAULT_BUILTIN_CATALOG = gateway.jvm.EnvironmentSettings.DEFAULT_BUILTIN_CATALOG
+
+        builder = EnvironmentSettings.new_instance()
+
+        # test the default behaviour to make sure it is consistent with the python doc
+        envrionment_settings = builder.build()
+
+        self.assertEqual(envrionment_settings.get_built_in_catalog_name(), DEFAULT_BUILTIN_CATALOG)
+
+        envrionment_settings = builder.with_built_in_catalog_name("my_catalog").build()
+
+        self.assertEqual(envrionment_settings.get_built_in_catalog_name(), "my_catalog")
+
+    def test_with_built_in_database_name(self):
+
+        gateway = get_gateway()
+
+        DEFAULT_BUILTIN_DATABASE = gateway.jvm.EnvironmentSettings.DEFAULT_BUILTIN_DATABASE
+
+        builder = EnvironmentSettings.new_instance()
+
+        # test the default behaviour to make sure it is consistent with the python doc
+        envrionment_settings = builder.build()
+
+        self.assertEqual(envrionment_settings.get_built_in_database_name(),
+                         DEFAULT_BUILTIN_DATABASE)
+
+        envrionment_settings = builder.with_built_in_database_name("my_database").build()
+
+        self.assertEqual(envrionment_settings.get_built_in_database_name(), "my_database")

--- a/flink-python/pyflink/table/tests/test_environment_settings_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_settings_completeness.py
@@ -1,0 +1,52 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import unittest
+
+from pyflink.table import EnvironmentSettings
+from pyflink.testing.test_case_utils import PythonAPICompletenessTestCase
+
+
+class EnvironmentSettingsCompletenessTests(PythonAPICompletenessTestCase, unittest.TestCase):
+    """
+    Tests whether the Python :class:`EnvironmentSettings` is consistent with
+    Java `org.apache.flink.table.api.EnvironmentSettings`.
+    """
+
+    @classmethod
+    def python_class(cls):
+        return EnvironmentSettings
+
+    @classmethod
+    def java_class(cls):
+        return "org.apache.flink.table.api.EnvironmentSettings"
+
+    @classmethod
+    def excluded_methods(cls):
+        # internal interfaces, no need to expose to users.
+        return {'toPlannerProperties', 'toExecutorProperties'}
+
+
+if __name__ == '__main__':
+    import unittest
+
+    try:
+        import xmlrunner
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/table/tests/test_environment_settings_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_settings_completeness.py
@@ -41,6 +41,21 @@ class EnvironmentSettingsCompletenessTests(PythonAPICompletenessTestCase, unitte
         return {'toPlannerProperties', 'toExecutorProperties'}
 
 
+class EnvironmentSettingsBuilderCompletenessTests(PythonAPICompletenessTestCase, unittest.TestCase):
+    """
+    Tests whether the Python :class:`EnvironmentSettings.Builder` is consistent with
+    Java `org.apache.flink.table.api.EnvironmentSettings$Builder`.
+    """
+
+    @classmethod
+    def python_class(cls):
+        return EnvironmentSettings.Builder
+
+    @classmethod
+    def java_class(cls):
+        return "org.apache.flink.table.api.EnvironmentSettings$Builder"
+
+
 if __name__ == '__main__':
     import unittest
 

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -21,7 +21,7 @@ from py4j.compat import unicode
 
 from pyflink.dataset import ExecutionEnvironment
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import DataTypes, CsvTableSink, StreamTableEnvironment
+from pyflink.table import DataTypes, CsvTableSink, StreamTableEnvironment, EnvironmentSettings
 from pyflink.table.table_config import TableConfig
 from pyflink.table.table_environment import BatchTableEnvironment
 from pyflink.table.types import RowType
@@ -197,6 +197,17 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         self.assertEqual(readed_table_config.get_max_generated_code_length(), 32000)
         self.assertEqual(readed_table_config.get_local_timezone(), "Asia/Shanghai")
 
+    def test_create_table_environment_with_blink_planner(self):
+        t_env = StreamTableEnvironment.create(
+            self.env,
+            environment_settings=EnvironmentSettings.new_instance().use_blink_planner().build())
+
+        planner = t_env._j_tenv.getPlanner()
+
+        self.assertEqual(
+            planner.getClass().getName(),
+            "org.apache.flink.table.planner.delegation.StreamPlanner")
+
 
 class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
 
@@ -273,3 +284,14 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
         self.assertFalse(readed_table_config.get_null_check())
         self.assertEqual(readed_table_config.get_max_generated_code_length(), 32000)
         self.assertEqual(readed_table_config.get_local_timezone(), "Asia/Shanghai")
+
+    def test_create_table_environment_with_blink_planner(self):
+        t_env = BatchTableEnvironment.create(
+            environment_settings=EnvironmentSettings.new_instance().in_batch_mode()
+            .use_blink_planner().build())
+
+        planner = t_env._j_tenv.getPlanner()
+
+        self.assertEqual(
+            planner.getClass().getName(),
+            "org.apache.flink.table.planner.delegation.BatchPlanner")

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -25,6 +25,8 @@ import unittest
 from abc import abstractmethod
 
 from py4j.java_gateway import JavaObject
+from py4j.protocol import Py4JJavaError
+
 from pyflink.table.sources import CsvTableSource
 
 from pyflink.dataset import ExecutionEnvironment
@@ -46,6 +48,23 @@ else:
     log_level = logging.INFO
 logging.basicConfig(stream=sys.stdout, level=log_level,
                     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+
+def get_private_field(java_obj, field_name):
+    try:
+        field = java_obj.getClass().getDeclaredField(field_name)
+        field.setAccessible(True)
+        return field.get(java_obj)
+    except Py4JJavaError:
+        cls = java_obj.getClass()
+        while cls.getSuperclass() is not None:
+            cls = cls.getSuperclass()
+            try:
+                field = cls.getDeclaredField(field_name)
+                field.setAccessible(True)
+                return field.get(java_obj)
+            except Py4JJavaError:
+                pass
 
 
 class PyFlinkTestCase(unittest.TestCase):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds the `EnvironmentSettings` class for flink python API to enable the configuration of using blink planner.*


## Brief change log

  - *Add `EnvironmentSettings` and relevant tests for flink python API.*
  - *Modify the create method of `StreamTableEnvironment` and `BatchTableEnvironment` to accept the `EnvironmentSettings` parameter.*
  - *Adjusted other interfaces of BatchTableEnvironment to match the behavior when using blink planner.`*


## Verifying this change

This change is already covered by existing tests, such as *test_environment_settings.py*, *test_environment_settings_completeness.py*, *test_table_environment_api.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (python docs)
