### PR TITLE
[FLINK-13634][Formats]: added module to compress data using StreamingFileSink

### DIFF
--- a/flink-formats/flink-compress/pom.xml
+++ b/flink-formats/flink-compress/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-formats</artifactId>
+		<version>1.10-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-compress</artifactId>
+	<name>flink-compress</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-hadoop-2</artifactId>
+			<version>${hadoop.version}-${flink.shaded.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- skip dependency convergence due to Hadoop dependency -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>dependency-convergence</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriterFactory.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriterFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.compress;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.formats.compress.extractor.Extractor;
+import org.apache.flink.formats.compress.writers.HadoopCompressionBulkWriter;
+import org.apache.flink.formats.compress.writers.NoCompressionBulkWriter;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+
+import java.io.IOException;
+
+/**
+ * A factory that creates a {@link BulkWriter} implementation that compress file.
+ *
+ * @param <IN> The type of element to write.
+ */
+@PublicEvolving
+public class CompressWriterFactory<IN> implements BulkWriter.Factory<IN> {
+
+	private Extractor<IN> extractor;
+	private CompressionCodec hadoopCodec;
+
+	public CompressWriterFactory(Extractor<IN> extractor) {
+		this.extractor = Preconditions.checkNotNull(extractor, "extractor cannot be null");
+	}
+
+	public CompressWriterFactory<IN> withHadoopCompression(String hadoopCodecName) {
+		return withHadoopCompression(hadoopCodecName, new Configuration());
+	}
+
+	public CompressWriterFactory<IN> withHadoopCompression(String hadoopCodecName, Configuration hadoopConfiguration) {
+		return withHadoopCompression(new CompressionCodecFactory(hadoopConfiguration).getCodecByName(hadoopCodecName));
+	}
+
+	public CompressWriterFactory<IN> withHadoopCompression(CompressionCodec hadoopCodec) {
+		this.hadoopCodec = Preconditions.checkNotNull(hadoopCodec, "hadoopCodec cannot be null");
+		return this;
+	}
+
+	@Override
+	public BulkWriter<IN> create(FSDataOutputStream out) throws IOException {
+		try {
+			return (hadoopCodec != null)
+				? new HadoopCompressionBulkWriter<>(out, extractor, hadoopCodec)
+				: new NoCompressionBulkWriter<>(out, extractor);
+		} catch (Exception e) {
+			throw new IOException(e.getLocalizedMessage(), e);
+		}
+	}
+
+	public String codecExtension() {
+		return (hadoopCodec != null)
+			? hadoopCodec.getDefaultExtension()
+			: "";
+	}
+
+}

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriterFactory.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriterFactory.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import java.io.IOException;
 
 /**
- * A factory that creates a {@link BulkWriter} implementation that compress file.
+ * A factory that creates a {@link BulkWriter} implementation that compresses the written data.
  *
  * @param <IN> The type of element to write.
  */

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriters.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriters.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.compress;
+
+import org.apache.flink.formats.compress.extractor.Extractor;
+
+/**
+ * Convenience builder to create {@link CompressWriterFactory} instances.
+ */
+public class CompressWriters {
+
+	public static <IN> CompressWriterFactory<IN> forExtractor(Extractor<IN> extractor) {
+		return new CompressWriterFactory<>(extractor);
+	}
+}
+

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriters.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriters.java
@@ -21,7 +21,7 @@ package org.apache.flink.formats.compress;
 import org.apache.flink.formats.compress.extractor.Extractor;
 
 /**
- * Convenience builder to create {@link CompressWriterFactory} instances.
+ * Convenience builder for creating {@link CompressWriterFactory} instances.
  */
 public class CompressWriters {
 

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/DefaultExtractor.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/DefaultExtractor.java
@@ -19,7 +19,7 @@
 package org.apache.flink.formats.compress.extractor;
 
 /**
- * A {@link Extractor} implementation that extract element to string with line separator.
+ * A {@link Extractor} implementation that extracts element to string with line separator.
  *
  * @param <T> The type of element to extract from.
  */

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/DefaultExtractor.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/DefaultExtractor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.compress.extractor;
+
+/**
+ * A {@link Extractor} implementation that extract element to string with line separator.
+ *
+ * @param <T> The type of element to extract from.
+ */
+public class DefaultExtractor<T> implements Extractor<T> {
+
+	@Override
+	public byte[] extract(T element) {
+		return (element.toString() + System.lineSeparator()).getBytes();
+	}
+
+}

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/Extractor.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/Extractor.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.compress.extractor;
+
+import java.io.Serializable;
+
+/**
+ * Interface for extract nested value from record.
+ */
+public interface Extractor<T> extends Serializable {
+
+	byte[] extract(T element);
+
+}

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/Extractor.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/Extractor.java
@@ -21,7 +21,8 @@ package org.apache.flink.formats.compress.extractor;
 import java.io.Serializable;
 
 /**
- * Interface for extract nested value from record.
+ * An {@link Extractor} turns a record into a byte array for writing data. For use with {@link
+ * org.apache.flink.formats.compress.CompressWriters}.
  */
 public interface Extractor<T> extends Serializable {
 

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/HadoopCompressionBulkWriter.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/HadoopCompressionBulkWriter.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.io.compress.CompressionOutputStream;
 import java.io.IOException;
 
 /**
- * A {@link BulkWriter} implementation that compress file using Hadoop codecs.
+ * A {@link BulkWriter} implementation that compresses data using Hadoop codecs.
  *
  * @param <T> The type of element to write.
  */
@@ -38,7 +38,10 @@ public class HadoopCompressionBulkWriter<T> implements BulkWriter<T> {
 	private FSDataOutputStream outputStream;
 	private CompressionOutputStream compressor;
 
-	public HadoopCompressionBulkWriter(FSDataOutputStream outputStream, Extractor<T> extractor, CompressionCodec compressionCodec) throws Exception {
+	public HadoopCompressionBulkWriter(
+			FSDataOutputStream outputStream,
+			Extractor<T> extractor,
+			CompressionCodec compressionCodec) throws Exception {
 		this.outputStream = outputStream;
 		this.extractor = extractor;
 		this.compressor = compressionCodec.createOutputStream(outputStream);

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/HadoopCompressionBulkWriter.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/HadoopCompressionBulkWriter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.compress.writers;
+
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.formats.compress.extractor.Extractor;
+
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionOutputStream;
+
+import java.io.IOException;
+
+/**
+ * A {@link BulkWriter} implementation that compress file using Hadoop codecs.
+ *
+ * @param <T> The type of element to write.
+ */
+public class HadoopCompressionBulkWriter<T> implements BulkWriter<T> {
+
+	private Extractor<T> extractor;
+	private FSDataOutputStream outputStream;
+	private CompressionOutputStream compressor;
+
+	public HadoopCompressionBulkWriter(FSDataOutputStream outputStream, Extractor<T> extractor, CompressionCodec compressionCodec) throws Exception {
+		this.outputStream = outputStream;
+		this.extractor = extractor;
+		this.compressor = compressionCodec.createOutputStream(outputStream);
+	}
+
+	@Override
+	public void addElement(T element) throws IOException {
+		compressor.write(extractor.extract(element));
+	}
+
+	@Override
+	public void flush() throws IOException {
+		compressor.flush();
+		outputStream.flush();
+	}
+
+	@Override
+	public void finish() throws IOException {
+		compressor.finish();
+		outputStream.sync();
+	}
+}

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/NoCompressionBulkWriter.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/NoCompressionBulkWriter.java
@@ -25,7 +25,9 @@ import org.apache.flink.formats.compress.extractor.Extractor;
 import java.io.IOException;
 
 /**
- * A {@link BulkWriter} implementation that dont compress the file.
+ * A {@link BulkWriter} implementation that does not compress data. This is essentially a no-op
+ * writer for use with {@link org.apache.flink.formats.compress.CompressWriterFactory} for the case
+ * that no compression codec is specified.
  *
  * @param <T> The type of element to write.
  */

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/NoCompressionBulkWriter.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/NoCompressionBulkWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.compress.writers;
+
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.formats.compress.extractor.Extractor;
+
+import java.io.IOException;
+
+/**
+ * A {@link BulkWriter} implementation that dont compress the file.
+ *
+ * @param <T> The type of element to write.
+ */
+public class NoCompressionBulkWriter<T> implements BulkWriter<T> {
+
+	private Extractor<T> extractor;
+	private FSDataOutputStream outputStream;
+
+	public NoCompressionBulkWriter(FSDataOutputStream outputStream, Extractor<T> extractor) {
+		this.outputStream = outputStream;
+		this.extractor = extractor;
+	}
+
+	@Override
+	public void addElement(T element) throws IOException {
+		outputStream.write(extractor.extract(element));
+	}
+
+	@Override
+	public void flush() throws IOException {
+		outputStream.flush();
+	}
+
+	@Override
+	public void finish() throws IOException {
+		outputStream.sync();
+	}
+}

--- a/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
+++ b/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.compress;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.formats.compress.extractor.DefaultExtractor;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.BZip2Codec;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.io.compress.DefaultCodec;
+import org.apache.hadoop.io.compress.DeflateCodec;
+import org.apache.hadoop.io.compress.GzipCodec;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for {@link CompressWriterFactory}.
+ */
+public class CompressWriterFactoryTest extends TestLogger {
+
+	@ClassRule
+	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+	@Test
+	public void testBzip2CompressByName() throws Exception {
+		testCompressByName("Bzip2");
+	}
+
+	@Test
+	public void testBzip2CompressCodec() throws Exception {
+		BZip2Codec codec = new BZip2Codec();
+		codec.setConf(new Configuration());
+		testCompressCodec(codec);
+	}
+
+	@Test
+	public void testGzipCompressByName() throws Exception {
+		testCompressByName("Gzip");
+	}
+
+	@Test
+	public void testGzipCompressCodec() throws Exception {
+		GzipCodec codec = new GzipCodec();
+		codec.setConf(new Configuration());
+		testCompressCodec(codec);
+	}
+
+	@Test
+	public void testDeflateCompressByName() throws Exception {
+		DeflateCodec codec = new DeflateCodec();
+		codec.setConf(new Configuration());
+		testCompressCodec(codec);
+	}
+
+	@Test
+	public void testDefaultCompressByName() throws Exception {
+		DefaultCodec codec = new DefaultCodec();
+		codec.setConf(new Configuration());
+		testCompressCodec(codec);
+	}
+
+	private void testCompressByName(String codec) throws Exception {
+		CompressWriterFactory<String> writer = CompressWriters.forExtractor(new DefaultExtractor<String>()).withHadoopCompression(codec);
+		List<String> lines = Arrays.asList("line1", "line2", "line3");
+
+		File directory = prepareCompressedFile(writer, lines);
+
+		validateResults(directory, lines, new CompressionCodecFactory(new Configuration()).getCodecByName(codec));
+	}
+
+	private void testCompressCodec(CompressionCodec codec) throws Exception {
+
+		CompressWriterFactory<String> writer = CompressWriters.forExtractor(new DefaultExtractor<String>()).withHadoopCompression(codec);
+		List<String> lines = Arrays.asList("line1", "line2", "line3");
+
+		File directory = prepareCompressedFile(writer, lines);
+
+		validateResults(directory, lines, codec);
+	}
+
+	private File prepareCompressedFile(CompressWriterFactory<String> writer, List<String> lines) throws Exception {
+		final File outDir = TEMPORARY_FOLDER.newFolder();
+
+		final BucketAssigner<String, String> assigner = new BucketAssigner<String, String> () {
+			@Override
+			public String getBucketId(String element, BucketAssigner.Context context) {
+				return "bucket";
+			}
+
+			@Override
+			public SimpleVersionedSerializer<String> getSerializer() {
+				return SimpleVersionedStringSerializer.INSTANCE;
+			}
+		};
+
+		StreamingFileSink<String> sink = StreamingFileSink
+			.forBulkFormat(new Path(outDir.toURI()), writer)
+			.withBucketAssigner(assigner)
+			.build();
+
+		try (
+			OneInputStreamOperatorTestHarness<String, Object> testHarness = new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), 1, 1, 0)
+		) {
+			testHarness.setup();
+			testHarness.open();
+
+			int time = 0;
+			for (String line: lines) {
+				testHarness.processElement(new StreamRecord<>(line, ++time));
+			}
+
+			testHarness.snapshot(1, ++time);
+			testHarness.notifyOfCompletedCheckpoint(1);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return outDir;
+	}
+
+	private void validateResults(File folder, List<String> expected, CompressionCodec codec) throws Exception {
+		File[] buckets = folder.listFiles();
+		assertNotNull(buckets);
+		assertEquals(1, buckets.length);
+
+		final File[] partFiles = buckets[0].listFiles();
+		assertNotNull(partFiles);
+		assertEquals(1, partFiles.length);
+
+		for (File partFile : partFiles) {
+			assertTrue(partFile.length() > 0);
+			final List<String> fileContent = readFile(partFile, codec);
+			assertEquals(expected, fileContent);
+		}
+	}
+
+	private List<String> readFile(File file, CompressionCodec codec) throws Exception {
+		try (FileInputStream inputStream = new FileInputStream(file)) {
+			try (InputStreamReader readerStream = new InputStreamReader((codec == null) ? inputStream : codec.createInputStream(inputStream))) {
+				try (BufferedReader reader = new BufferedReader(readerStream)) {
+					return reader.lines().collect(Collectors.toList());
+				}
+			}
+		}
+	}
+}

--- a/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
+++ b/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test class for {@link CompressWriterFactory}.
+ * Tests for {@link CompressWriterFactory}.
  */
 public class CompressWriterFactoryTest extends TestLogger {
 
@@ -150,9 +150,8 @@ public class CompressWriterFactoryTest extends TestLogger {
 
 			testHarness.snapshot(1, ++time);
 			testHarness.notifyOfCompletedCheckpoint(1);
-		} catch (Exception e) {
-			e.printStackTrace();
 		}
+
 		return outDir;
 	}
 

--- a/flink-formats/flink-compress/src/test/resources/log4j-test.properties
+++ b/flink-formats/flink-compress/src/test/resources/log4j-test.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=OFF, testlogger
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target=System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -41,6 +41,7 @@ under the License.
 		<module>flink-avro-confluent-registry</module>
 		<module>flink-parquet</module>
 		<module>flink-sequence-file</module>
+		<module>flink-compress</module>
 		<module>flink-csv</module>
 		<module>flink-orc</module>
 	</modules>


### PR DESCRIPTION
## What is the purpose of the change
This pull request is to create a CompressFileWriter which allows user to compressed the stream to filesystem using StreamingFileSink

## Brief change log
added a new module on flink-formats 

## Verifying this change
This change added tests and can be verified as follows:
  - *Added test that validates that file is created compressed and can be read after creation*

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no 

## Documentation
  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? JavaDocs
