### PR TITLE
[FLINK-13884] Set default failure rate restart strategy delay to 0s

### DIFF
--- a/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
+++ b/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
@@ -1,0 +1,26 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>restart-strategy.failure-rate.delay</h5></td>
+            <td style="word-wrap: break-word;">"10 s"</td>
+            <td>Delay between two consecutive restart attempts when using <span markdown="span">`FailureRateRestartStrategy`</span>. It can be specified using Scala's <span markdown="span">`FiniteDuration`</span> notation: "1 min", "20 s"</td>
+        </tr>
+        <tr>
+            <td><h5>restart-strategy.failure-rate.failure-rate-interval</h5></td>
+            <td style="word-wrap: break-word;">"1 min"</td>
+            <td>Time interval for measuring failure rate when using <span markdown="span">`FailureRateRestartStrategy`</span>. It can be specified using Scala's <span markdown="span">`FiniteDuration`</span> notation: "1 min", "20 s"</td>
+        </tr>
+        <tr>
+            <td><h5>restart-strategy.failure-rate.max-failures-per-interval</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Maximum number of restarts in given time interval before failing a job when using <span markdown="span">`FailureRateRestartStrategy`</span>.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
+++ b/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
@@ -9,7 +9,7 @@
     <tbody>
         <tr>
             <td><h5>restart-strategy.failure-rate.delay</h5></td>
-            <td style="word-wrap: break-word;">"10 s"</td>
+            <td style="word-wrap: break-word;">"0 s"</td>
             <td>Delay between two consecutive restart attempts when using <span markdown="span">`FailureRateRestartStrategy`</span>. It can be specified using Scala's <span markdown="span">`FiniteDuration`</span> notation: "1 min", "20 s"</td>
         </tr>
         <tr>

--- a/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
+++ b/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
@@ -1,0 +1,21 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>restart-strategy.fixed-delay.attempts</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>The number of times that Flink retries the execution before the job is declared as failed when using <span markdown="span">`FixedDelayRestartStrategy`</span>. If checkpointing is enabled, then the default value is <span markdown="span">`Integer.MAX_VALUE`</span>. If checkpointing is disabled, then the default value is <span markdown="span">`1`</span>.</td>
+        </tr>
+        <tr>
+            <td><h5>restart-strategy.fixed-delay.delay</h5></td>
+            <td style="word-wrap: break-word;">"0 s"</td>
+            <td>Delay between two consecutive restart attempts when using <span markdown="span">`FixedDelayRestartStrategy`</span>. Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted. It can be specified using Scala's <span markdown="span">`FiniteDuration`</span> notation: "1 min", "20 s"</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/restart_strategy_configuration.html
+++ b/docs/_includes/generated/restart_strategy_configuration.html
@@ -1,0 +1,16 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>restart-strategy</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Defines the restart strategy to use in case of job failures.<br />Accepted values are:<ul><li><span markdown="span">`none`</span>, <span markdown="span">`off`</span>, <span markdown="span">`disable`</span>: No restart strategy.</li><li><span markdown="span">`fixeddelay`</span>, <span markdown="span">`fixed-delay`</span>: Fixed delay restart strategy. More details can be found <a href="../dev/task_failure_recovery.html#fixed-delay-restart-strategy">here</a>.</li><li><span markdown="span">`failurerate`</span>, <span markdown="span">`failure-rate`</span>: Failure rate restart strategy. More details can be found <a href="../dev/task_failure_recovery.html#failure-rate-restart-strategy">here</a>.</li><li><span markdown="span">`org.foobar.MyRestartStrategyFactoryFactory`</span>: Fully qualified name of <span markdown="span">`RestartStrategyFactory`</span> factory which has has a method <span markdown="span">`RestartStrategyFactory createFactory(Configuration configuration)`</span>.</li></ul>If checkpointing is disabled, the default value is <span markdown="span">`none`</span>. If checkpointing is enabled, the default value is <span markdown="span">`fixed-delay`</span> with <span markdown="span">`Integer.MAX_VALUE`</span> restart attempts.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/dev/task_failure_recovery.md
+++ b/docs/dev/task_failure_recovery.md
@@ -47,28 +47,7 @@ Each restart strategy comes with its own set of parameters which control its beh
 These values are also set in the configuration file.
 The description of each restart strategy contains more information about the respective configuration values.
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 50%">Restart Strategy</th>
-      <th class="text-left">Value for restart-strategy</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td>Fixed delay</td>
-        <td>fixed-delay</td>
-    </tr>
-    <tr>
-        <td>Failure rate</td>
-        <td>failure-rate</td>
-    </tr>
-    <tr>
-        <td>No restart</td>
-        <td>none</td>
-    </tr>
-  </tbody>
-</table>
+{% include generated/restart_strategy_configuration.html %}
 
 Apart from defining a default restart strategy, it is possible to define for each Flink job a specific restart strategy.
 This restart strategy is set programmatically by calling the `setRestartStrategy` method on the `ExecutionEnvironment`.
