### PR TITLE
[FLINK-13521][sql-client] Allow setting configurations in SQL CLI

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -233,6 +233,20 @@ execution:
   restart-strategy:                 # optional: restart strategy
     type: fallback                  #   "fallback" to global restart strategy by default
 
+# Table configurations allow for tuning the table environment in which the queries run.
+# These configurations currently only work with blink planner.
+# For a detailed list of available options,
+# see ExecutionConfigOptions.java and OptimizerConfigOptions.java
+
+# Every table config has its default value,
+# so the default configuration part does not exist.
+# You can directly set the table environment config options here, for example,
+
+# configuration:
+#   table.exec.spill-compression.enabled: true
+#   table.exec.spill-compression.block-size: 128kb
+#   table.optimizer.join-reorder-enabled: true
+
 # Deployment properties allow for describing the cluster to which table programs are submitted to.
 
 deployment:

--- a/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
@@ -117,6 +117,23 @@ execution:
     # possible values are "fixed-delay", "failure-rate", "none", or "fallback" (default)
     type: fallback
 
+#==============================================================================
+# Table Configurations
+#==============================================================================
+
+# Table configurations allow for tuning the table environment in which the queries run.
+# These configurations currently only work with blink planner.
+# For a detailed list of available options,
+# see ExecutionConfigOptions.java and OptimizerConfigOptions.java
+
+# Every table config has its default value,
+# so the default configuration part does not exist.
+# You can directly set the table environment config options here, for example,
+
+# configuration:
+#   table.exec.spill-compression.enabled: true
+#   table.exec.spill-compression.block-size: 128kb
+#   table.optimizer.join-reorder-enabled: true
 
 #==============================================================================
 # Deployment properties

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.client.config;
 
 import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.config.entries.CatalogEntry;
+import org.apache.flink.table.client.config.entries.ConfigurationEntry;
 import org.apache.flink.table.client.config.entries.DeploymentEntry;
 import org.apache.flink.table.client.config.entries.ExecutionEntry;
 import org.apache.flink.table.client.config.entries.FunctionEntry;
