### PR TITLE
[FLINK-13593][checkpointing] Prevent failing the wrong execution attempt in CheckpointFailureManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -21,7 +21,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -52,7 +51,7 @@ public class CheckpointFailureManager {
 	}
 
 	/**
-	 * Handle checkpoint exception with a handler callback.
+	 * Handle job level checkpoint exception with a handler callback.
 	 *
 	 * @param exception the checkpoint exception.
 	 * @param checkpointId the failed checkpoint id used to count the continuous failure number based on
@@ -60,12 +59,16 @@ public class CheckpointFailureManager {
 	 *                     happens before the checkpoint id generation. In this case, it will be specified a negative
 	 *                      latest generated checkpoint id as a special flag.
 	 */
-	public void handleCheckpointException(CheckpointException exception, long checkpointId) {
-		handleCheckpointException(exception, checkpointId, null);
+	public void handleJobLevelCheckpointException(CheckpointException exception, long checkpointId) {
+		checkFailureCounter(exception, checkpointId);
+		if (continuousFailureCounter.get() > tolerableCpFailureNumber) {
+			clearCount();
+			failureCallback.failJob(new FlinkRuntimeException("Exceeded checkpoint tolerable failure threshold."));
+		}
 	}
 
 	/**
-	 * Handle checkpoint exception with a handler callback.
+	 * Handle task level checkpoint exception with a handler callback.
 	 *
 	 * @param exception the checkpoint exception.
 	 * @param checkpointId the failed checkpoint id used to count the continuous failure number based on
@@ -74,10 +77,20 @@ public class CheckpointFailureManager {
 	 *                      latest generated checkpoint id as a special flag.
 	 * @param executionAttemptID the execution attempt id, as a safe guard.
 	 */
-	public void handleCheckpointException(
+	public void handleTaskLevelCheckpointException(
 			CheckpointException exception,
 			long checkpointId,
-			@Nullable ExecutionAttemptID executionAttemptID) {
+			ExecutionAttemptID executionAttemptID) {
+		checkFailureCounter(exception, checkpointId);
+		if (continuousFailureCounter.get() > tolerableCpFailureNumber) {
+			clearCount();
+			failureCallback.failJobDueToTaskFailure(new FlinkRuntimeException("Exceeded checkpoint tolerable failure threshold."), executionAttemptID);
+		}
+	}
+
+	public void checkFailureCounter(
+			CheckpointException exception,
+			long checkpointId) {
 		if (tolerableCpFailureNumber == UNLIMITED_TOLERABLE_FAILURE_NUMBER) {
 			return;
 		}
@@ -120,11 +133,6 @@ public class CheckpointFailureManager {
 
 			default:
 				throw new FlinkRuntimeException("Unknown checkpoint failure reason : " + reason.name());
-		}
-
-		if (continuousFailureCounter.get() > tolerableCpFailureNumber) {
-			clearCount();
-			failureCallback.failJob(new FlinkRuntimeException("Exceeded checkpoint tolerable failure threshold."), executionAttemptID);
 		}
 	}
 
@@ -173,19 +181,17 @@ public class CheckpointFailureManager {
 		/**
 		 * Fails the whole job graph.
 		 *
-		 * @param cause The reason why the job is cancelled.
+		 * @param cause The reason why the synchronous savepoint fails.
 		 */
-		default void failJob(final Throwable cause) {
-			failJob(cause, null);
-		}
+		default void failJob(final Throwable cause){}
 
 		/**
-		 * Fails the whole job graph.
+		 * Fails the whole job graph due to task failure.
 		 *
 		 * @param cause The reason why the job is cancelled.
-		 * @param failingAttempt The failing attempt id to prevent failing the wrong job.
+		 * @param failingTask The id of the failing task attempt to prevent failing the job multiple times.
 		 */
-		void failJob(final Throwable cause, @Nullable final ExecutionAttemptID failingAttempt);
+		default void failJobDueToTaskFailure(final Throwable cause, final ExecutionAttemptID failingTask){}
 
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -75,9 +75,9 @@ public class CheckpointFailureManager {
 	 * @param executionAttemptID the execution attempt id, as a safe guard.
 	 */
 	public void handleCheckpointException(
-		CheckpointException exception,
-		long checkpointId,
-		@Nullable ExecutionAttemptID executionAttemptID) {
+			CheckpointException exception,
+			long checkpointId,
+			@Nullable ExecutionAttemptID executionAttemptID) {
 		if (tolerableCpFailureNumber == UNLIMITED_TOLERABLE_FAILURE_NUMBER) {
 			return;
 		}
@@ -154,7 +154,7 @@ public class CheckpointFailureManager {
 	 * */
 	void handleSynchronousSavepointFailure(final Throwable cause) {
 		if (!isPreFlightFailure(cause)) {
-			failureCallback.failJob(cause, null);
+			failureCallback.failJob(cause);
 		}
 	}
 
@@ -169,6 +169,15 @@ public class CheckpointFailureManager {
 	 * A callback interface about how to fail a job.
 	 */
 	public interface FailJobCallback {
+
+		/**
+		 * Fails the whole job graph.
+		 *
+		 * @param cause The reason why the job is cancelled.
+		 */
+		default void failJob(final Throwable cause) {
+			failJob(cause, null);
+		}
 
 		/**
 		 * Fails the whole job graph.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -183,7 +183,7 @@ public class CheckpointFailureManager {
 		 *
 		 * @param cause The reason why the synchronous savepoint fails.
 		 */
-		default void failJob(final Throwable cause){}
+		void failJob(final Throwable cause);
 
 		/**
 		 * Fails the whole job graph due to task failure.
@@ -191,7 +191,7 @@ public class CheckpointFailureManager {
 		 * @param cause The reason why the job is cancelled.
 		 * @param failingTask The id of the failing task attempt to prevent failing the job multiple times.
 		 */
-		default void failJobDueToTaskFailure(final Throwable cause, final ExecutionAttemptID failingTask){}
+		void failJobDueToTaskFailure(final Throwable cause, final ExecutionAttemptID failingTask);
 
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -66,7 +66,9 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 
 		final long triggerTimestamp = 1L;
 
-		CheckpointFailureManager failureManager = new CheckpointFailureManager(0, (throwable, attemptID) -> {});
+		CheckpointFailureManager failureManager = new CheckpointFailureManager(
+			0,
+			new CheckpointFailureManager.FailJobCallback() {});
 
 		// set up the coordinator and validate the initial state
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -66,7 +66,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 
 		final long triggerTimestamp = 1L;
 
-		CheckpointFailureManager failureManager = new CheckpointFailureManager(0, throwable -> {});
+		CheckpointFailureManager failureManager = new CheckpointFailureManager(0, (throwable, attemptID) -> {});
 
 		// set up the coordinator and validate the initial state
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -68,7 +68,13 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(
 			0,
-			new CheckpointFailureManager.FailJobCallback() {});
+			new CheckpointFailureManager.FailJobCallback() {
+				@Override
+				public void failJob(Throwable cause) {}
+
+				@Override
+				public void failJobDueToTaskFailure(Throwable cause, ExecutionAttemptID failingTask) {}
+			});
 
 		// set up the coordinator and validate the initial state
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -442,7 +442,8 @@ public class CheckpointCoordinatorMasterHooksTest {
 				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY,
-				new CheckpointFailureManager(0, (throwable, attemptID) -> {}));
+				new CheckpointFailureManager(0, new CheckpointFailureManager.FailJobCallback() {})
+		);
 	}
 
 	private static <T> T mockGeneric(Class<?> clazz) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -442,7 +442,15 @@ public class CheckpointCoordinatorMasterHooksTest {
 				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY,
-				new CheckpointFailureManager(0, new CheckpointFailureManager.FailJobCallback() {})
+				new CheckpointFailureManager(
+					0,
+					new CheckpointFailureManager.FailJobCallback() {
+						@Override
+						public void failJob(Throwable cause) {}
+
+						@Override
+						public void failJobDueToTaskFailure(Throwable cause, ExecutionAttemptID failingTask) {}
+				})
 		);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -442,7 +442,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY,
-				new CheckpointFailureManager(0, throwable -> {}));
+				new CheckpointFailureManager(0, (throwable, attemptID) -> {}));
 	}
 
 	private static <T> T mockGeneric(Class<?> clazz) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -128,7 +128,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(0, new CheckpointFailureManager.FailJobCallback() {
+		failureManager = new CheckpointFailureManager(
+			0,
+			new CheckpointFailureManager.FailJobCallback() {
+				@Override
+				public void failJob(Throwable cause) {}
+
+				@Override
+				public void failJobDueToTaskFailure(Throwable cause, ExecutionAttemptID failingTask) {}
 		});
 	}
 
@@ -3929,6 +3936,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 							invocationCounterAndException.f0 += 1;
 							invocationCounterAndException.f1 = cause;
 						}
+
+						@Override
+						public void failJobDueToTaskFailure(Throwable cause, ExecutionAttemptID failingTask) {}
 					}));
 
 		final CompletableFuture<CompletedCheckpoint> savepointFuture = coordinator

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -128,7 +128,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(0, throwable -> {});
+		failureManager = new CheckpointFailureManager(0, (throwable,attemptID) -> {});
 	}
 
 	@Test
