### PR TITLE
[FLINK-13542][metrics] Update datadog reporter to send metrics if the…

### DIFF
--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -155,7 +155,13 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 		}
 
 		try {
-			client.send(request);
+			int seriesSize = request.getSeries().getSeries().size();
+			if (seriesSize > 0) {
+				client.send(request);
+			}
+			else  {
+				LOGGER.debug("Series size {}, so skipping sending to Datadog", seriesSize);
+			}
 		} catch (SocketTimeoutException e) {
 			LOGGER.warn("Failed reporting metrics to Datadog because of socket timeout.", e.getMessage());
 		} catch (Exception e) {


### PR DESCRIPTION
… metrics are available

## What is the purpose of the change

* Update datadog metrics reporter to only post metrics if they are available.  

## Brief change log

* Check series size before sending metrics to Datadog and if there are no series, just log a message.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
