### PR TITLE
[FLINK-13532][docs] Fix broken links of zh docs

### DIFF
--- a/docs/dev/table/hive_integration.zh.md
+++ b/docs/dev/table/hive_integration.zh.md
@@ -1,0 +1,70 @@
+---
+title: "Hive Integration"
+is_beta: true
+nav-parent_id: tableapi
+nav-pos: 9
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+With its wide adoption in streaming processing, Flink has also shown its potentials in batch processing. Improving Flink’s batch processing, especially in terms of SQL, would offer user a complete set of solutions for both their streaming and batch processing needs.
+
+On the other hand, Hive has established its focal point in big data technology and its complete ecosystem. For most of big data users, Hive is not only a SQL engine for big data analytics and ETL, but also a data management platform, on which data are discovered, defined, and evolved. In another words, Hive is a de facto standard for big data on Hadoop.
+
+Therefore, it’s imperative for Flink to integrate with Hive ecosystem to further its reach to batch and SQL users. In doing that, integration with Hive metadata and data is necessary. 
+
+The goal here is neither to replace nor to copy Hive. Rather, we leverage Hive as much as we can. Flink is an alternative batch engine to Hive's batch engine. With Flink and Flink SQL, both Hive and Flink users can enjoy Hive’s rich SQL functionality and ecosystem as well as Flink's outstanding batch processing performance.
+
+
+Supported Hive version
+----------------------
+
+The target versions are Hive `2.3.4` and `1.2.1`
+
+
+Hive Metastore Integration
+--------------------------
+
+There are two aspects of Hive metadata integration:
+
+1. Make Hive’s meta-objects such as tables and views available to Flink and Flink is also able to create such meta-objects for and in Hive. This is achieved through `HiveCatalog`.
+
+2. Persist Flink’s meta-objects (tables, views, and UDFs) using Hive Metastore as an persistent storage. This is achieved through `HiveCatalog`, which is under active development.
+
+For how to use and configure `HiveCatalog` in Flink, see [Catalogs]({{ site.baseurl }}/dev/table/catalog.html)
+
+Hive Data Integration
+---------------------
+
+Please refer to [Connecting to other systems]({{ site.baseurl }}/dev/batch/connectors.html) for how to query Hive data using Flink's Hive data connector. 
+
+
+Examples
+--------
+
+For more detailed examples using Table API or SQL, please refer to [Hive Integration Example] ({{ site.baseurl }}/dev/table/hive_integration_example.html)
+
+
+Trouble Shoot
+-------------
+
+Limitations & Future
+--------------------
+
+Currently Flink's Hive data connector does not support writing into partitions. The feature of writing into partitions is under active development now.

