### PR TITLE
[FLINK-13738][blink-table-planner] Fix NegativeArraySizeException in LongHybridHashTable

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinITCase.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.runtime.batch.sql.join
 
 import org.apache.flink.api.common.ExecutionConfig
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO}
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{DOUBLE_TYPE_INFO, INT_TYPE_INFO, LONG_TYPE_INFO}
 import org.apache.flink.api.common.typeutils.TypeComparator
 import org.apache.flink.api.java.typeutils.{GenericTypeInfo, RowTypeInfo}
 import org.apache.flink.table.api.Types
@@ -66,6 +66,31 @@ class JoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
         row("Hi", "Hallo"),
         row("Hello", "Hallo Welt"),
         row("Hello world", "Hallo Welt")
+      ))
+  }
+
+  @Test
+  def testLongJoinWithBigRange(): Unit = {
+    registerCollection(
+      "inputT1",
+      Seq(
+        row(Long.box(Long.MaxValue), Double.box(1)),
+        row(Long.box(Long.MinValue), Double.box(1))),
+      new RowTypeInfo(LONG_TYPE_INFO, DOUBLE_TYPE_INFO),
+      "a, b")
+    registerCollection(
+      "inputT2",
+      Seq(
+        row(Long.box(Long.MaxValue), Double.box(1)),
+        row(Long.box(Long.MinValue), Double.box(1))),
+      new RowTypeInfo(LONG_TYPE_INFO, DOUBLE_TYPE_INFO),
+      "c, d")
+
+    checkResult(
+      "SELECT a, b, c, d FROM inputT1, inputT2 WHERE a = c",
+      Seq(
+        row(Long.box(Long.MaxValue), Double.box(1), Long.box(Long.MaxValue), Double.box(1)),
+        row(Long.box(Long.MinValue), Double.box(1), Long.box(Long.MinValue), Double.box(1))
       ))
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
@@ -206,7 +206,11 @@ public abstract class LongHybridHashTable extends BaseHybridHashTable {
 		}
 
 		long range = maxKey - minKey + 1;
-		if (range <= recordCount * 4 || range <= segmentSize / 8) {
+
+		// 1.range is negative mean: range is to big to overflow
+		// 2.range is zero, maybe the max is Long.Max, and the min is Long.Min,
+		// so we should not use dense mode too.
+		if (range > 0 && (range <= recordCount * 4 || range <= segmentSize / 8)) {
 
 			// try to request memory.
 			int buffers = (int) Math.ceil(((double) (range * 8)) / segmentSize);


### PR DESCRIPTION

## What is the purpose of the change

The dense range is computed by (maxKey - minKey + 1) in LongHybridHashTable.
it may be negative. it mean the range is bigger than Long.MaxValue when range is negative...
If range is zero, maybe the max is Long.Max, and the min is Long.Min, so we should not use dense mode too.

## Verifying this change

JoinITCase.testLongJoinWithBigRange

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
