### PR TITLE
[Flink 13585][tests] Harden TaskAsyncCallTest by fixing race condition

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -196,9 +196,9 @@ public class TaskAsyncCallTest extends TestLogger {
 			triggerLatch.await();
 
 			task.notifyCheckpointComplete(1);
-			task.cancelExecution();
-
 			notifyCheckpointCompleteLatch.await();
+
+			task.cancelExecution();
 			stopLatch.await();
 
 			assertThat(classLoaders, hasSize(greaterThanOrEqualTo(2)));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -41,9 +41,7 @@ import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
-import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
-import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
 import org.apache.flink.runtime.io.network.partition.NoOpResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -53,8 +51,10 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
+import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.SerializedValue;
@@ -80,6 +80,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Testing asynchronous call of {@link Task}.
+ */
 public class TaskAsyncCallTest extends TestLogger {
 
 	/** Number of expected checkpoints. */
@@ -265,6 +268,9 @@ public class TaskAsyncCallTest extends TestLogger {
 			executor);
 	}
 
+	/**
+	 * Invokable for testing checkpoints.
+	 */
 	public static class CheckpointsInOrderInvokable extends AbstractInvokable {
 
 		private volatile long lastCheckpointId = 0;


### PR DESCRIPTION
## What is the purpose of the change

* Harden `TaskAsyncCallTest`
* There is a race condition of `TaskAsyncCallTest#testSetsUserCodeClassLoader` between `task.notifyCheckpointComplete(1)` and `task.cancelExecution()`. If the cancellation is executed too fast, the `Task#asyncCallDispatcher` might be shut down prematurely without invoking the asynchronous notification. The `notifyCheckpointCompleteLatch` can never be triggered anymore.

## Brief change log

* Execute the cancellation after `notifyCheckpointCompleteLatch.await()` to avoid race condition
* Fix the code style error of `TaskAsyncCallTest`

## Verifying this change

* This change is already covered by existing tests
* The deadlock scenario can be reproduced by making the asynchronous invocation a bit delayed. For example, using a delayed queue to replace the `LinkedBlockingQueue` of `Task#asyncCallDispatcher`.  Wait a second before `take/poll` in delayed queue.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
