### PR TITLE
[FLINK-13503][API] Add contract in `LookupableTableSource` to specify the behavior when lookupKeys contains null.

### DIFF
--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/util/HBaseReadWriteHelper.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/util/HBaseReadWriteHelper.java
@@ -87,16 +87,26 @@ public class HBaseReadWriteHelper {
 	}
 
 	/**
+	 * Serializes a rowkey object into byte array.
+	 * @param rowKey rowkey object to serialize
+	 *
+	 * @return serialize bytes.
+	 */
+	public byte[] serialize(Object rowKey) {
+		byte[] key = HBaseTypeUtils.serializeFromObject(
+				rowKey,
+				rowKeyType,
+				charset);
+		return key;
+	}
+
+	/**
 	 * Returns an instance of Get that retrieves the matches records from the HBase table.
 	 *
 	 * @return The appropriate instance of Get for this use case.
 	 */
-	public Get createGet(Object rowKey) {
-		byte[] rowkey = HBaseTypeUtils.serializeFromObject(
-			rowKey,
-			rowKeyType,
-			charset);
-		Get get = new Get(rowkey);
+	public Get createGet(byte[] row) {
+		Get get = new Get(row);
 		for (int f = 0; f < families.length; f++) {
 			byte[] family = families[f];
 			for (byte[] qualifier : qualifiers[f]) {

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
@@ -116,6 +116,20 @@ public interface JDBCDialect extends Serializable {
 	}
 
 	/**
+	 * Get select fields statement by `is not distinct from` condition fields. Default use SELECT.
+	 */
+	default String getSelectNotDistinctFromStatement(String tableName, String[] selectFields, String[] conditionFields) {
+		String selectExpressions = Arrays.stream(selectFields)
+				.map(this::quoteIdentifier)
+				.collect(Collectors.joining(", "));
+		String fieldExpressions = Arrays.stream(conditionFields)
+				.map(f -> "(" + quoteIdentifier(f) + "=? OR (" + quoteIdentifier(f) + " IS NULL AND ? IS NULL))")
+				.collect(Collectors.joining(" AND "));
+		return "SELECT " + selectExpressions + " FROM " +
+				quoteIdentifier(tableName) + (conditionFields.length > 0 ? " WHERE " + fieldExpressions : "");
+	}
+
+	/**
 	 * Get select fields statement by condition fields. Default use SELECT.
 	 */
 	default String getSelectFromStatement(String tableName, String[] selectFields, String[] conditionFields) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LookupableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LookupableTableSource.java
@@ -33,13 +33,33 @@ import org.apache.flink.table.functions.TableFunction;
 public interface LookupableTableSource<T> extends TableSource<T> {
 
 	/**
-	 * Gets the {@link TableFunction} which supports lookup one key at a time.
+	 * Gets the {@link TableFunction} which supports lookup one key at a time. Calling `eval`
+	 * method in the returned {@link TableFunction} means send a lookup request to the TableSource.
+	 *
+	 * <p><strong>IMPORTANT:</strong>
+	 * Lookup keys in a request may contain null value. When it happens, it expects to lookup
+	 * records with null value on the lookup key field.
+	 * E.g., for a MySQL table with the following schema, send a lookup request with null value
+	 * on `age` field means to find students whose age are unknown (CAUTION: It is equivalent to filter condition:
+	 * `WHERE age IS NULL` instead of `WHERE age = null`).
+	 *
+	 * -----------------
+	 *  Table : Student
+	 * -----------------
+	 * id    |   LONG
+	 * age   |   INT
+	 * name  |   STRING
+	 * -----------------
+	 * For the external system which does not support null value (E.g, HBase does not support null value on rowKey),
+	 * it could throw an exception or discard the request when receiving a request with null value on lookup key.
+	 *
 	 * @param lookupKeys the chosen field names as lookup keys, it is in the defined order
 	 */
 	TableFunction<T> getLookupFunction(String[] lookupKeys);
 
 	/**
 	 * Gets the {@link AsyncTableFunction} which supports async lookup one key at a time.
+	 *
 	 * @param lookupKeys the chosen field names as lookup keys, it is in the defined order
 	 */
 	AsyncTableFunction<T> getAsyncLookupFunction(String[] lookupKeys);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LookupableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LookupableTableSource.java
@@ -42,7 +42,6 @@ public interface LookupableTableSource<T> extends TableSource<T> {
 	 * E.g., for a MySQL table with the following schema, send a lookup request with null value
 	 * on `age` field means to find students whose age are unknown (CAUTION: It is equivalent to filter condition:
 	 * `WHERE age IS NULL` instead of `WHERE age = null`).
-	 *
 	 * -----------------
 	 *  Table : Student
 	 * -----------------


### PR DESCRIPTION
## What is the purpose of the change

Add contract in `LookupableTableSource` to specify the behavior when lookupKeys contains null.
And update existed connector to comply with this contract.
## Brief change log

  - Add contract in `LookupableTableSource` to specify the behavior when lookupKeys contains null.
  - Update HBase lookupFunction
  - Update JDBC lookupFunction


## Verifying this change

existed IT.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
