### PR TITLE
[FLINK-10368] Harden Docker-based Kerberos/YARN e2e test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
@@ -162,6 +162,13 @@ function copy_and_show_logs {
     done
     echo "Docker logs:"
     docker logs master
+
+    echo "Flink logs:"
+    docker exec -it master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
+    application_id=`docker exec -it master bash -c "yarn application -list -appStates ALL" | grep "Flink session cluster" | awk '{print \$1}'`
+    echo "Application ID: $application_id"
+    docker exec -it master bash -c "yarn logs -applicationId $application_id"
+    docker exec -it master bash -c "kdestroy"
 }
 
 start_time=$(date +%s)

--- a/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
@@ -139,7 +139,7 @@ docker exec -it master bash -c "tar xzf /home/hadoop-user/$FLINK_TARBALL --direc
 FLINK_CONFIG=$(cat << END
 security.kerberos.login.keytab: /home/hadoop-user/hadoop-user.keytab
 security.kerberos.login.principal: hadoop-user
-slot.request.timeout: 60000
+slot.request.timeout: 120000
 containerized.heap-cutoff-min: 100
 END
 )


### PR DESCRIPTION
## What is the purpose of the change

* harden the test to fix flakiness


## Brief change log

 * we now wait for YARN NodeManagers to be up to ensure that Flink has the required resources
 * we print to YARN logs of the Flink application to aid future debugging efforts
 * we increase the slot request timeout
  
## Verifying this change
I ran the test on Travis many times to provoke the instability.

 * This is a Travis run without the fix: https://travis-ci.org/aljoscha/flink/builds/565881922
 * This is with the fix: https://travis-ci.org/aljoscha/flink/builds/567768485

With the fix, there are no failures in the tests, only timeouts because Maven dependencies couldn't be fetched
