### PR TITLE
[FLINK-13601][tests] Harden RegionFailoverITCase by recording info when checkpoint just completed

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
@@ -117,7 +117,7 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
 	 */
 	public static class TestHAFactory implements HighAvailabilityServicesFactory {
 
-		public static HighAvailabilityServices haServices;
+		static HighAvailabilityServices haServices;
 		static ClientHighAvailabilityServices clientHAServices;
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
@@ -117,7 +117,7 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
 	 */
 	public static class TestHAFactory implements HighAvailabilityServicesFactory {
 
-		static HighAvailabilityServices haServices;
+		public static HighAvailabilityServices haServices;
 		static ClientHighAvailabilityServices clientHAServices;
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -442,6 +442,9 @@ public class RegionFailoverITCase extends TestLogger {
 		}
 	}
 
+	/**
+	 * Testing HA factory which needs to be public in order to be instantiatable.
+	 */
 	public static class TestingHAFactory implements HighAvailabilityServicesFactory {
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -29,14 +29,22 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.TestingCheckpointRecoveryFactory;
 import org.apache.flink.runtime.executiongraph.restart.FailingRestartStrategy;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtilsTest;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
@@ -63,6 +71,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -102,8 +111,14 @@ public class RegionFailoverITCase extends TestLogger {
 
 	@Before
 	public void setup() throws Exception {
+		HighAvailabilityServicesUtilsTest.TestHAFactory.haServices = new TestingHaServices(
+			new TestingCheckpointRecoveryFactory(
+				new TestingCompletedCheckpointStore(), new StandaloneCheckpointIDCounter()), TestingUtils.defaultExecutor());
+
 		Configuration configuration = new Configuration();
 		configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
+		configuration.setString(HighAvailabilityOptions.HA_MODE, HighAvailabilityServicesUtilsTest.TestHAFactory.class.getName());
+
 		// global failover times: 3, region failover times: NUM_OF_RESTARTS
 		configuration.setInteger(FailingRestartStrategy.NUM_FAILURES_CONFIG_OPTION, 3);
 		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY, FailingRestartStrategy.class.getName());
@@ -189,7 +204,8 @@ public class RegionFailoverITCase extends TestLogger {
 	}
 
 	private static class StringGeneratingSourceFunction extends RichParallelSourceFunction<Tuple2<Integer, Integer>>
-		implements CheckpointListener, CheckpointedFunction {
+		implements CheckpointedFunction {
+
 		private static final long serialVersionUID = 1L;
 
 		private final long numElements;
@@ -260,15 +276,6 @@ public class RegionFailoverITCase extends TestLogger {
 		}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) {
-			if (getRuntimeContext().getIndexOfThisSubtask() == NUM_OF_REGIONS - 1) {
-				lastCompletedCheckpointId.set(checkpointId);
-				snapshotIndicesOfSubTask.put(checkpointId, lastRegionIndex);
-				numCompletedCheckpoints.incrementAndGet();
-			}
-		}
-
-		@Override
 		public void snapshotState(FunctionSnapshotContext context) throws Exception {
 			int indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
 			if (indexOfThisSubtask != 0) {
@@ -276,6 +283,7 @@ public class RegionFailoverITCase extends TestLogger {
 				listState.add(index);
 				if (indexOfThisSubtask == NUM_OF_REGIONS - 1) {
 					lastRegionIndex = index;
+					snapshotIndicesOfSubTask.put(context.getCheckpointId(), lastRegionIndex);
 				}
 			}
 			unionListState.clear();
@@ -402,5 +410,39 @@ public class RegionFailoverITCase extends TestLogger {
 
 	private static class TestException extends IOException{
 		private static final long serialVersionUID = 1L;
+	}
+
+	private static class TestingHaServices extends EmbeddedHaServices {
+		private final CheckpointRecoveryFactory checkpointRecoveryFactory;
+
+		TestingHaServices(CheckpointRecoveryFactory checkpointRecoveryFactory, Executor executor) {
+			super(executor);
+			this.checkpointRecoveryFactory = checkpointRecoveryFactory;
+		}
+
+		@Override
+		public CheckpointRecoveryFactory getCheckpointRecoveryFactory() {
+			return checkpointRecoveryFactory;
+		}
+	}
+
+	/**
+	 * An extension of {@link StandaloneCompletedCheckpointStore} which would record information
+	 * of last completed checkpoint id and the number of completed checkpoints.
+	 */
+	private static class TestingCompletedCheckpointStore extends StandaloneCompletedCheckpointStore {
+
+		TestingCompletedCheckpointStore() {
+			super(1);
+		}
+
+		@Override
+		public void addCheckpoint(CompletedCheckpoint checkpoint) throws Exception {
+			super.addCheckpoint(checkpoint);
+			// we record the information when adding completed checkpoint instead of 'notifyCheckpointComplete' invoked
+			// on task side to avoid race condition. See FLINK-13601.
+			lastCompletedCheckpointId.set(checkpoint.getCheckpointID());
+			numCompletedCheckpoints.incrementAndGet();
+		}
 	}
 }


### PR DESCRIPTION
# What is the purpose of the change

Harden `RegionFailoverITCase` by recording info when checkpoint just completed to avoid the race condition in [FLINK-13601].


## Brief change log

  - Harden `RegionFailoverITCase`.


## Verifying this change

This change added tests and can be verified as follows:
  - We use `TestingCompletedCheckpointStore` to record information of checkpoints instead of previous `notifyCheckpointComplete` invoked on task side. This could avoid the race condition in [FLINK-13601](https://issues.apache.org/jira/browse/FLINK-13601).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
