### PR TITLE
[FLNK-13885] Remove HighAvailabilityOptions#HA_JOB_DELAY

### DIFF
--- a/docs/_includes/generated/high_availability_configuration.html
+++ b/docs/_includes/generated/high_availability_configuration.html
@@ -18,11 +18,6 @@
             <td>The ID of the Flink cluster, used to separate multiple Flink clusters from each other. Needs to be set for standalone clusters but is automatically inferred in YARN and Mesos.</td>
         </tr>
         <tr>
-            <td><h5>high-availability.job.delay</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>The time before a JobManager after a fail over recovers the current jobs.</td>
-        </tr>
-        <tr>
             <td><h5>high-availability.jobmanager.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
             <td>Optional port (range) used by the job manager in high-availability mode.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1044,11 +1044,6 @@ public final class ConfigConstants {
 	@PublicEvolving
 	public static final String HA_JOB_MANAGER_PORT = "high-availability.jobmanager.port";
 
-	/** @deprecated Deprecated in favour of {@link HighAvailabilityOptions#HA_JOB_DELAY}. */
-	@PublicEvolving
-	@Deprecated
-	public static final String HA_JOB_DELAY = "high-availability.job.delay";
-
 	/** @deprecated Deprecated in favour of {@link #HA_MODE}. */
 	@Deprecated
 	public static final String RECOVERY_MODE = "recovery.mode";
@@ -1057,7 +1052,7 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String RECOVERY_JOB_MANAGER_PORT = "recovery.jobmanager.port";
 
-	/** @deprecated Deprecated in favour of {@link #HA_JOB_DELAY}. */
+	/** @deprecated This option is no longer used and has no effect on Flink. */
 	@Deprecated
 	public static final String RECOVERY_JOB_DELAY = "recovery.job.delay";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -87,15 +87,6 @@ public class HighAvailabilityOptions {
 			.withDeprecatedKeys("recovery.jobmanager.port")
 			.withDescription("Optional port (range) used by the job manager in high-availability mode.");
 
-	/**
-	 * The time before a JobManager after a fail over recovers the current jobs.
-	 */
-	public static final ConfigOption<String> HA_JOB_DELAY =
-			key("high-availability.job.delay")
-			.noDefaultValue()
-			.withDeprecatedKeys("recovery.job.delay")
-			.withDescription("The time before a JobManager after a fail over recovers the current jobs.");
-
 	// ------------------------------------------------------------------------
 	//  ZooKeeper Options
 	// ------------------------------------------------------------------------
@@ -200,6 +191,22 @@ public class HighAvailabilityOptions {
 			.withDescription("Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be" +
 				" set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use" +
 				" SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos).");
+
+	// ------------------------------------------------------------------------
+	//  Deprecated options
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The time before a JobManager after a fail over recovers the current jobs.
+	 *
+	 * @deprecated Don't use this option anymore. It has no effect on Flink.
+	 */
+	@Deprecated
+	public static final ConfigOption<String> HA_JOB_DELAY =
+		key("high-availability.job.delay")
+			.noDefaultValue()
+			.withDeprecatedKeys("recovery.job.delay")
+			.withDescription("The time before a JobManager after a fail over recovers the current jobs.");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -86,7 +86,6 @@ public class ZooKeeperTestUtils {
 		config.setString(AkkaOptions.WATCH_HEARTBEAT_PAUSE, "6 s");
 		config.setInteger(AkkaOptions.WATCH_THRESHOLD, 9);
 		config.setString(AkkaOptions.ASK_TIMEOUT, "100 s");
-		config.setString(HighAvailabilityOptions.HA_JOB_DELAY, "10 s");
 
 		return config;
 	}


### PR DESCRIPTION
## What is the purpose of the change

The HighAvailabilityOptions#HA_JOB_DELAY is no longer used. Hence, this commit removes
the old code and updates the configuration documentation.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
