### PR TITLE
[FLINK-13630][table-api-bridge] Use values retention configuration from TableConfig if not specified explicitly

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImplTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImplTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.java.internal;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.delegation.Executor;
+import org.apache.flink.table.delegation.Planner;
+import org.apache.flink.table.operations.ModifyOperation;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link StreamTableEnvironmentImpl}.
+ */
+public class StreamTableEnvironmentImplTest {
+	@Test
+	public void testAppendStreamDoesNotOverwriteTableConfig() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements = env.fromElements(1, 2, 3);
+
+		StreamTableEnvironmentImpl tEnv = getStreamTableEnvironment(env, elements);
+
+		Time minRetention = Time.minutes(1);
+		Time maxRetention = Time.minutes(10);
+		tEnv.getConfig().setIdleStateRetentionTime(minRetention, maxRetention);
+		Table table = tEnv.fromDataStream(elements);
+		tEnv.toAppendStream(table, Row.class);
+
+		assertThat(
+			tEnv.getConfig().getMinIdleStateRetentionTime(),
+			equalTo(minRetention.toMilliseconds()));
+		assertThat(
+			tEnv.getConfig().getMaxIdleStateRetentionTime(),
+			equalTo(maxRetention.toMilliseconds()));
+	}
+
+	@Test
+	public void testRetractStreamDoesNotOverwriteTableConfig() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements = env.fromElements(1, 2, 3);
+
+		StreamTableEnvironmentImpl tEnv = getStreamTableEnvironment(env, elements);
+
+		Time minRetention = Time.minutes(1);
+		Time maxRetention = Time.minutes(10);
+		tEnv.getConfig().setIdleStateRetentionTime(minRetention, maxRetention);
+		Table table = tEnv.fromDataStream(elements);
+		tEnv.toRetractStream(table, Row.class);
+
+		assertThat(
+			tEnv.getConfig().getMinIdleStateRetentionTime(),
+			equalTo(minRetention.toMilliseconds()));
+		assertThat(
+			tEnv.getConfig().getMaxIdleStateRetentionTime(),
+			equalTo(maxRetention.toMilliseconds()));
+	}
+
+	private StreamTableEnvironmentImpl getStreamTableEnvironment(
+			StreamExecutionEnvironment env,
+			DataStreamSource<Integer> elements) {
+		CatalogManager catalogManager = new CatalogManager("cat", new GenericInMemoryCatalog("cat", "db"));
+		return new StreamTableEnvironmentImpl(
+			catalogManager,
+			new FunctionCatalog(catalogManager),
+			new TableConfig(),
+			env,
+			new TestPlanner(elements.getTransformation()),
+			executor,
+			true
+		);
+	}
+
+	private static class TestPlanner implements Planner {
+		private final Transformation<?> transformation;
+
+		private TestPlanner(Transformation<?> transformation) {
+			this.transformation = transformation;
+		}
+
+		@Override
+		public List<Operation> parse(String statement) {
+			throw new AssertionError("Should not be called");
+		}
+
+		@Override
+		public List<Transformation<?>> translate(List<ModifyOperation> modifyOperations) {
+			return Collections.singletonList(transformation);
+		}
+
+		@Override
+		public String explain(List<Operation> operations, boolean extended) {
+			throw new AssertionError("Should not be called");
+		}
+
+		@Override
+		public String[] getCompletionHints(String statement, int position) {
+			throw new AssertionError("Should not be called");
+		}
+	}
+
+	private final Executor executor = new Executor() {
+		@Override
+		public void apply(List<Transformation<?>> transformations) {
+
+		}
+
+		@Override
+		public JobExecutionResult execute(String jobName) throws Exception {
+			throw new AssertionError("Should not be called");
+		}
+	};
+}

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImpl.scala
@@ -95,44 +95,43 @@ class StreamTableEnvironmentImpl (
   }
 
   override def toAppendStream[T: TypeInformation](table: Table): DataStream[T] = {
-    toAppendStream(table, new StreamQueryConfig)
-  }
-
-  override def toAppendStream[T: TypeInformation](
-      table: Table,
-      queryConfig: StreamQueryConfig)
-    : DataStream[T] = {
     val returnType = createTypeInformation[T]
 
     val modifyOperation = new OutputConversionModifyOperation(
       table.getQueryOperation,
       TypeConversions.fromLegacyInfoToDataType(returnType),
       OutputConversionModifyOperation.UpdateMode.APPEND)
+    toDataStream[T](table, modifyOperation)
+  }
+
+  override def toAppendStream[T: TypeInformation](
+      table: Table,
+      queryConfig: StreamQueryConfig)
+    : DataStream[T] = {
     tableConfig.setIdleStateRetentionTime(
       Time.milliseconds(queryConfig.getMinIdleStateRetentionTime),
       Time.milliseconds(queryConfig.getMaxIdleStateRetentionTime))
-    toDataStream(table, modifyOperation)
+    toAppendStream(table)
   }
 
   override def toRetractStream[T: TypeInformation](table: Table): DataStream[(Boolean, T)] = {
-    toRetractStream(table, new StreamQueryConfig)
-  }
-
-  override def toRetractStream[T: TypeInformation](
-      table: Table,
-      queryConfig: StreamQueryConfig)
-    : DataStream[(Boolean, T)] = {
     val returnType = createTypeInformation[(Boolean, T)]
 
     val modifyOperation = new OutputConversionModifyOperation(
       table.getQueryOperation,
       TypeConversions.fromLegacyInfoToDataType(returnType),
       OutputConversionModifyOperation.UpdateMode.RETRACT)
+    toDataStream(table, modifyOperation)
+  }
 
