### PR TITLE
[FLINK-13699][table-api] Fix TableFactory doesn't work with DDL when containing TIMESTAMP/DATE/TIME types

### DIFF
--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/util/HBaseTypeUtils.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/util/HBaseTypeUtils.java
@@ -21,7 +21,6 @@ package org.apache.flink.addons.hbase.util;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
-import org.apache.commons.net.ntp.TimeStamp;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import java.math.BigDecimal;
@@ -102,7 +101,7 @@ public class HBaseTypeUtils {
 			case 8:
 				return Bytes.toBytes((boolean) value);
 			case 9: // sql.Timestamp encoded to Long
-				return Bytes.toBytes(((TimeStamp) value).getTime());
+				return Bytes.toBytes(((Timestamp) value).getTime());
 			case 10: // sql.Date encoded as long
 				return Bytes.toBytes(((Date) value).getTime());
 			case 11: // sql.Time encoded as long

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -562,7 +562,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 			CollectTableSink<Row> configuredSink = (CollectTableSink<Row>) sink.configure(
 				schema.getFieldNames(), types.toArray(new TypeInformation[0]));
 			return JavaScalaConversionUtil.toJava(
-				BatchTableEnvUtil.collect(t.getTableEnvironment(), table, configuredSink, Option.apply("JOB")));
+				BatchTableEnvUtil.collect(t.getTableEnvironment(), table, configuredSink, Option.apply("JOB"), "catalog", "database"));
 		}
 	}
 

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -38,7 +38,9 @@ import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.TableFactoryService;
 import org.apache.flink.table.functions.ScalarFunction;
-import org.apache.flink.table.planner.runtime.utils.TableUtil;
+import org.apache.flink.table.planner.runtime.utils.BatchTableEnvUtil;
+import org.apache.flink.table.planner.sinks.CollectRowTableSink;
+import org.apache.flink.table.planner.sinks.CollectTableSink;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.runtime.utils.StreamITCase;
 import org.apache.flink.table.sinks.TableSink;
@@ -53,10 +55,15 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import scala.Option;
 
 import static org.apache.flink.addons.hbase.util.PlannerType.OLD_PLANNER;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
@@ -228,18 +235,27 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 	// prepare a source collection.
 	private static final List<Row> testData1 = new ArrayList<>();
 	private static final RowTypeInfo testTypeInfo1 = new RowTypeInfo(
-		new TypeInformation[]{Types.INT, Types.INT, Types.STRING, Types.LONG, Types.DOUBLE, Types.BOOLEAN, Types.STRING},
-		new String[]{"rowkey", "f1c1", "f2c1", "f2c2", "f3c1", "f3c2", "f3c3"});
+		new TypeInformation[]{Types.INT, Types.INT, Types.STRING, Types.LONG, Types.DOUBLE,
+			Types.BOOLEAN, Types.STRING, Types.SQL_TIMESTAMP, Types.SQL_DATE, Types.SQL_TIME},
+		new String[]{"rowkey", "f1c1", "f2c1", "f2c2", "f3c1", "f3c2", "f3c3", "f4c1", "f4c2", "f4c3"});
 
 	static {
-		testData1.add(Row.of(1, 10, "Hello-1", 100L, 1.01, false, "Welt-1"));
-		testData1.add(Row.of(2, 20, "Hello-2", 200L, 2.02, true, "Welt-2"));
-		testData1.add(Row.of(3, 30, "Hello-3", 300L, 3.03, false, "Welt-3"));
-		testData1.add(Row.of(4, 40, null, 400L, 4.04, true, "Welt-4"));
-		testData1.add(Row.of(5, 50, "Hello-5", 500L, 5.05, false, "Welt-5"));
-		testData1.add(Row.of(6, 60, "Hello-6", 600L, 6.06, true, "Welt-6"));
-		testData1.add(Row.of(7, 70, "Hello-7", 700L, 7.07, false, "Welt-7"));
-		testData1.add(Row.of(8, 80, null, 800L, 8.08, true, "Welt-8"));
+		testData1.add(Row.of(1, 10, "Hello-1", 100L, 1.01, false, "Welt-1",
+			Timestamp.valueOf("2019-08-18 19:00:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:00:00")));
+		testData1.add(Row.of(2, 20, "Hello-2", 200L, 2.02, true, "Welt-2",
+			Timestamp.valueOf("2019-08-18 19:01:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:01:00")));
+		testData1.add(Row.of(3, 30, "Hello-3", 300L, 3.03, false, "Welt-3",
+			Timestamp.valueOf("2019-08-18 19:02:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:02:00")));
+		testData1.add(Row.of(4, 40, null, 400L, 4.04, true, "Welt-4",
+			Timestamp.valueOf("2019-08-18 19:03:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:03:00")));
+		testData1.add(Row.of(5, 50, "Hello-5", 500L, 5.05, false, "Welt-5",
+			Timestamp.valueOf("2019-08-19 19:10:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:10:00")));
+		testData1.add(Row.of(6, 60, "Hello-6", 600L, 6.06, true, "Welt-6",
+			Timestamp.valueOf("2019-08-19 19:20:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:20:00")));
+		testData1.add(Row.of(7, 70, "Hello-7", 700L, 7.07, false, "Welt-7",
+			Timestamp.valueOf("2019-08-19 19:30:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:30:00")));
+		testData1.add(Row.of(8, 80, null, 800L, 8.08, true, "Welt-8",
+			Timestamp.valueOf("2019-08-19 19:40:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:40:00")));
 	}
 
 	@Test
