### PR TITLE
[FLINK-13489]Fix the broken heavy deployment e2e test by adjusting config values

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
+++ b/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
@@ -25,7 +25,10 @@ TEST=flink-heavy-deployment-stress-test
 TEST_PROGRAM_NAME=HeavyDeploymentStressTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-set_config_key "taskmanager.heap.size" "512m" # 512Mb x 10TMs = 5Gb total heap
+set_config_key "containerized.heap-cutoff-min" "100"
+
+set_config_key "jobmanager.heap.size" "2048m"
+set_config_key "taskmanager.heap.size" "1024m" # 1024Mb x 10TMs = 10Gb total heap
 
 set_config_key "taskmanager.memory.size" "8" # 8Mb
 set_config_key "taskmanager.network.memory.min" "8mb"


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
The purpose of this PR is fix the broken heavy deployment e2e test. By adjusting three config values of the heavy deployment test, the cluster startup failure problem can be solved and the memory pressure of JM/TM can be reduced, which make the e2e test more stable.

## Brief change log
Three config values are changed for the heavy deployment e2e test.
  - *Decrease config value of containerized.heap-cutoff-min from default (600M) to 100M*
  - *Increase JobManager heap size from default (1024M) to 2048M*
  - *Increase TaskManager heap size from 512M to 1024M*


## Verifying this change
Manually verified the change by running ./flink-end-to-end-tests/run-single-test.sh ./flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh 500 times locally and modify the .travis.yml config file to trigger heavy deployment test when pushing code and run the test for dozens of times on Travis. All the tests were passed.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
