### PR TITLE
[FLINK-13741][table] "SHOW FUNCTIONS" should include Flink built-in functions' names

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -236,6 +236,16 @@ class TableEnvironment(object):
         j_udf_name_array = self._j_tenv.listUserDefinedFunctions()
         return [item for item in j_udf_name_array]
 
+    def list_functions(self):
+        """
+        Gets the names of all functions in this environment.
+
+        :return: List of the names of all functions in this environment.
+        :rtype: list[str]
+        """
+        j_function_name_array = self._j_tenv.listFunctions()
+        return [item for item in j_function_name_array]
+
     def explain(self, table=None, extended=False):
         """
         Returns the AST of the specified Table API and SQL queries and the execution plan to compute

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -406,7 +406,7 @@ public class CliClient {
 	private void callShowFunctions() {
 		final List<String> functions;
 		try {
-			functions = executor.listUserDefinedFunctions(context);
+			functions = executor.listFunctions(context);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -49,6 +49,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -414,6 +415,7 @@ public class CliClient {
 		if (functions.isEmpty()) {
 			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
 		} else {
+			Collections.sort(functions);
 			functions.forEach((v) -> terminal.writer().println(v));
 		}
 		terminal.flush();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -61,6 +61,11 @@ public interface Executor {
 	List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException;
 
 	/**
+	 * Lists all functions known to the executor.
+	 */
+	List<String> listFunctions(SessionContext session) throws SqlExecutionException;
+
+	/**
 	 * Sets a catalog with given name as the current catalog.
 	 */
 	void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -233,6 +233,15 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public List<String> listFunctions(SessionContext session) throws SqlExecutionException {
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+		final TableEnvironment tableEnv = context
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listFunctions()));
+	}
+
+	@Override
 	public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
 		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
 		final TableEnvironment tableEnv = context

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -233,6 +233,11 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public List<String> listFunctions(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
 
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -146,6 +146,11 @@ public class CliResultViewTest {
 		}
 
 		@Override
+		public List<String> listFunctions(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
 
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -222,7 +222,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final List<String> actualTables = executor.listUserDefinedFunctions(session);
 
-		final List<String> expectedTables = Arrays.asList("aggregateUDF", "scalarUDF", "tableUDF");
+		final List<String> expectedTables = Arrays.asList("aggregateUDF", "tableUDF", "scalarUDF");
 		assertEquals(expectedTables, actualTables);
 	}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -222,7 +222,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final List<String> actualTables = executor.listUserDefinedFunctions(session);
 
-		final List<String> expectedTables = Arrays.asList("aggregateUDF", "tableUDF", "scalarUDF");
+		final List<String> expectedTables = Arrays.asList("aggregateUDF", "scalarUDF", "tableUDF");
 		assertEquals(expectedTables, actualTables);
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -257,6 +257,11 @@ public interface TableEnvironment {
 	String[] listUserDefinedFunctions();
 
 	/**
+	 * Gets the names of all functions in this environment.
+	 */
+	String[] listFunctions();
+
+	/**
 	 * Returns the AST of the specified Table API and SQL queries and the execution plan to compute
 	 * the result of the given {@link Table}.
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -258,6 +258,11 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	}
 
 	@Override
+	public String[] listFunctions() {
+		return functionCatalog.getFunctions();
+	}
+
+	@Override
 	public String explain(Table table) {
 		return explain(table, false);
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
@@ -39,11 +40,11 @@ import org.apache.flink.table.functions.UserDefinedAggregateFunction;
 import org.apache.flink.table.functions.UserFunctionsTypeHelper;
 import org.apache.flink.util.Preconditions;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -134,7 +135,25 @@ public class FunctionCatalog implements FunctionLookup {
 	}
 
 	public String[] getUserDefinedFunctions() {
-		List<String> result = new ArrayList<>();
+		return getUserDefinedFunctionNames().toArray(new String[0]);
+	}
+
+	public String[] getFunctions() {
+		Set<String> result = getUserDefinedFunctionNames();
+
+		// Get built-in functions
+		result.addAll(
+			BuiltInFunctionDefinitions.getDefinitions()
+				.stream()
+				.map(f -> normalizeName(f.getName()))
+				.collect(Collectors.toSet())
+		);
+
+		return result.toArray(new String[0]);
+	}
+
+	private Set<String> getUserDefinedFunctionNames() {
+		Set<String> result = new HashSet<>();
 
 		// Get functions in catalog
 		Catalog catalog = catalogManager.getCatalog(catalogManager.getCurrentCatalog()).get();
@@ -148,9 +167,9 @@ public class FunctionCatalog implements FunctionLookup {
 		result.addAll(
 			userFunctions.values().stream()
 				.map(FunctionDefinition::toString)
-				.collect(Collectors.toList()));
+				.collect(Collectors.toSet()));
 
-		return result.toArray(new String[0]);
+		return result;
 	}
 
 	@Override
@@ -226,7 +245,8 @@ public class FunctionCatalog implements FunctionLookup {
 		userFunctions.put(normalizeName(name), functionDefinition);
 	}
 
-	private String normalizeName(String name) {
+	@VisibleForTesting
+	static String normalizeName(String name) {
 		return name.toUpperCase();
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.functions.UserDefinedAggregateFunction;
 import org.apache.flink.table.functions.UserFunctionsTypeHelper;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -135,7 +136,10 @@ public class FunctionCatalog implements FunctionLookup {
 	}
 
 	public String[] getUserDefinedFunctions() {
-		return getUserDefinedFunctionNames().toArray(new String[0]);
+		String[] names = getUserDefinedFunctionNames().toArray(new String[0]);
+		Arrays.sort(names);
+
+		return names;
 	}
 
 	public String[] getFunctions() {
@@ -149,7 +153,10 @@ public class FunctionCatalog implements FunctionLookup {
 				.collect(Collectors.toSet())
 		);
 
-		return result.toArray(new String[0]);
+		String[] names = result.toArray(new String[0]);
+		Arrays.sort(names);
+
+		return names;
 	}
 
 	private Set<String> getUserDefinedFunctionNames() {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -40,7 +40,6 @@ import org.apache.flink.table.functions.UserDefinedAggregateFunction;
 import org.apache.flink.table.functions.UserFunctionsTypeHelper;
 import org.apache.flink.util.Preconditions;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -136,10 +135,7 @@ public class FunctionCatalog implements FunctionLookup {
 	}
 
 	public String[] getUserDefinedFunctions() {
-		String[] names = getUserDefinedFunctionNames().toArray(new String[0]);
-		Arrays.sort(names);
-
-		return names;
+		return getUserDefinedFunctionNames().toArray(new String[0]);
 	}
 
 	public String[] getFunctions() {
@@ -153,10 +149,7 @@ public class FunctionCatalog implements FunctionLookup {
 				.collect(Collectors.toSet())
 		);
 
-		String[] names = result.toArray(new String[0]);
-		Arrays.sort(names);
-
-		return names;
+		return result.toArray(new String[0]);
 	}
 
 	private Set<String> getUserDefinedFunctionNames() {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FunctionCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FunctionCatalogTest.java
@@ -40,7 +40,7 @@ public class FunctionCatalogTest {
 			new CatalogManager("test", new GenericInMemoryCatalog("test")));
 
 		Set<String> actual = new HashSet<>();
-		Collections.addAll(actual, functionCatalog.getUserDefinedFunctions());
+		Collections.addAll(actual, functionCatalog.getFunctions());
 
 		Set<String> expected = BuiltInFunctionDefinitions.getDefinitions()
 			.stream()

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FunctionCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FunctionCatalogTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link FunctionCatalog}.
+ */
+public class FunctionCatalogTest {
+
+	@Test
+	public void testGetBuiltInFunctions() {
+		FunctionCatalog functionCatalog = new FunctionCatalog(
+			new CatalogManager("test", new GenericInMemoryCatalog("test")));
+
+		Set<String> actual = new HashSet<>();
+		Collections.addAll(actual, functionCatalog.getUserDefinedFunctions());
+
+		Set<String> expected = BuiltInFunctionDefinitions.getDefinitions()
+			.stream()
+			.map(f -> FunctionCatalog.normalizeName(f.getName()))
+			.collect(Collectors.toSet());
+
+		assertTrue(actual.containsAll(expected));
+	}
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -352,6 +352,8 @@ abstract class TableEnvImpl(
 
   override def listUserDefinedFunctions(): Array[String] = functionCatalog.getUserDefinedFunctions
 
+  override def listFunctions(): Array[String] = functionCatalog.getFunctions
+
   override def explain(table: Table): String
 
   override def getCompletionHints(statement: String, position: Int): Array[String] = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -58,6 +58,8 @@ class MockTableEnvironment extends TableEnvironment {
 
   override def listUserDefinedFunctions(): Array[String] = ???
 
+  override def listFunctions(): Array[String] = ???
+
   override def explain(table: Table): String = ???
 
   override def explain(table: Table, extended: Boolean): String = ???


### PR DESCRIPTION
## What is the purpose of the change

FunctionCatalog.getUserDefinedFunctions() only returns catalog functions and FunctionDefinitions registered in memory, but does not include Flink built-in functions' names.

It means currently {{show functions;}} thru SQL would not be able to see Flink's built-in functions.

Should be fixed to include Flink built-in functions' names

## Brief change log

- added `listFunctions()` API to TableEnv, LocalExecutor
- added `getFunctions()` API to FunctionCatalog
- made `SHOW FUNCTIONS` call the stack of `listFunctions` and eventually `getFunctions()`
- added UT

## Verifying this change

This change added tests and can be verified as follows: `FunctionCatalogTest.testGetBuiltInFunctions()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