@@ -316,6 +332,72 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 				"6,60,Hello-6,600,6.06,true,Welt-6\n" +
 				"7,70,Hello-7,700,7.07,false,Welt-7\n" +
 				"8,80,,800,8.08,true,Welt-8\n";
+
+		TestBaseUtils.compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testTableSourceSinkWithDDL() throws Exception {
+		StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
+
+		DataStream<Row> ds = execEnv.fromCollection(testData1).returns(testTypeInfo1);
+		tEnv.registerDataStream("src", ds);
+
+		// register hbase table
+		String quorum = getZookeeperQuorum();
+		String ddl = "CREATE TABLE hbase (\n" +
+			"    rowkey INT," +
+			"    family1 ROW<col1 INT>,\n" +
+			"    family2 ROW<col1 VARCHAR, col2 BIGINT>,\n" +
+			"    family3 ROW<col1 DOUBLE, col2 BOOLEAN, col3 VARCHAR>,\n" +
+			"    family4 ROW<col1 TIMESTAMP, col2 DATE, col3 TIME>\n" +
+			") WITH (\n" +
+			"    'connector.type' = 'hbase',\n" +
+			"    'connector.version' = '1.4.3',\n" +
+			"    'connector.table-name' = 'testTable3',\n" +
+			"    'connector.zookeeper.quorum' = '" + quorum + "',\n" +
+			"    'connector.zookeeper.znode.parent' = '/hbase' " +
+			")";
+		tEnv.sqlUpdate(ddl);
+
+		String query = "INSERT INTO hbase " +
+			"SELECT rowkey, ROW(f1c1), ROW(f2c1, f2c2), ROW(f3c1, f3c2, f3c3), ROW(f4c1, f4c2, f4c3) " +
+			"FROM src";
+		tEnv.sqlUpdate(query);
+
+		// wait to finish
+		tEnv.execute("HBase Job");
+
+		// start a batch scan job to verify contents in HBase table
+		TableEnvironment batchTableEnv = createBatchTableEnv();
+		batchTableEnv.sqlUpdate(ddl);
+
+		Table table = batchTableEnv.sqlQuery(
+			"SELECT " +
+				"  h.rowkey, " +
+				"  h.family1.col1, " +
+				"  h.family2.col1, " +
+				"  h.family2.col2, " +
+				"  h.family3.col1, " +
+				"  h.family3.col2, " +
+				"  h.family3.col3, " +
+				"  h.family4.col1, " +
+				"  h.family4.col2, " +
+				"  h.family4.col3 " +
+				"FROM hbase AS h"
+		);
+
+		List<Row> results = collectBatchResult(table);
+		String expected =
+				"1,10,Hello-1,100,1.01,false,Welt-1,2019-08-18 19:00:00.0,2019-08-18,19:00:00\n" +
+				"2,20,Hello-2,200,2.02,true,Welt-2,2019-08-18 19:01:00.0,2019-08-18,19:01:00\n" +
+				"3,30,Hello-3,300,3.03,false,Welt-3,2019-08-18 19:02:00.0,2019-08-18,19:02:00\n" +
+				"4,40,,400,4.04,true,Welt-4,2019-08-18 19:03:00.0,2019-08-18,19:03:00\n" +
+				"5,50,Hello-5,500,5.05,false,Welt-5,2019-08-19 19:10:00.0,2019-08-19,19:10:00\n" +
+				"6,60,Hello-6,600,6.06,true,Welt-6,2019-08-19 19:20:00.0,2019-08-19,19:20:00\n" +
+				"7,70,Hello-7,700,7.07,false,Welt-7,2019-08-19 19:30:00.0,2019-08-19,19:30:00\n" +
+				"8,80,,800,8.08,true,Welt-8,2019-08-19 19:40:00.0,2019-08-19,19:40:00\n";
 
 		TestBaseUtils.compareResultAsText(results, expected);
 	}