--- a/docs/dev/table/hive_integration_example.zh.md
+++ b/docs/dev/table/hive_integration_example.zh.md
@@ -1,0 +1,277 @@
+---
+title: "Hive Compatibility Example"
+is_beta: true
+nav-parent_id: examples
+nav-pos: 21
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+The following examples showcase how to use Flink SQL Client to query Hive meta-data and tables.
+
+## Environment
+
+Assume all physical machines are accessible in the working environment, and the following components have been successfully setup:
+
+- Hadoop Cluster (HDFS + YARN)
+- Hive 2.3.4
+- Flink cluster
+
+## Setup Flink
+
+### Setup Flink Cluster in yarn-session mode
+
+Start a yarn session
+
+{% highlight bash %}
+$ ./bin/yarn-session.sh -n 4 -qu root.default -s 4 -tm 2048 -nm test_session_001
+{% endhighlight %}
+
+### Setup Flink Cluster in local mode
+
+Simply run
+
+{% highlight bash %}
+$ ./bin/start-cluster.sh
+{% endhighlight %}
+
+### Setup Flink SQL Cli
+
+Let's set the SQL Cli yaml config file now. For more detailed instructions on Flink SQL Client and catalogs, see [Flink SQL CLI]({{ site.baseurl }}/dev/table/sqlClient.html) and [Catalogs]({{ site.baseurl }}/dev/table/catalog.html).
+
+{% highlight yaml %}
+execution:
+    # Use batch mode
+    type: batch
+    # Use table result mode
+    result-mode: table
+    time-characteristic: event-time
+    periodic-watermarks-interval: 200
+    parallelism: 1
+    max-parallelism: 12
+    min-idle-state-retention: 0
+    max-idle-state-retention: 0
+    current-catalog: myhive
+    current-database: default
+
+deployment:
+  response-timeout: 5000
+
+catalogs:
+   - name: myhive
+   type: hive
+   property-version: 1
+   hive-conf-dir: /opt/hive-conf
+   hive-version: 2.3.4
+   
+{% endhighlight %}
+
+
+Note that, if users are using Flink yarn-session mode, you'll get the sessionId as `\${appId}`. Set it in `yid: ${appId}` of `deployment` section in the `conf/sql-client-defaults.yaml` file
+
+If users are using Flink local mode, no other config is required.
+
+Make sure all the required jars are in the `/lib` dir, including jars of `flink-connector-hive`, `flink-hadoop-compatibility`, `flink-shaded-hadoop-2-uber`, and Hive's jars. See [Catalogs]({{ site.baseurl }}/dev/table/catalog.html) for more details.
+
+Get Flink SQL CLI running by execute command
+
+{% highlight bash %}
+$ ./bin/sql-client.sh embedded
+{% endhighlight %}
+
+## Flink SQL Client Examples
+
+### Example 1
+
+#### Prepare Hive
+
+Assuming that Hive has been successfully set up and running, let's prepare some data in Hive.
+
+First, we locate the current database in Hive, which is `default` in this case, and make sure no table exists in the database at this time.
+
+{% highlight bash %}
+hive> show databases;
+OK
+default
+Time taken: 0.841 seconds, Fetched: 1 row(s)
+
+hive> show tables;
+OK
+Time taken: 0.087 seconds
+{% endhighlight %}
+
+Second, we create a simple table with two columns - name as string and value as double - in a textfile format and each row is delimited by ','.
+
+{% highlight bash %}
+hive> CREATE TABLE mytable(name string, value double) row format delimited fields terminated by ',' stored as textfile;
+OK
+Time taken: 0.127 seconds
+{% endhighlight %}
+
+This way, we created a table named `mytable` under the `default` database in Hive.
+
+Then let's load the data into table `mytable`. Here's some data we prepared to load into the table, and assume the file path is '/tmp/data.txt'. 
+
+{% highlight txt %}
+Tom,4.72
+John,8.00
+Tom,24.2
+Bob,3.14
+Bob,4.72
+Tom,34.9
+Mary,4.79
+Tiff,2.72
+Bill,4.33
+Mary,77.7
+{% endhighlight %}
+
+Load and check data by running: 
+
+{% highlight bash %}
+hive> load data local inpath '/tmp/data.txt' into table mytable;
+Loading data to table default.mytable
+OK
+Time taken: 0.324 seconds
+
+hive> select * from mytable;
+OK
+Tom	4.72
+John	8.0
+Tom	24.2
+Bob	3.14
+Bob	4.72
+Tom	34.9
+Mary	4.79
+Tiff	2.72
+Bill	4.33
+Mary	77.7
+Time taken: 0.097 seconds, Fetched: 10 row(s)
+{% endhighlight %}
+
+#### Access Hive metadata and data in Flink SQL CLI
+
+In Flink SQL CLI, we can start query Hive metadata.
+
+{% highlight bash %}
+
+Flink SQL> show catalogs;
+myhive
+default_catalog
+
+# ------ Set the current catalog to be 'myhive' catalog if you haven't set it in the yaml file ------
+
+Flink SQL> use catalog myhive;
+
+# ------ See all registered database in catalog 'mytable' ------
+
+Flink SQL> show databases;
+default
+
+# ------ See the previously registered table 'mytable' ------
+
+Flink SQL> show tables;
+mytable
+
+# ------ The table schema that Flink sees is the same that we created in Hive, two columns - name as string and value as double ------ 
+Flink SQL> describe mytable;
+root
+ |-- name: name
+ |-- type: STRING
+ |-- name: value
+ |-- type: DOUBLE
+
+
+Flink SQL> select * from mytable;
+
+      name      value
+__________ __________
+
+      Tom        4.72
+      John	     8.0
+      Tom	     24.2
+      Bob	     3.14
+      Bob	     4.72
+      Tom	     34.9
+      Mary	     4.79
+      Tiff	     2.72
+      Bill	     4.33
+      Mary	     77.7
+
+Flink SQL> select * from mytable;
+
+{% endhighlight %}
+
+
+### Example 2
+
+Following all the common steps above, we have prepared another two tables in Hive, order_details and products, which can be described in Hive SQL CLI:
+
+{% highlight bash %}
+Hive> describe order_details;
+OK
+orderid               bigint
+productid             bigint
+unitprice             double
+quantity              int
+discount              double
+
+Hive> describe products;
+OK
+productid             bigint
+productname           string
+supplierid            bigint
+categoryid            bigint
+quantityperunit       string
+unitprice             double
+unitsinstock          bigint
+unitsonorder          bigint
+reorderlevel          int
+discontinued          int
+);
+{% endhighlight %}
+
+We can run a few SQL query to get Hive data
+
+{% highlight sql %}
+Flink SQL> select * from products;
+
+Flink SQL> select count(*) from order_details;
+
+Flink SQL> select
+   t.productid,
+   t.productname,
+   sum(t.price) as sale
+from
+  (select
+      A.productid,
+      A.productname as productname,
+        B.unitprice * discount as price
+     from
+      products as A, order_details as B
+     where A.productid = B.productid) as t
+  group by t.productid, t.productname;
+
+{% endhighlight %}
+
+
+Flink Table API Example
+-----------------------
+
+To be added.

