### PR TITLE
[FLINK-13767][task] Refactor StreamInputProcessor#processInput based on InputStatus

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
  * {@link CompletableFuture}. For usage check out for example {@link PullingAsyncDataInput}.
  */
 @Internal
-public interface AvailabilityListener {
+public interface AvailabilityProvider {
 	/**
 	 * Constant that allows to avoid volatile checks {@link CompletableFuture#isDone()}. Check
 	 * {@link #isAvailable()} for more explanation.
@@ -45,8 +45,8 @@ public interface AvailabilityListener {
 	 * this method should do the following check:
 	 * <pre>
 	 * {@code
-	 *	AvailabilityListener input = ...;
-	 *	if (input.isAvailable() == AvailabilityListener.AVAILABLE || input.isAvailable().isDone()) {
+	 *	AvailabilityProvider input = ...;
+	 *	if (input.isAvailable() == AvailabilityProvider.AVAILABLE || input.isAvailable().isDone()) {
 	 *		// do something;
 	 *	}
 	 * }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
@@ -34,11 +34,6 @@ public interface AvailabilityProvider {
 	CompletableFuture<?> AVAILABLE = CompletableFuture.completedFuture(null);
 
 	/**
-	 * @return true if is finished and for example end of input was reached, false otherwise.
-	 */
-	boolean isFinished();
-
-	/**
 	 * Check if this instance is available for further processing.
 	 *
 	 * <p>When hot looping to avoid volatile access in {@link CompletableFuture#isDone()} user of
@@ -55,7 +50,7 @@ public interface AvailabilityProvider {
 	 * @return a future that is completed if there are more records available. If there are more
 	 * records available immediately, {@link #AVAILABLE} should be returned. Previously returned
 	 * not completed futures should become completed once there is more input available or if
-	 * the input {@link #isFinished()}.
+	 * the input is finished.
 	 */
 	CompletableFuture<?> isAvailable();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/NullableAsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/NullableAsyncDataInput.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
  * {@link PullingAsyncDataInput#pollNext()}.
  */
 @Internal
-public interface NullableAsyncDataInput<T> extends AvailabilityListener {
+public interface NullableAsyncDataInput<T> extends AvailabilityProvider {
 	/**
 	 * Poll the next element. This method should be non blocking.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
@@ -50,7 +50,7 @@ import java.util.concurrent.CompletableFuture;
  * </pre>
  */
 @Internal
-public interface PullingAsyncDataInput<T> extends AvailabilityListener {
+public interface PullingAsyncDataInput<T> extends AvailabilityProvider {
 	/**
 	 * Poll the next element. This method should be non blocking.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
@@ -58,4 +58,9 @@ public interface PullingAsyncDataInput<T> extends AvailabilityProvider {
 	 * if {@link #isFinished()} returns true. Otherwise {@code Optional.of(element)}.
 	 */
 	Optional<T> pollNext() throws Exception;
+
+	/**
+	 * @return true if is finished and for example end of input was reached, false otherwise.
+	 */
+	boolean isFinished();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.io.AvailabilityListener;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
@@ -31,7 +31,7 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
  * of returning {@code Optional.empty()} via {@link PullingAsyncDataInput#pollNext()}.
  */
 @Internal
-public interface PushingAsyncDataInput<T> extends AvailabilityListener {
+public interface PushingAsyncDataInput<T> extends AvailabilityProvider {
 
 	/**
 	 * Pushes the next element to the output from current data input, and returns

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -29,9 +29,9 @@ import java.io.Closeable;
 @Internal
 public interface StreamInputProcessor extends AvailabilityProvider, Closeable {
 	/**
-	 * @return true if {@link StreamInputProcessor} estimates that more records can be processed
-	 * immediately. Otherwise false, which means that there are no more records available at the
-	 * moment and the caller should check {@link #isFinished()} and/or {@link #isAvailable()}.
+	 * @return input status to estimate whether more records can be processed immediately or not.
+	 * If there are no more records available at the moment and the caller should check finished
+	 * state and/or {@link #isAvailable()}.
 	 */
-	boolean processInput() throws Exception;
+	InputStatus processInput() throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -19,7 +19,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.io.AvailabilityListener;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 
 import java.io.Closeable;
 
@@ -27,7 +27,7 @@ import java.io.Closeable;
  * Interface for processing records by {@link org.apache.flink.streaming.runtime.tasks.StreamTask}.
  */
 @Internal
-public interface StreamInputProcessor extends AvailabilityListener, Closeable {
+public interface StreamInputProcessor extends AvailabilityProvider, Closeable {
 	/**
 	 * @return true if {@link StreamInputProcessor} estimates that more records can be processed
 	 * immediately. Otherwise false, which means that there are no more records available at the

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -60,17 +60,12 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	}
 
 	@Override
-	public boolean isFinished() {
-		return input.isFinished();
-	}
-
-	@Override
 	public CompletableFuture<?> isAvailable() {
 		return input.isAvailable();
 	}
 
 	@Override
-	public boolean processInput() throws Exception {
+	public InputStatus processInput() throws Exception {
 		InputStatus status = input.emitNext(output);
 
 		if (status == InputStatus.END_OF_INPUT) {
@@ -79,7 +74,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 			}
 		}
 
-		return status == InputStatus.MORE_AVAILABLE;
+		return status;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -74,8 +74,6 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 
 	private RecordDeserializer<DeserializationDelegate<StreamElement>> currentRecordDeserializer = null;
 
-	private boolean isFinished = false;
-
 	@SuppressWarnings("unchecked")
 	public StreamTaskNetworkInput(
 			CheckpointedInputGate checkpointedInputGate,
@@ -137,7 +135,6 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 				processBufferOrEvent(bufferOrEvent.get());
 			} else {
 				if (checkpointedInputGate.isFinished()) {
-					isFinished = true;
 					checkState(checkpointedInputGate.isAvailable().isDone(), "Finished BarrierHandler should be available");
 					if (!checkpointedInputGate.isEmpty()) {
 						throw new IllegalStateException("Trailing data in checkpoint barrier handler.");
@@ -190,11 +187,6 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 	@Override
 	public int getInputIndex() {
 		return inputIndex;
-	}
-
-	@Override
-	public boolean isFinished() {
-		return isFinished;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -184,10 +184,6 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 		}
 		checkFinished(status, lastReadInputIndex);
 
-		if (status != InputStatus.MORE_AVAILABLE) {
-			inputSelectionHandler.setUnavailableInput(readingInputIndex);
-		}
-
 		return status == InputStatus.MORE_AVAILABLE;
 	}
 
@@ -253,11 +249,15 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 	}
 
 	private void updateAvailability() {
-		if (!input1.isFinished() && input1.isAvailable() == AVAILABLE) {
-			inputSelectionHandler.setAvailableInput(input1.getInputIndex());
-		}
-		if (!input2.isFinished() && input2.isAvailable() == AVAILABLE) {
-			inputSelectionHandler.setAvailableInput(input2.getInputIndex());
+		updateAvailability(input1);
+		updateAvailability(input2);
+	}
+
+	private void updateAvailability(StreamTaskInput input) {
+		if (!input.isFinished() && input.isAvailable() == AVAILABLE) {
+			inputSelectionHandler.setAvailableInput(input.getInputIndex());
+		} else {
+			inputSelectionHandler.setUnavailableInput(input.getInputIndex());
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -279,7 +279,7 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 
 	private CompletableFuture<?> isAnyInputAvailable() {
 		if (input1.isFinished()) {
-			return input2.isFinished() ? AVAILABLE : input2.isAvailable();
+			return input2.isAvailable();
 		}
 
 		if (input2.isFinished()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -109,6 +109,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorStateContext;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.runtime.io.InputStatus;
 import org.apache.flink.streaming.runtime.io.StreamInputProcessor;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
@@ -1150,17 +1151,12 @@ public class StreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		public boolean processInput() throws Exception {
-			return false;
+		public InputStatus processInput() throws Exception {
+			return isFinished ? InputStatus.END_OF_INPUT : InputStatus.NOTHING_AVAILABLE;
 		}
 
 		@Override
 		public void close() throws IOException {
-		}
-
-		@Override
-		public boolean isFinished() {
-			return isFinished;
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

`StreamInputProcessor#processInput` could return `InputStatus` instead of current boolean value to keep consistent with `PushingAsyncDataInput#emitNext`.
    
For the implementation of `StreamTwoInputProcessor#processInput`, we could maintain and judge the two input status together with the next selected input index to determine the final precise status. To do so we could avoid invalid `processInput` call except for the first call.
    
In addition, `AvailabilityProvider#isFinished` has the duplicated semantic with `InputStatus#END_OF_INPUT` for `PushingAsyncDataInput`, and it is only meaningful for `PullingAsyncDataInput` now. So we migrate the `#isFinished` method from `AvailabilityProvider` to `PullingAsyncDataInput`.

Note: This PR is based on #9478 , then only review the last four commits for this PR change.

## Brief change log

  - *Migrate `isFinished` method from `AvailabilityProvider` to `PullingAsyncDataInput`.*
  - *Make `StreamInputProcessor#processInput` return `InputStatus` instead.*
  - *Refactor the relevant processes in `StreamOneInputProcessor`.*
  - *Refactor the relevant processes in `StreamTwoInputProcessor`.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)