### PR TITLE
[FLINK-13829] [docs] Fix the base url of release 1.9 docs and mark 1.9 as stable

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -47,14 +47,14 @@ github_url: "https://github.com/apache/flink"
 download_url: "http://flink.apache.org/downloads.html"
 
 # please use a protocol relative URL here
-baseurl: //ci.apache.org/projects/flink/flink-docs-master
+baseurl: //ci.apache.org/projects/flink/flink-docs-release-1.9
 stable_baseurl: //ci.apache.org/projects/flink/flink-docs-stable
 
-javadocs_baseurl: //ci.apache.org/projects/flink/flink-docs-master
-pythondocs_baseurl: //ci.apache.org/projects/flink/flink-docs-master
+javadocs_baseurl: //ci.apache.org/projects/flink/flink-docs-release-1.9
+pythondocs_baseurl: //ci.apache.org/projects/flink/flink-docs-release-1.9
 
 # Flag whether this is a stable version or not. Used for the quickstart page.
-is_stable: false
+is_stable: true
 
 # Flag to indicate whether an outdated warning should be shown.
 show_outdated_warning: false


### PR DESCRIPTION

## What is the purpose of the change

*The links in release 1.9 docs to pages of master docs, rather than pages of release-1.9 docs.*

*Besides that, release 1.9 is not marked as stable in _config.yml, resulting in that the project templates in quickstart pages be incorrect.*


## Brief change log

  - *fix baseurl/javadocs_baseurl/pythondocs_baseurl in docs/_config.yml*
  - *set is_stable to true in docs/_config.yml*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
