### PR TITLE
[FLINK-13764][task, metrics] Pass the counter of numRecordsIn into the constructor of StreamInputProcessor

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -22,10 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
-import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -85,7 +83,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	// ---------------- Metrics ------------------
 
 	private final WatermarkGauge watermarkGauge;
-	private Counter numRecordsIn;
+	private final Counter numRecordsIn;
 
 	@SuppressWarnings("unchecked")
 	public StreamOneInputProcessor(
@@ -101,7 +99,8 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 			TaskIOMetricGroup metrics,
 			WatermarkGauge watermarkGauge,
 			String taskName,
-			OperatorChain<?, ?> operatorChain) throws IOException {
+			OperatorChain<?, ?> operatorChain,
+			Counter numRecordsIn) throws IOException {
 
 		InputGate inputGate = InputGateUtil.createInputGate(inputGates);
 
@@ -127,6 +126,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 		metrics.gauge("checkpointAlignmentTime", barrierHandler::getAlignmentDurationNanos);
 
 		this.operatorChain = checkNotNull(operatorChain);
+		this.numRecordsIn = checkNotNull(numRecordsIn);
 	}
 
 	@Override
@@ -141,8 +141,6 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 
 	@Override
 	public boolean processInput() throws Exception {
-		initializeNumRecordsIn();
-
 		StreamElement recordOrMark = input.pollNextNullable();
 		if (recordOrMark != null) {
 			int channel = input.getLastChannel();
@@ -185,17 +183,6 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 		if (input.isFinished()) {
 			synchronized (lock) {
 				operatorChain.endInput(1);
-			}
-		}
-	}
-
-	private void initializeNumRecordsIn() {
-		if (numRecordsIn == null) {
-			try {
-				numRecordsIn = ((OperatorMetricGroup) streamOperator.getMetricGroup()).getIOMetricGroup().getNumRecordsInCounter();
-			} catch (Exception e) {
-				LOG.warn("An exception occurred during the metrics setup.", e);
-				numRecordsIn = new SimpleCounter();
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -88,7 +88,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 					getEnvironment().getMetricGroup().getIOMetricGroup(),
 					inputWatermarkGauge,
 					getTaskNameWithSubtaskAndId(),
-					operatorChain);
+					operatorChain,
+					setupNumRecordsInCounter(headOperator));
 		}
 		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge);
 		// wrap watermark gauge since registered metrics must be unique

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -76,20 +76,20 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			InputGate[] inputGates = getEnvironment().getAllInputGates();
 
 			inputProcessor = new StreamOneInputProcessor<>(
-					inputGates,
-					inSerializer,
-					this,
-					configuration.getCheckpointMode(),
-					getCheckpointLock(),
-					getEnvironment().getIOManager(),
-					getEnvironment().getTaskManagerInfo().getConfiguration(),
-					getStreamStatusMaintainer(),
-					this.headOperator,
-					getEnvironment().getMetricGroup().getIOMetricGroup(),
-					inputWatermarkGauge,
-					getTaskNameWithSubtaskAndId(),
-					operatorChain,
-					setupNumRecordsInCounter(headOperator));
+				inputGates,
+				inSerializer,
+				this,
+				configuration.getCheckpointMode(),
+				getCheckpointLock(),
+				getEnvironment().getIOManager(),
+				getEnvironment().getTaskManagerInfo().getConfiguration(),
+				getStreamStatusMaintainer(),
+				headOperator,
+				getEnvironment().getMetricGroup().getIOMetricGroup(),
+				inputWatermarkGauge,
+				getTaskNameWithSubtaskAndId(),
+				operatorChain,
+				setupNumRecordsInCounter(headOperator));
 		}
 		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge);
 		// wrap watermark gauge since registered metrics must be unique

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -24,6 +24,8 @@ import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FileSystemSafetyNet;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -36,6 +38,7 @@ import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -317,6 +320,15 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			getEnvironment(),
 			stateBackend,
 			timerService);
+	}
+
+	protected Counter setupNumRecordsInCounter(StreamOperator streamOperator) {
+		try {
+			return ((OperatorMetricGroup) streamOperator.getMetricGroup()).getIOMetricGroup().getNumRecordsInCounter();
+		} catch (Exception e) {
+			LOG.warn("An exception occurred during the metrics setup.", e);
+			return new SimpleCounter();
+		}
 	}
 
 	@VisibleForTesting

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputSelectableStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputSelectableStreamTask.java
@@ -58,6 +58,7 @@ public class TwoInputSelectableStreamTask<IN1, IN2, OUT> extends AbstractTwoInpu
 			input1WatermarkGauge,
 			input2WatermarkGauge,
 			getTaskNameWithSubtaskAndId(),
-			operatorChain);
+			operatorChain,
+			setupNumRecordsInCounter(headOperator));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently the counter of `numRecordsIn` is setup while processing input in processor. In order to integrate the processing logic based on `StreamTaskInput#emitNext(Output)` later, we need to pass the counter into output functions then. So there are three reasons to do this:

- It is the precondition of following integration work.
- We could make the counter as final fields in `StreamInputProcessor` and `StreamTwoInputSelectableProcessor`.
- We could reuse the counter setup logic for all the input processors. 

There should be no side effects if we make the counter setup a bit earlier than the previous way.

## Brief change log

  - *Introduce the method of setup `numRecordsIn` counter in `StreamTask`*
  - *Pass the counter into the constructors of `StreamOne/TwoInputProcessors`*
  - *Remove the logic of initializing counter in `StreamOne/TwoInputProcessors`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)