### PR TITLE
[FLINK-13737][flink-dist][bp-1.9] Added examples-table to flink-dist dependencies

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -205,6 +205,13 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-examples-table_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!--
 			The following dependencies are packaged in 'opt/' 
 			The scope of these dependencies needs to be 'provided' so that


### PR DESCRIPTION
## What is the purpose of the change

This PR adds examples-table to flink-dist dependencies. In https://issues.apache.org/jira/browse/FLINK-13558 we added table examples to the distribution package, but forgot to add it to the build dependencies of flink-dist.


## Verifying this change

Run

```
mvn clean install -pl flink-dist -am
```

and see that the distribution contain table examples.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
