### PR TITLE
[FLINK-13665][flink-planner] Use of decimal(p, s) where p is less tha…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
@@ -410,7 +410,14 @@ object FlinkTypeFactory {
     case FLOAT => FLOAT_TYPE_INFO
     case DOUBLE => DOUBLE_TYPE_INFO
     case VARCHAR | CHAR => STRING_TYPE_INFO
-    case DECIMAL => BIG_DEC_TYPE_INFO
+    case DECIMAL =>
+      val precision = relDataType.getPrecision
+      val scale = relDataType.getScale
+      if (precision < scale) {
+        throw new TableException(
+          "scale of DECIMAL type should between 0 to precision(included).")
+      }
+      BIG_DEC_TYPE_INFO
 
     // time indicators
     case TIMESTAMP if relDataType.isInstanceOf[TimeIndicatorRelDataType] =>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -127,7 +127,7 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("E()", "2.718281828459045")
     testSqlApi("BIN(12)", "1100")
     testSqlApi("truncate(42.345)", "42")
-    testSqlApi("truncate(cast(42.345 as decimal(2, 3)), 2)", "42.34")
+    testSqlApi("truncate(cast(42.345 as decimal(5, 3)), 2)", "42.34")
   }
 
   @Test


### PR DESCRIPTION
…n s should be illegal

## What is the purpose of the change

Fix illegal use of decimal type

## Brief change log

Fix illegal use of decimal type

## Verifying this change

This change is already covered by existing tests, such as *SqlExpressionTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
