### PR TITLE
[FLINK-13814][hive] HiveTableSink should strip quotes from partition …

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.thrift.TException;
 
@@ -170,7 +171,7 @@ public class HiveTableSink extends OutputFormatTableSink<Row> implements Partiti
 		staticPartitionSpec = new LinkedHashMap<>();
 		for (String partitionCol : getPartitionFieldNames()) {
 			if (partitionSpec.containsKey(partitionCol)) {
-				staticPartitionSpec.put(partitionCol, partitionSpec.get(partitionCol));
+				staticPartitionSpec.put(partitionCol, PlanUtils.stripQuotes(partitionSpec.get(partitionCol)));
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.thrift.TException;
 
@@ -171,7 +170,7 @@ public class HiveTableSink extends OutputFormatTableSink<Row> implements Partiti
 		staticPartitionSpec = new LinkedHashMap<>();
 		for (String partitionCol : getPartitionFieldNames()) {
 			if (partitionSpec.containsKey(partitionCol)) {
-				staticPartitionSpec.put(partitionCol, PlanUtils.stripQuotes(partitionSpec.get(partitionCol)));
+				staticPartitionSpec.put(partitionCol, partitionSpec.get(partitionCol));
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.connectors.hive;
 
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
@@ -183,6 +184,57 @@ public class TableEnvHiveConnectorTest {
 			tableEnv.sqlUpdate("insert overwrite db1.dest values (3,'c')");
 			tableEnv.execute("test insert overwrite");
 			verifyHiveQueryResult("select * from db1.dest", Collections.singletonList("3\tc"));
+		} finally {
+			hiveShell.execute("drop database db1 cascade");
+		}
+	}
+
+	@Test
+	public void testStaticPartition() throws Exception {
+		hiveShell.execute("create database db1");
+		try {
+			hiveShell.execute("create table db1.src (x int)");
+			hiveShell.insertInto("db1", "src").addRow(1).addRow(2).commit();
+			hiveShell.execute("create table db1.dest (x int) partitioned by (p1 string, p2 double)");
+			TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
+			tableEnv.sqlUpdate("insert into db1.dest partition (p1='1', p2=1.1) select x from db1.src");
+			tableEnv.execute("static partitioning");
+			assertEquals(1, hiveCatalog.listPartitions(new ObjectPath("db1", "dest")).size());
+			verifyHiveQueryResult("select * from db1.dest", Arrays.asList("1\t1\t1.1", "2\t1\t1.1"));
+		} finally {
+			hiveShell.execute("drop database db1 cascade");
+		}
+	}
+
+	@Test
+	public void testDynamicPartition() throws Exception {
+		hiveShell.execute("create database db1");
+		try {
+			hiveShell.execute("create table db1.src (x int, y string, z double)");
+			hiveShell.insertInto("db1", "src").addRow(1, "a", 1.1).addRow(2, "a", 2.2).addRow(3, "b", 3.3).commit();
+			hiveShell.execute("create table db1.dest (x int) partitioned by (p1 string, p2 double)");
+			TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
+			tableEnv.sqlUpdate("insert into db1.dest select * from db1.src");
+			tableEnv.execute("dynamic partitioning");
+			assertEquals(3, hiveCatalog.listPartitions(new ObjectPath("db1", "dest")).size());
+			verifyHiveQueryResult("select * from db1.dest", Arrays.asList("1\ta\t1.1", "2\ta\t2.2", "3\tb\t3.3"));
+		} finally {
+			hiveShell.execute("drop database db1 cascade");
+		}
+	}
+
+	@Test
+	public void testPartialDynamicPartition() throws Exception {
+		hiveShell.execute("create database db1");
+		try {
+			hiveShell.execute("create table db1.src (x int, y string)");
+			hiveShell.insertInto("db1", "src").addRow(1, "a").addRow(2, "b").commit();
+			hiveShell.execute("create table db1.dest (x int) partitioned by (p1 double, p2 string)");
+			TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
+			tableEnv.sqlUpdate("insert into db1.dest partition (p1=1.1) select x,y from db1.src");
+			tableEnv.execute("partial dynamic partitioning");
+			assertEquals(2, hiveCatalog.listPartitions(new ObjectPath("db1", "dest")).size());
+			verifyHiveQueryResult("select * from db1.dest", Arrays.asList("1\t1.1\ta", "2\t1.1\tb"));
 		} finally {
 			hiveShell.execute("drop database db1 cascade");
 		}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
@@ -197,10 +197,10 @@ public class TableEnvHiveConnectorTest {
 			hiveShell.insertInto("db1", "src").addRow(1).addRow(2).commit();
 			hiveShell.execute("create table db1.dest (x int) partitioned by (p1 string, p2 double)");
 			TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-			tableEnv.sqlUpdate("insert into db1.dest partition (p1='1', p2=1.1) select x from db1.src");
+			tableEnv.sqlUpdate("insert into db1.dest partition (p1='1''1', p2=1.1) select x from db1.src");
 			tableEnv.execute("static partitioning");
 			assertEquals(1, hiveCatalog.listPartitions(new ObjectPath("db1", "dest")).size());
-			verifyHiveQueryResult("select * from db1.dest", Arrays.asList("1\t1\t1.1", "2\t1\t1.1"));
+			verifyHiveQueryResult("select * from db1.dest", Arrays.asList("1\t1'1\t1.1", "2\t1'1\t1.1"));
 		} finally {
 			hiveShell.execute("drop database db1 cascade");
 		}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.NlsString;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -61,7 +62,8 @@ public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 
 	/** Get static partition key value pair as strings.
 	 *
-	 * <p>Caution that we use {@link SqlLiteral#toString()} to get
+	 * <p>For character literals we return the unquoted and unescaped values.
+	 * For other types we use {@link SqlLiteral#toString()} to get
 	 * the string format of the value literal. If the string format is not
 	 * what you need, use {@link #getStaticPartitions()}.
 	 *
@@ -75,7 +77,8 @@ public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 		}
 		for (SqlNode node : this.staticPartitions.getList()) {
 			SqlProperty sqlProperty = (SqlProperty) node;
-			String value = SqlLiteral.value(sqlProperty.getValue()).toString();
+			Comparable comparable = SqlLiteral.value(sqlProperty.getValue());
+			String value = comparable instanceof NlsString ? ((NlsString) comparable).getValue() : comparable.toString();
 			ret.put(sqlProperty.getKey().getSimple(), value);
 		}
 		return ret;


### PR DESCRIPTION
…values

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Strip quotes from partition value in order to get proper string values.


## Brief change log

  - Strip quotes when we get partition spec from the planner
  - Added test to verify string partition values are properly handled
  - Migrated some existing tests to `TableEnvHiveConnectorTest` since the planner has now supported `PartitionableTableSink`


## Verifying this change

Added test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
