### PR TITLE
[FLINK-13868][REST] Job vertex add taskmanager id in rest api

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -2564,7 +2564,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "start_time" : {
             "type" : "integer"
           },
-          "resource-id" : {
+          "taskmanager-id" : {
             "type" : "string"
           }
         }
@@ -3044,7 +3044,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         }
       }
     },
-    "resource-id" : {
+    "taskmanager-id" : {
       "type" : "string"
     }
   }
@@ -3153,7 +3153,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         }
       }
     },
-    "resource-id" : {
+    "taskmanager-id" : {
       "type" : "string"
     }
   }

--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -2563,6 +2563,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "start_time" : {
             "type" : "integer"
+          },
+          "resource-id" : {
+            "type" : "string"
           }
         }
       }
@@ -3040,6 +3043,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "boolean"
         }
       }
+    },
+    "resource-id" : {
+      "type" : "string"
     }
   }
 }            </code>
@@ -3146,6 +3152,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "boolean"
         }
       }
+    },
+    "resource-id" : {
+      "type" : "string"
     }
   }
 }            </code>

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1684,6 +1684,9 @@
               },
               "start_time" : {
                 "type" : "integer"
+              },
+              "resource-id" : {
+                "type" : "string"
               }
             }
           }
@@ -1955,6 +1958,9 @@
         "duration" : {
           "type" : "integer"
         },
+        "resource-id" : {
+          "type" : "string"
+        },
         "metrics" : {
           "type" : "object",
           "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
@@ -2034,6 +2040,9 @@
         },
         "duration" : {
           "type" : "integer"
+        },
+        "resource-id" : {
+          "type" : "string"
         },
         "metrics" : {
           "type" : "object",

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1685,7 +1685,7 @@
               "start_time" : {
                 "type" : "integer"
               },
-              "resource-id" : {
+              "taskmanager-id" : {
                 "type" : "string"
               }
             }
@@ -1958,7 +1958,7 @@
         "duration" : {
           "type" : "integer"
         },
-        "resource-id" : {
+        "taskmanager-id" : {
           "type" : "string"
         },
         "metrics" : {
@@ -2041,7 +2041,7 @@
         "duration" : {
           "type" : "integer"
         },
-        "resource-id" : {
+        "taskmanager-id" : {
           "type" : "string"
         },
         "metrics" : {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
@@ -115,6 +115,7 @@ public class JobVertexDetailsHandler extends AbstractExecutionGraphHandler<JobVe
 
 			TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
 			String locationString = location == null ? "(unassigned)" : location.getHostname() + ":" + location.dataPort();
+			String resourceId = location == null ? "(unassigned)" : location.getResourceID().getResourceIdString();
 
 			long startTime = vertex.getStateTimestamp(ExecutionState.DEPLOYING);
 			if (startTime == 0) {
@@ -145,7 +146,8 @@ public class JobVertexDetailsHandler extends AbstractExecutionGraphHandler<JobVe
 					counts.getNumRecordsIn(),
 					counts.isNumRecordsInComplete(),
 					counts.getNumRecordsOut(),
-					counts.isNumRecordsOutComplete())));
+					counts.isNumRecordsOutComplete()),
+				resourceId));
 
 			num++;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
@@ -122,7 +122,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
 		public static final String FIELD_NAME_END_TIME = "end-time";
 		public static final String FIELD_NAME_DURATION = "duration";
 		public static final String FIELD_NAME_METRICS = "metrics";
-		public static final String FIELD_NAME_RESOURCE_ID = "resource-id";
+		public static final String FIELD_NAME_TASKMANAGER_ID = "taskmanager-id";
 
 		@JsonProperty(FIELD_NAME_SUBTASK)
 		private final int subtask;