@@ -50,6 +51,9 @@ public class Environment {
 
 	public static final String DEPLOYMENT_ENTRY = "deployment";
 
+	public static final String[] CONFIGURATION_ENTRIES = new String[]{
+		"table.exec", "table.optimizer"};
+
 	private Map<String, CatalogEntry> catalogs;
 
 	private Map<String, TableEntry> tables;
@@ -60,12 +64,15 @@ public class Environment {
 
 	private DeploymentEntry deployment;
 
+	private ConfigurationEntry configuration;
+
 	public Environment() {
 		this.catalogs = Collections.emptyMap();
 		this.tables = Collections.emptyMap();
 		this.functions = Collections.emptyMap();
 		this.execution = ExecutionEntry.DEFAULT_INSTANCE;
 		this.deployment = DeploymentEntry.DEFAULT_INSTANCE;
+		this.configuration = ConfigurationEntry.DEFAULT_INSTANCE;
 	}
 
 	public Map<String, CatalogEntry> getCatalogs() {
@@ -136,6 +143,14 @@ public class Environment {
 		return deployment;
 	}
 
+	public void setConfiguration(Map<String, Object> config) {
+		this.configuration = ConfigurationEntry.create(config);
+	}
+
+	public ConfigurationEntry getConfiguration() {
+		return configuration;
+	}
+
 	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder();
@@ -158,6 +173,8 @@ public class Environment {
 		execution.asTopLevelMap().forEach((k, v) -> sb.append(k).append(": ").append(v).append('\n'));
 		sb.append("=================== Deployment ===================\n");
 		deployment.asTopLevelMap().forEach((k, v) -> sb.append(k).append(": ").append(v).append('\n'));
+		sb.append("================== Configuration =================\n");
+		configuration.asMap().forEach((k, v) -> sb.append(k).append(": ").append(v).append('\n'));
 		return sb.toString();
 	}
 
@@ -212,6 +229,9 @@ public class Environment {
 		// merge deployment properties
 		mergedEnv.deployment = DeploymentEntry.merge(env1.getDeployment(), env2.getDeployment());
 
+		// merge execution properties
+		mergedEnv.configuration = ConfigurationEntry.merge(env1.getConfiguration(), env2.getConfiguration());
+
 		return mergedEnv;
 	}
 
@@ -239,6 +259,9 @@ public class Environment {
 
 		// enrich deployment properties
 		enrichedEnv.deployment = DeploymentEntry.enrich(env.deployment, properties);
+
+		// enrich configuration properties
+		enrichedEnv.configuration = ConfigurationEntry.enrich(env.configuration, properties);
 
 		return enrichedEnv;
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -49,10 +49,9 @@ public class Environment {
 
 	public static final String EXECUTION_ENTRY = "execution";
 
-	public static final String DEPLOYMENT_ENTRY = "deployment";
+	public static final String CONFIGURATION_ENTRY = "table";
 
-	public static final String[] CONFIGURATION_ENTRIES = new String[]{
-		"table.exec", "table.optimizer"};
+	public static final String DEPLOYMENT_ENTRY = "deployment";
 
 	private Map<String, CatalogEntry> catalogs;
 
@@ -62,17 +61,17 @@ public class Environment {
 
 	private ExecutionEntry execution;
 
-	private DeploymentEntry deployment;
-
 	private ConfigurationEntry configuration;
+
+	private DeploymentEntry deployment;
 
 	public Environment() {
 		this.catalogs = Collections.emptyMap();
 		this.tables = Collections.emptyMap();
 		this.functions = Collections.emptyMap();
 		this.execution = ExecutionEntry.DEFAULT_INSTANCE;
-		this.deployment = DeploymentEntry.DEFAULT_INSTANCE;
 		this.configuration = ConfigurationEntry.DEFAULT_INSTANCE;
+		this.deployment = DeploymentEntry.DEFAULT_INSTANCE;
 	}
 
 	public Map<String, CatalogEntry> getCatalogs() {
@@ -135,20 +134,20 @@ public class Environment {
 		return execution;
 	}
 
-	public void setDeployment(Map<String, Object> config) {
-		this.deployment = DeploymentEntry.create(config);
-	}
-
-	public DeploymentEntry getDeployment() {
-		return deployment;
-	}
-
 	public void setConfiguration(Map<String, Object> config) {
 		this.configuration = ConfigurationEntry.create(config);
 	}
 
 	public ConfigurationEntry getConfiguration() {
 		return configuration;
+	}
+
+	public void setDeployment(Map<String, Object> config) {
+		this.deployment = DeploymentEntry.create(config);
+	}
+
+	public DeploymentEntry getDeployment() {
+		return deployment;
 	}
 
 	@Override
@@ -171,10 +170,10 @@ public class Environment {
 		});
 		sb.append("=================== Execution ====================\n");
 		execution.asTopLevelMap().forEach((k, v) -> sb.append(k).append(": ").append(v).append('\n'));
-		sb.append("=================== Deployment ===================\n");
-		deployment.asTopLevelMap().forEach((k, v) -> sb.append(k).append(": ").append(v).append('\n'));
 		sb.append("================== Configuration =================\n");
 		configuration.asMap().forEach((k, v) -> sb.append(k).append(": ").append(v).append('\n'));
+		sb.append("=================== Deployment ===================\n");
+		deployment.asTopLevelMap().forEach((k, v) -> sb.append(k).append(": ").append(v).append('\n'));
 		return sb.toString();
 	}
 
@@ -226,11 +225,11 @@ public class Environment {
 		// merge execution properties
 		mergedEnv.execution = ExecutionEntry.merge(env1.getExecution(), env2.getExecution());
 
+		// merge configuration properties
+		mergedEnv.configuration = ConfigurationEntry.merge(env1.getConfiguration(), env2.getConfiguration());
+
 		// merge deployment properties
 		mergedEnv.deployment = DeploymentEntry.merge(env1.getDeployment(), env2.getDeployment());
-
-		// merge execution properties
-		mergedEnv.configuration = ConfigurationEntry.merge(env1.getConfiguration(), env2.getConfiguration());
 
 		return mergedEnv;
 	}
@@ -257,11 +256,11 @@ public class Environment {
 		// enrich execution properties
 		enrichedEnv.execution = ExecutionEntry.enrich(env.execution, properties);
 
-		// enrich deployment properties
-		enrichedEnv.deployment = DeploymentEntry.enrich(env.deployment, properties);
-
 		// enrich configuration properties
 		enrichedEnv.configuration = ConfigurationEntry.enrich(env.configuration, properties);
+
+		// enrich deployment properties
+		enrichedEnv.deployment = DeploymentEntry.enrich(env.deployment, properties);
 
 		return enrichedEnv;
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ConfigurationEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ConfigurationEntry.java
@@ -18,19 +18,16 @@
 
 package org.apache.flink.table.client.config.entries;
 
-import org.apache.flink.table.api.config.ExecutionConfigOptions;
-import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.client.config.ConfigUtil;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.flink.table.client.config.Environment.CONFIGURATION_ENTRIES;
+import static org.apache.flink.table.client.config.Environment.CONFIGURATION_ENTRY;
 
 /**
- * Configuration of a table environment.
- * The options are the same with {@link ExecutionConfigOptions} and {@link OptimizerConfigOptions}.
+ * Configuration for configuring {@link org.apache.flink.table.api.TableConfig}.
  */
 public class ConfigurationEntry extends ConfigEntry {
 
@@ -53,7 +50,7 @@ public class ConfigurationEntry extends ConfigEntry {
 	}
 
 	/**
-	 * Merges two execution entries. The properties of the first execution entry might be
+	 * Merges two configuration entries. The properties of the first configuration entry might be
 	 * overwritten by the second one.
 	 */
 	public static ConfigurationEntry merge(ConfigurationEntry configuration1, ConfigurationEntry configuration2) {
@@ -71,11 +68,8 @@ public class ConfigurationEntry extends ConfigEntry {
 
 		prefixedProperties.forEach((k, v) -> {
 			final String normalizedKey = k.toLowerCase();
-			for (String prefix : CONFIGURATION_ENTRIES) {
-				if (k.startsWith(prefix + ".")) {
-					enrichedProperties.put(normalizedKey, v);
-					break;
-				}
+			if (k.startsWith(CONFIGURATION_ENTRY + ".")) {
+				enrichedProperties.put(normalizedKey, v);
 			}
 		});
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ConfigurationEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ConfigurationEntry.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.config.entries;
+
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.client.config.ConfigUtil;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.client.config.Environment.CONFIGURATION_ENTRIES;
+
+/**
+ * Configuration of a table environment.
+ * The options are the same with {@link ExecutionConfigOptions} and {@link OptimizerConfigOptions}.
+ */
+public class ConfigurationEntry extends ConfigEntry {
+
+	public static final ConfigurationEntry DEFAULT_INSTANCE =
+		new ConfigurationEntry(new DescriptorProperties(true));
+
+	private ConfigurationEntry(DescriptorProperties properties) {
+		super(properties);
+	}
+
+	@Override
+	protected void validate(DescriptorProperties properties) {
+		// Nothing to validate as the planner will check the options
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	public static ConfigurationEntry create(Map<String, Object> config) {
+		return new ConfigurationEntry(ConfigUtil.normalizeYaml(config));
+	}
+
+	/**
+	 * Merges two execution entries. The properties of the first execution entry might be
+	 * overwritten by the second one.
+	 */
+	public static ConfigurationEntry merge(ConfigurationEntry configuration1, ConfigurationEntry configuration2) {
+		final Map<String, String> mergedProperties = new HashMap<>(configuration1.asMap());
+		mergedProperties.putAll(configuration2.asMap());
+
+		final DescriptorProperties properties = new DescriptorProperties(true);
+		properties.putProperties(mergedProperties);
+
+		return new ConfigurationEntry(properties);
+	}
+
+	public static ConfigurationEntry enrich(ConfigurationEntry configuration, Map<String, String> prefixedProperties) {
+		final Map<String, String> enrichedProperties = new HashMap<>(configuration.asMap());
+
+		prefixedProperties.forEach((k, v) -> {
+			final String normalizedKey = k.toLowerCase();
+			for (String prefix : CONFIGURATION_ENTRIES) {
+				if (k.startsWith(prefix + ".")) {
+					enrichedProperties.put(normalizedKey, v);
+					break;
+				}
+			}
+		});
+
+		final DescriptorProperties properties = new DescriptorProperties(true);
+		properties.putProperties(enrichedProperties);
+
+		return new ConfigurationEntry(properties);
+	}
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -368,6 +368,10 @@ public class ExecutionContext<T> {
 				throw new SqlExecutionException("Unsupported execution type specified.");
 			}
 
+			// set table configs
+			mergedEnv.getConfiguration().asMap().forEach((k, v) ->
+				tableEnv.getConfig().getConfiguration().setString(k, v));
+
 			// register catalogs
 			catalogs.forEach(tableEnv::registerCatalog);
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -187,6 +187,7 @@ public class LocalExecutor implements Executor {
 		final Map<String, String> properties = new HashMap<>();
 		properties.putAll(env.getExecution().asTopLevelMap());
 		properties.putAll(env.getDeployment().asTopLevelMap());
+		properties.putAll(env.getConfiguration().asMap());
 		return properties;
 	}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -313,13 +313,6 @@ public class ExecutionContextTest {
 	}
 
 	private <T> ExecutionContext<T> createConfigurationExecutionContext() throws Exception {
-		final Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_PLANNER", "blink");
-		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
-		replaceVars.put("$VAR_RESULT_MODE", "table");
-		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-		replaceVars.put("$VAR_MAX_ROWS", "100");
-		replaceVars.put("$SORT_DEFAULT_LIMIT", "100");
-		return createExecutionContext(CONFIGURATIONS_ENVIRONMENT_FILE, replaceVars);
+		return createExecutionContext(CONFIGURATIONS_ENVIRONMENT_FILE, new HashMap<>());
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
@@ -60,6 +62,7 @@ public class ExecutionContextTest {
 	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-client-defaults.yaml";
 	private static final String CATALOGS_ENVIRONMENT_FILE = "test-sql-client-catalogs.yaml";
 	private static final String STREAMING_ENVIRONMENT_FILE = "test-sql-client-streaming.yaml";
+	private static final String CONFIGURATIONS_ENVIRONMENT_FILE = "test-sql-client-configurations.yaml";
 
 	@Test
 	public void testExecutionConfig() throws Exception {
@@ -230,6 +233,42 @@ public class ExecutionContextTest {
 			tableEnv.scan("TemporalTableUsage").getSchema().getFieldNames());
 	}
 
+	@Test
+	public void testConfigurations() throws Exception {
+		final ExecutionContext<?> context = createConfigurationExecutionContext();
+		final TableEnvironment tableEnv = context.createEnvironmentInstance().getTableEnvironment();
+
+		assertEquals(
+			100,
+			tableEnv.getConfig().getConfiguration().getInteger(
+				ExecutionConfigOptions.TABLE_EXEC_SORT_DEFAULT_LIMIT));
+		assertTrue(
+			tableEnv.getConfig().getConfiguration().getBoolean(
+				ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED));
+		assertEquals(
+			"128kb",
+			tableEnv.getConfig().getConfiguration().getString(
+				ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_BLOCK_SIZE));
+
+		assertTrue(
+			tableEnv.getConfig().getConfiguration().getBoolean(
+				OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED));
+
+		// These options are not modified, should equal to their default value
+		assertEquals(
+			ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED.defaultValue(),
+			tableEnv.getConfig().getConfiguration().getBoolean(
+				ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED));
+		assertEquals(
+			ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE.defaultValue(),
+			tableEnv.getConfig().getConfiguration().getString(
+				ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE));
+		assertEquals(
+			OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD.defaultValue().longValue(),
+			tableEnv.getConfig().getConfiguration().getLong(
+				OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD));
+	}
+
 	private <T> ExecutionContext<T> createExecutionContext(String file, Map<String, String> replaceVars) throws Exception {
 		final Environment env = EnvironmentFileUtil.parseModified(
 			file,
@@ -271,5 +310,16 @@ public class ExecutionContextTest {
 		replaceVars.put("$VAR_CONNECTOR_PROPERTY", DummyTableSourceFactory.TEST_PROPERTY);
 		replaceVars.put("$VAR_CONNECTOR_PROPERTY_VALUE", "");
 		return createExecutionContext(STREAMING_ENVIRONMENT_FILE, replaceVars);
+	}
+
+	private <T> ExecutionContext<T> createConfigurationExecutionContext() throws Exception {
+		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", "blink");
+		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
+		replaceVars.put("$VAR_RESULT_MODE", "table");
+		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+		replaceVars.put("$VAR_MAX_ROWS", "100");
+		replaceVars.put("$SORT_DEFAULT_LIMIT", "100");
+		return createExecutionContext(CONFIGURATIONS_ENVIRONMENT_FILE, replaceVars);
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -506,45 +506,6 @@ public class LocalExecutorITCase extends TestLogger {
 		}
 	}
 
-	@Test(timeout = 30_000L)
-	public void testTableEnvConfigurations() throws Exception {
-		if (!planner.equals("blink")) {
-			// Table env configurations can only be used on blink planner
-			return;
-		}
-
-		final URL url = getClass().getClassLoader().getResource("test-data.csv");
-		Objects.requireNonNull(url);
-
-		final Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_PLANNER", planner);
-		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
-		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
-		replaceVars.put("$VAR_RESULT_MODE", "table");
-		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-		replaceVars.put("$VAR_MAX_ROWS", "100");
-		replaceVars.put("$SORT_DEFAULT_LIMIT", "3");
-
-		final String query = "SELECT * FROM TableNumber1 ORDER BY IntegerField1";
-
-		final List<String> expectedResults = new ArrayList<>();
-		expectedResults.add("22,Hello World");
-		expectedResults.add("32,Hello World");
-		expectedResults.add("32,Hello World");
-
-		final Executor executor = createModifiedExecutor(CONFIGURATIONS_ENVIRONMENT_FILE, clusterClient, replaceVars);
-		final SessionContext session = new SessionContext("test-session", new Environment());
-
-		try {
-			final ResultDescriptor desc = executor.executeQuery(session, query);
-			assertTrue(desc.isMaterialized());
-			final List<String> actualResults = retrieveTableResult(executor, session, desc.getResultId());
-			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
-		} finally {
-			executor.stop(session);
-		}
-	}
-
 	private void executeStreamQueryTable(
 			Map<String, String> replaceVars,
 			String query,

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-configurations.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-configurations.yaml
@@ -1,0 +1,149 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+#==============================================================================
+# TEST ENVIRONMENT FILE
+# General purpose default environment file.
+#==============================================================================
+
+# this file has variables that can be filled with content by replacing $VAR_XXX
+
+tables:
+  - name: TableNumber1
+    type: source-table
+    $VAR_UPDATE_MODE
+    schema:
+      - name: IntegerField1
+        type: INT
+      - name: StringField1
+        type: VARCHAR
+    connector:
+      type: filesystem
+      path: "$VAR_SOURCE_PATH1"
+    format:
+      type: csv
+      fields:
+        - name: IntegerField1
+          type: INT
+        - name: StringField1
+          type: VARCHAR
+      line-delimiter: "\n"
+      comment-prefix: "#"
+  - name: TestView1
+    type: view
+    query: SELECT scalarUDF(IntegerField1) FROM TableNumber1
+  - name: TableNumber2
+    # Test backwards compatibility ("source" -> "source-table")
+    type: source
+    $VAR_UPDATE_MODE
+    schema:
+      - name: IntegerField2
+        type: INT
+      - name: StringField2
+        type: VARCHAR
+    connector:
+      type: filesystem
+      path: "$VAR_SOURCE_PATH2"
+    format:
+      type: csv
+      fields:
+        - name: IntegerField2
+          type: INT
+        - name: StringField2
+          type: VARCHAR
+      line-delimiter: "\n"
+      comment-prefix: "#"
+  - name: TableSourceSink
+    type: source-sink-table
+    $VAR_UPDATE_MODE
+    schema:
+      - name: BooleanField
+        type: BOOLEAN
+      - name: StringField
+        type: VARCHAR
+    connector:
+      type: filesystem
+      path: "$VAR_SOURCE_SINK_PATH"
+    format:
+      type: csv
+      fields:
+        - name: BooleanField
+          type: BOOLEAN
+        - name: StringField
+          type: VARCHAR
+  - name: TestView2
+    type: view
+    query: SELECT * FROM TestView1
+
+functions:
+  - name: scalarUDF
+    from: class
+    class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$ScalarUDF
+    constructor:
+      - 5
+  - name: aggregateUDF
+    from: class
+    class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$AggregateUDF
+    constructor:
+      - StarryName
+      - false
+      - class: java.lang.Integer
+        constructor:
+          - class: java.lang.String
+            constructor:
+              - type: VARCHAR
+                value: 3
+  - name: tableUDF
+    from: class
+    class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$TableUDF
+    constructor:
+      - type: LONG
+        value: 5
+
+catalogs:
+  - name: catalog1
+    type: DependencyTest
+  - name: simple-catalog
+    type: simple-catalog
+    test-table: test-table
+
+execution:
+  planner: "$VAR_PLANNER"
+  type: "$VAR_EXECUTION_TYPE"
+  time-characteristic: event-time
+  periodic-watermarks-interval: 99
+  parallelism: 1
+  max-parallelism: 16
+  min-idle-state-retention: 0
+  max-idle-state-retention: 0
+  result-mode: "$VAR_RESULT_MODE"
+  max-table-result-rows: "$VAR_MAX_ROWS"
+  restart-strategy:
+    type: failure-rate
+    max-failures-per-interval: 10
+    failure-rate-interval: 99000
+    delay: 1000
+
+deployment:
+  response-timeout: 5000
+
+configuration:
+  table.exec.sort.default-limit: "$SORT_DEFAULT_LIMIT"
+  table.exec.spill-compression.enabled: true
+  table.exec.spill-compression.block-size: 128kb
+  table.optimizer.join-reorder-enabled: true

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-configurations.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-configurations.yaml
@@ -18,132 +18,16 @@
 
 #==============================================================================
 # TEST ENVIRONMENT FILE
-# General purpose default environment file.
+# This test file is to check whether the table configs can be successfully set.
 #==============================================================================
 
-# this file has variables that can be filled with content by replacing $VAR_XXX
-
-tables:
-  - name: TableNumber1
-    type: source-table
-    $VAR_UPDATE_MODE
-    schema:
-      - name: IntegerField1
-        type: INT
-      - name: StringField1
-        type: VARCHAR
-    connector:
-      type: filesystem
-      path: "$VAR_SOURCE_PATH1"
-    format:
-      type: csv
-      fields:
-        - name: IntegerField1
-          type: INT
-        - name: StringField1
-          type: VARCHAR
-      line-delimiter: "\n"
-      comment-prefix: "#"
-  - name: TestView1
-    type: view
-    query: SELECT scalarUDF(IntegerField1) FROM TableNumber1
-  - name: TableNumber2
-    # Test backwards compatibility ("source" -> "source-table")
-    type: source
-    $VAR_UPDATE_MODE
-    schema:
-      - name: IntegerField2
-        type: INT
-      - name: StringField2
-        type: VARCHAR
-    connector:
-      type: filesystem
-      path: "$VAR_SOURCE_PATH2"
-    format:
-      type: csv
-      fields:
-        - name: IntegerField2
-          type: INT
-        - name: StringField2
-          type: VARCHAR
-      line-delimiter: "\n"
-      comment-prefix: "#"
-  - name: TableSourceSink
-    type: source-sink-table
-    $VAR_UPDATE_MODE
-    schema:
-      - name: BooleanField
-        type: BOOLEAN
-      - name: StringField
-        type: VARCHAR
-    connector:
-      type: filesystem
-      path: "$VAR_SOURCE_SINK_PATH"
-    format:
-      type: csv
-      fields:
-        - name: BooleanField
-          type: BOOLEAN
-        - name: StringField
-          type: VARCHAR
-  - name: TestView2
-    type: view
-    query: SELECT * FROM TestView1
-
-functions:
-  - name: scalarUDF
-    from: class
-    class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$ScalarUDF
-    constructor:
-      - 5
-  - name: aggregateUDF
-    from: class
-    class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$AggregateUDF
-    constructor:
-      - StarryName
-      - false
-      - class: java.lang.Integer
-        constructor:
-          - class: java.lang.String
-            constructor:
-              - type: VARCHAR
-                value: 3
-  - name: tableUDF
-    from: class
-    class: org.apache.flink.table.client.gateway.utils.UserDefinedFunctions$TableUDF
-    constructor:
-      - type: LONG
-        value: 5
-
-catalogs:
-  - name: catalog1
-    type: DependencyTest
-  - name: simple-catalog
-    type: simple-catalog
-    test-table: test-table
-
 execution:
-  planner: "$VAR_PLANNER"
-  type: "$VAR_EXECUTION_TYPE"
-  time-characteristic: event-time
-  periodic-watermarks-interval: 99
-  parallelism: 1
-  max-parallelism: 16
-  min-idle-state-retention: 0
-  max-idle-state-retention: 0
-  result-mode: "$VAR_RESULT_MODE"
-  max-table-result-rows: "$VAR_MAX_ROWS"
-  restart-strategy:
-    type: failure-rate
-    max-failures-per-interval: 10
-    failure-rate-interval: 99000
-    delay: 1000
-
-deployment:
-  response-timeout: 5000
+  planner: blink
+  type: batch
+  result-mode: table
 
 configuration:
-  table.exec.sort.default-limit: "$SORT_DEFAULT_LIMIT"
+  table.exec.sort.default-limit: 100
   table.exec.spill-compression.enabled: true
   table.exec.spill-compression.block-size: 128kb
   table.optimizer.join-reorder-enabled: true

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -26,6 +26,8 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  * This class holds configuration constants used by Flink's table module.
  *
  * <p>This is only used for the Blink planner.
+ *
+ * <p>NOTE: all options in this class must start with "table.exec".
  */
 public class ExecutionConfigOptions {
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -26,6 +26,8 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  * This class holds configuration constants used by Flink's table planner module.
  *
  * <p>This is only used for the Blink planner.
+ *
+ * <p>NOTE: All options in this class must start with "table.optimizer".
  */
 public class OptimizerConfigOptions {
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, we provide a set of configurations in blink planner to support optimization or enable some advanced feature. However, all the configurations can't be set in SQL CLI.

This PR allows setting table environment configurations in SQL CLI by using the following methods:

* Modify config files:
```yaml
configuration:
  table.exec.spill-compression.enabled: true
  table.exec.spill-compression.block-size: 128kb
  table.optimizer.join-reorder-enabled: true
```
* Or use `set` command:
```
SET table.exec.spill-compression.enable=true;
SET table.exec.spill-compression.block-size=128kb;
SET table.optimizer.join-reorder-enabled=true;
```

Note that different from other options in SQL CLI, the `SET` command about table environment configurations does not start with `configuration.` prefix but directly uses the option name.

## Brief change log

 - Allow setting configurations in SQL CLI

## Verifying this change

This change added tests and can be verified as follows: run the newly added tests `LocalExecutorITCase::testTableEnvConfigurations` and `ExecutionContextTest::testConfigurations`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
