### PR TITLE
[FLINK-13380][k8s] Improve the usability of Flink session cluster on Kubernetes

### DIFF
--- a/docs/ops/deployment/kubernetes.md
+++ b/docs/ops/deployment/kubernetes.md
@@ -69,9 +69,9 @@ You can then access the Flink UI via different ways:
 
 *  `kubectl port-forward`:
     1. Run `kubectl port-forward ${flink-jobmanager-pod} 8081:8081` to forward your jobmanager's web ui port to local 8081.
-    2. Navigate to [http://localhost:8001](http://localhost:8001) in your browser.
+    2. Navigate to [http://localhost:8081](http://localhost:8081) in your browser.
     3. Moreover, you could use the following command below to submit jobs to the cluster:
-    {% highlight bash %}./bin/flink run -m localhost:8001 ./examples/streaming/WordCount.jar{% endhighlight %}
+    {% highlight bash %}./bin/flink run -m localhost:8081 ./examples/streaming/WordCount.jar{% endhighlight %}
 
 *  Create a `NodePort` service on the rest service of jobmanager:
     1. Run `kubectl create -f jobmanager-rest-service.yaml` to create the `NodePort` service on jobmanager. The example of `jobmanager-rest-service.yaml` can be found in [appendix](#session-cluster-resource-definitions).
@@ -262,7 +262,7 @@ spec:
     component: jobmanager
 {% endhighlight %}
 
-`jobmanager-rest-service.yaml`. Optional service, which is used to add a `NodePort` on the jobmanager rest service so that user could submit job via `<public-node-ip>:<node-port>`.
+`jobmanager-rest-service.yaml`. Optional service, that exposes the jobmanager `rest` port as public Kubernetes node's port.
 {% highlight yaml %}
 apiVersion: v1
 kind: Service

--- a/docs/ops/deployment/kubernetes.md
+++ b/docs/ops/deployment/kubernetes.md
@@ -54,21 +54,21 @@ A basic Flink session cluster deployment in Kubernetes has three components:
 
 Using the resource definitions for a [session cluster](#session-cluster-resource-definitions), launch the cluster with the `kubectl` command:
 
-    kubectl create -f configmap.yaml
+    kubectl create -f flink-configuration-configmap.yaml
     kubectl create -f jobmanager-service.yaml
     kubectl create -f jobmanager-deployment.yaml
     kubectl create -f taskmanager-deployment.yaml
 
-Note that you could define your own customized options of `flink-conf.yaml` within `configmap.yaml`.
+Note that you could define your own customized options of `flink-conf.yaml` within `flink-configuration-configmap.yaml`.
 
 You can then access the Flink UI via `kubectl proxy`:
 
 1. Run `kubectl proxy` in a terminal
 2. Navigate to [http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy](http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy) in your browser
 
-Another way to view the Flink UI is via [service with NodePort](https://kubernetes.io/docs/tasks/access-application-cluster/service-access-application-cluster/#creating-a-service-for-an-application-running-in-two-pods) 
-(which has been defined as `flink-jobmanager-svc` in our template) of address `http://<public-node-ip>:<node-port>`. 
-What's more，your could use command below to submit your jobs:
+In order to view the Flink's web UI, it needs to be exposed via a Kubernetes service which exposes the port on the node's public ip. 
+The service `flink-rest-service` exactly achieves this. Using this service, the web ui can be accessed via `http://<public-node-ip>:<node-port>`.
+What's more, you could use the following command below to submit jobs to the cluster:
 {% highlight bash %}
 ./bin/flink run -m <public-node-ip>:<node-port> ./examples/streaming/WordCount.jar
 {% endhighlight %}
@@ -78,7 +78,7 @@ In order to terminate the Flink session cluster, use `kubectl`:
     kubectl delete -f jobmanager-deployment.yaml
     kubectl delete -f taskmanager-deployment.yaml
     kubectl delete -f jobmanager-service.yaml
-    kubectl delete -f configmap.yaml
+    kubectl delete -f flink-configuration-configmap.yaml
 
 ## Flink job cluster on Kubernetes
 
@@ -106,7 +106,7 @@ An early version of a [Flink Helm chart](https://github.com/docker-flink/example
 The Deployment definitions use the pre-built image `flink:latest` which can be found [on Docker Hub](https://hub.docker.com/r/_/flink/).
 The image is built from this [Github repository](https://github.com/docker-flink/docker-flink).
 
-`configmap.yaml`
+`flink-configuration-configmap.yaml`
 {% highlight yaml %}
 apiVersion: v1
 kind: ConfigMap
@@ -257,7 +257,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: flink-jobmanager-svc
+  name: flink-rest-service
 spec:
   type: NodePort
   ports:

--- a/docs/ops/deployment/kubernetes.md
+++ b/docs/ops/deployment/kubernetes.md
@@ -54,20 +54,31 @@ A basic Flink session cluster deployment in Kubernetes has three components:
 
 Using the resource definitions for a [session cluster](#session-cluster-resource-definitions), launch the cluster with the `kubectl` command:
 
+    kubectl create -f configmap.yaml
     kubectl create -f jobmanager-service.yaml
     kubectl create -f jobmanager-deployment.yaml
     kubectl create -f taskmanager-deployment.yaml
+
+Note that you could define your own customized options of `flink-conf.yaml` within `configmap.yaml`.
 
 You can then access the Flink UI via `kubectl proxy`:
 
 1. Run `kubectl proxy` in a terminal
 2. Navigate to [http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy](http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy) in your browser
 
+Another way to view the Flink UI is via [service with NodePort](https://kubernetes.io/docs/tasks/access-application-cluster/service-access-application-cluster/#creating-a-service-for-an-application-running-in-two-pods) 
+(which has been defined as `flink-jobmanager-svc` in our template) of address `http://<public-node-ip>:<node-port>`. 
+What's more，your could use command below to submit your jobs:
+{% highlight bash %}
+./bin/flink run -m <public-node-ip>:<node-port> ./examples/streaming/WordCount.jar
+{% endhighlight %}
+
 In order to terminate the Flink session cluster, use `kubectl`:
 
     kubectl delete -f jobmanager-deployment.yaml
     kubectl delete -f taskmanager-deployment.yaml
     kubectl delete -f jobmanager-service.yaml
+    kubectl delete -f configmap.yaml
 
 ## Flink job cluster on Kubernetes
 
@@ -95,6 +106,36 @@ An early version of a [Flink Helm chart](https://github.com/docker-flink/example
 The Deployment definitions use the pre-built image `flink:latest` which can be found [on Docker Hub](https://hub.docker.com/r/_/flink/).
 The image is built from this [Github repository](https://github.com/docker-flink/docker-flink).
 
+`configmap.yaml`
+{% highlight yaml %}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flink-config
+  labels:
+    app: flink
+data:
+  flink-conf.yaml: |+
+    jobmanager.rpc.address: flink-jobmanager
+    taskmanager.numberOfTaskSlots: 1
+    blob.server.port: 6124
+    jobmanager.rpc.port: 6123
+    taskmanager.rpc.port: 6122
+    jobmanager.heap.size: 1024m
+    taskmanager.heap.size: 1024m
+  log4j.properties: |+
+    log4j.rootLogger=INFO, file
+    log4j.logger.akka=INFO
+    log4j.logger.org.apache.kafka=INFO
+    log4j.logger.org.apache.hadoop=INFO
+    log4j.logger.org.apache.zookeeper=INFO
+    log4j.appender.file=org.apache.log4j.FileAppender
+    log4j.appender.file.file=${log.file}
+    log4j.appender.file.layout=org.apache.log4j.PatternLayout
+    log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+    log4j.logger.org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file
+{% endhighlight %}
+
 `jobmanager-deployment.yaml`
 {% highlight yaml %}
 apiVersion: extensions/v1beta1
@@ -112,20 +153,38 @@ spec:
       containers:
       - name: jobmanager
         image: flink:latest
-        args:
-        - jobmanager
+        workingDir: /opt/flink
+        command: ["/bin/bash", "-c", "$FLINK_HOME/bin/jobmanager.sh start;\
+          while :;
+          do
+            if [[ -f $(find log -name '*jobmanager*.log' -print -quit) ]];
+              then tail -f -n +1 log/*jobmanager*.log;
+            fi;
+          done"]
         ports:
         - containerPort: 6123
           name: rpc
         - containerPort: 6124
           name: blob
-        - containerPort: 6125
-          name: query
         - containerPort: 8081
           name: ui
-        env:
-        - name: JOB_MANAGER_RPC_ADDRESS
-          value: flink-jobmanager
+        livenessProbe:
+          tcpSocket:
+            port: 6123
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        volumeMounts:
+        - name: flink-config-volume
+          mountPath: /opt/flink/conf
+      volumes:
+      - name: flink-config-volume
+        configMap:
+          name: flink-config
+          items:
+          - key: flink-conf.yaml
+            path: flink-conf.yaml
+          - key: log4j.properties
+            path: log4j.properties
 {% endhighlight %}
 
 `taskmanager-deployment.yaml`
@@ -145,18 +204,35 @@ spec:
       containers:
       - name: taskmanager
         image: flink:latest
-        args:
-        - taskmanager
+        workingDir: /opt/flink
+        command: ["/bin/bash", "-c", "$FLINK_HOME/bin/taskmanager.sh start; \
+          while :;
+          do
+            if [[ -f $(find log -name '*taskmanager*.log' -print -quit) ]];
+              then tail -f -n +1 log/*taskmanager*.log;
+            fi;
+          done"]
         ports:
-        - containerPort: 6121
-          name: data
         - containerPort: 6122
           name: rpc
-        - containerPort: 6125
-          name: query
-        env:
-        - name: JOB_MANAGER_RPC_ADDRESS
-          value: flink-jobmanager
+        livenessProbe:
+          tcpSocket:
+            port: 6122
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        volumeMounts:
+        - name: flink-config-volume
+          mountPath: /opt/flink/conf/
+      volumes:
+      - name: flink-config-volume
+        configMap:
+          name: flink-config
+          items:
+          - key: flink-conf.yaml
+            path: flink-conf.yaml
+          - key: log4j.properties
+            path: log4j.properties
+
 {% endhighlight %}
 
 `jobmanager-service.yaml`
@@ -166,15 +242,28 @@ kind: Service
 metadata:
   name: flink-jobmanager
 spec:
+  type: ClusterIP
   ports:
   - name: rpc
     port: 6123
   - name: blob
     port: 6124
-  - name: query
-    port: 6125
   - name: ui
     port: 8081
+  selector:
+    app: flink
+    component: jobmanager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flink-jobmanager-svc
+spec:
+  type: NodePort
+  ports:
+  - name: ui
+    port: 8081
+    targetPort: 8081
   selector:
     app: flink
     component: jobmanager

--- a/docs/ops/deployment/kubernetes.zh.md
+++ b/docs/ops/deployment/kubernetes.zh.md
@@ -69,9 +69,9 @@ You can then access the Flink UI via different ways:
 
 *  `kubectl port-forward`:
     1. Run `kubectl port-forward ${flink-jobmanager-pod} 8081:8081` to forward your jobmanager's web ui port to local 8081.
-    2. Navigate to [http://localhost:8001](http://localhost:8001) in your browser.
+    2. Navigate to [http://localhost:8081](http://localhost:8081) in your browser.
     3. Moreover, you could use the following command below to submit jobs to the cluster:
-    {% highlight bash %}./bin/flink run -m localhost:8001 ./examples/streaming/WordCount.jar{% endhighlight %}
+    {% highlight bash %}./bin/flink run -m localhost:8081 ./examples/streaming/WordCount.jar{% endhighlight %}
 
 *  Create a `NodePort` service on the rest service of jobmanager:
     1. Run `kubectl create -f jobmanager-rest-service.yaml` to create the `NodePort` service on jobmanager. The example of `jobmanager-rest-service.yaml` can be found in [appendix](#session-cluster-resource-definitions).
@@ -262,7 +262,7 @@ spec:
     component: jobmanager
 {% endhighlight %}
 
-`jobmanager-rest-service.yaml`. Optional service, which is used to add a `NodePort` on the jobmanager rest service so that user could submit job via `<public-node-ip>:<node-port>`.
+`jobmanager-rest-service.yaml`. Optional service, that exposes the jobmanager `rest` port as public Kubernetes node's port.
 {% highlight yaml %}
 apiVersion: v1
 kind: Service

--- a/docs/ops/deployment/kubernetes.zh.md
+++ b/docs/ops/deployment/kubernetes.zh.md
@@ -54,20 +54,31 @@ A basic Flink session cluster deployment in Kubernetes has three components:
 
 Using the resource definitions for a [session cluster](#session-cluster-resource-definitions), launch the cluster with the `kubectl` command:
 
+    kubectl create -f flink-configuration-configmap.yaml
     kubectl create -f jobmanager-service.yaml
     kubectl create -f jobmanager-deployment.yaml
     kubectl create -f taskmanager-deployment.yaml
+
+Note that you could define your own customized options of `flink-conf.yaml` within `flink-configuration-configmap.yaml`.
 
 You can then access the Flink UI via `kubectl proxy`:
 
 1. Run `kubectl proxy` in a terminal
 2. Navigate to [http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy](http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy) in your browser
 
+In order to view the Flink's web UI, it needs to be exposed via a Kubernetes service which exposes the port on the node's public ip. 
+The service `flink-rest-service` exactly achieves this. Using this service, the web ui can be accessed via `http://<public-node-ip>:<node-port>`.
+What's more, you could use the following command below to submit jobs to the cluster:
+{% highlight bash %}
+./bin/flink run -m <public-node-ip>:<node-port> ./examples/streaming/WordCount.jar
+{% endhighlight %}
+
 In order to terminate the Flink session cluster, use `kubectl`:
 
     kubectl delete -f jobmanager-deployment.yaml
     kubectl delete -f taskmanager-deployment.yaml
     kubectl delete -f jobmanager-service.yaml
+    kubectl delete -f flink-configuration-configmap.yaml
 
 ## Flink job cluster on Kubernetes
 
@@ -95,6 +106,36 @@ An early version of a [Flink Helm chart](https://github.com/docker-flink/example
 The Deployment definitions use the pre-built image `flink:latest` which can be found [on Docker Hub](https://hub.docker.com/r/_/flink/).
 The image is built from this [Github repository](https://github.com/docker-flink/docker-flink).
 
+`flink-configuration-configmap.yaml`
+{% highlight yaml %}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flink-config
+  labels:
+    app: flink
+data:
+  flink-conf.yaml: |+
+    jobmanager.rpc.address: flink-jobmanager
+    taskmanager.numberOfTaskSlots: 1
+    blob.server.port: 6124
+    jobmanager.rpc.port: 6123
+    taskmanager.rpc.port: 6122
+    jobmanager.heap.size: 1024m
+    taskmanager.heap.size: 1024m
+  log4j.properties: |+
+    log4j.rootLogger=INFO, file
+    log4j.logger.akka=INFO
+    log4j.logger.org.apache.kafka=INFO
+    log4j.logger.org.apache.hadoop=INFO
+    log4j.logger.org.apache.zookeeper=INFO
+    log4j.appender.file=org.apache.log4j.FileAppender
+    log4j.appender.file.file=${log.file}
+    log4j.appender.file.layout=org.apache.log4j.PatternLayout
+    log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+    log4j.logger.org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file
+{% endhighlight %}
+
 `jobmanager-deployment.yaml`
 {% highlight yaml %}
 apiVersion: extensions/v1beta1
@@ -112,20 +153,38 @@ spec:
       containers:
       - name: jobmanager
         image: flink:latest
-        args:
-        - jobmanager
+        workingDir: /opt/flink
+        command: ["/bin/bash", "-c", "$FLINK_HOME/bin/jobmanager.sh start;\
+          while :;
+          do
+            if [[ -f $(find log -name '*jobmanager*.log' -print -quit) ]];
+              then tail -f -n +1 log/*jobmanager*.log;
+            fi;
+          done"]
         ports:
         - containerPort: 6123
           name: rpc
         - containerPort: 6124
           name: blob
-        - containerPort: 6125
-          name: query
         - containerPort: 8081
           name: ui
-        env:
-        - name: JOB_MANAGER_RPC_ADDRESS
-          value: flink-jobmanager
+        livenessProbe:
+          tcpSocket:
+            port: 6123
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        volumeMounts:
+        - name: flink-config-volume
+          mountPath: /opt/flink/conf
+      volumes:
+      - name: flink-config-volume
+        configMap:
+          name: flink-config
+          items:
+          - key: flink-conf.yaml
+            path: flink-conf.yaml
+          - key: log4j.properties
+            path: log4j.properties
 {% endhighlight %}
 
 `taskmanager-deployment.yaml`
@@ -145,18 +204,35 @@ spec:
       containers:
       - name: taskmanager
         image: flink:latest
-        args:
-        - taskmanager
+        workingDir: /opt/flink
+        command: ["/bin/bash", "-c", "$FLINK_HOME/bin/taskmanager.sh start; \
+          while :;
+          do
+            if [[ -f $(find log -name '*taskmanager*.log' -print -quit) ]];
+              then tail -f -n +1 log/*taskmanager*.log;
+            fi;
+          done"]
         ports:
-        - containerPort: 6121
-          name: data
         - containerPort: 6122
           name: rpc
-        - containerPort: 6125
-          name: query
-        env:
-        - name: JOB_MANAGER_RPC_ADDRESS
-          value: flink-jobmanager
+        livenessProbe:
+          tcpSocket:
+            port: 6122
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        volumeMounts:
+        - name: flink-config-volume
+          mountPath: /opt/flink/conf/
+      volumes:
+      - name: flink-config-volume
+        configMap:
+          name: flink-config
+          items:
+          - key: flink-conf.yaml
+            path: flink-conf.yaml
+          - key: log4j.properties
+            path: log4j.properties
+
 {% endhighlight %}
 
 `jobmanager-service.yaml`
@@ -166,15 +242,28 @@ kind: Service
 metadata:
   name: flink-jobmanager
 spec:
+  type: ClusterIP
   ports:
   - name: rpc
     port: 6123
   - name: blob
     port: 6124
-  - name: query
-    port: 6125
   - name: ui
     port: 8081
+  selector:
+    app: flink
+    component: jobmanager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flink-rest-service
+spec:
+  type: NodePort
+  ports:
+  - name: ui
+    port: 8081
+    targetPort: 8081
   selector:
     app: flink
     component: jobmanager


### PR DESCRIPTION

## What is the purpose of the change
Previous template of Flink session cluster on Kubernetes has several shortcoming:
* flink-conf.yaml is not supported to configure, user have to rebuild docker 
* No explicit documentation of how to submit jobs to session cluster. There existed some related question on stackoverflow. I think we should add nodeport for 8081 port in deployment 
* Cannot view logs via Flink web UI.
This PR is to help improve this.

## Brief change log
Modify `docs/ops/deployment/kubernetes.md ` to provide more powerful templates.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
