### PR TITLE
[FLINK-13708] [table-planner-blink] transformations should be cleared after execution in blink planner

### DIFF
--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -25,7 +25,8 @@ from pyflink.table.table_config import TableConfig
 from pyflink.table.table_environment import BatchTableEnvironment
 from pyflink.table.types import RowType
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, PyFlinkBatchTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, PyFlinkBatchTableTestCase, \
+    PyFlinkBlinkBatchTableTestCase
 from pyflink.util.exceptions import TableException
 
 
@@ -347,7 +348,7 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
         assert isinstance(actual, str)
 
     def test_explain_with_multi_sinks(self):
-        t_env = self.bt_env
+        t_env = self.t_env
         source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
@@ -361,8 +362,8 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
         t_env.sql_update("insert into sink1 select * from %s where a > 100" % source)
         t_env.sql_update("insert into sink2 select * from %s where a < 100" % source)
 
-        actual = t_env.explain(extended=True)
-        assert isinstance(actual, str) or isinstance(actual, unicode)
+        with self.assertRaises(TableException):
+            t_env.explain(extended=True)
 
     def test_register_java_function(self):
         t_env = self.t_env
@@ -438,3 +439,24 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
                         line = f.readline()
 
         self.assert_equals(results, ['2,hi,hello\n', '3,hello,hello\n'])
+
+
+class BlinkBatchTableEnvironmentTests(PyFlinkBlinkBatchTableTestCase):
+
+    def test_explain_with_multi_sinks(self):
+        t_env = self.t_env
+        source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
+        t_env.register_table_sink(
+            "sink1",
+            CsvTableSink(field_names, field_types, "path1"))
+        t_env.register_table_sink(
+            "sink2",
+            CsvTableSink(field_names, field_types, "path2"))
+
+        t_env.sql_update("insert into sink1 select * from %s where a > 100" % source)
+        t_env.sql_update("insert into sink2 select * from %s where a < 100" % source)
+
+        actual = t_env.explain(extended=True)
+        self.assertIsInstance(actual, str)

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -207,9 +207,8 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         t_env.sql_update("insert into sink1 select * from %s where a > 100" % source)
         t_env.sql_update("insert into sink2 select * from %s where a < 100" % source)
 
-        actual = t_env.explain(extended=True)
-
-        assert isinstance(actual, str)
+        with self.assertRaises(TableException):
+            t_env.explain(extended=True)
 
     def test_sql_query(self):
         t_env = self.t_env
@@ -348,7 +347,7 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
         assert isinstance(actual, str)
 
     def test_explain_with_multi_sinks(self):
-        t_env = self.t_env
+        t_env = self.bt_env
         source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
@@ -362,8 +361,8 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
         t_env.sql_update("insert into sink1 select * from %s where a > 100" % source)
         t_env.sql_update("insert into sink2 select * from %s where a < 100" % source)
 
-        with self.assertRaises(TableException):
-            t_env.explain(extended=True)
+        actual = t_env.explain(extended=True)
+        assert isinstance(actual, str) or isinstance(actual, unicode)
 
     def test_register_java_function(self):
         t_env = self.t_env

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -135,6 +135,9 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
         self.env.set_parallelism(2)
         self.t_env = BatchTableEnvironment.create(self.env)
 
+        setting = EnvironmentSettings.new_instance().use_blink_planner().in_batch_mode().build()
+        self.bt_env = BatchTableEnvironment.create(environment_settings=setting)
+
     def collect(self, table):
         j_table = table._j_table
         gateway = get_gateway()

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -135,9 +135,6 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
         self.env.set_parallelism(2)
         self.t_env = BatchTableEnvironment.create(self.env)
 