@@ -113,27 +92,7 @@ This strategy is enabled as default by setting the following configuration param
 restart-strategy: fixed-delay
 {% endhighlight %}
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 40%">Configuration Parameter</th>
-      <th class="text-left" style="width: 40%">Description</th>
-      <th class="text-left">Default Value</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td><code>restart-strategy.fixed-delay.attempts</code></td>
-        <td>The number of times that Flink retries the execution before the job is declared as failed.</td>
-        <td>1, or <code>Integer.MAX_VALUE</code> if activated by checkpointing</td>
-    </tr>
-    <tr>
-        <td><code>restart-strategy.fixed-delay.delay</code></td>
-        <td>Delaying the retry means that after a failed execution, the re-execution does not start immediately, but only after a certain delay. Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted.</td>
-        <td><code>akka.ask.timeout</code>, or 10s if activated by checkpointing</td>
-    </tr>
-  </tbody>
-</table>
+{% include generated/fixed_delay_restart_strategy_configuration.html %}
 
 For example:
 
@@ -177,32 +136,7 @@ This strategy is enabled as default by setting the following configuration param
 restart-strategy: failure-rate
 {% endhighlight %}
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 40%">Configuration Parameter</th>
-      <th class="text-left" style="width: 40%">Description</th>
-      <th class="text-left">Default Value</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td><it>restart-strategy.failure-rate.max-failures-per-interval</it></td>
-        <td>Maximum number of restarts in given time interval before failing a job</td>
-        <td>1</td>
-    </tr>
-    <tr>
-        <td><it>restart-strategy.failure-rate.failure-rate-interval</it></td>
-        <td>Time interval for measuring failure rate.</td>
-        <td>1 minute</td>
-    </tr>
-    <tr>
-        <td><it>restart-strategy.failure-rate.delay</it></td>
-        <td>Delay between two consecutive restart attempts</td>
-        <td><it>akka.ask.timeout</it></td>
-    </tr>
-  </tbody>
-</table>
+{% include generated/failure_rate_restart_strategy_configuration.html %}
 
 {% highlight yaml %}
 restart-strategy.failure-rate.max-failures-per-interval: 3

--- a/docs/dev/task_failure_recovery.zh.md
+++ b/docs/dev/task_failure_recovery.zh.md
@@ -42,28 +42,7 @@ Flink 作业如果没有定义重启策略，则会遵循集群启动时加载�
 这些参数也在配置文件中设置。
 后文的描述中会详细介绍每种重启策略的配置项。
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 50%">重启策略</th>
-      <th class="text-left">restart-strategy 配置值</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td>固定延时重启策略</td>
-        <td>fixed-delay</td>
-    </tr>
-    <tr>
-        <td>故障率重启策略</td>
-        <td>failure-rate</td>
-    </tr>
-    <tr>
-        <td>不重启策略</td>
-        <td>none</td>
-    </tr>
-  </tbody>
-</table>
+{% include generated/restart_strategy_configuration.html %}
 
 除了定义默认的重启策略以外，还可以为每个 Flink 作业单独定义重启策略。
 这个重启策略通过在程序中的 `ExecutionEnvironment` 对象上调用 `setRestartStrategy` 方法来设置。
