### PR TITLE
[FLINK-13541][state-processor-api] State Processor Api sets the wrong key selector when writing savepoints

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/BootstrapTransformationTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/BootstrapTransformationTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.state.api;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.operators.DataSource;
 import org.apache.flink.api.java.operators.Operator;
 import org.apache.flink.core.fs.Path;
@@ -28,9 +29,11 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.state.api.functions.BroadcastStateBootstrapFunction;
+import org.apache.flink.state.api.functions.KeyedStateBootstrapFunction;
 import org.apache.flink.state.api.functions.StateBootstrapFunction;
 import org.apache.flink.state.api.output.TaggedOperatorSubtaskState;
 import org.apache.flink.state.api.runtime.OperatorIDGenerator;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.test.util.AbstractTestBase;
 
 import org.junit.Assert;
@@ -138,6 +141,32 @@ public class BootstrapTransformationTest extends AbstractTestBase {
 		Assert.assertEquals("The parallelism of a data set should be constrained my the savepoint max parallelism", 1, getParallelism(result));
 	}
 
+	@Test
+	public void testStreamConfig() {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSource<String> input = env.fromElements("");
+
+		BootstrapTransformation<String> transformation = OperatorTransformation
+			.bootstrapWith(input)
+			.keyBy(new CustomKeySelector())
+			.transform(new ExampleKeyedStateBootstrapFunction());
+
+		StreamConfig config = transformation.getConfig(OperatorIDGenerator.fromUid("uid"), new MemoryStateBackend(), null);
+		KeySelector selector = config.getStatePartitioner(0, Thread.currentThread().getContextClassLoader());
+
+		Assert.assertEquals("Incorrect key selector forwarded to stream operator", CustomKeySelector.class, selector.getClass());
+	}
+
+	private static class CustomKeySelector implements KeySelector<String, String> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public String getKey(String value) throws Exception {
+			return value;
+		}
+	}
+
 	private static <T> int getParallelism(DataSet<T> dataSet) {
 		//All concrete implementations of DataSet are operators so this should always be safe.
 		return ((Operator) dataSet).getParallelism();
@@ -162,6 +191,13 @@ public class BootstrapTransformationTest extends AbstractTestBase {
 
 		@Override
 		public void initializeState(FunctionInitializationContext context) throws Exception {
+		}
+	}
+
+	private static class ExampleKeyedStateBootstrapFunction extends KeyedStateBootstrapFunction<String, String> {
+
+		@Override
+		public void processElement(String value, Context ctx) throws Exception {
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The state processor api is setting the wrong key selector for its StreamConfig when writing savepoints. It uses two key selectors internally that happen to output the same value for integer keys but not in general.

## Brief change log
  - set the correct key selector

## Verifying this change

UT

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
