### PR TITLE
[FLINK-13875][docs] Add missing redirects to the documentation

### DIFF
--- a/docs/redirects/examples_index.md
+++ b/docs/redirects/examples_index.md
@@ -1,0 +1,24 @@
+---
+title: "Examples"
+layout: redirect
+redirect: /examples/index.html
+permalink: /getting-started/examples/index.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/tutorials_api_tutorials.md
+++ b/docs/redirects/tutorials_api_tutorials.md
@@ -1,0 +1,24 @@
+---
+title: "Api Tutorials"
+layout: redirect
+redirect: /tutorials/api_tutorials.html
+permalink: /getting-started/tutorials/api_tutorials.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/tutorials_datastream_api.md
+++ b/docs/redirects/tutorials_datastream_api.md
@@ -1,0 +1,24 @@
+---
+title: "DataStream Api"
+layout: redirect
+redirect: /tutorials/datastream_api.html
+permalink: /getting-started/tutorials/datastream_api.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/tutorials_flink_on_windows.md
+++ b/docs/redirects/tutorials_flink_on_windows.md
@@ -1,0 +1,24 @@
+---
+title: "Flink On Windows"
+layout: redirect
+redirect: /tutorials/flink_on_windows.html
+permalink: /getting-started/tutorials/flink_on_windows.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/tutorials_index.md
+++ b/docs/redirects/tutorials_index.md
@@ -1,0 +1,24 @@
+---
+title: "Tutorials"
+layout: redirect
+redirect: /tutorials/index.html
+permalink: /getting-started/tutorials/index.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/tutorials_local_setup.md
+++ b/docs/redirects/tutorials_local_setup.md
@@ -1,0 +1,24 @@
+---
+title: "Local Setup"
+layout: redirect
+redirect: /tutorials/local_setup.html
+permalink: /getting-started/tutorials/local_setup.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/tutorials_setup_instructions.md
+++ b/docs/redirects/tutorials_setup_instructions.md
@@ -1,0 +1,24 @@
+---
+title: "Setup Instructions"
+layout: redirect
+redirect: /tutorials/setup_instructions.html
+permalink: /getting-started/tutorials/setup_instructions.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->


### PR DESCRIPTION

## What is the purpose of the change

Add missing redirects to the flink documentation 

/examples_index.md                  =>  /getting_started/examples_index.md
/examples_index.zh.md               =>  /getting_started/examples_index.zh.md
/tutorials_api_tutorials.md         =>  /getting_started/tutorials_api_tutorials.md
/tutorials_api_tutorials.zh.md      =>  /getting_started/tutorials_api_tutorials.zh.md
/tutorials_datastream_api.md        =>  /getting_started/tutorials_datastream_api.md
/tutorials_datastream_api.zh.md     =>  /getting_started/tutorials_datastream_api.zh.md
/tutorials_flink_on_windows.md      =>  /getting_started/tutorials_flink_on_windows.md
/tutorials_flink_on_windows.zh.md   =>  /getting_started/tutorials_flink_on_windows.zh.md
/tutorials_index.md                 =>  /getting_started/tutorials_index.md
/tutorials_index.zh.md              =>  /getting_started/tutorials_index.zh.md
/tutorials_local_setup.md           =>  /getting_started/tutorials_local_setup.md
/tutorials_local_setup.zh.md        =>  /getting_started/tutorials_local_setup.zh.md
/tutorials_setup_instructions.md    =>  /getting_started/tutorials_setup_instructions.md
/tutorials_setup_instructions.zh.md =>  /getting_started/tutorials_setup_instructions.zh.md
