### PR TITLE
[FLINK-13806][metrics] Log all errors on DEBUG

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherImpl.java
@@ -139,7 +139,7 @@ public class MetricFetcherImpl<T extends RestfulGateway> implements MetricFetche
 				queryServiceAddressesFuture.whenCompleteAsync(
 					(Collection<String> queryServiceAddresses, Throwable throwable) -> {
 						if (throwable != null) {
-							LOG.warn("Requesting paths for query services failed.", throwable);
+							LOG.debug("Requesting paths for query services failed.", throwable);
 						} else {
 							for (String queryServiceAddress : queryServiceAddresses) {
 								retrieveAndQueryMetrics(queryServiceAddress);
@@ -157,7 +157,7 @@ public class MetricFetcherImpl<T extends RestfulGateway> implements MetricFetche
 				taskManagerQueryServiceGatewaysFuture.whenCompleteAsync(
 					(Collection<Tuple2<ResourceID, String>> queryServiceGateways, Throwable throwable) -> {
 						if (throwable != null) {
-							LOG.warn("Requesting TaskManager's path for query services failed.", throwable);
+							LOG.debug("Requesting TaskManager's path for query services failed.", throwable);
 						} else {
 							List<String> taskManagersToRetain = queryServiceGateways
 								.stream()
@@ -175,7 +175,7 @@ public class MetricFetcherImpl<T extends RestfulGateway> implements MetricFetche
 					executor);
 			}
 		} catch (Exception e) {
-			LOG.warn("Exception while fetching metrics.", e);
+			LOG.debug("Exception while fetching metrics.", e);
 		}
 	}
 


### PR DESCRIPTION
This PR sets the log level of all messages in the `MetricFetcher` to debug.

Errors in the MetricFetcher are mostly due the connection with a TaskExecutor breaking down, which are logged in a more appropriate way elsewhere (relevant: FLINK-13805).
Additionally, the MetricFetcher is one of those components which does not crash when running into exceptions, and thus should special care on what it logs, as any message will likely be logged several times.