### PR TITLE
[FLINK-13716][docs] Remove Program-related Chinese documentation

### DIFF
--- a/docs/dev/packaging.zh.md
+++ b/docs/dev/packaging.zh.md
@@ -45,33 +45,15 @@ the same one that is used by the Java Virtual Machine to find the main method wh
 files through the command `java -jar pathToTheJarFile`. Most IDEs offer to include that attribute
 automatically when exporting JAR files.
 
-
-### Packaging Programs through Plans
-
-Additionally, we support packaging programs as *Plans*. Instead of defining a program in the main
-method and calling
-`execute()` on the environment, plan packaging returns the *Program Plan*, which is a description of
-the program's data flow. To do that, the program must implement the
-`org.apache.flink.api.common.Program` interface, defining the `getPlan(String...)` method. The
-strings passed to that method are the command line arguments. The program's plan can be created from
-the environment via the `ExecutionEnvironment#createProgramPlan()` method. When packaging the
-program's plan, the JAR manifest must point to the class implementing the
-`org.apache.flink.api.common.Program` interface, instead of the class with the main method.
-
-
 ### Summary
 
-The overall procedure to invoke a packaged program is as follows:
+The overall procedure to invoke a packaged program consists of two steps:
 
 1. The JAR's manifest is searched for a *main-class* or *program-class* attribute. If both
 attributes are found, the *program-class* attribute takes precedence over the *main-class*
 attribute. Both the command line and the web interface support a parameter to pass the entry point
 class name manually for cases where the JAR manifest contains neither attribute.
 
-2. If the entry point class implements the `org.apache.flink.api.common.Program`, then the system
-calls the `getPlan(String...)` method to obtain the program plan to execute.
-
-3. If the entry point class does not implement the `org.apache.flink.api.common.Program` interface,
-the system will invoke the main method of the class.
+2. The system invokes the main method of the class.
 
 {% top %}


### PR DESCRIPTION
# What is the purpose of the change

This PR is part of the removal of the `Program` interface, as discussed in [FLIP-52](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=125308637)

Specifically it is for the Chinese documentation update. In fact the translation haven't done.

# Verifying this change

This change is code cleanup and it is already covered by existing tests.

# Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
- The S3 file system connector: (no)

# Documentation
- Does this pull request introduce a new feature? (no)
- How is the feature documented? (docs)

cc @kl0u 