### PR TITLE
[FLINK-13608] [docs] Update upgrade compatibility table for 1.9.x

### DIFF
--- a/docs/ops/upgrading.md
+++ b/docs/ops/upgrading.md
@@ -245,9 +245,15 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
-          <td class="text-left">When migrating from Flink 1.2.x to Flink 1.3.x+, changing parallelism at the same
+          <td class="text-left">
+          When migrating from Flink 1.2.x to Flink 1.3.x+, changing parallelism at the same
           time is not supported. Users have to first take a savepoint after migrating to Flink 1.3.x+, and then change
-          parallelism. Savepoints created for CEP applications cannot be restored in 1.4.x+.</td>
+          parallelism.
+          <br/><br/>Savepoints created for CEP applications cannot be restored in 1.4.x+.
+          <br/><br/>Savepoints from Flink 1.2 that contain a Scala TraversableSerializer are not compatible with Flink 1.8 anymore
+          because of an update in this serializer. You can get around this restriction by first upgrading to a version between Flink 1.3 and
+          Flink 1.7 and then updating to Flink 1.8.
+          </td>
     </tr>
     <tr>
           <td class="text-center"><strong>1.3.x</strong></td>
@@ -328,11 +334,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
-          <td class="text-left">Savepoints from Flink 1.2 that contain a Scala
-          TraversableSerializer are not compatible with Flink 1.8 anymore
-          because of an update in this serializer. You can get around this
-          restriction by first upgrading to a version between Flink 1.3 and
-          Flink 1.7 and then updating to Flink 1.8.</td>
+          <td class="text-left"></td>
     </tr>
     <tr>
           <td class="text-center"><strong>1.9.x</strong></td>

--- a/docs/ops/upgrading.md
+++ b/docs/ops/upgrading.md
@@ -214,6 +214,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
       <th class="text-center">1.6.x</th>
       <th class="text-center">1.7.x</th>
       <th class="text-center">1.8.x</th>
+      <th class="text-center">1.9.x</th>
       <th class="text-center">Limitations</th>
     </tr>
   </thead>
@@ -228,6 +229,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left">The maximum parallelism of a job that was migrated from Flink 1.1.x to 1.2.x+ is
           currently fixed as the parallelism of the job. This means that the parallelism can not be increased after
           migration. This limitation might be removed in a future bugfix release.</td>
@@ -235,6 +237,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
     <tr>
           <td class="text-center"><strong>1.2.x</strong></td>
           <td class="text-center"></td>
+          <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
@@ -256,6 +259,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center">O</td>
           <td class="text-left">Migrating from Flink 1.3.0 to Flink 1.4.[0,1] will fail if the savepoint contains Scala case classes. Users have to directly migrate to 1.4.2+ instead.</td>
     </tr>
     <tr>
@@ -263,6 +267,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
+          <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
@@ -276,6 +281,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
+          <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
@@ -295,6 +301,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center">O</td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -305,6 +312,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
+          <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-left"></td>
@@ -319,11 +327,25 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center">O</td>
+          <td class="text-center">O</td>
           <td class="text-left">Savepoints from Flink 1.2 that contain a Scala
           TraversableSerializer are not compatible with Flink 1.8 anymore
           because of an update in this serializer. You can get around this
           restriction by first upgrading to a version between Flink 1.3 and
           Flink 1.7 and then updating to Flink 1.8.</td>
+    </tr>
+    <tr>
+          <td class="text-center"><strong>1.9.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-left"></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the upgrade compatibility table in https://ci.apache.org/projects/flink/flink-docs-master/ops/upgrading.html#compatibility-table for 1.9.0.

It also includes a fix to move 1.2.x related limitations to the correct row in the table.

## Verifying this change

This change only touches documents.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)
