### PR TITLE
[FLINK-13793][docs] build each language in a separate subprocess

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,5 +3,6 @@
 .jekyll-cache/
 .rubydeps/
 content/
+content_*/
 ruby2/.bundle/
 ruby2/.rubydeps/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -82,6 +82,11 @@ previous_docs:
 # to change anything here.
 #------------------------------------------------------------------------------
 
+exclude:
+  - "build_docs.sh"
+  - "build_docs.bat"
+  - "check_links.sh"
+
 # Used in some documents to initialize arrays. Don't delete.
 array: []
 

--- a/docs/_config_dev_en.yml
+++ b/docs/_config_dev_en.yml
@@ -17,6 +17,9 @@
 
 exclude:
   - "*.zh.md"
+  - "build_docs.sh"
+  - "build_docs.bat"
+  - "check_links.sh"
   - "content"
   - "content_en"
   - "content_zh"

--- a/docs/_config_dev_en.yml
+++ b/docs/_config_dev_en.yml
@@ -17,3 +17,6 @@
 
 exclude:
   - "*.zh.md"
+  - "content"
+  - "content_en"
+  - "content_zh"

--- a/docs/_config_dev_zh.yml
+++ b/docs/_config_dev_zh.yml
@@ -17,6 +17,9 @@
 
 exclude:
   - "*.md"
+  - "build_docs.sh"
+  - "build_docs.bat"
+  - "check_links.sh"
   - "content"
   - "content_en"
   - "content_zh"

--- a/docs/_config_dev_zh.yml
+++ b/docs/_config_dev_zh.yml
@@ -17,6 +17,9 @@
 
 exclude:
   - "*.md"
+  - "content"
+  - "content_en"
+  - "content_zh"
 
 include:
   - "*.zh.md"

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -72,6 +72,8 @@ while getopts "piez" opt; do
 		z)
 		JEKYLL_CONFIG="--config _config.yml,_config_dev_zh.yml"
 		;;
+		*) echo "usage: $0 [-e|-z] [-i|-p]" >&2
+		exit 1 ;;
 	esac
 done
 

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -53,6 +53,8 @@ JEKYLL_CMD="build"
 
 JEKYLL_CONFIG=""
 
+DOC_LANGUAGES="en zh"
+
 # if -p flag is provided, serve site on localhost
 # -i is like -p, but incremental (only rebuilds the modified file)
 # -e builds only english documentation
@@ -78,4 +80,28 @@ while getopts "piez" opt; do
 done
 
 # use 'bundle exec' to insert the local Ruby dependencies
-bundle exec jekyll ${JEKYLL_CMD} ${JEKYLL_CONFIG} --source "${DOCS_SRC}" --destination "${DOCS_DST}"
+
+if [ "${JEKYLL_CMD}" = "build" ] && [ -z "${JEKYLL_CONFIG}" ]; then
+  # run parallel builds for all languages if not serving or creating a single language only
+
+  # run processes and store pids
+  echo "Spawning parallel builds for languages: ${DOC_LANGUAGES}..."
+  pids=""
+  for lang in ${DOC_LANGUAGES}; do
+    bundle exec jekyll ${JEKYLL_CMD} --config _config.yml,_config_dev_${lang}.yml --source "${DOCS_SRC}" --destination "${DOCS_DST}_${lang}" &
+    pid=$!
+    pids="${pids} ${pid}"
+  done
+
+  # wait for all pids (since jekyll returns 0 even in case of failures, we do not parse exit codes)
+  wait ${pids}
+  rm -rf "${DOCS_DST}"
+  mkdir -p "${DOCS_DST}"
+  for lang in ${DOC_LANGUAGES}; do
+    cp -aln "${DOCS_DST}_${lang}/." "${DOCS_DST}"
+    rm -rf "${DOCS_DST}_${lang}"
+  done
+  exit 0
+else
+  bundle exec jekyll ${JEKYLL_CMD} ${JEKYLL_CONFIG} --source "${DOCS_SRC}" --destination "${DOCS_DST}"
+fi


### PR DESCRIPTION
## What is the purpose of the change

When not serving docs and just building them, e.g. via `./build_docs.sh`, we can spawn sub-processes for each language build instead of running them single-threaded (jekyll currently does not support parallel builds).

before: ~37s
after: ~20s

## Brief change log

Building on top of #9487, this PR adds:
- change `build_docs.sh` to support parallel builds and merge resulting files together
(admittedly this seems a bit hacky)
- enhance `build_docs.sh`: show usage if wrong option is given
- exclude build scripts from generated contents

## Verifying this change

I verified the changes in the generated HTML pages (nothing changed except for the build scripts which I removed from the generated pages via a hotfix).
