### PR TITLE
[FLINK-13765][task] Introduce TwoInputSelectionHandler for selecting input in StreamTwoInputSelectableProcessor

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputSelectableProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputSelectableProcessor.java
@@ -25,8 +25,6 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.streaming.api.CheckpointingMode;
-import org.apache.flink.streaming.api.operators.InputSelectable;
-import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
@@ -64,7 +62,8 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 	private static final CompletableFuture<?> UNAVAILABLE = new CompletableFuture<>();
 
 	private final TwoInputStreamOperator<IN1, IN2, ?> streamOperator;
-	private final InputSelectable inputSelector;
+
+	private final TwoInputSelectionHandler inputSelectionHandler;
 
 	private final Object lock;
 
@@ -86,11 +85,7 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 	private StreamStatus firstStatus;
 	private StreamStatus secondStatus;
 
-	private int availableInputsMask;
-
 	private int lastReadInputIndex;
-
-	private InputSelection inputSelection;
 
 	private final Counter numRecordsIn;
 
@@ -108,16 +103,15 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 		Configuration taskManagerConfig,
 		StreamStatusMaintainer streamStatusMaintainer,
 		TwoInputStreamOperator<IN1, IN2, ?> streamOperator,
+		TwoInputSelectionHandler inputSelectionHandler,
 		WatermarkGauge input1WatermarkGauge,
 		WatermarkGauge input2WatermarkGauge,
 		String taskName,
 		OperatorChain<?, ?> operatorChain,
 		Counter numRecordsIn) throws IOException {
 
-		checkState(streamOperator instanceof InputSelectable);
-
 		this.streamOperator = checkNotNull(streamOperator);
-		this.inputSelector = (InputSelectable) streamOperator;
+		this.inputSelectionHandler = checkNotNull(inputSelectionHandler);
 
 		this.lock = checkNotNull(lock);
 
@@ -150,8 +144,6 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 		this.firstStatus = StreamStatus.ACTIVE;
 		this.secondStatus = StreamStatus.ACTIVE;
 
-		this.availableInputsMask = (int) new InputSelection.Builder().select(1).select(2).build().getInputMask();
-
 		this.lastReadInputIndex = 1; // always try to read from the first input
 
 		this.isPrepared = false;
@@ -164,10 +156,10 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 
 	@Override
 	public CompletableFuture<?> isAvailable() {
-		if (inputSelection.isALLMaskOf2()) {
+		if (inputSelectionHandler.areAllInputsSelected()) {
 			return isAnyInputAvailable();
 		} else {
-			StreamTaskInput input = (inputSelection.getInputMask() == InputSelection.FIRST.getInputMask()) ? input1 : input2;
+			StreamTaskInput input = (inputSelectionHandler.isFirstInputSelected()) ? input1 : input2;
 			return input.isAvailable();
 		}
 	}
@@ -202,7 +194,7 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 		}
 
 		if (recordOrMark == null) {
-			setUnavailableInput(readingInputIndex);
+			inputSelectionHandler.setUnavailableInput(readingInputIndex);
 		}
 
 		return recordOrMark != null;
@@ -212,7 +204,7 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 		if (input.isFinished()) {
 			synchronized (lock) {
 				operatorChain.endInput(getInputId(inputIndex));
-				inputSelection = inputSelector.nextSelection();
+				inputSelectionHandler.nextSelection();
 			}
 		}
 	}
@@ -240,7 +232,8 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 	private int selectNextReadingInputIndex() throws IOException {
 		updateAvailability();
 		checkInputSelectionAgainstIsFinished();
-		int readingInputIndex = inputSelection.fairSelectNextIndexOutOf2(availableInputsMask, lastReadInputIndex);
+
+		int readingInputIndex = inputSelectionHandler.selectNextInputIndex(lastReadInputIndex);
 		if (readingInputIndex == -1) {
 			return -1;
 		}
@@ -249,7 +242,7 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 		// always try to check and set the availability of another input
 		// TODO: because this can be a costly operation (checking volatile inside CompletableFuture`
 		//  this might be optimized to only check once per processed NetworkBuffer
-		if (availableInputsMask < 3 && inputSelection.isALLMaskOf2()) {
+		if (inputSelectionHandler.shouldSetAvailableForAnotherInput()) {
 			checkAndSetAvailable(1 - readingInputIndex);
 		}
 
@@ -257,23 +250,23 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 	}
 
 	private void checkInputSelectionAgainstIsFinished() throws IOException {
-		if (inputSelection.isALLMaskOf2()) {
+		if (inputSelectionHandler.areAllInputsSelected()) {
 			return;
 		}
-		if (inputSelection.isInputSelected(1) && input1.isFinished()) {
+		if (inputSelectionHandler.isFirstInputSelected() && input1.isFinished()) {
 			throw new IOException("Can not make a progress: only first input is selected but it is already finished");
 		}
-		if (inputSelection.isInputSelected(2) && input2.isFinished()) {
+		if (inputSelectionHandler.isSecondInputSelected() && input2.isFinished()) {
 			throw new IOException("Can not make a progress: only second input is selected but it is already finished");
 		}
 	}
 
 	private void updateAvailability() {
 		if (!input1.isFinished() && input1.isAvailable() == AVAILABLE) {
-			setAvailableInput(input1.getInputIndex());
+			inputSelectionHandler.setAvailableInput(input1.getInputIndex());
 		}
 		if (!input2.isFinished() && input2.isAvailable() == AVAILABLE) {
-			setAvailableInput(input2.getInputIndex());
+			inputSelectionHandler.setAvailableInput(input2.getInputIndex());
 		}
 	}
 
@@ -284,7 +277,7 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 				numRecordsIn.inc();
 				streamOperator.setKeyContextElement1(record);
 				streamOperator.processElement1(record);
-				inputSelection = inputSelector.nextSelection();
+				inputSelectionHandler.nextSelection();
 			}
 		}
 		else if (recordOrMark.isWatermark()) {
@@ -307,7 +300,7 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 				numRecordsIn.inc();
 				streamOperator.setKeyContextElement2(record);
 				streamOperator.processElement2(record);
-				inputSelection = inputSelector.nextSelection();
+				inputSelectionHandler.nextSelection();
 			}
 		}
 		else if (recordOrMark.isWatermark()) {
@@ -327,7 +320,7 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 		// Note: the first call to nextSelection () on the operator must be made after this operator
 		// is opened to ensure that any changes about the input selection in its open()
 		// method take effect.
-		inputSelection = inputSelector.nextSelection();
+		inputSelectionHandler.nextSelection();
 
 		isPrepared = true;
 	}
@@ -335,7 +328,7 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 	private void checkAndSetAvailable(int inputIndex) {
 		StreamTaskInput input = getInput(inputIndex);
 		if (!input.isFinished() && input.isAvailable().isDone()) {
-			setAvailableInput(inputIndex);
+			inputSelectionHandler.setAvailableInput(inputIndex);
 		}
 	}
 
@@ -353,14 +346,6 @@ public final class StreamTwoInputSelectableProcessor<IN1, IN2> implements Stream
 
 		return (input1Available == AVAILABLE || input2Available == AVAILABLE) ?
 			AVAILABLE : CompletableFuture.anyOf(input1Available, input2Available);
-	}
-
-	private void setAvailableInput(int inputIndex) {
-		availableInputsMask |= 1 << inputIndex;
-	}
-
-	private void setUnavailableInput(int inputIndex) {
-		availableInputsMask &= ~(1 << inputIndex);
 	}
 
 	private StreamTaskInput getInput(int inputIndex) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/TwoInputSelectionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/TwoInputSelectionHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This handler is mainly used for selecting the next available input index
