### PR TITLE
[FLINK-13561][table-planner-blink] Verify and correct time function's semantic for Blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -782,10 +782,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		SqlKind.OTHER_FUNCTION,
 		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.FORCE_NULLABLE),
 		null,
-		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING,
-				SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
+		OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING),
 		SqlFunctionCategory.TIMEDATE);
 
 	public static final SqlFunction LOCATE = new SqlFunction(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -761,9 +761,8 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.TIMESTAMP), SqlTypeTransforms.FORCE_NULLABLE),
 		null,
 		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.NUMERIC),
-			OperandTypes.family(SqlTypeFamily.STRING),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
+			OperandTypes.family(SqlTypeFamily.CHARACTER),
+			OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)),
 		SqlFunctionCategory.TIMEDATE);
 
 	public static final SqlFunction TO_DATE = new SqlFunction(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -632,8 +632,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		OperandTypes.or(
 			OperandTypes.NILADIC,
 			OperandTypes.family(SqlTypeFamily.STRING),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING),
-			OperandTypes.family(SqlTypeFamily.TIMESTAMP)),
+			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
 		SqlFunctionCategory.TIMEDATE) {
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -659,38 +659,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 			OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.STRING)),
 		SqlFunctionCategory.TIMEDATE);
 
-	public static final SqlFunction DATEDIFF = new SqlFunction(
-		"DATEDIFF",
-		SqlKind.OTHER_FUNCTION,
-		ReturnTypes.INTEGER_NULLABLE,
-		null,
-		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.STRING),
-			OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.TIMESTAMP),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.TIMESTAMP),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
-		SqlFunctionCategory.TIMEDATE);
-
-	public static final SqlFunction DATE_SUB = new SqlFunction(
-		"DATE_SUB",
-		SqlKind.OTHER_FUNCTION,
-		VARCHAR_2000_NULLABLE,
-		null,
-		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.INTEGER),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER)),
-		SqlFunctionCategory.TIMEDATE);
-
-	public static final SqlFunction DATE_ADD = new SqlFunction(
-		"DATE_ADD",
-		SqlKind.OTHER_FUNCTION,
-		VARCHAR_2000_NULLABLE,
-		null,
-		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.INTEGER),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER)),
-		SqlFunctionCategory.TIMEDATE);
-
 	public static final SqlFunction IF = new SqlFunction(
 		"IF",
 		SqlKind.OTHER_FUNCTION,
@@ -800,14 +768,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
 		SqlFunctionCategory.TIMEDATE);
 
