### PR TITLE
[FLINK-13700] [pubsub] Add pubsub example jar to flink-dist

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -212,6 +212,13 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-examples-streaming-gcp-pubsub_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!--
 			The following dependencies are packaged in 'opt/' 
 			The scope of these dependencies needs to be 'provided' so that

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -250,6 +250,17 @@ under the License.
 				<exclude>original-*.jar</exclude>
 			</excludes>
 		</fileSet>
+		<fileSet>
+			<directory>../flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/target</directory>
+			<outputDirectory>examples/streaming</outputDirectory>
+			<fileMode>0644</fileMode>
+			<includes>
+				<include>*.jar</include>
+			</includes>
+			<excludes>
+				<exclude>original-*.jar</exclude>
+			</excludes>
+		</fileSet>
 
 		<!-- copy jar files of the gelly examples -->
 		<fileSet>


### PR DESCRIPTION
## What is the purpose of the change

**Make sure the PubSub connector example is added to flink-dist**

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no, except for a jar in the dist tar
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no