### PR TITLE
[FLINK-13374][scala][build] Set -Xss2m when compiling scala

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1775,6 +1775,9 @@ under the License.
 						<args>
 							<arg>-nobootcp</arg>
 						</args>
+						<jvmArgs>
+							<arg>-Xss2m</arg>
+						</jvmArgs>
 					</configuration>
 				</plugin>
 


### PR DESCRIPTION
This PR bumps the ThreadStackSize to 2MB when compiling scala. This appears to be the common approach for handling StackOverflowErrors by the scala compiler.

see https://www.scala-lang.org/old/node/10931, https://github.com/scala/bug/issues/10604

I haven't observed an increase in compile time.