### PR TITLE
[FLINK-13592][e2e] Fix hardcoded flink version in tpch end-to-end test.

### DIFF
--- a/flink-end-to-end-tests/flink-tpch-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpch-test/pom.xml
@@ -54,6 +54,22 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>TpchTestProgram</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>TpchTestProgram</finalName>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-end-to-end-tests/test-scripts/test_tpch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpch.sh
@@ -72,6 +72,7 @@ execution:
   planner: blink
   type: batch
   result-mode: table
+  parallelism: 2
 EOF
 
     if [[ -e "$MODIFIED_QUERY_DIR/q$i.sql" ]]

--- a/flink-end-to-end-tests/test-scripts/test_tpch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpch.sh
@@ -72,7 +72,6 @@ execution:
   planner: blink
   type: batch
   result-mode: table
-  parallelism: 2
 EOF
 
     if [[ -e "$MODIFIED_QUERY_DIR/q$i.sql" ]]

--- a/flink-end-to-end-tests/test-scripts/test_tpch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpch.sh
@@ -31,9 +31,7 @@ echo "Generating test data..."
 
 TARGET_DIR="$END_TO_END_DIR/flink-tpch-test/target"
 TPCH_DATA_DIR="$END_TO_END_DIR/test-scripts/test-data/tpch"
-FLINK_VERSION=`ls "${END_TO_END_DIR}/../flink-table/flink-table-api-java/target" | sed -n "s/.*flink-table-api-java-\(.*\)-tests\.jar/\1/p" | uniq`
-
-java -cp "$TARGET_DIR/flink-tpch-test-"$FLINK_VERSION".jar:$TARGET_DIR/lib/*" org.apache.flink.table.tpch.TpchDataGenerator "$SCALE" "$TARGET_DIR"
+java -cp "$TARGET_DIR/TpchTestProgram.jar:$TARGET_DIR/lib/*" org.apache.flink.table.tpch.TpchDataGenerator "$SCALE" "$TARGET_DIR"
 
 ################################################################################
 # Prepare Flink
@@ -90,5 +88,5 @@ EOF
 
     wait_job_terminal_state "$JOB_ID" "FINISHED"
 
-    java -cp "$TARGET_DIR/flink-tpch-test-"$FLINK_VERSION".jar" org.apache.flink.table.tpch.TpchResultComparator "$EXPECTED_DIR/q$i.csv" "$RESULT_DIR/q$i.csv"
+    java -cp "$TARGET_DIR/TpchTestProgram.jar" org.apache.flink.table.tpch.TpchResultComparator "$EXPECTED_DIR/q$i.csv" "$RESULT_DIR/q$i.csv"
 done

--- a/flink-end-to-end-tests/test-scripts/test_tpch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpch.sh
@@ -31,7 +31,9 @@ echo "Generating test data..."
 
 TARGET_DIR="$END_TO_END_DIR/flink-tpch-test/target"
 TPCH_DATA_DIR="$END_TO_END_DIR/test-scripts/test-data/tpch"
-java -cp "$TARGET_DIR/flink-tpch-test-1.10-SNAPSHOT.jar:$TARGET_DIR/lib/*" org.apache.flink.table.tpch.TpchDataGenerator "$SCALE" "$TARGET_DIR"
+FLINK_VERSION=`ls "${END_TO_END_DIR}/../flink-table/flink-table-api-java/target" | sed -n "s/.*flink-table-api-java-\(.*\)-tests\.jar/\1/p" | uniq`
+
+java -cp "$TARGET_DIR/flink-tpch-test-"$FLINK_VERSION".jar:$TARGET_DIR/lib/*" org.apache.flink.table.tpch.TpchDataGenerator "$SCALE" "$TARGET_DIR"
 
 ################################################################################
 # Prepare Flink
@@ -72,6 +74,7 @@ execution:
   planner: blink
   type: batch
   result-mode: table
+  parallelism: 2
 EOF
 
     if [[ -e "$MODIFIED_QUERY_DIR/q$i.sql" ]]
@@ -87,5 +90,5 @@ EOF
 
     wait_job_terminal_state "$JOB_ID" "FINISHED"
 
-    java -cp "$TARGET_DIR/flink-tpch-test-1.10-SNAPSHOT.jar" org.apache.flink.table.tpch.TpchResultComparator "$EXPECTED_DIR/q$i.csv" "$RESULT_DIR/q$i.csv"
+    java -cp "$TARGET_DIR/flink-tpch-test-"$FLINK_VERSION".jar" org.apache.flink.table.tpch.TpchResultComparator "$EXPECTED_DIR/q$i.csv" "$RESULT_DIR/q$i.csv"
 done


### PR DESCRIPTION
## What is the purpose of the change

- Fix hardcoded flink version in tpch end-to-end test.

## Brief change log

- Use auto fetched flink version in tpch end-to-end test.
- Changes test parallelism to 2 to cover the situation that parallelism is higher than the slot number, since the testing cluster only have one task manager and contains only one slot.


## Verifying this change

Tested on a linux server and passed. 

