### PR TITLE
[FLINK-13340][kafka][table] Add 'topics' and 'subscriptionPattern' option for Flink Kafka connector

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSource.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Kafka {@link StreamTableSource} for Kafka 0.10.
@@ -46,7 +48,7 @@ public class Kafka010TableSource extends KafkaTableSourceBase {
 	 * @param rowtimeAttributeDescriptors Descriptor for a rowtime attribute
 	 * @param fieldMapping                Mapping for the fields of the table schema to
 	 *                                    fields of the physical returned type.
-	 * @param topic                       Kafka topic to consume.
+	 * @param kafkaTopicDescriptor        Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties                  Properties for the Kafka consumer.
 	 * @param deserializationSchema       Deserialization schema for decoding records from Kafka.
 	 * @param startupMode                 Startup mode for the contained consumer.
@@ -58,7 +60,7 @@ public class Kafka010TableSource extends KafkaTableSourceBase {
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Optional<Map<String, String>> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -69,7 +71,7 @@ public class Kafka010TableSource extends KafkaTableSourceBase {
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			fieldMapping,
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,
@@ -80,21 +82,31 @@ public class Kafka010TableSource extends KafkaTableSourceBase {
 	 * Creates a Kafka 0.10 {@link StreamTableSource}.
 	 *
 	 * @param schema                Schema of the produced table.
-	 * @param topic                 Kafka topic to consume.
+	 * @param kafkaTopicDescriptor  Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties            Properties for the Kafka consumer.
 	 * @param deserializationSchema Deserialization schema for decoding records from Kafka.
 	 */
 	public Kafka010TableSource(
 			TableSchema schema,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema) {
 
-		super(schema, topic, properties, deserializationSchema);
+		super(schema, kafkaTopicDescriptor, properties, deserializationSchema);
 	}
 
 	@Override
 	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer010<>(topic, deserializationSchema, properties);
+	}
+
+	@Override
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(List<String> topics, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+		return new FlinkKafkaConsumer010<Row>(topics, deserializationSchema, properties);
+	}
+
+	@Override
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(Pattern subscriptionPattern, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+		return new FlinkKafkaConsumer010<Row>(subscriptionPattern, deserializationSchema, properties);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSourceSinkFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -54,7 +55,7 @@ public class Kafka010TableSourceSinkFactory extends KafkaTableSourceSinkFactoryB
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Map<String, String> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -65,7 +66,7 @@ public class Kafka010TableSourceSinkFactory extends KafkaTableSourceSinkFactoryB
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSourceSinkFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -61,7 +62,7 @@ public class Kafka010TableSourceSinkFactoryTest extends KafkaTableSourceSinkFact
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Map<String, String> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -72,7 +73,7 @@ public class Kafka010TableSourceSinkFactoryTest extends KafkaTableSourceSinkFact
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSource.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Kafka {@link StreamTableSource} for Kafka 0.11.
@@ -46,7 +48,7 @@ public class Kafka011TableSource extends KafkaTableSourceBase {
 	 * @param rowtimeAttributeDescriptors Descriptor for a rowtime attribute
 	 * @param fieldMapping                Mapping for the fields of the table schema to
 	 *                                    fields of the physical returned type.
-	 * @param topic                       Kafka topic to consume.
+	 * @param kafkaTopicDescriptor        Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties                  Properties for the Kafka consumer.
 	 * @param deserializationSchema       Deserialization schema for decoding records from Kafka.
 	 * @param startupMode                 Startup mode for the contained consumer.
@@ -58,7 +60,7 @@ public class Kafka011TableSource extends KafkaTableSourceBase {
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Optional<Map<String, String>> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -69,7 +71,7 @@ public class Kafka011TableSource extends KafkaTableSourceBase {
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			fieldMapping,
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,
@@ -80,21 +82,31 @@ public class Kafka011TableSource extends KafkaTableSourceBase {
 	 * Creates a Kafka 0.11 {@link StreamTableSource}.
 	 *
 	 * @param schema                Schema of the produced table.
-	 * @param topic                 Kafka topic to consume.
+	 * @param kafkaTopicDescriptor  Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties            Properties for the Kafka consumer.
 	 * @param deserializationSchema Deserialization schema for decoding records from Kafka.
 	 */
 	public Kafka011TableSource(
 			TableSchema schema,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema) {
 
-		super(schema, topic, properties, deserializationSchema);
+		super(schema, kafkaTopicDescriptor, properties, deserializationSchema);
 	}
 
 	@Override
 	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer011<>(topic, deserializationSchema, properties);
+	}
+
+	@Override
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(List<String> topics, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+		return new FlinkKafkaConsumer011<>(topics, deserializationSchema, properties);
+	}
+
+	@Override
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(Pattern pattern, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+		return new FlinkKafkaConsumer011<>(pattern, deserializationSchema, properties);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSourceSinkFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -54,7 +55,7 @@ public class Kafka011TableSourceSinkFactory extends KafkaTableSourceSinkFactoryB
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Map<String, String> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -65,7 +66,7 @@ public class Kafka011TableSourceSinkFactory extends KafkaTableSourceSinkFactoryB
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSourceSinkFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -61,7 +62,7 @@ public class Kafka011TableSourceSinkFactoryTest extends KafkaTableSourceSinkFact
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Map<String, String> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -72,7 +73,7 @@ public class Kafka011TableSourceSinkFactoryTest extends KafkaTableSourceSinkFact
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSource.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Kafka {@link StreamTableSource} for Kafka 0.8.
@@ -46,7 +48,7 @@ public class Kafka08TableSource extends KafkaTableSourceBase {
 	 * @param rowtimeAttributeDescriptors Descriptor for a rowtime attribute
 	 * @param fieldMapping                Mapping for the fields of the table schema to
 	 *                                    fields of the physical returned type.
-	 * @param topic                       Kafka topic to consume.
+	 * @param kafkaTopicDescriptor        Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties                  Properties for the Kafka consumer.
 	 * @param deserializationSchema       Deserialization schema for decoding records from Kafka.
 	 * @param startupMode                 Startup mode for the contained consumer.
@@ -58,7 +60,7 @@ public class Kafka08TableSource extends KafkaTableSourceBase {
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Optional<Map<String, String>> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -69,7 +71,7 @@ public class Kafka08TableSource extends KafkaTableSourceBase {
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			fieldMapping,
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,
@@ -80,21 +82,31 @@ public class Kafka08TableSource extends KafkaTableSourceBase {
 	 * Creates a Kafka 0.8 {@link StreamTableSource}.
 	 *
 	 * @param schema                Schema of the produced table.
-	 * @param topic                 Kafka topic to consume.
+	 * @param kafkaTopicDescriptor  Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties            Properties for the Kafka consumer.
 	 * @param deserializationSchema Deserialization schema for decoding records from Kafka.
 	 */
 	public Kafka08TableSource(
 			TableSchema schema,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema) {
 
-		super(schema, topic, properties, deserializationSchema);
+		super(schema, kafkaTopicDescriptor, properties, deserializationSchema);
 	}
 
 	@Override
 	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer08<>(topic, deserializationSchema, properties);
+	}
+
+	@Override
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(List<String> topics, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+		return new FlinkKafkaConsumer08<>(topics, deserializationSchema, properties);
+	}
+
+	@Override
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(Pattern subscriptionPattern, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+		return new FlinkKafkaConsumer08<>(subscriptionPattern, deserializationSchema, properties);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSourceSinkFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -54,7 +55,7 @@ public class Kafka08TableSourceSinkFactory extends KafkaTableSourceSinkFactoryBa
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Map<String, String> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -65,7 +66,7 @@ public class Kafka08TableSourceSinkFactory extends KafkaTableSourceSinkFactoryBa
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSourceSinkFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -61,7 +62,7 @@ public class Kafka08TableSourceSinkFactoryTest extends KafkaTableSourceSinkFacto
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Map<String, String> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -72,7 +73,7 @@ public class Kafka08TableSourceSinkFactoryTest extends KafkaTableSourceSinkFacto
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSource.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Kafka {@link StreamTableSource} for Kafka 0.9.
@@ -46,7 +48,7 @@ public class Kafka09TableSource extends KafkaTableSourceBase {
 	 * @param rowtimeAttributeDescriptors Descriptor for a rowtime attribute
 	 * @param fieldMapping                Mapping for the fields of the table schema to
 	 *                                    fields of the physical returned type.
-	 * @param topic                       Kafka topic to consume.
+	 * @param kafkaTopicDescriptor        Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties                  Properties for the Kafka consumer.
 	 * @param deserializationSchema       Deserialization schema for decoding records from Kafka.
 	 * @param startupMode                 Startup mode for the contained consumer.
@@ -58,7 +60,7 @@ public class Kafka09TableSource extends KafkaTableSourceBase {
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Optional<Map<String, String>> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -69,7 +71,7 @@ public class Kafka09TableSource extends KafkaTableSourceBase {
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			fieldMapping,
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,
@@ -80,21 +82,31 @@ public class Kafka09TableSource extends KafkaTableSourceBase {
 	 * Creates a Kafka 0.9 {@link StreamTableSource}.
 	 *
 	 * @param schema                Schema of the produced table.
-	 * @param topic                 Kafka topic to consume.
+	 * @param kafkaTopicDescriptor  Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties            Properties for the Kafka consumer.
 	 * @param deserializationSchema Deserialization schema for decoding records from Kafka.
 	 */
 	public Kafka09TableSource(
 			TableSchema schema,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema) {
 
-		super(schema, topic, properties, deserializationSchema);
+		super(schema, kafkaTopicDescriptor, properties, deserializationSchema);
 	}
 
 	@Override
 	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer09<>(topic, deserializationSchema, properties);
+	}
+
+	@Override
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(List<String> topics, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+		return new FlinkKafkaConsumer09<>(topics, deserializationSchema, properties);
+	}
+
+	@Override
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(Pattern subscriptionPattern, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+		return new FlinkKafkaConsumer09<>(subscriptionPattern, deserializationSchema, properties);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSourceSinkFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -54,7 +55,7 @@ public class Kafka09TableSourceSinkFactory extends KafkaTableSourceSinkFactoryBa
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Map<String, String> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -65,7 +66,7 @@ public class Kafka09TableSourceSinkFactory extends KafkaTableSourceSinkFactoryBa
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSourceSinkFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -61,7 +62,7 @@ public class Kafka09TableSourceSinkFactoryTest extends KafkaTableSourceSinkFacto
 			Optional<String> proctimeAttribute,
 			List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 			Map<String, String> fieldMapping,
-			String topic,
+			KafkaTopicDescriptor kafkaTopicDescriptor,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
@@ -72,7 +73,7 @@ public class Kafka09TableSourceSinkFactoryTest extends KafkaTableSourceSinkFacto
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -26,9 +26,7 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartiti
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.descriptors.DescriptorProperties;
-import org.apache.flink.table.descriptors.KafkaValidator;
-import org.apache.flink.table.descriptors.SchemaValidator;
+import org.apache.flink.table.descriptors.*;
 import org.apache.flink.table.factories.DeserializationSchemaFactory;
 import org.apache.flink.table.factories.SerializationSchemaFactory;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
@@ -47,25 +45,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_KEY;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_VALUE;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_CLASS;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_CUSTOM;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_FIXED;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_ROUND_ROBIN;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_OFFSET;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_PARTITION;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_STARTUP_MODE;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TOPIC;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TYPE_VALUE_KAFKA;
+import static org.apache.flink.table.descriptors.KafkaValidator.*;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SUBSCRIPTION_PATTERN;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_CLASS;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_FROM;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_SERIALIZED;
@@ -105,6 +92,8 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 
 		// kafka
 		properties.add(CONNECTOR_TOPIC);
+		properties.add(CONNECTOR_TOPICS);
+		properties.add(CONNECTOR_SUBSCRIPTION_PATTERN);
 		properties.add(CONNECTOR_PROPERTIES);
 		properties.add(CONNECTOR_PROPERTIES + ".#." + CONNECTOR_PROPERTIES_KEY);
 		properties.add(CONNECTOR_PROPERTIES + ".#." + CONNECTOR_PROPERTIES_VALUE);
@@ -138,9 +127,16 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 
 	@Override
 	public StreamTableSource<Row> createStreamTableSource(Map<String, String> properties) {
-		final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
+		final DescriptorProperties descriptorProperties = getValidatedTableSourceProperties(properties);
 
-		final String topic = descriptorProperties.getString(CONNECTOR_TOPIC);
+		final String topic = descriptorProperties.containsKey(CONNECTOR_TOPIC)?
+			descriptorProperties.getString(CONNECTOR_TOPIC): null;
+		final List<String> topics = descriptorProperties.containsKey(CONNECTOR_TOPICS)?
+			Arrays.asList(descriptorProperties.getString(CONNECTOR_TOPICS).split(",")): null;
+		final Pattern subscriptionPattern = descriptorProperties.containsKey(CONNECTOR_SUBSCRIPTION_PATTERN)?
+			Pattern.compile(descriptorProperties.getString(CONNECTOR_SUBSCRIPTION_PATTERN)): null;
+		final KafkaTopicDescriptor kafkaTopicDescriptor = new KafkaTopicDescriptor(topic, topics, subscriptionPattern);
+
 		final DeserializationSchema<Row> deserializationSchema = getDeserializationSchema(properties);
 		final StartupOptions startupOptions = getStartupOptions(descriptorProperties, topic);
 
@@ -151,7 +147,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 			SchemaValidator.deriveFieldMapping(
 				descriptorProperties,
 				Optional.of(deserializationSchema.getProducedType())),
-			topic,
+			kafkaTopicDescriptor,
 			getKafkaProperties(descriptorProperties),
 			deserializationSchema,
 			startupOptions.startupMode,
@@ -160,7 +156,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 
 	@Override
 	public StreamTableSink<Row> createStreamTableSink(Map<String, String> properties) {
-		final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
+		final DescriptorProperties descriptorProperties = getValidatedTableSinkProperties(properties);
 
 		final TableSchema schema = descriptorProperties.getTableSchema(SCHEMA);
 		final String topic = descriptorProperties.getString(CONNECTOR_TOPIC);
@@ -206,7 +202,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 	 * @param rowtimeAttributeDescriptors Descriptor for a rowtime attribute
 	 * @param fieldMapping                Mapping for the fields of the table schema to
 	 *                                    fields of the physical returned type.
-	 * @param topic                       Kafka topic to consume.
+	 * @param kafkaTopicDescriptor        Kafka topic descriptor to describe which topic(topics or pattern) to consume.
 	 * @param properties                  Properties for the Kafka consumer.
 	 * @param deserializationSchema       Deserialization schema for decoding records from Kafka.
 	 * @param startupMode                 Startup mode for the contained consumer.
@@ -218,7 +214,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		Optional<String> proctimeAttribute,
 		List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 		Map<String, String> fieldMapping,
-		String topic,
+		KafkaTopicDescriptor kafkaTopicDescriptor,
 		Properties properties,
 		DeserializationSchema<Row> deserializationSchema,
 		StartupMode startupMode,
@@ -249,8 +245,19 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 
 		// allow Kafka timestamps to be used, watermarks can not be received from source
 		new SchemaValidator(true, supportsKafkaTimestamps(), false).validate(descriptorProperties);
-		new KafkaValidator().validate(descriptorProperties);
 
+		return descriptorProperties;
+	}
+
+	private DescriptorProperties getValidatedTableSourceProperties(Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
+		new KafkaConsumerValidator().validate(descriptorProperties);
+		return descriptorProperties;
+	}
+
+	private DescriptorProperties getValidatedTableSinkProperties(Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
+		new KafkaProducerValidator().validate(descriptorProperties);
 		return descriptorProperties;
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -26,7 +26,12 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartiti
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.descriptors.*;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.KafkaConsumerValidator;
+import org.apache.flink.table.descriptors.KafkaProducerValidator;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
+import org.apache.flink.table.descriptors.KafkaValidator;
+import org.apache.flink.table.descriptors.SchemaValidator;
 import org.apache.flink.table.factories.DeserializationSchemaFactory;
 import org.apache.flink.table.factories.SerializationSchemaFactory;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
@@ -51,8 +56,22 @@ import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CO
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
-import static org.apache.flink.table.descriptors.KafkaValidator.*;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_KEY;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_VALUE;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_CLASS;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_CUSTOM;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_FIXED;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_ROUND_ROBIN;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_OFFSET;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_PARTITION;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_STARTUP_MODE;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SUBSCRIPTION_PATTERN;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TOPIC;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TOPICS;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TYPE_VALUE_KAFKA;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_CLASS;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_FROM;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_SERIALIZED;
@@ -129,12 +148,12 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 	public StreamTableSource<Row> createStreamTableSource(Map<String, String> properties) {
 		final DescriptorProperties descriptorProperties = getValidatedTableSourceProperties(properties);
 
-		final String topic = descriptorProperties.containsKey(CONNECTOR_TOPIC)?
-			descriptorProperties.getString(CONNECTOR_TOPIC): null;
-		final List<String> topics = descriptorProperties.containsKey(CONNECTOR_TOPICS)?
-			Arrays.asList(descriptorProperties.getString(CONNECTOR_TOPICS).split(",")): null;
-		final Pattern subscriptionPattern = descriptorProperties.containsKey(CONNECTOR_SUBSCRIPTION_PATTERN)?
-			Pattern.compile(descriptorProperties.getString(CONNECTOR_SUBSCRIPTION_PATTERN)): null;
+		final String topic = descriptorProperties.containsKey(CONNECTOR_TOPIC) ?
+			descriptorProperties.getString(CONNECTOR_TOPIC) : null;
+		final List<String> topics = descriptorProperties.containsKey(CONNECTOR_TOPICS) ?
+			Arrays.asList(descriptorProperties.getString(CONNECTOR_TOPICS).split(",")) : null;
+		final Pattern subscriptionPattern = descriptorProperties.containsKey(CONNECTOR_SUBSCRIPTION_PATTERN) ?
+			Pattern.compile(descriptorProperties.getString(CONNECTOR_SUBSCRIPTION_PATTERN)) : null;
 		final KafkaTopicDescriptor kafkaTopicDescriptor = new KafkaTopicDescriptor(topic, topics, subscriptionPattern);
 
 		final DeserializationSchema<Row> deserializationSchema = getDeserializationSchema(properties);

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
@@ -32,7 +32,22 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.KafkaValidator.*;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_KEY;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_VALUE;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_CLASS;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_CUSTOM;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_FIXED;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_ROUND_ROBIN;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_OFFSET;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_PARTITION;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_STARTUP_MODE;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SUBSCRIPTION_PATTERN;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TOPIC;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TOPICS;
+import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TYPE_VALUE_KAFKA;
 
 /**
  * Connector descriptor for the Apache Kafka message queue.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
@@ -32,20 +32,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_KEY;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_VALUE;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_CLASS;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_CUSTOM;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_FIXED;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_ROUND_ROBIN;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_OFFSET;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_PARTITION;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_STARTUP_MODE;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TOPIC;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TYPE_VALUE_KAFKA;
+import static org.apache.flink.table.descriptors.KafkaValidator.*;
 
 /**
  * Connector descriptor for the Apache Kafka message queue.
@@ -54,6 +41,8 @@ public class Kafka extends ConnectorDescriptor {
 
 	private String version;
 	private String topic;
+	private String topics;
+	private String subscriptionPattern;
 	private StartupMode startupMode;
 	private Map<Integer, Long> specificOffsets;
 	private Map<String, String> kafkaProperties;
@@ -86,6 +75,28 @@ public class Kafka extends ConnectorDescriptor {
 	public Kafka topic(String topic) {
 		Preconditions.checkNotNull(topic);
 		this.topic = topic;
+		return this;
+	}
+
+	/**
+	 * Set the topics from which the table is read.
+	 *
+	 * @param topics The topics from which the table is read.
+	 */
+	public Kafka topics(String... topics) {
+		Preconditions.checkNotNull(topics);
+		this.topics = String.join(",", topics);
+		return this;
+	}
+
+	/**
+	 * Set the regex pattern of topics from which the table is read.
+	 *
+	 * @param subscriptionPattern The regex pattern of topics from which the table is read.
+	 */
+	public Kafka subscriptionPattern(String subscriptionPattern) {
+		Preconditions.checkNotNull(subscriptionPattern);
+		this.subscriptionPattern = subscriptionPattern;
 		return this;
 	}
 
@@ -256,6 +267,14 @@ public class Kafka extends ConnectorDescriptor {
 
 		if (topic != null) {
 			properties.putString(CONNECTOR_TOPIC, topic);
+		}
+
+		if (topics != null) {
+			properties.putString(CONNECTOR_TOPICS, topics);
+		}
+
+		if (subscriptionPattern != null) {
+			properties.putString(CONNECTOR_SUBSCRIPTION_PATTERN, subscriptionPattern);
 		}
 
 		if (startupMode != null) {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaConsumerValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaConsumerValidator.java
@@ -1,0 +1,54 @@
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public class KafkaConsumerValidator extends KafkaValidator {
+
+	/**
+	 * For Kafka consumer:
+	 * 1. Check only one of the topic, topics or subscriptionPattern is specified.
+	 * 2. Check the regex pattern is valid if the subscriptionPattern is specified.
+	 */
+	@Override
+	public void validateTopicSetting(DescriptorProperties properties) {
+		int topicSettingCount = keyCount(
+			properties,
+			CONNECTOR_TOPIC,
+			CONNECTOR_TOPICS,
+			CONNECTOR_SUBSCRIPTION_PATTERN
+		);
+		if (topicSettingCount != 1) {
+			throw new ValidationException("specify topic, topics or subscriptionPattern");
+		}
+		// Validate topic or topics or subscriptionPattern
+		if (properties.containsKey(CONNECTOR_TOPIC)) {
+			properties.validateString(CONNECTOR_TOPIC, false, 1, Integer.MAX_VALUE);
+			return;
+		}
+		if (properties.containsKey(CONNECTOR_TOPICS)) {
+			properties.validateString(CONNECTOR_TOPICS, false, 1, Integer.MAX_VALUE);
+			return;
+		}
+
+		// First Valid subscriptionPattern string
+		properties.validateString(CONNECTOR_SUBSCRIPTION_PATTERN, false, 1, Integer.MAX_VALUE);
+		// Then valid regex pattern
+		try {
+			Pattern.compile(properties.getString(CONNECTOR_SUBSCRIPTION_PATTERN));
+		} catch (PatternSyntaxException e) {
+			throw new ValidationException("subscriptionPattern is not a valid java regex pattern");
+		}
+
+	}
+
+	private int keyCount(DescriptorProperties properties, String... keys) {
+		int count = 0;
+		for (String key: keys) {
+			if (properties.containsKey(key)) count++;
+		}
+		return count;
+	}
+}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaConsumerValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaConsumerValidator.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.descriptors;
 
 import org.apache.flink.table.api.ValidationException;

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaConsumerValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaConsumerValidator.java
@@ -23,6 +23,9 @@ import org.apache.flink.table.api.ValidationException;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+/**
+ * Validator for Kafka producer setting.
+ */
 public class KafkaConsumerValidator extends KafkaValidator {
 
 	/**
@@ -64,8 +67,10 @@ public class KafkaConsumerValidator extends KafkaValidator {
 
 	private int keyCount(DescriptorProperties properties, String... keys) {
 		int count = 0;
-		for (String key: keys) {
-			if (properties.containsKey(key)) count++;
+		for (String key : keys) {
+			if (properties.containsKey(key)) {
+				count++;
+			}
 		}
 		return count;
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaProducerValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaProducerValidator.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.table.descriptors;
 
+/**
+ * Validator for Kafka producer setting.
+ */
 public class KafkaProducerValidator extends KafkaValidator {
 
 	/**

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaProducerValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaProducerValidator.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.descriptors;
 
 public class KafkaProducerValidator extends KafkaValidator {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaProducerValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaProducerValidator.java
@@ -1,0 +1,13 @@
+package org.apache.flink.table.descriptors;
+
+public class KafkaProducerValidator extends KafkaValidator {
+
+	/**
+	 * For Kafka producer:
+	 * Only need to check topic is specified or not.
+	 */
+	@Override
+	public void validateTopicSetting(DescriptorProperties properties) {
+		properties.validateString(CONNECTOR_TOPIC, false, 1, Integer.MAX_VALUE);
+	}
+}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaTopicDescriptor.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaTopicDescriptor.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.descriptors;
 
 import java.util.List;

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaTopicDescriptor.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaTopicDescriptor.java
@@ -1,0 +1,73 @@
+package org.apache.flink.table.descriptors;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Kafka Topic Descriptor.
+ */
+public class KafkaTopicDescriptor {
+
+	/**
+	 * SINGLE: Kafka topic is specified.
+	 * LIST: Kafka topics is specified.
+	 * PATTERN: Kafka subscription pattern is specified.
+	 * UNKNOWN: None of above is specified.
+	 */
+	public enum TYPE {SINGLE, LIST, PATTERN, UNKNOWN}
+
+	private String topic;
+	private List<String> topics;
+	private Pattern subscriptionPattern;
+	private TYPE type = TYPE.UNKNOWN;
+
+	public KafkaTopicDescriptor() {}
+
+	public KafkaTopicDescriptor(String topic, List<String> topics, Pattern subscriptionPattern) {
+		if (topic != null && !topic.equals("")) {
+			this.setTopic(topic);
+		}
+		if (topics != null && topics.size() != 0) {
+			this.setTopics(topics);
+		}
+		if (subscriptionPattern != null) {
+			this.setSubscriptionPattern(subscriptionPattern);
+		}
+	}
+
+	public String getTopic() {
+		return topic;
+	}
+
+	public void setTopic(String topic) {
+		this.topic = topic;
+		this.type = TYPE.SINGLE;
+	}
+
+	public List<String> getTopics() {
+		return topics;
+	}
+
+	public void setTopics(List<String> topics) {
+		this.topics = topics;
+		this.type = TYPE.LIST;
+	}
+
+	public Pattern getSubscriptionPattern() {
+		return subscriptionPattern;
+	}
+
+	public void setSubscriptionPattern(Pattern subscriptionPattern) {
+		this.subscriptionPattern = subscriptionPattern;
+		this.type = TYPE.PATTERN;
+	}
+
+	public TYPE getType() {
+		return type;
+	}
+
+	public void setType(TYPE type) {
+		this.type = type;
+	}
+
+}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaTopicDescriptor.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaTopicDescriptor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.descriptors;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -88,4 +89,23 @@ public class KafkaTopicDescriptor {
 		this.type = type;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		KafkaTopicDescriptor that = (KafkaTopicDescriptor) o;
+		return Objects.equals(topic, that.topic) &&
+			Objects.equals(topics, that.topics) &&
+			Objects.equals(subscriptionPattern, that.subscriptionPattern) &&
+			type == that.type;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(topic, topics, subscriptionPattern, type);
+	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
@@ -31,7 +31,7 @@ import static org.apache.flink.table.descriptors.DescriptorProperties.noValidati
  * The validator for {@link Kafka}.
  */
 @Internal
-public class KafkaValidator extends ConnectorDescriptorValidator {
+public abstract class KafkaValidator extends ConnectorDescriptorValidator {
 
 	public static final String CONNECTOR_TYPE_VALUE_KAFKA = "kafka";
 	public static final String CONNECTOR_VERSION_VALUE_08 = "0.8";
@@ -40,6 +40,8 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 	public static final String CONNECTOR_VERSION_VALUE_011 = "0.11";
 	public static final String CONNECTOR_VERSION_VALUE_UNIVERSAL = "universal";
 	public static final String CONNECTOR_TOPIC = "connector.topic";
+	public static final String CONNECTOR_TOPICS = "connector.topics";
+	public static final String CONNECTOR_SUBSCRIPTION_PATTERN = "connector.subscription-pattern";
 	public static final String CONNECTOR_STARTUP_MODE = "connector.startup-mode";
 	public static final String CONNECTOR_STARTUP_MODE_VALUE_EARLIEST = "earliest-offset";
 	public static final String CONNECTOR_STARTUP_MODE_VALUE_LATEST = "latest-offset";
@@ -62,7 +64,7 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 		super.validate(properties);
 		properties.validateValue(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE_KAFKA, false);
 
-		properties.validateString(CONNECTOR_TOPIC, false, 1, Integer.MAX_VALUE);
+		validateTopicSetting(properties);
 
 		validateStartupMode(properties);
 
@@ -70,6 +72,11 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 
 		validateSinkPartitioner(properties);
 	}
+
+	/**
+	 * Different validate rules for Kafka consumer or producer.
+	 */
+	public abstract void validateTopicSetting(DescriptorProperties properties);
 
 	private void validateStartupMode(DescriptorProperties properties) {
 		final Map<String, Consumer<String>> specificOffsetValidators = new HashMap<>();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -36,10 +36,7 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartiti
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
-import org.apache.flink.table.descriptors.Kafka;
-import org.apache.flink.table.descriptors.Rowtime;
-import org.apache.flink.table.descriptors.Schema;
-import org.apache.flink.table.descriptors.TestTableDescriptor;
+import org.apache.flink.table.descriptors.*;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
 import org.apache.flink.table.factories.StreamTableSourceFactory;
 import org.apache.flink.table.factories.TableFactoryService;
@@ -118,6 +115,9 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		fieldMapping.put(NAME, NAME);
 		fieldMapping.put(COUNT, COUNT);
 		fieldMapping.put(TIME, TIME);
+		
+		final KafkaTopicDescriptor kafkaTopicDescriptor = new KafkaTopicDescriptor();
+		kafkaTopicDescriptor.setTopic(TOPIC);
 
 		final Map<KafkaTopicPartition, Long> specificOffsets = new HashMap<>();
 		specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_0), OFFSET_0);
@@ -132,12 +132,13 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 				.toRowType()
 		);
 
+		// TODO: 2019/8/3 add more test for topics and subscriptionPattern
 		final KafkaTableSourceBase expected = getExpectedKafkaTableSource(
 			schema,
 			Optional.of(PROC_TIME),
 			rowtimeAttributeDescriptors,
 			fieldMapping,
-			TOPIC,
+			kafkaTopicDescriptor,
 			KAFKA_PROPERTIES,
 			deserializationSchema,
 			StartupMode.SPECIFIC_OFFSETS,
@@ -285,7 +286,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		Optional<String> proctimeAttribute,
 		List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 		Map<String, String> fieldMapping,
-		String topic,
+		KafkaTopicDescriptor kafkaTopicDescriptor,
 		Properties properties,
 		DeserializationSchema<Row> deserializationSchema,
 		StartupMode startupMode,

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -36,7 +36,11 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartiti
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
-import org.apache.flink.table.descriptors.*;
+import org.apache.flink.table.descriptors.Kafka;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
+import org.apache.flink.table.descriptors.Rowtime;
+import org.apache.flink.table.descriptors.Schema;
+import org.apache.flink.table.descriptors.TestTableDescriptor;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
 import org.apache.flink.table.factories.StreamTableSourceFactory;
 import org.apache.flink.table.factories.TableFactoryService;
@@ -115,7 +119,6 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		fieldMapping.put(NAME, NAME);
 		fieldMapping.put(COUNT, COUNT);
 		fieldMapping.put(TIME, TIME);
-		
 		final KafkaTopicDescriptor kafkaTopicDescriptor = new KafkaTopicDescriptor();
 		kafkaTopicDescriptor.setTopic(TOPIC);
 
@@ -132,7 +135,6 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 				.toRowType()
 		);
 
-		// TODO: 2019/8/3 add more test for topics and subscriptionPattern
 		final KafkaTableSourceBase expected = getExpectedKafkaTableSource(
 			schema,
 			Optional.of(PROC_TIME),

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.descriptors;
 
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
+
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.descriptors;
 
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -68,8 +69,7 @@ public class KafkaTest extends DescriptorTestBase {
 			new Kafka()
 				.version("0.11")
 				.topic("MyTable")
-				.startFromEarliest()
-				.topic("WhateverTopic");
+				.startFromEarliest();
 
 		final Descriptor specificConsumerTopicsDesc =
 			new Kafka()
@@ -129,25 +129,25 @@ public class KafkaTest extends DescriptorTestBase {
 		props3.put("connector.sink-partitioner-class", FlinkFixedPartitioner.class.getName());
 
 		final Map<String, String> props4 = new HashMap<>();
-		props1.put("connector.property-version", "1");
-		props1.put("connector.type", "kafka");
-		props1.put("connector.version", "0.11");
-		props1.put("connector.topic", "MyTable");
-		props1.put("connector.startup-mode", "earliest-offset");
+		props4.put("connector.property-version", "1");
+		props4.put("connector.type", "kafka");
+		props4.put("connector.version", "0.11");
+		props4.put("connector.topic", "MyTable");
+		props4.put("connector.startup-mode", "earliest-offset");
 
 		final Map<String, String> props5 = new HashMap<>();
-		props1.put("connector.property-version", "1");
-		props1.put("connector.type", "kafka");
-		props1.put("connector.version", "0.11");
-		props1.put("connector.topics", "MyTable1,MyTable2,MyTable3");
-		props1.put("connector.startup-mode", "earliest-offset");
+		props5.put("connector.property-version", "1");
+		props5.put("connector.type", "kafka");
+		props5.put("connector.version", "0.11");
+		props5.put("connector.topics", "MyTable1,MyTable2,MyTable3");
+		props5.put("connector.startup-mode", "earliest-offset");
 
 		final Map<String, String> props6 = new HashMap<>();
-		props1.put("connector.property-version", "1");
-		props1.put("connector.type", "kafka");
-		props1.put("connector.version", "0.11");
-		props1.put("connector.subscription-pattern", "MyTable*");
-		props1.put("connector.startup-mode", "earliest-offset");
+		props6.put("connector.property-version", "1");
+		props6.put("connector.type", "kafka");
+		props6.put("connector.version", "0.11");
+		props6.put("connector.subscription-pattern", "MyTable*");
+		props6.put("connector.startup-mode", "earliest-offset");
 
 		return Arrays.asList(props1, props2, props3, props4, props5, props6);
 	}
@@ -156,4 +156,34 @@ public class KafkaTest extends DescriptorTestBase {
 	public DescriptorValidator validator() {
 		return new KafkaConsumerValidator();
 	}
+
+	@Test(expected = org.apache.flink.table.api.ValidationException.class)
+	public void testInvalidTopicSetting() {
+		final Map<String, String> props = new HashMap<>();
+		props.put("connector.property-version", "1");
+		props.put("connector.type", "kafka");
+		props.put("connector.version", "0.11");
+		props.put("connector.topic", "MyTable");
+		props.put("connector.topics", "MyTable1,MyTable2,MyTable3");
+		props.put("connector.startup-mode", "earliest-offset");
+
+		final DescriptorProperties properties = new DescriptorProperties();
+		properties.putProperties(props);
+		validator().validate(properties);
+	}
+
+	@Test(expected = org.apache.flink.table.api.ValidationException.class)
+	public void testInvalidSubscriptionPatternSetting() {
+		final Map<String, String> props = new HashMap<>();
+		props.put("connector.property-version", "1");
+		props.put("connector.type", "kafka");
+		props.put("connector.version", "0.11");
+		props.put("connector.subscription-pattern", "MyTable[");
+		props.put("connector.startup-mode", "earliest-offset");
+
+		final DescriptorProperties properties = new DescriptorProperties();
+		properties.putProperties(props);
+		validator().validate(properties);
+	}
+
 }

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
@@ -64,7 +64,27 @@ public class KafkaTest extends DescriptorTestBase {
 				.properties(properties)
 				.sinkPartitionerCustom(FlinkFixedPartitioner.class);
 
-		return Arrays.asList(earliestDesc, specificOffsetsDesc, specificOffsetsMapDesc);
+		final Descriptor specificConsumerTopicDesc =
+			new Kafka()
+				.version("0.11")
+				.topic("MyTable")
+				.startFromEarliest()
+				.topic("WhateverTopic");
+
+		final Descriptor specificConsumerTopicsDesc =
+			new Kafka()
+				.version("0.11")
+				.topics("MyTable1", "MyTable2", "MyTable3")
+				.startFromEarliest();
+
+		final Descriptor specificConsumerPatternDesc =
+			new Kafka()
+				.version("0.11")
+				.subscriptionPattern("MyTable*")
+				.startFromEarliest();
+
+		return Arrays.asList(earliestDesc, specificOffsetsDesc, specificOffsetsMapDesc,
+			specificConsumerTopicDesc, specificConsumerTopicsDesc, specificConsumerPatternDesc);
 	}
 
 	@Override
@@ -108,11 +128,32 @@ public class KafkaTest extends DescriptorTestBase {
 		props3.put("connector.sink-partitioner", "custom");
 		props3.put("connector.sink-partitioner-class", FlinkFixedPartitioner.class.getName());
 
-		return Arrays.asList(props1, props2, props3);
+		final Map<String, String> props4 = new HashMap<>();
+		props1.put("connector.property-version", "1");
+		props1.put("connector.type", "kafka");
+		props1.put("connector.version", "0.11");
+		props1.put("connector.topic", "MyTable");
+		props1.put("connector.startup-mode", "earliest-offset");
+
+		final Map<String, String> props5 = new HashMap<>();
+		props1.put("connector.property-version", "1");
+		props1.put("connector.type", "kafka");
+		props1.put("connector.version", "0.11");
+		props1.put("connector.topics", "MyTable1,MyTable2,MyTable3");
+		props1.put("connector.startup-mode", "earliest-offset");
+
+		final Map<String, String> props6 = new HashMap<>();
+		props1.put("connector.property-version", "1");
+		props1.put("connector.type", "kafka");
+		props1.put("connector.version", "0.11");
+		props1.put("connector.subscription-pattern", "MyTable*");
+		props1.put("connector.startup-mode", "earliest-offset");
+
+		return Arrays.asList(props1, props2, props3, props4, props5, props6);
 	}
 
 	@Override
 	public DescriptorValidator validator() {
-		return new KafkaValidator();
+		return new KafkaConsumerValidator();
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -53,7 +54,7 @@ public class KafkaTableSourceSinkFactory extends KafkaTableSourceSinkFactoryBase
 		Optional<String> proctimeAttribute,
 		List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 		Map<String, String> fieldMapping,
-		String topic,
+		KafkaTopicDescriptor kafkaTopicDescriptor,
 		Properties properties,
 		DeserializationSchema<Row> deserializationSchema,
 		StartupMode startupMode,
@@ -64,7 +65,7 @@ public class KafkaTableSourceSinkFactory extends KafkaTableSourceSinkFactoryBase
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.KafkaTopicDescriptor;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.types.Row;
@@ -59,7 +60,7 @@ public class KafkaTableSourceSinkFactoryTest extends KafkaTableSourceSinkFactory
 		Optional<String> proctimeAttribute,
 		List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
 		Map<String, String> fieldMapping,
-		String topic,
+		KafkaTopicDescriptor kafkaTopicDescriptor,
 		Properties properties,
 		DeserializationSchema<Row> deserializationSchema,
 		StartupMode startupMode,
@@ -70,7 +71,7 @@ public class KafkaTableSourceSinkFactoryTest extends KafkaTableSourceSinkFactory
 			proctimeAttribute,
 			rowtimeAttributeDescriptors,
 			Optional.of(fieldMapping),
-			topic,
+			kafkaTopicDescriptor,
 			properties,
 			deserializationSchema,
 			startupMode,


### PR DESCRIPTION
## What is the purpose of the change
This pull request enable Flink Kafka table enable more topic option:

```
          new Kafka()
          .version("0.11")
          .topic("test-flink-1")
 //       .subscriptionPattern("test-flink-.*")
//        .topics("test-flink-1", "test-flink-2")
          .startFromEarliest()
          .property("zookeeper.connect", "sap-zookeeper1:2181")
          .property("bootstrap.servers", "sap-kafka1:9092"))
```

any one of 'topic', 'topics', 'subscriptionPattern' is functional.

## Brief change log

  - *Implement a new Class 'KafkaTopicDescriptor' to describe the Kafka topic option*
  - *Implement 'KafkaConsumerValidator' and 'KafkaProducerValidator' instead of one single 'KafkaValidator' to valid the consumer topic setting and producer setting*
  - *Implement the consumer function with help of 'KafkaConsumer' of different Kafka version*

## Verifying this change

This change is already covered by existing tests, such as *KafkaTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  yes 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  don't know
  - The runtime per-record code paths (performance sensitive):  no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no 
  - The S3 file system connector:  no 

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  JavaDocs
