### PR TITLE
[FLINK-13728][docs] fix wrong closing tag order in sidenav

### DIFF
--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -88,7 +88,7 @@ level is determined by 'nav-pos'.
     {% else %}
       {% assign elementsPos = elementsPosStack | last %}
       {% assign pos = posStack | last %}
-</li></ul></div>
+</ul></div></li>
       {% assign elementsPosStack = elementsPosStack | pop %}
       {% assign posStack = posStack | pop %}
     {% endif %}


### PR DESCRIPTION
## What is the purpose of the change

The side navigation was closing some tags incorrectly as `</li></ul></div>` which should rather be `</ul></div></li>`.

Next PR in this series: #9440.

## Brief change log

- fix tag order as proposed

## Verifying this change

This change is a trivial rework which I checked in the generated HTML pages.
