### PR TITLE
[FLINK-13750][client] Separate client/cluster-side high-availability services

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -3506,6 +3506,53 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
 <table class="table table-bordered">
   <tbody>
     <tr>
+      <td class="text-left" colspan="2"><h5><strong>/leader-info</strong></h5></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Get leader info of the cluster</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-555102593">Request</button>
+        <div id="-555102593" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#990896146">Response</button>
+        <div id="990896146" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:LeaderInfo",
+  "properties" : {
+    "address" : {
+      "type" : "string"
+    },
+    "dispatcher-id" : {
+      "type" : "string"
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
       <td class="text-left" colspan="2"><h5><strong>/overview</strong></h5></td>
     </tr>
     <tr>

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.util.LeaderConnectionInfo;
+import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
@@ -51,14 +53,14 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	private final MiniCluster miniCluster;
 
 	public MiniClusterClient(@Nonnull Configuration configuration, @Nonnull MiniCluster miniCluster) {
-		super(configuration, miniCluster.getHighAvailabilityServices(), true);
+		super(configuration);
 
 		this.miniCluster = miniCluster;
 	}
 
 	@Override
 	public void shutdown() throws Exception {
-		super.shutdown();
+		// no op
 	}
 
 	@Override
@@ -94,6 +96,13 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 				throw new ProgramInvocationException("Job failed", jobGraph.getJobID(), e);
 			}
 		}
