### PR TITLE
[FLINK-13651][table-planner-blink] Blink planner should parse char(n)/varchar(n)/decimal(p, s) inside a string to corresponding datatype

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionParserImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionParserImpl.scala
@@ -202,7 +202,16 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
     SQL_DATE ^^ { e => DataTypes.DATE().bridgedTo(classOf[JDate]) } |
     SQL_TIMESTAMP ^^ { e => DataTypes.TIMESTAMP(3).bridgedTo(classOf[JTimestamp]) } |
     SQL_TIME ^^ { e => DataTypes.TIME(0).bridgedTo(classOf[JTime]) } |
-    DECIMAL ^^ { e => DataTypes.DECIMAL(DecimalType.DEFAULT_PRECISION, DecimalType.DEFAULT_SCALE) }
+    DECIMAL ~ "(" ~> wholeNumber ~ "," ~ wholeNumber <~ ")" ^^ {
+      e =>
+        val precision = e._1._1.toInt
+        val scale = e._2.toInt
+        DataTypes.DECIMAL(precision, scale)
+    } |
+    DECIMAL ^^ {
+      e =>
+        DataTypes.DECIMAL(DecimalType.DEFAULT_PRECISION, DecimalType.DEFAULT_SCALE)
+    }
 
   // literals
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionParserImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionParserImpl.scala
@@ -31,8 +31,7 @@ import org.apache.flink.table.planner.JDouble
 import org.apache.flink.table.planner.JString
 import org.apache.flink.table.planner.JBigDecimal
 import org.apache.flink.table.types.DataType
-import org.apache.flink.table.types.logical.DecimalType
-
+import org.apache.flink.table.types.logical.{CharType, DecimalType}
 import _root_.java.sql.{Date => JDate, Time => JTime, Timestamp => JTimestamp}
 import _root_.java.util.{List => JList}
 
@@ -148,6 +147,7 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
   lazy val TRIM_MODE_TRAILING: Keyword = Keyword("TRAILING")
   lazy val TRIM_MODE_BOTH: Keyword = Keyword("BOTH")
   lazy val TO: Keyword = Keyword("TO")
+  lazy val CHAR: Keyword = Keyword("CHAR")
 
   def functionIdent: PlannerExpressionParserImpl.Parser[String] = super.ident
 
@@ -211,7 +211,13 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
     DECIMAL ^^ {
       e =>
         DataTypes.DECIMAL(DecimalType.DEFAULT_PRECISION, DecimalType.DEFAULT_SCALE)
-    }
+    } |
+    CHAR ~ "(" ~> wholeNumber <~ ")" ^^ {
+      e =>
+        val length = e.toInt
+        DataTypes.CHAR(length)
+    } |
+    CHAR ^^ { e => DataTypes.CHAR(CharType.DEFAULT_LENGTH) }
 
   // literals
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionParserImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionParserImpl.scala
@@ -31,7 +31,7 @@ import org.apache.flink.table.planner.JDouble
 import org.apache.flink.table.planner.JString
 import org.apache.flink.table.planner.JBigDecimal
 import org.apache.flink.table.types.DataType
-import org.apache.flink.table.types.logical.{CharType, DecimalType}
+import org.apache.flink.table.types.logical.{CharType, DecimalType, VarCharType}
 import _root_.java.sql.{Date => JDate, Time => JTime, Timestamp => JTimestamp}
 import _root_.java.util.{List => JList}
 
@@ -148,6 +148,7 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
   lazy val TRIM_MODE_BOTH: Keyword = Keyword("BOTH")
   lazy val TO: Keyword = Keyword("TO")
   lazy val CHAR: Keyword = Keyword("CHAR")
+  lazy val VARCHAR: Keyword = Keyword("VARCHAR")
 
   def functionIdent: PlannerExpressionParserImpl.Parser[String] = super.ident
 
@@ -217,7 +218,13 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
         val length = e.toInt
         DataTypes.CHAR(length)
     } |
-    CHAR ^^ { e => DataTypes.CHAR(CharType.DEFAULT_LENGTH) }
+    CHAR ^^ { e => DataTypes.CHAR(CharType.DEFAULT_LENGTH) } |
+    VARCHAR ~ "(" ~> wholeNumber <~ ")" ^^ {
+      e =>
+        val length = e.toInt
+        DataTypes.VARCHAR(length)
+    } |
+    VARCHAR ^^ { e => DataTypes.VARCHAR(VarCharType.DEFAULT_LENGTH) }
 
   // literals
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/DecimalTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/DecimalTypeTest.scala
@@ -117,18 +117,17 @@ class DecimalTypeTest extends ExpressionTestBase {
       Long.MinValue.toString)
   }
 
