### PR TITLE
[FLINK-13635][datastream] Avoid unexpected interruption of AsyncFunction

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncFunction.java
@@ -89,6 +89,7 @@ public interface AsyncFunction<IN, OUT> extends Function, Serializable {
 	/**
 	 * {@link AsyncFunction#asyncInvoke} timeout occurred.
 	 * By default, the result future is exceptionally completed with a timeout exception.
+	 * Note that timeout and asyncInvoke might be invoked at the same time.
 	 *
 	 * @param input element coming from an upstream task
 	 * @param resultFuture to be completed with the result data

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala
@@ -179,7 +179,8 @@ class AsyncFunctionWithTimeoutExpired extends RichAsyncFunction[Int, Int] {
 
 /**
   * The asyncInvoke and timeout might be invoked at the same time.
-  * The target is checking whether there is a race condition or not between asyncInvoke, timeout and timer cancellation.
+  * The target is checking whether there is a race condition or not between asyncInvoke,
+  * timeout and timer cancellation.
   * See https://issues.apache.org/jira/browse/FLINK-13605 for more details.
   */
 class AsyncFunctionWithoutTimeoutExpired extends RichAsyncFunction[Int, Int] {


### PR DESCRIPTION
## What is the purpose of the change

* Fix the race condition that `AsyncFunction#timeout` might be interrupted unexpectedly

## Brief change log

* Introduce an `AtomicBoolean` as a mutex of `timeout` and cancellation

## Verifying this change

* This change added tests case in `AsyncDataStreamITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