@@ -327,7 +327,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		final String errorMsg = "Exceeded checkpoint failure tolerance number!";
 
-		CheckpointFailureManager checkpointFailureManager = new CheckpointFailureManager(0, throwable -> {
+		CheckpointFailureManager checkpointFailureManager = new CheckpointFailureManager(0, (throwable, attemptID) -> {
 			throw new RuntimeException(errorMsg);
 		});
 
@@ -3910,7 +3910,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		// set up the coordinator and validate the initial state
 		final CheckpointCoordinator coordinator = getCheckpointCoordinator(jobId, vertex1, vertex2,
-				new CheckpointFailureManager(0, throwable -> {
+				new CheckpointFailureManager(0, (throwable, attemptID) -> {
 					invocationCounterAndException.f0 += 1;
 					invocationCounterAndException.f1 = throwable;
 				}));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -34,15 +34,15 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
 
-		failureManager.handleCheckpointException(new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 1);
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 1);
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
 
 		//ignore this
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), 3);
 
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 4);
 		assertEquals(1, callback.getInvokeCounter());
 	}
@@ -52,18 +52,18 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
 
-		failureManager.handleCheckpointException(new CheckpointException(CheckpointFailureReason.EXCEPTION), 1);
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.EXCEPTION), 1);
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
 
 		//ignore this
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), 3);
 
 		//reset
 		failureManager.handleCheckpointSuccess(4);
 
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.CHECKPOINT_EXPIRED), 5);
 		assertEquals(0, callback.getInvokeCounter());
 	}
