### PR TITLE
[FLINK-12958] Integrate AsyncWaitOperator with mailbox (preserving compatibility with legacy sources)

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/Emitter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/Emitter.java
@@ -26,12 +26,16 @@ import org.apache.flink.streaming.api.operators.async.queue.AsyncResult;
 import org.apache.flink.streaming.api.operators.async.queue.AsyncWatermarkResult;
 import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueue;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutor;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * Runnable responsible for consuming elements from the given queue and outputting them to the
@@ -47,6 +51,9 @@ public class Emitter<OUT> implements Runnable {
 	/** Lock to hold before outputting. */
 	private final Object checkpointLock;
 
+	/** Access to the mailbox of the stream task to enqueue processing requests. */
+	private final MailboxExecutor mailboxExecutor;
+
 	/** Output for the watermark elements. */
 	private final Output<StreamRecord<OUT>> output;
 
@@ -58,71 +65,71 @@ public class Emitter<OUT> implements Runnable {
 	/** Output for stream records. */
 	private final TimestampedCollector<OUT> timestampedCollector;
 
-	private volatile boolean running;
+	private volatile boolean stopped;
+
+	private volatile boolean done;
 
 	public Emitter(
+			final MailboxExecutor mailboxExecutor,
 			final Object checkpointLock,
 			final Output<StreamRecord<OUT>> output,
 			final StreamElementQueue streamElementQueue,
 			final OperatorActions operatorActions) {
 
+		this.mailboxExecutor = Preconditions.checkNotNull(mailboxExecutor, "mailboxExecutor");
 		this.checkpointLock = Preconditions.checkNotNull(checkpointLock, "checkpointLock");
 		this.output = Preconditions.checkNotNull(output, "output");
 		this.streamElementQueue = Preconditions.checkNotNull(streamElementQueue, "streamElementQueue");
 		this.operatorActions = Preconditions.checkNotNull(operatorActions, "operatorActions");
 
 		this.timestampedCollector = new TimestampedCollector<>(this.output);
-		this.running = true;
+		this.stopped = false;
+		this.done = false;
 	}
 
 	@Override
 	public void run() {
 		try {
-			while (running) {
+			while (!stopped) {
 				LOG.debug("Wait for next completed async stream element result.");
 				AsyncResult streamElementEntry = streamElementQueue.peekBlockingly();
 
 				output(streamElementEntry);
 			}
-		} catch (InterruptedException e) {
-			if (running) {
+		} catch (InterruptedException | RejectedExecutionException e) {
+			if (!stopped) {
 				operatorActions.failOperator(e);
 			} else {
 				// Thread got interrupted which means that it should shut down
-				LOG.debug("Emitter thread got interrupted, shutting down.");
+				LOG.debug("Emitter thread got interrupted or mailbox was closed, shutting down.", e);
 			}
 		} catch (Throwable t) {
 			operatorActions.failOperator(new Exception("AsyncWaitOperator's emitter caught an " +
 				"unexpected throwable.", t));
+		} finally {
+			synchronized (checkpointLock) {
+				done = true;
+				checkpointLock.notifyAll();
+			}
 		}
 	}
 
-	private void output(AsyncResult asyncResult) throws InterruptedException {
-		if (asyncResult.isWatermark()) {
-			synchronized (checkpointLock) {
+	private void output(AsyncResult asyncResult) throws ExecutionException, InterruptedException {
+		final Runnable processingRequest = () -> {
+			if (asyncResult.isWatermark()) {
 				AsyncWatermarkResult asyncWatermarkResult = asyncResult.asWatermark();
 
 				LOG.debug("Output async watermark.");
 				output.emitWatermark(asyncWatermarkResult.getWatermark());
-
-				// remove the peeked element from the async collector buffer so that it is no longer
-				// checkpointed
-				streamElementQueue.poll();
-
-				// notify the main thread that there is again space left in the async collector
-				// buffer
-				checkpointLock.notifyAll();
-			}
-		} else {
-			AsyncCollectionResult<OUT> streamRecordResult = asyncResult.asResultCollection();
-
-			if (streamRecordResult.hasTimestamp()) {
-				timestampedCollector.setAbsoluteTimestamp(streamRecordResult.getTimestamp());
 			} else {
-				timestampedCollector.eraseTimestamp();
-			}
+				AsyncCollectionResult<OUT> streamRecordResult = asyncResult.asResultCollection();
 
-			synchronized (checkpointLock) {
+				if (streamRecordResult.hasTimestamp()) {
+					timestampedCollector.setAbsoluteTimestamp(streamRecordResult.getTimestamp());
+				} else {
+					timestampedCollector.eraseTimestamp();
+				}
+
 				LOG.debug("Output async stream element collection result.");
 
 				try {
@@ -138,19 +145,33 @@ public class Emitter<OUT> implements Runnable {
 						new Exception("An async function call terminated with an exception. " +
 							"Failing the AsyncWaitOperator.", e));
 				}
-
-				// remove the peeked element from the async collector buffer so that it is no longer
-				// checkpointed
-				streamElementQueue.poll();
-
-				// notify the main thread that there is again space left in the async collector
-				// buffer
-				checkpointLock.notifyAll();
 			}
+
+			// remove the peeked element from the async collector buffer so that it is no longer
+			// checkpointed
+			try {
+				streamElementQueue.poll();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		};
+
+		CompletableFuture<Void> writebackFuture = CompletableFuture.runAsync(processingRequest, mailboxExecutor);
+
+		// TODO: This is needed for support of legacy source compatibility. This is the counterpart to waiting on
+		//  the checkpointing lock in {AsyncWaitOperator#addAsyncBufferEntry}.
+		synchronized (checkpointLock) {
+			checkpointLock.notifyAll();
 		}
+
+		writebackFuture.get();
 	}
 
 	public void stop() {
-		running = false;
+		stopped = true;
+	}
+
+	public boolean isDone() {
+		return done;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -63,6 +63,8 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.TestMailboxExecutor;
+import org.apache.flink.streaming.util.MockOutput;
 import org.apache.flink.streaming.util.MockStreamConfig;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.TestHarnessUtil;
@@ -74,8 +76,6 @@ import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import javax.annotation.Nonnull;
 
@@ -102,7 +102,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -765,6 +764,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 	@Test(timeout = 10000L)
 	public void testClosingWithBlockedEmitter() throws Exception {
 		final Object lock = new Object();
+		final TestMailboxExecutor mailboxExecutor = new TestMailboxExecutor();
 
 		ArgumentCaptor<Throwable> failureReason = ArgumentCaptor.forClass(Throwable.class);
 
@@ -773,6 +773,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		StreamTask<?, ?> containingTask = mock(StreamTask.class);
 		when(containingTask.getEnvironment()).thenReturn(environment);
 		when(containingTask.getCheckpointLock()).thenReturn(lock);
+		when(containingTask.getTaskMailboxExecutor()).thenReturn(mailboxExecutor);
 		when(containingTask.getProcessingTimeService()).thenReturn(new TestProcessingTimeService());
 
 		StreamConfig streamConfig = new MockStreamConfig();
@@ -781,22 +782,22 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		final OneShotLatch closingLatch = new OneShotLatch();
 		final OneShotLatch outputLatch = new OneShotLatch();
 
-		Output<StreamRecord<Integer>> output = mock(Output.class);
-		doAnswer(new Answer() {
-			@Override
-			public Object answer(InvocationOnMock invocation) throws Throwable {
-				assertTrue("Output should happen under the checkpoint lock.", Thread.currentThread().holdsLock(lock));
+		Output<StreamRecord<Integer>> output = new MockOutput<Integer>(new ArrayList<>()) {
 
+			@Override
+			public void collect(StreamRecord<Integer> record) {
+				super.collect(record);
 				outputLatch.trigger();
 
 				// wait until we're in the closing method of the operator
-				while (!closingLatch.isTriggered()) {
-					lock.wait();
+				try {
+					closingLatch.await();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new RuntimeException("Waiting on latch interrupted.", e);
 				}
-
-				return null;
 			}
-		}).when(output).collect(any(StreamRecord.class));
+		};
 
 		AsyncWaitOperator<Integer, Integer> operator = new TestAsyncWaitOperator<>(
 			new MyAsyncFunction(),
@@ -847,7 +848,6 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		@Override
 		public void close() throws Exception {
 			closingLatch.trigger();
-			checkpointingLock.notifyAll();
 			super.close();
 		}
 	}
@@ -869,6 +869,8 @@ public class AsyncWaitOperatorTest extends TestLogger {
 
 		ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
 
+		final TestMailboxExecutor mailboxExecutor = new TestMailboxExecutor();
+
 		ProcessingTimeService processingTimeService = mock(ProcessingTimeService.class);
 		when(processingTimeService.getCurrentProcessingTime()).thenReturn(timestamp);
 		doReturn(scheduledFuture).when(processingTimeService).registerTimer(anyLong(), any(ProcessingTimeCallback.class));
@@ -876,6 +878,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		StreamTask<?, ?> containingTask = mock(StreamTask.class);
 		when(containingTask.getEnvironment()).thenReturn(environment);
 		when(containingTask.getCheckpointLock()).thenReturn(lock);
+		when(containingTask.getTaskMailboxExecutor()).thenReturn(mailboxExecutor);
 		when(containingTask.getProcessingTimeService()).thenReturn(processingTimeService);
 
 		StreamConfig streamConfig = new MockStreamConfig();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/EmitterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/EmitterTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.operators.async.queue.WatermarkQueueEntry;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.TestMailboxExecutor;
 import org.apache.flink.streaming.util.CollectorOutput;
 import org.apache.flink.util.TestLogger;
 
@@ -99,7 +100,7 @@ public class EmitterTest extends TestLogger {
 
 		StreamElementQueue queue = new OrderedStreamElementQueue(capacity, executor, operatorActions);
 
-		final Emitter<Integer> emitter = new Emitter<>(lock, output, queue, operatorActions);
+		final Emitter<Integer> emitter = new Emitter<>(new TestMailboxExecutor(), lock, output, queue, operatorActions);
 
 		final Thread emitterThread = new Thread(emitter);
 		emitterThread.start();
@@ -151,7 +152,7 @@ public class EmitterTest extends TestLogger {
 
 		StreamElementQueue queue = new OrderedStreamElementQueue(capacity, executor, operatorActions);
 
-		final Emitter<Integer> emitter = new Emitter<>(lock, output, queue, operatorActions);
+		final Emitter<Integer> emitter = new Emitter<>(new TestMailboxExecutor(), lock, output, queue, operatorActions);
 
 		final Thread emitterThread = new Thread(emitter);
 		emitterThread.start();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -111,8 +111,8 @@ public class StreamTaskTestHarness<OUT> {
 	protected StreamTestSingleInputGate[] inputGates;
 
 	public StreamTaskTestHarness(
-			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
-			TypeInformation<OUT> outputType) {
+		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		TypeInformation<OUT> outputType) {
 		this(taskFactory, outputType, TestLocalRecoveryConfig.disabled());
 	}
 
@@ -397,7 +397,7 @@ public class StreamTaskTestHarness<OUT> {
 		while (true) {
 			Thread.State state = taskThread.getState();
 			if (state == Thread.State.BLOCKED || state == Thread.State.TERMINATED ||
-					state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
+				state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
 				break;
 			}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -182,7 +182,6 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		this.config.setOperatorID(operatorID);
 		this.executionConfig = env.getExecutionConfig();
 		this.closableRegistry = new CloseableRegistry();
-		this.checkpointLock = new Object();
 
 		this.environment = Preconditions.checkNotNull(env);
 
@@ -199,7 +198,6 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		};
 
 		mockTask = new MockStreamTaskBuilder(env)
-			.setCheckpointLock(checkpointLock)
 			.setConfig(config)
 			.setExecutionConfig(executionConfig)
 			.setStreamTaskStateInitializer(streamTaskStateInitializer)
@@ -208,6 +206,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			.setProcessingTimeService(processingTimeService)
 			.setHandleAsyncException(handleAsyncException)
 			.build();
+
+		this.checkpointLock = mockTask.getCheckpointLock();
 	}
 
 	protected StreamTaskStateInitializer createStreamTaskStateManager(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -29,6 +29,7 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.mailbox.execution.DefaultActionContext;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutor;
 
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -40,6 +41,7 @@ public class MockStreamTask extends StreamTask {
 
 	private final String name;
 	private final Object checkpointLock;
+	private final MailboxExecutor taskMailboxExecutor;
 	private final StreamConfig config;
 	private final ExecutionConfig executionConfig;
 	private StreamTaskStateInitializer streamTaskStateInitializer;
@@ -54,6 +56,7 @@ public class MockStreamTask extends StreamTask {
 		Environment environment,
 		String name,
 		Object checkpointLock,
+		MailboxExecutor mailboxExecutor,
 		StreamConfig config,
 		ExecutionConfig executionConfig,
 		StreamTaskStateInitializer streamTaskStateInitializer,
@@ -67,6 +70,7 @@ public class MockStreamTask extends StreamTask {
 		super(environment);
 		this.name = name;
 		this.checkpointLock = checkpointLock;
+		this.taskMailboxExecutor = mailboxExecutor;
 		this.config = config;
 		this.executionConfig = executionConfig;
 		this.streamTaskStateInitializer = streamTaskStateInitializer;
@@ -151,5 +155,10 @@ public class MockStreamTask extends StreamTask {
 	@Override
 	public Map<String, Accumulator<?, ?>> getAccumulatorMap() {
 		return accumulatorMap;
+	}
+
+	@Override
+	public MailboxExecutor getTaskMailboxExecutor() {
+		return taskMailboxExecutor;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -35,6 +35,8 @@ import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutor;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.TestMailboxExecutor;
 
 import java.util.Collections;
 import java.util.Map;
@@ -47,6 +49,7 @@ public class MockStreamTaskBuilder {
 	private final Environment environment;
 	private String name = "Mock Task";
 	private Object checkpointLock = new Object();
+	private MailboxExecutor mailboxExecutor = new TestMailboxExecutor(checkpointLock);
 	private StreamConfig config = new StreamConfig(new Configuration());
 	private ExecutionConfig executionConfig = new ExecutionConfig();
 	private CloseableRegistry closableRegistry = new CloseableRegistry();
@@ -115,11 +118,17 @@ public class MockStreamTaskBuilder {
 		return this;
 	}
 
+	public MockStreamTaskBuilder setMailboxExecutor(MailboxExecutor mailboxExecutor) {
+		this.mailboxExecutor = mailboxExecutor;
+		return this;
+	}
+
 	public MockStreamTask build() {
 		return new MockStreamTask(
 			environment,
 			name,
 			checkpointLock,
+			mailboxExecutor,
 			config,
 			executionConfig,
 			streamTaskStateInitializer,


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates `AsyncWaitOperator` with task's mailbox, by coordinating `AsyncWaitOperator` with it's `Emitter` thread via mailbox (the `Emitter` now delegates the execution of the element processing to the main task thread).

## Brief change log

  - the `AsyncWaitOperator` may execute letters from the task's mailbox if the elements queue is full;
  - the `Emitter` thread is delegating elememnt processing and pop up from the `StreamElementQueue` to the main task thread (via mailbox).

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
