### PR TITLE
[FLINK-13742][table-planner-blink] Fix code generation when aggregation contains both distinct aggregate with and without filter.

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
@@ -234,7 +234,9 @@ class DistinctAggCodeGen(
        """.stripMargin
     }
 
-    if (filterResults.exists(_.isDefined)) {
+    if (filterResults.forall(_.isDefined)) {
+      // using the `condition` below to filter data so as to reduce state cost
+      // if all distinct aggregations on same column have filter.
       val condition = filterResults.flatten.mkString(" || ")
       s"""
          |if ($condition) {
@@ -281,7 +283,9 @@ class DistinctAggCodeGen(
          |}
        """.stripMargin
 
-    if (filterResults.exists(_.isDefined)) {
+    if (filterResults.forall(_.isDefined)) {
+      // using the `condition` below to filter data so as to reduce state cost
+      // if all distinct aggregations on same column have filter.
       val condition = filterResults.flatten.mkString(" || ")
       s"""
          |if ($condition) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -1169,6 +1169,46 @@ class AggregateITCase(
   }
 
   @Test
+  def testDistinctWithMultiFilter(): Unit = {
+    val data = new mutable.MutableList[(Int, Long, String)]
+    data.+=((1, 1L, "Hi"))
+    data.+=((2, 2L, "Hello"))
+    data.+=((3, 2L, "Hello world"))
+    data.+=((4, 3L, "Hello world, how are you?"))
+    data.+=((5, 3L, "I am fine."))
+    data.+=((6, 3L, "Luke Skywalker"))
+    data.+=((7, 4L, "Comment#1"))
+    data.+=((8, 4L, "Comment#2"))
+    data.+=((9, 4L, "Comment#3"))
+    data.+=((10, 4L, "Comment#4"))
+
+    val sqlQuery =
+      s"""
+         |SELECT
+         |  b,
+         |  SUM(DISTINCT (a * 3)),
+         |  COUNT(DISTINCT SUBSTRING(c FROM 1 FOR 2)),
+         |  COUNT(DISTINCT c),
+         |  COUNT(DISTINCT c) filter (where MOD(a, 3) = 0),
+         |  COUNT(DISTINCT c) filter (where MOD(a, 3) = 1)
+         |FROM MyTable
+         |GROUP BY b"
+       """.stripMargin
+    val t = failingDataSource(data).toTable(tEnv).as('a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val sink = new TestingRetractSink
+    result.addSink(sink)
+    env.execute()
+    val expected = List(
+      "1,3,1,1,0,1",
+      "2,15,1,2,1,0",
+      "3,45,3,3,1,1",
+      "4,102,1,4,1,2")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
   def testPruneUselessAggCall(): Unit = {
     val data = new mutable.MutableList[(Int, Long, String)]
     data .+= ((1, 1L, "Hi"))


### PR DESCRIPTION
## What is the purpose of the change

fix a bug of distinct aggregation code generation when there exists distinct aggregations on same column, and some of them have filter condition.

## Verifying this change
add new IT case in 'AggregateITCase' to cover the change.

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): no
* The public API, i.e., is any changed class annotated with @Public(Evolving): no
* The serializers: no
* The runtime per-record code paths (performance sensitive): no
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, * Yarn/Mesos, ZooKeeper: no
* The S3 file system connector: no

## Documentation
* Does this pull request introduce a new feature? no