-	public static final SqlFunction FROM_TIMESTAMP = new SqlFunction(
-		"FROM_TIMESTAMP",
-		SqlKind.OTHER_FUNCTION,
-		ReturnTypes.cascade(ReturnTypes.BIGINT, SqlTypeTransforms.TO_NULLABLE),
-		null,
-		OperandTypes.family(SqlTypeFamily.TIMESTAMP),
-		SqlFunctionCategory.TIMEDATE);
-
 	public static final SqlFunction TO_DATE = new SqlFunction(
 		"TO_DATE",
 		SqlKind.OTHER_FUNCTION,
@@ -817,26 +777,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 			OperandTypes.family(SqlTypeFamily.NUMERIC),
 			OperandTypes.family(SqlTypeFamily.STRING),
 			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
-		SqlFunctionCategory.TIMEDATE);
-
-	public static final SqlFunction TO_TIMESTAMP_TZ = new SqlFunction(
-		"TO_TIMESTAMP_TZ",
-		SqlKind.OTHER_FUNCTION,
-		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.TIMESTAMP), SqlTypeTransforms.FORCE_NULLABLE),
-		null,
-		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
-		SqlFunctionCategory.TIMEDATE);
-
-	public static final SqlFunction DATE_FORMAT_TZ = new SqlFunction(
-		"DATE_FORMAT_TZ",
-		SqlKind.OTHER_FUNCTION,
-		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE),
-		InferTypes.RETURN_TYPE,
-		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.STRING, SqlTypeFamily.STRING),
-			OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.STRING)),
 		SqlFunctionCategory.TIMEDATE);
 
 	public static final SqlFunction CONVERT_TZ = new SqlFunction(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -771,7 +771,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.DATE), SqlTypeTransforms.FORCE_NULLABLE),
 		null,
 		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.NUMERIC),
 			OperandTypes.family(SqlTypeFamily.STRING),
 			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
 		SqlFunctionCategory.TIMEDATE);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -606,11 +606,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	public static final SqlFunction NOW = new SqlFunction(
 		"NOW",
 		SqlKind.OTHER_FUNCTION,
-		ReturnTypes.BIGINT,
+		ReturnTypes.explicit(SqlTypeName.TIMESTAMP, 0),
 		null,
-		OperandTypes.or(
-			OperandTypes.NILADIC,
-			OperandTypes.family(SqlTypeFamily.INTEGER)),
+		OperandTypes.NILADIC,
 		SqlFunctionCategory.TIMEDATE) {
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -573,9 +573,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.FORCE_NULLABLE),
 		InferTypes.RETURN_TYPE,
 		OperandTypes.or(
-			OperandTypes.sequence("'(TIMESTAMP, FORMAT)'",
-				OperandTypes.DATETIME, OperandTypes.STRING),
-			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING),
+			OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.STRING),
 			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
 		SqlFunctionCategory.TIMEDATE);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -653,8 +653,8 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		VARCHAR_2000_NULLABLE,
 		null,
 		OperandTypes.or(
-			OperandTypes.family(SqlTypeFamily.NUMERIC),
-			OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.STRING)),
+			OperandTypes.family(SqlTypeFamily.INTEGER),
+			OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.STRING)),
 		SqlFunctionCategory.TIMEDATE);
 
 	public static final SqlFunction IF = new SqlFunction(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -47,8 +47,6 @@ object CodeGenUtils {
 
   val DEFAULT_TIMEZONE_TERM = "timeZone"
 
-  val DEFAULT_TIMEZONE_ID_TERM = "zoneId"
-
   val DEFAULT_INPUT1_TERM = "in1"
 
   val DEFAULT_INPUT2_TERM = "in2"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -519,17 +519,6 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   }
 
   /**
-    * Adds a reusable Time ZoneId to the member area of the generated class.
-    */
-  def addReusableTimeZoneID(): String = {
-    val zoneID = tableConfig.getLocalTimeZone.getId
-    val stmt =
-      s"""private static final java.time.ZoneId $DEFAULT_TIMEZONE_TERM =
-         |                 java.time.ZoneId.of("$zoneID");""".stripMargin
-    DEFAULT_TIMEZONE_ID_TERM
-  }
-
-  /**
     * Adds a reusable [[java.util.Random]] to the member area of the generated class.
     *
     * The seed parameter must be a literal/constant expression.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -290,28 +290,10 @@ object BuiltInMethods {
     classOf[SqlDateTimeUtils], "unixTimestamp", classOf[Long])
 
   val FROM_UNIXTIME_FORMAT = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "fromUnixtime", classOf[Long], classOf[String])
-
-  val FROM_UNIXTIME = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "fromUnixtime", classOf[Long])
-
-  val FROM_UNIXTIME_AS_DOUBLE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "fromUnixtime", classOf[Double])
-
-  val FROM_UNIXTIME_AS_DECIMAL = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "fromUnixtime", classOf[Decimal])
-
-  val FROM_UNIXTIME_FORMAT_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "fromUnixtime", classOf[Long], classOf[String], classOf[TimeZone])
 
-  val FROM_UNIXTIME_TIME_ZONE = Types.lookupMethod(
+  val FROM_UNIXTIME = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "fromUnixtime", classOf[Long], classOf[TimeZone])
-
-  val FROM_UNIXTIME_AS_DOUBLE_TIME_ZONE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "fromUnixtime", classOf[Double], classOf[TimeZone])
-
-  val FROM_UNIXTIME_AS_DECIMAL_TIME_ZONE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "fromUnixtime", classOf[Decimal], classOf[TimeZone])
 
   val DATEDIFF_T_S_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateDiff", classOf[Long], classOf[String], classOf[TimeZone])
@@ -360,11 +342,6 @@ object BuiltInMethods {
 
   val DATE_ADD_T = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateAdd", classOf[Long], classOf[Int])
-
-  val INT_TO_DATE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils],
-    "toDate",
-    classOf[Int])
 
   val LONG_TO_TIMESTAMP = Types.lookupMethod(
     classOf[SqlDateTimeUtils],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -258,10 +258,6 @@ object BuiltInMethods {
   val DATE_FORMAT_LONG_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[Long], classOf[String], classOf[TimeZone])
 
-  val DATE_FORMAT_STRING_STRING_STRING = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "dateFormat", classOf[String],
-    classOf[String], classOf[String])
-
   val DATE_FORMAT_STIRNG_STRING = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String], classOf[String])
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -245,9 +245,6 @@ object BuiltInMethods {
   val NOW = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "now")
 
-  val NOW_OFFSET = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "now", classOf[Long])
-
   val DATE_FORMAT_STRING_STRING_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String],
     classOf[String], classOf[String], classOf[TimeZone])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -460,22 +460,6 @@ object BuiltInMethods {
     "timestampCeil",
     classOf[TimeUnitRange], classOf[Long], classOf[TimeZone])
 
-  val STRING_TO_TIMESTAMP_TZ = Types.lookupMethod(
-    classOf[SqlDateTimeUtils],
-    "toTimestampTz",
-    classOf[String], classOf[String])
-
-  val STRING_TO_TIMESTAMP_FORMAT_TZ = Types.lookupMethod(
-    classOf[SqlDateTimeUtils],
-    "toTimestampTz",
-    classOf[String], classOf[String], classOf[String])
-
-  val DATE_FORMAT_LONG_ZONE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "dateFormatTz", classOf[Long], classOf[String])
-
-  val DATE_FORMAT_LONG_STRING_ZONE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "dateFormatTz", classOf[Long], classOf[String], classOf[String])
-
   val CONVERT_TZ = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "convertTz",

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -268,19 +268,10 @@ object BuiltInMethods {
     classOf[SqlDateTimeUtils],
     "unixTimestamp",
     classOf[String],
-    classOf[String])
-
-  val UNIX_TIMESTAMP_FORMAT_TIME_ZONE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils],
-    "unixTimestamp",
-    classOf[String],
     classOf[String],
     classOf[TimeZone])
 
   val UNIX_TIMESTAMP_STR = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "unixTimestamp", classOf[String])
-
-  val UNIX_TIMESTAMP_STR_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "unixTimestamp", classOf[String], classOf[TimeZone])
 
   val UNIX_TIMESTAMP = Types.lookupMethod(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -629,11 +629,6 @@ object FunctionGenerator {
     BuiltInMethods.NOW)
 
   addSqlFunctionMethod(
-    NOW,
-    Seq(INTEGER),
-    BuiltInMethods.NOW_OFFSET)
-
-  addSqlFunctionMethod(
     UNIX_TIMESTAMP,
     Seq(),
     BuiltInMethods.UNIX_TIMESTAMP)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -648,12 +648,6 @@ object FunctionGenerator {
     Seq(TIMESTAMP_WITH_LOCAL_TIME_ZONE),
     BuiltInMethods.UNIX_TIMESTAMP_TS)
 
-  addSqlFunctionMethod(
-    DATEDIFF,
-    Seq(TIMESTAMP_WITHOUT_TIME_ZONE,
-      TIMESTAMP_WITHOUT_TIME_ZONE),
-    BuiltInMethods.DATEDIFF_T_T)
-
   // This sequence must be in sync with [[NumericOrDefaultReturnTypeInference]]
   val numericTypes = Seq(
     INTEGER,
@@ -817,11 +811,6 @@ object FunctionGenerator {
     Seq(DECIMAL),
     BuiltInMethods.DECIMAL_TO_TIMESTAMP)
 
-  addSqlFunctionMethod(
-    FROM_TIMESTAMP,
-    Seq(TIMESTAMP_WITHOUT_TIME_ZONE),
-    BuiltInMethods.TIMESTAMP_TO_BIGINT)
-
   INTEGRAL_TYPES foreach (
     dt => addSqlFunctionMethod(
       FROM_UNIXTIME,
@@ -841,18 +830,6 @@ object FunctionGenerator {
 
   addSqlFunctionMethod(FROM_UNIXTIME, Seq(BIGINT, VARCHAR), BuiltInMethods.FROM_UNIXTIME_FORMAT)
   addSqlFunctionMethod(FROM_UNIXTIME, Seq(BIGINT, CHAR), BuiltInMethods.FROM_UNIXTIME_FORMAT)
-
-  addSqlFunctionMethod(DATE_SUB, Seq(VARCHAR, INTEGER), BuiltInMethods.DATE_SUB_S)
-  addSqlFunctionMethod(DATE_SUB, Seq(CHAR, INTEGER), BuiltInMethods.DATE_SUB_S)
-
-  addSqlFunctionMethod(
-    DATE_SUB, Seq(TIMESTAMP_WITHOUT_TIME_ZONE, INTEGER), BuiltInMethods.DATE_SUB_T)
-
-  addSqlFunctionMethod(DATE_ADD, Seq(VARCHAR, INTEGER), BuiltInMethods.DATE_ADD_S)
-  addSqlFunctionMethod(DATE_ADD, Seq(CHAR, INTEGER), BuiltInMethods.DATE_ADD_S)
-
-  addSqlFunctionMethod(
-    DATE_ADD, Seq(TIMESTAMP_WITHOUT_TIME_ZONE, INTEGER), BuiltInMethods.DATE_ADD_T)
 
   // ----------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -792,11 +792,6 @@ object FunctionGenerator {
     Seq(DECIMAL),
     new HashCodeCallGen())
 
-  addSqlFunctionMethod(
-    TO_DATE,
-    Seq(INTEGER),
-    BuiltInMethods.INT_TO_DATE)
-
   INTEGRAL_TYPES foreach (
     dt => addSqlFunctionMethod(TO_TIMESTAMP,
       Seq(dt),
@@ -816,17 +811,6 @@ object FunctionGenerator {
       FROM_UNIXTIME,
       Seq(dt),
       BuiltInMethods.FROM_UNIXTIME))
-
-  FRACTIONAL_TYPES foreach (
-    dt => addSqlFunctionMethod(
-      FROM_UNIXTIME,
-      Seq(dt),
-      BuiltInMethods.FROM_UNIXTIME_AS_DOUBLE))
-
-  addSqlFunctionMethod(
-    FROM_UNIXTIME,
-    Seq(DECIMAL),
-    BuiltInMethods.FROM_UNIXTIME_AS_DECIMAL)
 
   addSqlFunctionMethod(FROM_UNIXTIME, Seq(BIGINT, VARCHAR), BuiltInMethods.FROM_UNIXTIME_FORMAT)
   addSqlFunctionMethod(FROM_UNIXTIME, Seq(BIGINT, CHAR), BuiltInMethods.FROM_UNIXTIME_FORMAT)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -168,8 +168,15 @@ object ScalarOperatorGens {
         generateBinaryArithmeticOperator(ctx, op, left.resultType, left, right)
 
       case (DATE, INTERVAL_DAY_TIME) =>
-        generateOperatorIfNotNull(ctx, new DateType(), left, right) {
-          (l, r) => s"$l $op ((int) ($r / ${MILLIS_PER_DAY}L))"
+        resultType.getTypeRoot match {
+          case DATE =>
+            generateOperatorIfNotNull(ctx, new DateType(), left, right) {
+              (l, r) => s"$l $op ((int) ($r / ${MILLIS_PER_DAY}L))"
+            }
+          case TIMESTAMP_WITHOUT_TIME_ZONE =>
+            generateOperatorIfNotNull(ctx, new TimestampType(), left, right) {
+              (l, r) => s"($l * ${MILLIS_PER_DAY}L) $op $r"
+            }
         }
 
       case (DATE, INTERVAL_YEAR_MONTH) =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -227,13 +227,6 @@ object StringCallGen {
           isCharacterString(operands(2).resultType) =>
         methodGen(BuiltInMethods.CONVERT_TZ)
 
-      case CONVERT_TZ if operands.size == 4 &&
-          isCharacterString(operands.head.resultType) &&
-          isCharacterString(operands(1).resultType) &&
-          isCharacterString(operands(2).resultType) &&
-          isCharacterString(operands(3).resultType) =>
-        methodGen(BuiltInMethods.CONVERT_FORMAT_TZ)
-
       case _ => null
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -221,12 +221,6 @@ object StringCallGen {
           isCharacterString(operands(1).resultType) =>
         methodGen(BuiltInMethods.DATE_FORMAT_STIRNG_STRING)
 
-      case DATE_FORMAT if operands.size == 3 &&
-          isCharacterString(operands.head.resultType) &&
-          isCharacterString(operands(1).resultType) &&
-          isCharacterString(operands(2).resultType) =>
-        methodGen(BuiltInMethods.DATE_FORMAT_STRING_STRING_STRING)
-
       case CONVERT_TZ if operands.size == 3 &&
           isCharacterString(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) &&

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -206,18 +206,6 @@ object StringCallGen {
           isCharacterString(operands(1).resultType) =>
         methodGen(BuiltInMethods.UNIX_TIMESTAMP_FORMAT)
 
-      case DATEDIFF if isTimestamp(operands.head.resultType) &&
-          isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATEDIFF_T_S)
-
-      case DATEDIFF if isCharacterString(operands.head.resultType) &&
-          isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATEDIFF_S_S)
-
-      case DATEDIFF if isCharacterString(operands.head.resultType) &&
-          isTimestamp(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATEDIFF_S_T)
-
       case DATE_FORMAT if operands.size == 2 &&
           isTimestamp(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) =>
@@ -238,28 +226,6 @@ object StringCallGen {
           isCharacterString(operands(1).resultType) &&
           isCharacterString(operands(2).resultType) =>
         methodGen(BuiltInMethods.DATE_FORMAT_STRING_STRING_STRING)
-
-      case TO_TIMESTAMP_TZ if operands.size == 2 &&
-          isCharacterString(operands.head.resultType) &&
-          isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.STRING_TO_TIMESTAMP_TZ)
-
-      case TO_TIMESTAMP_TZ if operands.size == 3 &&
-          isCharacterString(operands.head.resultType) &&
-          isCharacterString(operands(1).resultType) &&
-          isCharacterString(operands(2).resultType) =>
-        methodGen(BuiltInMethods.STRING_TO_TIMESTAMP_FORMAT_TZ)
-
-      case DATE_FORMAT_TZ if operands.size == 2 &&
-          isTimestamp(operands.head.resultType) &&
-          isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATE_FORMAT_LONG_ZONE)
-
-      case DATE_FORMAT_TZ if operands.size == 3 &&
-          isTimestamp(operands.head.resultType) &&
-          isCharacterString(operands(1).resultType) &&
-          isCharacterString(operands(2).resultType) =>
-        methodGen(BuiltInMethods.DATE_FORMAT_LONG_STRING_ZONE)
 
       case CONVERT_TZ if operands.size == 3 &&
           isCharacterString(operands.head.resultType) &&

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -22,8 +22,12 @@ import org.apache.flink.table.api.scala.{currentDate, currentTime, currentTimest
 import org.apache.flink.table.api.{DataTypes, Types}
 import org.apache.flink.table.expressions.{Expression, ExpressionParser, TimeIntervalUnit, TimePointUnit}
 import org.apache.flink.table.planner.expressions.utils.ScalarTypesTestBase
-
 import org.junit.Test
+
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
+import java.time.ZoneId
+import java.util.Locale
 
 class ScalarFunctionsTest extends ScalarTypesTestBase {
 
@@ -3528,7 +3532,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testToTimestamp(): Unit = {
     testSqlApi("to_timestamp('abc')", "null")
-    testSqlApi("to_timestamp(1513135677000)", "2017-12-13 03:27:57.000")
     testSqlApi("to_timestamp('2017-09-15 00:00:00')", "2017-09-15 00:00:00.000")
     testSqlApi("to_timestamp('20170915000000', 'yyyyMMddHHmmss')", "2017-09-15 00:00:00.000")
     testSqlApi("to_timestamp('2017-09-15', 'yyyy-MM-dd')", "2017-09-15 00:00:00.000")
@@ -3539,30 +3542,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testToDate(): Unit = {
     testSqlApi("to_date('2017-09-15 00:00:00')", "2017-09-15")
-  }
-
-  @Test
-  def testDateSub(): Unit = {
-    testSqlApi("date_sub(f18, 10)", "1996-10-31")
-    testSqlApi("date_sub(f18, -10)", "1996-11-20")
-    testSqlApi("date_sub(TIMESTAMP '2017-10-15 23:00:00', 30)", "2017-09-15")
-    testSqlApi("date_sub(f40, 30)", "null")
-    testSqlApi("date_sub(CAST(NULL AS TIMESTAMP), 30)", "null")
-    testSqlApi("date_sub(CAST(NULL AS VARCHAR), 30)", "null")
-    testSqlApi("date_sub('2017-10--11', 30)", "null")
-    testSqlApi("date_sub('2017--10-11', 30)", "null")
-  }
-
-  @Test
-  def testDateAdd(): Unit = {
-    testSqlApi("date_add(f18, 10)", "1996-11-20")
-    testSqlApi("date_add(f18, -10)", "1996-10-31")
-    testSqlApi("date_add(TIMESTAMP '2017-10-15 23:00:00', 30)", "2017-11-14")
-    testSqlApi("date_add(f40, 30)", "null")
-    testSqlApi("date_add(CAST(NULL AS TIMESTAMP), 30)", "null")
-    testSqlApi("date_add(CAST(NULL AS VARCHAR), 30)", "null")
-    testSqlApi("date_add('2017-10--11', 30)", "null")
-    testSqlApi("date_add('2017--10-11', 30)", "null")
   }
 
   // ----------------------------------------------------------------------------------------------
@@ -3989,37 +3968,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi(
       "IF(f7 < 5, f18, f52)",
       "1996-11-10 06:55:44.333")
-  }
-
-  @Test
-  def testFromUnixTimeWithNumeric(): Unit = {
-    // Test integral and fractional numeric from_unixtime.
-    testSqlApi(
-      "from_unixtime(f2)",
-      "1970-01-01 00:00:42")
-    testSqlApi(
-      "from_unixtime(f3)",
-      "1970-01-01 00:00:43")
-    testSqlApi(
-      "from_unixtime(f4)",
-      "1970-01-01 00:00:44")
-    testSqlApi(
-      "from_unixtime(f5)",
-      "1970-01-01 00:00:04")
-    testSqlApi(
-      "from_unixtime(f6)",
-      "1970-01-01 00:00:04")
-    testSqlApi(
-      "from_unixtime(f7)",
-      "1970-01-01 00:00:03")
-    // Test decimal to from_unixtime.
-    testSqlApi(
-      "from_unixtime(f15)",
-      "1969-12-31 23:39:29")
-    // test with null input
-    testSqlApi(
-      "from_unixtime(cast(null as int))",
-      "null")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -25,9 +25,7 @@ import org.apache.flink.table.planner.expressions.utils.ScalarTypesTestBase
 import org.junit.Test
 
 import java.sql.Timestamp
-import java.text.SimpleDateFormat
 import java.time.ZoneId
-import java.util.Locale
 
 class ScalarFunctionsTest extends ScalarTypesTestBase {
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -24,9 +24,6 @@ import org.apache.flink.table.expressions.{Expression, ExpressionParser, TimeInt
 import org.apache.flink.table.planner.expressions.utils.ScalarTypesTestBase
 import org.junit.Test
 
-import java.sql.Timestamp
-import java.time.ZoneId
-
 class ScalarFunctionsTest extends ScalarTypesTestBase {
 
   // ----------------------------------------------------------------------------------------------
@@ -3474,26 +3471,25 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "timestampadd(DAY, 1, date '2016-06-15')",
       "2016-06-16")
 
-    // TODO support '2016-06-15'.toTimestamp
-//    testAllApis("2016-06-15".toTimestamp - 1.hour,
-//      "'2016-06-15'.toTimestamp - 1.hour",
-//      "timestampadd(HOUR, -1, date '2016-06-15')",
-//      "2016-06-14 23:00:00.0")
+    testAllApis("2016-06-15".toTimestamp - 1.hour,
+      "'2016-06-15'.toTimestamp - 1.hour",
+      "timestampadd(HOUR, -1, date '2016-06-15')",
+      "2016-06-14 23:00:00.000")
 
-//    testAllApis("2016-06-15".toTimestamp + 1.minute,
-//      "'2016-06-15'.toTimestamp + 1.minute",
-//      "timestampadd(MINUTE, 1, date '2016-06-15')",
-//      "2016-06-15 00:01:00.0")
+    testAllApis("2016-06-15".toTimestamp + 1.minute,
+      "'2016-06-15'.toTimestamp + 1.minute",
+      "timestampadd(MINUTE, 1, date '2016-06-15')",
+      "2016-06-15 00:01:00.000")
 
-//    testAllApis("2016-06-15".toTimestamp - 1.second,
-//      "'2016-06-15'.toTimestamp - 1.second",
-//      "timestampadd(SQL_TSI_SECOND, -1, date '2016-06-15')",
-//      "2016-06-14 23:59:59.0")
+    testAllApis("2016-06-15".toTimestamp - 1.second,
+      "'2016-06-15'.toTimestamp - 1.second",
+      "timestampadd(SQL_TSI_SECOND, -1, date '2016-06-15')",
+      "2016-06-14 23:59:59.000")
 
-//    testAllApis("2016-06-15".toTimestamp + 1.second,
-//      "'2016-06-15'.toTimestamp + 1.second",
-//      "timestampadd(SECOND, 1, date '2016-06-15')",
-//      "2016-06-15 00:00:01.0")
+    testAllApis("2016-06-15".toTimestamp + 1.second,
+      "'2016-06-15'.toTimestamp + 1.second",
+      "timestampadd(SECOND, 1, date '2016-06-15')",
+      "2016-06-15 00:00:01.000")
 
     testAllApis(nullOf(Types.SQL_TIMESTAMP) + 1.second,
       "nullOf(SQL_TIMESTAMP) + 1.second",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -3531,6 +3531,9 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi("to_timestamp(1513135677000)", "2017-12-13 03:27:57.000")
     testSqlApi("to_timestamp('2017-09-15 00:00:00')", "2017-09-15 00:00:00.000")
     testSqlApi("to_timestamp('20170915000000', 'yyyyMMddHHmmss')", "2017-09-15 00:00:00.000")
+    testSqlApi("to_timestamp('2017-09-15', 'yyyy-MM-dd')", "2017-09-15 00:00:00.000")
+    // test with null input
+    testSqlApi("to_timestamp(cast(null as varchar))", "null")
   }
 
   @Test
@@ -3986,37 +3989,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi(
       "IF(f7 < 5, f18, f52)",
       "1996-11-10 06:55:44.333")
-  }
-
-  @Test
-  def testToTimestampWithNumeric(): Unit = {
-    // Test integral and fractional numeric to timestamp.
-    testSqlApi(
-      "to_timestamp(f2)",
-      "1970-01-01 00:00:00.042")
-    testSqlApi(
-      "to_timestamp(f3)",
-      "1970-01-01 00:00:00.043")
-    testSqlApi(
-      "to_timestamp(f4)",
-      "1970-01-01 00:00:00.044")
-    testSqlApi(
-      "to_timestamp(f5)",
-      "1970-01-01 00:00:00.004")
-    testSqlApi(
-      "to_timestamp(f6)",
-      "1970-01-01 00:00:00.004")
-    testSqlApi(
-      "to_timestamp(f7)",
-      "1970-01-01 00:00:00.003")
-    // Test decimal to timestamp.
-    testSqlApi(
-      "to_timestamp(f15)",
-      "1969-12-31 23:59:58.769")
-    // test with null input
-    testSqlApi(
-      "to_timestamp(cast(null as varchar))",
-      "null")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -854,7 +854,7 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(s"TO_TIMESTAMP('$invalidStr', 'yyyy-mm-dd')", nullable)
     testSqlApi(s"TO_DATE('$invalidStr')", nullable)
     testSqlApi(
-      s"CONVERT_TZ('$invalidStr', 'yyyy-MM-dd HH:mm:ss', 'UTC', 'Asia/Shanghai')",
+      s"CONVERT_TZ('$invalidStr', 'UTC', 'Asia/Shanghai')",
       nullable)
   }
 
@@ -865,7 +865,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       s"DATE_FORMAT('$invalidStr', 'yyyy/MM/dd HH:mm:ss')",
       s"TO_TIMESTAMP('$invalidStr', 'yyyy-mm-dd')",
       s"TO_DATE('$invalidStr')",
-      s"CONVERT_TZ('$invalidStr', 'yyyy-MM-dd HH:mm:ss', 'UTC', 'Asia/Shanghai')")
+      s"CONVERT_TZ('$invalidStr', 'UTC', 'Asia/Shanghai')")
 
     cases.foreach {
       caseExpr =>
@@ -875,7 +875,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testConvertTZ(): Unit = {
-    testSqlApi("CONVERT_TZ('2018-03-14 11:00:00', 'yyyy-MM-dd HH:mm:ss', 'UTC', 'Asia/Shanghai')",
+    testSqlApi("CONVERT_TZ('2018-03-14 11:00:00', 'UTC', 'Asia/Shanghai')",
                "2018-03-14 19:00:00")
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -839,28 +839,14 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testNullableCases(): Unit = {
-    testSqlApi(
-      "DATE_FORMAT_TZ(TO_TIMESTAMP(cast(NUll as bigInt)), 'yyyy/MM/dd HH:mm:ss', 'Asia/Shanghai')",
+    testSqlApi("CONVERT_TZ(cast(NULL as varchar), 'UTC', 'Asia/Shanghai')",
       nullable)
 
-    testSqlApi("CONVERT_TZ(cast(NUll as varchar), 'yyyy-MM-dd HH:mm:ss', 'UTC', 'Asia/Shanghai')",
-      nullable)
+    testSqlApi("DATE_FORMAT(cast(NULL as varchar), 'yyyy/MM/dd HH:mm:ss')", nullable)
 
-    testSqlApi("FROM_TIMESTAMP(f13)", nullable)
+    testSqlApi("FROM_UNIXTIME(cast(NULL as bigInt))", nullable)
 
-    testSqlApi("DATE_FORMAT(cast(NUll as varchar), 'yyyy/MM/dd HH:mm:ss')", nullable)
-
-    testSqlApi("UNIX_TIMESTAMP(TO_TIMESTAMP(cast(NUll as bigInt)))", nullable)
-
-    testSqlApi("FROM_UNIXTIME(cast(NUll as bigInt))", nullable)
-
-    testSqlApi("TO_DATE(cast(NUll as varchar))", nullable)
-
-    testSqlApi("TO_TIMESTAMP_TZ(cast(NUll as varchar), 'Asia/Shanghai')", nullable)
-
-    testSqlApi(
-      "DATE_FORMAT_TZ(cast(NUll as timestamp), 'yyyy/MM/dd HH:mm:ss', 'Asia/Shanghai')",
-      nullable)
+    testSqlApi("TO_DATE(cast(NULL as varchar))", nullable)
   }
 
   @Test
@@ -869,7 +855,6 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(s"DATE_FORMAT('$invalidStr', 'yyyy/MM/dd HH:mm:ss')", nullable)
     testSqlApi(s"TO_TIMESTAMP('$invalidStr', 'yyyy-mm-dd')", nullable)
     testSqlApi(s"TO_DATE('$invalidStr')", nullable)
-    testSqlApi(s"TO_TIMESTAMP_TZ('$invalidStr', 'Asia/Shanghai')", nullable)
     testSqlApi(
       s"CONVERT_TZ('$invalidStr', 'yyyy-MM-dd HH:mm:ss', 'UTC', 'Asia/Shanghai')",
       nullable)
@@ -882,7 +867,6 @@ class TemporalTypesTest extends ExpressionTestBase {
       s"DATE_FORMAT('$invalidStr', 'yyyy/MM/dd HH:mm:ss')",
       s"TO_TIMESTAMP('$invalidStr', 'yyyy-mm-dd')",
       s"TO_DATE('$invalidStr')",
-      s"TO_TIMESTAMP_TZ('$invalidStr', 'Asia/Shanghai')",
       s"CONVERT_TZ('$invalidStr', 'yyyy-MM-dd HH:mm:ss', 'UTC', 'Asia/Shanghai')")
 
     cases.foreach {
@@ -892,20 +876,9 @@ class TemporalTypesTest extends ExpressionTestBase {
   }
 
   @Test
-  def testTimeZoneFunction(): Unit = {
-    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'Asia/Shanghai')", "2018-03-14 03:00:00.000")
-    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'yyyy-MM-dd HH:mm:ss', 'Asia/Shanghai')",
-               "2018-03-14 03:00:00.000")
-
+  def testConvertTZ(): Unit = {
     testSqlApi("CONVERT_TZ('2018-03-14 11:00:00', 'yyyy-MM-dd HH:mm:ss', 'UTC', 'Asia/Shanghai')",
                "2018-03-14 19:00:00")
-
-    testSqlApi("TO_TIMESTAMP_TZ(f14, 'UTC')", "null")
-
-    // Note that, if timezone is invalid, here we follow the default behavior of JDK's getTimeZone()
-    // It will use UTC timezone by default.
-    // TODO: it is would be better to report the error at compiling stage. timezone/format codegen
-    testSqlApi("TO_TIMESTAMP_TZ('2018-03-14 11:00:00', 'invalid_tz')", "2018-03-14 11:00:00.000")
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -590,11 +590,6 @@ class TemporalTypesTest extends ExpressionTestBase {
     )
 
     testSqlApi(
-      "FROM_TIMESTAMP(f13)",
-      "null"
-    )
-
-    testSqlApi(
       "TO_TIMESTAMP(SUBSTR('', 2, -1))",
       "null"
     )
@@ -606,11 +601,14 @@ class TemporalTypesTest extends ExpressionTestBase {
   }
 
   @Test
-  def testdebug() = {
-    testSqlApi("DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
+  def testDateFormat(): Unit = {
+    testSqlApi(
+      "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
       "2018/03/14 01:02:03")
-    testSqlApi("DATE_FORMAT('2018-03-14 01:02:03', 'yyyy-MM-dd HH:mm:ss', " +
-        "'yyyy/MM/dd HH:mm:ss')", "2018/03/14 01:02:03")
+
+    testSqlApi(
+      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
+      "2018-03-14 01:02:03")
   }
 
   @Test
@@ -659,12 +657,12 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(timestampTz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.010")
 
     // DATE_FORMAT
-    testSqlApi("DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
+    testSqlApi(
+      "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
       "2018/03/14 01:02:03")
-    testSqlApi("DATE_FORMAT('2018-03-14 01:02:03', 'yyyy-MM-dd HH:mm:ss', " +
-      "'yyyy/MM/dd HH:mm:ss')", "2018/03/14 01:02:03")
-    testSqlApi(s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}," +
-        " 'yyyy-MM-dd HH:mm:ss')",
+
+    testSqlApi(
+      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
 
     // EXTRACT

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1168,35 +1168,6 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
-  def testDateDiff(): Unit = {
-    checkResult("SELECT" +
-        " DATEDIFF('2017-12-14 01:00:34', '2016-12-14 12:00:00')," +
-        " DATEDIFF(TIMESTAMP '2017-12-14 01:00:23', '2016-08-14 12:00:00')," +
-        " DATEDIFF('2017-12-14 09:00:23', TIMESTAMP '2013-08-19 11:00:00')," +
-        " DATEDIFF(TIMESTAMP '2017-12-14 09:00:23', TIMESTAMP '2018-08-19 11:00:00')" +
-        " FROM testTable WHERE a = TRUE",
-      Seq(row(365, 487, 1578, -248)))
-  }
-
-  @Test
-  def testDateSub(): Unit = {
-    checkResult("SELECT" +
-        " DATE_SUB(TIMESTAMP '2017-12-14 09:00:23', 3)," +
-        " DATE_SUB('2017-12-14 09:00:23', -3)" +
-        " FROM testTable WHERE a = TRUE",
-      Seq(row("2017-12-11", "2017-12-17")))
-  }
-
-  @Test
-  def testDateAdd(): Unit = {
-    checkResult("SELECT" +
-        " DATE_ADD('2017-12-14', 4)," +
-        " DATE_ADD(TIMESTAMP '2017-12-14 09:10:20',-4)" +
-        " FROM testTable WHERE a = TRUE",
-      Seq(row("2017-12-18", "2017-12-10")))
-  }
-
-  @Test
   def testToDate(): Unit = {
     checkResult("SELECT" +
         " TO_DATE(CAST(null AS VARCHAR))," +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1158,14 +1158,6 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
-  def testFromUnixTime(): Unit = {
-    checkResult("SELECT" +
-        " FROM_UNIXTIME(1513193130), FROM_UNIXTIME(1513193130, 'MM/dd/yyyy HH:mm:ss')" +
-        " FROM testTable WHERE a = TRUE",
-      Seq(row("2017-12-13 19:25:30", "12/13/2017 19:25:30")))
-  }
-
-  @Test
   def testToDate(): Unit = {
     checkResult("SELECT" +
         " TO_DATE(CAST(null AS VARCHAR))," +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1149,15 +1149,6 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
-  def testUnixTimestamp(): Unit = {
-    checkResult("SELECT" +
-        " UNIX_TIMESTAMP('2017-12-13 19:25:30')," +
-        " UNIX_TIMESTAMP('2017-12-13 19:25:30', 'yyyy-MM-dd HH:mm:ss')" +
-        " FROM testTable WHERE a = TRUE",
-      Seq(row(1513193130, 1513193130)))
-  }
-
-  @Test
   def testToDate(): Unit = {
     checkResult("SELECT" +
         " TO_DATE(CAST(null AS VARCHAR))," +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1079,12 +1079,10 @@ class CalcITCase extends BatchTestBase {
     //j 2015-05-20 10:00:00.887
     checkResult("SELECT j, " +
         " DATE_FORMAT(j, 'yyyy/MM/dd HH:mm:ss')," +
-        " DATE_FORMAT('2015-05-20 10:00:00.887', 'yyyy/MM/dd HH:mm:ss')," +
-        " DATE_FORMAT('2015-05-20 10:00:00.887', 'yyyy-MM-dd HH:mm:ss', 'yyyy/MM/dd HH:mm:ss')" +
+        " DATE_FORMAT('2015-05-20 10:00:00.887', 'yyyy/MM/dd HH:mm:ss')" +
         " FROM testTable WHERE a = TRUE",
       Seq(
         row(localDateTime("2015-05-20 10:00:00.887"),
-          "2015/05/20 10:00:00",
           "2015/05/20 10:00:00",
           "2015/05/20 10:00:00")
       ))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
@@ -214,7 +214,7 @@ class CorrelateITCase extends StreamingTestBase {
     val sql =
       """
         |SELECT * FROM TMP1
-        |where TIMESTAMP_ADD(day, 3, v) > DATE_FORMAT(CURRENT_TIMESTAMP, 'yyyy-MM-dd')
+        |where TIMESTAMPADD(day, 3, cast(v as date)) > DATE_FORMAT(CURRENT_TIMESTAMP, 'yyyy-MM-dd')
       """.stripMargin
 
     val sink = new TestingAppendSink

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
@@ -214,7 +214,7 @@ class CorrelateITCase extends StreamingTestBase {
     val sql =
       """
         |SELECT * FROM TMP1
-        |where DATE_ADD(v, 3) > DATE_FORMAT(CURRENT_TIMESTAMP, 'yyyy-MM-dd')
+        |where TIMESTAMP_ADD(day, 3, v) > DATE_FORMAT(CURRENT_TIMESTAMP, 'yyyy-MM-dd')
       """.stripMargin
 
     val sink = new TestingAppendSink

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -220,7 +220,9 @@ public class SqlDateTimeUtils {
 	public static Long toTimestamp(String dateStr, TimeZone tz) {
 		int length = dateStr.length();
 		String format;
-		if (length == 21) {
+		if (length == 10) {
+			format = DATE_FORMAT_STRING;
+		} else if (length == 21) {
 			format = DEFAULT_DATETIME_FORMATS[1];
 		} else if (length == 22) {
 			format = DEFAULT_DATETIME_FORMATS[2];


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix behavior of several datetime builtin functions in blink planner.

## Brief change log

1. af3db19573d91acae9cc15e2186680b49b659fdd  Fix NOW() should return TIMESTAMP instead of BIGINT
    This aligns the behavior to other systems (MySQL, Spark). Because NOW() is Synonyms for CURRENT_TIMESTAMP.


2. d3af9e280d705e51c1f3bc16908e5650c7a639ea  Fix UNIX_TIMESTAMP(string [,format]) should work in session time zone
    This aligns the behavior to other systems (MySQL, Spark). UNIX_TIMESTAMP(string [,format]) is an inverse of FROM_UNIXTIME(bigint [,format]). We also remove the support of UNIX_TIMESTAMP(timestamp) in this commit.

3. 5939a990cd86fc16141a39587e565988734162bc  Fix FROM_UNIXTIME(bigint [,format]) should work in session time zone
    This aligns the behavior to other systems (MySQL, Spark).

4. 584df370a4feb34b1ef1bdb4a81b60809dad7128  Drop TO_DATE(int) function support
    This commit drops TO_DATE(int) function support in blink planner to align with other systems. We only support TO_DATE(string [,format]) in this version.

5. 1a590b6d9c792b136a109cc5f3ad1ab3bf0f6916  Drop TO_TIMESTAMP(bigint) function support
    This commit drops TO_TIMESTAMP(bigint) function support in blink planner to align with other systems. We only support TO_TIMESTAMP(string [,format]) in this version.

6. 7dfb34225535a673c99baa4cd7b7dd0ed8a34783  Drop CONVERT_TZ(timestamp, format, from_tz, to_tz) function support
    This commit drops CONVERT_TZ(timestamp, format, from_tz, to_tz) function support in blink planner to align with other systems. We only support CONVERT_TZ(timestamp, from_tz, to_tz) in this version.

7. c2b09aa4f5c00eb5436e5f2e4ed1983657c9753e  Drop DATE_FORMAT(timestamp, from_format, to_format) function support
    This commit drops DATE_FORMAT(timestamp, from_format, to_format) function support in blink planner to align with other systems. We only support DATE_FORMAT(timestamp, to_format) and DATE_FORMAT(string, to_format) in this version.

8. 84be6c933af6b8a960df17f6767d620db7f3a59f  Remove some builtin datetime functions which can be covered by existing functions
    Removes DATE_FORMAT_TZ, DATE_ADD,DATE_SUB, DATEDIFF, FROM_TIMESTAMP, TO_TIMESTAMP_TZ builtin functions which can be covered by existing functions.


## Verifying this change

This change is already covered by existing tests. For the functions changed behavior, we modified existing tests and add some more tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
