### PR TITLE
[FLINK-13762][task] Add the exception throwable in the interface methods of ValveOutputHandler

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -215,26 +215,18 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 		}
 
 		@Override
-		public void handleWatermark(Watermark watermark) {
-			try {
-				synchronized (lock) {
-					watermarkGauge.setCurrentWatermark(watermark.getTimestamp());
-					operator.processWatermark(watermark);
-				}
-			} catch (Exception e) {
-				throw new RuntimeException("Exception occurred while processing valve output watermark: ", e);
+		public void handleWatermark(Watermark watermark) throws Exception {
+			synchronized (lock) {
+				watermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+				operator.processWatermark(watermark);
 			}
 		}
 
 		@SuppressWarnings("unchecked")
 		@Override
 		public void handleStreamStatus(StreamStatus streamStatus) {
-			try {
-				synchronized (lock) {
-					streamStatusMaintainer.toggleStreamStatus(streamStatus);
-				}
-			} catch (Exception e) {
-				throw new RuntimeException("Exception occurred while processing valve output stream status: ", e);
+			synchronized (lock) {
+				streamStatusMaintainer.toggleStreamStatus(streamStatus);
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamstatus/StatusWatermarkValve.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamstatus/StatusWatermarkValve.java
@@ -41,9 +41,9 @@ public class StatusWatermarkValve {
 	 * to handle watermark and stream status outputs from the valve.
 	 */
 	public interface ValveOutputHandler {
-		void handleWatermark(Watermark watermark);
+		void handleWatermark(Watermark watermark) throws Exception;
 
-		void handleStreamStatus(StreamStatus streamStatus);
+		void handleStreamStatus(StreamStatus streamStatus) throws Exception;
 	}
 
 	private final ValveOutputHandler outputHandler;
@@ -93,7 +93,7 @@ public class StatusWatermarkValve {
 	 * @param watermark the watermark to feed to the valve
 	 * @param channelIndex the index of the channel that the fed watermark belongs to (index starting from 0)
 	 */
-	public void inputWatermark(Watermark watermark, int channelIndex) {
+	public void inputWatermark(Watermark watermark, int channelIndex) throws Exception {
 		// ignore the input watermark if its input channel, or all input channels are idle (i.e. overall the valve is idle).
 		if (lastOutputStreamStatus.isActive() && channelStatuses[channelIndex].streamStatus.isActive()) {
 			long watermarkMillis = watermark.getTimestamp();
@@ -121,7 +121,7 @@ public class StatusWatermarkValve {
 	 * @param streamStatus the stream status to feed to the valve
 	 * @param channelIndex the index of the channel that the fed stream status belongs to (index starting from 0)
 	 */
-	public void inputStreamStatus(StreamStatus streamStatus, int channelIndex) {
+	public void inputStreamStatus(StreamStatus streamStatus, int channelIndex) throws Exception {
 		// only account for stream status inputs that will result in a status change for the input channel
 		if (streamStatus.isIdle() && channelStatuses[channelIndex].streamStatus.isActive()) {
 			// handle active -> idle toggle for the input channel
@@ -170,7 +170,7 @@ public class StatusWatermarkValve {
 		}
 	}
 
-	private void findAndOutputNewMinWatermarkAcrossAlignedChannels() {
+	private void findAndOutputNewMinWatermarkAcrossAlignedChannels() throws Exception {
 		long newMinWatermark = Long.MAX_VALUE;
 		boolean hasAlignedChannels = false;
 
@@ -190,7 +190,7 @@ public class StatusWatermarkValve {
 		}
 	}
 
-	private void findAndOutputMaxWatermarkAcrossAllChannels() {
+	private void findAndOutputMaxWatermarkAcrossAllChannels() throws Exception {
 		long maxWatermark = Long.MIN_VALUE;
 
 		for (InputChannelStatus channelStatus : channelStatuses) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamstatus/StatusWatermarkValveTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamstatus/StatusWatermarkValveTest.java
@@ -48,7 +48,7 @@ public class StatusWatermarkValveTest {
 	 * Tests that watermarks correctly advance with increasing watermarks for a single input valve.
 	 */
 	@Test
-	public void testSingleInputIncreasingWatermarks() {
+	public void testSingleInputIncreasingWatermarks() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(1, valveOutput);
 
@@ -65,7 +65,7 @@ public class StatusWatermarkValveTest {
 	 * Tests that watermarks do not advance with decreasing watermark inputs for a single input valve.
 	 */
 	@Test
-	public void testSingleInputDecreasingWatermarksYieldsNoOutput() {
+	public void testSingleInputDecreasingWatermarksYieldsNoOutput() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(1, valveOutput);
 
@@ -85,7 +85,7 @@ public class StatusWatermarkValveTest {
 	 * inputs do not yield output for a single input valve.
 	 */
 	@Test
-	public void testSingleInputStreamStatusToggling() {
+	public void testSingleInputStreamStatusToggling() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(1, valveOutput);
 
@@ -108,7 +108,7 @@ public class StatusWatermarkValveTest {
 	 * Tests that the watermark of an input channel remains intact while in the IDLE status.
 	 */
 	@Test
-	public void testSingleInputWatermarksIntactDuringIdleness() {
+	public void testSingleInputWatermarksIntactDuringIdleness() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(1, valveOutput);
 
@@ -136,7 +136,7 @@ public class StatusWatermarkValveTest {
 	 * Tests that the valve yields a watermark only when all inputs have received a watermark.
 	 */
 	@Test
-	public void testMultipleInputYieldsWatermarkOnlyWhenAllChannelsReceivesWatermarks() {
+	public void testMultipleInputYieldsWatermarkOnlyWhenAllChannelsReceivesWatermarks() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
 
@@ -155,7 +155,7 @@ public class StatusWatermarkValveTest {
 	 * new min watermark across inputs advances.
 	 */
 	@Test
-	public void testMultipleInputIncreasingWatermarks() {
+	public void testMultipleInputIncreasingWatermarks() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
 
@@ -189,7 +189,7 @@ public class StatusWatermarkValveTest {
 	 * Tests that for a multiple input valve, decreasing watermarks will yield no output.
 	 */
 	@Test
-	public void testMultipleInputDecreasingWatermarksYieldsNoOutput() {
+	public void testMultipleInputDecreasingWatermarksYieldsNoOutput() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
 
@@ -209,7 +209,7 @@ public class StatusWatermarkValveTest {
 	 * inputs do not yield output for a multiple input valve.
 	 */
 	@Test
-	public void testMultipleInputStreamStatusToggling() {
+	public void testMultipleInputStreamStatusToggling() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(2, valveOutput);
 
@@ -243,7 +243,7 @@ public class StatusWatermarkValveTest {
 	 * is correctly computed and advanced from the remaining active inputs.
 	 */
 	@Test
-	public void testMultipleInputWatermarkAdvancingWithPartiallyIdleChannels() {
+	public void testMultipleInputWatermarkAdvancingWithPartiallyIdleChannels() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
 
@@ -272,7 +272,7 @@ public class StatusWatermarkValveTest {
 	 * are output as soon remaining active channels can yield a new min watermark.
 	 */
 	@Test
-	public void testMultipleInputWatermarkAdvancingAsChannelsIndividuallyBecomeIdle() {
+	public void testMultipleInputWatermarkAdvancingAsChannelsIndividuallyBecomeIdle() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
 
@@ -300,7 +300,7 @@ public class StatusWatermarkValveTest {
 	 * is independent of the order that the inputs become idle.
 	 */
 	@Test
-	public void testMultipleInputFlushMaxWatermarkAndStreamStatusOnceAllInputsBecomeIdle() {
+	public void testMultipleInputFlushMaxWatermarkAndStreamStatusOnceAllInputsBecomeIdle() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
 
@@ -338,7 +338,7 @@ public class StatusWatermarkValveTest {
 	 * the latest watermark before they are considered for min watermark computation again.
 	 */
 	@Test
-	public void testMultipleInputWatermarkRealignmentAfterResumeActive() {
+	public void testMultipleInputWatermarkRealignmentAfterResumeActive() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
 
@@ -379,7 +379,7 @@ public class StatusWatermarkValveTest {
 	 * watermark in that case.
 	 */
 	@Test
-	public void testNoOutputWhenAllActiveChannelsAreUnaligned() {
+	public void testNoOutputWhenAllActiveChannelsAreUnaligned() throws Exception {
 		BufferedValveOutputHandler valveOutput = new BufferedValveOutputHandler();
 		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
 


### PR DESCRIPTION
## What is the purpose of the change

It is only for simplifying the implementations of specific methods to not wrap the exception into `RuntimeException`.

## Brief change log

  - *Add the exception throwable in the interface methods of `ValveOutputHandler`*
  - *Adjust the implementations in `StreamOneInputProcessor` and `StreamTwoInputSelectableProcessor`.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)