### PR TITLE
[FLINK-13438][hive] Fix DataTypes.DATE/TIME/TIMESTAMP support for hive connectors

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
+import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
 import org.apache.flink.table.sinks.OutputFormatTableSink;
 import org.apache.flink.table.sinks.OverwritableTableSink;
 import org.apache.flink.table.sinks.PartitionableTableSink;
@@ -74,10 +75,13 @@ public class HiveTableSink extends OutputFormatTableSink<Row> implements Partiti
 	public HiveTableSink(JobConf jobConf, ObjectPath tablePath, CatalogTable table) {
 		this.jobConf = jobConf;
 		this.tablePath = tablePath;
-		this.catalogTable = table;
+
+		this.catalogTable = HiveTableUtil.toHiveCatalogTable(table);
+
 		hiveVersion = Preconditions.checkNotNull(jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION),
 				"Hive version is not defined");
-		tableSchema = table.getSchema();
+
+		tableSchema = catalogTable.getSchema();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -76,7 +76,7 @@ public class HiveTableSink extends OutputFormatTableSink<Row> implements Partiti
 		this.jobConf = jobConf;
 		this.tablePath = tablePath;
 
-		this.catalogTable = HiveTableUtil.toHiveCatalogTable(table);
+		this.catalogTable = HiveTableUtil.convertTableSchemaForHive(table);
 
 		hiveVersion = Preconditions.checkNotNull(jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION),
 				"Hive version is not defined");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -73,7 +73,7 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 		this.tablePath = Preconditions.checkNotNull(tablePath);
 
 		Preconditions.checkNotNull(catalogTable);
-		this.catalogTable = HiveTableUtil.toHiveCatalogTable(catalogTable);
+		this.catalogTable = HiveTableUtil.convertTableSchemaForHive(catalogTable);
 
 		this.hiveVersion = Preconditions.checkNotNull(jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION),
 				"Hive version is not defined");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
+import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
 import org.apache.flink.table.sources.InputFormatTableSource;
 import org.apache.flink.table.sources.PartitionableTableSource;
 import org.apache.flink.table.sources.TableSource;
@@ -70,7 +71,10 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 	public HiveTableSource(JobConf jobConf, ObjectPath tablePath, CatalogTable catalogTable) {
 		this.jobConf = Preconditions.checkNotNull(jobConf);
 		this.tablePath = Preconditions.checkNotNull(tablePath);
-		this.catalogTable = Preconditions.checkNotNull(catalogTable);
+
+		Preconditions.checkNotNull(catalogTable);
+		this.catalogTable = HiveTableUtil.toHiveCatalogTable(catalogTable);
+
 		this.hiveVersion = Preconditions.checkNotNull(jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION),
 				"Hive version is not defined");
 		initAllPartitions = false;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -150,7 +150,7 @@ public class HiveTableUtil {
 	 * Can we just change the table schema of the given catalog table
 	 * without creating a new catalog table?
 	 */
-	public static CatalogTable toHiveCatalogTable(CatalogTable oldTable) {
+	public static CatalogTable convertTableSchemaForHive(CatalogTable oldTable) {
 		TableSchema oldSchema = oldTable.getSchema();
 		DataType[] fieldDataTypes = oldSchema.getFieldDataTypes();
 		String[] fieldNames = oldSchema.getFieldNames();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
 
+import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -165,9 +166,10 @@ public class HiveTypeUtil {
 			case DOUBLE:
 				return DataTypes.DOUBLE();
 			case DATE:
-				return DataTypes.DATE();
+				return DataTypes.DATE().bridgedTo(Date.class);
 			case TIMESTAMP:
-				return DataTypes.TIMESTAMP();
+				throw new UnsupportedOperationException(
+					"Hive connector does not support timestamp type currently, as the precision may be lost.");
 			case BINARY:
 				return DataTypes.BYTES();
 			case DECIMAL:

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
@@ -250,7 +250,7 @@ public final class LegacyTypeInfoDataTypeConverter {
 				dataType.getConversionClass().getName()));
 	}
 
-	private static boolean canConvertToTimestampTypeInfoLenient(DataType dataType) {
+	public static boolean canConvertToTimestampTypeInfoLenient(DataType dataType) {
 		LogicalType logicalType = dataType.getLogicalType();
 		return hasRoot(logicalType, LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) &&
 			dataType.getConversionClass() != LocalDateTime.class &&


### PR DESCRIPTION
## What is the purpose of the change

Similar to JDBC connectors, Hive connectors communicate with Flink framework using TableSchema, which contains DataType. As the time data read from and write to Hive connectors must be `java.sql.*` types and the default conversion class of our time data types are `java.time.*`, we have to fix Hive connector with DataTypes.DATE/TIME/TIMESTAMP support.

This PR fixes `DataTypes.DATE/TIME/TIMESTAMP` support for hive connectors, and is similar to PR #9236 .

## Brief change log

 - Fix `DataTypes.DATE/TIME/TIMESTAMP` support for hive connectors.

## Verifying this change

This change added tests and can be verified as follows: run the newly added `HiveFullTest`. This new test is to test if the time data can correctly flow from hive source to flink system and finally to hive sink.

There seems to be other bugs in hive connectors. When running this tests along with other hive tests in idea, `HiveTableSinkTest` will fail; bug when running this tests along with others in maven the tests will all pass. @zjuwangg please take a look into this issue.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