@@ -461,7 +543,26 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 			DataSet<Row> resultSet = batchTableEnv.toDataSet(table, Row.class);
 			return resultSet.collect();
 		} else {
-			return JavaScalaConversionUtil.toJava(TableUtil.collect(tableImpl));
+			TableImpl t = (TableImpl) table;
+			TableSchema schema = t.getSchema();
+			List<TypeInformation> types = new ArrayList<>();
+			for (TypeInformation typeInfo : t.getSchema().getFieldTypes()) {
+				// convert LOCAL_DATE_TIME to legacy TIMESTAMP to make the output consistent with flink batch planner
+				if (typeInfo.equals(Types.LOCAL_DATE_TIME)) {
+					types.add(Types.SQL_TIMESTAMP);
+				} else if (typeInfo.equals(Types.LOCAL_DATE)) {
+					types.add(Types.SQL_DATE);
+				} else if (typeInfo.equals(Types.LOCAL_TIME)) {
+					types.add(Types.SQL_TIME);
+				} else {
+					types.add(typeInfo);
+				}
+			}
+			CollectRowTableSink sink = new CollectRowTableSink();
+			CollectTableSink<Row> configuredSink = (CollectTableSink<Row>) sink.configure(
+				schema.getFieldNames(), types.toArray(new TypeInformation[0]));
+			return JavaScalaConversionUtil.toJava(
+				BatchTableEnvUtil.collect(t.getTableEnvironment(), table, configuredSink, Option.apply("JOB")));
 		}
 	}
 

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -351,7 +351,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 			"    family1 ROW<col1 INT>,\n" +
 			"    family2 ROW<col1 VARCHAR, col2 BIGINT>,\n" +
 			"    family3 ROW<col1 DOUBLE, col2 BOOLEAN, col3 VARCHAR>,\n" +
-			"    family4 ROW<col1 TIMESTAMP, col2 DATE, col3 TIME>\n" +
+			"    family4 ROW<col1 TIMESTAMP(3), col2 DATE, col3 TIME(3)>\n" +
 			") WITH (\n" +
 			"    'connector.type' = 'hbase',\n" +
 			"    'connector.version' = '1.4.3',\n" +

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
@@ -562,7 +563,9 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 			CollectTableSink<Row> configuredSink = (CollectTableSink<Row>) sink.configure(
 				schema.getFieldNames(), types.toArray(new TypeInformation[0]));
 			return JavaScalaConversionUtil.toJava(
-				BatchTableEnvUtil.collect(t.getTableEnvironment(), table, configuredSink, Option.apply("JOB"), "catalog", "database"));
+				BatchTableEnvUtil.collect(
+					t.getTableEnvironment(), table, configuredSink, Option.apply("JOB"),
+					EnvironmentSettings.DEFAULT_BUILTIN_CATALOG, EnvironmentSettings.DEFAULT_BUILTIN_DATABASE));
 		}
 	}
 

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/util/HBaseTestBase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/util/HBaseTestBase.java
@@ -44,6 +44,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 
 	protected static final String TEST_TABLE_1 = "testTable1";
 	protected static final String TEST_TABLE_2 = "testTable2";
+	protected static final String TEST_TABLE_3 = "testTable3";
 
 	protected static final String ROWKEY = "rk";
 	protected static final String FAMILY1 = "family1";
@@ -57,6 +58,8 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 	protected static final String F3COL1 = "col1";
 	protected static final String F3COL2 = "col2";
 	protected static final String F3COL3 = "col3";
