### PR TITLE
[FLINK-13159] Prevent potential NPE of restored PojoSerializer when deserializing

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -123,7 +123,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 			this.fields[i].setAccessible(true);
 		}
 
-		cl = Thread.currentThread().getContextClassLoader();
+		this.cl = Thread.currentThread().getContextClassLoader();
 
 		// We only want those classes that are not our own class and are actually sub-classes.
 		LinkedHashSet<Class<?>> registeredSubclasses =
@@ -156,6 +156,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		this.registeredSerializers = checkNotNull(registeredSerializers);
 		this.subclassSerializerCache = checkNotNull(subclassSerializerCache);
 		this.executionConfig = checkNotNull(executionConfig);
+		this.cl = Thread.currentThread().getContextClassLoader();
 	}
 	
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -42,6 +42,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CyclicBarrier;
 
 import static org.junit.Assert.assertEquals;
@@ -83,6 +84,10 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 	protected abstract Class<T> getTypeClass();
 
 	protected abstract T[] getTestData();
+
+	protected boolean isObjectEquals(T originalObject, T deserializedObject) {
+		return Objects.equals(originalObject, deserializedObject);
+	}
 
 	// --------------------------------------------------------------------------------------------
 
@@ -162,6 +167,7 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			for (T datum : testData) {
 				serializer.serialize(datum, outView);
 			}
+			outView.flush();
 		}
 
 		final TypeSerializerSnapshot<T> configSnapshot = serializer.snapshotConfiguration();
@@ -172,7 +178,9 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			int length = inputView.readInt();
 			assertEquals(testData.length, length);
 			for (int i = 0; i < length; i++) {
-				assertEquals(testData[i], restoreSerializer.deserialize(inputView));
+				T datum = testData[i];
+				T deserialize = restoreSerializer.deserialize(inputView);
+				assertTrue(isObjectEquals(datum, deserialize));
 			}
 		}
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializerTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BooleanPrimitiveArraySerializer;
 import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
 
+import java.util.Arrays;
+
 /**
  * A test for the {@link LongPrimitiveArraySerializer}.
  */
@@ -50,5 +52,10 @@ public class BooleanPrimitiveArraySerializerTest extends SerializerTestBase<bool
 			new boolean[] {},
 			new boolean[] {false, true, false, false, false, false, true, false}
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(boolean[] originalArray, boolean[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
@@ -63,7 +64,12 @@ public class BytePrimitiveArraySerializerTest extends SerializerTestBase<byte[]>
 			new byte[] {}
 		};
 	}
