### PR TITLE
[1.9][FLINK-13484][tests] ConnectedComponents E2E test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -17,37 +17,27 @@
 # limitations under the License.
 ################################################################################
 
+set -Eexuo pipefail
+
 source "$(dirname "$0")"/common.sh
 
 PARALLELISM="${1:-25}"
+TM_NUM=2
+let "SLOTS_PER_TM = (PARALLELISM + TM_NUM - 1) / TM_NUM"
 
 TEST=flink-high-parallelism-iterations-test
 TEST_PROGRAM_NAME=HighParallelismIterationsTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-set_config_key "taskmanager.heap.size" "52m" # 52Mb x 100 TMs = 5Gb total heap
-
-set_config_key "taskmanager.memory.size" "8" # 8Mb
-set_config_key "taskmanager.network.memory.min" "8mb"
-set_config_key "taskmanager.network.memory.max" "8mb"
-set_config_key "taskmanager.memory.segment-size" "8kb"
-
-set_config_key "taskmanager.network.netty.server.numThreads" "1"
-set_config_key "taskmanager.network.netty.client.numThreads" "1"
-set_config_key "taskmanager.network.request-backoff.max" "60000"
-
-set_config_key "taskmanager.numberOfTaskSlots" "1"
+set_config_key "taskmanager.numberOfTaskSlots" "$SLOTS_PER_TM"
 
 print_mem_use
 start_cluster
 print_mem_use
 
-let TMNUM=$PARALLELISM-1
-echo "Start $TMNUM more task managers"
-for i in `seq 1 $TMNUM`; do
-    $FLINK_DIR/bin/taskmanager.sh start
-    print_mem_use
-done
+let "TM_NUM -= 1"
+start_taskmanagers ${TM_NUM}
+print_mem_use
 
 $FLINK_DIR/bin/flink run -p $PARALLELISM $TEST_PROGRAM_JAR
 print_mem_use


### PR DESCRIPTION
## What is the purpose of the change

*This hardens the ConnectedComponents end-to-end test on Travis CI.*


## Brief change log

  - *See commit*

## Verifying this change

This change is already covered by existing tests, such as *ConnectedComponents E2E test*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
