### PR TITLE
[FLINK-13891][build] Increment flink-shaded version 

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -3284,12 +3284,13 @@ Copyright 2014-2019 The Apache Software Foundation
 Apache Flink-shaded
 Copyright 2006-2019 The Apache Software Foundation
 
-flink-shaded-asm6
+flink-shaded-asm7
 Copyright 2014-2018 The Apache Software Foundation
 
-- org.ow2.asm:asm:6.2.1
-- org.ow2.asm:asm-analysis:6.2.1
-- org.ow2.asm:asm-tree:6.2.1
+- org.ow2.asm:asm:7.1
+- org.ow2.asm:asm-analysis:7.1
+- org.ow2.asm:asm-commons:7.1
+- org.ow2.asm:asm-tree:7.1
 
 Apache Commons Lang
 Copyright 2001-2014 The Apache Software Foundation

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -3408,7 +3408,7 @@ Copyright 2014-2018 The Apache Software Foundation
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
-- io.netty:netty-all:4.1.32.Final
+- io.netty:netty-all:4.1.39.Final
 
 flink-shaded-jackson
 Copyright 2014-2018 The Apache Software Foundation

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -49,7 +49,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-asm-6</artifactId>
+			<artifactId>flink-shaded-asm-7</artifactId>
 		</dependency>
 
 		<!-- standard utilities -->

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
@@ -35,8 +35,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.shaded.asm6.org.objectweb.asm.Type.getConstructorDescriptor;
-import static org.apache.flink.shaded.asm6.org.objectweb.asm.Type.getMethodDescriptor;
+import static org.apache.flink.shaded.asm7.org.objectweb.asm.Type.getConstructorDescriptor;
+import static org.apache.flink.shaded.asm7.org.objectweb.asm.Type.getMethodDescriptor;
 
 @Internal
 public class TypeExtractionUtils {

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -43,7 +43,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-asm-6</artifactId>
+			<artifactId>flink-shaded-asm-7</artifactId>
 		</dependency>
 
 		<dependency>

--- a/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -23,10 +23,10 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.util.InstantiationUtil;
 
-import org.apache.flink.shaded.asm6.org.objectweb.asm.ClassReader;
-import org.apache.flink.shaded.asm6.org.objectweb.asm.ClassVisitor;
-import org.apache.flink.shaded.asm6.org.objectweb.asm.MethodVisitor;
-import org.apache.flink.shaded.asm6.org.objectweb.asm.Opcodes;
+import org.apache.flink.shaded.asm7.org.objectweb.asm.ClassReader;
+import org.apache.flink.shaded.asm7.org.objectweb.asm.ClassVisitor;
+import org.apache.flink.shaded.asm7.org.objectweb.asm.MethodVisitor;
+import org.apache.flink.shaded.asm7.org.objectweb.asm.Opcodes;
 
 import org.apache.commons.lang3.ClassUtils;
 import org.slf4j.Logger;
@@ -248,7 +248,7 @@ class This0AccessFinder extends ClassVisitor {
 	private boolean isThis0Accessed;
 
 	public This0AccessFinder(String this0Name) {
-		super(Opcodes.ASM6);
+		super(Opcodes.ASM7);
 		this.this0Name = this0Name;
 	}
 
@@ -258,7 +258,7 @@ class This0AccessFinder extends ClassVisitor {
 
 	@Override
 	public MethodVisitor visitMethod(int access, String name, String desc, String sig, String[] exceptions) {
-		return new MethodVisitor(Opcodes.ASM6) {
+		return new MethodVisitor(Opcodes.ASM7) {
 
 			@Override
 			public void visitFieldInsn(int op, String owner, String name, String desc) {

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -90,7 +90,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-asm-6</artifactId>
+			<artifactId>flink-shaded-asm-7</artifactId>
 		</dependency>
 
 		<dependency>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -47,7 +47,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-asm-6</artifactId>
+			<artifactId>flink-shaded-asm-7</artifactId>
 		</dependency>
 
 		<dependency>

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.Map
 import scala.collection.mutable.Set
-import org.apache.flink.shaded.asm6.org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Type}
-import org.apache.flink.shaded.asm6.org.objectweb.asm.Opcodes._
+import org.apache.flink.shaded.asm7.org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Type}
+import org.apache.flink.shaded.asm7.org.objectweb.asm.Opcodes._
 
 import scala.collection.mutable
 

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-netty</artifactId>
-				<version>4.1.32.Final-7.0</version>
+				<version>4.1.39.Final-${flink.shaded.version}</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -252,8 +252,8 @@ under the License.
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-shaded-asm-6</artifactId>
-				<version>6.2.1-7.0</version>
+				<artifactId>flink-shaded-asm-7</artifactId>
+				<version>7.1-${flink.shaded.version}</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ under the License.
 		<flink.forkCountTestPackage>${flink.forkCount}</flink.forkCountTestPackage>
 		<flink.reuseForks>true</flink.reuseForks>
 		<log4j.configuration>log4j-test.properties</log4j.configuration>
-		<flink.shaded.version>7.0</flink.shaded.version>
+		<flink.shaded.version>8.0</flink.shaded.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.5.21</akka.version>
 		<java.version>1.8</java.version>
@@ -253,7 +253,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-asm-6</artifactId>
-				<version>6.2.1-${flink.shaded.version}</version>
+				<version>6.2.1-7.0</version>
 			</dependency>
 
 			<dependency>
@@ -277,7 +277,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-netty</artifactId>
-				<version>4.1.32.Final-${flink.shaded.version}</version>
+				<version>4.1.32.Final-7.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Bumps flink-shaded to 8.0, and updates the ASM and netty dependencies to 7.1/4.1.39.Final respectively.