### PR TITLE
[FLINK-13544][connectors] Set parallelism of table sink operator to input transformation parallelism

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraAppendTableSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraAppendTableSink.java
@@ -92,6 +92,7 @@ public class CassandraAppendTableSink implements AppendStreamTableSink<Row> {
 
 		return dataStream
 				.addSink(sink)
+				.setParallelism(dataStream.getParallelism())
 				.name(TableConnectorUtils.generateRuntimeName(this.getClass(), fieldNames));
 
 	}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
@@ -186,6 +186,7 @@ public abstract class ElasticsearchUpsertTableSinkBase implements UpsertStreamTa
 			sinkOptions,
 			upsertFunction);
 		return dataStream.addSink(sinkFunction)
+			.setParallelism(dataStream.getParallelism())
 			.name(TableConnectorUtils.generateRuntimeName(this.getClass(), getFieldNames()));
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkBase.java
@@ -96,7 +96,10 @@ public abstract class KafkaTableSinkBase implements AppendStreamTableSink<Row> {
 			properties,
 			serializationSchema,
 			partitioner);
-		return dataStream.addSink(kafkaProducer).name(TableConnectorUtils.generateRuntimeName(this.getClass(), getFieldNames()));
+		return dataStream
+			.addSink(kafkaProducer)
+			.setParallelism(dataStream.getParallelism())
+			.name(TableConnectorUtils.generateRuntimeName(this.getClass(), getFieldNames()));
 	}
 
 	@Override

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSink.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSink.java
@@ -64,6 +64,7 @@ public class JDBCAppendTableSink implements AppendStreamTableSink<Row>, BatchTab
 	public DataStreamSink<?> consumeDataStream(DataStream<Row> dataStream) {
 		return dataStream
 			.addSink(new JDBCSinkFunction(outputFormat))
+			.setParallelism(dataStream.getParallelism())
 			.name(TableConnectorUtils.generateRuntimeName(this.getClass(), fieldNames));
 	}
 

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
@@ -91,6 +91,7 @@ public class JDBCUpsertTableSink implements UpsertStreamTableSink<Row> {
 	public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, Row>> dataStream) {
 		return dataStream
 				.addSink(new JDBCUpsertSinkFunction(newFormat()))
+				.setParallelism(dataStream.getParallelism())
 				.name(TableConnectorUtils.generateRuntimeName(this.getClass(), schema.getFieldNames()));
 	}
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
@@ -117,6 +117,10 @@ public class CsvTableSink implements BatchTableSink<Row>, AppendStreamTableSink<
 		if (numFiles > 0) {
 			csvRows.setParallelism(numFiles);
 			sink.setParallelism(numFiles);
+		} else {
+			// if file number is not set, use input parallelism to make it chained.
+			csvRows.setParallelism(dataStream.getParallelism());
+			sink.setParallelism(dataStream.getParallelism());
 		}
 
 		sink.name(TableConnectorUtils.generateRuntimeName(CsvTableSink.class, fieldNames));

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
@@ -44,6 +44,8 @@ public abstract class OutputFormatTableSink<T> implements StreamTableSink<T> {
 
 	@Override
 	public final DataStreamSink<T> consumeDataStream(DataStream<T> dataStream) {
-		return dataStream.writeUsingOutputFormat(getOutputFormat());
+		return dataStream
+			.writeUsingOutputFormat(getOutputFormat())
+			.setParallelism(dataStream.getParallelism());
 	}
 }

--- a/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/table/SpendReportTableSink.java
+++ b/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/table/SpendReportTableSink.java
@@ -60,7 +60,8 @@ public class SpendReportTableSink implements AppendStreamTableSink<Row>, BatchTa
 	public void emitDataStream(DataStream<Row> dataStream) {
 		dataStream
 			.map(SpendReportTableSink::format)
-			.writeUsingOutputFormat(new LoggerOutputFormat());
+			.writeUsingOutputFormat(new LoggerOutputFormat())
+			.setParallelism(dataStream.getParallelism());
 	}
 
 	@Override


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, there are a lot of TableSink connectors uses `dataStream.addSink()` without `.setParallelism()` explicitly. This will use default parallelism of the environment. However, the parallelism of input transformation might not be `env.parallelism`, for example, global aggregation has 1 parallelism. In this case, it will lead to data reorder, and result in incorrect result.

## Brief change log

Checks all the implementation of `StreamTableSink#emitDataStream/consumeDataStream`, and set parallelism as input parallelism. 

## Verifying this change

This is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

