### PR TITLE
[FLINK-13564] [table-planner-blink] throw exception if constant with YEAR TO MONTH resolution was used for group windows

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/BatchLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/BatchLogicalWindowAggregateRule.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.expressions.FieldReferenceExpression
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory.toLogicalType
@@ -27,6 +28,8 @@ import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLog
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
 import org.apache.calcite.rex._
+
+import _root_.java.math.{BigDecimal => JBigDecimal}
 
 /**
   * Planner rule that transforms simple [[LogicalAggregate]] on a [[LogicalProject]]
@@ -73,6 +76,12 @@ class BatchLogicalWindowAggregateRule
           ref.getIndex)
     }
   }
+
+  def getOperandAsLong(call: RexCall, idx: Int): Long =
+    call.getOperands.get(idx) match {
+      case v: RexLiteral => v.getValue.asInstanceOf[JBigDecimal].longValue()
+      case _ => throw new TableException("Only constant window descriptors are supported")
+    }
 }
 
 object BatchLogicalWindowAggregateRule {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/LogicalWindowAggregateRuleBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/LogicalWindowAggregateRuleBase.scala
@@ -39,8 +39,6 @@ import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeUtil
 import org.apache.calcite.util.ImmutableBitSet
 
-import _root_.java.math.BigDecimal
-
 import _root_.scala.collection.JavaConversions._
 
 /**
@@ -247,11 +245,6 @@ abstract class LogicalWindowAggregateRuleBase(description: String)
       windowExpr: RexCall,
       windowExprIdx: Int,
       rowType: RelDataType): LogicalWindow = {
-    def getOperandAsLong(call: RexCall, idx: Int): Long =
-      call.getOperands.get(idx) match {
-        case v: RexLiteral => v.getValue.asInstanceOf[BigDecimal].longValue()
-        case _ => throw new TableException("Only constant window descriptors are supported")
-      }
 
     val timeField = getTimeFieldReference(windowExpr.getOperands.get(0), windowExprIdx, rowType)
     val resultType = Some(fromDataTypeToLogicalType(timeField.getOutputDataType))
@@ -288,4 +281,9 @@ abstract class LogicalWindowAggregateRuleBase(description: String)
       operand: RexNode,
       windowExprIdx: Int,
       rowType: RelDataType): FieldReferenceExpression
+
+  /**
+    * get operand value as Long type
+    */
+  def getOperandAsLong(call: RexCall, idx: Int): Long
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
@@ -90,8 +90,10 @@ class StreamLogicalWindowAggregateRule
     call.getOperands.get(idx) match {
       case v: RexLiteral if v.getTypeName.getFamily == SqlTypeFamily.INTERVAL_DAY_TIME =>
         v.getValue.asInstanceOf[JBigDecimal].longValue()
-      case _ => throw new TableException(
-        "Only constant window intervals with millisecond resolution are supported.")
+      case _: RexLiteral => throw new TableException(
+        "Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit. " +
+          "MONTH and YEAR time unit are not supported yet.")
+      case _ => throw new TableException("Only constant window descriptors are supported.")
     }
 }
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -134,6 +134,27 @@ Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testIntervalDay">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime, INTERVAL '35' DAY)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1])
++- LogicalAggregate(group=[{0}], EXPR$0=[COUNT()])
+   +- LogicalProject($f0=[TUMBLE($3, 3024000000:INTERVAL DAY)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+GroupWindowAggregate(window=[TumblingGroupWindow], select=[COUNT(*) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[proctime])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTumbleFunNotInGroupBy">
     <Resource name="sql">
       <![CDATA[
@@ -369,6 +390,41 @@ LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
       <![CDATA[
 Calc(select=[CAST(CASE(=($f1, 0), null:INTEGER, s)) AS s, CAST(CAST(/(CASE(=($f1, 0), null:INTEGER, s), $f1))) AS a, w$start AS wStart])
 +- GroupWindowAggregate(window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[$SUM0($f1) AS s, COUNT(*) AS $f1, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[rowtime, CASE(=(a, 1), 1, 99) AS $f1])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReturnTypeInferenceForWindowAgg">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(rowtime, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, rowtime
+  FROM MyTable
+)
+GROUP BY TUMBLE(rowtime, INTERVAL '15' MINUTE)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($4, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[CAST(CASE(=($f1, 0), null:INTEGER, s)) AS s, CAST(CAST(/(CASE(=($f1, 0), null:INTEGER, s), $f1))) AS a, w$start AS wStart])
++- GroupWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime, w$proctime], select=[$SUM0($f1) AS s, COUNT(*) AS $f1, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
    +- Exchange(distribution=[single])
       +- Calc(select=[rowtime, CASE(=(a, 1), 1, 99) AS $f1])
          +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -148,7 +148,7 @@ LogicalProject(EXPR$0=[$1])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-GroupWindowAggregate(window=[TumblingGroupWindow], select=[COUNT(*) AS EXPR$0])
+GroupWindowAggregate(window=[TumblingGroupWindow('w$, proctime, 3024000000)], select=[COUNT(*) AS EXPR$0])
 +- Exchange(distribution=[single])
    +- Calc(select=[proctime])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
@@ -390,41 +390,6 @@ LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
       <![CDATA[
 Calc(select=[CAST(CASE(=($f1, 0), null:INTEGER, s)) AS s, CAST(CAST(/(CASE(=($f1, 0), null:INTEGER, s), $f1))) AS a, w$start AS wStart])
 +- GroupWindowAggregate(window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[$SUM0($f1) AS s, COUNT(*) AS $f1, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
-   +- Exchange(distribution=[single])
-      +- Calc(select=[rowtime, CASE(=(a, 1), 1, 99) AS $f1])
-         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testReturnTypeInferenceForWindowAgg">
-    <Resource name="sql">
-      <![CDATA[
-SELECT
-  SUM(correct) AS s,
-  AVG(correct) AS a,
-  TUMBLE_START(rowtime, INTERVAL '15' MINUTE) AS wStart
-FROM (
-  SELECT CASE a
-      WHEN 1 THEN 1
-      ELSE 99
-    END AS correct, rowtime
-  FROM MyTable
-)
-GROUP BY TUMBLE(rowtime, INTERVAL '15' MINUTE)
-      ]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
-+- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
-   +- LogicalProject($f0=[TUMBLE($4, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[CAST(CASE(=($f1, 0), null:INTEGER, s)) AS s, CAST(CAST(/(CASE(=($f1, 0), null:INTEGER, s), $f1))) AS a, w$start AS wStart])
-+- GroupWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime, w$proctime], select=[$SUM0($f1) AS s, COUNT(*) AS $f1, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
    +- Exchange(distribution=[single])
       +- Calc(select=[rowtime, CASE(=(a, 1), 1, 99) AS $f1])
          +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
@@ -86,14 +86,35 @@ class WindowAggregateTest extends TableTestBase {
   }
 
   @Test
-  def testWindowWrongWindowParameter(): Unit = {
+  def testWindowWrongWindowParameter1(): Unit = {
     expectedException.expect(classOf[TableException])
     expectedException.expectMessage(
-      "Only constant window intervals with millisecond resolution are supported")
+      "Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit. " +
+        "MONTH and YEAR time unit are not supported yet.")
+
+    val sqlQuery =
+      "SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime, INTERVAL '1' MONTH)"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testWindowWrongWindowParameter2(): Unit = {
+    expectedException.expect(classOf[TableException])
+    expectedException.expectMessage(
+      "Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit. " +
+        "MONTH and YEAR time unit are not supported yet.")
 
     val sqlQuery =
       "SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime, INTERVAL '2-10' YEAR TO MONTH)"
 
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testIntervalDay(): Unit = {
+    val sqlQuery =
+      "SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime, INTERVAL '35' DAY)"
     util.verifyPlan(sqlQuery)
   }
 
@@ -308,7 +329,7 @@ class WindowAggregateTest extends TableTestBase {
   }
 
   @Test
-  def testReturnTypeInferenceForWindowAgg() = {
+  def testReturnTypeInferenceForWindowAgg(): Unit = {
 
     val sql =
       """

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
@@ -86,6 +86,18 @@ class WindowAggregateTest extends TableTestBase {
   }
 
   @Test
+  def testWindowWrongWindowParameter(): Unit = {
+    expectedException.expect(classOf[TableException])
+    expectedException.expectMessage(
+      "Only constant window intervals with millisecond resolution are supported")
+
+    val sqlQuery =
+      "SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime, INTERVAL '2-10' YEAR TO MONTH)"
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
   def testTumbleFunction(): Unit = {
     val sql =
       """


### PR DESCRIPTION


## What is the purpose of the change

*Checking if a proper resolution was used for group window parameter. Without this check INTERVAL '2-10' YEAR TO MONTH would be a valid window size that would be translated to 34 milliseconds window.*


## Brief change log

  - *add check in StreamLogicalWindowAggregateRule*


## Verifying this change

org.apache.flink.table.planner.plan.stream.sql.agg.WindowAggregateTest#testWindowWrongWindowParameter


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
