### PR TITLE
[FLINK-13766][task] Refactor the implementation of StreamInputProcessor based on StreamTaskInput#emitNext

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityListener.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Interface defining couple of essential methods for listening on data availability using
- * {@link CompletableFuture}. For usage check out for example {@link AsyncDataInput}.
+ * {@link CompletableFuture}. For usage check out for example {@link PullingAsyncDataInput}.
  */
 @Internal
 public interface AvailabilityListener {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/NullableAsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/NullableAsyncDataInput.java
@@ -22,9 +22,9 @@ import org.apache.flink.annotation.Internal;
 import javax.annotation.Nullable;
 
 /**
- * The variant of {@link AsyncDataInput} that for performance reasons returns {@code null} from
- * {@link #pollNextNullable()} instead returning {@code Optional.empty()} from
- * {@link AsyncDataInput#pollNext()}.
+ * The variant of {@link PullingAsyncDataInput} that for performance reasons returns {@code null}
+ * from {@link #pollNextNullable()} instead returning {@code Optional.empty()} from
+ * {@link PullingAsyncDataInput#pollNext()}.
  */
 @Internal
 public interface NullableAsyncDataInput<T> extends AvailabilityListener {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
@@ -50,7 +50,7 @@ import java.util.concurrent.CompletableFuture;
  * </pre>
  */
 @Internal
-public interface AsyncDataInput<T> extends AvailabilityListener {
+public interface PullingAsyncDataInput<T> extends AvailabilityListener {
 	/**
 	 * Poll the next element. This method should be non blocking.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.event.TaskEvent;
-import org.apache.flink.runtime.io.AsyncDataInput;
+import org.apache.flink.runtime.io.PullingAsyncDataInput;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -69,7 +69,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * will have an input gate attached to it. This will provide its input, which will consist of one
  * subpartition from each partition of the intermediate result.
  */
-public abstract class InputGate implements AsyncDataInput<BufferOrEvent>, AutoCloseable {
+public abstract class InputGate implements PullingAsyncDataInput<BufferOrEvent>, AutoCloseable {
 
 	protected CompletableFuture<?> isAvailable = new CompletableFuture<>();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.runtime.io.AsyncDataInput;
+import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 
@@ -69,7 +69,7 @@ public abstract class InputGateTestBase {
 
 		assertTrue(isAvailable.isDone());
 		assertTrue(inputGateToTest.isAvailable().isDone());
-		assertEquals(AsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
+		assertEquals(PullingAsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
 	}
 
 	protected void testIsAvailableAfterFinished(
@@ -86,7 +86,7 @@ public abstract class InputGateTestBase {
 
 		assertTrue(available.isDone());
 		assertTrue(inputGateToTest.isAvailable().isDone());
-		assertEquals(AsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
+		assertEquals(PullingAsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
 	}
 
 	protected SingleInputGate createInputGate() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.io.AsyncDataInput;
+import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
@@ -42,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * {@link CheckpointBarrier} from the {@link InputGate}.
  */
 @Internal
-public class CheckpointedInputGate implements AsyncDataInput<BufferOrEvent> {
+public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEvent> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(CheckpointedInputGate.class);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputStatus.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputStatus.java
@@ -18,18 +18,30 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-
-import java.io.Closeable;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
 
 /**
- * Basic interface for inputs of stream operators.
+ * An {@link InputStatus} indicates one input state which might be currently
+ * available, not available or already finished. It is returned while calling
+ * {@link PushingAsyncDataInput#emitNext(DataOutput)}.
  */
 @Internal
-public interface StreamTaskInput<T> extends PushingAsyncDataInput<T>, Closeable {
-	int UNSPECIFIED = -1;
+public enum InputStatus {
 
 	/**
-	 * Returns the input index of this input.
+	 * Indicator that more data is available and the input can be called immediately again
+	 * to emit more data.
 	 */
-	int getInputIndex();
+	MORE_AVAILABLE,
+
+	/**
+	 * Indicator that no data is currently available, but more data will be available in the
+	 * future again.
+	 */
+	NOTHING_AVAILABLE,
+
+	/**
+	 * Indicator that the input has reached the end of data.
+	 */
+	END_OF_INPUT
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.AvailabilityListener;
+import org.apache.flink.runtime.io.PullingAsyncDataInput;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
+/**
+ * The variant of {@link PullingAsyncDataInput} that is defined for handling both network
+ * input and source input in a unified way via {@link #emitNext(DataOutput)} instead
+ * of returning {@code Optional.empty()} via {@link PullingAsyncDataInput#pollNext()}.
+ */
+@Internal
+public interface PushingAsyncDataInput<T> extends AvailabilityListener {
+
+	/**
+	 * Pushes the next element to the output from current data input, and returns
+	 * the input status to indicate whether there are more available data in
+	 * current input.
+	 *
+	 * <p>This method should be non blocking.
+	 */
+	InputStatus emitNext(DataOutput<T> output) throws Exception;
+
+	/**
+	 * Basic data output interface used in emitting the next element from data input.
+	 *
+	 * @param <T> The type encapsulated with the stream record.
+	 */
+	interface DataOutput<T> {
+
+		void emitRecord(StreamRecord<T> streamRecord) throws Exception;
+
+		void emitWatermark(Watermark watermark) throws Exception;
+
+		void emitStreamStatus(StreamStatus streamStatus) throws Exception;
+
+		void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -85,7 +85,6 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	private final WatermarkGauge watermarkGauge;
 	private final Counter numRecordsIn;
 
-	@SuppressWarnings("unchecked")
 	public StreamOneInputProcessor(
 			InputGate[] inputGates,
 			TypeSerializer<IN> inputSerializer,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -143,10 +143,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	public boolean processInput() throws Exception {
 		StreamElement recordOrMark = input.pollNextNullable();
 		if (recordOrMark != null) {
-			int channel = input.getLastChannel();
-			checkState(channel != StreamTaskInput.UNSPECIFIED);
-
-			processElement(recordOrMark, channel);
+			processElement(recordOrMark, input.getLastChannel());
 		}
 		checkFinished();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -31,28 +31,42 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
-
-import javax.annotation.Nullable;
+import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Implementation of {@link StreamTaskInput} that wraps an input from network taken from {@link CheckpointedInputGate}.
+ *
+ * <p>This internally uses a {@link StatusWatermarkValve} to keep track of {@link Watermark} and
+ * {@link StreamStatus} events, and forwards them to event subscribers once the
+ * {@link StatusWatermarkValve} determines the {@link Watermark} from all inputs has advanced, or
+ * that a {@link StreamStatus} needs to be propagated downstream to denote a status change.
+ *
+ * <p>Forwarding elements, watermarks, or status status elements must be protected by synchronizing
+ * on the given lock object. This ensures that we don't call methods on a
+ * {@link StreamInputProcessor} concurrently with the timer callback or other things.
  */
 @Internal
-public final class StreamTaskNetworkInput implements StreamTaskInput {
+public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 
 	private final CheckpointedInputGate checkpointedInputGate;
 
 	private final DeserializationDelegate<StreamElement> deserializationDelegate;
 
 	private final RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers;
+
+	/** Valve that controls how watermarks and stream statuses are forwarded. */
+	private final StatusWatermarkValve statusWatermarkValve;
 
 	private final int inputIndex;
 
@@ -67,6 +81,7 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 			CheckpointedInputGate checkpointedInputGate,
 			TypeSerializer<?> inputSerializer,
 			IOManager ioManager,
+			StatusWatermarkValve statusWatermarkValve,
 			int inputIndex) {
 		this.checkpointedInputGate = checkpointedInputGate;
 		this.deserializationDelegate = new NonReusingDeserializationDelegate<>(
@@ -79,6 +94,7 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 				ioManager.getSpillingDirectoriesPaths());
 		}
 
+		this.statusWatermarkValve = checkNotNull(statusWatermarkValve);
 		this.inputIndex = inputIndex;
 	}
 
@@ -86,6 +102,7 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 	StreamTaskNetworkInput(
 		CheckpointedInputGate checkpointedInputGate,
 		TypeSerializer<?> inputSerializer,
+		StatusWatermarkValve statusWatermarkValve,
 		int inputIndex,
 		RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers) {
 
@@ -93,12 +110,12 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 		this.deserializationDelegate = new NonReusingDeserializationDelegate<>(
 			new StreamElementSerializer<>(inputSerializer));
 		this.recordDeserializers = recordDeserializers;
+		this.statusWatermarkValve = statusWatermarkValve;
 		this.inputIndex = inputIndex;
 	}
 
 	@Override
-	@Nullable
-	public StreamElement pollNextNullable() throws Exception {
+	public InputStatus emitNext(DataOutput<T> output) throws Exception {
 
 		while (true) {
 			// get the stream element from the deserializer
@@ -110,7 +127,8 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 				}
 
 				if (result.isFullRecord()) {
-					return deserializationDelegate.getInstance();
+					processElement(deserializationDelegate.getInstance(), output);
+					return InputStatus.MORE_AVAILABLE;
 				}
 			}
 
@@ -124,9 +142,24 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 					if (!checkpointedInputGate.isEmpty()) {
 						throw new IllegalStateException("Trailing data in checkpoint barrier handler.");
 					}
+					return InputStatus.END_OF_INPUT;
 				}
-				return null;
+				return InputStatus.NOTHING_AVAILABLE;
 			}
+		}
+	}
+
+	private void processElement(StreamElement recordOrMark, DataOutput<T> output) throws Exception {
+		if (recordOrMark.isRecord()){
+			output.emitRecord(recordOrMark.asRecord());
+		} else if (recordOrMark.isWatermark()) {
+			statusWatermarkValve.inputWatermark(recordOrMark.asWatermark(), lastChannel);
+		} else if (recordOrMark.isLatencyMarker()) {
+			output.emitLatencyMarker(recordOrMark.asLatencyMarker());
+		} else if (recordOrMark.isStreamStatus()) {
+			statusWatermarkValve.inputStreamStatus(recordOrMark.asStreamStatus(), lastChannel);
+		} else {
+			throw new UnsupportedOperationException("Unknown type of StreamElement");
 		}
 	}
 
@@ -152,11 +185,6 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 			// which is very valuable in case of bounded stream
 			releaseDeserializer(bufferOrEvent.getChannelIndex());
 		}
-	}
-
-	@Override
-	public int getLastChannel() {
-		return lastChannel;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -86,7 +86,6 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 	StreamTaskNetworkInput(
 		CheckpointedInputGate checkpointedInputGate,
 		TypeSerializer<?> inputSerializer,
-		IOManager ioManager,
 		int inputIndex,
 		RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers) {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -134,6 +134,7 @@ public final class StreamTaskNetworkInput implements StreamTaskInput {
 	private void processBufferOrEvent(BufferOrEvent bufferOrEvent) throws IOException {
 		if (bufferOrEvent.isBuffer()) {
 			lastChannel = bufferOrEvent.getChannelIndex();
+			checkState(lastChannel != StreamTaskInput.UNSPECIFIED);
 			currentRecordDeserializer = recordDeserializers[lastChannel];
 			checkState(currentRecordDeserializer != null,
 				"currentRecordDeserializer has already been released");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -20,11 +20,8 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
-import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
@@ -34,16 +31,13 @@ import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
 import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Input reader for {@link TwoInputStreamTask}.
@@ -75,71 +69,46 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 	 * Stream status for the two inputs. We need to keep track for determining when
 	 * to forward stream status changes downstream.
 	 */
-	private StreamStatus firstStatus;
-	private StreamStatus secondStatus;
+	private StreamStatus firstStatus = StreamStatus.ACTIVE;
+	private StreamStatus secondStatus = StreamStatus.ACTIVE;
 
-	private int lastReadInputIndex;
+	/** Always try to read from the first input. */
+	private int lastReadInputIndex = 1;
 
 	private final Counter numRecordsIn;
 
 	private boolean isPrepared;
 
 	public StreamTwoInputProcessor(
-		Collection<InputGate> inputGates1,
-		Collection<InputGate> inputGates2,
-		TypeSerializer<IN1> inputSerializer1,
-		TypeSerializer<IN2> inputSerializer2,
-		StreamTask<?, ?> streamTask,
-		CheckpointingMode checkpointingMode,
-		Object lock,
-		IOManager ioManager,
-		Configuration taskManagerConfig,
-		StreamStatusMaintainer streamStatusMaintainer,
-		TwoInputStreamOperator<IN1, IN2, ?> streamOperator,
-		TwoInputSelectionHandler inputSelectionHandler,
-		WatermarkGauge input1WatermarkGauge,
-		WatermarkGauge input2WatermarkGauge,
-		String taskName,
-		OperatorChain<?, ?> operatorChain,
-		Counter numRecordsIn) throws IOException {
+			CheckpointedInputGate[] checkpointedInputGates,
+			TypeSerializer<IN1> inputSerializer1,
+			TypeSerializer<IN2> inputSerializer2,
+			Object lock,
+			IOManager ioManager,
+			StreamStatusMaintainer streamStatusMaintainer,
+			TwoInputStreamOperator<IN1, IN2, ?> streamOperator,
+			TwoInputSelectionHandler inputSelectionHandler,
+			WatermarkGauge input1WatermarkGauge,
+			WatermarkGauge input2WatermarkGauge,
+			OperatorChain<?, ?> operatorChain,
+			Counter numRecordsIn) {
 
-		this.streamOperator = checkNotNull(streamOperator);
-		this.inputSelectionHandler = checkNotNull(inputSelectionHandler);
-
-		this.lock = checkNotNull(lock);
-
-		InputGate unionedInputGate1 = InputGateUtil.createInputGate(inputGates1.toArray(new InputGate[0]));
-		InputGate unionedInputGate2 = InputGateUtil.createInputGate(inputGates2.toArray(new InputGate[0]));
-
-		// create a Input instance for each input
-		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedInputGatePair(
-			streamTask,
-			checkpointingMode,
-			ioManager,
-			unionedInputGate1,
-			unionedInputGate2,
-			taskManagerConfig,
-			taskName);
-		checkState(checkpointedInputGates.length == 2);
 		this.input1 = new StreamTaskNetworkInput(checkpointedInputGates[0], inputSerializer1, ioManager, 0);
 		this.input2 = new StreamTaskNetworkInput(checkpointedInputGates[1], inputSerializer2, ioManager, 1);
 
+		this.lock = checkNotNull(lock);
+		this.streamOperator = checkNotNull(streamOperator);
+		this.inputSelectionHandler = checkNotNull(inputSelectionHandler);
+
 		this.statusWatermarkValve1 = new StatusWatermarkValve(
-			unionedInputGate1.getNumberOfInputChannels(),
+			checkpointedInputGates[0].getNumberOfInputChannels(),
 			new ForwardingValveOutputHandler(streamOperator, lock, streamStatusMaintainer, input1WatermarkGauge, 0));
 		this.statusWatermarkValve2 = new StatusWatermarkValve(
-			unionedInputGate2.getNumberOfInputChannels(),
+			checkpointedInputGates[1].getNumberOfInputChannels(),
 			new ForwardingValveOutputHandler(streamOperator, lock, streamStatusMaintainer, input2WatermarkGauge, 1));
 
 		this.operatorChain = checkNotNull(operatorChain);
 		this.numRecordsIn = checkNotNull(numRecordsIn);
-
-		this.firstStatus = StreamStatus.ACTIVE;
-		this.secondStatus = StreamStatus.ACTIVE;
-
-		this.lastReadInputIndex = 1; // always try to read from the first input
-
-		this.isPrepared = false;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamstatus/StatusWatermarkValve.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamstatus/StatusWatermarkValve.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.streamstatus;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -29,24 +30,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * A {@code StatusWatermarkValve} embodies the logic of how {@link Watermark} and {@link StreamStatus} are propagated to
  * downstream outputs, given a set of one or multiple input channels that continuously receive them. Usages of this
- * class need to define the number of input channels that the valve needs to handle, as well as provide a customized
- * implementation of {@link ValveOutputHandler}, which is called by the valve only when it determines a new watermark or
- * stream status can be propagated.
+ * class need to define the number of input channels that the valve needs to handle, as well as provide a implementation of
+ * {@link DataOutput}, which is called by the valve only when it determines a new watermark or stream status can be propagated.
  */
 @Internal
 public class StatusWatermarkValve {
 
-	/**
-	 * Usages of {@code StatusWatermarkValve} should implement a {@code ValveOutputHandler}
-	 * to handle watermark and stream status outputs from the valve.
-	 */
-	public interface ValveOutputHandler {
-		void handleWatermark(Watermark watermark) throws Exception;
-
-		void handleStreamStatus(StreamStatus streamStatus) throws Exception;
-	}
-
-	private final ValveOutputHandler outputHandler;
+	private final DataOutput output;
 
 	// ------------------------------------------------------------------------
 	//	Runtime state for watermark & stream status output determination
@@ -68,9 +58,9 @@ public class StatusWatermarkValve {
 	 * Returns a new {@code StatusWatermarkValve}.
 	 *
 	 * @param numInputChannels the number of input channels that this valve will need to handle
-	 * @param outputHandler the customized output handler for the valve
+	 * @param output the customized output handler for the valve
 	 */
-	public StatusWatermarkValve(int numInputChannels, ValveOutputHandler outputHandler) {
+	public StatusWatermarkValve(int numInputChannels, DataOutput output) {
 		checkArgument(numInputChannels > 0);
 		this.channelStatuses = new InputChannelStatus[numInputChannels];
 		for (int i = 0; i < numInputChannels; i++) {
@@ -80,7 +70,7 @@ public class StatusWatermarkValve {
 			channelStatuses[i].isWatermarkAligned = true;
 		}
 
-		this.outputHandler = checkNotNull(outputHandler);
+		this.output = checkNotNull(output);
 
 		this.lastOutputWatermark = Long.MIN_VALUE;
 		this.lastOutputStreamStatus = StreamStatus.ACTIVE;
@@ -88,7 +78,7 @@ public class StatusWatermarkValve {
 
 	/**
 	 * Feed a {@link Watermark} into the valve. If the input triggers the valve to output a new Watermark,
-	 * {@link ValveOutputHandler#handleWatermark(Watermark)} will be called to process the new Watermark.
+	 * {@link DataOutput#emitWatermark(Watermark)} will be called to process the new Watermark.
 	 *
 	 * @param watermark the watermark to feed to the valve
 	 * @param channelIndex the index of the channel that the fed watermark belongs to (index starting from 0)
@@ -115,8 +105,8 @@ public class StatusWatermarkValve {
 
 	/**
 	 * Feed a {@link StreamStatus} into the valve. This may trigger the valve to output either a new Stream Status,
-	 * for which {@link ValveOutputHandler#handleStreamStatus(StreamStatus)} will be called, or a new Watermark,
-	 * for which {@link ValveOutputHandler#handleWatermark(Watermark)} will be called.
+	 * for which {@link DataOutput#emitStreamStatus(StreamStatus)} will be called, or a new Watermark,
+	 * for which {@link DataOutput#emitWatermark(Watermark)} will be called.
 	 *
 	 * @param streamStatus the stream status to feed to the valve
 	 * @param channelIndex the index of the channel that the fed stream status belongs to (index starting from 0)
@@ -144,7 +134,7 @@ public class StatusWatermarkValve {
 				}
 
 				lastOutputStreamStatus = StreamStatus.IDLE;
-				outputHandler.handleStreamStatus(lastOutputStreamStatus);
+				output.emitStreamStatus(lastOutputStreamStatus);
 			} else if (channelStatuses[channelIndex].watermark == lastOutputWatermark) {
 				// if the watermark of the channel that just became idle equals the last output
 				// watermark (the previous overall min watermark), we may be able to find a new
@@ -165,7 +155,7 @@ public class StatusWatermarkValve {
 			// status because at least one of the input channels is now active
 			if (lastOutputStreamStatus.isIdle()) {
 				lastOutputStreamStatus = StreamStatus.ACTIVE;
-				outputHandler.handleStreamStatus(lastOutputStreamStatus);
+				output.emitStreamStatus(lastOutputStreamStatus);
 			}
 		}
 	}
@@ -186,7 +176,7 @@ public class StatusWatermarkValve {
 		// from some remaining aligned channel, and is also larger than the last output watermark
 		if (hasAlignedChannels && newMinWatermark > lastOutputWatermark) {
 			lastOutputWatermark = newMinWatermark;
-			outputHandler.handleWatermark(new Watermark(lastOutputWatermark));
+			output.emitWatermark(new Watermark(lastOutputWatermark));
 		}
 	}
 
@@ -199,7 +189,7 @@ public class StatusWatermarkValve {
 
 		if (maxWatermark > lastOutputWatermark) {
 			lastOutputWatermark = maxWatermark;
-			outputHandler.handleWatermark(new Watermark(lastOutputWatermark));
+			output.emitWatermark(new Watermark(lastOutputWatermark));
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -21,19 +21,33 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.InputGateUtil;
 import org.apache.flink.streaming.runtime.io.InputProcessorUtil;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
 import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+import org.apache.flink.streaming.runtime.io.StreamTaskNetworkInput;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 
 import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A {@link StreamTask} for executing a {@link OneInputStreamOperator}.
@@ -72,37 +86,120 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 	@Override
 	public void init() throws Exception {
 		StreamConfig configuration = getConfiguration();
-
-		TypeSerializer<IN> inSerializer = configuration.getTypeSerializerIn1(getUserCodeClassLoader());
 		int numberOfInputs = configuration.getNumberOfInputs();
 
 		if (numberOfInputs > 0) {
-			InputGate[] inputGates = getEnvironment().getAllInputGates();
-			InputGate inputGate = InputGateUtil.createInputGate(inputGates);
-			CheckpointedInputGate checkpointedInputGate = InputProcessorUtil.createCheckpointedInputGate(
-				this,
-				configuration.getCheckpointMode(),
-				getEnvironment().getIOManager(),
-				inputGate,
-				getEnvironment().getTaskManagerInfo().getConfiguration(),
-				getTaskNameWithSubtaskAndId());
-
+			CheckpointedInputGate inputGate = createCheckpointedInputGate();
 			TaskIOMetricGroup taskIOMetricGroup = getEnvironment().getMetricGroup().getIOMetricGroup();
-			taskIOMetricGroup.gauge("checkpointAlignmentTime", checkpointedInputGate::getAlignmentDurationNanos);
+			taskIOMetricGroup.gauge("checkpointAlignmentTime", inputGate::getAlignmentDurationNanos);
 
+			DataOutput<IN> output = createDataOutput();
+			StreamTaskInput<IN> input = createTaskInput(inputGate, output);
 			inputProcessor = new StreamOneInputProcessor<>(
-				checkpointedInputGate,
-				inSerializer,
+				input,
+				output,
 				getCheckpointLock(),
-				getEnvironment().getIOManager(),
-				getStreamStatusMaintainer(),
-				headOperator,
-				inputWatermarkGauge,
-				operatorChain,
-				setupNumRecordsInCounter(headOperator));
+				operatorChain);
 		}
 		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge);
 		// wrap watermark gauge since registered metrics must be unique
 		getEnvironment().getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge::getValue);
+	}
+
+	private CheckpointedInputGate createCheckpointedInputGate() throws IOException {
+		InputGate[] inputGates = getEnvironment().getAllInputGates();
+		InputGate inputGate = InputGateUtil.createInputGate(inputGates);
+
+		return InputProcessorUtil.createCheckpointedInputGate(
+			this,
+			configuration.getCheckpointMode(),
+			getEnvironment().getIOManager(),
+			inputGate,
+			getEnvironment().getTaskManagerInfo().getConfiguration(),
+			getTaskNameWithSubtaskAndId());
+	}
+
+	private DataOutput<IN> createDataOutput() {
+		return new StreamTaskNetworkOutput<>(
+			headOperator,
+			getStreamStatusMaintainer(),
+			getCheckpointLock(),
+			inputWatermarkGauge,
+			setupNumRecordsInCounter(headOperator));
+	}
+
+	private StreamTaskInput<IN> createTaskInput(CheckpointedInputGate inputGate, DataOutput<IN> output) {
+		int numberOfInputChannels = inputGate.getNumberOfInputChannels();
+		StatusWatermarkValve statusWatermarkValve = new StatusWatermarkValve(numberOfInputChannels, output);
+
+		TypeSerializer<IN> inSerializer = configuration.getTypeSerializerIn1(getUserCodeClassLoader());
+		return new StreamTaskNetworkInput<>(
+			inputGate,
+			inSerializer,
+			getEnvironment().getIOManager(),
+			statusWatermarkValve,
+			0);
+	}
+
+	/**
+	 * The network data output implementation used for processing stream elements
+	 * from {@link StreamTaskNetworkInput} in one input processor.
+	 */
+	private static class StreamTaskNetworkOutput<IN> implements DataOutput<IN> {
+
+		private final OneInputStreamOperator<IN, ?> operator;
+
+		/** The maintainer toggles the current stream status. */
+		private final StreamStatusMaintainer streamStatusMaintainer;
+
+		private final Object lock;
+
+		private final WatermarkGauge watermarkGauge;
+		private final Counter numRecordsIn;
+
+		private StreamTaskNetworkOutput(
+				OneInputStreamOperator<IN, ?> operator,
+				StreamStatusMaintainer streamStatusMaintainer,
+				Object lock,
+				WatermarkGauge watermarkGauge,
+				Counter numRecordsIn) {
+
+			this.operator = checkNotNull(operator);
+			this.streamStatusMaintainer = checkNotNull(streamStatusMaintainer);
+			this.lock = checkNotNull(lock);
+			this.watermarkGauge = checkNotNull(watermarkGauge);
+			this.numRecordsIn = checkNotNull(numRecordsIn);
+		}
+
+		@Override
+		public void emitRecord(StreamRecord<IN> record) throws Exception {
+			synchronized (lock) {
+				numRecordsIn.inc();
+				operator.setKeyContextElement1(record);
+				operator.processElement(record);
+			}
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) throws Exception {
+			synchronized (lock) {
+				watermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+				operator.processWatermark(watermark);
+			}
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+			synchronized (lock) {
+				operator.processLatencyMarker(latencyMarker);
+			}
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) {
+			synchronized (lock) {
+				streamStatusMaintainer.toggleStreamStatus(streamStatus);
+			}
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -32,9 +32,14 @@ import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 
 import org.junit.After;
 import org.junit.Test;
@@ -44,9 +49,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -74,17 +82,20 @@ public class StreamTaskNetworkInputTest {
 
 		List<BufferOrEvent> buffers = Collections.singletonList(new BufferOrEvent(buffer, 0, false));
 
-		StreamTaskNetworkInput input = new StreamTaskNetworkInput(
+		VerifyRecordsDataOutput output = new VerifyRecordsDataOutput<>();
+		StreamTaskNetworkInput input = new StreamTaskNetworkInput<>(
 			new CheckpointedInputGate(
 				new MockInputGate(1, buffers, false),
 				new EmptyBufferStorage(),
 				new CheckpointBarrierTracker(1)),
 			LongSerializer.INSTANCE,
 			ioManager,
+			new StatusWatermarkValve(1, output),
 			0);
 
-		assertHasNextElement(input);
-		assertHasNextElement(input);
+		assertHasNextElement(input, output);
+		assertHasNextElement(input, output);
+		assertEquals(2, output.getNumberOfEmittedRecords());
 	}
 
 	@Test
@@ -101,19 +112,21 @@ public class StreamTaskNetworkInputTest {
 		}
 
 		TestRecordDeserializer[] copiedDeserializers = Arrays.copyOf(deserializers, deserializers.length);
-		StreamTaskNetworkInput input = new StreamTaskNetworkInput(
+		DataOutput output = new NoOpDataOutput<>();
+		StreamTaskNetworkInput input = new StreamTaskNetworkInput<>(
 			new CheckpointedInputGate(
 				inputGate.getInputGate(),
 				new EmptyBufferStorage(),
 				new CheckpointBarrierTracker(1)),
 			inSerializer,
+			new StatusWatermarkValve(1, output),
 			0,
 			deserializers);
 
 		for (int i = 0; i < numInputChannels; i++) {
 			assertNotNull(deserializers[i]);
 			inputGate.sendEvent(EndOfPartitionEvent.INSTANCE, i);
-			input.pollNextNullable();
+			input.emitNext(output);
 			assertNull(deserializers[i]);
 			assertTrue(copiedDeserializers[i].isCleared());
 		}
@@ -130,11 +143,10 @@ public class StreamTaskNetworkInputTest {
 		assertFalse(serializer.copyToBufferBuilder(bufferBuilder).isFullBuffer());
 	}
 
-	private static void assertHasNextElement(StreamTaskNetworkInput input) throws Exception {
+	private static void assertHasNextElement(StreamTaskNetworkInput input, DataOutput output) throws Exception {
 		assertTrue(input.isAvailable().isDone());
-		StreamElement element = input.pollNextNullable();
-		assertNotNull(element);
-		assertTrue(element.isRecord());
+		InputStatus status = input.emitNext(output);
+		assertThat(status, is(InputStatus.MORE_AVAILABLE));
 	}
 
 	private static class TestRecordDeserializer
@@ -153,6 +165,39 @@ public class StreamTaskNetworkInputTest {
 
 		public boolean isCleared() {
 			return cleared;
+		}
+	}
+
+	private static class NoOpDataOutput<T> implements DataOutput<T> {
+
+		@Override
+		public void emitRecord(StreamRecord<T> record) {
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) {
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) {
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		}
+	}
+
+	private static class VerifyRecordsDataOutput<T> extends NoOpDataOutput<T> {
+
+		private int numberOfEmittedRecords;
+
+		@Override
+		public void emitRecord(StreamRecord<T> record) {
+			numberOfEmittedRecords++;
+		}
+
+		int getNumberOfEmittedRecords() {
+			return numberOfEmittedRecords;
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -107,7 +107,6 @@ public class StreamTaskNetworkInputTest {
 				new EmptyBufferStorage(),
 				new CheckpointBarrierTracker(1)),
 			inSerializer,
-			ioManager,
 			0,
 			deserializers);
 


### PR DESCRIPTION
## What is the purpose of the change

The current data processing in task input processor is based on the way of `NullableAsyncDataInput#pollNext`. In order to unify the processing stack for new source operator, we introduce the new `PushBasedAsyncDataInput#emitNext(Output)` instead. Then we need to adjust the existing implementations of `StreamOneInputProcessor`/`StreamTwoInputSelectableProcessor` based on this new way. To do so, we could integrate all the task inputs from network/source in a unified processor on runtime side.

To do so, we could integrate all the task inputs from network/source in a unified processing on runtime side.

## Brief change log

  - *Introduce  relevant new interfaces `PushBasedAsyncDataInput` `InputStatus` and `DataOutput`
  - *Refactor the implementation of `StreamOneInputProcessor` based on new interface*
  - *Refactor the implementation of `StreamTwoInputSelectableProcessor` based on new interface*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)