### PR TITLE
[FLINK-13745][travis] Retain cache of most recent build

### DIFF
--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -80,8 +80,8 @@ function deleteOldCaches() {
 	done
 }
 
-# delete leftover caches from previous builds
-find "$CACHE_DIR" -mindepth 1 -maxdepth 1 | grep -v "$TRAVIS_BUILD_NUMBER" | deleteOldCaches
+# delete leftover caches from previous builds; except the most recent
+find "$CACHE_DIR" -mindepth 1 -maxdepth 1 | grep -v "$TRAVIS_BUILD_NUMBER" | sort -Vr | tail -n +2 | deleteOldCaches
 
 STAGE=$1
 echo "Current stage: \"$STAGE\""


### PR DESCRIPTION
Whenever we run a Travis build we first delete the cached artifacts of previous builds. This must be done because there's no build-wide cleanup hook, and we can't have the cache grow indefinitely.

However, this also means that if 2 builds are running at the same time, the latter may _at some point_ delete the cache of the first build, while the first one may still need it. Lately we've seen a few failures due to this.

This PR is a compromise between timely cleanup and build stability, and relaxes the cleanup logic slightly so that the artifacts of the most recent build will not be deleted.