-	
+
+	@Override
+	protected boolean isObjectEquals(byte[] originalArray, byte[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
+	}
+
 	private final byte[] randomByteArray() {
 		int len = rnd.nextInt(1024 * 1024);
 		byte[] data = new byte[len];

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializerTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.api.common.typeutils.base.array;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+import java.util.Arrays;
+
 /**
  * A test for the {@link LongPrimitiveArraySerializer}.
  */
@@ -48,5 +50,10 @@ public class CharPrimitiveArraySerializerTest extends SerializerTestBase<char[]>
 			new char[] {},
 			new char[] {100, 200, 315, 0, 17, 0, 0}
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(char[] originalArray, char[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializerTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.DoublePrimitiveArraySerializer;
 import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
 
+import java.util.Arrays;
+
 /**
  * A test for the {@link LongPrimitiveArraySerializer}.
  */
@@ -51,5 +53,10 @@ public class DoublePrimitiveArraySerializerTest extends SerializerTestBase<doubl
 			new double[] {},
 			new double[] {-1, -2, 96769243, Double.NaN, Double.POSITIVE_INFINITY, 26782, Double.MIN_NORMAL, 0, 0, 0}
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(double[] originalArray, double[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializerTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.FloatPrimitiveArraySerializer;
 import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
 
+import java.util.Arrays;
+
 /**
  * A test for the {@link LongPrimitiveArraySerializer}.
  */
@@ -51,5 +53,10 @@ public class FloatPrimitiveArraySerializerTest extends SerializerTestBase<float[
 			new float[] {},
 			new float[] {-1, -2, 96769243, Float.NaN, Float.POSITIVE_INFINITY, 26782, Float.MIN_NORMAL, 0, 0, 0}
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(float[] originalArray, float[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializerTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.IntPrimitiveArraySerializer;
 import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
 
+import java.util.Arrays;
+
 /**
  * A test for the {@link LongPrimitiveArraySerializer}.
  */
@@ -50,5 +52,10 @@ public class IntPrimitiveArraySerializerTest extends SerializerTestBase<int[]> {
 			new int[] {},
 			new int[] {-1, -2, 96769243, 26782, 0, 0, 0}
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(int[] originalArray, int[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializerTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
 
+import java.util.Arrays;
+
 /**
  * A test for the {@link LongPrimitiveArraySerializer}.
  */
@@ -49,5 +51,10 @@ public class LongPrimitiveArraySerializerTest extends SerializerTestBase<long[]>
 			new long[] {},
 			new long[] {-1, -2, 96769243, 26782, 0, 0, 0}
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(long[] originalArray, long[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializerTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
 import org.apache.flink.api.common.typeutils.base.array.ShortPrimitiveArraySerializer;
 
+import java.util.Arrays;
+
 /**
  * A test for the {@link LongPrimitiveArraySerializer}.
  */
@@ -50,5 +52,10 @@ public class ShortPrimitiveArraySerializerTest extends SerializerTestBase<short[
 			new short[] {},
 			new short[] {-1, -2, 9673, 26782, 0, 0, 0}
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(short[] originalArray, short[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
@@ -78,5 +79,10 @@ public class StringArraySerializerTest extends SerializerTestBase<String[]> {
 	public void arrayTypeIsMutable() {
 		StringArraySerializer serializer = (StringArraySerializer) createSerializer();
 		assertFalse(serializer.isImmutableType());
+	}
+
+	@Override
+	protected boolean isObjectEquals(String[] originalArray, String[] deserializedArray) {
+		return Arrays.equals(originalArray, deserializedArray);
 	}
 }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/ScalaSpecialTypesSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/ScalaSpecialTypesSerializerTest.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.api.scala.runtime
 
 import java.lang.{Boolean => JBoolean}
+import java.util
 import java.util.function.BiFunction
 
 import org.apache.flink.api.common.ExecutionConfig
@@ -231,6 +232,31 @@ class ScalaSpecialTypesSerializerTestInstance[T](
         e.printStackTrace()
         fail("Exception in test: " + e.getMessage)
       }
+    }
+  }
+
+  override protected def isObjectEquals(originalObject: T, deserializedObject: T): Boolean = {
+    originalObject match {
+      // 'scala.util.Failure' is not supported to directly compare with equals
+      case failure: Failure[Throwable] =>
+        deserializedObject match {
+          case value: Failure[Throwable] =>
+            failure.exception.getMessage.equals(value.exception.getMessage)
+          case _ => false
+        }
+      case array: Array[Int] =>
+        deserializedObject match {
+          case value: Array[Int] =>
+            util.Arrays.equals(array, value)
+          case _ => false
+        }
+      case array: Array[Object] =>
+        deserializedObject match {
+          case value: Array[Object] =>
+            util.Arrays.equals(array, value)
+          case _ => false
+        }
+      case _ => super.isObjectEquals(originalObject, deserializedObject)
     }
   }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -50,6 +50,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -424,6 +425,21 @@ public class CoGroupedStreams<T1, T2> {
 
 		public static <T1, T2> TaggedUnion<T1, T2> two(T2 two) {
 			return new TaggedUnion<>(null, two);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof TaggedUnion) {
+				TaggedUnion that = (TaggedUnion) obj;
+				return Objects.equals(one, that.one) && Objects.equals(two, that.two);
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			return 31 * Objects.hashCode(one) + Objects.hashCode(two);
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseArraySerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseArraySerializerTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.Objects;
 
 import static org.apache.flink.table.runtime.typeutils.SerializerTestUtil.MyObj;
 import static org.apache.flink.table.runtime.typeutils.SerializerTestUtil.MyObjSerializer;
@@ -48,6 +49,8 @@ import static org.junit.Assert.assertEquals;
  * A test for the {@link BaseArraySerializer}.
  */
 public class BaseArraySerializerTest extends SerializerTestBase<BaseArray> {
+
+	private final BaseArraySerializer baseArraySerializer;
 
 	public BaseArraySerializerTest() {
 		super(new DeeplyEqualsChecker().withCustomCheck(
@@ -72,6 +75,7 @@ public class BaseArraySerializerTest extends SerializerTestBase<BaseArray> {
 					return true;
 				}
 		));
+		this.baseArraySerializer = new BaseArraySerializer(DataTypes.STRING().getLogicalType(), new ExecutionConfig());
 	}
 
 	@Test
@@ -117,7 +121,7 @@ public class BaseArraySerializerTest extends SerializerTestBase<BaseArray> {
 
 	@Override
 	protected BaseArraySerializer createSerializer() {
-		return new BaseArraySerializer(DataTypes.STRING().getLogicalType(), new ExecutionConfig());
+		return baseArraySerializer;
 	}
 
 	@Override
@@ -139,6 +143,11 @@ public class BaseArraySerializerTest extends SerializerTestBase<BaseArray> {
 				createArray("11", "haa", "ke"),
 				createArray("11", "lele", "haa", "ke"),
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(BaseArray originalArray, BaseArray deserializedArray) {
+		return Objects.equals(baseArraySerializer.toBinaryArray(originalArray), baseArraySerializer.toBinaryArray(deserializedArray));
 	}
 
 	static BinaryArray createArray(String... vs) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseMapSerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseMapSerializerTest.java
@@ -42,6 +42,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.apache.flink.table.runtime.typeutils.SerializerTestUtil.MyObj;
 import static org.apache.flink.table.runtime.typeutils.SerializerTestUtil.MyObjSerializer;
@@ -55,6 +56,7 @@ public class BaseMapSerializerTest extends SerializerTestBase<BaseMap> {
 
 	private static final LogicalType INT = DataTypes.INT().getLogicalType();
 	private static final LogicalType STRING = DataTypes.STRING().getLogicalType();
+	private final BaseMapSerializer baseMapSerializer;
 
 	public BaseMapSerializerTest() {
 		super(new DeeplyEqualsChecker().withCustomCheck(
@@ -69,6 +71,7 @@ public class BaseMapSerializerTest extends SerializerTestBase<BaseMap> {
 						((BaseMap) o1).toJavaMap(INT, STRING)
 								.equals(((BaseMap) o2).toJavaMap(INT, STRING))
 		));
+		this.baseMapSerializer = new BaseMapSerializer(INT, STRING, new ExecutionConfig());
 	}
 
 	@Test
@@ -119,13 +122,9 @@ public class BaseMapSerializerTest extends SerializerTestBase<BaseMap> {
 			config);
 	}
 
-	private static BaseMapSerializer newSer() {
-		return new BaseMapSerializer(INT, STRING, new ExecutionConfig());
-	}
-
 	@Override
 	protected BaseMapSerializer createSerializer() {
-		return newSer();
+		return baseMapSerializer;
 	}
 
 	@Override
@@ -149,6 +148,11 @@ public class BaseMapSerializerTest extends SerializerTestBase<BaseMap> {
 				BinaryMap.valueOf(createArray(1, 4, 2), BaseArraySerializerTest.createArray("11", "haa", "ke")),
 				BinaryMap.valueOf(createArray(1, 5, 6, 7), BaseArraySerializerTest.createArray("11", "lele", "haa", "ke"))
 		};
+	}
+
+	@Override
+	protected boolean isObjectEquals(BaseMap originalMap, BaseMap deserializedMap) {
+		return Objects.equals(baseMapSerializer.toBinaryMap(originalMap), baseMapSerializer.toBinaryMap(deserializedMap));
 	}
 
 	private static BinaryArray createArray(int... vs) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializerTest.java
@@ -83,6 +83,11 @@ public class BaseRowSerializerTest extends SerializerTestInstance<BaseRow> {
 				testBaseRowSerializerWithComplexTypes());
 	}
 
+	@Override
+	protected boolean isObjectEquals(BaseRow originalRow, BaseRow deserializedRow) {
+		return Objects.equals(serializer.toBinaryRow(originalRow), serializer.toBinaryRow(deserializedRow));
+	}
+
 	private static Object[] testBaseRowSerializer() {
 		BaseRowTypeInfo typeInfo = new BaseRowTypeInfo(new IntType(), new VarCharType(VarCharType.MAX_LENGTH));
 		GenericRow row1 = new GenericRow(2);


### PR DESCRIPTION
## What is the purpose of the change

Prevent potential NPE when PojoSerializer restored.

## Brief change log

  - Ensure the `classloader` could be assigned when `PojoSerializer` restored.

## Verifying this change


This change added tests and can be verified as follows:

  - Added test `testRestoreSerializerDeserialize` into `SerializerTestBase` to ensure all restored serializes could deserialize values as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **yes**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**
## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
