### PR TITLE
[FLINK-13581][coordination][tests] Harden BatchFineGrainedRecoveryITCase

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
@@ -26,10 +26,12 @@ import org.apache.flink.runtime.rest.messages.json.JobVertexIDDeserializer;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDSerializer;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -73,6 +75,11 @@ public class JobVertexDetailsInfo implements ResponseBody {
 		this.parallelism = parallelism;
 		this.now = now;
 		this.subtasks = checkNotNull(subtasks);
+	}
+
+	@JsonIgnore
+	public List<VertexTaskDetail> getSubtasks() {
+		return Collections.unmodifiableList(subtasks);
 	}
 
 	@Override
@@ -162,6 +169,11 @@ public class JobVertexDetailsInfo implements ResponseBody {
 			this.endTime = endTime;
 			this.duration = duration;
 			this.metrics = checkNotNull(metrics);
+		}
+
+		@JsonIgnore
+		public int getAttempt() {
+			return attempt;
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

If counting of mapper restarts in `BatchFineGrainedRecoveryITCase` is based on the open method of user function, the fact of the restart depends on internal implementation of the local Task and whether the open method is eventually called.

If execution attempt numbers are used instead, the test behaviour is more stable because it depends only on coordination. The execution attempt numbers can be queried from the REST client of the testing mini cluster.

## Brief change log

  - Introduce `MiniClusterClient` for `BatchFineGrainedRecoveryITCase` to query task attempts
  - Use mapper task attempt numbers instead of user function open method call counters

## Verifying this change

Run `BatchFineGrainedRecoveryITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
