### PR TITLE
[FLINK-13479] [flink-cassandra-connector] Fix for Deterministic ordering for prepared statement

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -38,7 +38,7 @@ under the License.
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
 		<cassandra.version>2.2.5</cassandra.version>
-		<driver.version>3.0.0</driver.version>
+		<driver.version>3.3.1</driver.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
## What is the purpose of the change
This pull request fixes the issue with Cassandra Connector issue FLINK-13479 where the deterministic order of columns in prepared statements is not working.

## Brief change log
- Updated the cassandra driver version from 3.0.0 to 3.3.1 where the issue is fixed (https://datastax-oss.atlassian.net/browse/JAVA-1587)

## Verifying this change
This is trivial configuration change - only changes the depenndent cassandra driver version.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): yes - cassandra driver upgraded from 3.0.0 to 3.3.1
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: No
  - The S3 file system connector: No

## Documentation
  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? Not applicable