### PR TITLE
[FLINK-13555][runtime] SlotPool fails batch slot requests immediately if they are unfulfillable.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -58,7 +58,6 @@ import org.apache.flink.runtime.resourcemanager.registration.JobManagerRegistrat
 import org.apache.flink.runtime.resourcemanager.registration.WorkerRegistration;
 import org.apache.flink.runtime.resourcemanager.slotmanager.ResourceActions;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
-import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerException;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
@@ -442,7 +441,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 				try {
 					slotManager.registerSlotRequest(slotRequest);
-				} catch (SlotManagerException e) {
+				} catch (ResourceManagerException e) {
 					return FutureUtils.completedExceptionally(e);
 				}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/exceptions/UnfulfillableSlotRequestException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/exceptions/UnfulfillableSlotRequestException.java
@@ -16,19 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.resourcemanager.slotmanager;
+package org.apache.flink.runtime.resourcemanager.exceptions;
 
-import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 
-public class SlotManagerException extends ResourceManagerException {
 
-	private static final long serialVersionUID = -3723028616920379071L;
+/**
+ * Exception denoting that a slot request can not be fulfilled by any slot in the cluster.
+ * This usually indicates that the slot request should not be pended or retried.
+ */
+public class UnfulfillableSlotRequestException extends ResourceManagerException {
+	private static final long serialVersionUID = 4453490263648758730L;
 
-	public SlotManagerException(String message) {
-		super(message);
-	}
-
-	public SlotManagerException(String message, Throwable cause) {
-		super(message, cause);
+	public UnfulfillableSlotRequestException(AllocationID allocationId, ResourceProfile resourceProfile) {
+		super("Could not fulfill slot request " + allocationId + ". "
+			+ "Requested resource profile (" + resourceProfile + ") is unfulfillable.");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
@@ -73,9 +74,9 @@ public interface SlotManager extends AutoCloseable {
 	 *
 	 * @param slotRequest specifying the requested slot specs
 	 * @return true if the slot request was registered; false if the request is a duplicate
-	 * @throws SlotManagerException if the slot request failed (e.g. not enough resources left)
+	 * @throws ResourceManagerException if the slot request failed (e.g. not enough resources left)
 	 */
-	boolean registerSlotRequest(SlotRequest slotRequest) throws SlotManagerException;
+	boolean registerSlotRequest(SlotRequest slotRequest) throws ResourceManagerException;
 
 	/**
 	 * Cancels and removes a pending slot request with the given allocation id. If there is no such

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -117,7 +117,6 @@ public class SlotManagerImpl implements SlotManager {
 
 	/**
 	 * If true, fail unfulfillable slot requests immediately. Otherwise, allow unfulfillable request to pend.
-	 *
 	 * A slot request is considered unfulfillable if it cannot be fulfilled by neither a slot that is already registered
 	 * (including allocated ones) nor a pending slot that the {@link ResourceActions} can allocate.
 	 * */
@@ -211,8 +210,7 @@ public class SlotManagerImpl implements SlotManager {
 	 * @param newResourceActions to use for resource (de-)allocations
 	 */
 	@Override
-	public void start(ResourceManagerId newResourceManagerId, Executor newMainThreadExecutor,
-					  ResourceActions newResourceActions) {
+	public void start(ResourceManagerId newResourceManagerId, Executor newMainThreadExecutor, ResourceActions newResourceActions) {
 		LOG.info("Starting the SlotManager.");
 
 		this.resourceManagerId = Preconditions.checkNotNull(newResourceManagerId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+import org.apache.flink.runtime.resourcemanager.exceptions.UnfulfillableSlotRequestException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
@@ -290,10 +291,10 @@ public class SlotManagerImpl implements SlotManager {
 	 *
 	 * @param slotRequest specifying the requested slot specs
 	 * @return true if the slot request was registered; false if the request is a duplicate
-	 * @throws SlotManagerException if the slot request failed (e.g. not enough resources left)
+	 * @throws ResourceManagerException if the slot request failed (e.g. not enough resources left)
 	 */
 	@Override
-	public boolean registerSlotRequest(SlotRequest slotRequest) throws SlotManagerException {
+	public boolean registerSlotRequest(SlotRequest slotRequest) throws ResourceManagerException {
 		checkInit();
 
 		if (checkDuplicateRequest(slotRequest.getAllocationId())) {
@@ -311,7 +312,7 @@ public class SlotManagerImpl implements SlotManager {
 				// requesting the slot failed --> remove pending slot request
 				pendingSlotRequests.remove(slotRequest.getAllocationId());
 
-				throw new SlotManagerException("Could not fulfill slot request " + slotRequest.getAllocationId() + '.', e);
+				throw new ResourceManagerException("Could not fulfill slot request " + slotRequest.getAllocationId() + '.', e);
 			}
 
 			return true;
@@ -494,8 +495,7 @@ public class SlotManagerImpl implements SlotManager {
 					resourceActions.notifyAllocationFailure(
 						pendingSlotRequest.getJobId(),
 						pendingSlotRequest.getAllocationId(),
-						new ResourceManagerException("Could not fulfill slot request " + pendingSlotRequest.getAllocationId() + ". "
-							+ "Requested resource profile (" + pendingSlotRequest.getResourceProfile() + ") is unfulfillable.")
+						new UnfulfillableSlotRequestException(pendingSlotRequest.getAllocationId(), pendingSlotRequest.getResourceProfile())
 					);
 				}
 			}
@@ -745,9 +745,9 @@ public class SlotManagerImpl implements SlotManager {
 	 * registered.
 	 *
 	 * @param pendingSlotRequest to allocate a slot for
-	 * @throws ResourceManagerException if the resource manager cannot allocate more resource
+	 * @throws UnfulfillableSlotRequestException if the slot request is unfulfillable
 	 */
-	private void internalRequestSlot(PendingSlotRequest pendingSlotRequest) throws ResourceManagerException {
+	private void internalRequestSlot(PendingSlotRequest pendingSlotRequest) throws UnfulfillableSlotRequestException {
 		final ResourceProfile resourceProfile = pendingSlotRequest.getResourceProfile();
 		TaskManagerSlot taskManagerSlot = findMatchingSlot(resourceProfile);
 
@@ -767,8 +767,7 @@ public class SlotManagerImpl implements SlotManager {
 				// request can not be fulfilled by any free slot or pending slot that can be allocated,
 				// check whether it can be fulfilled by allocated slots
 				if (failUnfulfillableRequest && !isFulfillableByRegisteredSlots(pendingSlotRequest.getResourceProfile())) {
-					throw new ResourceManagerException("Requested resource profile (" +
-						pendingSlotRequest.getResourceProfile() + ") is unfulfillable.");
+					throw new UnfulfillableSlotRequestException(pendingSlotRequest.getAllocationId(), pendingSlotRequest.getResourceProfile());
 				}
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
@@ -97,9 +97,9 @@ public class SlotPoolUtils {
 		return taskManagerLocation.getResourceID();
 	}
 
-	public static void failAllocation(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, AllocationID allocationId) {
+	public static void failAllocation(SlotPoolImpl slotPool, ComponentMainThreadExecutor mainThreadExecutor, AllocationID allocationId, Exception exception) {
 		CompletableFuture.runAsync(
-			() -> slotPool.failAllocation(allocationId, new FlinkException("Test exception")),
+			() -> slotPool.failAllocation(allocationId, exception),
 			mainThreadExecutor).join();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -842,7 +842,7 @@ public class SlotManagerTest extends TestLogger {
 				(Object value) -> {
 					try {
 						slotManager.registerSlotRequest(slotRequest);
-					} catch (SlotManagerException e) {
+					} catch (ResourceManagerException e) {
 						throw new RuntimeException("Could not register slots.", e);
 					}
 				});
@@ -953,7 +953,7 @@ public class SlotManagerTest extends TestLogger {
 				() -> {
 					try {
 						return slotManager.registerSlotRequest(slotRequest);
-					} catch (SlotManagerException e) {
+					} catch (ResourceManagerException e) {
 						throw new CompletionException(e);
 					}
 				},


### PR DESCRIPTION
## What is the purpose of the change

This PR make SlotPool to fail batch slot requests immediately if they are unfulfillable, which means they cannot be fulfilled by any slot (available or not) in the cluster.

There are two kinds of request slots from RM failures:
1. RM does not have available slots. All slots are in use at the moment. But they might become available later when the currently running tasks finish.
2. The slot request requires too many resources that can not be fulfilled by any slot (available or not) in the cluster. The request is also not likely to be fulfilled later.

For the 2nd kinds of failures, it doesn't make sense to wait for the timeout. SlotPool should fail the job immediately, with proper error messages describing the problem and suggesting the user to tune job or cluster configurations.

## Brief change log

- 6af614c1647429d76c8514a67e7c5439e90a50e1, 8b5e9ff88e6052dc5845a9fcff684261c697899f: Cleanups for existing codes.
- dbdace5ae68331bd1203525425b357639e334752: Remove `SlotManagerException`, replace with its base class `ResourceException`.
- bb2c7c92fdbafe3644ab76041b300a23a6c87744: Introduce `UnfulfillableSlotRequestException` and fail pending batch slot requests on it.
- dfe5ef072dadfc0e1510f1923911304c635e54af: Add test cases for failing unfulfillable batch slot requests.

## Verifying this change

This change added tests and can be verified as follows:

- Add `SlotPoolBatchSlotRequestTest#testPendingBatchSlotRequestFailsIfAllocationFailsUnfulfillable` that validates that pending batch slot requests fail when allocation fail with unfulfillable exception.
- Add `SlotPoolBatchSlotRequestTest#testPendingBatchSlotRequestFailsIfRMRequestFailsUnfulfillable` that validates that pending batch slot requests fail when requesting slots from RM fail with unfulfillable exception. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