@@ -109,27 +88,7 @@ env.setRestartStrategy(RestartStrategies.fixedDelayRestart(
 restart-strategy: fixed-delay
 {% endhighlight %}
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 40%">配置参数</th>
-      <th class="text-left" style="width: 40%">描述</th>
-      <th class="text-left">默认配置值</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td><code>restart-strategy.fixed-delay.attempts</code></td>
-        <td>作业宣告失败之前 Flink 重试执行的最大次数</td>
-        <td>启用 checkpoint 的话是 <code>Integer.MAX_VALUE</code>，否则是 1</td>
-    </tr>
-    <tr>
-        <td><code>restart-strategy.fixed-delay.delay</code></td>
-        <td>延时重试意味着执行遭遇故障后，并不立即重新启动，而是延后一段时间。当程序与外部系统有交互时延时重试可能会有所帮助，比如程序里有连接或者挂起的事务的话，在尝试重新执行之前应该等待连接或者挂起的事务超时。</td>
-        <td>启用 checkpoint 的话是 10 秒，否则使用 <code>akka.ask.timeout</code> 的值</td>
-    </tr>
-  </tbody>
-</table>
+{% include generated/fixed_delay_restart_strategy_configuration.html %}
 
 例如：
 
@@ -173,32 +132,7 @@ env.setRestartStrategy(RestartStrategies.fixedDelayRestart(
 restart-strategy: failure-rate
 {% endhighlight %}
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 40%">配置参数</th>
-      <th class="text-left" style="width: 40%">描述</th>
-      <th class="text-left">配置默认值</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td><it>restart-strategy.failure-rate.max-failures-per-interval</it></td>
-        <td>单个时间间隔内允许的最大重启次数</td>
-        <td>1</td>
-    </tr>
-    <tr>
-        <td><it>restart-strategy.failure-rate.failure-rate-interval</it></td>
-        <td>测量故障率的时间间隔</td>
-        <td>1 分钟</td>
-    </tr>
-    <tr>
-        <td><it>restart-strategy.failure-rate.delay</it></td>
-        <td>连续两次重启尝试之间的延时</td>
-        <td><it>akka.ask.timeout</it></td>
-    </tr>
-  </tbody>
-</table>
+{% include generated/failure_rate_restart_strategy_configuration.html %}
 
 例如：
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -66,6 +66,20 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/job_manager_configuration.html %}
 
+### Restart Strategies
+
+Configuration options to control Flink's restart behaviour in case of job failures.
+
+{% include generated/restart_strategy_configuration.html %}
+
+#### Fixed Delay Restart Strategy
+
+{% include generated/fixed_delay_restart_strategy_configuration.html %}
+
+#### Failure Rate Restart Strategy
+
+{% include generated/failure_rate_restart_strategy_configuration.html %}
+
 ### TaskManager
 
 {% include generated/task_manager_configuration.html %}

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -66,6 +66,20 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/job_manager_configuration.html %}
 
+### Restart Strategies
+
+Configuration options to control Flink's restart behaviour in case of job failures.
+
+{% include generated/restart_strategy_configuration.html %}
+
+#### Fixed Delay Restart Strategy
+
+{% include generated/fixed_delay_restart_strategy_configuration.html %}
+
+#### Failure Rate Restart Strategy
+
+{% include generated/failure_rate_restart_strategy_configuration.html %}
+
 ### TaskManager
 
 {% include generated/task_manager_configuration.html %}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -21,7 +21,6 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -84,7 +83,6 @@ public class KafkaShortRetentionTestBase implements Serializable {
 	private static Configuration getConfiguration() {
 		Configuration flinkConfig = new Configuration();
 		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
-		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 		return flinkConfig;
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -121,7 +121,6 @@ public abstract class KafkaTestBase extends TestLogger {
 		flinkConfig.setString(AkkaOptions.WATCH_HEARTBEAT_PAUSE, "5 s");
 		flinkConfig.setString(AkkaOptions.WATCH_HEARTBEAT_INTERVAL, "1 s");
 		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
-		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 		flinkConfig.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
 		return flinkConfig;
 	}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -56,20 +56,29 @@ public final class ConfigConstants {
 	 * be "failurerate", "failure-rate" to use FailureRateRestartStrategy. You can also
 	 * specify a class name which implements the RestartStrategy interface and has a static
 	 * create method which takes a Configuration object.
+	 *
+	 * @deprecated use {@link RestartStrategyOptions#RESTART_STRATEGY} instead.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public static final String RESTART_STRATEGY = "restart-strategy";
 
 	/**
 	 * Maximum number of attempts the fixed delay restart strategy will try before failing a job.
+	 *
+	 * @deprecated use {@link RestartStrategyOptions#RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS} instead.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public static final String RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS = "restart-strategy.fixed-delay.attempts";
 
 	/**
 	 * Delay between two consecutive restart attempts in FixedDelayRestartStrategy. It can be specified using Scala's
 	 * FiniteDuration notation: "1 min", "20 s"
+	 *
+	 * @deprecated use {@link RestartStrategyOptions#RESTART_STRATEGY_FIXED_DELAY_DELAY} instead.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public static final ConfigOption<String> RESTART_STRATEGY_FIXED_DELAY_DELAY =
 		key("restart-strategy.fixed-delay.delay").defaultValue("0 s");
@@ -77,21 +86,30 @@ public final class ConfigConstants {
 	/**
 	 * Maximum number of restarts in given time interval {@link #RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL} before failing a job
 	 * in FailureRateRestartStrategy.
+	 *
+	 * @deprecated use {@link RestartStrategyOptions#RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL} instead.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public static final String RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL = "restart-strategy.failure-rate.max-failures-per-interval";
 
 	/**
 	 * Time interval in which greater amount of failures than {@link #RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL} causes
 	 * job fail in FailureRateRestartStrategy. It can be specified using Scala's FiniteDuration notation: "1 min", "20 s"
+	 *
+	 * @deprecated use {@link RestartStrategyOptions#RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL}
 	 */
+	@Deprecated
 	@PublicEvolving
 	public static final String RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL = "restart-strategy.failure-rate.failure-rate-interval";
 
 	/**
 	 * Delay between two consecutive restart attempts in FailureRateRestartStrategy.
 	 * It can be specified using Scala's FiniteDuration notation: "1 min", "20 s".
+	 *
+	 * @deprecated use {@link RestartStrategyOptions#RESTART_STRATEGY_FAILURE_RATE_DELAY} instead.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public static final String RESTART_STRATEGY_FAILURE_RATE_DELAY = "restart-strategy.failure-rate.delay";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -111,7 +111,12 @@ public final class ConfigConstants {
 	 */
 	@Deprecated
 	@PublicEvolving
-	public static final String RESTART_STRATEGY_FAILURE_RATE_DELAY = "restart-strategy.failure-rate.delay";
+	public static final ConfigOption<String> RESTART_STRATEGY_FAILURE_RATE_DELAY =
+		key("restart-strategy.failure-rate.delay")
+			.defaultValue("0 s")
+			.withDescription(
+				"Delay between two consecutive restart attempts in FailureRateRestartStrategy. " +
+				"It can be specified using Scala's FiniteDuration notation: \"1 min\", \"20 s\"");
 
 	/**
 	 * Config parameter for the number of re-tries for failed tasks. Setting this

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.configuration.description.Description;
+
+import static org.apache.flink.configuration.description.LinkElement.link;
+import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/**
+ * Config options for restart strategies.
+ */
+@PublicEvolving
+@ConfigGroups(groups = {
+	@ConfigGroup(name = "FixedDelayRestartStrategy", keyPrefix = "restart-strategy.fixed-delay"),
+	@ConfigGroup(name = "FailureRateRestartStrategy", keyPrefix = "restart-strategy.failure-rate")
+})
+public class RestartStrategyOptions {
+
+	public static final ConfigOption<String> RESTART_STRATEGY = ConfigOptions
+		.key("restart-strategy")
+		.noDefaultValue()
+		.withDescription(
+			Description.builder()
+				.text("Defines the restart strategy to use in case of job failures.")
+				.linebreak()
+				.text("Accepted values are:")
+				.list(
+					text("%s, %s, %s: No restart strategy.", code("none"), code("off"), code("disable")),
+					text(
+						"%s, %s: Fixed delay restart strategy. More details can be found %s.",
+						code("fixeddelay"),
+						code("fixed-delay"),
+						link("../dev/task_failure_recovery.html#fixed-delay-restart-strategy", "here")),
+					text(
+						"%s, %s: Failure rate restart strategy. More details can be found %s.",
+						code("failurerate"),
+						code("failure-rate"),
+						link("../dev/task_failure_recovery.html#failure-rate-restart-strategy", "here")),
+					text(
+						"%s: Fully qualified name of %s factory which has has a method %s.",
+						code("org.foobar.MyRestartStrategyFactoryFactory"),
+						code("RestartStrategyFactory"),
+						code("RestartStrategyFactory createFactory(Configuration configuration)"))
+				)
+				.text(
+					"If checkpointing is disabled, the default value is %s. " +
+						"If checkpointing is enabled, the default value is %s with %s restart attempts.",
+					code("none"),
+					code("fixed-delay"),
+					code("Integer.MAX_VALUE"))
+				.build());
+
+	public static final ConfigOption<Integer> RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS = ConfigOptions
+		.key("restart-strategy.fixed-delay.attempts")
+		.defaultValue(1)
+		.withDescription(
+			Description.builder()
+				.text(
+					"The number of times that Flink retries the execution before the job is declared as failed when using %s. " +
+						"If checkpointing is enabled, then the default value is %s. " +
+						"If checkpointing is disabled, then the default value is %s.",
+					code("FixedDelayRestartStrategy"),
+					code("Integer.MAX_VALUE"),
+					code("1"))
+				.build());
+
+	public static final ConfigOption<String> RESTART_STRATEGY_FIXED_DELAY_DELAY = ConfigOptions
+		.key("restart-strategy.fixed-delay.delay")
+		.defaultValue("0 s")
+		.withDescription(
+			Description.builder()
+				.text(
+					"Delay between two consecutive restart attempts when using %s. " +
+						"Delaying the retries can be helpful when the program interacts with external systems where " +
+						"for example connections or pending transactions should reach a timeout before re-execution " +
+						"is attempted. It can be specified using Scala's %s notation: \"1 min\", \"20 s\"",
+					code("FixedDelayRestartStrategy"),
+					code("FiniteDuration"))
+				.build());
+
+	public static final ConfigOption<Integer> RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL = ConfigOptions
+		.key("restart-strategy.failure-rate.max-failures-per-interval")
+		.defaultValue(1)
+		.withDescription(
+			Description.builder()
+				.text(
+					"Maximum number of restarts in given time interval before failing a job when using %s.",
+					code("FailureRateRestartStrategy"))
+				.build());
+
+	public static final ConfigOption<String> RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL = ConfigOptions
+		.key("restart-strategy.failure-rate.failure-rate-interval")
+		.defaultValue("1 min")
+		.withDescription(
+			Description.builder()
+				.text(
+					"Time interval for measuring failure rate when using %s. " +
+						"It can be specified using Scala's %s notation: \"1 min\", \"20 s\"",
+					code("FailureRateRestartStrategy"),
+					code("FiniteDuration"))
+				.build());
+
+	public static final ConfigOption<String> RESTART_STRATEGY_FAILURE_RATE_DELAY = ConfigOptions
+		.key("restart-strategy.failure-rate.delay")
+		.defaultValue(AkkaOptions.ASK_TIMEOUT.defaultValue())
+		.withDescription(
+			Description.builder()
+				.text(
+					"Delay between two consecutive restart attempts when using %s. " +
+						"It can be specified using Scala's %s notation: \"1 min\", \"20 s\"",
+					code("FailureRateRestartStrategy"),
+					code("FiniteDuration"))
+				.build());
+
+	private RestartStrategyOptions() {
+		throw new UnsupportedOperationException("This class should never be instantiated.");
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
@@ -123,7 +123,7 @@ public class RestartStrategyOptions {
 
 	public static final ConfigOption<String> RESTART_STRATEGY_FAILURE_RATE_DELAY = ConfigOptions
 		.key("restart-strategy.failure-rate.delay")
-		.defaultValue(AkkaOptions.ASK_TIMEOUT.defaultValue())
+		.defaultValue("0 s")
 		.withDescription(
 			Description.builder()
 				.text(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.executiongraph.restart;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -29,7 +29,6 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayDeque;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import scala.concurrent.duration.Duration;
 
@@ -92,12 +91,10 @@ public class FailureRateRestartStrategy implements RestartStrategy {
 	}
 
 	public static FailureRateRestartStrategyFactory createFactory(Configuration configuration) throws Exception {
-		int maxFailuresPerInterval = configuration.getInteger(ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 1);
-		String failuresIntervalString = configuration.getString(
-				ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL, Duration.apply(1, TimeUnit.MINUTES).toString()
-		);
+		int maxFailuresPerInterval = configuration.getInteger(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL);
+		String failuresIntervalString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL);
 		String timeoutString = configuration.getString(AkkaOptions.WATCH_HEARTBEAT_INTERVAL);
-		String delayString = configuration.getString(ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_DELAY, timeoutString);
+		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY, timeoutString);
 
 		Duration failuresInterval = Duration.apply(failuresIntervalString);
 		Duration delay = Duration.apply(delayString);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.executiongraph.restart;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -93,8 +92,7 @@ public class FailureRateRestartStrategy implements RestartStrategy {
 	public static FailureRateRestartStrategyFactory createFactory(Configuration configuration) throws Exception {
 		int maxFailuresPerInterval = configuration.getInteger(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL);
 		String failuresIntervalString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL);
-		String timeoutString = configuration.getString(AkkaOptions.WATCH_HEARTBEAT_INTERVAL);
-		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY, timeoutString);
+		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY);
 
 		Duration failuresInterval = Duration.apply(failuresIntervalString);
 		Duration delay = Duration.apply(delayString);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
@@ -99,7 +99,6 @@ public class FailureRateRestartStrategy implements RestartStrategy {
 		Duration failuresInterval = Duration.apply(failuresIntervalString);
 		Duration delay = Duration.apply(delayString);
 
-
 		return new FailureRateRestartStrategyFactory(maxFailuresPerInterval, Time.milliseconds(failuresInterval.toMillis()), Time.milliseconds(delay.toMillis()));
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.executiongraph.restart;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -75,9 +75,9 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 	 * @throws Exception
 	 */
 	public static FixedDelayRestartStrategyFactory createFactory(Configuration configuration) throws Exception {
-		int maxAttempts = configuration.getInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+		int maxAttempts = configuration.getInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS);
 
-		String delayString = configuration.getString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY);
+		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY);
 
 		long delay;
 
@@ -85,7 +85,7 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 			delay = Duration.apply(delayString).toMillis();
 		} catch (NumberFormatException nfe) {
 			throw new Exception("Invalid config value for " +
-					ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY + ": " + delayString +
+					RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key() + ": " + delayString +
 					". Value must be a valid duration (such as '100 milli' or '10 s')");
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,14 +88,14 @@ public abstract class RestartStrategyFactory implements Serializable {
 	 * @throws Exception which indicates that the RestartStrategy could not be instantiated.
 	 */
 	public static RestartStrategyFactory createRestartStrategyFactory(Configuration configuration) throws Exception {
-		String restartStrategyName = configuration.getString(ConfigConstants.RESTART_STRATEGY, null);
+		String restartStrategyName = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY, null);
 
 		if (restartStrategyName == null) {
 			// support deprecated ConfigConstants values
-			final int numberExecutionRetries = configuration.getInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS,
+			final int numberExecutionRetries = configuration.getInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS,
 				ConfigConstants.DEFAULT_EXECUTION_RETRIES);
 			String pauseString = configuration.getString(AkkaOptions.WATCH_HEARTBEAT_PAUSE);
-			String delayString = configuration.getString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
+			String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY,
 				pauseString);
 
 			long delay;
@@ -108,7 +109,7 @@ public abstract class RestartStrategyFactory implements Serializable {
 						". Value must be a valid duration (such as '10 s' or '1 min')");
 				} else {
 					throw new Exception("Invalid config value for " +
-						ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY + ": " + delayString +
+						RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key() + ": " + delayString +
 						". Value must be a valid duration (such as '100 milli' or '10 s')");
 				}
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/BlobsCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/BlobsCleanupITCase.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.BlobServerOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.BlobClient;
@@ -88,8 +88,8 @@ public class BlobsCleanupITCase extends TestLogger {
 
 		Configuration cfg = new Configuration();
 		cfg.setString(BlobServerOptions.STORAGE_DIRECTORY, blobBaseDir.getAbsolutePath());
-		cfg.setString(ConfigConstants.RESTART_STRATEGY, "fixeddelay");
-		cfg.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+		cfg.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixeddelay");
+		cfg.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
 		// BLOBs are deleted from BlobCache between 1s and 2s after last reference
 		// -> the BlobCache may still have the BLOB or not (let's test both cases randomly)
 		cfg.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -29,9 +29,9 @@ import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.BlobServerOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.core.io.InputSplitSource;
@@ -1049,8 +1049,8 @@ public class JobMasterTest extends TestLogger {
 
 	@Test
 	public void testRequestNextInputSplitWithGlobalFailover() throws Exception {
-		configuration.setLong(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
-		configuration.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
+		configuration.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 
 		final Function<List<List<InputSplit>>, Collection<InputSplit>> expectAllRemainingInputSplits = this::flattenCollection;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -28,9 +28,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.executiongraph.restart.FailingRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.state.CheckpointListener;
@@ -106,7 +106,7 @@ public class RegionFailoverITCase extends TestLogger {
 		configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
 		// global failover times: 3, region failover times: NUM_OF_RESTARTS
 		configuration.setInteger(FailingRestartStrategy.NUM_FAILURES_CONFIG_OPTION, 3);
-		configuration.setString(ConfigConstants.RESTART_STRATEGY, FailingRestartStrategy.class.getName());
+		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY, FailingRestartStrategy.class.getName());
 
 		cluster = new MiniClusterWithClientResource(
 			new MiniClusterResourceConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.test.recovery;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
@@ -40,10 +40,10 @@ public class SimpleRecoveryFailureRateStrategyITBase extends SimpleRecoveryITCas
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(ConfigConstants.RESTART_STRATEGY, "failure-rate");
-		config.setInteger(ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 1);
-		config.setString(ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL, "1 second");
-		config.setString(ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_DELAY, "100 ms");
+		config.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
+		config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 1);
+		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL, "1 second");
+		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY, "100 ms");
 
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
@@ -43,7 +43,6 @@ public class SimpleRecoveryFailureRateStrategyITBase extends SimpleRecoveryITCas
 		config.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 		config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 1);
 		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL, "1 second");
-		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY, "100 ms");
 
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.test.recovery;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
@@ -40,9 +40,9 @@ public class SimpleRecoveryFixedDelayRestartStrategyITBase extends SimpleRecover
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(ConfigConstants.RESTART_STRATEGY, "fixed-delay");
-		config.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
-		config.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "100 ms");
+		config.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+		config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, "100 ms");
 
 		return config;
 	}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -25,10 +25,10 @@ import org.apache.flink.client.deployment.ClusterDeploymentException;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.rest.RestClusterClient;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -278,8 +278,8 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 		flinkConfiguration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zkServer.getConnectString());
 		flinkConfiguration.setInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, 1000);
 
-		flinkConfiguration.setString(ConfigConstants.RESTART_STRATEGY, "fixed-delay");
-		flinkConfiguration.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, Integer.MAX_VALUE);
+		flinkConfiguration.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+		flinkConfiguration.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, Integer.MAX_VALUE);
 
 		final int minMemory = 100;
 		flinkConfiguration.setInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN, minMemory);


### PR DESCRIPTION
## What is the purpose of the change

Set default failure rate restart strategy delay to `0 s`.

This PR breaks the public evolving `RESTART_STRATEGY_FAILURE_RATE_DELAY` configuration by changing its type from `String` to `ConfigOption`. I believe that this is ok given that it is public evolving. We should add a release note when closing the JIRA issue, though.

This PR is based on #9562.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
