### PR TITLE
[FLINK-13645][table-planner] Error in code-gen when using blink planner in scala shell

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -603,7 +603,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     val byteArray = InstantiationUtil.serializeObject(obj)
     val objCopy: AnyRef = InstantiationUtil.deserializeObject(
       byteArray,
-      obj.getClass.getClassLoader)
+      Thread.currentThread().getContextClassLoader)
     references += objCopy
 
     reusableMemberStatements.add(s"private transient $fieldTypeTerm $fieldTerm;")


### PR DESCRIPTION

## What is the purpose of the change

This is a trivial PR to fix the issue when using blink planner in scala shell. The root cause is that we didn't use the right ClassPathLoader. This PR just fix it.

## Brief change log

Set the ClassPathLoader properly.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. I verify it manually in apache zeppelin which uses scala shell related code.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