-  @Ignore
   @Test
   def testDefaultDecimalCasting(): Unit = {
     // from String
     testTableApi(
-      "123456789123456789123456789".cast(DataTypes.DECIMAL(38, 0)),
-      "'123456789123456789123456789'.cast(DECIMAL)",
-      "123456789123456789123456789")
+      "1234567890".cast(DataTypes.DECIMAL(10, 0)),
+      "'1234567890'.cast(DECIMAL)",
+      "1234567890")
 
     // from double
     testAllApis(
-      'f3.cast(DataTypes.DECIMAL(38, 0)),
+      'f3.cast(DataTypes.DECIMAL(10, 0)),
       "f3.cast(DECIMAL)",
       "CAST(f3 AS DECIMAL)",
       "4")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -529,6 +529,20 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "char_length(cast('' AS CHAR))",
       "1"
     )
+
+    testAllApis(
+      "test".cast(DataTypes.VARCHAR(10)).charLength(),
+      "'test'.cast(VARCHAR(10)).charLength()",
+      "char_length(cast('test' AS VARCHAR(10)))",
+      "4"
+    )
+
+    testAllApis(
+      "".cast(DataTypes.VARCHAR(1)).charLength(),
+      "''.cast(VARCHAR).charLength()",
+      "char_length(cast('' AS VARCHAR))",
+      "0"
+    )
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -515,6 +515,20 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "charLength(f0)",
       "CHARACTER_LENGTH(f0)",
       "22")
+
+    testAllApis(
+      "test".cast(DataTypes.CHAR(10)).charLength(),
+      "'test'.cast(CHAR(10)).charLength()",
+      "char_length(cast('test' AS CHAR(10)))",
+      "10"
+    )
+
+    testAllApis(
+      "".cast(DataTypes.CHAR(1)).charLength(),
+      "''.cast(CHAR).charLength()",
+      "char_length(cast('' AS CHAR))",
+      "1"
+    )
   }
 
   @Test
@@ -4123,6 +4137,5 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "f49.cast(DECIMAL)",
       "cast(1345.1231231321321321111 as decimal)",
       "1345")
-
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -1380,19 +1380,17 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "truncate(cast(f28 as DOUBLE), 1)",
       "0.4")
 
-    // TODO: ignore TableApiTest for cast to DECIMAL(p, s) is not support now.
-    //  see https://issues.apache.org/jira/browse/FLINK-13651
-//    testAllApis(
-//      'f31.cast(DataTypes.DECIMAL(38, 18)).truncate(2),
-//      "f31.cast(DECIMAL(10, 10)).truncate(2)",
-//      "truncate(cast(f31 as decimal(38, 18)), 2)",
-//      "-0.12")
-//
-//    testAllApis(
-//      'f36.cast(DataTypes.DECIMAL(38, 18)).truncate(),
-//      "f36.cast(DECIMAL(10, 10)).truncate()",
-//      "truncate(42.324)",
-//      "42")
+    testAllApis(
+      'f31.cast(DataTypes.DECIMAL(38, 18)).truncate(2),
+      "f31.cast(DECIMAL(38, 18)).truncate(2)",
+      "truncate(cast(f31 as decimal(38, 18)), 2)",
+      "-0.12")
+
+    testAllApis(
+      'f49.cast(DataTypes.DECIMAL(38, 18)).truncate(),
+      "f49.cast(DECIMAL(38, 18)).truncate()",
+      "truncate(1345.1231231321321321111)",
+      "1345")
 
     testSqlApi("truncate(cast(f31 as decimal(38, 18)), 2)", "-0.12")
 
@@ -4110,5 +4108,21 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi(
       "IS_ALPHA(f33)",
       "false")
+  }
+
+  @Test
+  def testCastDecimal(): Unit = {
+    testAllApis(
+      'f31.cast(DataTypes.DECIMAL(10, 0)),
+      "f31.cast(DECIMAL)",
+      "cast(f31 as decimal)",
+      "0")
+
+    testAllApis(
+      'f49.cast(DataTypes.DECIMAL(10, 0)),
+      "f49.cast(DECIMAL)",
+      "cast(1345.1231231321321321111 as decimal)",
+      "1345")
+
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

Blink planner should parse decimal(p,s)/char(n)/varchar(n) inside a string to corresponding datatype

## Brief change log

- Refactor PlannerExpressionParserImpl for not using TypeInformation
- Support parse decimal(p, s) inside a string to datatype
- Support parse char(n) inside a string to datatype
- Support parse varchar(n) inside a string to datatype

## Verifying this change

This change is already covered by existing tests, such as *(ScalarFunctionsTest)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
