### PR TITLE
[FLINK-13805] Properly forward cause for slot removal in SlotManager

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/util/CoreMatchers.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CoreMatchers.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.Optional;
+
+/**
+ * Hamcrest matchers.
+ */
+public class CoreMatchers {
+
+	public static Matcher<Throwable> containsCause(Throwable failureCause) {
+		return new ContainsCauseMatcher(failureCause);
+	}
+
+	private static class ContainsCauseMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
+
+		private final Throwable failureCause;
+
+		private ContainsCauseMatcher(Throwable failureCause) {
+			this.failureCause = failureCause;
+		}
+
+		@Override
+		protected boolean matchesSafely(Throwable throwable, Description description) {
+			final Optional<Throwable> optionalCause = ExceptionUtils.findThrowable(throwable, cause -> cause.equals(failureCause));
+
+			if (!optionalCause.isPresent()) {
+				description
+					.appendText("The throwable ")
+					.appendValue(throwable)
+					.appendText(" does not contain the expected failure cause ")
+					.appendValue(failureCause);
+			}
+
+			return optionalCause.isPresent();
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description
+				.appendText("Expected failure cause is ")
+				.appendValue(failureCause);
+		}
+	}
+
+	private CoreMatchers() {
+		throw new UnsupportedOperationException("Cannot instantiate an instance of this class.");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -695,7 +695,9 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			log.debug("Replacing old registration of TaskExecutor {}.", taskExecutorResourceId);
 
 			// remove old task manager registration from slot manager
-			slotManager.unregisterTaskManager(oldRegistration.getInstanceID());
+			slotManager.unregisterTaskManager(
+				oldRegistration.getInstanceID(),
+				new ResourceManagerException(String.format("TaskExecutor %s re-connected to the ResourceManager.", taskExecutorResourceId)));
 		}
 
 		final WorkerType newWorker = workerStarted(taskExecutorResourceId);
@@ -803,7 +805,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			log.info("Closing TaskExecutor connection {} because: {}", resourceID, cause.getMessage());
 
 			// TODO :: suggest failed task executor to stop itself
-			slotManager.unregisterTaskManager(workerRegistration.getInstanceID());
+			slotManager.unregisterTaskManager(workerRegistration.getInstanceID(), cause);
 
 			workerRegistration.getTaskExecutorGateway().disconnectResourceManager(cause);
 		} else {
@@ -859,7 +861,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			}
 		} else {
 			// unregister in order to clean up potential left over state
-			slotManager.unregisterTaskManager(instanceId);
+			slotManager.unregisterTaskManager(instanceId, cause);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/exceptions/ResourceManagerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/exceptions/ResourceManagerException.java
@@ -19,11 +19,12 @@
 package org.apache.flink.runtime.resourcemanager.exceptions;
 
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.util.FlinkException;
 
 /**
  * Base class for {@link ResourceManager} exceptions.
  */
-public class ResourceManagerException extends Exception {
+public class ResourceManagerException extends FlinkException {
 	private static final long serialVersionUID = -5503307426519195160L;
 
 	public ResourceManagerException(String message) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -101,9 +101,10 @@ public interface SlotManager extends AutoCloseable {
 	 * from the slot manager.
 	 *
 	 * @param instanceId identifying the task manager to unregister
+	 * @param cause for unregistering the TaskManager
 	 * @return True if there existed a registered task manager with the given instance id
 	 */
-	boolean unregisterTaskManager(InstanceID instanceId);
+	boolean unregisterTaskManager(InstanceID instanceId, Exception cause);
 
 	/**
 	 * Reports the current slot allocations for a task manager identified by the given instance id.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+
+/**
+ * Base class for exceptions thrown by the {@link SlotManager}.
+ */
+public class SlotManagerException extends ResourceManagerException {
+	public SlotManagerException(String message) {
+		super(message);
+	}
+
+	public SlotManagerException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SlotManagerException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -707,7 +707,6 @@ public class SlotManagerImplTest extends TestLogger {
 	 * Tests that a slot request is retried if it times out on the task manager side.
 	 */
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testTaskManagerSlotRequestTimeoutHandling() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
@@ -774,7 +773,6 @@ public class SlotManagerImplTest extends TestLogger {
 	 * is received.
 	 */
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testSlotReportWhileActiveSlotRequest() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -97,7 +97,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the {@link SlotManagerImpl}.
  */
-public class SlotManagerTest extends TestLogger {
+public class SlotManagerImplTest extends TestLogger {
 
 	/**
 	 * Tests that we can register task manager and their slots at the slot manager.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -96,7 +96,7 @@ public class TestingSlotManager implements SlotManager {
 	}
 
 	@Override
-	public boolean unregisterTaskManager(InstanceID instanceId) {
+	public boolean unregisterTaskManager(InstanceID instanceId, Exception cause) {
 		return false;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Forwarding the slot removal cause to the ResourceActions allows to notify the JobMaster
about the allocation failure cause. This improves debuggability and understanding of the
system.

## Verifying this change

- Added `SlotManagerImplTest#unregisterTaskManager_withAllocatedSlot_failsAllocationsWithCause`
- Tested manually that the correct failure cause is forwarded to the `JobMaster`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