--- a/docs/dev/table/types.zh.md
+++ b/docs/dev/table/types.zh.md
@@ -1,0 +1,1203 @@
+---
+title: "Data Types"
+nav-parent_id: tableapi
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Due to historical reasons, before Flink 1.9, Flink's Table & SQL API data types were
+tightly coupled to Flink's `TypeInformation`. `TypeInformation` is used in the DataStream
+and DataSet API and is sufficient to describe all information needed to serialize and
+deserialize JVM-based objects in a distributed setting.
+
+However, `TypeInformation` was not designed to represent logical types independent of
+an actual JVM class. In the past, it was difficult to map SQL standard types to this
+abstraction. Furthermore, some types were not SQL-compliant and introduced without a
+bigger picture in mind.
+
+Starting with Flink 1.9, the Table & SQL API will receive a new type system that serves as a long-term
+solution for API stability and standard compliance.
+
+Reworking the type system is a major effort that touches almost all user-facing interfaces. Therefore, its
+introduction spans multiple releases, and the community aims to finish this effort by Flink 1.10.
+
+Due to the simultaneous addition of a new planner for table programs (see [FLINK-11439](https://issues.apache.org/jira/browse/FLINK-11439)),
+not every combination of planner and data type is supported. Furthermore, planners might not support every
+data type with the desired precision or parameter.
+
+<span class="label label-danger">Attention</span> Please see the planner compatibility table and limitations
+section before using a data type.
+
+* This will be replaced by the TOC
+{:toc}
+
+Data Type
+---------
+
+A *data type* describes the logical type of a value in the table ecosystem. It can be used to declare input and/or
+output types of operations.
+
+Flink's data types are similar to the SQL standard's *data type* terminology but also contain information
+about the nullability of a value for efficient handling of scalar expressions.
+
+Examples of data types are:
+- `INT`
+- `INT NOT NULL`
+- `INTERVAL DAY TO SECOND(3)`
+- `ROW<myField ARRAY<BOOLEAN>, myOtherField TIMESTAMP(3)>`
+
+A list of all pre-defined data types can be found [below](#list-of-data-types).
+
+### Data Types in the Table API
+
+Users of the JVM-based API work with instances of `org.apache.flink.table.types.DataType` within the Table API or when
+defining connectors, catalogs, or user-defined functions.
+
+A `DataType` instance has two responsibilities:
+- **Declaration of a logical type** which does not imply a concrete physical representation for transmission
+or storage but defines the boundaries between JVM-based languages and the table ecosystem.
+- *Optional:* **Giving hints about the physical representation of data to the planner** which is useful at the edges to other APIs .
+
+For JVM-based languages, all pre-defined data types are available in `org.apache.flink.table.api.DataTypes`.
+
+It is recommended to add a star import to your table programs for having a fluent API:
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="Java" markdown="1">
+{% highlight java %}
+import static org.apache.flink.table.api.DataTypes.*;
+
+DataType t = INTERVAL(DAY(), SECOND(3));
+{% endhighlight %}
+</div>
+
+<div data-lang="Scala" markdown="1">
+{% highlight scala %}
+import org.apache.flink.table.api.DataTypes._
+
+val t: DataType = INTERVAL(DAY(), SECOND(3));
+{% endhighlight %}
+</div>
+
+</div>
+
+#### Physical Hints
+
+Physical hints are required at the edges of the table ecosystem where the SQL-based type system ends and
+programming-specific data types are required. Hints indicate the data format that an implementation
+expects.
+
+For example, a data source could express that it produces values for logical `TIMESTAMP`s using a `java.sql.Timestamp` class
+instead of using `java.time.LocalDateTime` which would be the default. With this information, the runtime is able to convert
+the produced class into its internal data format. In return, a data sink can declare the data format it consumes from the runtime.
+
+Here are some examples of how to declare a bridging conversion class:
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="Java" markdown="1">
+{% highlight java %}
+// tell the runtime to not produce or consume java.time.LocalDateTime instances
+// but java.sql.Timestamp
+DataType t = DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class);
+
+// tell the runtime to not produce or consume boxed integer arrays
+// but primitive int arrays
+DataType t = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(int[].class);
+{% endhighlight %}
+</div>
+
+<div data-lang="Scala" markdown="1">
+{% highlight scala %}
+// tell the runtime to not produce or consume java.time.LocalDateTime instances
+// but java.sql.Timestamp
+val t: DataType = DataTypes.TIMESTAMP(3).bridgedTo(classOf[java.sql.Timestamp]);
+
+// tell the runtime to not produce or consume boxed integer arrays
+// but primitive int arrays
+val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[Array[Int]]);
+{% endhighlight %}
+</div>
+
+</div>
+
+<span class="label label-danger">Attention</span> Please note that physical hints are usually only required if the
+API is extended. Users of predefined sources/sinks/functions do not need to define such hints. Hints within
+a table program (e.g. `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`) are ignored.
+
+Planner Compatibility
+---------------------
+
+As mentioned in the introduction, reworking the type system will span multiple releases, and the support of each data
+type depends on the used planner. This section aims to summarize the most significant differences.
+
+### Old Planner
+
+Flink's old planner, introduced before Flink 1.9, primarily supports type information. It has only limited
+support for data types. It is possible to declare data types that can be translated into type information such that the
+old planner understands them.
+
+The following table summarizes the difference between data type and type information. Most simple types, as well as the
+row type remain the same. Time types, array types, and the decimal type need special attention. Other hints as the ones
+mentioned are not allowed.
+
+For the *Type Information* column the table omits the prefix `org.apache.flink.table.api.Types`.
+
+For the *Data Type Representation* column the table omits the prefix `org.apache.flink.table.api.DataTypes`.
+
+| Type Information | Java Expression String | Data Type Representation | Remarks for Data Type |
+|:-----------------|:-----------------------|:-------------------------|:----------------------|
+| `STRING()` | `STRING` | `STRING()` | |
+| `BOOLEAN()` | `BOOLEAN` | `BOOLEAN()` | |
+| `BYTE()` | `BYTE` | `TINYINT()` | |
+| `SHORT()` | `SHORT` | `SMALLINT()` | |
+| `INT()` | `INT` | `INT()` | |
+| `LONG()` | `LONG` | `BIGINT()` | |
+| `FLOAT()` | `FLOAT` | `FLOAT()` | |
+| `DOUBLE()` | `DOUBLE` | `DOUBLE()` | |
+| `ROW(...)` | `ROW<...>` | `ROW(...)` | |
+| `BIG_DEC()` | `DECIMAL` | [`DECIMAL()`] | Not a 1:1 mapping as precision and scale are ignored and Java's variable precision and scale are used. |
+| `SQL_DATE()` | `SQL_DATE` | `DATE()`<br>`.bridgedTo(java.sql.Date.class)` | |
+| `SQL_TIME()` | `SQL_TIME` | `TIME(0)`<br>`.bridgedTo(java.sql.Time.class)` | |
+| `SQL_TIMESTAMP()` | `SQL_TIMESTAMP` | `TIMESTAMP(3)`<br>`.bridgedTo(java.sql.Timestamp.class)` | |
+| `INTERVAL_MONTHS()` | `INTERVAL_MONTHS` | `INTERVAL(MONTH())`<br>`.bridgedTo(Integer.class)` | |
+| `INTERVAL_MILLIS()` | `INTERVAL_MILLIS` | `INTERVAL(DataTypes.SECOND(3))`<br>`.bridgedTo(Long.class)` | |
+| `PRIMITIVE_ARRAY(...)` | `PRIMITIVE_ARRAY<...>` | `ARRAY(DATATYPE.notNull()`<br>`.bridgedTo(PRIMITIVE.class))` | Applies to all JVM primitive types except for `byte`. |
+| `PRIMITIVE_ARRAY(BYTE())` | `PRIMITIVE_ARRAY<BYTE>` | `BYTES()` | |
+| `OBJECT_ARRAY(...)` | `OBJECT_ARRAY<...>` | `ARRAY(`<br>`DATATYPE.bridgedTo(OBJECT.class))` | |
+| `MULTISET(...)` | | `MULTISET(...)` | |
+| `MAP(..., ...)` | `MAP<...,...>` | `MAP(...)` | |
+| other generic types | | `ANY(...)` | |
+
+<span class="label label-danger">Attention</span> If there is a problem with the new type system. Users
+can fallback to type information defined in `org.apache.flink.table.api.Types` at any time.
+
+### New Blink Planner
+
+The new Blink planner supports all of types of the old planner. This includes in particular
+the listed Java expression strings and type information.
+
+The following data types are supported:
+
+| Data Type | Remarks for Data Type |
+|:----------|:----------------------|
+| `STRING` | `CHAR` and `VARCHAR` are not supported yet. |
+| `BOOLEAN` | |
+| `BYTES` | `BINARY` and `VARBINARY` are not supported yet. |
+| `DECIMAL` | Supports fixed precision and scale. |
+| `TINYINT` | |
+| `SMALLINT` | |
+| `INTEGER` | |
+| `BIGINT` | |
+| `FLOAT` | |
+| `DOUBLE` | |
+| `DATE` | |
+| `TIME` | Supports only a precision of `0`. |
+| `TIMESTAMP` | Supports only a precision of `3`. |
+| `TIMESTAMP WITH LOCAL TIME ZONE` | Supports only a precision of `3`. |
+| `INTERVAL` | Supports only interval of `MONTH` and `SECOND(3)`. |
+| `ARRAY` | |
+| `MULTISET` | |
+| `MAP` | |
+| `ROW` | |
+| `ANY` | |
+
+Limitations
+-----------
+
+**Java Expression String**: Java expression strings in the Table API such as `table.select("field.cast(STRING)")`
+have not been updated to the new type system yet. Use the string representations declared in
+the [old planner section](#old-planner).
+
+**Connector Descriptors and SQL Client**: Descriptor string representations have not been updated to the new
+type system yet. Use the string representation declared in the [Connect to External Systems section](./connect.html#type-strings)
+
+**User-defined Functions**: User-defined functions cannot declare a data type yet.
+
+List of Data Types
+------------------
+
+This section lists all pre-defined data types. For the JVM-based Table API those types are also available in `org.apache.flink.table.api.DataTypes`.
+
+### Character Strings
+
+#### `CHAR`
+
+Data type of a fixed-length character string.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+CHAR
+CHAR(n)
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.CHAR(n)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `CHAR(n)` where `n` is the number of code points. `n` must have a value between `1`
+and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                 |
+|:-------------------|:-----:|:------:|:------------------------|
+|`java.lang.String`  | X     | X      | *Default*               |
+|`byte[]`            | X     | X      | Assumes UTF-8 encoding. |
+
+#### `VARCHAR` / `STRING`
+
+Data type of a variable-length character string.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+VARCHAR
+VARCHAR(n)
+
+STRING
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.VARCHAR(n)
+
+DataTypes.STRING()
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `VARCHAR(n)` where `n` is the maximum number of code points. `n` must have a value
+between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
+
+`STRING` is a synonym for `VARCHAR(2147483647)`.
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                 |
+|:-------------------|:-----:|:------:|:------------------------|
+|`java.lang.String`  | X     | X      | *Default*               |
+|`byte[]`            | X     | X      | Assumes UTF-8 encoding. |
+
+### Binary Strings
+
+#### `BINARY`
+
+Data type of a fixed-length binary string (=a sequence of bytes).
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+BINARY
+BINARY(n)
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.BINARY(n)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `BINARY(n)` where `n` is the number of bytes. `n` must have a value
+between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                 |
+|:-------------------|:-----:|:------:|:------------------------|
+|`byte[]`            | X     | X      | *Default*               |
+
+#### `VARBINARY` / `BYTES`
+
+Data type of a variable-length binary string (=a sequence of bytes).
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+VARBINARY
+VARBINARY(n)
+
+BYTES
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.VARBINARY(n)
+
+DataTypes.BYTES()
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `VARBINARY(n)` where `n` is the maximum number of bytes. `n` must
+have a value between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n` is
+equal to `1`.
+
+`BYTES` is a synonym for `VARBINARY(2147483647)`.
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                 |
+|:-------------------|:-----:|:------:|:------------------------|
+|`byte[]`            | X     | X      | *Default*               |
+
+### Exact Numerics
+
+#### `DECIMAL`
+
+Data type of a decimal number with fixed precision and scale.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+DECIMAL
+DECIMAL(p)
+DECIMAL(p, s)
+
+DEC
+DEC(p)
+DEC(p, s)
+
+NUMERIC
+NUMERIC(p)
+NUMERIC(p, s)
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.DECIMAL(p, s)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `DECIMAL(p, s)` where `p` is the number of digits in a
+number (*precision*) and `s` is the number of digits to the right of the decimal point
+in a number (*scale*). `p` must have a value between `1` and `38` (both inclusive). `s`
+must have a value between `0` and `p` (both inclusive). The default value for `p` is 10.
+The default value for `s` is `0`.
+
+`NUMERIC(p, s)` and `DEC(p, s)` are synonyms for this type.
+
+**Bridging to JVM Types**
+
+| Java Type             | Input | Output | Remarks                 |
+|:----------------------|:-----:|:------:|:------------------------|
+|`java.math.BigDecimal` | X     | X      | *Default*               |
+
+#### `TINYINT`
+
+Data type of a 1-byte signed integer with values from `-128` to `127`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+TINYINT
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.TINYINT()
+{% endhighlight %}
+</div>
+
+</div>
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                                      |
+|:-------------------|:-----:|:------:|:---------------------------------------------|
+|`java.lang.Byte`    | X     | X      | *Default*                                    |
+|`byte`              | X     | (X)    | Output only if type is not nullable. |
+
+#### `SMALLINT`
+
+Data type of a 2-byte signed integer with values from `-32,768` to `32,767`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+SMALLINT
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.SMALLINT()
+{% endhighlight %}
+</div>
+
+</div>
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                                      |
+|:-------------------|:-----:|:------:|:---------------------------------------------|
+|`java.lang.Short`   | X     | X      | *Default*                                    |
+|`short`             | X     | (X)    | Output only if type is not nullable. |
+
+#### `INT`
+
+Data type of a 4-byte signed integer with values from `-2,147,483,648` to `2,147,483,647`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+INT
+
+INTEGER
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.INT()
+{% endhighlight %}
+</div>
+
+</div>
+
+`INTEGER` is a synonym for this type.
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                                      |
+|:-------------------|:-----:|:------:|:---------------------------------------------|
+|`java.lang.Integer` | X     | X      | *Default*                                    |
+|`int`               | X     | (X)    | Output only if type is not nullable. |
+
+#### `BIGINT`
+
+Data type of an 8-byte signed integer with values from `-9,223,372,036,854,775,808` to
+`9,223,372,036,854,775,807`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+BIGINT
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.BIGINT()
+{% endhighlight %}
+</div>
+
+</div>
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                                      |
+|:-------------------|:-----:|:------:|:---------------------------------------------|
+|`java.lang.Long`    | X     | X      | *Default*                                    |
+|`long`              | X     | (X)    | Output only if type is not nullable. |
+
+### Approximate Numerics
+
+#### `FLOAT`
+
+Data type of a 4-byte single precision floating point number.
+
+Compared to the SQL standard, the type does not take parameters.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+FLOAT
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.FLOAT()
+{% endhighlight %}
+</div>
+
+</div>
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                                      |
+|:-------------------|:-----:|:------:|:---------------------------------------------|
+|`java.lang.Float`   | X     | X      | *Default*                                    |
+|`float`             | X     | (X)    | Output only if type is not nullable. |
+
+#### `DOUBLE`
+
+Data type of an 8-byte double precision floating point number.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+DOUBLE
+
+DOUBLE PRECISION
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.DOUBLE()
+{% endhighlight %}
+</div>
+
+</div>
+
+`DOUBLE PRECISION` is a synonym for this type.
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                                      |
+|:-------------------|:-----:|:------:|:---------------------------------------------|
+|`java.lang.Double`  | X     | X      | *Default*                                    |
+|`double`            | X     | (X)    | Output only if type is not nullable. |
+
+### Date and Time
+
+#### `DATE`
+
+Data type of a date consisting of `year-month-day` with values ranging from `0000-01-01`
+to `9999-12-31`.
+
+Compared to the SQL standard, the range starts at year `0000`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+DATE
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.DATE()
+{% endhighlight %}
+</div>
+
+</div>
+
+**Bridging to JVM Types**
+
+| Java Type            | Input | Output | Remarks                                      |
+|:---------------------|:-----:|:------:|:---------------------------------------------|
+|`java.time.LocalDate` | X     | X      | *Default*                                    |
+|`java.sql.Date`       | X     | X      |                                              |
+|`java.lang.Integer`   | X     | X      | Describes the number of days since epoch.    |
+|`int`                 | X     | (X)    | Describes the number of days since epoch.<br>Output only if type is not nullable. |
+
+#### `TIME`
+
+Data type of a time *without* time zone consisting of `hour:minute:second[.fractional]` with
+up to nanosecond precision and values ranging from `00:00:00.000000000` to
+`23:59:59.999999999`.
+
+Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported as
+the semantics are closer to `java.time.LocalTime`. A time *with* time zone is not provided.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+TIME
+TIME(p)
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.TIME(p)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `TIME(p)` where `p` is the number of digits of fractional
+seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no
+precision is specified, `p` is equal to `0`.
+
+**Bridging to JVM Types**
+
+| Java Type            | Input | Output | Remarks                                             |
+|:---------------------|:-----:|:------:|:----------------------------------------------------|
+|`java.time.LocalTime` | X     | X      | *Default*                                           |
+|`java.sql.Time`       | X     | X      |                                                     |
+|`java.lang.Integer`   | X     | X      | Describes the number of milliseconds of the day.    |
+|`int`                 | X     | (X)    | Describes the number of milliseconds of the day.<br>Output only if type is not nullable. |
+|`java.lang.Long`      | X     | X      | Describes the number of nanoseconds of the day.     |
+|`long`                | X     | (X)    | Describes the number of nanoseconds of the day.<br>Output only if type is not nullable. |
+
+#### `TIMESTAMP`
+
+Data type of a timestamp *without* time zone consisting of `year-month-day hour:minute:second[.fractional]`
+with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000` to
+`9999-12-31 23:59:59.999999999`.
+
+Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported as
+the semantics are closer to `java.time.LocalDateTime`.
+
+A conversion from and to `BIGINT` (a JVM `long` type) is not supported as this would imply a time
+zone. However, this type is time zone free. For more `java.time.Instant`-like semantics use
+`TIMESTAMP WITH LOCAL TIME ZONE`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+TIMESTAMP
+TIMESTAMP(p)
+
+TIMESTAMP WITHOUT TIME ZONE
+TIMESTAMP(p) WITHOUT TIME ZONE
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.TIMESTAMP(p)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `TIMESTAMP(p)` where `p` is the number of digits of fractional
+seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no precision
+is specified, `p` is equal to `6`.
+
+`TIMESTAMP(p) WITHOUT TIME ZONE` is a synonym for this type.
+
+**Bridging to JVM Types**
+
+| Java Type                | Input | Output | Remarks                                             |
+|:-------------------------|:-----:|:------:|:----------------------------------------------------|
+|`java.time.LocalDateTime` | X     | X      | *Default*                                           |
+|`java.sql.Timestamp`      | X     | X      |                                                     |
+
+#### `TIMESTAMP WITH TIME ZONE`
+
+Data type of a timestamp *with* time zone consisting of `year-month-day hour:minute:second[.fractional] zone`
+with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
+`9999-12-31 23:59:59.999999999 -14:59`.
+
+Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported as the semantics
+are closer to `java.time.OffsetDateTime`.
+
+Compared to `TIMESTAMP WITH LOCAL TIME ZONE`, the time zone offset information is physically
+stored in every datum. It is used individually for every computation, visualization, or communication
+to external systems.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+TIMESTAMP WITH TIME ZONE
+TIMESTAMP(p) WITH TIME ZONE
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.TIMESTAMP_WITH_TIME_ZONE(p)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `TIMESTAMP(p) WITH TIME ZONE` where `p` is the number of digits of
+fractional seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no
+precision is specified, `p` is equal to `6`.
+
+**Bridging to JVM Types**
+
+| Java Type                 | Input | Output | Remarks              |
+|:--------------------------|:-----:|:------:|:---------------------|
+|`java.time.OffsetDateTime` | X     | X      | *Default*            |
+|`java.time.ZonedDateTime`  | X     |        | Ignores the zone ID. |
+
+#### `TIMESTAMP WITH LOCAL TIME ZONE`
+
+Data type of a timestamp *with local* time zone consisting of `year-month-day hour:minute:second[.fractional] zone`
+with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
+`9999-12-31 23:59:59.999999999 -14:59`.
+
+Leap seconds (`23:59:60` and `23:59:61`) are not supported as the semantics are closer to `java.time.OffsetDateTime`.
+
+Compared to `TIMESTAMP WITH TIME ZONE`, the time zone offset information is not stored physically
+in every datum. Instead, the type assumes `java.time.Instant` semantics in UTC time zone at
+the edges of the table ecosystem. Every datum is interpreted in the local time zone configured in
+the current session for computation and visualization.
+
+This type fills the gap between time zone free and time zone mandatory timestamp types by allowing
+the interpretation of UTC timestamps according to the configured session time zone.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+TIMESTAMP WITH LOCAL TIME ZONE
+TIMESTAMP(p) WITH LOCAL TIME ZONE
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `TIMESTAMP(p) WITH LOCAL TIME ZONE` where `p` is the number
+of digits of fractional seconds (*precision*). `p` must have a value between `0` and `9`
+(both inclusive). If no precision is specified, `p` is equal to `6`.
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                                           |
+|:-------------------|:-----:|:------:|:--------------------------------------------------|
+|`java.time.Instant` | X     | X      | *Default*                                         |
+|`java.lang.Integer` | X     | X      | Describes the number of seconds since epoch.      |
+|`int`               | X     | (X)    | Describes the number of seconds since epoch.<br>Output only if type is not nullable. |
+|`java.lang.Long`    | X     | X      | Describes the number of milliseconds since epoch. |
+|`long`              | X     | (X)    | Describes the number of milliseconds since epoch.<br>Output only if type is not nullable. |
+
+#### `INTERVAL YEAR TO MONTH`
+
+Data type for a group of year-month interval types.
+
+The type must be parameterized to one of the following resolutions:
+- interval of years,
+- interval of years to months,
+- or interval of months.
+
+An interval of year-month consists of `+years-months` with values ranging from `-9999-11` to
+`+9999-11`.
+
+The value representation is the same for all types of resolutions. For example, an interval
+of months of 50 is always represented in an interval-of-years-to-months format (with default
+year precision): `+04-02`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+INTERVAL YEAR
+INTERVAL YEAR(p)
+INTERVAL YEAR(p) TO MONTH
+INTERVAL MONTH
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.INTERVAL(DataTypes.YEAR())
+DataTypes.INTERVAL(DataTypes.YEAR(p))
+DataTypes.INTERVAL(DataTypes.YEAR(p), DataTypes.MONTH())
+DataTypes.INTERVAL(DataTypes.MONTH())
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using the above combinations where `p` is the number of digits of years
+(*year precision*). `p` must have a value between `1` and `4` (both inclusive). If no year precision
+is specified, `p` is equal to `2`.
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                            |
+|:-------------------|:-----:|:------:|:-----------------------------------|
+|`java.time.Period`  | X     | X      | Ignores the `days` part. *Default* |
+|`java.lang.Integer` | X     | X      | Describes the number of months.    |
+|`int`               | X     | (X)    | Describes the number of months.<br>Output only if type is not nullable. |
+
+#### `INTERVAL DAY TO MONTH`
+
+Data type for a group of day-time interval types.
+
+The type must be parameterized to one of the following resolutions with up to nanosecond precision:
+- interval of days,
+- interval of days to hours,
+- interval of days to minutes,
+- interval of days to seconds,
+- interval of hours,
+- interval of hours to minutes,
+- interval of hours to seconds,
+- interval of minutes,
+- interval of minutes to seconds,
+- or interval of seconds.
+
+An interval of day-time consists of `+days hours:months:seconds.fractional` with values ranging from
+`-999999 23:59:59.999999999` to `+999999 23:59:59.999999999`. The value representation is the same
+for all types of resolutions. For example, an interval of seconds of 70 is always represented in
+an interval-of-days-to-seconds format (with default precisions): `+00 00:01:10.000000`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+INTERVAL DAY
+INTERVAL DAY(p1)
+INTERVAL DAY(p1) TO HOUR
+INTERVAL DAY(p1) TO MINUTE
+INTERVAL DAY(p1) TO SECOND(p2)
+INTERVAL HOUR
+INTERVAL HOUR TO MINUTE
+INTERVAL HOUR TO SECOND(p2)
+INTERVAL MINUTE
+INTERVAL MINUTE TO SECOND(p2)
+INTERVAL SECOND
+INTERVAL SECOND(p2)
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.INTERVAL(DataTypes.DAY())
+DataTypes.INTERVAL(DataTypes.DAY(p1))
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.HOUR())
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.HOUR())
+DataTypes.INTERVAL(DataTypes.HOUR(), DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.HOUR(), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.MINUTE(), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.SECOND())
+DataTypes.INTERVAL(DataTypes.SECOND(p2))
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using the above combinations where `p1` is the number of digits of days
+(*day precision*) and `p2` is the number of digits of fractional seconds (*fractional precision*).
+`p1` must have a value between `1` and `6` (both inclusive). `p2` must have a value between `0`
+and `9` (both inclusive). If no `p1` is specified, it is equal to `2` by default. If no `p2` is
+specified, it is equal to `6` by default.
+
+**Bridging to JVM Types**
+
+| Java Type           | Input | Output | Remarks                               |
+|:--------------------|:-----:|:------:|:--------------------------------------|
+|`java.time.Duration` | X     | X      | *Default*                             |
+|`java.lang.Long`     | X     | X      | Describes the number of milliseconds. |
+|`long`               | X     | (X)    | Describes the number of milliseconds.<br>Output only if type is not nullable. |
+
+### Constructured Data Types
+
+#### `ARRAY`
+
+Data type of an array of elements with same subtype.
+
+Compared to the SQL standard, the maximum cardinality of an array cannot be specified but is
+fixed at `2,147,483,647`. Also, any valid type is supported as a subtype.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+ARRAY<t>
+t ARRAY
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.ARRAY(t)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `ARRAY<t>` where `t` is the data type of the contained
+elements.
+
+`t ARRAY` is a synonym for being closer to the SQL standard. For example, `INT ARRAY` is
+equivalent to `ARRAY<INT>`.
+
+**Bridging to JVM Types**
+
+| Java Type | Input | Output | Remarks                           |
+|:----------|:-----:|:------:|:----------------------------------|
+|*t*`[]`    | (X)   | (X)    | Depends on the subtype. *Default* |
+
+#### `MULTISET`
+
+Data type of a multiset (=bag). Unlike a set, it allows for multiple instances for each of its
+elements with a common subtype. Each unique value (including `NULL`) is mapped to some multiplicity.
+
+There is no restriction of element types; it is the responsibility of the user to ensure uniqueness.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+MULTISET<t>
+t MULTISET
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.MULTISET(t)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `MULTISET<t>` where `t` is the data type
+of the contained elements.
+
+`t MULTISET` is a synonym for being closer to the SQL standard. For example, `INT MULTISET` is
+equivalent to `MULTISET<INT>`.
+
+**Bridging to JVM Types**
+
+| Java Type                            | Input | Output | Remarks                                                  |
+|:-------------------------------------|:-----:|:------:|:---------------------------------------------------------|
+|`java.util.Map<t, java.lang.Integer>` | X     | X      | Assigns each value to an integer multiplicity. *Default* |
+
+#### `ROW`
+
+Data type of a sequence of fields.
+
+A field consists of a field name, field type, and an optional description. The most specific type
+of a row of a table is a row type. In this case, each column of the row corresponds to the field
+of the row type that has the same ordinal position as the column.
+
+Compared to the SQL standard, an optional field description simplifies the handling with complex
+structures.
+
+A row type is similar to the `STRUCT` type known from other non-standard-compliant frameworks.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight sql %}
+ROW<n0 t0, n1 t1, ...>
+ROW<n0 t0 'd0', n1 t1 'd1', ...>
+
+ROW(n0 t0, n1 t1, ...>
+ROW(n0 t0 'd0', n1 t1 'd1', ...)
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.ROW(DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...)
+DataTypes.ROW(DataTypes.FIELD(n0, t0, d0), DataTypes.FIELD(n1, t1, d1), ...)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `ROW<n0 t0 'd0', n1 t1 'd1', ...>` where `n` is the unique name of
+a field, `t` is the logical type of a field, `d` is the description of a field.
+
+`ROW(...)` is a synonym for being closer to the SQL standard. For example, `ROW(myField INT, myOtherField BOOLEAN)` is
+equivalent to `ROW<myField INT, myOtherField BOOLEAN>`.
+
+**Bridging to JVM Types**
+
+| Java Type                   | Input | Output | Remarks                 |
+|:----------------------------|:-----:|:------:|:------------------------|
+|`org.apache.flink.types.Row` | X     | X      | *Default*               |
+
+### Other Data Types
+
+#### `BOOLEAN`
+
+Data type of a boolean with a (possibly) three-valued logic of `TRUE`, `FALSE`, and `UNKNOWN`.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+BOOLEAN
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.BOOLEAN()
+{% endhighlight %}
+</div>
+
+</div>
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                              |
+|:-------------------|:-----:|:------:|:-------------------------------------|
+|`java.lang.Boolean` | X     | X      | *Default*                            |
+|`boolean`           | X     | (X)    | Output only if type is not nullable. |
+
+#### `NULL`
+
+Data type for representing untyped `NULL` values.
+
+The null type is an extension to the SQL standard. A null type has no other value
+except `NULL`, thus, it can be cast to any nullable type similar to JVM semantics.
+
+This type helps in representing unknown types in API calls that use a `NULL` literal
+as well as bridging to formats such as JSON or Avro that define such a type as well.
+
+This type is not very useful in practice and is just mentioned here for completeness.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+NULL
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.NULL()
+{% endhighlight %}
+</div>
+
+</div>
+
+**Bridging to JVM Types**
+
+| Java Type         | Input | Output | Remarks                              |
+|:------------------|:-----:|:------:|:-------------------------------------|
+|`java.lang.Object` | X     | X      | *Default*                            |
+|*any class*        |       | (X)    | Any non-primitive type.              |
+
+#### `ANY`
+
+Data type of an arbitrary serialized type. This type is a black box within the table ecosystem
+and is only deserialized at the edges.
+
+The any type is an extension to the SQL standard.
+
+**Declaration**
+
+<div class="codetabs" markdown="1">
+
+<div data-lang="SQL" markdown="1">
+{% highlight text %}
+ANY('class', 'snapshot')
+{% endhighlight %}
+</div>
+
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+DataTypes.ANY(class, serializer)
+
+DataTypes.ANY(typeInfo)
+{% endhighlight %}
+</div>
+
+</div>
+
+The type can be declared using `ANY('class', 'snapshot')` where `class` is the originating class and
+`snapshot` is the serialized `TypeSerializerSnapshot` in Base64 encoding. Usually, the type string is not
+declared directly but is generated while persisting the type.
+
+In the API, the `ANY` type can be declared either by directly supplying a `Class` + `TypeSerializer` or
+by passing `TypeInformation` and let the framework extract `Class` + `TypeSerializer` from there.
+
+**Bridging to JVM Types**
+
+| Java Type         | Input | Output | Remarks                              |
+|:------------------|:-----:|:------:|:-------------------------------------------|
+|*class*            | X     | X      | Originating class or subclasses (for input) or superclasses (for output). *Default* |
+|`byte[]`           |       | X      |                                      |
+
+{% top %}

--- a/docs/redirects/restart_strategies.zh.md
+++ b/docs/redirects/restart_strategies.zh.md
@@ -1,0 +1,24 @@
+---
+title: "Restart Strategies"
+layout: redirect
+redirect: /dev/task_failure_recovery.html
+permalink: /dev/restart_strategies.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->


### PR DESCRIPTION
## What is the purpose of the change

* Fix broken links of zh docs

## Brief change log

* Just copy the missing docs from english version

## Verifying this change

* Run docs/check_links.sh

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
