### PR TITLE
[FLINK-13643][docs]Document the workaround for users with a different minor Hive version

### DIFF
--- a/docs/dev/table/hive/index.md
+++ b/docs/dev/table/hive/index.md
@@ -40,8 +40,8 @@ You do not need to modify your existing Hive Metastore or change the data placem
 
 ## Supported Hive Version's
 
-Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guarantee's for other 
-versions.   
+Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guarantee's for other minor versions.
+
 If you use a different minor Hive version such as `1.2.2` or `2.3.1`, it should also be ok to 
 chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround.
 

--- a/docs/dev/table/hive/index.md
+++ b/docs/dev/table/hive/index.md
@@ -40,7 +40,10 @@ You do not need to modify your existing Hive Metastore or change the data placem
 
 ## Supported Hive Version's
 
-Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guarantee's for other versions.
+Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guarantee's for other 
+versions.   
+If you use a different minor Hive version such as `1.2.2` or `2.3.1`, it should also be ok to 
+chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround.
 
 ### Depedencies 
 

--- a/docs/dev/table/hive/index.md
+++ b/docs/dev/table/hive/index.md
@@ -45,7 +45,11 @@ Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guara
 If you use a different minor Hive version such as `1.2.2` or `2.3.1`, it should also be ok to 
 chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround. For 
 example, you want to use Flink to integrate `2.3.1` hive version in sql client, just set the 
-hive-version to `2.3.4` in YAML config.
+hive-version to `2.3.4` in YAML config. Similarly pass the version string when creating 
+HiveCatalog instance via Table API.
+
+Users are welcome to try out different versions with this workaround. Since only `2.3.4` and `1.2
+.1` have been tested, there might be unexpected issues. We will test and support more versions in future releases.
 
 ### Depedencies 
 

--- a/docs/dev/table/hive/index.md
+++ b/docs/dev/table/hive/index.md
@@ -43,7 +43,9 @@ You do not need to modify your existing Hive Metastore or change the data placem
 Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guarantee's for other minor versions.
 
 If you use a different minor Hive version such as `1.2.2` or `2.3.1`, it should also be ok to 
-chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround.
+chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround. For 
+example, you want to use Flink to integrate `2.3.1` hive version in sql client, just set the 
+hive-version to `2.3.4` in YAML config.
 
 ### Depedencies 
 

--- a/docs/dev/table/hive/index.zh.md
+++ b/docs/dev/table/hive/index.zh.md
@@ -40,7 +40,10 @@ You do not need to modify your existing Hive Metastore or change the data placem
 
 ## Supported Hive Version's
 
-Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guarantee's for other versions.
+Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guarantee's for other minor versions.
+
+If you use a different minor Hive version such as `1.2.2` or `2.3.1`, it should also be ok to 
+chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround.
 
 ### Depedencies 
 

--- a/docs/dev/table/hive/index.zh.md
+++ b/docs/dev/table/hive/index.zh.md
@@ -45,7 +45,11 @@ Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guara
 If you use a different minor Hive version such as `1.2.2` or `2.3.1`, it should also be ok to 
 chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround. For 
 example, you want to use Flink to integrate `2.3.1` hive version in sql client, just set the 
-hive-version to `2.3.4` in YAML config.
+hive-version to `2.3.4` in YAML config. Similarly pass the version string when creating 
+HiveCatalog instance via Table API.
+
+Users are welcome to try out different versions with this workaround. Since only `2.3.4` and `1.2
+.1` have been tested, there might be unexpected issues. We will test and support more versions in future releases.
 
 ### Depedencies 
 

--- a/docs/dev/table/hive/index.zh.md
+++ b/docs/dev/table/hive/index.zh.md
@@ -43,7 +43,9 @@ You do not need to modify your existing Hive Metastore or change the data placem
 Flink supports Hive `2.3.4` and `1.2.1` and relies on Hive's compatibility guarantee's for other minor versions.
 
 If you use a different minor Hive version such as `1.2.2` or `2.3.1`, it should also be ok to 
-chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround.
+chose the closest version `1.2.1` (for `1.2.2`) or `2.3.4` (for `2.3.1`) to workaround. For 
+example, you want to use Flink to integrate `2.3.1` hive version in sql client, just set the 
+hive-version to `2.3.4` in YAML config.
 
 ### Depedencies 
 


### PR DESCRIPTION


## What is the purpose of the change

*Document the workaround for users with a different minor Hive version*


## Brief change log
  - *Document the workaround for users with a different minor Hive version*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