@@ -151,8 +151,8 @@ public class JobVertexDetailsInfo implements ResponseBody {
 		@JsonProperty(FIELD_NAME_METRICS)
 		private final IOMetricsInfo metrics;
 
-		@JsonProperty(FIELD_NAME_RESOURCE_ID)
-		private final String resourceId;
+		@JsonProperty(FIELD_NAME_TASKMANAGER_ID)
+		private final String taskmanagerId;
 
 		@JsonCreator
 		public VertexTaskDetail(
@@ -164,7 +164,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
 				@JsonProperty(FIELD_NAME_END_TIME) long endTime,
 				@JsonProperty(FIELD_NAME_DURATION) long duration,
 				@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo metrics,
-				@JsonProperty(FIELD_NAME_RESOURCE_ID) String resourceId) {
+				@JsonProperty(FIELD_NAME_TASKMANAGER_ID) String taskmanagerId) {
 			this.subtask = subtask;
 			this.status = checkNotNull(status);
 			this.attempt = attempt;
@@ -174,7 +174,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
 			this.endTime = endTime;
 			this.duration = duration;
 			this.metrics = checkNotNull(metrics);
-			this.resourceId = checkNotNull(resourceId);
+			this.taskmanagerId = checkNotNull(taskmanagerId);
 		}
 
 		@JsonIgnore
@@ -202,12 +202,12 @@ public class JobVertexDetailsInfo implements ResponseBody {
 				endTime == that.endTime &&
 				duration == that.duration &&
 				Objects.equals(metrics, that.metrics) &&
-				Objects.equals(resourceId, that.resourceId);
+				Objects.equals(taskmanagerId, that.taskmanagerId);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(subtask, status, attempt, host, startTime, startTimeCompatible, endTime, duration, metrics, resourceId);
+			return Objects.hash(subtask, status, attempt, host, startTime, startTimeCompatible, endTime, duration, metrics, taskmanagerId);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
@@ -122,6 +122,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
 		public static final String FIELD_NAME_END_TIME = "end-time";
 		public static final String FIELD_NAME_DURATION = "duration";
 		public static final String FIELD_NAME_METRICS = "metrics";
+		public static final String FIELD_NAME_RESOURCE_ID = "resource-id";
 
 		@JsonProperty(FIELD_NAME_SUBTASK)
 		private final int subtask;
@@ -150,6 +151,9 @@ public class JobVertexDetailsInfo implements ResponseBody {
 		@JsonProperty(FIELD_NAME_METRICS)
 		private final IOMetricsInfo metrics;
 
+		@JsonProperty(FIELD_NAME_RESOURCE_ID)
+		private final String resourceId;
+
 		@JsonCreator
 		public VertexTaskDetail(
 				@JsonProperty(FIELD_NAME_SUBTASK) int subtask,
@@ -159,7 +163,8 @@ public class JobVertexDetailsInfo implements ResponseBody {
 				@JsonProperty(FIELD_NAME_START_TIME) long startTime,
 				@JsonProperty(FIELD_NAME_END_TIME) long endTime,
 				@JsonProperty(FIELD_NAME_DURATION) long duration,
-				@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo metrics) {
+				@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo metrics,
+				@JsonProperty(FIELD_NAME_RESOURCE_ID) String resourceId) {
 			this.subtask = subtask;
 			this.status = checkNotNull(status);
 			this.attempt = attempt;
@@ -169,6 +174,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
 			this.endTime = endTime;
 			this.duration = duration;
 			this.metrics = checkNotNull(metrics);
+			this.resourceId = checkNotNull(resourceId);
 		}
 
 		@JsonIgnore
@@ -195,12 +201,13 @@ public class JobVertexDetailsInfo implements ResponseBody {
 				startTimeCompatible == that.startTimeCompatible &&
 				endTime == that.endTime &&
 				duration == that.duration &&
-				Objects.equals(metrics, that.metrics);
+				Objects.equals(metrics, that.metrics) &&
+				Objects.equals(resourceId, that.resourceId);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(subtask, status, attempt, host, startTime, startTimeCompatible, endTime, duration, metrics);
+			return Objects.hash(subtask, status, attempt, host, startTime, startTimeCompatible, endTime, duration, metrics, resourceId);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -52,6 +52,8 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 
 	public static final String FIELD_NAME_METRICS = "metrics";
 
+	public static final String FIELD_NAME_RESOURCE_ID = "resource-id";
+
 	@JsonProperty(FIELD_NAME_SUBTASK_INDEX)
 	private final int subtaskIndex;
 
@@ -76,6 +78,9 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 	@JsonProperty(FIELD_NAME_METRICS)
 	private final IOMetricsInfo ioMetricsInfo;
 
+	@JsonProperty(FIELD_NAME_RESOURCE_ID)
+	private final String resourceId;
+
 	@JsonCreator
 	public SubtaskExecutionAttemptDetailsInfo(
 			@JsonProperty(FIELD_NAME_SUBTASK_INDEX) int subtaskIndex,
@@ -85,7 +90,8 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			@JsonProperty(FIELD_NAME_START_TIME) long startTime,
 			@JsonProperty(FIELD_NAME_END_TIME) long endTime,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
-			@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo ioMetricsInfo) {
+			@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo ioMetricsInfo,
+			@JsonProperty(FIELD_NAME_RESOURCE_ID) String resourceId) {
 
 		this.subtaskIndex = subtaskIndex;
 		this.status = Preconditions.checkNotNull(status);
@@ -95,6 +101,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 		this.endTime = endTime;
 		this.duration = duration;
 		this.ioMetricsInfo = Preconditions.checkNotNull(ioMetricsInfo);
+		this.resourceId = Preconditions.checkNotNull(resourceId);
 	}
 
 	public int getSubtaskIndex() {
@@ -129,6 +136,10 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 		return ioMetricsInfo;
 	}
 
+	public String getResourceId() {
+		return resourceId;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -147,12 +158,13 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			startTime == that.startTime &&
 			endTime == that.endTime &&
 			duration == that.duration &&
-			Objects.equals(ioMetricsInfo, that.ioMetricsInfo);
+			Objects.equals(ioMetricsInfo, that.ioMetricsInfo) &&
+			Objects.equals(resourceId, that.resourceId);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(subtaskIndex, status, attempt, host, startTime, endTime, duration, ioMetricsInfo);
+		return Objects.hash(subtaskIndex, status, attempt, host, startTime, endTime, duration, ioMetricsInfo, resourceId);
 	}
 
 	public static SubtaskExecutionAttemptDetailsInfo create(AccessExecution execution, MutableIOMetrics ioMetrics) {
@@ -161,6 +173,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 
 		final TaskManagerLocation location = execution.getAssignedResourceLocation();
 		final String locationString = location == null ? "(unassigned)" : location.getHostname();
+		String resourceId = location == null ? "(unassigned)" : location.getResourceID().toString();
 
 		long startTime = execution.getStateTimestamp(ExecutionState.DEPLOYING);
 		if (startTime == 0) {
@@ -187,7 +200,8 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			startTime,
 			endTime,
 			duration,
-			ioMetricsInfo
+			ioMetricsInfo,
+			resourceId
 		);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -52,7 +52,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 
 	public static final String FIELD_NAME_METRICS = "metrics";
 
-	public static final String FIELD_NAME_RESOURCE_ID = "resource-id";
+	public static final String FIELD_NAME_TASKMANAGER_ID = "taskmanager-id";
 
 	@JsonProperty(FIELD_NAME_SUBTASK_INDEX)
 	private final int subtaskIndex;
@@ -78,8 +78,8 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 	@JsonProperty(FIELD_NAME_METRICS)
 	private final IOMetricsInfo ioMetricsInfo;
 
-	@JsonProperty(FIELD_NAME_RESOURCE_ID)
-	private final String resourceId;
+	@JsonProperty(FIELD_NAME_TASKMANAGER_ID)
+	private final String taskmanagerId;
 
 	@JsonCreator
 	public SubtaskExecutionAttemptDetailsInfo(
@@ -91,7 +91,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			@JsonProperty(FIELD_NAME_END_TIME) long endTime,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
 			@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo ioMetricsInfo,
-			@JsonProperty(FIELD_NAME_RESOURCE_ID) String resourceId) {
+			@JsonProperty(FIELD_NAME_TASKMANAGER_ID) String taskmanagerId) {
 
 		this.subtaskIndex = subtaskIndex;
 		this.status = Preconditions.checkNotNull(status);
@@ -101,7 +101,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 		this.endTime = endTime;
 		this.duration = duration;
 		this.ioMetricsInfo = Preconditions.checkNotNull(ioMetricsInfo);
-		this.resourceId = Preconditions.checkNotNull(resourceId);
+		this.taskmanagerId = Preconditions.checkNotNull(taskmanagerId);
 	}
 
 	public int getSubtaskIndex() {
@@ -136,8 +136,8 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 		return ioMetricsInfo;
 	}
 
-	public String getResourceId() {
-		return resourceId;
+	public String getTaskmanagerId() {
+		return taskmanagerId;
 	}
 
 	@Override
@@ -159,12 +159,12 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			endTime == that.endTime &&
 			duration == that.duration &&
 			Objects.equals(ioMetricsInfo, that.ioMetricsInfo) &&
-			Objects.equals(resourceId, that.resourceId);
+			Objects.equals(taskmanagerId, that.taskmanagerId);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(subtaskIndex, status, attempt, host, startTime, endTime, duration, ioMetricsInfo, resourceId);
+		return Objects.hash(subtaskIndex, status, attempt, host, startTime, endTime, duration, ioMetricsInfo, taskmanagerId);
 	}
 
 	public static SubtaskExecutionAttemptDetailsInfo create(AccessExecution execution, MutableIOMetrics ioMetrics) {
@@ -173,7 +173,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 
 		final TaskManagerLocation location = execution.getAssignedResourceLocation();
 		final String locationString = location == null ? "(unassigned)" : location.getHostname();
-		String resourceId = location == null ? "(unassigned)" : location.getResourceID().toString();
+		String taskmanagerId = location == null ? "(unassigned)" : location.getResourceID().toString();
 
 		long startTime = execution.getStateTimestamp(ExecutionState.DEPLOYING);
 		if (startTime == 0) {
@@ -201,7 +201,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			endTime,
 			duration,
 			ioMetricsInfo,
-			resourceId
+			taskmanagerId
 		);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -164,7 +164,8 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
 			deployingTs,
 			finishedTs,
 			finishedTs - deployingTs,
-			ioMetricsInfo
+			ioMetricsInfo,
+			assignedResourceLocation.getResourceID().getResourceIdString()
 		);
 
 		assertEquals(expectedDetailsInfo, detailsInfo);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -172,7 +172,8 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
 			-1L,
 			0L,
 			-1L,
-			ioMetricsInfo
+			ioMetricsInfo,
+			"(unassigned)"
 		);
 
 		assertEquals(expectedDetailsInfo, detailsInfo);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
@@ -57,7 +57,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			1L,
 			jobVertexMetrics,
-			"resourceId1"));
+			"taskmanagerId1"));
 		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
 			1,
 			ExecutionState.FAILED,
@@ -67,7 +67,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			1L,
 			jobVertexMetrics,
-			"resourceId2"));
+			"taskmanagerId2"));
 		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
 			2,
 			ExecutionState.FINISHED,
