### PR TITLE
[FLINK-13530][qs][tests] Increase port range size

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
@@ -44,6 +44,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Tests general behavior of the {@link AbstractServerBase}.
@@ -88,10 +90,9 @@ public class AbstractServerTest extends TestLogger {
 		AtomicKvStateRequestStats serverStats = new AtomicKvStateRequestStats();
 		AtomicKvStateRequestStats clientStats = new AtomicKvStateRequestStats();
 
-		List<Integer> portList = new ArrayList<>();
-		portList.add(7777);
-		portList.add(7778);
-		portList.add(7779);
+		final int portRangeStart = 7777;
+		final int portRangeEnd = 7900;
+		List<Integer> portList = IntStream.range(portRangeStart, portRangeEnd + 1).boxed().collect(Collectors.toList());
 
 		try (
 				TestServer server1 = new TestServer("Test Server 1", serverStats, portList.iterator());
@@ -104,10 +105,10 @@ public class AbstractServerTest extends TestLogger {
 				)
 		) {
 			server1.start();
-			Assert.assertTrue(server1.getServerAddress().getPort() >= 7777 && server1.getServerAddress().getPort() <= 7779);
+			Assert.assertTrue(server1.getServerAddress().getPort() >= portRangeStart && server1.getServerAddress().getPort() <= portRangeEnd);
 
 			server2.start();
-			Assert.assertTrue(server2.getServerAddress().getPort() >= 7777 && server2.getServerAddress().getPort() <= 7779);
+			Assert.assertTrue(server2.getServerAddress().getPort() >= portRangeStart && server2.getServerAddress().getPort() <= portRangeEnd);
 
 			TestMessage response1 = client.sendRequest(server1.getServerAddress(), new TestMessage("ping")).join();
 			Assert.assertEquals(server1.getServerName() + "-ping", response1.getMessage());


### PR DESCRIPTION
Increase the size of the port range used in `AbstractServerTest#testPortRangeSuccess` by 4000%, which should make it quite likely that we find an open port; should the test fail again for the same reason we can conclude that there is an actual problem in the code.