+ * in {@link StreamTwoInputSelectableProcessor}.
+ */
+@Internal
+public class TwoInputSelectionHandler {
+
+	private final InputSelectable inputSelector;
+
+	private InputSelection inputSelection;
+
+	private int availableInputsMask;
+
+	public TwoInputSelectionHandler(InputSelectable inputSelectable) {
+		this.inputSelector = checkNotNull(inputSelectable);
+		this.availableInputsMask = (int) new InputSelection.Builder().select(1).select(2).build().getInputMask();
+	}
+
+	void nextSelection() {
+		inputSelection = inputSelector.nextSelection();
+	}
+
+	int selectNextInputIndex(int lastReadInputIndex) {
+		return inputSelection.fairSelectNextIndexOutOf2(availableInputsMask, lastReadInputIndex);
+	}
+
+	boolean shouldSetAvailableForAnotherInput() {
+		return availableInputsMask < 3 && inputSelection.isALLMaskOf2();
+	}
+
+	void setAvailableInput(int inputIndex) {
+		availableInputsMask |= 1 << inputIndex;
+	}
+
+	void setUnavailableInput(int inputIndex) {
+		availableInputsMask &= ~(1 << inputIndex);
+	}
+
+	boolean areAllInputsSelected() {
+		return inputSelection.isALLMaskOf2();
+	}
+
+	boolean isFirstInputSelected() {
+		return inputSelection.isInputSelected(1);
+	}
+
+	boolean isSecondInputSelected() {
+		return inputSelection.isInputSelected(2);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputSelectableStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputSelectableStreamTask.java
@@ -21,11 +21,15 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputSelectableProcessor;
+import org.apache.flink.streaming.runtime.io.TwoInputSelectionHandler;
 
 import java.io.IOException;
 import java.util.Collection;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A {@link StreamTask} for executing a {@link TwoInputStreamOperator} and supporting
@@ -45,6 +49,9 @@ public class TwoInputSelectableStreamTask<IN1, IN2, OUT> extends AbstractTwoInpu
 		TypeSerializer<IN1> inputDeserializer1,
 		TypeSerializer<IN2> inputDeserializer2) throws IOException {
 
+		checkState(headOperator instanceof InputSelectable);
+		TwoInputSelectionHandler twoInputSelectionHandler = new TwoInputSelectionHandler((InputSelectable) headOperator);
+
 		this.inputProcessor = new StreamTwoInputSelectableProcessor<>(
 			inputGates1, inputGates2,
 			inputDeserializer1, inputDeserializer2,
@@ -55,6 +62,7 @@ public class TwoInputSelectableStreamTask<IN1, IN2, OUT> extends AbstractTwoInpu
 			getEnvironment().getTaskManagerInfo().getConfiguration(),
 			getStreamStatusMaintainer(),
 			this.headOperator,
+			twoInputSelectionHandler,
 			input1WatermarkGauge,
 			input2WatermarkGauge,
 			getTaskNameWithSubtaskAndId(),


### PR DESCRIPTION
## What is the purpose of the change

 In `StreamTwoInputSelectableProcessor` there are three fields {`InputSelectable`, `InputSelection`, `availableInputsMask`} to be used together for the function of selecting next available input index.
    
From design aspect, these fields can be abstracted into a separate component called `TwoInputSelectionHandler`, which is passed into the constructor of `StreamTwoInputSelectableProcessor` as a final field. So the internal implementation details  of `TwoInputSelectionHandler` is hidden from processor view which only needs to interact with exposed methods from selection handler.
    
Another tiny benefit is that we make the `StreamTwoInputSelectableProcessor` a bit because two methods are removed from it.

## Brief change log

  - *Introduce the `TwoInputSelectionHandler` for handling the logic of next available input index*
  - *Refactor the related process in `StreamTwoInputSelectableProcessor` based on `InputSelectionHandler`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