+  override def toRetractStream[T: TypeInformation](
+      table: Table,
+      queryConfig: StreamQueryConfig)
+    : DataStream[(Boolean, T)] = {
     tableConfig.setIdleStateRetentionTime(
         Time.milliseconds(queryConfig.getMinIdleStateRetentionTime),
         Time.milliseconds(queryConfig.getMaxIdleStateRetentionTime))
-    toDataStream(table, modifyOperation)
+    toRetractStream(table)
   }
 
   override def registerFunction[T: TypeInformation](name: String, tf: TableFunction[T]): Unit = {

--- a/flink-table/flink-table-api-scala-bridge/src/test/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImplTest.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/test/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImplTest.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.scala.internal
+
+import org.apache.flink.api.common.time.Time
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, GenericInMemoryCatalog}
+import org.apache.flink.table.delegation.{Executor, Planner}
+import org.apache.flink.table.operations.{ModifyOperation, Operation}
+import org.apache.flink.types.Row
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+import java.util.{Collections, List => JList}
+
+/**
+ * Tests for [[StreamTableEnvironmentImpl]].
+ */
+class StreamTableEnvironmentImplTest {
+  @Test
+  def testAppendStreamDoesNotOverwriteTableConfig(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val elements = env.fromElements(1, 2, 3)
+    val tEnv: StreamTableEnvironmentImpl = getStreamTableEnvironment(env, elements)
+
+    val minRetention = Time.minutes(1)
+    val maxRetention = Time.minutes(10)
+    tEnv.getConfig.setIdleStateRetentionTime(minRetention, maxRetention)
+    val table = tEnv.fromDataStream(elements)
+    tEnv.toAppendStream[Row](table)
+
+    assertThat(
+      tEnv.getConfig.getMinIdleStateRetentionTime,
+      equalTo(minRetention.toMilliseconds))
+    assertThat(
+      tEnv.getConfig.getMaxIdleStateRetentionTime,
+      equalTo(maxRetention.toMilliseconds))
+  }
+
+  @Test
+  def testRetractStreamDoesNotOverwriteTableConfig(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val elements = env.fromElements(1, 2, 3)
+    val tEnv: StreamTableEnvironmentImpl = getStreamTableEnvironment(env, elements)
+
+    val minRetention = Time.minutes(1)
+    val maxRetention = Time.minutes(10)
+    tEnv.getConfig.setIdleStateRetentionTime(minRetention, maxRetention)
+    val table = tEnv.fromDataStream(elements)
+    tEnv.toRetractStream[Row](table)
+
+    assertThat(
+      tEnv.getConfig.getMinIdleStateRetentionTime,
+      equalTo(minRetention.toMilliseconds))
+    assertThat(
+      tEnv.getConfig.getMaxIdleStateRetentionTime,
+      equalTo(maxRetention.toMilliseconds))
+  }
+
+  private def getStreamTableEnvironment(
+      env: StreamExecutionEnvironment,
+      elements: DataStream[Int]) = {
+    val catalogManager = new CatalogManager(
+      "cat",
+      new GenericInMemoryCatalog("cat", "db"))
+    new StreamTableEnvironmentImpl(
+      catalogManager,
+      new FunctionCatalog(catalogManager),
+      new TableConfig,
+      env,
+      new TestPlanner(elements.javaStream.getTransformation),
+      executor,
+      true)
+  }
+
+  private class TestPlanner(transformation: Transformation[_]) extends Planner {
+    override def parse(statement: String) = throw new AssertionError("Should not be called")
+
+    override def translate(modifyOperations: JList[ModifyOperation])
+      : JList[Transformation[_]] = {
+      Collections.singletonList(transformation)
+    }
+
+    override def explain(operations: JList[Operation], extended: Boolean) =
+      throw new AssertionError("Should not be called")
+
+    override def getCompletionHints(statement: String, position: Int) =
+      throw new AssertionError("Should not be called")
+  }
+
+  private val executor = new Executor() {
+    override def apply(transformations: JList[Transformation[_]]): Unit = {}
+
+    override def execute(jobName: String) = throw new AssertionError("Should not be called")
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

In a sequence like this:

```
tEnv.getConfig().setIdleStateRetentionTime(minRetention, maxRetention);
Table table = tEnv.fromDataStream(elements);
tEnv.toAppendStream(table, Row.class);
```

the call to toAppendStream will override the value set in tEnv.getConfig.setIdleStateRetentionTime. I think we should change that behavior, as we want to drop the version with explicit QueryConfig and recommend the described setup.


## Brief change log

If methods that do not specify QueryConfig explicitly are used in
StreamTableEnvironment than the values from TableConfig will be used.
If methods that accept QueryConfig are used than those values will be
used to overwrite the TableConfig.


## Verifying this change

This change added tests:
* org.apache.flink.table.api.java.internal.StreamTableEnvironmentImplTest
* org.apache.flink.table.api.scala.internal.StreamTableEnvironmentImplTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no /** don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no /** don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
