### PR TITLE
[FLINK-13718][hbase] Disable tests on Java 11

### DIFF
--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -352,7 +352,7 @@ under the License.
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
 						<configuration>
-							<!-- hive does not support Java 11 -->
+							<!-- hbase currently does not support Java 11, see HBASE-21110 -->
 							<skip>true</skip>
 						</configuration>
 					</plugin>

--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -340,6 +340,25 @@ under the License.
 				</dependencies>
 			</dependencyManagement>
 		</profile>
+		<profile>
+			<id>java11</id>
+			<activation>
+				<jdk>11</jdk>
+			</activation>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<!-- hive does not support Java 11 -->
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
Disables all HBase tests on Java 11; The HBaseConnectorITCase fails since it requires changes to the classpath that hbase uses, but this isn't possible on Java 9+.

(Note that tests are already disabled for java 9 in tools/travis/stage.sh)