### PR TITLE
[FLINK-13841][hive] Extend Hive version support to all 1.2 and 2.3 ve…

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveMetastoreClientWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveMetastoreClientWrapper.java
@@ -156,11 +156,6 @@ public class HiveMetastoreClientWrapper implements AutoCloseable {
 		return client.dropPartition(databaseName, tableName, partitionValues, deleteData);
 	}
 
-	public void alter_partition(String databaseName, String tableName, Partition partition)
-			throws InvalidOperationException, MetaException, TException {
-		client.alter_partition(databaseName, tableName, partition);
-	}
-
 	public void renamePartition(String databaseName, String tableName, List<String> partitionValues, Partition partition)
 			throws InvalidOperationException, MetaException, TException {
 		client.renamePartition(databaseName, tableName, partitionValues, partition);
@@ -235,4 +230,11 @@ public class HiveMetastoreClientWrapper implements AutoCloseable {
 		HiveShim hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
 		hiveShim.alterTable(client, databaseName, tableName, table);
 	}
+
+	public void alter_partition(String databaseName, String tableName, Partition partition)
+			throws InvalidOperationException, MetaException, TException {
+		HiveShim hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
+		hiveShim.alterPartition(client, databaseName, tableName, partition);
+	}
+
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShim.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShim.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.metastore.api.Function;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
@@ -98,6 +99,9 @@ public interface HiveShim {
 	 * @param table        the new Hive table
 	 */
 	void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table)
+			throws InvalidOperationException, MetaException, TException;
+
+	void alterPartition(IMetaStoreClient client, String databaseName, String tableName, Partition partition)
 			throws InvalidOperationException, MetaException, TException;
 
 	/**

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimLoader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimLoader.java
@@ -32,8 +32,15 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class HiveShimLoader {
 
-	public static final String HIVE_V1_VERSION_NAME = "1.2.1";
-	public static final String HIVE_V2_VERSION_NAME = "2.3.4";
+	public static final String HIVE_VERSION_V1_2_0 = "1.2.0";
+	public static final String HIVE_VERSION_V1_2_1 = "1.2.1";
+	public static final String HIVE_VERSION_V1_2_2 = "1.2.2";
+	public static final String HIVE_VERSION_V2_3_0 = "2.3.0";
+	public static final String HIVE_VERSION_V2_3_1 = "2.3.1";
+	public static final String HIVE_VERSION_V2_3_2 = "2.3.2";
+	public static final String HIVE_VERSION_V2_3_3 = "2.3.3";
+	public static final String HIVE_VERSION_V2_3_4 = "2.3.4";
+	public static final String HIVE_VERSION_V2_3_5 = "2.3.5";
 
 	private static final Map<String, HiveShim> hiveShims = new ConcurrentHashMap<>(2);
 
@@ -44,11 +51,32 @@ public class HiveShimLoader {
 
 	public static HiveShim loadHiveShim(String version) {
 		return hiveShims.computeIfAbsent(version, (v) -> {
-			if (v.startsWith(HIVE_V1_VERSION_NAME)) {
-				return new HiveShimV1();
+			if (v.startsWith(HIVE_VERSION_V1_2_0)) {
+				return new HiveShimV120();
 			}
-			if (v.startsWith(HIVE_V2_VERSION_NAME)) {
-				return new HiveShimV2();
+			if (v.startsWith(HIVE_VERSION_V1_2_1)) {
+				return new HiveShimV121();
+			}
+			if (v.startsWith(HIVE_VERSION_V1_2_2)) {
+				return new HiveShimV122();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_3_0)) {
+				return new HiveShimV230();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_3_1)) {
+				return new HiveShimV231();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_3_2)) {
+				return new HiveShimV232();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_3_3)) {
+				return new HiveShimV233();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_3_4)) {
+				return new HiveShimV234();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_3_5)) {
+				return new HiveShimV235();
 			}
 			throw new CatalogException("Unsupported Hive version " + v);
 		});

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV121.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV121.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 1.2.1.
+ */
+public class HiveShimV121 extends HiveShimV120 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV122.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV122.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 1.2.2.
+ */
+public class HiveShimV122 extends HiveShimV121 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
@@ -28,10 +28,12 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.Function;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
@@ -45,9 +47,9 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 /**
- * Shim for Hive version 2.x.
+ * Shim for Hive version 2.3.0.
  */
-public class HiveShimV2 implements HiveShim {
+public class HiveShimV230 extends HiveShimV122 {
 
 	@Override
 	public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
@@ -86,7 +88,7 @@ public class HiveShimV2 implements HiveShim {
 	public boolean moveToTrash(FileSystem fs, Path path, Configuration conf, boolean purge) throws IOException {
 		try {
 			Method method = FileUtils.class.getDeclaredMethod("moveToTrash", FileSystem.class, Path.class,
-					Configuration.class, boolean.class);
+				Configuration.class, boolean.class);
 			return (boolean) method.invoke(null, fs, path, conf, purge);
 		} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 			throw new IOException("Failed to move " + path + " to trash", e);
@@ -100,13 +102,37 @@ public class HiveShimV2 implements HiveShim {
 	}
 
 	@Override
+	public void alterPartition(IMetaStoreClient client, String databaseName, String tableName, Partition partition)
+		throws InvalidOperationException, MetaException, TException {
+		try {
+			Method method = client.getClass().getMethod("alter_partition", String.class, String.class,
+				Partition.class, EnvironmentContext.class);
+			method.invoke(client, databaseName, tableName, partition, null);
+		} catch (InvocationTargetException ite) {
+			Throwable targetEx = ite.getTargetException();
+			if (targetEx instanceof TException) {
+				throw (TException) targetEx;
+			} else {
+				throw new CatalogException(
+					String.format("Failed to alter partition for table %s in database %s", tableName, databaseName),
+					targetEx);
+			}
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			throw new CatalogException(
+				String.format("Failed to alter partition for table %s in database %s", tableName, databaseName),
+				e);
+		}
+	}
+
+	@Override
 	public SimpleGenericUDAFParameterInfo createUDAFParameterInfo(ObjectInspector[] params, boolean isWindowing, boolean distinct, boolean allColumns) {
 		try {
 			Constructor constructor = SimpleGenericUDAFParameterInfo.class.getConstructor(ObjectInspector[].class,
-					boolean.class, boolean.class, boolean.class);
+				boolean.class, boolean.class, boolean.class);
 			return (SimpleGenericUDAFParameterInfo) constructor.newInstance(params, isWindowing, distinct, allColumns);
 		} catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
 			throw new CatalogException("Failed to create SimpleGenericUDAFParameterInfo", e);
 		}
 	}
+
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
@@ -104,6 +104,7 @@ public class HiveShimV230 extends HiveShimV122 {
 	@Override
 	public void alterPartition(IMetaStoreClient client, String databaseName, String tableName, Partition partition)
 		throws InvalidOperationException, MetaException, TException {
+		String errorMsg = "Failed to alter partition for table %s in database %s";
 		try {
 			Method method = client.getClass().getMethod("alter_partition", String.class, String.class,
 				Partition.class, EnvironmentContext.class);
@@ -113,14 +114,10 @@ public class HiveShimV230 extends HiveShimV122 {
 			if (targetEx instanceof TException) {
 				throw (TException) targetEx;
 			} else {
-				throw new CatalogException(
-					String.format("Failed to alter partition for table %s in database %s", tableName, databaseName),
-					targetEx);
+				throw new CatalogException(String.format(errorMsg, tableName, databaseName), targetEx);
 			}
 		} catch (NoSuchMethodException | IllegalAccessException e) {
-			throw new CatalogException(
-				String.format("Failed to alter partition for table %s in database %s", tableName, databaseName),
-				e);
+			throw new CatalogException(String.format(errorMsg, tableName, databaseName), e);
 		}
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
@@ -88,7 +88,7 @@ public class HiveShimV230 extends HiveShimV122 {
 	public boolean moveToTrash(FileSystem fs, Path path, Configuration conf, boolean purge) throws IOException {
 		try {
 			Method method = FileUtils.class.getDeclaredMethod("moveToTrash", FileSystem.class, Path.class,
-				Configuration.class, boolean.class);
+					Configuration.class, boolean.class);
 			return (boolean) method.invoke(null, fs, path, conf, purge);
 		} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 			throw new IOException("Failed to move " + path + " to trash", e);
@@ -103,7 +103,7 @@ public class HiveShimV230 extends HiveShimV122 {
 
 	@Override
 	public void alterPartition(IMetaStoreClient client, String databaseName, String tableName, Partition partition)
-		throws InvalidOperationException, MetaException, TException {
+			throws InvalidOperationException, MetaException, TException {
 		String errorMsg = "Failed to alter partition for table %s in database %s";
 		try {
 			Method method = client.getClass().getMethod("alter_partition", String.class, String.class,
@@ -125,7 +125,7 @@ public class HiveShimV230 extends HiveShimV122 {
 	public SimpleGenericUDAFParameterInfo createUDAFParameterInfo(ObjectInspector[] params, boolean isWindowing, boolean distinct, boolean allColumns) {
 		try {
 			Constructor constructor = SimpleGenericUDAFParameterInfo.class.getConstructor(ObjectInspector[].class,
-				boolean.class, boolean.class, boolean.class);
+					boolean.class, boolean.class, boolean.class);
 			return (SimpleGenericUDAFParameterInfo) constructor.newInstance(params, isWindowing, distinct, allColumns);
 		} catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
 			throw new CatalogException("Failed to create SimpleGenericUDAFParameterInfo", e);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV231.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV231.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 2.3.1.
+ */
+public class HiveShimV231 extends HiveShimV230 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV232.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV232.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 2.3.2.
+ */
+public class HiveShimV232 extends HiveShimV231 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV233.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV233.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 2.3.3.
+ */
+public class HiveShimV233 extends HiveShimV232 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV234.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV234.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 2.3.4.
+ */
+public class HiveShimV234 extends HiveShimV233 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV235.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV235.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 2.3.5.
+ */
+public class HiveShimV235 extends HiveShimV234 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerShimLoader.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerShimLoader.java
@@ -37,9 +37,16 @@ public class HiveRunnerShimLoader {
 		String hiveVersion = HiveShimLoader.getHiveVersion();
 		return hiveRunnerShims.computeIfAbsent(hiveVersion, v -> {
 			switch (v) {
-				case HiveShimLoader.HIVE_V1_VERSION_NAME:
+				case HiveShimLoader.HIVE_VERSION_V1_2_0:
+				case HiveShimLoader.HIVE_VERSION_V1_2_1:
+				case HiveShimLoader.HIVE_VERSION_V1_2_2:
 					return new HiveRunnerShimV3();
-				case HiveShimLoader.HIVE_V2_VERSION_NAME:
+				case HiveShimLoader.HIVE_VERSION_V2_3_0:
+				case HiveShimLoader.HIVE_VERSION_V2_3_1:
+				case HiveShimLoader.HIVE_VERSION_V2_3_2:
+				case HiveShimLoader.HIVE_VERSION_V2_3_3:
+				case HiveShimLoader.HIVE_VERSION_V2_3_4:
+				case HiveShimLoader.HIVE_VERSION_V2_3_5:
 					return new HiveRunnerShimV4();
 				default:
 					throw new RuntimeException("Unsupported Hive version " + v);


### PR DESCRIPTION
…rsions
## What is the purpose of the change

Support all 1.2 and 2.3 minor Hive versions instead of currently 1.2.1 and 2.3.4 only.

## Brief change log

  - Added new shims for each version
  - Made inheritance relationships between the shims
  - Shimmed methods to deal with API difference


## Verifying this change


This change is already covered by existing tests, and manually ran the tests for all versions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
