### PR TITLE
[FLINK-13761][datastream] Deprecate SplitStream

### DIFF
--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/SplitStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/SplitStream.scala
@@ -29,6 +29,7 @@ import org.apache.flink.streaming.api.datastream.{ SplitStream => SplitJavaStrea
  * the appropriate method on this stream.
  */
 @Public
+@deprecated
 class SplitStream[T](javaStream: SplitJavaStream[T]) extends DataStream[T](javaStream){
 
   /**


### PR DESCRIPTION
The split() API was deprecated, but the scala SplitStream class was missed when this was done.