+
+	protected static final String FAMILY4 = "family4";
 
 	private static final byte[][] FAMILIES = new byte[][]{
 		Bytes.toBytes(FAMILY1),
@@ -100,6 +103,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 	private static void prepareTables() throws IOException {
 		createHBaseTable1();
 		createHBaseTable2();
+		createHBaseTable3();
 	}
 
 	private static void createHBaseTable1() throws IOException {
@@ -129,6 +133,18 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 		// create a table
 		TableName tableName = TableName.valueOf(TEST_TABLE_2);
 		createTable(tableName, FAMILIES, SPLIT_KEYS);
+	}
+
+	private static void createHBaseTable3() {
+		// create a table
+		byte[][] families = new byte[][]{
+			Bytes.toBytes(FAMILY1),
+			Bytes.toBytes(FAMILY2),
+			Bytes.toBytes(FAMILY3),
+			Bytes.toBytes(FAMILY4),
+		};
+		TableName tableName = TableName.valueOf(TEST_TABLE_3);
+		createTable(tableName, families, SPLIT_KEYS);
 	}
 
 	private static Put putRow(int rowKey, int f1c1, String f2c1, long f2c2, double f3c1, boolean f3c2, String f3c3) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeStringUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeStringUtils.java
@@ -96,11 +96,14 @@ public class TypeStringUtils {
 			return DOUBLE;
 		} else if (typeInfo.equals(Types.BIG_DEC)) {
 			return DECIMAL;
-		} else if (typeInfo.equals(Types.SQL_DATE)) {
+		} else if (typeInfo.equals(Types.SQL_DATE) || typeInfo.equals(Types.LOCAL_DATE)) {
+			// write LOCAL_DATE as "DATE" to keep compatible when using new types
 			return DATE;
-		} else if (typeInfo.equals(Types.SQL_TIME)) {
+		} else if (typeInfo.equals(Types.SQL_TIME) || typeInfo.equals(Types.LOCAL_TIME)) {
+			// write LOCAL_TIME as "TIME" to keep compatible when using new types
 			return TIME;
-		} else if (typeInfo.equals(Types.SQL_TIMESTAMP)) {
+		} else if (typeInfo.equals(Types.SQL_TIMESTAMP) || typeInfo.equals(Types.LOCAL_DATE_TIME)) {
+			// write LOCAL_DATE_TIME as "TIMESTAMP" to keep compatible when using new types
 			return TIMESTAMP;
 		} else if (typeInfo instanceof RowTypeInfo) {
 			final RowTypeInfo rt = (RowTypeInfo) typeInfo;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TypeStringUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TypeStringUtilsTest.java
@@ -47,6 +47,9 @@ public class TypeStringUtilsTest {
 		testReadAndWrite("DATE", Types.SQL_DATE);
 		testReadAndWrite("TIME", Types.SQL_TIME);
 		testReadAndWrite("TIMESTAMP", Types.SQL_TIMESTAMP);
+		testWrite("DATE", Types.LOCAL_DATE);
+		testWrite("TIME", Types.LOCAL_TIME);
+		testWrite("TIMESTAMP", Types.LOCAL_DATE_TIME);
 
 		// unsupported type information
 		testReadAndWrite(
@@ -129,6 +132,11 @@ public class TypeStringUtilsTest {
 				Types.ROW_NAMED(
 					new String[] {"Field 1", "Field`s 2"},
 					Types.ROW(Types.BIG_DEC), Types.STRING)));
+
+		testWrite("ROW<f0 DECIMAL, f1 TIMESTAMP, f2 TIME, f3 DATE>",
+			Types.ROW_NAMED(
+				new String[] {"f0", "f1", "f2", "f3"},
+				Types.BIG_DEC, Types.LOCAL_DATE_TIME, Types.LOCAL_TIME, Types.LOCAL_DATE));
 	}
 
 	@Test(expected = ValidationException.class)
@@ -150,6 +158,11 @@ public class TypeStringUtilsTest {
 		// test read from string
 		assertEquals(type, TypeStringUtils.readTypeInfo(expected));
 
+		// test write to string
+		assertEquals(expected, TypeStringUtils.writeTypeInfo(type));
+	}
+
+	private void testWrite(String expected, TypeInformation<?> type) {
 		// test write to string
 		assertEquals(expected, TypeStringUtils.writeTypeInfo(type));
 	}


### PR DESCRIPTION

The solution is encode DataTypes.TIMESTAMP() as "TIMESTAMP" when translating to properties.
And will be converted back to the old TypeInformation: Types.SQL_TIMESTAMP.
This would fix all factories at once.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, in blink planner, we will convert DDL to TableSchema with new type system, i.e. DataTypes.TIMESTAMP()/DATE()/TIME() whose underlying TypeInformation are Types.LOCAL_DATETIME/LOCAL_DATE/LOCAL_TIME.

However, this makes the existing connector implementations (Kafka, ES, CSV, etc..) don't work because they only accept the old TypeInformations (Types.SQL_TIMESTAMP/SQL_DATE/SQL_TIME).

A simple solution is encode DataTypes.TIMESTAMP() as "TIMESTAMP" when translating to properties. And will be converted back to the old TypeInformation: Types.SQL_TIMESTAMP. This would fix all factories at once.

## Brief change log

- Convert Types.LOCAL_DATETIME/LOCAL_DATE/LOCAL_TIME to "TIMESTAMP"/"DATE"/"TIME" as well.


## Verifying this change

- Add unit test in `TypeStringUtilsTest` to verify the conversion from LocalDataTime/LocalDate/LocalTime.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
