### PR TITLE
[FLINK-13531] Do not print log and call 'release' if no requests should be evicted from the shared slot

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -600,29 +600,31 @@ public class SlotSharingManager {
 				}
 			}
 
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Not all requests are fulfilled due to over-allocated, number of requests is {}, " +
-						"number of evicted requests is {}, underlying allocated is {}, fulfilled is {}, " +
-						"evicted requests is {},",
-					children.size(),
-					childrenToEvict.size(),
-					slotContext.getResourceProfile(),
-					requiredResources,
-					childrenToEvict);
-			}
+			if (childrenToEvict.size() > 0) {
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("Not all requests are fulfilled due to over-allocated, number of requests is {}, " +
+									"number of evicted requests is {}, underlying allocated is {}, fulfilled is {}, " +
+									"evicted requests is {},",
+							children.size(),
+							childrenToEvict.size(),
+							slotContext.getResourceProfile(),
+							requiredResources,
+							childrenToEvict);
+				}
 
-			if (childrenToEvict.size() == children.size()) {
-				// Since RM always return a slot whose resource is larger than the requested one,
-				// The current situation only happens when we request to RM using the resource
-				// profile of a task who is belonging to a CoLocationGroup. Similar to dealing
-				// with the failure of the underlying request, currently we fail all the requests
-				// directly.
-				release(new SharedSlotOversubscribedException(
-					"The allocated slot does not have enough resource for any task.", false));
-			} else {
-				for (TaskSlot taskSlot : childrenToEvict) {
-					taskSlot.release(new SharedSlotOversubscribedException(
-						"The allocated slot does not have enough resource for all the tasks.", true));
+				if (childrenToEvict.size() == children.size()) {
+					// Since RM always return a slot whose resource is larger than the requested one,
+					// The current situation only happens when we request to RM using the resource
+					// profile of a task who is belonging to a CoLocationGroup. Similar to dealing
+					// with the failure of the underlying request, currently we fail all the requests
+					// directly.
+					release(new SharedSlotOversubscribedException(
+							"The allocated slot does not have enough resource for any task.", false));
+				} else {
+					for (TaskSlot taskSlot : childrenToEvict) {
+						taskSlot.release(new SharedSlotOversubscribedException(
+								"The allocated slot does not have enough resource for all the tasks.", true));
+					}
 				}
 			}
 		}


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This PR fixes the code problem for checking the over-reserved requests when the underlying slots are  allocated. This is a part of the bookkeeping logic for sharing slot introduced in #8841 .

The current implementation does not check the amount to fail before printing the over-reserved and tries to fail them. Although it should not cause actual error, it will print a over-reserved log wrongly. Besides, if the slot has been already allocated when constructing the` MultiTaskSlot`, the `released` method will be called. Although `release` will do nothing due to the slot is still being constructed, it may cause error if the `release` logic changes in the future.

To fix the above issue, we need to add the explicit checking for the number of requests to evict.

For the tests, it is hard to add a test for the fix since currently it will not cause actual errors. It will print a wrong debug log and call `release`, but `release` will do nothing actually. Therefore, to add a test, I have to make some assumption on the detailed implementation of `SlotShareManager` and use some hack methods to detect if `release` is called. 

## Brief change log
- 187030df57d4fc62a2d121ddda3a4047a390f576 add the explicit check.

## Verifying this change

- Manually checked that the debug log does not been printed, and `release` does not get called if the underlying slot has already been allocated when creating MultiTaskSlot.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