@@ -73,7 +73,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(0, callback);
 		for (CheckpointFailureReason reason : CheckpointFailureReason.values()) {
-			failureManager.handleCheckpointException(new CheckpointException(reason), -1);
+			failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), -1);
 		}
 
 		assertEquals(1, callback.getInvokeCounter());
@@ -84,16 +84,16 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
 
-		failureManager.handleCheckpointException(new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 1);
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 1);
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
 
 		//ignore this
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), 3);
 
 		//ignore repeatedly report from one checkpoint
-		failureManager.handleCheckpointException(
+		failureManager.handleJobLevelCheckpointException(
 			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
 		assertEquals(0, callback.getInvokeCounter());
 	}
@@ -106,7 +106,12 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		private int invokeCounter = 0;
 
 		@Override
-		public void failJob(final Throwable cause, final ExecutionAttemptID executionAttemptID) {
+		public void failJob(Throwable cause) {
+			invokeCounter++;
+		}
+
+		@Override
+		public void failJobDueToTaskFailure(final Throwable cause, final ExecutionAttemptID executionAttemptID) {
 			invokeCounter++;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -105,7 +106,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		private int invokeCounter = 0;
 
 		@Override
-		public void failJob(final Throwable cause) {
+		public void failJob(final Throwable cause, final ExecutionAttemptID executionAttemptID) {
 			invokeCounter++;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -67,7 +67,15 @@ public class CheckpointStateRestoreTest {
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(0, new CheckpointFailureManager.FailJobCallback() {});
+		failureManager = new CheckpointFailureManager(
+			0,
+			new CheckpointFailureManager.FailJobCallback() {
+				@Override
+				public void failJob(Throwable cause) {}
+
+				@Override
+				public void failJobDueToTaskFailure(Throwable cause, ExecutionAttemptID failingTask) {}
+			});
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -67,7 +67,7 @@ public class CheckpointStateRestoreTest {
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(0, (throwable, attemptID) -> {});
+		failureManager = new CheckpointFailureManager(0, new CheckpointFailureManager.FailJobCallback() {});
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -67,7 +67,7 @@ public class CheckpointStateRestoreTest {
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(0, throwable -> {});
+		failureManager = new CheckpointFailureManager(0, (throwable, attemptID) -> {});
 	}
 
 	/**


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes the issue as reported in FLINK_13593, that due to the asynchronously handling of checkpoint decline message in `LegacyScheduler#declineCheckpoint`, it's possible that the message is handled before job status transition thus `receiveDeclineMessage` grabbed the lock in `CheckpointCoordinator` before `pendingCheckpoints` got cleared by `stopCheckpointScheduler` (as triggered by the job status listener `CheckpointCoordinatorDeActivator`). If the job/tasks restarts quickly enough, the FailJobCallback in CheckpointFailureManager might unexpectedly fail the job again.

## Brief change log

Add a safe guard when failing the job, passing through the `ExecutionAttemptID` and checking against the current executions to make sure the to-be-failed one is still running, so we won't fail the newly restarted one by accident.


## Verifying this change

The issue is revealed by the unstable failure of `KafkaProducerExactlyOnceITCase` thus is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