-        setting = EnvironmentSettings.new_instance().use_blink_planner().in_batch_mode().build()
-        self.bt_env = BatchTableEnvironment.create(environment_settings=setting)
-
     def collect(self, table):
         j_table = table._j_table
         gateway = get_gateway()

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -497,7 +497,7 @@ public class ExecutionContext<ClusterID> {
 				// special case for Blink planner to apply batch optimizations
 				// note: it also modifies the ExecutionConfig!
 				if (executor instanceof ExecutorBase) {
-					return ((ExecutorBase) executor).generateStreamGraph(name);
+					return ((ExecutorBase) executor).getStreamGraph(name);
 				}
 				return streamExecEnv.getStreamGraph(name);
 			} else {

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
@@ -370,7 +370,7 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl imple
 	@Override
 	public String explain(boolean extended) {
 		// throw exception directly, because the operations to explain are always empty
-		throw new TableException("This method is unsupported in StreamTableEnvironment.");
+		throw new TableException("'explain' method is unsupported in StreamTableEnvironment.");
 	}
 
 	private <T> TypeInformation<T> extractTypeInformation(Table table, Class<T> clazz) {

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
@@ -370,7 +370,7 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl imple
 	@Override
 	public String explain(boolean extended) {
 		// throw exception directly, because the operations to explain are always empty
-		throw new TableException("'explain' method is unsupported in StreamTableEnvironment.");
+		throw new TableException("'explain' method without any tables is unsupported in StreamTableEnvironment.");
 	}
 
 	private <T> TypeInformation<T> extractTypeInformation(Table table, Class<T> clazz) {

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
@@ -367,6 +367,12 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl imple
 		return true;
 	}
 
+	@Override
+	public String explain(boolean extended) {
+		// throw exception directly, because the operations to explain are always empty
+		throw new TableException("This method is unsupported in StreamTableEnvironment.");
+	}
+
 	private <T> TypeInformation<T> extractTypeInformation(Table table, Class<T> clazz) {
 		try {
 			return TypeExtractor.createTypeInfo(clazz);

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImpl.scala
@@ -196,6 +196,11 @@ class StreamTableEnvironmentImpl (
 
   override protected def isEagerOperationTranslation(): Boolean = true
 
+  override def explain(extended: Boolean): String = {
+    // throw exception directly, because the operations to explain are always empty
+    throw new TableException("'explain' method is unsupported in StreamTableEnvironment.")
+  }
+
   private def toDataStream[T](
       table: Table,
       modifyOperation: OutputConversionModifyOperation)

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImpl.scala
@@ -198,7 +198,8 @@ class StreamTableEnvironmentImpl (
 
   override def explain(extended: Boolean): String = {
     // throw exception directly, because the operations to explain are always empty
-    throw new TableException("'explain' method is unsupported in StreamTableEnvironment.")
+    throw new TableException(
+      "'explain' method without any tables is unsupported in StreamTableEnvironment.")
   }
 
   private def toDataStream[T](

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InputDependencyConstraint;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
@@ -48,13 +47,6 @@ public class BatchExecutor extends ExecutorBase {
 		super(executionEnvironment);
 	}
 
-	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		StreamExecutionEnvironment execEnv = getExecutionEnvironment();
-		StreamGraph streamGraph = generateStreamGraph(jobName);
-		return execEnv.execute(streamGraph);
-	}
-
 	/**
 	 * Sets batch configs.
 	 */
@@ -70,12 +62,10 @@ public class BatchExecutor extends ExecutorBase {
 	}
 
 	@Override
-	public StreamGraph generateStreamGraph(List<Transformation<?>> transformations, String jobName) {
+	public StreamGraph getStreamGraph(List<Transformation<?>> transformations, String jobName) {
 		StreamExecutionEnvironment execEnv = getExecutionEnvironment();
 		setBatchProperties(execEnv);
-		transformations.forEach(execEnv::addOperator);
-		StreamGraph streamGraph;
-		streamGraph = execEnv.getStreamGraph(getNonEmptyJobName(jobName));
+		StreamGraph streamGraph = generateStreamGraph(transformations, getNonEmptyJobName(jobName));
 		// All transformations should set managed memory size.
 		ResourceSpec managedResourceSpec = NodeResourceUtil.fromManagedMem(0);
 		streamGraph.getStreamNodes().forEach(sn -> {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
@@ -20,22 +20,11 @@ package org.apache.flink.table.planner.delegation;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.operators.ResourceSpec;
-import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.runtime.jobgraph.ScheduleMode;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
-import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.delegation.Executor;
-import org.apache.flink.table.planner.plan.nodes.resource.NodeResourceUtil;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.flink.table.planner.utils.ExecutorUtils;
 
 /**
  * An implementation of {@link Executor} that is backed by a {@link StreamExecutionEnvironment}.
@@ -43,17 +32,10 @@ import java.util.List;
  */
 @Internal
 public class BatchExecutor extends ExecutorBase {
-	// buffer transformations to generate StreamGraph
-	private List<Transformation<?>> transformations = new ArrayList<>();
 
 	@VisibleForTesting
 	public BatchExecutor(StreamExecutionEnvironment executionEnvironment) {
 		super(executionEnvironment);
-	}
-
-	@Override
-	public void apply(List<Transformation<?>> transformations) {
-		this.transformations.addAll(transformations);
 	}
 
 	@Override
@@ -64,60 +46,12 @@ public class BatchExecutor extends ExecutorBase {
 
 	@Override
 	public StreamGraph getStreamGraph(String jobName) {
-		try {
-			return getStreamGraph(transformations, jobName);
-		} finally {
-			transformations.clear();
-		}
-	}
-
-	public StreamGraph getStreamGraph(List<Transformation<?>> transformations, String jobName) {
 		StreamExecutionEnvironment execEnv = getExecutionEnvironment();
-		setBatchProperties(execEnv);
-		StreamGraph streamGraph = generateStreamGraph(transformations, getNonEmptyJobName(jobName));
-		// All transformations should set managed memory size.
-		ResourceSpec managedResourceSpec = NodeResourceUtil.fromManagedMem(0);
-		streamGraph.getStreamNodes().forEach(sn -> {
-			if (sn.getMinResources().equals(ResourceSpec.DEFAULT)) {
-				sn.setResources(managedResourceSpec, managedResourceSpec);
-			}
-		});
-		streamGraph.setChaining(true);
-		streamGraph.setAllVerticesInSameSlotSharingGroupByDefault(false);
-		streamGraph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
-		streamGraph.setStateBackend(null);
-		if (streamGraph.getCheckpointConfig().isCheckpointingEnabled()) {
-			throw new IllegalArgumentException("Checkpoint is not supported for batch jobs.");
-		}
-		if (isShuffleModeAllBatch()) {
-			streamGraph.setBlockingConnectionsBetweenChains(true);
-		}
+		ExecutorUtils.setBatchProperties(execEnv, tableConfig);
+		StreamGraph streamGraph = execEnv.getStreamGraph();
+		streamGraph.setJobName(getNonEmptyJobName(jobName));
+		ExecutorUtils.setBatchProperties(streamGraph, tableConfig);
 		return streamGraph;
 	}
 
-	/**
-	 * Sets batch configs.
-	 */
-	private void setBatchProperties(StreamExecutionEnvironment execEnv) {
-		ExecutionConfig executionConfig = execEnv.getConfig();
-		executionConfig.enableObjectReuse();
-		executionConfig.setLatencyTrackingInterval(-1);
-		execEnv.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
-		execEnv.setBufferTimeout(-1);
-		if (isShuffleModeAllBatch()) {
-			executionConfig.setDefaultInputDependencyConstraint(InputDependencyConstraint.ALL);
-		}
-		executionConfig.disableAllVerticesInSameSlotSharingGroupByDefault();
-	}
-
-	private boolean isShuffleModeAllBatch() {
-		String value = tableConfig.getConfiguration().getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE);
-		if (value.equalsIgnoreCase(ShuffleMode.BATCH.toString())) {
-			return true;
-		} else if (!value.equalsIgnoreCase(ShuffleMode.PIPELINED.toString())) {
-			throw new IllegalArgumentException(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE.key() +
-					" can only be set to " + ShuffleMode.BATCH.toString() + " or " + ShuffleMode.PIPELINED.toString());
-		}
-		return false;
-	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
@@ -19,12 +19,15 @@
 package org.apache.flink.table.planner.delegation;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.util.StringUtils;
+import org.apache.flink.table.api.TableEnvironment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,12 +40,13 @@ public abstract class ExecutorBase implements Executor {
 
 	private static final String DEFAULT_JOB_NAME = "Flink Exec Table Job";
 
-	private final StreamExecutionEnvironment executionEnvironment;
-	protected List<Transformation<?>> transformations = new ArrayList<>();
+	private final StreamExecutionEnvironment execEnv;
+	// buffer transformations to generate StreamGraph
+	private List<Transformation<?>> transformations = new ArrayList<>();
 	protected TableConfig tableConfig;
 
 	public ExecutorBase(StreamExecutionEnvironment executionEnvironment) {
-		this.executionEnvironment = executionEnvironment;
+		this.execEnv = executionEnvironment;
 	}
 
 	public void setTableConfig(TableConfig tableConfig) {
@@ -54,16 +58,22 @@ public abstract class ExecutorBase implements Executor {
 		this.transformations.addAll(transformations);
 	}
 
+	@Override
+	public JobExecutionResult execute(String jobName) throws Exception {
+		StreamGraph streamGraph = getStreamGraph(jobName);
+		return execEnv.execute(streamGraph);
+	}
+
 	public StreamExecutionEnvironment getExecutionEnvironment() {
-		return executionEnvironment;
+		return execEnv;
 	}
 
 	/**
 	 * Translates the applied transformations to a stream graph.
 	 */
-	public StreamGraph generateStreamGraph(String jobName) {
+	public StreamGraph getStreamGraph(String jobName) {
 		try {
-			return generateStreamGraph(transformations, jobName);
+			return getStreamGraph(transformations, jobName);
 		} finally {
 			transformations.clear();
 		}
@@ -72,7 +82,33 @@ public abstract class ExecutorBase implements Executor {
 	/**
 	 * Translates the given transformations to a stream graph.
 	 */
-	public abstract StreamGraph generateStreamGraph(List<Transformation<?>> transformations, String jobName);
+	public abstract StreamGraph getStreamGraph(List<Transformation<?>> transformations, String jobName);
+
+	/**
+	 * {@link StreamExecutionEnvironment} will hold the transformations and can not be cleared unless
+	 * {@link StreamExecutionEnvironment#execute()} method is called.
+	 * so if {@link TableEnvironment#explain(boolean)} is called before {@link TableEnvironment#execute(String)},
+	 * the StreamGraph to executed will contain duplicated transformations,
+	 * one is from explain method, and another is from execute method.
+	 *
+	 * use {@link StreamGraphGenerator} directly instead of {@link StreamExecutionEnvironment#getStreamGraph}
+	 * to avoid above case.
+	 */
+	protected StreamGraph generateStreamGraph(List<Transformation<?>> transformations, String jobName) {
+		if (transformations.size() <= 0) {
+			throw new IllegalStateException("No operators defined in streaming topology. Cannot generate StreamGraph.");
+		}
+		return getStreamGraphGenerator(transformations).setJobName(jobName).generate();
+	}
+
+	private StreamGraphGenerator getStreamGraphGenerator(List<Transformation<?>> transformations) {
+		return new StreamGraphGenerator(transformations, execEnv.getConfig(), execEnv.getCheckpointConfig())
+				.setStateBackend(execEnv.getStateBackend())
+				.setChaining(execEnv.isChainingEnabled())
+				.setUserArtifacts(execEnv.getCachedFiles())
+				.setTimeCharacteristic(execEnv.getStreamTimeCharacteristic())
+				.setDefaultBufferTimeout(execEnv.getBufferTimeout());
+	}
 
 	protected String getNonEmptyJobName(String jobName) {
 		if (StringUtils.isNullOrWhitespaceOnly(jobName)) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
@@ -62,7 +62,11 @@ public abstract class ExecutorBase implements Executor {
 	 * Translates the applied transformations to a stream graph.
 	 */
 	public StreamGraph generateStreamGraph(String jobName) {
-		return generateStreamGraph(transformations, jobName);
+		try {
+			return generateStreamGraph(transformations, jobName);
+		} finally {
+			transformations.clear();
+		}
 	}
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
@@ -25,9 +25,9 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.util.StringUtils;
-import org.apache.flink.table.api.TableEnvironment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,7 +91,7 @@ public abstract class ExecutorBase implements Executor {
 	 * the StreamGraph to executed will contain duplicated transformations,
 	 * one is from explain method, and another is from execute method.
 	 *
-	 * use {@link StreamGraphGenerator} directly instead of {@link StreamExecutionEnvironment#getStreamGraph}
+	 * <p>use {@link StreamGraphGenerator} directly instead of {@link StreamExecutionEnvironment#getStreamGraph}
 	 * to avoid above case.
 	 */
 	protected StreamGraph generateStreamGraph(List<Transformation<?>> transformations, String jobName) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
@@ -41,8 +41,6 @@ public abstract class ExecutorBase implements Executor {
 	private static final String DEFAULT_JOB_NAME = "Flink Exec Table Job";
 
 	private final StreamExecutionEnvironment execEnv;
-	// buffer transformations to generate StreamGraph
-	private List<Transformation<?>> transformations = new ArrayList<>();
 	protected TableConfig tableConfig;
 
 	public ExecutorBase(StreamExecutionEnvironment executionEnvironment) {
@@ -53,34 +51,17 @@ public abstract class ExecutorBase implements Executor {
 		this.tableConfig = tableConfig;
 	}
 
-	@Override
-	public void apply(List<Transformation<?>> transformations) {
-		this.transformations.addAll(transformations);
-	}
-
-	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		StreamGraph streamGraph = getStreamGraph(jobName);
-		return execEnv.execute(streamGraph);
-	}
-
 	public StreamExecutionEnvironment getExecutionEnvironment() {
 		return execEnv;
 	}
 
 	/**
-	 * Translates the applied transformations to a stream graph.
+	 * Translates the transformations applied into this executor to a stream graph.
 	 */
-	public StreamGraph getStreamGraph(String jobName) {
-		try {
-			return getStreamGraph(transformations, jobName);
-		} finally {
-			transformations.clear();
-		}
-	}
+	public abstract StreamGraph getStreamGraph(String jobName);
 
 	/**
-	 * Translates the given transformations to a stream graph.
+	 * Translates the given transformations to a stream graph. This method is used for {@code Planner#explain} method.
 	 */
 	public abstract StreamGraph getStreamGraph(List<Transformation<?>> transformations, String jobName);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/StreamExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/StreamExecutor.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.delegation;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -40,16 +39,10 @@ public class StreamExecutor extends ExecutorBase {
 		super(executionEnvironment);
 	}
 
-	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		StreamExecutionEnvironment execEnv = getExecutionEnvironment();
-		return execEnv.execute(generateStreamGraph(transformations, jobName));
+	/**
+	 * Translates the given transformations to a stream graph.
+	 */
+	public StreamGraph getStreamGraph(List<Transformation<?>> transformations, String jobName) {
+		return generateStreamGraph(transformations, getNonEmptyJobName(jobName));
 	}
-
-	@Override
-	public StreamGraph generateStreamGraph(List<Transformation<?>> transformations, String jobName) {
-		transformations.forEach(getExecutionEnvironment()::addOperator);
-		return getExecutionEnvironment().getStreamGraph(getNonEmptyJobName(jobName));
-	}
-
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/StreamExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/StreamExecutor.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.delegation;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -39,9 +40,22 @@ public class StreamExecutor extends ExecutorBase {
 		super(executionEnvironment);
 	}
 
-	/**
-	 * Translates the given transformations to a stream graph.
-	 */
+	@Override
+	public void apply(List<Transformation<?>> transformations) {
+		transformations.forEach(getExecutionEnvironment()::addOperator);
+	}
+
+	@Override
+	public JobExecutionResult execute(String jobName) throws Exception {
+		return getExecutionEnvironment().execute(jobName);
+	}
+
+	@Override
+	public StreamGraph getStreamGraph(String jobName) {
+		return getExecutionEnvironment().getStreamGraph();
+	}
+
+	@Override
 	public StreamGraph getStreamGraph(List<Transformation<?>> transformations, String jobName) {
 		return generateStreamGraph(transformations, getNonEmptyJobName(jobName));
 	}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/StreamExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/StreamExecutor.java
@@ -21,12 +21,9 @@ package org.apache.flink.table.planner.delegation;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.delegation.Executor;
-
-import java.util.List;
 
 /**
  * An implementation of {@link Executor} that is backed by a {@link StreamExecutionEnvironment}.
@@ -41,22 +38,14 @@ public class StreamExecutor extends ExecutorBase {
 	}
 
 	@Override
-	public void apply(List<Transformation<?>> transformations) {
-		transformations.forEach(getExecutionEnvironment()::addOperator);
-	}
-
-	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
-		return getExecutionEnvironment().execute(jobName);
+		return getExecutionEnvironment().execute(getNonEmptyJobName(jobName));
 	}
 
 	@Override
 	public StreamGraph getStreamGraph(String jobName) {
-		return getExecutionEnvironment().getStreamGraph();
-	}
-
-	@Override
-	public StreamGraph getStreamGraph(List<Transformation<?>> transformations, String jobName) {
-		return generateStreamGraph(transformations, getNonEmptyJobName(jobName));
+		StreamGraph streamGraph = getExecutionEnvironment().getStreamGraph();
+		streamGraph.setJobName(getNonEmptyJobName(jobName));
+		return streamGraph;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
@@ -32,6 +32,8 @@ import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.sinks.StreamTableSink;
 
 import com.esotericsoftware.kryo.Serializer;
 
@@ -48,9 +50,12 @@ import java.util.List;
  * translating will happen in explain method. If calling explain method before execute method, the transformations in
  * StreamExecutionEnvironment is dirty, and execution result may be incorrect.
  *
- * <p> All set methods (e.g. setXXX, enableXXX, disableXXX, etc) are disabled to prohibit changing configuration,
+ * <p>All set methods (e.g. setXXX, enableXXX, disableXXX, etc) are disabled to prohibit changing configuration,
  * all get methods (e.g. getXXX, isXXX) will be delegated to real StreamExecutionEnvironment.
  * `execute`, `getStreamGraph`, `getExecutionPlan` methods are also disabled.
+ *
+ * <p>This class could be removed once the {@link TableSource} interface and {@link StreamTableSink} interface
+ * are reworked.
  */
 public class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment {
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+
+import com.esotericsoftware.kryo.Serializer;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * This is dummy {@link StreamExecutionEnvironment}, only used for {@link PlannerBase#explain(List, boolean)} method.
+ *
+ * <P>{@link Transformation}s will be added into a {@link StreamExecutionEnvironment} when translating ExecNode to plan,
+ * and they will be cleared only when calling {@link StreamExecutionEnvironment#execute()} method.
+ *
+ * <p>{@link PlannerBase#explain(List, boolean)} method will not only print logical plan but also execution plan,
+ * translating will happen in explain method. If calling explain method before execute method, the transformations in
+ * StreamExecutionEnvironment is dirty, and execution result may be incorrect.
+ *
+ * <p> All set methods (e.g. setXXX, enableXXX, disableXXX, etc) are disabled to prohibit changing configuration,
+ * all get methods (e.g. getXXX, isXXX) will be delegated to real StreamExecutionEnvironment.
+ * `execute`, `getStreamGraph`, `getExecutionPlan` methods are also disabled.
+ */
+public class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment {
+
+	private final StreamExecutionEnvironment realExecEnv;
+
+	public DummyStreamExecutionEnvironment(StreamExecutionEnvironment realExecEnv) {
+		this.realExecEnv = realExecEnv;
+	}
+
+	@Override
+	public ExecutionConfig getConfig() {
+		return realExecEnv.getConfig();
+	}
+
+	@Override
+	public List<Tuple2<String, DistributedCache.DistributedCacheEntry>> getCachedFiles() {
+		return realExecEnv.getCachedFiles();
+	}
+
+	@Override
+	public StreamExecutionEnvironment setParallelism(int parallelism) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, setParallelism method is unsupported.");
+	}
+
+	@Override
+	public StreamExecutionEnvironment setMaxParallelism(int maxParallelism) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, setMaxParallelism method is unsupported.");
+	}
+
+	@Override
+	public int getParallelism() {
+		return realExecEnv.getParallelism();
+	}
+
+	@Override
+	public int getMaxParallelism() {
+		return realExecEnv.getMaxParallelism();
+	}
+
+	@Override
+	public StreamExecutionEnvironment setBufferTimeout(long timeoutMillis) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, setBufferTimeout method is unsupported.");
+	}
+
+	@Override
+	public long getBufferTimeout() {
+		return realExecEnv.getBufferTimeout();
+	}
+
+	@Override
+	public StreamExecutionEnvironment disableOperatorChaining() {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, disableOperatorChaining method is unsupported.");
+	}
+
+	@Override
+	public boolean isChainingEnabled() {
+		return realExecEnv.isChainingEnabled();
+	}
+
+	@Override
+	public CheckpointConfig getCheckpointConfig() {
+		return realExecEnv.getCheckpointConfig();
+	}
+
+	@Override
+	public StreamExecutionEnvironment enableCheckpointing(long interval) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, enableCheckpointing method is unsupported.");
+	}
+
+	@Override
+	public StreamExecutionEnvironment enableCheckpointing(long interval, CheckpointingMode mode) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, enableCheckpointing method is unsupported.");
+	}
+
+	@Override
+	public StreamExecutionEnvironment enableCheckpointing(long interval, CheckpointingMode mode, boolean force) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, enableCheckpointing method is unsupported.");
+	}
+
+	@Override
+	public StreamExecutionEnvironment enableCheckpointing() {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, enableCheckpointing method is unsupported.");
+	}
+
+	@Override
+	public long getCheckpointInterval() {
+		return realExecEnv.getCheckpointInterval();
+	}
+
+	@Override
+	public boolean isForceCheckpointing() {
+		return realExecEnv.isForceCheckpointing();
+	}
+
+	@Override
+	public CheckpointingMode getCheckpointingMode() {
+		return realExecEnv.getCheckpointingMode();
+	}
+
+	@Override
+	public StreamExecutionEnvironment setStateBackend(StateBackend backend) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, setStateBackend method is unsupported.");
+	}
+
+	@Override
+	public StreamExecutionEnvironment setStateBackend(AbstractStateBackend backend) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, setStateBackend method is unsupported.");
+	}
+
+	@Override
+	public StateBackend getStateBackend() {
+		return realExecEnv.getStateBackend();
+	}
+
+	@Override
+	public void setRestartStrategy(RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, setRestartStrategy method is unsupported.");
+	}
+
+	@Override
+	public RestartStrategies.RestartStrategyConfiguration getRestartStrategy() {
+		return realExecEnv.getRestartStrategy();
+	}
+
+	@Override
+	public void setNumberOfExecutionRetries(int numberOfExecutionRetries) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, setNumberOfExecutionRetries method is unsupported.");
+	}
+
+	@Override
+	public int getNumberOfExecutionRetries() {
+		return realExecEnv.getNumberOfExecutionRetries();
+	}
+
+	@Override
+	public <T extends Serializer<?> & Serializable> void addDefaultKryoSerializer(Class<?> type, T serializer) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, addDefaultKryoSerializer method is unsupported.");
+	}
+
+	@Override
+	public void addDefaultKryoSerializer(Class<?> type, Class<? extends Serializer<?>> serializerClass) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, addDefaultKryoSerializer method is unsupported.");
+	}
+
+	@Override
+	public <T extends Serializer<?> & Serializable> void registerTypeWithKryoSerializer(Class<?> type, T serializer) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, registerTypeWithKryoSerializer method is unsupported.");
+	}
+
+	@Override
+	public void registerTypeWithKryoSerializer(Class<?> type, Class<? extends Serializer> serializerClass) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, registerTypeWithKryoSerializer method is unsupported.");
+	}
+
+	@Override
+	public void registerType(Class<?> type) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, registerType method is unsupported.");
+	}
+
+	@Override
+	public void setStreamTimeCharacteristic(TimeCharacteristic characteristic) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, setStreamTimeCharacteristic method is unsupported.");
+	}
+
+	@Override
+	public TimeCharacteristic getStreamTimeCharacteristic() {
+		return realExecEnv.getStreamTimeCharacteristic();
+	}
+
+	@Override
+	public JobExecutionResult execute() throws Exception {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, execute method is unsupported.");
+	}
+
+	@Override
+	public JobExecutionResult execute(String jobName) throws Exception {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, execute method is unsupported.");
+	}
+
+	@Override
+	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, execute method is unsupported.");
+	}
+
+	@Override
+	public void registerCachedFile(String filePath, String name) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, registerCachedFile method is unsupported.");
+	}
+
+	@Override
+	public void registerCachedFile(String filePath, String name, boolean executable) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, registerCachedFile method is unsupported.");
+	}
+
+	@Override
+	public StreamGraph getStreamGraph() {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, getStreamGraph method is unsupported.");
+	}
+
+	@Override
+	public StreamGraph getStreamGraph(String jobName) {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, getStreamGraph method is unsupported.");
+	}
+
+	@Override
+	public String getExecutionPlan() {
+		throw new UnsupportedOperationException(
+				"This is a dummy StreamExecutionEnvironment, getExecutionPlan method is unsupported.");
+	}
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
@@ -32,8 +32,8 @@ import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.sinks.StreamTableSink;
+import org.apache.flink.table.sources.TableSource;
 
 import com.esotericsoftware.kryo.Serializer;
 
@@ -50,9 +50,10 @@ import java.util.List;
  * translating will happen in explain method. If calling explain method before execute method, the transformations in
  * StreamExecutionEnvironment is dirty, and execution result may be incorrect.
  *
- * <p>All set methods (e.g. setXXX, enableXXX, disableXXX, etc) are disabled to prohibit changing configuration,
- * all get methods (e.g. getXXX, isXXX) will be delegated to real StreamExecutionEnvironment.
- * `execute`, `getStreamGraph`, `getExecutionPlan` methods are also disabled.
+ * <p>All set methods (e.g. `setXX`, `enableXX`, `disableXX`, etc) are disabled to prohibit changing configuration,
+ * all get methods (e.g. `getXX`, `isXX`, etc) will be delegated to real StreamExecutionEnvironment.
+ * `execute`, `getStreamGraph`, `getExecutionPlan` methods are also disabled, while `addOperator` method is enabled to
+ * let `explain` method add Transformations to this StreamExecutionEnvironment.
  *
  * <p>This class could be removed once the {@link TableSource} interface and {@link StreamTableSink} interface
  * are reworked.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.InputDependencyConstraint;
+import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.planner.plan.nodes.resource.NodeResourceUtil;
+
+import java.util.List;
+
+/**
+ * Utility class to generate StreamGraph and set properties for batch.
+ */
+public class ExecutorUtils {
+
+	/**
+	 * Generate {@link StreamGraph} by {@link StreamGraphGenerator}.
+	 */
+	public static StreamGraph generateStreamGraph(
+			StreamExecutionEnvironment execEnv,
+			List<Transformation<?>> transformations) {
+		if (transformations.size() <= 0) {
+			throw new IllegalStateException("No operators defined in streaming topology. Cannot generate StreamGraph.");
+		}
+		StreamGraphGenerator generator =
+				new StreamGraphGenerator(transformations, execEnv.getConfig(), execEnv.getCheckpointConfig())
+						.setStateBackend(execEnv.getStateBackend())
+						.setChaining(execEnv.isChainingEnabled())
+						.setUserArtifacts(execEnv.getCachedFiles())
+						.setTimeCharacteristic(execEnv.getStreamTimeCharacteristic())
+						.setDefaultBufferTimeout(execEnv.getBufferTimeout());
+		return generator.generate();
+	}
+
+	/**
+	 * Sets batch properties for {@link StreamExecutionEnvironment}.
+	 */
+	public static void setBatchProperties(StreamExecutionEnvironment execEnv, TableConfig tableConfig) {
+		ExecutionConfig executionConfig = execEnv.getConfig();
+		executionConfig.enableObjectReuse();
+		executionConfig.setLatencyTrackingInterval(-1);
+		execEnv.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+		execEnv.setBufferTimeout(-1);
+		if (isShuffleModeAllBatch(tableConfig)) {
+			executionConfig.setDefaultInputDependencyConstraint(InputDependencyConstraint.ALL);
+		}
+	}
+
+	/**
+	 * Sets batch properties for {@link StreamGraph}.
+	 */
+	public static void setBatchProperties(StreamGraph streamGraph, TableConfig tableConfig) {
+		// All transformations should set managed memory size.
+		ResourceSpec managedResourceSpec = NodeResourceUtil.fromManagedMem(0);
+		streamGraph.getStreamNodes().forEach(sn -> {
+			if (sn.getMinResources().equals(ResourceSpec.DEFAULT)) {
+				sn.setResources(managedResourceSpec, managedResourceSpec);
+			}
+		});
+		streamGraph.setChaining(true);
+		streamGraph.setAllVerticesInSameSlotSharingGroupByDefault(false);
+		streamGraph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
+		streamGraph.setStateBackend(null);
+		if (streamGraph.getCheckpointConfig().isCheckpointingEnabled()) {
+			throw new IllegalArgumentException("Checkpoint is not supported for batch jobs.");
+		}
+		if (ExecutorUtils.isShuffleModeAllBatch(tableConfig)) {
+			streamGraph.setBlockingConnectionsBetweenChains(true);
+		}
+	}
+
+	private static boolean isShuffleModeAllBatch(TableConfig tableConfig) {
+		String value = tableConfig.getConfiguration().getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE);
+		if (value.equalsIgnoreCase(ShuffleMode.BATCH.toString())) {
+			return true;
+		} else if (!value.equalsIgnoreCase(ShuffleMode.PIPELINED.toString())) {
+			throw new IllegalArgumentException(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE.key() +
+					" can only be set to " + ShuffleMode.BATCH.toString() + " or " + ShuffleMode.PIPELINED.toString());
+		}
+		return false;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -88,7 +88,7 @@ class BatchPlanner(
     val transformations = translateToPlan(execNodes)
     val batchExecutor = new BatchExecutor(getExecEnv)
     batchExecutor.setTableConfig(getTableConfig)
-    val streamGraph = batchExecutor.generateStreamGraph(transformations, "")
+    val streamGraph = batchExecutor.getStreamGraph(transformations, "")
     val executionPlan = PlanUtil.explainStreamGraph(streamGraph)
 
     val sb = new StringBuilder

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -86,9 +86,7 @@ class BatchPlanner(
     val optimizedRelNodes = optimize(sinkRelNodes)
     val execNodes = translateToExecNodePlan(optimizedRelNodes)
     val transformations = translateToPlan(execNodes)
-    val batchExecutor = new BatchExecutor(getExecEnv)
-    batchExecutor.setTableConfig(getTableConfig)
-    val streamGraph = batchExecutor.getStreamGraph(transformations, "")
+    val streamGraph = executor.asInstanceOf[ExecutorBase].getStreamGraph(transformations, "")
     val executionPlan = PlanUtil.explainStreamGraph(streamGraph)
 
     val sb = new StringBuilder

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -65,7 +65,6 @@ class BatchPlanner(
 
   override protected def translateToPlan(
       execNodes: util.List[ExecNode[_, _]]): util.List[Transformation[_]] = {
-    overrideEnvParallelism()
     execNodes.map {
       case node: BatchExecNode[_] => node.translateToPlan(this)
       case _ =>
@@ -87,6 +86,7 @@ class BatchPlanner(
     val execNodes = translateToExecNodePlan(optimizedRelNodes)
 
     val plannerForExplain = createDummyPlannerForExplain()
+    plannerForExplain.overrideEnvParallelism()
     val transformations = plannerForExplain.translateToPlan(execNodes)
 
     val execEnv = getExecEnv

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -144,7 +144,7 @@ abstract class PlannerBase(
     val relNodes = modifyOperations.map(translateToRel)
     val optimizedRelNodes = optimize(relNodes)
     val execNodes = translateToExecNodePlan(optimizedRelNodes)
-    translateToPlan(execNodes, this)
+    translateToPlan(execNodes)
   }
 
   protected def overrideEnvParallelism(): Unit = {
@@ -248,12 +248,9 @@ abstract class PlannerBase(
     * Translates a [[ExecNode]] DAG into a [[Transformation]] DAG.
     *
     * @param execNodes The node DAG to translate.
-    * @param planner The planner to do the translation.
     * @return The [[Transformation]] DAG that corresponds to the node DAG.
     */
-  protected def translateToPlan(
-      execNodes: util.List[ExecNode[_, _]],
-      planner: PlannerBase): util.List[Transformation[_]]
+  protected def translateToPlan(execNodes: util.List[ExecNode[_, _]]): util.List[Transformation[_]]
 
   private def getTableSink(objectIdentifier: ObjectIdentifier)
     : Option[(CatalogTable, TableSink[_])] = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -140,7 +140,10 @@ abstract class PlannerBase(
     if (modifyOperations.isEmpty) {
       return List.empty[Transformation[_]]
     }
+    // prepare the execEnv before translating
     mergeParameters()
+    overrideEnvParallelism()
+
     val relNodes = modifyOperations.map(translateToRel)
     val optimizedRelNodes = optimize(relNodes)
     val execNodes = translateToExecNodePlan(optimizedRelNodes)
@@ -152,7 +155,7 @@ abstract class PlannerBase(
     val defaultParallelism = getTableConfig.getConfiguration.getInteger(
       ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM)
     if (defaultParallelism > 0) {
-      getExecEnv.setParallelism(defaultParallelism)
+      getExecEnv.getConfig.setParallelism(defaultParallelism)
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -144,7 +144,7 @@ abstract class PlannerBase(
     val relNodes = modifyOperations.map(translateToRel)
     val optimizedRelNodes = optimize(relNodes)
     val execNodes = translateToExecNodePlan(optimizedRelNodes)
-    translateToPlan(execNodes)
+    translateToPlan(execNodes, this)
   }
 
   protected def overrideEnvParallelism(): Unit = {
@@ -248,9 +248,12 @@ abstract class PlannerBase(
     * Translates a [[ExecNode]] DAG into a [[Transformation]] DAG.
     *
     * @param execNodes The node DAG to translate.
+    * @param planner The planner to do the translation.
     * @return The [[Transformation]] DAG that corresponds to the node DAG.
     */
-  protected def translateToPlan(execNodes: util.List[ExecNode[_, _]]): util.List[Transformation[_]]
+  protected def translateToPlan(
+      execNodes: util.List[ExecNode[_, _]],
+      planner: PlannerBase): util.List[Transformation[_]]
 
   private def getTableSink(objectIdentifier: ObjectIdentifier)
     : Option[(CatalogTable, TableSink[_])] = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -79,7 +79,7 @@ class StreamPlanner(
     val transformations = translateToPlan(execNodes)
     val streamExecutor = new StreamExecutor(getExecEnv)
     streamExecutor.setTableConfig(getTableConfig)
-    val streamGraph = streamExecutor.generateStreamGraph(transformations, "")
+    val streamGraph = streamExecutor.getStreamGraph(transformations, "")
     val executionPlan = PlanUtil.explainStreamGraph(streamGraph)
 
     val sb = new StringBuilder

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -56,7 +56,6 @@ class StreamPlanner(
 
   override protected def translateToPlan(
       execNodes: util.List[ExecNode[_, _]]): util.List[Transformation[_]] = {
-    overrideEnvParallelism()
     execNodes.map {
       case node: StreamExecNode[_] => node.translateToPlan(this)
       case _ =>
@@ -76,7 +75,9 @@ class StreamPlanner(
     }
     val optimizedRelNodes = optimize(sinkRelNodes)
     val execNodes = translateToExecNodePlan(optimizedRelNodes)
+
     val plannerForExplain = createDummyPlannerForExplain()
+    plannerForExplain.overrideEnvParallelism()
     val transformations = plannerForExplain.translateToPlan(execNodes)
     val streamGraph = ExecutorUtils.generateStreamGraph(getExecEnv, transformations)
     val executionPlan = PlanUtil.explainStreamGraph(streamGraph)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -77,9 +77,7 @@ class StreamPlanner(
     val optimizedRelNodes = optimize(sinkRelNodes)
     val execNodes = translateToExecNodePlan(optimizedRelNodes)
     val transformations = translateToPlan(execNodes)
-    val streamExecutor = new StreamExecutor(getExecEnv)
-    streamExecutor.setTableConfig(getTableConfig)
-    val streamGraph = streamExecutor.getStreamGraph(transformations, "")
+    val streamGraph = executor.asInstanceOf[ExecutorBase].getStreamGraph(transformations, "")
     val executionPlan = PlanUtil.explainStreamGraph(streamGraph)
 
     val sb = new StringBuilder

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/BatchExecutorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/BatchExecutorTest.java
@@ -60,8 +60,8 @@ public class BatchExecutorTest extends TestLogger {
 			}),
 			BasicTypeInfo.STRING_TYPE_INFO,
 			1);
-
-		streamGraph = batchExecutor.generateStreamGraph(Collections.singletonList(testTransform), "Test Job");
+		batchExecutor.apply(Collections.singletonList(testTransform));
+		streamGraph = batchExecutor.getStreamGraph("Test Job");
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeinfo.Types.STRING
+import org.apache.flink.core.fs.FileSystem.WriteMode
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.internal.TableEnvironmentImpl
+import org.apache.flink.table.api.scala.StreamTableEnvironment
+import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSources}
+import org.apache.flink.table.sinks.CsvTableSink
+import org.apache.flink.util.FileUtils
+
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.rules.TemporaryFolder
+import org.junit.{Rule, Test}
+
+import _root_.java.io.File
+
+
+class TableEnvironmentITCase {
+
+  private val _tempFolder = new TemporaryFolder()
+
+  @Rule
+  def tempFolder: TemporaryFolder = _tempFolder
+
+  @Test
+  def testExecuteTwiceUsingSameTableEnvOnBatch(): Unit = {
+    val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build()
+    testExecuteTwiceUsingSameTableEnv(TableEnvironmentImpl.create(settings))
+  }
+
+  @Test
+  def testExecuteTwiceUsingSameTableEnvOnStream(): Unit = {
+    // test TableEnvironment
+    val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+    testExecuteTwiceUsingSameTableEnv(TableEnvironmentImpl.create(settings))
+
+    // test StreamTableEnvironment
+    testExecuteTwiceUsingSameTableEnv(StreamTableEnvironment.create(
+      StreamExecutionEnvironment.getExecutionEnvironment, settings))
+  }
+
+  private def testExecuteTwiceUsingSameTableEnv(tEnv: TableEnvironment): Unit = {
+    tEnv.registerTableSource("MyTable", TestTableSources.getPersonCsvTableSource)
+    val sink1Path = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink1")
+    val sink2Path = registerCsvTableSink(tEnv, Array("last"), Array(STRING), "MySink2")
+    checkEmptyFile(sink1Path)
+    checkEmptyFile(sink2Path)
+
+    val table1 = tEnv.sqlQuery("select first from MyTable")
+    tEnv.insertInto(table1, "MySink1")
+    tEnv.execute("test1")
+    assertFirstValues(sink1Path)
+    checkEmptyFile(sink2Path)
+
+    // delete first csv file
+    new File(sink1Path).delete()
+    assertFalse(new File(sink1Path).exists())
+
+    val table2 = tEnv.sqlQuery("select last from MyTable")
+    tEnv.insertInto(table2, "MySink2")
+    tEnv.execute("test2")
+    assertFalse(new File(sink1Path).exists())
+    assertLastValues(sink2Path)
+  }
+
+  @Test
+  def testExplainAndExecuteTableEnvOnBatch(): Unit = {
+    val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build()
+    testExplainAndExecuteSingleSink(TableEnvironmentImpl.create(settings))
+    testExplainAndExecuteMultipleSink(TableEnvironmentImpl.create(settings))
+  }
+
+  @Test
+  def testExplainAndExecuteTableEnvOnStream(): Unit = {
+    val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+    testExplainAndExecuteSingleSink(TableEnvironmentImpl.create(settings))
+    testExplainAndExecuteMultipleSink(TableEnvironmentImpl.create(settings))
+  }
+
+  private def testExplainAndExecuteSingleSink(tEnv: TableEnvironment): Unit = {
+    tEnv.registerTableSource("MyTable", TestTableSources.getPersonCsvTableSource)
+    val sinkPath = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink1")
+
+    val table1 = tEnv.sqlQuery("select first from MyTable")
+    tEnv.insertInto(table1, "MySink1")
+
+    tEnv.explain(false)
+    tEnv.execute("test1")
+    assertFirstValues(sinkPath)
+  }
+
+  private def testExplainAndExecuteMultipleSink(tEnv: TableEnvironment): Unit = {
+    tEnv.registerTableSource("MyTable", TestTableSources.getPersonCsvTableSource)
+    val sink1Path = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink1")
+    val sink2Path = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink2")
+
+    val table1 = tEnv.sqlQuery("select first from MyTable")
+    tEnv.insertInto(table1, "MySink1")
+    val table2 = tEnv.sqlQuery("select last from MyTable")
+    tEnv.insertInto(table2, "MySink2")
+
+    tEnv.explain(false)
+    tEnv.execute("test1")
+    assertFirstValues(sink1Path)
+    assertLastValues(sink2Path)
+  }
+
+  @Test
+  def testExplainTwiceOnBatch(): Unit = {
+    val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build()
+    testExplainTwice(TableEnvironmentImpl.create(settings))
+  }
+
+  @Test
+  def testExplainTwiceOnStream(): Unit = {
+    val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+    testExplainTwice(TableEnvironmentImpl.create(settings))
+  }
+
+  private def testExplainTwice(tEnv: TableEnvironment): Unit = {
+    tEnv.registerTableSource("MyTable", TestTableSources.getPersonCsvTableSource)
+    registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink1")
+    registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink2")
+
+    val table1 = tEnv.sqlQuery("select first from MyTable")
+    tEnv.insertInto(table1, "MySink1")
+    val table2 = tEnv.sqlQuery("select last from MyTable")
+    tEnv.insertInto(table2, "MySink2")
+
+    val result1 = tEnv.explain(false)
+    val result2 = tEnv.explain(false)
+    assertEquals(TableTestUtil.replaceStageId(result1), TableTestUtil.replaceStageId(result2))
+  }
+
+  private def registerCsvTableSink(
+      tEnv: TableEnvironment,
+      fieldNames: Array[String],
+      fieldTypes: Array[TypeInformation[_]],
+      tableName: String): String = {
+    val resultFile = _tempFolder.newFile()
+    val path = resultFile.getAbsolutePath
+
+    val configuredSink = new CsvTableSink(path, ",", 1, WriteMode.OVERWRITE)
+      .configure(fieldNames, fieldTypes)
+    tEnv.registerTableSink(tableName, configuredSink)
+
+    path
+  }
+
+  private def assertFirstValues(csvFilePath: String): Unit = {
+    val expected = List("Mike", "Bob", "Sam", "Peter", "Liz", "Sally", "Alice", "Kelly")
+    val actual = FileUtils.readFileUtf8(new File(csvFilePath)).split("\n").toList
+    assertEquals(expected.sorted, actual.sorted)
+  }
+
+  private def assertLastValues(csvFilePath: String): Unit = {
+    val expected = List(
+      "Smith", "Taylor", "Miller", "Smith", "Williams", "Miller", "Smith", "Williams")
+    val actual = FileUtils.readFileUtf8(new File(csvFilePath)).split("\n").toList
+    assertEquals(expected.sorted, actual.sorted)
+  }
+
+  private def checkEmptyFile(csvFilePath: String): Unit = {
+    assertTrue(FileUtils.readFileUtf8(new File(csvFilePath)).isEmpty)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -82,7 +82,8 @@ class TableEnvironmentTest {
   @Test
   def testStreamTableEnvironmentExplain(): Unit = {
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("'explain' method is unsupported in StreamTableEnvironment.")
+    thrown.expectMessage(
+      "'explain' method without any tables is unsupported in StreamTableEnvironment.")
 
     val execEnv = StreamExecutionEnvironment.getExecutionEnvironment
     val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -18,11 +18,20 @@
 
 package org.apache.flink.table.api
 
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeinfo.Types.STRING
+import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.api.scala.{StreamTableEnvironment, _}
-import org.apache.flink.table.planner.utils.TableTestUtil
+import org.apache.flink.table.planner.delegation.PlannerBase
+import org.apache.flink.table.planner.sinks.{CollectRowTableSink, CollectTableSink}
+import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSources}
+import org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo
+import org.apache.flink.types.Row
+import org.apache.flink.util.AbstractID
 
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.sql.SqlExplainLevel
@@ -76,4 +85,41 @@ class TableEnvironmentTest {
       "  LogicalTableScan\n"
     assertEquals(expected, actual)
   }
+
+  @Test
+  def testExecuteTwiceUsingSameTableEnv(): Unit = {
+    val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build()
+    val tEnv = TableEnvironmentImpl.create(settings)
+    tEnv.registerTableSource("MyTable", TestTableSources.getPersonCsvTableSource)
+    registerTableSink(tEnv, Array("first"), Array(STRING), "MySink1")
+    registerTableSink(tEnv, Array("last"), Array(STRING), "MySink2")
+
+    val table1 = tEnv.sqlQuery("select first from MyTable")
+    tEnv.insertInto(table1, "MySink1")
+    val res1 = tEnv.execute("test1")
+    assertEquals(1, res1.getAllAccumulatorResults.size())
+
+    val table2 = tEnv.sqlQuery("select last from MyTable")
+    tEnv.insertInto(table2, "MySink2")
+    val res2 = tEnv.execute("test2")
+    assertEquals(1, res2.getAllAccumulatorResults.size())
+  }
+
+  private def registerTableSink(
+      tEnv: TableEnvironment,
+      fieldNames: Array[String],
+      fieldTypes: Array[TypeInformation[_]],
+      tableName: String): Unit = {
+    val sink = new CollectRowTableSink()
+      .configure(fieldNames, fieldTypes)
+      .asInstanceOf[CollectTableSink[Row]]
+    val id = new AbstractID().toString
+    val typeSerializer = fromDataTypeToLegacyInfo(sink.getConsumedDataType)
+      .asInstanceOf[TypeInformation[Row]]
+      .createSerializer(tEnv.asInstanceOf[TableEnvironmentImpl]
+        .getPlanner.asInstanceOf[PlannerBase].getExecEnv.getConfig)
+    sink.init(typeSerializer.asInstanceOf[TypeSerializer[Row]], id)
+    tEnv.registerTableSink(tableName, sink)
+  }
+
 }


### PR DESCRIPTION

## What is the purpose of the change

*transformations should be cleared after execution in blink planner*


## Brief change log

  - *clear transformations in ExecutorBase*


## Verifying this change



This change added tests and can be verified as follows:

  - *Added testExecuteTwiceUsingSameTableEnv to verify this bug*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
