### PR TITLE
[FLINK-13584][table-planner-blink] RankLikeAggFunctionBase should respect type to construct literal

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverWindowITCase.scala
@@ -292,6 +292,31 @@ class OverWindowITCase extends BatchTestBase {
   }
 
   @Test
+  def testRankByDecimal(): Unit = {
+    checkResult(
+      "SELECT d, de, rank() over (order by de desc), dense_rank() over (order by de desc) FROM" +
+          " (select d, cast(e as decimal(10, 0)) as de from Table5)",
+      Seq(
+        row(5, 15, 1, 1),
+        row(5, 14, 2, 2),
+        row(5, 13, 3, 3),
+        row(5, 12, 4, 4),
+        row(5, 11, 5, 5),
+        row(4, 10, 6, 6),
+        row(4, 9, 7, 7),
+        row(4, 8, 8, 8),
+        row(4, 7, 9, 9),
+        row(3, 6, 10, 10),
+        row(3, 5, 11, 11),
+        row(3, 4, 12, 12),
+        row(2, 3, 13, 13),
+        row(2, 2, 14, 14),
+        row(1, 1, 15, 15)
+      )
+    )
+  }
+
+  @Test
   def testWindowAggregationRank3(): Unit = {
 
     checkResult(


### PR DESCRIPTION

## What is the purpose of the change

Should invoke "valueLiteral(value, fromLogicalTypeToDataType(orderType))" instead of valueLiteral(value). Previous way will lose precision information of decimal type.

## Verifying this change

OverWindowITCase.testRankByDecimal

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no