### PR TITLE
[FLINK-13588] flink-streaming-java don't throw away exception info in logging 

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -66,9 +66,9 @@ import static org.junit.Assert.fail;
  * IMPORTANT! Remember to close environment after usage!
  */
 public class MockEnvironment implements Environment, AutoCloseable {
-	
+
 	private final TaskInfo taskInfo;
-	
+
 	private final ExecutionConfig executionConfig;
 
 	private final MemoryManager memManager;
@@ -107,9 +107,9 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
 	private final TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 
-	private Optional<Class<Throwable>> expectedExternalFailureCause = Optional.empty();
+	private Optional<Class<? extends Throwable>> expectedExternalFailureCause = Optional.empty();
 
-	private Optional<Throwable> actualExternalFailureCause = Optional.empty();
+	private Optional<? extends Throwable> actualExternalFailureCause = Optional.empty();
 
 	private final TaskMetricGroup taskMetricGroup;
 
@@ -163,7 +163,6 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
 		this.taskMetricGroup = taskMetricGroup;
 	}
-
 
 	public IteratorWrappingTestSingleInputGate<Record> addInput(MutableObjectIterator<Record> inputIterator) {
 		try {
@@ -346,11 +345,11 @@ public class MockEnvironment implements Environment, AutoCloseable {
 		ioManager.close();
 	}
 
-	public void setExpectedExternalFailureCause(Class<Throwable> expectedThrowableClass) {
+	public void setExpectedExternalFailureCause(Class<? extends Throwable> expectedThrowableClass) {
 		this.expectedExternalFailureCause = Optional.of(expectedThrowableClass);
 	}
 
-	public Optional<Throwable> getActualExternalFailureCause() {
+	public Optional<? extends Throwable> getActualExternalFailureCause() {
 		return actualExternalFailureCause;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsynchronousException.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsynchronousException.java
@@ -35,9 +35,4 @@ public class AsynchronousException extends Exception {
 	public AsynchronousException(String message, Throwable cause) {
 		super(message, cause);
 	}
-
-	@Override
-	public String toString() {
-		return "AsynchronousException{" + getCause() + "}";
-	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -176,6 +176,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	/** The currently active background materialization threads. */
 	private final CloseableRegistry cancelables = new CloseableRegistry();
 
+	private final StreamTaskAsyncExceptionHandler asyncExceptionHandler;
+
 	/**
 	 * Flag to mark the task "in operation", in which case check needs to be initialized to true,
 	 * so that early cancel() before invoke() behaves correctly.
@@ -243,6 +245,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		this.recordWriters = createRecordWriters(configuration, environment);
 		this.syncSavepointLatch = new SynchronousSavepointLatch();
 		this.mailboxProcessor = new MailboxProcessor(this::performDefaultAction);
+		this.asyncExceptionHandler = new StreamTaskAsyncExceptionHandler(environment);
 	}
 
 	// ------------------------------------------------------------------------
@@ -934,7 +937,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	public void handleAsyncException(String message, Throwable exception) {
 		if (isRunning) {
 			// only fail if the task is still running
-			getEnvironment().failExternally(new AsynchronousException(message, exception));
+			asyncExceptionHandler.handleAsyncException(message, exception);
 		}
 	}
 
@@ -948,6 +951,21 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	// ------------------------------------------------------------------------
+
+	/**
+	 * Utility class to encapsulate the handling of asynchronous exceptions.
+	 */
+	static class StreamTaskAsyncExceptionHandler {
+		private final Environment environment;
+
+		StreamTaskAsyncExceptionHandler(Environment environment) {
+			this.environment = environment;
+		}
+
+		void handleAsyncException(String message, Throwable exception) {
+			environment.failExternally(new AsynchronousException(message, exception));
+		}
+	}
 
 	/**
 	 * This runnable executes the asynchronous parts of all involved backend snapshots for the subtask.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -934,7 +934,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	public void handleAsyncException(String message, Throwable exception) {
 		if (isRunning) {
 			// only fail if the task is still running
-			getEnvironment().failExternally(exception);
+			getEnvironment().failExternally(new AsynchronousException(message, exception));
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -132,11 +132,7 @@ import org.mockito.stubbing.Answer;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -182,6 +178,50 @@ public class StreamTaskTest extends TestLogger {
 
 	@Rule
 	public final Timeout timeoutPerTest = Timeout.seconds(30);
+
+	/**
+	 * This test checks the async exceptions handling wraps the message and cause as an AsynchronousException
+	 * and propagates this to the environment.
+	 */
+	@Test
+	public void handleAsyncException() throws Throwable {
+		MockEnvironment e = MockEnvironment.builder().build();
+		RuntimeException expectedException = new RuntimeException("RUNTIME EXCEPTION");
+
+		BlockingCloseStreamOperator.resetLatches();
+		Configuration taskConfiguration = new Configuration();
+		StreamConfig streamConfig = new StreamConfig(taskConfiguration);
+		streamConfig.setStreamOperator(new BlockingCloseStreamOperator());
+		streamConfig.setOperatorID(new OperatorID());
+
+		try (MockEnvironment mockEnvironment =
+				 new MockEnvironmentBuilder()
+					 .setTaskName("Test Task")
+					 .setMemorySize(32L * 1024L)
+					 .setInputSplitProvider(new MockInputSplitProvider())
+					 .setBufferSize(1)
+					 .setTaskConfiguration(taskConfiguration)
+					 .build()) {
+
+			RunningTask<StreamTask<Void, BlockingCloseStreamOperator>> task = runTask(() -> new NoOpStreamTask<>(mockEnvironment));
+
+			BlockingCloseStreamOperator.inClose.await();
+
+			// check that the StreamTask is not yet in isRunning == false
+			assertTrue(task.streamTask.isRunning());
+
+
+			// generate an error report and expect it to be caught by the Environment
+			mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
+			task.streamTask.handleAsyncException("EXPECTED_ERROR MESSAGE", expectedException);
+
+			// expect an AsynchronousException containing the supplied error details
+			Optional<Throwable> actualExternalFailureCause = mockEnvironment.getActualExternalFailureCause();
+			AsynchronousException cause = (AsynchronousException)actualExternalFailureCause.get();
+			assertEquals(cause.getMessage(), "EXPECTED_ERROR MESSAGE");
+			assertEquals(cause.getCause(), expectedException);
+		}
+	}
 
 	/**
 	 * This test checks that cancel calls that are issued before the operator is

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -132,7 +132,12 @@ import org.mockito.stubbing.Answer;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -195,13 +200,12 @@ public class StreamTaskTest extends TestLogger {
 		streamConfig.setOperatorID(new OperatorID());
 
 		try (MockEnvironment mockEnvironment =
-				 new MockEnvironmentBuilder()
-					 .setTaskName("Test Task")
-					 .setMemorySize(32L * 1024L)
-					 .setInputSplitProvider(new MockInputSplitProvider())
-					 .setBufferSize(1)
-					 .setTaskConfiguration(taskConfiguration)
-					 .build()) {
+				new MockEnvironmentBuilder()
+					.setTaskName("Test Task")
+					.setMemorySize(32L * 1024L)
+					.setBufferSize(1)
+					.setTaskConfiguration(taskConfiguration)
+					.build()) {
 
 			RunningTask<StreamTask<Void, BlockingCloseStreamOperator>> task = runTask(() -> new NoOpStreamTask<>(mockEnvironment));
 
@@ -210,16 +214,18 @@ public class StreamTaskTest extends TestLogger {
 			// check that the StreamTask is not yet in isRunning == false
 			assertTrue(task.streamTask.isRunning());
 
-
 			// generate an error report and expect it to be caught by the Environment
-			mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
+			mockEnvironment.setExpectedExternalFailureCause(AsynchronousException.class);
 			task.streamTask.handleAsyncException("EXPECTED_ERROR MESSAGE", expectedException);
 
 			// expect an AsynchronousException containing the supplied error details
-			Optional<Throwable> actualExternalFailureCause = mockEnvironment.getActualExternalFailureCause();
-			AsynchronousException cause = (AsynchronousException)actualExternalFailureCause.get();
-			assertEquals(cause.getMessage(), "EXPECTED_ERROR MESSAGE");
-			assertEquals(cause.getCause(), expectedException);
+			Optional<? extends Throwable> actualExternalFailureCause = mockEnvironment.getActualExternalFailureCause();
+			final Throwable actualException = actualExternalFailureCause
+				.orElseThrow(() -> new AssertionError("Expected exceptional completion"));
+
+			assertThat(actualException, instanceOf(AsynchronousException.class));
+			assertThat(actualException.getMessage(), is("EXPECTED_ERROR MESSAGE"));
+			assertThat(actualException.getCause(), is(expectedException));
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StreamTaskTimerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StreamTaskTimerITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.TimerException;
 import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,7 +42,10 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.Semaphore;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the timer service of {@code StreamTask}.
@@ -73,27 +77,26 @@ public class StreamTaskTimerITCase extends AbstractTestBase {
 
 		source.transform("Custom Operator", BasicTypeInfo.STRING_TYPE_INFO, new TimerOperator(ChainingStrategy.ALWAYS));
 
-		boolean testSuccess = false;
 		try {
 			env.execute("Timer test");
 		} catch (JobExecutionException e) {
-			if (e.getCause() instanceof TimerException) {
-				TimerException te = (TimerException) e.getCause();
-				if (te.getCause() instanceof RuntimeException) {
-					RuntimeException re = (RuntimeException) te.getCause();
-					if (re.getMessage().equals("TEST SUCCESS")) {
-						testSuccess = true;
-					} else {
-						throw e;
-					}
-				} else {
-					throw e;
-				}
-			} else {
+			verifyJobExecutionException(e);
+		}
+	}
+
+	private void verifyJobExecutionException(JobExecutionException e) throws JobExecutionException {
+		final Optional<TimerException> optionalTimerException = ExceptionUtils.findThrowable(e, TimerException.class);
+		assertTrue(optionalTimerException.isPresent());
+
+		TimerException te = optionalTimerException.get();
+		if (te.getCause() instanceof RuntimeException) {
+			RuntimeException re = (RuntimeException) te.getCause();
+			if (!re.getMessage().equals("TEST SUCCESS")) {
 				throw e;
 			}
+		} else {
+			throw e;
 		}
-		Assert.assertTrue(testSuccess);
 	}
 
 	/**
@@ -110,27 +113,11 @@ public class StreamTaskTimerITCase extends AbstractTestBase {
 
 		source.transform("Custom Operator", BasicTypeInfo.STRING_TYPE_INFO, new TimerOperator(ChainingStrategy.NEVER));
 
-		boolean testSuccess = false;
 		try {
 			env.execute("Timer test");
 		} catch (JobExecutionException e) {
-			if (e.getCause() instanceof TimerException) {
-				TimerException te = (TimerException) e.getCause();
-				if (te.getCause() instanceof RuntimeException) {
-					RuntimeException re = (RuntimeException) te.getCause();
-					if (re.getMessage().equals("TEST SUCCESS")) {
-						testSuccess = true;
-					} else {
-						throw e;
-					}
-				} else {
-					throw e;
-				}
-			} else {
-				throw e;
-			}
+			verifyJobExecutionException(e);
 		}
-		Assert.assertTrue(testSuccess);
 	}
 
 	@Test
@@ -146,27 +133,11 @@ public class StreamTaskTimerITCase extends AbstractTestBase {
 				BasicTypeInfo.STRING_TYPE_INFO,
 				new TwoInputTimerOperator(ChainingStrategy.NEVER));
 
-		boolean testSuccess = false;
 		try {
 			env.execute("Timer test");
 		} catch (JobExecutionException e) {
-			if (e.getCause() instanceof TimerException) {
-				TimerException te = (TimerException) e.getCause();
-				if (te.getCause() instanceof RuntimeException) {
-					RuntimeException re = (RuntimeException) te.getCause();
-					if (re.getMessage().equals("TEST SUCCESS")) {
-						testSuccess = true;
-					} else {
-						throw e;
-					}
-				} else {
-					throw e;
-				}
-			} else {
-				throw e;
-			}
+			verifyJobExecutionException(e);
 		}
-		Assert.assertTrue(testSuccess);
 	}
 
 	private static class TimerOperator extends AbstractStreamOperator<String> implements OneInputStreamOperator<String, String>, ProcessingTimeCallback {


### PR DESCRIPTION
Previously the async error handler threw away the descriptive text provided by the call site. This makes diagnosis of errors really difficult. 

## Brief change log

This change wraps the error message and cause exception into a wrapper exception that properly conveys the descriptive text to the logs.

## Verifying this change

Test added to StreamTaskTest to verify that objects are passed correctly to the Environment object and also to verify that the toString rendering includes the given text.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  