+	}
+
+	@Override
+	public LeaderConnectionInfo getClusterConnectionInfo() throws Exception {
+		return LeaderRetrievalUtils.retrieveLeaderConnectionInfo(
+			miniCluster.getHighAvailabilityServices().getDispatcherLeaderRetriever(),
+			timeout);
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/RemoteExecutorHostnameResolutionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/RemoteExecutorHostnameResolutionTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Collections;
 
@@ -51,35 +50,31 @@ public class RemoteExecutorHostnameResolutionTest extends TestLogger {
 
 	@Test
 	public void testUnresolvableHostname1() throws Exception {
-
 		RemoteExecutor exec = new RemoteExecutor(nonExistingHostname, port);
 		try {
 			exec.executePlan(getProgram());
 			fail("This should fail with an ProgramInvocationException");
-		}
-		catch (UnknownHostException ignored) {
-			// that is what we want!
+		} catch (UnknownHostException ignore) {
+			// expected
 		}
 	}
 
 	@Test
 	public void testUnresolvableHostname2() throws Exception {
-
 		InetSocketAddress add = new InetSocketAddress(nonExistingHostname, port);
-		RemoteExecutor exec = new RemoteExecutor(add, new Configuration(),
-				Collections.<URL>emptyList(), Collections.<URL>emptyList());
+
+		RemoteExecutor exec = new RemoteExecutor(add, new Configuration(), Collections.emptyList(), Collections.emptyList());
 		try {
 			exec.executePlan(getProgram());
 			fail("This should fail with an ProgramInvocationException");
-		}
-		catch (UnknownHostException ignored) {
-			// that is what we want!
+		} catch (UnknownHostException ignore) {
+			// expected
 		}
 	}
 
 	private static Plan getProgram() {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.fromElements(1, 2, 3).output(new DiscardingOutputFormat<Integer>());
+		env.fromElements(1, 2, 3).output(new DiscardingOutputFormat<>());
 		return env.createProgramPlan();
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/RetrieveLeaderInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/RetrieveLeaderInfoTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client;
+
+import org.apache.flink.client.deployment.StandaloneClusterId;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.MiniClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ *
+ */
+public class RetrieveLeaderInfoTest extends TestLogger {
+
+	@Test
+	public void testRestClusterClientProperlyRetrieveLeaderInfo() throws Exception {
+		MiniClusterResourceConfiguration cfg = new MiniClusterResourceConfiguration.Builder().build();
+		MiniClusterResource resource = new MiniClusterResource(cfg);
+
+		ClusterClient<?> client = null;
+		try {
+			resource.before();
+
+			HighAvailabilityServices haServices = resource.getMiniCluster().getHighAvailabilityServices();
+
+			LeaderRetriever webMonitorLeaderRetriever = new LeaderRetriever();
+			haServices.getWebMonitorLeaderRetriever().start(webMonitorLeaderRetriever);
+
+			URL url = webMonitorLeaderRetriever.getLeaderFuture()
+				.thenApply(leaderAddressSessionId -> {
+					final String address = leaderAddressSessionId.f0;
+					try {
+						return new URL(address);
+					} catch (MalformedURLException e) {
+						throw new IllegalArgumentException("Could not parse URL from " + address, e);
+					}
+				})
+				.get(2L, TimeUnit.SECONDS);
+
+			Configuration conf = new Configuration();
+			conf.setString(RestOptions.ADDRESS, url.getHost());
+			conf.setInteger(RestOptions.PORT, url.getPort());
+
+			client = new RestClusterClient<>(conf, StandaloneClusterId.getInstance());
+
+			assertThat(client.getClusterConnectionInfo().getHostname(), equalTo("localhost"));
+		} finally {
+			resource.after();
+
+			if (client != null) {
+				client.shutdown();
+			}
+		}
+	}
+
+	@Test
+	public void testMiniClusterClientProperlyRetrieveLeaderInfo() throws Exception {
+		MiniClusterResourceConfiguration cfg = new MiniClusterResourceConfiguration.Builder().build();
+		MiniClusterResource resource = new MiniClusterResource(cfg);
+
+		ClusterClient<?> client = null;
+		try {
+			resource.before();
+
+			client = new MiniClusterClient(resource.getClientConfiguration(), resource.getMiniCluster());
+
+			assertThat(client.getClusterConnectionInfo().getHostname(), equalTo("localhost"));
+		} finally {
+			resource.after();
+
+			if (client != null) {
+				client.shutdown();
+			}
+		}
+	}
+
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/RetrieveLeaderInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/RetrieveLeaderInfoTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
 import java.net.MalformedURLException;

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -23,14 +23,13 @@ import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.runtime.util.LeaderConnectionInfo;
 
 import org.apache.commons.cli.CommandLine;
-import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -54,9 +53,7 @@ public class DefaultCLITest extends CliFrontendTestBase {
 
 		configuration.setString(JobManagerOptions.ADDRESS, localhost);
 		configuration.setInteger(JobManagerOptions.PORT, port);
-
-		@SuppressWarnings("unchecked")
-		final AbstractCustomCommandLine<StandaloneClusterId> defaultCLI =
+		@SuppressWarnings("unchecked") final AbstractCustomCommandLine<StandaloneClusterId> defaultCLI =
 			(AbstractCustomCommandLine<StandaloneClusterId>) getCli(configuration);
 
 		final String[] args = {};
@@ -67,11 +64,10 @@ public class DefaultCLITest extends CliFrontendTestBase {
 			defaultCLI.createClusterDescriptor(commandLine);
 
 		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
+		final Configuration clientConf = clusterClient.getFlinkConfiguration();
 
-		final LeaderConnectionInfo clusterConnectionInfo = clusterClient.getClusterConnectionInfo();
-
-		assertThat(clusterConnectionInfo.getHostname(), Matchers.equalTo(localhost));
-		assertThat(clusterConnectionInfo.getPort(), Matchers.equalTo(port));
+		assertThat(clientConf.getString(JobManagerOptions.ADDRESS), equalTo(localhost));
+		assertThat(clientConf.getInteger(JobManagerOptions.PORT), equalTo(port));
 	}
 
 	/**
@@ -101,10 +97,10 @@ public class DefaultCLITest extends CliFrontendTestBase {
 
 		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
-		final LeaderConnectionInfo clusterConnectionInfo = clusterClient.getClusterConnectionInfo();
+		final Configuration clientConf = clusterClient.getFlinkConfiguration();
 
-		assertThat(clusterConnectionInfo.getHostname(), Matchers.equalTo(manualHostname));
-		assertThat(clusterConnectionInfo.getPort(), Matchers.equalTo(manualPort));
+		assertThat(clientConf.getString(JobManagerOptions.ADDRESS), equalTo(manualHostname));
+		assertThat(clientConf.getInteger(JobManagerOptions.PORT), equalTo(manualPort));
 	}
 
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
@@ -298,7 +298,6 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 			clientConfig,
 			new RestClient(RestClientConfiguration.fromConfiguration(REST_CONFIG), executor),
 			StandaloneClusterId.getInstance(),
-			(attempt) -> 0,
-			null);
+			(attempt) -> 0);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -187,8 +187,7 @@ public class RestClusterClientTest extends TestLogger {
 			clientConfig,
 			createRestClient(),
 			StandaloneClusterId.getInstance(),
-			(attempt) -> 0,
-			null);
+			(attempt) -> 0);
 	}
 
 	@Nonnull

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2300,6 +2300,32 @@
       }
     }
   }, {
+    "url" : "/leader-info",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:LeaderInfo",
+      "properties" : {
+        "address" : {
+          "type" : "string"
+        },
+        "dispatcher-id" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
     "url" : "/overview",
     "method" : "GET",
     "status-code" : "200 OK",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ClientHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ClientHaServices.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability;
+
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+
+/**
+ *
+ */
+public interface ClientHaServices extends AutoCloseable {
+	LeaderRetrievalService getWebMonitorLeaderRetriever();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesFactory.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.highavailability;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 
 import java.util.concurrent.Executor;
 
@@ -36,4 +38,19 @@ public interface HighAvailabilityServicesFactory {
 	 * @throws Exception when HAServices cannot be created
 	 */
 	HighAvailabilityServices createHAServices(Configuration configuration, Executor executor) throws Exception;
+
+	default ClientHaServices createClientHaService(Configuration configuration) throws Exception {
+		return new ClientHaServices() {
+			private HighAvailabilityServices haServices = createHAServices(configuration, Executors.directExecutor());
+			@Override
+			public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+				return haServices.getWebMonitorLeaderRetriever();
+			}
+
+			@Override
+			public void close() throws Exception {
+				haServices.close();
+			}
+		};
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneClientHaService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneClientHaService.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.nonha.standalone;
+
+import org.apache.flink.runtime.highavailability.ClientHaServices;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.StandaloneLeaderRetrievalService;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import static org.apache.flink.runtime.highavailability.HighAvailabilityServices.DEFAULT_LEADER_ID;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ *
+ */
+public class StandaloneClientHaService implements ClientHaServices {
+
+	private final Object lock = new Object();
+	private final String webMonitorAddress;
+
+	@GuardedBy("lock")
+	private boolean running;
+
+	public StandaloneClientHaService(String webMonitorAddress) {
+		this.webMonitorAddress = webMonitorAddress;
+		this.running = true;
+	}
+
+	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		synchronized (lock) {
+			checkState(running, "ClientHaService has already been closed.");
+			return new StandaloneLeaderRetrievalService(webMonitorAddress, DEFAULT_LEADER_ID);
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		synchronized (lock) {
+			running = false;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZKClientHaService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZKClientHaService.java
@@ -18,11 +18,12 @@
 
 package org.apache.flink.runtime.highavailability.zookeeper;
 
-import org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.ClientHaServices;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
+
+import org.apache.curator.framework.CuratorFramework;
 
 import javax.annotation.Nonnull;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZKClientHaService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZKClientHaService.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.zookeeper;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.highavailability.ClientHaServices;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+
+import javax.annotation.Nonnull;
+
+/**
+ *
+ */
+public class ZKClientHaService implements ClientHaServices {
+
+	private static final String REST_SERVER_LEADER_PATH = "/rest_server_lock";
+
+	private final CuratorFramework client;
+	private final Configuration configuration;
+
+	public ZKClientHaService(
+		@Nonnull CuratorFramework client,
+		@Nonnull Configuration configuration
+	) {
+		this.client = client;
+		this.configuration = configuration;
+	}
+
+	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		return ZooKeeperUtils.createLeaderRetrievalService(client, configuration, REST_SERVER_LEADER_PATH);
+	}
+
+	@Override
+	public void close() throws Exception {
+		client.close();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/LeaderInfoHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/LeaderInfoHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.cluster;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.LeaderInfo;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ *
+ */
+public class LeaderInfoHandler extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, LeaderInfo, EmptyMessageParameters> {
+	public LeaderInfoHandler(
+		final GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+		final Time timeout,
+		final Map<String, String> responseHeaders,
+		final MessageHeaders<EmptyRequestBody, LeaderInfo, EmptyMessageParameters> messageHeaders) {
+		super(leaderRetriever, timeout, responseHeaders, messageHeaders);
+	}
+
+	@Override
+	protected CompletableFuture<LeaderInfo> handleRequest(
+		@Nonnull final HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+		@Nonnull final RestfulGateway gateway
+	) throws RestHandlerException {
+		DispatcherGateway dispatcherGateway = (DispatcherGateway) gateway;
+		String address = dispatcherGateway.getAddress();
+		String dispatcherId = dispatcherGateway.getFencingToken().toUUID().toString();
+		return CompletableFuture.completedFuture(new LeaderInfo(address, dispatcherId));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/LeaderInfoHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/LeaderInfoHandler.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 
 import javax.annotation.Nonnull;
+
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/LeaderInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/LeaderInfo.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ *
+ */
+public class LeaderInfo implements ResponseBody {
+
+	public static final String FIELD_ADDRESS = "address";
+	public static final String FIELD_DISPATCHER_ID = "dispatcher-id";
+
+	@JsonProperty(FIELD_ADDRESS)
+	private String address;
+
+	@JsonProperty(FIELD_DISPATCHER_ID)
+	private String dispatcherId;
+
+
+	@JsonCreator
+	public LeaderInfo(
+		@JsonProperty(FIELD_ADDRESS) String address,
+		@JsonProperty(FIELD_DISPATCHER_ID) String dispatcherId
+	) {
+		this.address = checkNotNull(address);
+		this.dispatcherId = checkNotNull(dispatcherId);
+	}
+
+	@JsonIgnore
+	public String getAddress() {
+		return address;
+	}
+
+	@JsonIgnore
+	public String getDispatcherId() {
+		return dispatcherId;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		LeaderInfo that = (LeaderInfo) o;
+		return Objects.equals(address, that.address) &&
+			Objects.equals(dispatcherId, that.dispatcherId);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(address, dispatcherId);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/LeaderInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/LeaderInfo.java
@@ -40,7 +40,6 @@ public class LeaderInfo implements ResponseBody {
 	@JsonProperty(FIELD_DISPATCHER_ID)
 	private String dispatcherId;
 
-
 	@JsonCreator
 	public LeaderInfo(
 		@JsonProperty(FIELD_ADDRESS) String address,
@@ -62,8 +61,13 @@ public class LeaderInfo implements ResponseBody {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		LeaderInfo that = (LeaderInfo) o;
 		return Objects.equals(address, that.address) &&
 			Objects.equals(dispatcherId, that.dispatcherId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/LeaderInfoHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/LeaderInfoHeaders.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.cluster;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.LeaderInfo;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ *
+ */
+public class LeaderInfoHeaders implements MessageHeaders<EmptyRequestBody, LeaderInfo, EmptyMessageParameters> {
+
+	private static final LeaderInfoHeaders INSTANCE = new LeaderInfoHeaders();
+
+	public static LeaderInfoHeaders getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public Class<LeaderInfo> getResponseClass() {
+		return LeaderInfo.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public EmptyMessageParameters getUnresolvedMessageParameters() {
+		return EmptyMessageParameters.getInstance();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return "/leader-info";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Get leader info of the cluster";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/LeaderInfoHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/LeaderInfoHeaders.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.LeaderInfo;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.cluster.ClusterConfigHandler;
 import org.apache.flink.runtime.rest.handler.cluster.ClusterOverviewHandler;
 import org.apache.flink.runtime.rest.handler.cluster.DashboardConfigHandler;
+import org.apache.flink.runtime.rest.handler.cluster.LeaderInfoHandler;
 import org.apache.flink.runtime.rest.handler.cluster.ShutdownHandler;
 import org.apache.flink.runtime.rest.handler.job.JobAccumulatorsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobCancellationHandler;
@@ -104,6 +105,7 @@ import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigHeader
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatisticDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatisticsHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.TaskCheckpointStatisticsHeaders;
+import org.apache.flink.runtime.rest.messages.cluster.LeaderInfoHeaders;
 import org.apache.flink.runtime.rest.messages.cluster.ShutdownHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskCurrentAttemptDetailsHeaders;
@@ -525,6 +527,12 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			responseHeaders,
 			ShutdownHeaders.getInstance());
 
+		final LeaderInfoHandler leaderInfoHandler = new LeaderInfoHandler(
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			LeaderInfoHeaders.getInstance());
+
 		final File webUiDir = restConfiguration.getWebUiDir();
 
 		Optional<StaticFileServerHandler<T>> optWebContent;
@@ -587,6 +595,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(YarnStopJobTerminationHeaders.getInstance(), jobStopTerminationHandler));
 
 		handlers.add(Tuple2.of(shutdownHandler.getMessageHeaders(), shutdownHandler));
+		handlers.add(Tuple2.of(leaderInfoHandler.getMessageHeaders(), leaderInfoHandler));
 
 		optWebContent.ifPresent(
 			webContent -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
@@ -27,8 +28,10 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils.AddressResolution;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.rest.handler.legacy.files.StaticFileServerHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.FlinkException;
@@ -44,13 +47,17 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Utilities for the web runtime monitor. This class contains for example methods to build
@@ -140,6 +147,28 @@ public final class WebMonitorUtils {
 		} else {
 			return Optional.empty();
 		}
+	}
+
+	/**
+	 * @param configuration Configuration contains those for WebMonitor.
+	 * @param resolution Whether to try address resolution of the given hostname or not.
+	 *                   This allows to fail fast in case that the hostname cannot be resolved.
+	 * @return Address of WebMonitor.
+	 */
+	public static String getWebMonitorAddress(Configuration configuration, AddressResolution resolution) throws UnknownHostException {
+		final String address = checkNotNull(configuration.getString(RestOptions.ADDRESS), "%s must be set", RestOptions.ADDRESS.key());
+
+		if (resolution == AddressResolution.TRY_ADDRESS_RESOLUTION) {
+			// Fail fast if the hostname cannot be resolved
+			//noinspection ResultOfMethodCallIgnored
+			InetAddress.getByName(address);
+		}
+
+		final int port = configuration.getInteger(RestOptions.PORT);
+		final boolean enableSSL = SSLUtils.isRestSSLEnabled(configuration);
+		final String protocol = enableSSL ? "https://" : "http://";
+
+		return String.format("%s%s:%s", protocol, address, port);
 	}
 
 	/**

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -273,7 +273,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				final HostAndPort hostAndPort = parseJobManagerHostname(logs);
 				final String host = hostAndPort.getHostText();
 				final int port = hostAndPort.getPort();
-				LOG.info("Extracted hostname:port: {}", host, port);
+				LOG.info("Extracted hostname:port: {}:{}", host, port);
 
 				submitJob("WindowJoin.jar");
 
@@ -314,7 +314,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	}
 
 	private static HostAndPort parseJobManagerHostname(final String logs) {
-		final Pattern p = Pattern.compile("Flink JobManager is now running on ([a-zA-Z0-9.-]+):([0-9]+)");
+		final Pattern p = Pattern.compile("JobManager Web Interface: http://([a-zA-Z0-9.-]+):([0-9]+)");
 		final Matcher matches = p.matcher(logs);
 		String hostname = null;
 		String port = null;

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.util.OptionalFailure;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -62,6 +63,16 @@ public class FakeClusterClient extends ClusterClient<ApplicationId> {
 	}
 
 	public CompletableFuture<JobStatus> getJobStatus(JobID jobId) {
+		throw new UnsupportedOperationException("Not needed in test.");
+	}
+
+	@Override
+	public void shutdown() throws Exception {
+		// no op
+	}
+
+	@Override
+	public LeaderConnectionInfo getClusterConnectionInfo() throws Exception {
 		throw new UnsupportedOperationException("Not needed in test.");
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Follow FLINK-13750 we decide to separate client-side/cluster-side high-availability services, in order to avoid issues like FLINK-13500 which initialized blob store service without auth.

**NOTE:** This pull request is functionality completed but still a rough attempt to solve the problem. There is no tricky code in production scope(I hope so) but could be optimized in code style, local strategy, document and so on. I publish it here for early review and make sure we go on the right way.

cc @tillrohrmann @zentol 

## Brief change log

+ Introduce a new interface `ClientHaServices` and its implementations `StandaloneClientHaService` and `ZKClientHaService`. This interface include only one method, `getWebMonitorLeaderRetriever`, since client is only supposed to communicate with WebMonitor.
+ Add a method `createClientHaService` to `HighAvailabilityServicesFactory` for customized. By default it reuses `createHAServices` and `getWebMonitorLeaderRetriever`. The default behavior is for backward compatibility.
+ Add a method `createClientHaService` to `HighAvailabilityServicesUtils`.
+ Support "/leader-info" request on WebMonitor for a proper `LeaderConnectionInfo` query. (`LeaderInfo`, `LeaderInfoHandler`, and `LeaderInfoHeaders`)

+ Remove unused constructor in `RestClusterClient` and `ClusterClient`.
+ Adjust existing code.
+ Add a new tests `RetrieveLeaderInfoTest`.

## Verifying this change

This change added tests and can be verified as follows:

+ `org.apache.flink.client.RetrieveLeaderInfoTest` to test `getClusterConnectionInfo` dedicatedly.
+ other functions should be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know, we introduce client ha service but actually it has nothing to do with recovery)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
