### PR TITLE
  [FLINK-10257][FLINK-13463][table] Support VARCHAR type generalization consistently

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeDuplicator.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeDuplicator.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Returns a deep copy of a {@link LogicalType}.
+ *
+ * <p>It also enables replacing children of possibly nested structures by overwriting corresponding
+ * {@code visit()} methods.
+ */
+@Internal
+public class LogicalTypeDuplicator extends LogicalTypeDefaultVisitor<LogicalType> {
+
+	@Override
+	public LogicalType visit(ArrayType arrayType) {
+		return new ArrayType(
+			arrayType.isNullable(),
+			arrayType.getElementType().accept(this));
+	}
+
+	@Override
+	public LogicalType visit(MultisetType multisetType) {
+		return new MultisetType(
+			multisetType.isNullable(),
+			multisetType.getElementType().accept(this));
+	}
+
+	@Override
+	public LogicalType visit(MapType mapType) {
+		return new MapType(
+			mapType.isNullable(),
+			mapType.getKeyType().accept(this),
+			mapType.getValueType().accept(this));
+	}
+
+	@Override
+	public LogicalType visit(RowType rowType) {
+		final List<RowField> fields = rowType.getFields().stream()
+			.map(f -> {
+				if (f.getDescription().isPresent()) {
+					return new RowField(
+						f.getName(),
+						f.getType().accept(this),
+						f.getDescription().get());
+				}
+				return new RowField(f.getName(), f.getType().accept(this));
+			})
+			.collect(Collectors.toList());
+
+		return new RowType(
+			rowType.isNullable(),
+			fields);
+	}
+
+	@Override
+	public LogicalType visit(DistinctType distinctType) {
+		final DistinctType.Builder builder = new DistinctType.Builder(
+			distinctType.getObjectIdentifier(),
+			distinctType.getSourceType().accept(this));
+		distinctType.getDescription().ifPresent(builder::setDescription);
+		return builder.build();
+	}
+
+	@Override
+	public LogicalType visit(StructuredType structuredType) {
+		final List<StructuredAttribute> attributes = structuredType.getAttributes().stream()
+			.map(a -> {
+				if (a.getDescription().isPresent()) {
+					return new StructuredAttribute(
+						a.getName(),
+						a.getType().accept(this),
+						a.getDescription().get());
+				}
+				return new StructuredAttribute(
+					a.getName(),
+					a.getType().accept(this));
+			})
+			.collect(Collectors.toList());
+		final StructuredType.Builder builder = new StructuredType.Builder(
+			structuredType.getObjectIdentifier(),
+			attributes);
+		builder.setNullable(structuredType.isNullable());
+		builder.setFinal(structuredType.isFinal());
+		builder.setInstantiable(structuredType.isInstantiable());
+		builder.setComparision(structuredType.getComparision());
+		structuredType.getSuperType().ifPresent(st -> {
+			final LogicalType visited = st.accept(this);
+			if (!(visited instanceof StructuredType)) {
+				throw new TableException("Unexpected super type. Structured type expected but was: " + visited);
+			}
+			builder.setSuperType((StructuredType) visited);
+		});
+		structuredType.getDescription().ifPresent(builder::setDescription);
+		structuredType.getImplementationClass().ifPresent(builder::setImplementationClass);
+		return builder.build();
+	}
+
+	@Override
+	protected LogicalType defaultMethod(LogicalType logicalType) {
+		return logicalType.copy();
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
+
+/**
+ * Utilities for handling {@link LogicalType}s.
+ */
+@Internal
+public final class LogicalTypeUtils {
+
+	private static final TimeAttributeRemover TIME_ATTRIBUTE_REMOVER = new TimeAttributeRemover();
+
+	public static LogicalType removeTimeAttributes(LogicalType logicalType) {
+		return logicalType.accept(TIME_ATTRIBUTE_REMOVER);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static class TimeAttributeRemover extends LogicalTypeDuplicator {
+
+		@Override
+		public LogicalType visit(TimestampType timestampType) {
+			return new TimestampType(
+				timestampType.isNullable(),
+				timestampType.getPrecision());
+		}
+
+		@Override
+		public LogicalType visit(ZonedTimestampType zonedTimestampType) {
+			return new ZonedTimestampType(
+				zonedTimestampType.isNullable(),
+				zonedTimestampType.getPrecision());
+		}
+
+		@Override
+		public LogicalType visit(LocalZonedTimestampType localZonedTimestampType) {
+			return new LocalZonedTimestampType(
+				localZonedTimestampType.isNullable(),
+				localZonedTimestampType.getPrecision());
+		}
+	}
+
+	private LogicalTypeUtils() {
+		// no instantiation
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+/**
+ * Utilities for handling {@link DataType}s.
+ */
+@Internal
+public final class DataTypeUtils {
+
+	public static DataType replaceLogicalType(DataType dataType, LogicalType replacement) {
+		return LogicalTypeDataTypeConverter.toDataType(replacement)
+			.bridgedTo(dataType.getConversionClass());
+	}
+
+	private DataTypeUtils() {
+		// no instantiation
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
@@ -197,7 +197,7 @@ public final class LegacyTypeInfoDataTypeConverter {
 			return foundTypeInfo;
 		}
 
-		// we are relaxing the constraint for DECIMAL, CHAR, TIMESTAMP_WITHOUT_TIME_ZONE to
+		// we are relaxing the constraint for DECIMAL, CHAR, VARCHAR, TIMESTAMP_WITHOUT_TIME_ZONE to
 		// support value literals in legacy planner
 		LogicalType logicalType = dataType.getLogicalType();
 		if (hasRoot(logicalType, LogicalTypeRoot.DECIMAL)) {
@@ -205,6 +205,10 @@ public final class LegacyTypeInfoDataTypeConverter {
 		}
 
 		else if (hasRoot(logicalType, LogicalTypeRoot.CHAR)) {
+			return Types.STRING;
+		}
+
+		else if (hasRoot(logicalType, LogicalTypeRoot.VARCHAR)) {
 			return Types.STRING;
 		}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeDuplicatorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeDuplicatorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types;
+
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeDuplicator;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link LogicalTypeDuplicator}.
+ */
+@RunWith(Parameterized.class)
+public class LogicalTypeDuplicatorTest {
+
+	private static final LogicalTypeDuplicator DUPLICATOR = new LogicalTypeDuplicator();
+
+	private static final LogicalTypeDuplicator INT_REPLACER = new IntReplacer();
+
+	@Parameters(name = "{index}: {0}")
+	public static List<Object[]> testData() {
+		return Arrays.asList(
+			new Object[][]{
+				{new CharType(2), new CharType(2)},
+				{createMultisetType(new IntType()), createMultisetType(new BigIntType())},
+				{createArrayType(new IntType()), createArrayType(new BigIntType())},
+				{createMapType(new IntType()), createMapType(new BigIntType())},
+				{createRowType(new IntType()), createRowType(new BigIntType())},
+				{createDistinctType(new IntType()), createDistinctType(new BigIntType())},
+				{createUserType(new IntType()), createUserType(new BigIntType())},
+				{createHumanType(), createHumanType()}
+			}
+		);
+	}
+
+	@Parameter
+	public LogicalType logicalType;
+
+	@Parameter(1)
+	public LogicalType replacedLogicalType;
+
+	@Test
+	public void testDuplication() {
+		assertThat(logicalType.accept(DUPLICATOR), equalTo(logicalType));
+	}
+
+	@Test
+	public void testReplacement() {
+		assertThat(logicalType.accept(INT_REPLACER), equalTo(replacedLogicalType));
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static class IntReplacer extends LogicalTypeDuplicator {
+		@Override
+		public LogicalType visit(IntType intType) {
+			return new BigIntType();
+		}
+	}
+
+	private static MultisetType createMultisetType(LogicalType replacedType) {
+		return new MultisetType(new MultisetType(replacedType));
+	}
+
+	private static ArrayType createArrayType(LogicalType replacedType) {
+		return new ArrayType(new ArrayType(replacedType));
+	}
+
+	private static MapType createMapType(LogicalType replacedType) {
+		return new MapType(replacedType, new SmallIntType());
+	}
+
+	private static DistinctType createDistinctType(LogicalType replacedType) {
+		return new DistinctType.Builder(
+				ObjectIdentifier.of("cat", "db", "Money"),
+				replacedType)
+			.setDescription("Money type desc.")
+			.build();
+	}
+
+	private static RowType createRowType(LogicalType replacedType) {
+		return new RowType(
+			Arrays.asList(
+				new RowType.RowField("field1", new CharType(2)),
+				new RowType.RowField("field2", new BooleanType()),
+				new RowType.RowField("field3", replacedType)));
+	}
+
+	private static StructuredType createHumanType() {
+		return new StructuredType.Builder(
+				ObjectIdentifier.of("cat", "db", "Human"),
+				Collections.singletonList(
+					new StructuredType.StructuredAttribute("name", new VarCharType(), "Description.")))
+			.setDescription("Human type desc.")
+			.setFinal(false)
+			.setInstantiable(false)
+			.setImplementationClass(Human.class)
+			.build();
+	}
+
+	private static StructuredType createUserType(LogicalType replacedType) {
+		return new StructuredType.Builder(
+				ObjectIdentifier.of("cat", "db", "User"),
+				Collections.singletonList(
+					new StructuredType.StructuredAttribute("setting", replacedType)))
+			.setDescription("User type desc.")
+			.setFinal(false)
+			.setInstantiable(true)
+			.setImplementationClass(User.class)
+			.setSuperType(createHumanType())
+			.build();
+	}
+
+	private abstract static class Human {
+		public String name;
+	}
+
+	private static final class User extends Human {
+		public int setting;
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeGeneralizationTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeGeneralizationTest.java
@@ -86,6 +86,12 @@ public class LogicalTypeGeneralizationTest {
 					null
 				},
 
+				// incompatible types
+				{
+					Arrays.asList(new BinaryType(), new VarCharType(23)),
+					null
+				},
+
 				// NOT NULL types
 				{
 					Arrays.asList(new IntType(false), new IntType(false)),
@@ -144,10 +150,16 @@ public class LogicalTypeGeneralizationTest {
 					RowType.of(new BigIntType(), new IntType(), new BigIntType())
 				},
 
+				// CHAR types of same length
+				{
+					Arrays.asList(new CharType(2), new CharType(2)),
+					new CharType(2)
+				},
+
 				// CHAR types of different length
 				{
 					Arrays.asList(new CharType(2), new CharType(4)),
-					new CharType(4)
+					new VarCharType(4)
 				},
 
 				// VARCHAR types of different length
@@ -166,6 +178,12 @@ public class LogicalTypeGeneralizationTest {
 				{
 					Arrays.asList(new CharType(5), new VarCharType(2), new VarCharType(7)),
 					new VarCharType(7)
+				},
+
+				// BINARY types of different length
+				{
+					Arrays.asList(new BinaryType(2), new BinaryType(4)),
+					new VarBinaryType(4)
 				},
 
 				// mixed BINARY and VARBINARY types

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ValuesITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ValuesITCase.scala
@@ -23,8 +23,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestingAppendBaseRowSink}
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
-import org.apache.flink.table.types.logical.IntType
-
+import org.apache.flink.table.types.logical.{IntType, VarCharType}
 import org.junit.Assert._
 import org.junit.Test
 
@@ -33,17 +32,18 @@ class ValuesITCase extends StreamingTestBase {
   @Test
   def testValues(): Unit = {
 
-    val sqlQuery = "SELECT * FROM (VALUES (1, 2, 3)) T(a, b, c)"
+    val sqlQuery = "SELECT * FROM (VALUES (1, 'Bob'), (1, 'Alice')) T(a, b)"
 
-    val outputType = new BaseRowTypeInfo(new IntType(), new IntType(), new IntType())
+    val outputType = new BaseRowTypeInfo(
+      new IntType(),
+      new VarCharType(VarCharType.MAX_LENGTH))
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[BaseRow]
     val sink = new TestingAppendBaseRowSink(outputType)
     result.addSink(sink).setParallelism(1)
     env.execute()
 
-    val expected = List("0|1,2,3")
+    val expected = List("0|1,Alice", "0|1,Bob")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
-
 }


### PR DESCRIPTION
## What is the purpose of the change

The Blink planner generalizes multiple `CHAR` literals into `VARCHAR`. It seems likely that we will adopt this behavior in the future to prevent unwanted side-effects for users. This PR removes the exception in the SQL Client and updates the existing type generalization classes.

## Brief change log

See commit messages.

## Verifying this change

Manually tested.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