@@ -77,7 +77,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			1L,
 			jobVertexMetrics,
-			"resourceId3"));
+			"taskmanagerId3"));
 
 		return new JobVertexDetailsInfo(
 			new JobVertexID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
@@ -56,7 +56,8 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			System.currentTimeMillis(),
 			1L,
-			jobVertexMetrics));
+			jobVertexMetrics,
+			"resourceId1"));
 		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
 			1,
 			ExecutionState.FAILED,
@@ -65,7 +66,8 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			System.currentTimeMillis(),
 			1L,
-			jobVertexMetrics));
+			jobVertexMetrics,
+			"resourceId2"));
 		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
 			2,
 			ExecutionState.FINISHED,
@@ -74,7 +76,8 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			System.currentTimeMillis(),
 			1L,
-			jobVertexMetrics));
+			jobVertexMetrics,
+			"resourceId3"));
 
 		return new JobVertexDetailsInfo(
 			new JobVertexID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
@@ -57,7 +57,8 @@ public class SubtaskExecutionAttemptDetailsInfoTest extends RestResponseMarshall
 			Math.abs(random.nextLong()),
 			Math.abs(random.nextLong()),
 			Math.abs(random.nextLong()),
-			ioMetricsInfo
+			ioMetricsInfo,
+			"resourceId"
 		);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
@@ -58,7 +58,7 @@ public class SubtaskExecutionAttemptDetailsInfoTest extends RestResponseMarshall
 			Math.abs(random.nextLong()),
 			Math.abs(random.nextLong()),
 			ioMetricsInfo,
-			"resourceId"
+			"taskmanagerId"
 		);
 	}
 }


### PR DESCRIPTION


## What is the purpose of the change
This pull request makes user can get ResourceId from vertex's subtask in rest api.



## Brief change log
- *Add ResourceId in SubtaskExecutionAttemptDetailsInfo*
- *Delete duplicated class JobVertexDetailsInfo.VertexTaskDetail instand of SubtaskExecutionAttemptDetailsInfo*
- *Add log src of taskmanager in the page of vertex's subtask*


## Verifying this change
This change is already covered by existing tests, such as SubtaskCurrentAttemptDetailsHandlerTest,SubtaskExecutionAttemptDetailsHandlerTest, SubtaskExecutionAttemptDetailsInfoTest, JobVertexDetailsInfoTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)