### PR TITLE
[FLINK-13892][hs] Harden HistoryServerTest

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -137,9 +137,9 @@ public class HistoryServer {
 		this(config, new CountDownLatch(0));
 	}
 
-	public HistoryServer(Configuration config, CountDownLatch numFinishedPolls) throws IOException, FlinkException {
+	public HistoryServer(Configuration config, CountDownLatch numArchivedJobs) throws IOException, FlinkException {
 		Preconditions.checkNotNull(config);
-		Preconditions.checkNotNull(numFinishedPolls);
+		Preconditions.checkNotNull(numArchivedJobs);
 
 		this.config = config;
 		if (HistoryServerUtils.isSSLEnabled(config)) {
@@ -184,7 +184,7 @@ public class HistoryServer {
 		}
 
 		long refreshIntervalMillis = config.getLong(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL);
-		archiveFetcher = new HistoryServerArchiveFetcher(refreshIntervalMillis, refreshDirs, webDir, numFinishedPolls);
+		archiveFetcher = new HistoryServerArchiveFetcher(refreshIntervalMillis, refreshDirs, webDir, numArchivedJobs);
 
 		this.shutdownHook = ShutdownHookUtil.addShutdownHook(
 			HistoryServer.this::stop,

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -116,11 +116,12 @@ public class HistoryServerTest extends TestLogger {
 		}
 		createLegacyArchive(jmDirectory.toPath());
 
-		CountDownLatch numFinishedPolls = new CountDownLatch(1);
+		CountDownLatch numExpectedArchivedJobs = new CountDownLatch(numJobs + 1);
 
 		Configuration historyServerConfig = new Configuration();
 		historyServerConfig.setString(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS, jmDirectory.toURI().toString());
 		historyServerConfig.setString(HistoryServerOptions.HISTORY_SERVER_WEB_DIR, hsDirectory.getAbsolutePath());
+		historyServerConfig.setLong(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL, 100L);
 
 		historyServerConfig.setInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, 0);
 
@@ -131,11 +132,11 @@ public class HistoryServerTest extends TestLogger {
 			archives = jmDirectory.listFiles();
 		}
 
-		HistoryServer hs = new HistoryServer(historyServerConfig, numFinishedPolls);
+		HistoryServer hs = new HistoryServer(historyServerConfig, numExpectedArchivedJobs);
 		try {
 			hs.start();
 			String baseUrl = "http://localhost:" + hs.getWebPort();
-			numFinishedPolls.await(10L, TimeUnit.SECONDS);
+			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
 
 			ObjectMapper mapper = new ObjectMapper();
 			String response = getFromHTTP(baseUrl + JobsOverviewHeaders.URL);


### PR DESCRIPTION
The HistoryServerTest can fail if the HS attempts to unpack a partially written archive. The test only checked that the HS made 1 _attempt_ at fetching archives, and just assumed that the polling cannot fail.

The test now instead tracks how many archives have been successfully fetched instead. Since we are now taking scenarios into account where the HS polls archives multiple times (in case of errors) the polling interval was reduced to 100ms to prevent excessive test durations.