### PR TITLE
[FLINK-13807][tests] Read file with UTF-8 charset in TestBaseUtils.getResultReader

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -37,14 +37,15 @@ import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -138,7 +139,7 @@ public class TestBaseUtils extends TestLogger {
 
 		BufferedReader[] readers = new BufferedReader[files.length];
 		for (int i = 0; i < files.length; i++) {
-			readers[i] = new BufferedReader(new FileReader(files[i]));
+			readers[i] = new BufferedReader(new InputStreamReader(new FileInputStream(files[i]), StandardCharsets.UTF_8));
 		}
 		return readers;
 	}


### PR DESCRIPTION
## What is the purpose of the change

Read file with UTF-8 charset in `TestBaseUtils.getResultReader`. Otherwise test depends on locale setting.

## Verifying this change

This change is itself a test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol 
