### PR TITLE
[FLINK-13794][client] Remove unused logic of printStatusDuringExecution

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -150,7 +150,6 @@ public class RemoteExecutor extends PlanExecutor {
 		synchronized (lock) {
 			if (client == null) {
 				client = new RestClusterClient<>(clientConfiguration, "RemoteExecutor");
-				client.setPrintStatusDuringExecution(isPrintingStatusDuringExecution());
 			}
 			else {
 				throw new IllegalStateException("The remote executor was already started.");

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -259,7 +259,6 @@ public class CliFrontend {
 				}
 
 				try {
-					client.setPrintStatusDuringExecution(runOptions.getStdoutLogging());
 					client.setDetached(runOptions.getDetachedMode());
 
 					LOG.debug("{}", runOptions.getSavepointRestoreSettings());

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -34,7 +34,6 @@ import static org.apache.flink.client.cli.CliFrontendParser.CLASSPATH_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.CLASS_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.LOGGING_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PARALLELISM_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
@@ -56,8 +55,6 @@ public abstract class ProgramOptions extends CommandLineOptions {
 	private final String[] programArgs;
 
 	private final int parallelism;
-
-	private final boolean stdoutLogging;
 
 	private final boolean detachedMode;
 
@@ -171,7 +168,6 @@ public abstract class ProgramOptions extends CommandLineOptions {
 			parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
 		}
 
-		stdoutLogging = !line.hasOption(LOGGING_OPTION.getOpt());
 		detachedMode = line.hasOption(DETACHED_OPTION.getOpt()) || line.hasOption(
 			YARN_DETACHED_OPTION.getOpt());
 		shutdownOnAttachedExit = line.hasOption(SHUTDOWN_IF_ATTACHED_OPTION.getOpt());
@@ -197,10 +193,6 @@ public abstract class ProgramOptions extends CommandLineOptions {
 
 	public int getParallelism() {
 		return parallelism;
-	}
-
-	public boolean getStdoutLogging() {
-		return stdoutLogging;
 	}
 
 	public boolean getDetachedMode() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -86,9 +86,6 @@ public abstract class ClusterClient<T> {
 
 	private final boolean sharedHaServices;
 
-	/** Flag indicating whether to sysout print execution updates. */
-	private boolean printStatusDuringExecution = true;
-
 	/**
 	 * For interactive invocations, the job results are only available after the ContextEnvironment has
 	 * been run inside the user JAR. We pass the Client to every instance of the ContextEnvironment
@@ -162,23 +159,6 @@ public abstract class ClusterClient<T> {
 	// ------------------------------------------------------------------------
 	//  Configuration
 	// ------------------------------------------------------------------------
-
-	/**
-	 * Configures whether the client should print progress updates during the execution to {@code System.out}.
-	 * All updates are logged via the SLF4J loggers regardless of this setting.
-	 *
-	 * @param print True to print updates to standard out during execution, false to not print them.
-	 */
-	public void setPrintStatusDuringExecution(boolean print) {
-		this.printStatusDuringExecution = print;
-	}
-
-	/**
-	 * @return whether the client will print progress updates during the execution to {@code System.out}
-	 */
-	public boolean getPrintStatusDuringExecution() {
-		return this.printStatusDuringExecution;
-	}
 
 	/**
 	 * Gets the current cluster connection info (may change in case of a HA setup).

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -55,25 +55,25 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		// test without parallelism
 		{
 			String[] parameters = {"-v", getTestJarPath()};
-			verifyCliFrontend(getCli(configuration), parameters, 1, true, false);
+			verifyCliFrontend(getCli(configuration), parameters, 1, false);
 		}
 
 		// test configure parallelism
 		{
 			String[] parameters = {"-v", "-p", "42",  getTestJarPath()};
-			verifyCliFrontend(getCli(configuration), parameters, 42, true, false);
+			verifyCliFrontend(getCli(configuration), parameters, 42, false);
 		}
 
 		// test configure sysout logging
 		{
 			String[] parameters = {"-p", "2", "-q", getTestJarPath()};
-			verifyCliFrontend(getCli(configuration), parameters, 2, false, false);
+			verifyCliFrontend(getCli(configuration), parameters, 2, false);
 		}
 
 		// test detached mode
 		{
 			String[] parameters = {"-p", "2", "-d", getTestJarPath()};
-			verifyCliFrontend(getCli(configuration), parameters, 2, true, true);
+			verifyCliFrontend(getCli(configuration), parameters, 2, true);
 		}
 
 		// test configure savepoint path (no ignore flag)
@@ -145,40 +145,34 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 	// --------------------------------------------------------------------------------------------
 
 	public static void verifyCliFrontend(
-			AbstractCustomCommandLine<?> cli,
-			String[] parameters,
-			int expectedParallelism,
-			boolean logging,
-			boolean isDetached) throws Exception {
+		AbstractCustomCommandLine<?> cli,
+		String[] parameters,
+		int expectedParallelism,
+		boolean isDetached) throws Exception {
 		RunTestingCliFrontend testFrontend =
-			new RunTestingCliFrontend(cli, expectedParallelism, logging,
-				isDetached);
+			new RunTestingCliFrontend(cli, expectedParallelism, isDetached);
 		testFrontend.run(parameters); // verifies the expected values (see below)
 	}
 
 	private static final class RunTestingCliFrontend extends CliFrontend {
 
 		private final int expectedParallelism;
-		private final boolean sysoutLogging;
 		private final boolean isDetached;
 
 		private RunTestingCliFrontend(
 				AbstractCustomCommandLine<?> cli,
 				int expectedParallelism,
-				boolean logging,
-				boolean isDetached) throws Exception {
+				boolean isDetached) {
 			super(
 				cli.getConfiguration(),
 				Collections.singletonList(cli));
 			this.expectedParallelism = expectedParallelism;
-			this.sysoutLogging = logging;
 			this.isDetached = isDetached;
 		}
 
 		@Override
 		protected void executeProgram(PackagedProgram program, ClusterClient client, int parallelism) {
 			assertEquals(isDetached, client.isDetached());
-			assertEquals(sysoutLogging, client.getPrintStatusDuringExecution());
 			assertEquals(expectedParallelism, parallelism);
 		}
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanAfterExecutionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanAfterExecutionTest.java
@@ -43,7 +43,6 @@ public class ExecutionPlanAfterExecutionTest extends TestLogger implements Seria
 	@Test
 	public void testExecuteAfterGetExecutionPlan() {
 		ExecutionEnvironment env = new LocalEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Integer> baseSet = env.fromElements(1, 2);
 
@@ -87,7 +86,6 @@ public class ExecutionPlanAfterExecutionTest extends TestLogger implements Seria
 	@Test
 	public void testGetExecutionPlanOfRangePartition() {
 		ExecutionEnvironment env = new LocalEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Integer> baseSet = env.fromElements(1, 2);
 

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
@@ -182,8 +182,7 @@ public class Kafka010ITCase extends KafkaConsumerTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		DataStream<Long> streamWithTimestamps = env.addSource(new SourceFunction<Long>() {
 			private static final long serialVersionUID = -2255105836471289626L;
@@ -224,8 +223,7 @@ public class Kafka010ITCase extends KafkaConsumerTestBase {
 		env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		FlinkKafkaConsumer010<Long> kafkaSource = new FlinkKafkaConsumer010<>(topic, new LimitedLongDeserializer(), standardProps);
 		kafkaSource.assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Long>() {

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011ITCase.java
@@ -189,8 +189,7 @@ public class Kafka011ITCase extends KafkaConsumerTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		DataStream<Long> streamWithTimestamps = env.addSource(new SourceFunction<Long>() {
 			private static final long serialVersionUID = -2255115836471289626L;
@@ -233,8 +232,7 @@ public class Kafka011ITCase extends KafkaConsumerTestBase {
 		env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		FlinkKafkaConsumer011<Long> kafkaSource = new FlinkKafkaConsumer011<>(topic, new LimitedLongDeserializer(), standardProps);
 		kafkaSource.assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Long>() {

--- a/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
@@ -92,7 +92,6 @@ public class Kafka08ITCase extends KafkaConsumerTestBase {
 		final int startFrom = 0;
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		readSequence(env, StartupMode.GROUP_OFFSETS, null, null, standardProps, parallelism, topic, valuesCount, startFrom);
 
@@ -191,8 +190,7 @@ public class Kafka08ITCase extends KafkaConsumerTestBase {
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		// NOTE: We are not enabling the checkpointing!
-		env.getConfig().disableSysoutLogging();
-		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+				env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env.setParallelism(parallelism);
 
 		// the readSequence operation sleeps for 20 ms between each record.

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -177,7 +177,6 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<String> stream = env.addSource(new SourceFunction<String>() {
 			private static final long serialVersionUID = 1L;
@@ -216,7 +215,6 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 		env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
 
 		// ---------- RateLimiter config -------------
 		final long globalRate = 10; // bytes/second

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -210,8 +210,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		final String topicName = writeSequence("testCommitOffsetsToKafkaTopic", recordsInEachPartition, parallelism, 1);
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+				env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(200);
 
@@ -293,8 +292,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		final String topicName = writeSequence("testAutoOffsetRetrievalAndCommitToKafkaTopic", recordsInEachPartition, parallelism, 1);
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+				env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(200);
 
@@ -371,8 +369,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		final String topicName = writeSequence("testStartFromEarliestOffsetsTopic", recordsInEachPartition, parallelism, 1);
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.setParallelism(parallelism);
+				env.setParallelism(parallelism);
 
 		Properties readProps = new Properties();
 		readProps.putAll(standardProps);
@@ -429,8 +426,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
 		// setup and run the latest-consuming job
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.setParallelism(parallelism);
+				env.setParallelism(parallelism);
 
 		final Properties readProps = new Properties();
 		readProps.putAll(standardProps);
@@ -547,8 +543,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		final String topicName = writeSequence("testStartFromGroupOffsetsTopic", recordsInEachPartition, parallelism, 1);
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.setParallelism(parallelism);
+				env.setParallelism(parallelism);
 
 		Properties readProps = new Properties();
 		readProps.putAll(standardProps);
@@ -606,8 +601,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		final String topicName = writeSequence("testStartFromSpecificOffsetsTopic", recordsInEachPartition, parallelism, 1);
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.setParallelism(parallelism);
+				env.setParallelism(parallelism);
 
 		Properties readProps = new Properties();
 		readProps.putAll(standardProps);
@@ -665,8 +659,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		writeAppendSequence(topic, initialRecordsInEachPartition, appendRecordsInEachPartition, parallelism);
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.setParallelism(parallelism);
+				env.setParallelism(parallelism);
 
 		Properties readProps = new Properties();
 		readProps.putAll(standardProps);
@@ -718,7 +711,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(500);
 		env.setRestartStrategy(RestartStrategies.noRestart()); // fail immediately
-		env.getConfig().disableSysoutLogging();
 
 		TypeInformation<Tuple2<Long, String>> longStringType =
 				TypeInformation.of(new TypeHint<Tuple2<Long, String>>(){});
@@ -857,7 +849,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		env.enableCheckpointing(500);
 		env.setParallelism(parallelism);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-		env.getConfig().disableSysoutLogging();
 
 		Properties props = new Properties();
 		props.putAll(standardProps);
@@ -909,7 +900,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		env.enableCheckpointing(500);
 		env.setParallelism(parallelism);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-		env.getConfig().disableSysoutLogging();
 
 		Properties props = new Properties();
 		props.putAll(standardProps);
@@ -961,8 +951,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		env.setParallelism(parallelism);
 		// set the number of restarts to one. The failing mapper will fail once, then it's only success exceptions.
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-		env.getConfig().disableSysoutLogging();
-		env.setBufferTimeout(0);
+				env.setBufferTimeout(0);
 
 		Properties props = new Properties();
 		props.putAll(standardProps);
@@ -1002,7 +991,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(100);
-		env.getConfig().disableSysoutLogging();
 
 		Properties props = new Properties();
 		props.putAll(standardProps);
@@ -1078,7 +1066,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(100);
-		env.getConfig().disableSysoutLogging();
 
 		Properties props = new Properties();
 		props.putAll(standardProps);
@@ -1135,7 +1122,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		final int numElements = 20;
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		// create topics with content
 		final List<String> topics = new ArrayList<>();
@@ -1184,7 +1170,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
 		// run second job consuming from multiple topics
 		env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		if (useLegacySchema) {
 			Tuple2WithTopicSchema schema = new Tuple2WithTopicSchema(env.getConfig());
@@ -1251,8 +1236,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
-		env.enableCheckpointing(100);
+				env.enableCheckpointing(100);
 		env.setParallelism(parallelism);
 
 		// add consuming topology:
@@ -1365,7 +1349,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(500);
 		env.setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
 
 		Properties props = new Properties();
 		props.putAll(standardProps);
@@ -1395,7 +1378,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Tuple2<Long, PojoValue>> kvStream = env.addSource(new SourceFunction<Tuple2<Long, PojoValue>>() {
 			@Override
@@ -1428,7 +1410,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
 
 		KafkaDeserializationSchema<Tuple2<Long, PojoValue>> readSchema = new TypeInformationKeyValueSerializationSchema<>(Long.class, PojoValue.class, env.getConfig());
 
@@ -1481,7 +1462,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Tuple2<byte[], PojoValue>> kvStream = env.addSource(new SourceFunction<Tuple2<byte[], PojoValue>>() {
 			@Override
@@ -1513,7 +1493,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 		env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
 
 		Properties props = new Properties();
 		props.putAll(standardProps);
@@ -1896,8 +1875,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
 			StreamExecutionEnvironment writeEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 			writeEnv.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-			writeEnv.getConfig().disableSysoutLogging();
-
 			DataStream<Tuple2<Integer, Integer>> stream = writeEnv.addSource(new RichParallelSourceFunction<Tuple2<Integer, Integer>>() {
 
 				private boolean running = true;
@@ -1984,8 +1961,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
 		StreamExecutionEnvironment writeEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		writeEnv.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		writeEnv.getConfig().disableSysoutLogging();
-
 		DataStream<Tuple2<Integer, Integer>> stream = writeEnv.addSource(new RichParallelSourceFunction<Tuple2<Integer, Integer>>() {
 
 			private boolean running = true;
@@ -2043,7 +2018,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
 		final StreamExecutionEnvironment readEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		readEnv.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		readEnv.getConfig().disableSysoutLogging();
 		readEnv.setParallelism(parallelism);
 
 		Properties readProps = (Properties) standardProps.clone();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -120,7 +120,6 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 
 			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 			env.setRestartStrategy(RestartStrategies.noRestart());
-			env.getConfig().disableSysoutLogging();
 
 			TypeInformationSerializationSchema<Tuple2<Long, String>> serSchema =
 				new TypeInformationSerializationSchema<>(longStringInfo, env.getConfig());
@@ -238,7 +237,6 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 		env.enableCheckpointing(500);
 		env.setParallelism(1);
 		env.setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
 
 		Properties properties = new Properties();
 		properties.putAll(standardProps);
@@ -335,7 +333,6 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 		env.enableCheckpointing(500);
 		env.setParallelism(1);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-		env.getConfig().disableSysoutLogging();
 
 		Properties properties = new Properties();
 		properties.putAll(standardProps);

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -143,7 +143,6 @@ public class KafkaShortRetentionTestBase implements Serializable {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(parallelism);
 		env.setRestartStrategy(RestartStrategies.noRestart()); // fail immediately
-		env.getConfig().disableSysoutLogging();
 
 		// ----------- add producer dataflow ----------
 
@@ -236,7 +235,6 @@ public class KafkaShortRetentionTestBase implements Serializable {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(parallelism);
 		env.setRestartStrategy(RestartStrategies.noRestart()); // fail immediately
-		env.getConfig().disableSysoutLogging();
 
 		// ----------- add consumer ----------
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
@@ -55,8 +55,7 @@ public class DataGenerators {
 			final int numElements,
 			final boolean randomizeOrder) throws Exception {
 		env.setParallelism(numPartitions);
-		env.getConfig().disableSysoutLogging();
-		env.setRestartStrategy(RestartStrategies.noRestart());
+				env.setRestartStrategy(RestartStrategies.noRestart());
 
 		DataStream<Integer> stream = env.addSource(
 				new RichParallelSourceFunction<Integer>() {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -194,8 +194,7 @@ public class KafkaITCase extends KafkaConsumerTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		DataStream<Long> streamWithTimestamps = env.addSource(new SourceFunction<Long>() {
 			private static final long serialVersionUID = -2255115836471289626L;
@@ -238,8 +237,7 @@ public class KafkaITCase extends KafkaConsumerTestBase {
 		env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		FlinkKafkaConsumer<Long> kafkaSource = new FlinkKafkaConsumer<>(topic, new KafkaITCase.LimitedLongDeserializer(), standardProps);
 		kafkaSource.assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Long>() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -122,9 +122,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	private CodeAnalysisMode codeAnalysisMode = CodeAnalysisMode.DISABLE;
 
-	/** If set to true, progress updates are printed to System.out during execution */
-	private boolean printProgressDuringExecution = true;
-
 	private long autoWatermarkInterval = 0;
 
 	/**
@@ -732,32 +729,27 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	}
 
 	/**
-	 * Enables the printing of progress update messages to {@code System.out}
-	 * 
-	 * @return The ExecutionConfig object, to allow for function chaining.
+	 * @deprecated Ineffective. Will be removed at 2.0.
 	 */
+	@Deprecated
 	public ExecutionConfig enableSysoutLogging() {
-		this.printProgressDuringExecution = true;
 		return this;
 	}
 
 	/**
-	 * Disables the printing of progress update messages to {@code System.out}
-	 *
-	 * @return The ExecutionConfig object, to allow for function chaining.
+	 * @deprecated Ineffective. Will be removed at 2.0.
 	 */
+	@Deprecated
 	public ExecutionConfig disableSysoutLogging() {
-		this.printProgressDuringExecution = false;
 		return this;
 	}
 
 	/**
-	 * Gets whether progress update messages should be printed to {@code System.out}
-	 * 
-	 * @return True, if progress update messages should be printed, false otherwise.
+	 * @deprecated Ineffective. Will be removed at 2.0.
 	 */
+	@Deprecated
 	public boolean isSysoutLoggingEnabled() {
-		return this.printProgressDuringExecution;
+		return false;
 	}
 
 	public GlobalJobParameters getGlobalJobParameters() {
@@ -989,7 +981,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 				autoTypeRegistrationEnabled == other.autoTypeRegistrationEnabled &&
 				forceAvro == other.forceAvro &&
 				Objects.equals(codeAnalysisMode, other.codeAnalysisMode) &&
-				printProgressDuringExecution == other.printProgressDuringExecution &&
 				Objects.equals(globalJobParameters, other.globalJobParameters) &&
 				autoWatermarkInterval == other.autoWatermarkInterval &&
 				registeredTypesWithKryoSerializerClasses.equals(other.registeredTypesWithKryoSerializerClasses) &&
@@ -1018,7 +1009,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 			autoTypeRegistrationEnabled,
 			forceAvro,
 			codeAnalysisMode,
-			printProgressDuringExecution,
 			globalJobParameters,
 			autoWatermarkInterval,
 			registeredTypesWithKryoSerializerClasses,

--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -45,33 +45,6 @@ public abstract class PlanExecutor {
 	private static final String REMOTE_EXECUTOR_CLASS = "org.apache.flink.client.RemoteExecutor";
 
 	// ------------------------------------------------------------------------
-	//  Config Options
-	// ------------------------------------------------------------------------
-	
-	/** If true, all execution progress updates are not only logged, but also printed to System.out */
-	private boolean printUpdatesToSysout = true;
-
-	/**
-	 * Sets whether the executor should print progress results to "standard out" ({@link System#out}).
-	 * All progress messages are logged using the configured logging framework independent of the value
-	 * set here.
-	 * 
-	 * @param printStatus True, to print progress updates to standard out, false to not do that. 
-	 */
-	public void setPrintStatusDuringExecution(boolean printStatus) {
-		this.printUpdatesToSysout = printStatus;
-	}
-
-	/**
-	 * Gets whether the executor prints progress results to "standard out" ({@link System#out}).
-	 * 
-	 * @return True, if the executor prints progress messages to standard out, false if not.
-	 */
-	public boolean isPrintingStatusDuringExecution() {
-		return this.printUpdatesToSysout;
-	}
-
-	// ------------------------------------------------------------------------
 	//  Startup & Shutdown
 	// ------------------------------------------------------------------------
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
@@ -105,8 +105,7 @@ public class ExecutionConfigTest extends TestLogger {
 				forceAvroEnabled = r.nextBoolean(),
 				forceKryoEnabled = r.nextBoolean(),
 				disableGenericTypes = r.nextBoolean(),
-				objectReuseEnabled = r.nextBoolean(),
-				sysoutLoggingEnabled = r.nextBoolean();
+				objectReuseEnabled = r.nextBoolean();
 
 		final ExecutionConfig config = new ExecutionConfig();
 
@@ -135,11 +134,6 @@ public class ExecutionConfigTest extends TestLogger {
 		} else {
 			config.disableObjectReuse();
 		}
-		if (sysoutLoggingEnabled) {
-			config.enableSysoutLogging();
-		} else {
-			config.disableSysoutLogging();
-		}
 		config.setParallelism(parallelism);
 
 		final ExecutionConfig copy1 = CommonTestUtils.createCopySerializable(config);
@@ -156,7 +150,6 @@ public class ExecutionConfigTest extends TestLogger {
 		assertEquals(forceKryoEnabled, copy1.isForceKryoEnabled());
 		assertEquals(disableGenericTypes, copy1.hasGenericTypesDisabled());
 		assertEquals(objectReuseEnabled, copy1.isObjectReuseEnabled());
-		assertEquals(sysoutLoggingEnabled, copy1.isSysoutLoggingEnabled());
 		assertEquals(parallelism, copy1.getParallelism());
 	}
 }

--- a/flink-end-to-end-tests/flink-confluent-schema-registry/src/main/java/org/apache/flink/schema/registry/test/TestAvroConsumerConfluent.java
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/src/main/java/org/apache/flink/schema/registry/test/TestAvroConsumerConfluent.java
@@ -59,7 +59,6 @@ public class TestAvroConsumerConfluent {
 		String schemaRegistryUrl = parameterTool.getRequired("schema-registry-url");
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataStreamSource<User> input = env
 			.addSource(

--- a/flink-end-to-end-tests/flink-elasticsearch2-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch2SinkExample.java
+++ b/flink-end-to-end-tests/flink-elasticsearch2-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch2SinkExample.java
@@ -54,8 +54,7 @@ public class Elasticsearch2SinkExample {
 		}
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.enableCheckpointing(5000);
+				env.enableCheckpointing(5000);
 
 		DataStream<Tuple2<String, String>> source = env.generateSequence(0, parameterTool.getInt("numRecords") - 1)
 			.flatMap(new FlatMapFunction<Long, Tuple2<String, String>>() {

--- a/flink-end-to-end-tests/flink-elasticsearch5-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch5SinkExample.java
+++ b/flink-end-to-end-tests/flink-elasticsearch5-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch5SinkExample.java
@@ -54,8 +54,7 @@ public class Elasticsearch5SinkExample {
 		}
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.enableCheckpointing(5000);
+				env.enableCheckpointing(5000);
 
 		DataStream<Tuple2<String, String>> source = env.generateSequence(0, parameterTool.getInt("numRecords") - 1)
 			.flatMap(new FlatMapFunction<Long, Tuple2<String, String>>() {

--- a/flink-end-to-end-tests/flink-elasticsearch6-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch6SinkExample.java
+++ b/flink-end-to-end-tests/flink-elasticsearch6-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch6SinkExample.java
@@ -55,8 +55,7 @@ public class Elasticsearch6SinkExample {
 		}
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.enableCheckpointing(5000);
+				env.enableCheckpointing(5000);
 
 		DataStream<Tuple2<String, String>> source = env.generateSequence(0, parameterTool.getInt("numRecords") - 1)
 			.flatMap(new FlatMapFunction<Long, Tuple2<String, String>>() {

--- a/flink-end-to-end-tests/flink-high-parallelism-iterations-test/src/main/java/org/apache/flink/batch/HighParallelismIterationsTestProgram.java
+++ b/flink-end-to-end-tests/flink-high-parallelism-iterations-test/src/main/java/org/apache/flink/batch/HighParallelismIterationsTestProgram.java
@@ -35,7 +35,6 @@ public class HighParallelismIterationsTestProgram {
 
 	public static void main(String[] args) throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		// read vertex and edge data
 		DataSet<Long> vertices = ConnectedComponentsData.getDefaultVertexDataSet(env)

--- a/flink-end-to-end-tests/flink-quickstart-test/src/main/java/org/apache/flink/quickstarts/test/Elasticsearch5SinkExample.java
+++ b/flink-end-to-end-tests/flink-quickstart-test/src/main/java/org/apache/flink/quickstarts/test/Elasticsearch5SinkExample.java
@@ -52,8 +52,7 @@ public class Elasticsearch5SinkExample {
 		}
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.enableCheckpointing(5000);
+				env.enableCheckpointing(5000);
 
 		DataStream<String> source = env.generateSequence(0, parameterTool.getInt("numRecords") - 1)
 			.map(new MapFunction<Long, String>() {

--- a/flink-end-to-end-tests/flink-streaming-kafka-test-base/src/main/java/org/apache/flink/streaming/kafka/test/base/KafkaExampleUtil.java
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test-base/src/main/java/org/apache/flink/streaming/kafka/test/base/KafkaExampleUtil.java
@@ -42,8 +42,7 @@ public class KafkaExampleUtil {
 		}
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
-		env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(4, 10000));
+				env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(4, 10000));
 		env.enableCheckpointing(5000); // create a checkpoint every 5 seconds
 		env.getConfig().setGlobalJobParameters(parameterTool); // make parameters available in the web interface
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -121,7 +121,6 @@ public class LocalEnvironment extends ExecutionEnvironment {
 
 		// create a new local executor
 		executor = PlanExecutor.createLocalExecutor(configuration);
-		executor.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());
 
 		// if we have a session, start the mini cluster eagerly to have it available across sessions
 		if (getSessionTimeout() > 0) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -208,7 +208,6 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		if (executor == null) {
 			executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration,
 				jarFiles, globalClasspaths);
-			executor.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());
 		}
 
 		// if we are using sessions, we keep the executor running

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/DegreesWithExceptionITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/DegreesWithExceptionITCase.java
@@ -44,7 +44,6 @@ public class DegreesWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidSrcData(env), env);
@@ -67,7 +66,6 @@ public class DegreesWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidTrgData(env), env);
@@ -90,7 +88,6 @@ public class DegreesWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidTrgData(env), env);
@@ -113,7 +110,6 @@ public class DegreesWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidSrcData(env), env);
@@ -136,7 +132,6 @@ public class DegreesWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidSrcTrgData(env), env);

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnEdgesWithExceptionITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnEdgesWithExceptionITCase.java
@@ -50,7 +50,6 @@ public class ReduceOnEdgesWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidSrcData(env), env);
@@ -76,7 +75,6 @@ public class ReduceOnEdgesWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidTrgData(env), env);

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnNeighborsWithExceptionITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnNeighborsWithExceptionITCase.java
@@ -52,7 +52,6 @@ public class ReduceOnNeighborsWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidSrcData(env), env);
@@ -79,7 +78,6 @@ public class ReduceOnNeighborsWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidTrgData(env), env);
@@ -106,7 +104,6 @@ public class ReduceOnNeighborsWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidTrgData(env), env);
@@ -131,7 +128,6 @@ public class ReduceOnNeighborsWithExceptionITCase extends AbstractTestBase {
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeInvalidSrcData(env), env);

--- a/flink-python/pyflink/common/tests/test_execution_config.py
+++ b/flink-python/pyflink/common/tests/test_execution_config.py
@@ -196,16 +196,6 @@ class ExecutionConfigTests(PyFlinkTestCase):
 
         self.assertTrue(self.execution_config.is_object_reuse_enabled())
 
-    def test_disable_enable_sysout_logging(self):
-
-        self.execution_config.disable_sysout_logging()
-
-        self.assertFalse(self.execution_config.is_sysout_logging_enabled())
-
-        self.execution_config.enable_sysout_logging()
-
-        self.assertTrue(self.execution_config.is_sysout_logging_enabled())
-
     def test_get_set_global_job_parameters(self):
 
         self.execution_config.set_global_job_parameters({"hello": "world"})

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
@@ -76,8 +76,6 @@ public class ScalaShellRemoteEnvironment extends RemoteEnvironment {
 			globalClasspaths
 		);
 
-		executor.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());
-
 		return executor;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -274,8 +274,6 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 				streamGraph.getJobGraph().getJobID(), e);
 		}
 
-		client.setPrintStatusDuringExecution(executionConfig.isSysoutLoggingEnabled());
-
 		if (savepointRestoreSettings == null) {
 			savepointRestoreSettings = SavepointRestoreSettings.none();
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorErrorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorErrorITCase.java
@@ -65,7 +65,6 @@ public class AccumulatorErrorITCase extends TestLogger {
 	@Test
 	public void testFaultyAccumulator() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		// Test Exception forwarding with faulty Accumulator implementation
 		env.generateSequence(0, 10000)
@@ -78,8 +77,6 @@ public class AccumulatorErrorITCase extends TestLogger {
 	@Test
 	public void testInvalidTypeAccumulator() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-
-		env.getConfig().disableSysoutLogging();
 
 		// Test Exception forwarding with faulty Accumulator implementation
 		env.generateSequence(0, 10000)
@@ -101,7 +98,6 @@ public class AccumulatorErrorITCase extends TestLogger {
 	@Test
 	public void testFaultyMergeAccumulator() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		// Test Exception forwarding with faulty Accumulator implementation
 		env.generateSequence(0, 10000)

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -87,7 +87,6 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
 
 			env
 					.addSource(new FailingSource(new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(numKeys, windowSize), numElementsPerKey))
@@ -148,7 +147,6 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
 
 			env
 				.addSource(new FailingSource(new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(numKeys, windowSlide), numElementsPerKey))
@@ -208,7 +206,6 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
 
 			env
 				.addSource(new FailingSource(new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(numKeys, windowSize), numElementsPerKey))
@@ -277,7 +274,6 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
 
 			env
 				.addSource(new FailingSource(new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(numKeys, windowSize), numElementsPerKey))
@@ -346,7 +342,6 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
 
 			env
 				.addSource(new FailingSource(new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(numKeys, windowSlide), numElementsPerKey))

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -260,8 +260,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
-			env.setStateBackend(this.stateBackend);
+						env.setStateBackend(this.stateBackend);
 			env.getConfig().setUseSnapshotCompression(true);
 
 			env
@@ -336,8 +335,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
-			env.setStateBackend(this.stateBackend);
+						env.setStateBackend(this.stateBackend);
 			env.getConfig().setUseSnapshotCompression(true);
 
 			env
@@ -405,8 +403,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
-			env.setStateBackend(this.stateBackend);
+						env.setStateBackend(this.stateBackend);
 			env.getConfig().setUseSnapshotCompression(true);
 
 			env
@@ -470,8 +467,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
-			env.setStateBackend(this.stateBackend);
+						env.setStateBackend(this.stateBackend);
 			env.getConfig().setUseSnapshotCompression(true);
 
 			env
@@ -543,8 +539,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
-			env.setStateBackend(this.stateBackend);
+						env.setStateBackend(this.stateBackend);
 			env.getConfig().setUseSnapshotCompression(true);
 
 			env

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/KeyedStateCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/KeyedStateCheckpointingITCase.java
@@ -145,8 +145,7 @@ public class KeyedStateCheckpointingITCase extends TestLogger {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(PARALLELISM);
 		env.enableCheckpointing(500);
-		env.getConfig().disableSysoutLogging();
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0L));
+				env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0L));
 
 		env.setStateBackend(stateBackend);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -167,7 +167,6 @@ public class RegionFailoverITCase extends TestLogger {
 		env.enableCheckpointing(200, CheckpointingMode.EXACTLY_ONCE);
 		env.getCheckpointConfig().enableExternalizedCheckpoints(CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
 		env.disableOperatorChaining();
-		env.getConfig().disableSysoutLogging();
 
 		// Use DataStreamUtils#reinterpretAsKeyed to avoid merge regions and this stream graph would exist num of 'NUM_OF_REGIONS' individual regions.
 		DataStreamUtils.reinterpretAsKeyedStream(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -510,7 +510,6 @@ public class SavepointITCase extends TestLogger {
 		env.setParallelism(parallelism);
 		env.disableOperatorChaining();
 		env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(numberOfRetries, restartDelay));
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> stream = env
 			.addSource(new InfiniteTestSource())

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
@@ -119,8 +119,7 @@ public abstract class StreamFaultToleranceTestBase extends TestLogger {
 			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARALLELISM);
 			env.enableCheckpointing(500);
-			env.getConfig().disableSysoutLogging();
-			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0L));
+						env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0L));
 
 			testProgram(env);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/WindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/WindowCheckpointingITCase.java
@@ -97,7 +97,6 @@ public class WindowCheckpointingITCase extends TestLogger {
 			env.getConfig().setAutoWatermarkInterval(10);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
 
 			SinkValidatorUpdaterAndChecker updaterAndChecker =
 				new SinkValidatorUpdaterAndChecker(numElements, 1);
@@ -155,8 +154,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 			env.getConfig().setAutoWatermarkInterval(10);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
-			SinkValidatorUpdaterAndChecker updaterAndChecker =
+						SinkValidatorUpdaterAndChecker updaterAndChecker =
 				new SinkValidatorUpdaterAndChecker(numElements, 3);
 			env
 					.addSource(new FailingSource(new Generator(), numElements, timeCharacteristic))
@@ -211,8 +209,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 			env.getConfig().setAutoWatermarkInterval(10);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
-			SinkValidatorUpdaterAndChecker updaterAndChecker =
+						SinkValidatorUpdaterAndChecker updaterAndChecker =
 				new SinkValidatorUpdaterAndChecker(numElements, 1);
 			env
 					.addSource(new FailingSource(new Generator(), numElements, timeCharacteristic))
@@ -257,8 +254,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 			env.getConfig().setAutoWatermarkInterval(10);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-			env.getConfig().disableSysoutLogging();
-			SinkValidatorUpdaterAndChecker updaterAndChecker =
+						SinkValidatorUpdaterAndChecker updaterAndChecker =
 				new SinkValidatorUpdaterAndChecker(numElements, 3);
 			env
 					.addSource(new FailingSource(new Generator(), numElements, timeCharacteristic))

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointedStreamingProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointedStreamingProgram.java
@@ -42,8 +42,7 @@ public class CheckpointedStreamingProgram {
 	public static void main(String[] args) throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-		env.getConfig().disableSysoutLogging();
-		env.enableCheckpointing(CHECKPOINT_INTERVALL);
+				env.enableCheckpointing(CHECKPOINT_INTERVALL);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 100L));
 		env.disableOperatorChaining();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointingCustomKvStateProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointingCustomKvStateProgram.java
@@ -61,8 +61,7 @@ public class CheckpointingCustomKvStateProgram {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		env.setParallelism(parallelism);
-		env.getConfig().disableSysoutLogging();
-		env.enableCheckpointing(100);
+				env.enableCheckpointing(100);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000));
 		env.setStateBackend(new FsStateBackend(checkpointPath));
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomInputSplitProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomInputSplitProgram.java
@@ -45,7 +45,6 @@ public class CustomInputSplitProgram {
 	public static void main(String[] args) throws Exception {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Integer> data = env.createInput(new CustomInputFormat());
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomKvStateProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomKvStateProgram.java
@@ -50,8 +50,7 @@ public class CustomKvStateProgram {
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(parallelism);
-		env.getConfig().disableSysoutLogging();
-		env.enableCheckpointing(checkpointingInterval);
+				env.enableCheckpointing(checkpointingInterval);
 		env.setStateBackend(new FsStateBackend(checkpointPath));
 
 		DataStream<Integer> source = env.addSource(new InfiniteIntegerSource());

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/KMeansForTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/KMeansForTest.java
@@ -60,7 +60,6 @@ public class KMeansForTest {
 		final int numIterations = Integer.parseInt(args[2]);
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		// get input data
 		DataSet<Point> points = env.fromElements(pointsData.split("\n"))

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
@@ -51,8 +51,6 @@ public class StreamingCustomInputSplitProgram {
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-		env.getConfig().disableSysoutLogging();
-
 		DataStream<Integer> data = env.createInput(new CustomInputFormat());
 
 		data.map(new MapFunction<Integer, Tuple2<Integer, Double>>() {

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingProgram.java
@@ -35,7 +35,6 @@ public class StreamingProgram {
 
 	public static void main(String[] args) throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<String> text = env.fromElements(WordCountData.TEXT).rebalance();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/UserCodeType.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/UserCodeType.java
@@ -44,7 +44,6 @@ public class UserCodeType {
 
 	public static void main(String[] args) throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Integer> input = env.fromElements(1, 2, 3, 4, 5);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
@@ -56,7 +56,6 @@ public class LocalExecutorITCase extends TestLogger {
 			LocalExecutor executor = new LocalExecutor();
 			executor.setDefaultOverwriteFiles(true);
 			executor.setTaskManagerNumSlots(parallelism);
-			executor.setPrintStatusDuringExecution(false);
 			executor.start();
 			Plan wcPlan = getWordCountPlan(inFile, outFile, parallelism);
 			wcPlan.setExecutionConfig(new ExecutionConfig());

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/OverwriteObjects.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/OverwriteObjects.java
@@ -70,7 +70,6 @@ public class OverwriteObjects {
 		LOG.info("Random seed = {}", RANDOM_SEED);
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		for (int parallelism = MAX_PARALLELISM; parallelism > 0; parallelism--) {
 			LOG.info("Parallelism = {}", parallelism);

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
@@ -68,7 +68,6 @@ public class CustomSerializationITCase extends TestLogger {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARLLELISM);
-			env.getConfig().disableSysoutLogging();
 
 			env
 				.generateSequence(1, 10 * PARLLELISM)
@@ -99,7 +98,6 @@ public class CustomSerializationITCase extends TestLogger {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARLLELISM);
-			env.getConfig().disableSysoutLogging();
 
 			env
 					.generateSequence(1, 10 * PARLLELISM)
@@ -130,7 +128,6 @@ public class CustomSerializationITCase extends TestLogger {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARLLELISM);
-			env.getConfig().disableSysoutLogging();
 
 			env
 					.generateSequence(1, 10 * PARLLELISM)
@@ -161,7 +158,6 @@ public class CustomSerializationITCase extends TestLogger {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARLLELISM);
-			env.getConfig().disableSysoutLogging();
 
 			env
 					.generateSequence(1, 10 * PARLLELISM)

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/MiscellaneousIssuesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/MiscellaneousIssuesITCase.java
@@ -66,7 +66,6 @@ public class MiscellaneousIssuesITCase extends TestLogger {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(1);
-			env.getConfig().disableSysoutLogging();
 
 			DataSet<String> data = env.fromElements("hallo")
 					.map(new MapFunction<String, String>() {
@@ -97,7 +96,6 @@ public class MiscellaneousIssuesITCase extends TestLogger {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(5);
-			env.getConfig().disableSysoutLogging();
 
 			// generate two different flows
 			env.generateSequence(1, 10).output(new DiscardingOutputFormat<Long>());
@@ -118,7 +116,6 @@ public class MiscellaneousIssuesITCase extends TestLogger {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(6);
-			env.getConfig().disableSysoutLogging();
 
 			env.generateSequence(1, 1000000)
 					.rebalance()

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -87,7 +87,6 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 	private static void runConnectedComponents(ExecutionEnvironment env) throws Exception {
 
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		// read vertex and edge data
 		DataSet<Long> vertices = ConnectedComponentsData.getDefaultVertexDataSet(env)
@@ -128,7 +127,6 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 	private static void runKMeans(ExecutionEnvironment env) throws Exception {
 
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		// get input data
 		DataSet<KMeans.Point> points =  KMeansData.getDefaultPointDataSet(env).rebalance();

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ExecutionEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ExecutionEnvironmentITCase.java
@@ -52,7 +52,6 @@ public class ExecutionEnvironmentITCase extends TestLogger {
 		conf.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, PARALLELISM);
 
 		final ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(conf);
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Integer> result = env.createInput(new ParallelismDependentInputFormat())
 				.rebalance()

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/RemoteEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/RemoteEnvironmentITCase.java
@@ -75,7 +75,6 @@ public class RemoteEnvironmentITCase extends TestLogger {
 				config
 		);
 		env.setParallelism(USER_DOP);
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Integer> result = env.createInput(new ParallelismDependentInputFormat())
 				.rebalance()

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/TypeHintITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/TypeHintITCase.java
@@ -48,7 +48,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testIdentityMapWithMissingTypesAndStringTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple3<Integer, Long, String>> identityMapDs = ds
@@ -66,7 +65,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testIdentityMapWithMissingTypesAndTypeInformationTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple3<Integer, Long, String>> identityMapDs = ds
@@ -86,7 +84,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testFlatMapWithClassTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Integer> identityMapDs = ds
@@ -104,7 +101,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testJoinWithTypeInformationTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
@@ -126,7 +122,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testFlatJoinWithTypeInformationTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
@@ -148,7 +143,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testUnsortedGroupReduceWithTypeInformationTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Integer> resultDs = ds
@@ -167,7 +161,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testSortedGroupReduceWithTypeInformationTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Integer> resultDs = ds
@@ -187,7 +180,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testCombineGroupWithTypeInformationTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Integer> resultDs = ds
@@ -206,7 +198,6 @@ public class TypeHintITCase extends AbstractTestBase {
 	@Test
 	public void testCoGroupWithTypeInformationTypeHint() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().disableSysoutLogging();
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/FastFailuresITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/FastFailuresITCase.java
@@ -49,8 +49,7 @@ public class FastFailuresITCase extends AbstractTestBase {
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-		env.getConfig().disableSysoutLogging();
-		env.setParallelism(parallelism);
+				env.setParallelism(parallelism);
 		env.enableCheckpointing(1000);
 		env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(210, 0));
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -161,7 +161,6 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0L));
 		env.getConfig().setExecutionMode(executionMode);
-		env.getConfig().disableSysoutLogging();
 
 		final long numElements = 100000L;
 		final DataSet<Long> result = env.generateSequence(1, numElements)

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -169,7 +169,6 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 						ExecutionEnvironment env = ExecutionEnvironment.createRemoteEnvironment("localhost", 1337, config);
 						env.setParallelism(2);
 						env.setRestartStrategy(RestartStrategies.noRestart());
-						env.getConfig().disableSysoutLogging();
 
 						env.generateSequence(0, Long.MAX_VALUE)
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
@@ -55,7 +55,6 @@ public abstract class SimpleRecoveryITCaseBase {
 
 				env.setParallelism(4);
 				env.setRestartStrategy(RestartStrategies.noRestart());
-				env.getConfig().disableSysoutLogging();
 
 				env.generateSequence(1, 10)
 						.rebalance()
@@ -84,7 +83,6 @@ public abstract class SimpleRecoveryITCaseBase {
 
 				env.setParallelism(4);
 				env.setRestartStrategy(RestartStrategies.noRestart());
-				env.getConfig().disableSysoutLogging();
 
 				env.generateSequence(1, 10)
 						.rebalance()
@@ -136,7 +134,6 @@ public abstract class SimpleRecoveryITCaseBase {
 
 			env.setParallelism(4);
 			// the default restart strategy should be taken
-			env.getConfig().disableSysoutLogging();
 
 			env.generateSequence(1, 10)
 					.rebalance()
@@ -174,7 +171,6 @@ public abstract class SimpleRecoveryITCaseBase {
 
 			env.setParallelism(4);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, 100));
-			env.getConfig().disableSysoutLogging();
 
 			env.generateSequence(1, 10)
 					.rebalance()

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -70,7 +70,6 @@ public class TaskManagerProcessFailureBatchRecoveryITCase extends AbstractTaskMa
 		env.setParallelism(PARALLELISM);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(2, 0L));
 		env.getConfig().setExecutionMode(executionMode);
-		env.getConfig().disableSysoutLogging();
 
 		final long numElements = 100000L;
 		final DataSet<Long> result = env.generateSequence(1, numElements)

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureStreamingRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureStreamingRecoveryITCase.java
@@ -70,8 +70,7 @@ public class TaskManagerProcessFailureStreamingRecoveryITCase extends AbstractTa
 			1337, // not needed since we use ZooKeeper
 			configuration);
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000));
+				env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000));
 		env.enableCheckpointing(200);
 
 		env.setStateBackend(new FsStateBackend(tempCheckpointDir.getAbsoluteFile().toURI()));

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
@@ -87,7 +87,6 @@ public class IPv6HostnamesITCase extends TestLogger {
 
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(4);
-			env.getConfig().disableSysoutLogging();
 
 			// get input data
 			DataSet<String> text = env.fromElements(WordCountData.TEXT.split("\n"));

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NettyEpollITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NettyEpollITCase.java
@@ -51,7 +51,6 @@ public class NettyEpollITCase extends TestLogger {
 		try {
 			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(NUM_TASK_MANAGERS);
-			env.getConfig().disableSysoutLogging();
 
 			DataStream<Integer> input = env.fromElements(1, 2, 3, 4, 1, 2, 3, 42);
 			input.keyBy(new KeySelector<Integer, Integer>() {

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
@@ -267,7 +267,6 @@ public class NetworkStackThroughputITCase extends TestLogger {
 			final int parallelism) throws Exception {
 		ClusterClient<?> client = cluster.getClusterClient();
 		client.setDetached(false);
-		client.setPrintStatusDuringExecution(false);
 
 		JobExecutionResult jer = (JobExecutionResult) client.submitJob(
 			createJobGraph(

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -119,7 +119,6 @@ public class TimestampITCase extends TestLogger {
 
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new MyTimestampSource(initialTime, numWatermarks));
 		DataStream<Integer> source2 = env.addSource(new MyTimestampSource(initialTime, numWatermarks / 2));
@@ -169,7 +168,6 @@ public class TimestampITCase extends TestLogger {
 
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new MyTimestampSourceInfinite(initialTime, numWatermarks));
 		DataStream<Integer> source2 = env.addSource(new MyTimestampSourceInfinite(initialTime, numWatermarks / 2));
@@ -257,7 +255,6 @@ public class TimestampITCase extends TestLogger {
 
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new MyTimestampSource(0L, numElements));
 		DataStream<Integer> source2 = env.addSource(new MyTimestampSource(0L, numElements));
@@ -282,7 +279,6 @@ public class TimestampITCase extends TestLogger {
 
 		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 		env.setParallelism(PARALLELISM);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new MyNonWatermarkingSource(numElements));
 		DataStream<Integer> source2 = env.addSource(new MyNonWatermarkingSource(numElements));
@@ -310,7 +306,6 @@ public class TimestampITCase extends TestLogger {
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.getConfig().setAutoWatermarkInterval(10);
 		env.setParallelism(1);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new SourceFunction<Integer>() {
 			@Override
@@ -373,7 +368,6 @@ public class TimestampITCase extends TestLogger {
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.getConfig().setAutoWatermarkInterval(10);
 		env.setParallelism(1);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new SourceFunction<Integer>() {
 			@Override
@@ -432,7 +426,6 @@ public class TimestampITCase extends TestLogger {
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.getConfig().setAutoWatermarkInterval(1);
 		env.setParallelism(1);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new SourceFunction<Integer>() {
 			@Override
@@ -492,7 +485,6 @@ public class TimestampITCase extends TestLogger {
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.getConfig().setAutoWatermarkInterval(1);
 		env.setParallelism(2);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new SourceFunction<Integer>() {
 			@Override
@@ -551,7 +543,6 @@ public class TimestampITCase extends TestLogger {
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.getConfig().setAutoWatermarkInterval(10);
 		env.setParallelism(2);
-		env.getConfig().disableSysoutLogging();
 
 		DataStream<Integer> source1 = env.addSource(new SourceFunction<Integer>() {
 			@Override
@@ -605,8 +596,7 @@ public class TimestampITCase extends TestLogger {
 				StreamExecutionEnvironment.getExecutionEnvironment();
 
 		env.setParallelism(2);
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
 		DataStream<Integer> source1 = env.addSource(new MyTimestampSource(0, 10));
 
@@ -626,8 +616,7 @@ public class TimestampITCase extends TestLogger {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		env.setParallelism(2);
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
 		DataStream<Tuple2<String, Integer>> source1 =
 				env.fromElements(new Tuple2<>("a", 1), new Tuple2<>("b", 2));
@@ -656,8 +645,7 @@ public class TimestampITCase extends TestLogger {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		env.setParallelism(2);
-		env.getConfig().disableSysoutLogging();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+				env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		DataStream<Tuple2<String, Integer>> source1 =
 				env.fromElements(new Tuple2<>("a", 1), new Tuple2<>("b", 2));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
@@ -82,13 +82,13 @@ public class CliFrontendRunWithYarnTest extends CliFrontendTestBase {
 		// test detached mode
 		{
 			String[] parameters = {"-m", "yarn-cluster", "-yn", "1", "-p", "2", "-d", testJarPath};
-			verifyCliFrontend(yarnCLI, parameters, 2, true, true);
+			verifyCliFrontend(yarnCLI, parameters, 2, true);
 		}
 
 		// test detached mode
 		{
 			String[] parameters = {"-m", "yarn-cluster", "-yn", "1", "-p", "2", "-yd", testJarPath};
-			verifyCliFrontend(yarnCLI, parameters, 2, true, true);
+			verifyCliFrontend(yarnCLI, parameters, 2, true);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Remove unused logic of printStatusDuringExecution. Because it accidentally depends on remove methods in `ExecutionConfig`(In any way the methods relevant are no power but the class is marked as `@Public`), we might fall back to mark the methods relevant as `@Deprecated` and still live with them.

Please let me know what is the proper approach to treat these "breaking changes".

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, ExecutionConfig, accidentally.)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @mxm 
