### PR TITLE
[FLINK-13535][kafka] do not abort transactions twice during KafkaProducer startup

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.time.Clock;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -210,7 +211,13 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 		abort(transaction);
 	}
 
-	protected void finishRecoveringContext() {
+	/**
+	 * Callback for subclasses which is called after restoring (each) user context.
+	 *
+	 * @param handledTransactions
+	 * 		transactions which were already committed or aborted and do not need further handling
+	 */
+	protected void finishRecoveringContext(Collection<TXN> handledTransactions) {
 	}
 
 	// ------ entry points for above methods implementing {@CheckPointedFunction} and {@CheckpointListener} ------
@@ -346,17 +353,23 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 			for (State<TXN, CONTEXT> operatorState : state.get()) {
 				userContext = operatorState.getContext();
 				List<TransactionHolder<TXN>> recoveredTransactions = operatorState.getPendingCommitTransactions();
+				List<TXN> handledTransactions = new ArrayList<>(recoveredTransactions.size() + 1);
 				for (TransactionHolder<TXN> recoveredTransaction : recoveredTransactions) {
 					// If this fails to succeed eventually, there is actually data loss
 					recoverAndCommitInternal(recoveredTransaction);
+					handledTransactions.add(recoveredTransaction.handle);
 					LOG.info("{} committed recovered transaction {}", name(), recoveredTransaction);
 				}
 
-				recoverAndAbort(operatorState.getPendingTransaction().handle);
-				LOG.info("{} aborted recovered transaction {}", name(), operatorState.getPendingTransaction());
+				{
+					TXN transaction = operatorState.getPendingTransaction().handle;
+					recoverAndAbort(transaction);
+					handledTransactions.add(transaction);
+					LOG.info("{} aborted recovered transaction {}", name(), operatorState.getPendingTransaction());
+				}
 
 				if (userContext.isPresent()) {
-					finishRecoveringContext();
+					finishRecoveringContext(handledTransactions);
 					recoveredUserContext = true;
 				}
 			}


### PR DESCRIPTION
## What is the purpose of the change

During startup of a transactional Kafka producer from previous state, we recover in two steps:
1) in `TwoPhaseCommitSinkFunction`, we commit pending commit-transactions and abort pending transactions and then call into `finishRecoveringContext()`
2) in `FlinkKafkaProducer#finishRecoveringContext()` we iterate over all recovered transaction IDs and abort them.

This may lead to some transactions being worked on twice and there is quite some overhead from creating a `KafkaProducer` for each of these transactions.

## Brief change log

- provide `finishRecoveringContext()` with a collection of all transactions that `TwoPhaseCommitSinkFunction` already covered
- adapt `FlinkKafkaProducer` and `FlinkKafkaProducer011` to ignores transactional IDs from that set

## Verifying this change

This change is already covered by existing tests, such as `FlinkKafkaProducerITCase` and `KafkaProducerExactlyOnceITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
