### PR TITLE
[FLINK-9941][ScalaAPI] Flush in ScalaCsvOutputFormat before close

### DIFF
--- a/flink-scala/src/main/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormat.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormat.java
@@ -168,6 +168,7 @@ public class ScalaCsvOutputFormat<T extends Product> extends FileOutputFormat<T>
 	@Override
 	public void close() throws IOException {
 		if (wrt != null) {
+			this.wrt.flush();
 			this.wrt.close();
 		}
 		super.close();

--- a/flink-scala/src/test/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormatTest.java
+++ b/flink-scala/src/test/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormatTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.operators;
+
+import org.apache.flink.api.common.io.FileOutputFormat;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import scala.Tuple3;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link ScalaCsvOutputFormat}.
+ */
+public class ScalaCsvOutputFormatTest {
+
+	private String path;
+	private ScalaCsvOutputFormat<Tuple3<String, String, Integer>> csvOutputFormat;
+
+	@Rule
+	public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	@Before
+	public void setUp() throws Exception {
+		path = tmpFolder.newFile().getAbsolutePath();
+		csvOutputFormat = new ScalaCsvOutputFormat<>(new Path(path));
+		csvOutputFormat.setWriteMode(FileSystem.WriteMode.OVERWRITE);
+		csvOutputFormat.setOutputDirectoryMode(FileOutputFormat.OutputDirectoryMode.PARONLY);
+		csvOutputFormat.open(0, 1);
+	}
+
+	@Test
+	public void testNullAllow() throws Exception {
+		try {
+			csvOutputFormat.setAllowNullValues(true);
+			csvOutputFormat.writeRecord(new Tuple3<>("One", null, 8));
+		} finally {
+			csvOutputFormat.close();
+		}
+		java.nio.file.Path p = Paths.get(path);
+		Assert.assertTrue(Files.exists(p));
+		List<String> lines = Files.readAllLines(Paths.get(path), StandardCharsets.UTF_8);
+		Assert.assertEquals(1, lines.size());
+		Assert.assertEquals("One,,8", lines.get(0));
+	}
+
+	@Test
+	public void testNullDisallowOnDefault() throws Exception {
+		try {
+			csvOutputFormat.setAllowNullValues(false);
+			csvOutputFormat.writeRecord(new Tuple3<>("One", null, 8));
+			fail("should fail with an exception");
+		} catch (RuntimeException e) {
+			// expected
+		} finally {
+			csvOutputFormat.close();
+		}
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull request update scala api `ScalaCsvOutputFormat` to add flush method before close to avoid inconsistent result with java `CsvOutputFormat` when auto flush not call in some io streams.


## Brief change log
Add flush method before close method in `ScalaCsvOutputFormat` for scala API.

## Verifying this change

Add `ScalaCsvOutputFormatTest` and test passed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no**/ don't know)
  - The runtime per-record code paths (performance sensitive): (yes /  **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes /  **no** / don't know)
  - The S3 file system connector: (yes /  **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes /  **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
