### PR TITLE
[FLINK-13810][Docs]Update `Elasticsearch Connector` label

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -771,7 +771,7 @@ Make sure to add the version-specific Kafka dependency. In addition, a correspon
 
 ### Elasticsearch Connector
 
-<span class="label label-primary">Sink: Streaming Append Mode</span>
+<span class="label label-primary">Source: Streaming Append Mode</span>
 <span class="label label-primary">Sink: Streaming Upsert Mode</span>
 <span class="label label-info">Format: JSON-only</span>
 

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -771,7 +771,7 @@ Make sure to add the version-specific Kafka dependency. In addition, a correspon
 
 ### Elasticsearch Connector
 
-<span class="label label-primary">Sink: Streaming Append Mode</span>
+<span class="label label-primary">Source: Streaming Append Mode</span>
 <span class="label label-primary">Sink: Streaming Upsert Mode</span>
 <span class="label label-info">Format: JSON-only</span>
 


### PR DESCRIPTION
## What is the purpose of the change

For document: https://ci.apache.org/projects/flink/flink-docs-release-1.8/dev/table/connect.html#elasticsearch-connector
 
<span class="label label-primary">Sink: Streaming Append Mode</span>
<span class="label label-primary">Sink: Streaming Upsert Mode</span>
<span class="label label-info">Format: JSON-only</span>
 
The first lable for `Elasticsearch Connector` should be Source.

![](https://issues.apache.org/jira/secure/attachment/12978156/12978156_image-2019-08-21-16-54-51-666.png)

## Documentation

  - Does this pull request introduce a new feature? (  no)
