### PR TITLE
[FLINK-12481][FLINK-12482][FLINK-12958] Streaming runtime: integrate mailbox for timer triggers, checkpoints and AsyncWaitOperator

### DIFF
--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetStreamingFileSinkITCase.java
@@ -39,7 +39,9 @@ import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -61,6 +63,9 @@ import static org.junit.Assert.assertTrue;
  */
 @SuppressWarnings("serial")
 public class ParquetStreamingFileSinkITCase extends AbstractTestBase {
+
+	@Rule
+	public final Timeout timeoutPerTest = Timeout.seconds(20);
 
 	@Test
 	public void testWriteParquetAvroSpecific() throws Exception {

--- a/flink-formats/flink-sequence-file/src/test/java/org/apache/flink/formats/sequencefile/SequenceStreamingFileSinkITCase.java
+++ b/flink-formats/flink-sequence-file/src/test/java/org/apache/flink/formats/sequencefile/SequenceStreamingFileSinkITCase.java
@@ -33,7 +33,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,6 +60,9 @@ public class SequenceStreamingFileSinkITCase extends AbstractTestBase {
 			new Tuple2<>(2L, "b"),
 			new Tuple2<>(3L, "c")
 	);
+
+	@Rule
+	public final Timeout timeoutPerTest = Timeout.seconds(20);
 
 	@Test
 	public void testWriteSequenceFile() throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -257,10 +257,9 @@ public abstract class AbstractInvokable {
 	 * Invoked when a checkpoint has been completed, i.e., when the checkpoint coordinator has received
 	 * the notification from all participating tasks.
 	 *
-	 * @param checkpointId The ID of the checkpoint that is complete..
-	 * @throws Exception The notification method may forward its exceptions.
+	 * @param checkpointId The ID of the checkpoint that is complete.
 	 */
-	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+	public void notifyCheckpointComplete(long checkpointId) {
 		throw new UnsupportedOperationException(String.format("notifyCheckpointComplete not supported by %s", this.getClass().getName()));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.taskmanager.Task;
 
 import java.util.Optional;
+import java.util.concurrent.Future;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -53,7 +54,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * the initial state structure by the Garbage Collector.
  *
  * <p>Any subclass that supports recoverable state and participates in
- * checkpointing needs to override {@link #triggerCheckpoint(CheckpointMetaData, CheckpointOptions, boolean)},
+ * checkpointing needs to override {@link #triggerCheckpointAsync(CheckpointMetaData, CheckpointOptions, boolean)},
  * {@link #triggerCheckpointOnBarrier(CheckpointMetaData, CheckpointOptions, CheckpointMetrics)},
  * {@link #abortCheckpointOnBarrier(long, Throwable)} and {@link #notifyCheckpointComplete(long)}.
  */
@@ -219,10 +220,13 @@ public abstract class AbstractInvokable {
 	 * @param advanceToEndOfEventTime Flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
 	 *                          to fire any registered event-time timers
 	 *
-	 * @return {@code false} if the checkpoint can not be carried out, {@code true} otherwise
+	 * @return future with value of {@code false} if the checkpoint was not carried out, {@code true} otherwise
 	 */
-	public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) throws Exception {
-		throw new UnsupportedOperationException(String.format("triggerCheckpoint not supported by %s", this.getClass().getName()));
+	public Future<Boolean> triggerCheckpointAsync(
+			CheckpointMetaData checkpointMetaData,
+			CheckpointOptions checkpointOptions,
+			boolean advanceToEndOfEventTime) {
+		throw new UnsupportedOperationException(String.format("triggerCheckpointAsync not supported by %s", this.getClass().getName()));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -56,7 +56,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Any subclass that supports recoverable state and participates in
  * checkpointing needs to override {@link #triggerCheckpointAsync(CheckpointMetaData, CheckpointOptions, boolean)},
  * {@link #triggerCheckpointOnBarrier(CheckpointMetaData, CheckpointOptions, CheckpointMetrics)},
- * {@link #abortCheckpointOnBarrier(long, Throwable)} and {@link #notifyCheckpointComplete(long)}.
+ * {@link #abortCheckpointOnBarrier(long, Throwable)} and {@link #notifyCheckpointCompleteAsync(long)}.
  */
 public abstract class AbstractInvokable {
 
@@ -262,8 +262,10 @@ public abstract class AbstractInvokable {
 	 * the notification from all participating tasks.
 	 *
 	 * @param checkpointId The ID of the checkpoint that is complete.
+	 *
+	 * @return future that completes when the notification has been processed by the task.
 	 */
-	public void notifyCheckpointComplete(long checkpointId) {
-		throw new UnsupportedOperationException(String.format("notifyCheckpointComplete not supported by %s", this.getClass().getName()));
+	public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
+		throw new UnsupportedOperationException(String.format("notifyCheckpointCompleteAsync not supported by %s", this.getClass().getName()));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/DispatcherThreadFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/DispatcherThreadFactory.java
@@ -20,8 +20,6 @@ package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 
-import javax.annotation.Nullable;
-
 import java.util.concurrent.ThreadFactory;
 
 /**
@@ -34,9 +32,6 @@ public class DispatcherThreadFactory implements ThreadFactory {
 
 	private final String threadName;
 
-	@Nullable
-	private final ClassLoader classLoader;
-
 	/**
 	 * Creates a new thread factory.
 	 *
@@ -44,31 +39,13 @@ public class DispatcherThreadFactory implements ThreadFactory {
 	 * @param threadName The name for the threads.
 	 */
 	public DispatcherThreadFactory(ThreadGroup group, String threadName) {
-		this(group, threadName, null);
-	}
-
-	/**
-	 * Creates a new thread factory.
-	 *
-	 * @param group The group that the threads will be associated with.
-	 * @param threadName The name for the threads.
-	 * @param classLoader The {@link ClassLoader} to be set as context class loader.
-	 */
-	public DispatcherThreadFactory(
-			ThreadGroup group,
-			String threadName,
-			@Nullable ClassLoader classLoader) {
 		this.group = group;
 		this.threadName = threadName;
-		this.classLoader = classLoader;
 	}
 
 	@Override
 	public Thread newThread(Runnable r) {
 		Thread t = new Thread(group, r, threadName);
-		if (classLoader != null) {
-			t.setContextClassLoader(classLoader);
-		}
 		t.setDaemon(true);
 		t.setUncaughtExceptionHandler(FatalExitExceptionHandler.INSTANCE);
 		return t;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -92,8 +92,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -259,19 +257,13 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 	/** The observed exception, in case the task execution failed. */
 	private volatile Throwable failureCause;
 
-	/** Serial executor for asynchronous calls (checkpoints, etc), lazily initialized. */
-	private volatile ExecutorService asyncCallDispatcher;
-
 	/** Initialized from the Flink configuration. May also be set at the ExecutionConfig */
 	private long taskCancellationInterval;
 
 	/** Initialized from the Flink configuration. May also be set at the ExecutionConfig */
 	private long taskCancellationTimeout;
 
-	/**
-	 * This class loader should be set as the context class loader of the threads in
-	 * {@link #asyncCallDispatcher} because user code may dynamically load classes in all callbacks.
-	 */
+	/** This class loader should be set as the context class loader for threads that may dynamically load user code. */
 	private ClassLoader userCodeClassLoader;
 
 	/**
@@ -806,13 +798,6 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 				// to the invokable and its structures in cases where this Task object is still referenced
 				this.invokable = null;
 
-				// stop the async dispatcher.
-				// copy dispatcher reference to stack, against concurrent release
-				ExecutorService dispatcher = this.asyncCallDispatcher;
-				if (dispatcher != null && !dispatcher.isShutdown()) {
-					dispatcher.shutdownNow();
-				}
-
 				// free the network resources
 				releaseNetworkResources();
 
@@ -1137,35 +1122,26 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 		final CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointID, checkpointTimestamp);
 
 		if (executionState == ExecutionState.RUNNING && invokable != null) {
-
-			Runnable runnable = new Runnable() {
-				@Override
-				public void run() {
-					try {
-						invokable.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
-					}
-					catch (RejectedExecutionException ex) {
-						// This may happen if the mailbox is closed. It means that the task is shutting down, so we just ignore it.
-						LOG.debug(
-							"Triggering checkpoint {} for {} ({}) was rejected by the mailbox",
-							checkpointID, taskNameWithSubtask, executionId);
-					}
-					catch (Throwable t) {
-						if (getExecutionState() == ExecutionState.RUNNING) {
-							failExternally(new Exception(
-								"Error while triggering checkpoint " + checkpointID + " for " +
-									taskNameWithSubtask, t));
-						} else {
-							LOG.debug("Encountered error while triggering checkpoint {} for " +
-								"{} ({}) while being not in state running.", checkpointID,
-								taskNameWithSubtask, executionId, t);
-						}
-					}
+			try {
+				invokable.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
+			}
+			catch (RejectedExecutionException ex) {
+				// This may happen if the mailbox is closed. It means that the task is shutting down, so we just ignore it.
+				LOG.debug(
+					"Triggering checkpoint {} for {} ({}) was rejected by the mailbox",
+					checkpointID, taskNameWithSubtask, executionId);
+			}
+			catch (Throwable t) {
+				if (getExecutionState() == ExecutionState.RUNNING) {
+					failExternally(new Exception(
+						"Error while triggering checkpoint " + checkpointID + " for " +
+							taskNameWithSubtask, t));
+				} else {
+					LOG.debug("Encountered error while triggering checkpoint {} for " +
+						"{} ({}) while being not in state running.", checkpointID,
+						taskNameWithSubtask, executionId, t);
 				}
-			};
-			executeAsyncCallRunnable(
-					runnable,
-					String.format("Checkpoint Trigger for %s (%s).", taskNameWithSubtask, executionId));
+			}
 		}
 		else {
 			LOG.debug("Declining checkpoint request for non-running task {} ({}).", taskNameWithSubtask, executionId);
@@ -1181,86 +1157,26 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 		final AbstractInvokable invokable = this.invokable;
 
 		if (executionState == ExecutionState.RUNNING && invokable != null) {
-
-			Runnable runnable = new Runnable() {
-				@Override
-				public void run() {
-					try {
-						invokable.notifyCheckpointCompleteAsync(checkpointID);
-					}
-					catch (RejectedExecutionException ex) {
-						// This may happen if the mailbox is closed. It means that the task is shutting down, so we just ignore it.
-						LOG.debug(
-							"Notify checkpoint complete {} for {} ({}) was rejected by the mailbox",
-							checkpointID, taskNameWithSubtask, executionId);
-					}
-					catch (Throwable t) {
-						if (getExecutionState() == ExecutionState.RUNNING) {
-							// fail task if checkpoint confirmation failed.
-							failExternally(new RuntimeException(
-								"Error while confirming checkpoint",
-								t));
-						}
-					}
+			try {
+				invokable.notifyCheckpointCompleteAsync(checkpointID);
+			}
+			catch (RejectedExecutionException ex) {
+				// This may happen if the mailbox is closed. It means that the task is shutting down, so we just ignore it.
+				LOG.debug(
+					"Notify checkpoint complete {} for {} ({}) was rejected by the mailbox",
+					checkpointID, taskNameWithSubtask, executionId);
+			}
+			catch (Throwable t) {
+				if (getExecutionState() == ExecutionState.RUNNING) {
+					// fail task if checkpoint confirmation failed.
+					failExternally(new RuntimeException(
+						"Error while confirming checkpoint",
+						t));
 				}
-			};
-			executeAsyncCallRunnable(
-					runnable,
-					"Checkpoint Confirmation for " + taskNameWithSubtask);
+			}
 		}
 		else {
 			LOG.debug("Ignoring checkpoint commit notification for non-running task {}.", taskNameWithSubtask);
-		}
-	}
-
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Utility method to dispatch an asynchronous call on the invokable.
-	 *  @param runnable The async call runnable.
-	 * @param callName The name of the call, for logging purposes.
-	 */
-	private void executeAsyncCallRunnable(Runnable runnable, String callName) {
-		// make sure the executor is initialized. lock against concurrent calls to this function
-		synchronized (this) {
-			if (executionState != ExecutionState.RUNNING) {
-				return;
-			}
-
-			// get ourselves a reference on the stack that cannot be concurrently modified
-			ExecutorService executor = this.asyncCallDispatcher;
-			if (executor == null) {
-				// first time use, initialize
-				checkState(userCodeClassLoader != null, "userCodeClassLoader must not be null");
-
-				executor = Executors.newSingleThreadExecutor(
-						new DispatcherThreadFactory(
-							TASK_THREADS_GROUP,
-							"Async calls on " + taskNameWithSubtask,
-							userCodeClassLoader));
-				this.asyncCallDispatcher = executor;
-
-				// double-check for execution state, and make sure we clean up after ourselves
-				// if we created the dispatcher while the task was concurrently canceled
-				if (executionState != ExecutionState.RUNNING) {
-					executor.shutdown();
-					asyncCallDispatcher = null;
-					return;
-				}
-			}
-
-			LOG.debug("Invoking async call {} on task {}", callName, taskNameWithSubtask);
-
-			try {
-				executor.submit(runnable);
-			}
-			catch (RejectedExecutionException e) {
-				// may be that we are concurrently finished or canceled.
-				// if not, report that something is fishy
-				if (executionState == ExecutionState.RUNNING) {
-					throw new RuntimeException("Async call was rejected, even though the task is running.", e);
-				}
-			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1151,7 +1151,13 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 					FileSystemSafetyNet.setSafetyNetCloseableRegistryForThread(safetyNetCloseableRegistry);
 
 					try {
-						invokable.triggerCheckpoint(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
+						invokable.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
+					}
+					catch (RejectedExecutionException ex) {
+						// This may happen if the mailbox is closed. It means that the task is shutting down, so we just ignore it.
+						LOG.debug(
+							"Triggering checkpoint {} for {} ({}) was rejected by the mailbox",
+							checkpointID, taskNameWithSubtask, executionId);
 					}
 					catch (Throwable t) {
 						if (getExecutionState() == ExecutionState.RUNNING) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1192,7 +1192,6 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 				public void run() {
 					try {
 						invokable.notifyCheckpointComplete(checkpointID);
-						taskStateManager.notifyCheckpointComplete(checkpointID);
 					} catch (Throwable t) {
 						if (getExecutionState() == ExecutionState.RUNNING) {
 							// fail task if checkpoint confirmation failed.
@@ -1205,8 +1204,7 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 			};
 			executeAsyncCallRunnable(
 					runnable,
-					"Checkpoint Confirmation for " + taskNameWithSubtask
-			);
+					"Checkpoint Confirmation for " + taskNameWithSubtask);
 		}
 		else {
 			LOG.debug("Ignoring checkpoint commit notification for non-running task {}.", taskNameWithSubtask);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1140,7 +1140,6 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 		if (executionState == ExecutionState.RUNNING && invokable != null) {
 
 			// build a local closure
-			final String taskName = taskNameWithSubtask;
 			final SafetyNetCloseableRegistry safetyNetCloseableRegistry =
 				FileSystemSafetyNet.getSafetyNetCloseableRegistryForThread();
 
@@ -1152,12 +1151,7 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 					FileSystemSafetyNet.setSafetyNetCloseableRegistryForThread(safetyNetCloseableRegistry);
 
 					try {
-						boolean success = invokable.triggerCheckpoint(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
-						if (!success) {
-							checkpointResponder.declineCheckpoint(
-									getJobID(), getExecutionId(), checkpointID,
-									new CheckpointException("Task Name" + taskName, CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_NOT_READY));
-						}
+						invokable.triggerCheckpoint(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
 					}
 					catch (Throwable t) {
 						if (getExecutionState() == ExecutionState.RUNNING) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -64,17 +64,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -99,17 +93,6 @@ public class TaskAsyncCallTest extends TestLogger {
 	 */
 	private static OneShotLatch triggerLatch;
 
-	/**
-	 * Triggered when {@link CheckpointsInOrderInvokable#notifyCheckpointCompleteAsync(long)}
-	 * was called {@link #numCalls} times.
-	 */
-	private static OneShotLatch notifyCheckpointCompleteLatch;
-
-	/** Triggered on {@link ContextClassLoaderInterceptingInvokable#cancel()}. */
-	private static OneShotLatch stopLatch;
-
-	private static final List<ClassLoader> classLoaders = Collections.synchronizedList(new ArrayList<>());
-
 	private ShuffleEnvironment<?, ?> shuffleEnvironment;
 
 	@Before
@@ -118,12 +101,8 @@ public class TaskAsyncCallTest extends TestLogger {
 
 		awaitLatch = new OneShotLatch();
 		triggerLatch = new OneShotLatch();
-		notifyCheckpointCompleteLatch = new OneShotLatch();
-		stopLatch = new OneShotLatch();
 
 		shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build();
-
-		classLoaders.clear();
 	}
 
 	@After
@@ -179,35 +158,6 @@ public class TaskAsyncCallTest extends TestLogger {
 
 			ExecutionState currentState = task.getExecutionState();
 			assertThat(currentState, isOneOf(ExecutionState.RUNNING, ExecutionState.FINISHED));
-		}
-	}
-
-	/**
-	 * Asserts that {@link AbstractInvokable#triggerCheckpointAsync(CheckpointMetaData, CheckpointOptions, boolean)},
-	 * and {@link AbstractInvokable#notifyCheckpointCompleteAsync(long)} are invoked by a thread whose context
-	 * class loader is set to the user code class loader.
-	 */
-	@Test
-	public void testSetsUserCodeClassLoader() throws Exception {
-		numCalls = 1;
-
-		Task task = createTask(ContextClassLoaderInterceptingInvokable.class);
-		try (TaskCleaner ignored = new TaskCleaner(task)) {
-			task.startTaskThread();
-
-			awaitLatch.await();
-
-			task.triggerCheckpointBarrier(1, 1, CheckpointOptions.forCheckpointWithDefaultLocation(), false);
-			triggerLatch.await();
-
-			task.notifyCheckpointComplete(1);
-			notifyCheckpointCompleteLatch.await();
-
-			task.cancelExecution();
-			stopLatch.await();
-
-			assertThat(classLoaders, hasSize(greaterThanOrEqualTo(2)));
-			assertThat(classLoaders, everyItem(instanceOf(TestUserCodeClassLoader.class)));
 		}
 	}
 
@@ -297,8 +247,6 @@ public class TaskAsyncCallTest extends TestLogger {
 			if (error != null) {
 				// exit method prematurely due to error but make sure that the tests can finish
 				triggerLatch.trigger();
-				notifyCheckpointCompleteLatch.trigger();
-				stopLatch.trigger();
 
 				throw error;
 			}
@@ -338,53 +286,14 @@ public class TaskAsyncCallTest extends TestLogger {
 				synchronized (this) {
 					notifyAll();
 				}
-			} else if (lastCheckpointId == numCalls) {
-				notifyCheckpointCompleteLatch.trigger();
 			}
 			return CompletableFuture.completedFuture(null);
 		}
 	}
 
-	/**
-	 * This is an {@link AbstractInvokable} that stores the context class loader of the invoking
-	 * thread in a static field so that tests can assert on the class loader instances.
-	 *
-	 * @see #testSetsUserCodeClassLoader()
-	 */
-	public static class ContextClassLoaderInterceptingInvokable extends CheckpointsInOrderInvokable {
-
-		public ContextClassLoaderInterceptingInvokable(Environment environment) {
-			super(environment);
-		}
-
-		@Override
-		public Future<Boolean> triggerCheckpointAsync(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
-			classLoaders.add(Thread.currentThread().getContextClassLoader());
-
-			return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
-		}
-
-		@Override
-		public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
-			classLoaders.add(Thread.currentThread().getContextClassLoader());
-
-			return super.notifyCheckpointCompleteAsync(checkpointId);
-		}
-
-		@Override
-		public void cancel() {
-			stopLatch.trigger();
-		}
-
-	}
-
-	/**
-	 * A {@link ClassLoader} that delegates everything to {@link ClassLoader#getSystemClassLoader()}.
-	 *
-	 * @see #testSetsUserCodeClassLoader()
-	 */
+	/** A {@link ClassLoader} that delegates everything to {@link ClassLoader#getSystemClassLoader()}. */
 	private static class TestUserCodeClassLoader extends ClassLoader {
-		public TestUserCodeClassLoader() {
+		TestUserCodeClassLoader() {
 			super(ClassLoader.getSystemClassLoader());
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -100,7 +100,7 @@ public class TaskAsyncCallTest extends TestLogger {
 	private static OneShotLatch triggerLatch;
 
 	/**
-	 * Triggered when {@link CheckpointsInOrderInvokable#notifyCheckpointComplete(long)}
+	 * Triggered when {@link CheckpointsInOrderInvokable#notifyCheckpointCompleteAsync(long)}
 	 * was called {@link #numCalls} times.
 	 */
 	private static OneShotLatch notifyCheckpointCompleteLatch;
@@ -184,7 +184,7 @@ public class TaskAsyncCallTest extends TestLogger {
 
 	/**
 	 * Asserts that {@link AbstractInvokable#triggerCheckpointAsync(CheckpointMetaData, CheckpointOptions, boolean)},
-	 * and {@link AbstractInvokable#notifyCheckpointComplete(long)} are invoked by a thread whose context
+	 * and {@link AbstractInvokable#notifyCheckpointCompleteAsync(long)} are invoked by a thread whose context
 	 * class loader is set to the user code class loader.
 	 */
 	@Test
@@ -332,7 +332,7 @@ public class TaskAsyncCallTest extends TestLogger {
 		}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) {
+		public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
 			if (checkpointId != lastCheckpointId && this.error == null) {
 				this.error = new Exception("calls out of order");
 				synchronized (this) {
@@ -341,6 +341,7 @@ public class TaskAsyncCallTest extends TestLogger {
 			} else if (lastCheckpointId == numCalls) {
 				notifyCheckpointCompleteLatch.trigger();
 			}
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 
@@ -364,10 +365,10 @@ public class TaskAsyncCallTest extends TestLogger {
 		}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) {
+		public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
 			classLoaders.add(Thread.currentThread().getContextClassLoader());
 
-			super.notifyCheckpointComplete(checkpointId);
+			return super.notifyCheckpointCompleteAsync(checkpointId);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -67,7 +67,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -92,7 +94,7 @@ public class TaskAsyncCallTest extends TestLogger {
 	private static OneShotLatch awaitLatch;
 
 	/**
-	 * Triggered when {@link CheckpointsInOrderInvokable#triggerCheckpoint(CheckpointMetaData, CheckpointOptions, boolean)}
+	 * Triggered when {@link CheckpointsInOrderInvokable#triggerCheckpointAsync(CheckpointMetaData, CheckpointOptions, boolean)}
 	 * was called {@link #numCalls} times.
 	 */
 	private static OneShotLatch triggerLatch;
@@ -181,7 +183,7 @@ public class TaskAsyncCallTest extends TestLogger {
 	}
 
 	/**
-	 * Asserts that {@link AbstractInvokable#triggerCheckpoint(CheckpointMetaData, CheckpointOptions, boolean)},
+	 * Asserts that {@link AbstractInvokable#triggerCheckpointAsync(CheckpointMetaData, CheckpointOptions, boolean)},
 	 * and {@link AbstractInvokable#notifyCheckpointComplete(long)} are invoked by a thread whose context
 	 * class loader is set to the user code class loader.
 	 */
@@ -303,7 +305,7 @@ public class TaskAsyncCallTest extends TestLogger {
 		}
 
 		@Override
-		public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
+		public Future<Boolean> triggerCheckpointAsync(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
 			lastCheckpointId++;
 			if (checkpointMetaData.getCheckpointId() == lastCheckpointId) {
 				if (lastCheckpointId == numCalls) {
@@ -316,7 +318,7 @@ public class TaskAsyncCallTest extends TestLogger {
 					notifyAll();
 				}
 			}
-			return true;
+			return CompletableFuture.completedFuture(true);
 		}
 
 		@Override
@@ -355,10 +357,10 @@ public class TaskAsyncCallTest extends TestLogger {
 		}
 
 		@Override
-		public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
+		public Future<Boolean> triggerCheckpointAsync(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
 			classLoaders.add(Thread.currentThread().getContextClassLoader());
 
-			return super.triggerCheckpoint(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
+			return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
 		}
 
 		@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -229,7 +229,8 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 			}
 		}
 
-		task.triggerCheckpoint(new CheckpointMetaData(42, 17), CheckpointOptions.forCheckpointWithDefaultLocation(), false);
+		task.triggerCheckpointAsync(new CheckpointMetaData(42, 17), CheckpointOptions.forCheckpointWithDefaultLocation(), false)
+			.get();
 
 		testHarness.processElement(new StreamRecord<>("Wohoo", 0));
 
@@ -343,10 +344,11 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 			}
 		}
 
-		task.triggerCheckpoint(
+		task.triggerCheckpointAsync(
 			new CheckpointMetaData(42, 17),
 			CheckpointOptions.forCheckpointWithDefaultLocation(),
-			false);
+			false)
+			.get();
 
 		testHarness.processElement(new StreamRecord<>("Wohoo", 0));
 		blockerCheckpointStreamFactory.getWaiterLatch().await();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -94,6 +94,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.END_OF_KEY_GROUP_MARK;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.FIRST_BIT_IN_BYTE_MASK;
@@ -212,6 +213,8 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 			testHarness.bufferSize,
 			taskStateManagerTestMock);
 
+		AtomicReference<Throwable> errorRef = new AtomicReference<>();
+		mockEnv.setExternalExceptionHandler(errorRef::set);
 		testHarness.invoke(mockEnv);
 
 		final OneInputStreamTask<String, String> task = testHarness.getTask();
@@ -243,7 +246,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 		Assert.assertTrue(threadPool.awaitTermination(60_000, TimeUnit.MILLISECONDS));
 
 		testHarness.waitForTaskCompletion();
-		if (mockEnv.wasFailedExternally()) {
+		if (errorRef.get() != null) {
 			fail("Unexpected exception during execution.");
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AsyncDataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AsyncDataStream.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.functions.async.AsyncFunction;
 import org.apache.flink.streaming.api.operators.async.AsyncWaitOperator;
+import org.apache.flink.streaming.api.operators.async.AsyncWaitOperatorFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -78,13 +79,13 @@ public class AsyncDataStream {
 			true);
 
 		// create transform
-		AsyncWaitOperator<IN, OUT> operator = new AsyncWaitOperator<>(
+		AsyncWaitOperatorFactory<IN, OUT> operatorFactory = new AsyncWaitOperatorFactory<>(
 			in.getExecutionEnvironment().clean(func),
 			timeout,
 			bufSize,
 			mode);
 
-		return in.transform("async wait operator", outTypeInfo, operator);
+		return in.transform("async wait operator", outTypeInfo, operatorFactory);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.streaming.api.datastream.AsyncDataStream;
+import org.apache.flink.streaming.api.functions.async.AsyncFunction;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutor;
+
+/**
+ * The factory of {@link AsyncWaitOperator}.
+ *
+ * @param <OUT> The output type of the operator
+ */
+public class AsyncWaitOperatorFactory<IN, OUT> implements OneInputStreamOperatorFactory<IN, OUT>, YieldingOperatorFactory<OUT> {
+	private final AsyncFunction<IN, OUT> asyncFunction;
+	private final long timeout;
+	private final int capacity;
+	private final AsyncDataStream.OutputMode outputMode;
+	private MailboxExecutor mailboxExecutor;
+	private ChainingStrategy strategy = ChainingStrategy.HEAD;
+
+	public AsyncWaitOperatorFactory(
+			AsyncFunction<IN, OUT> asyncFunction,
+			long timeout,
+			int capacity,
+			AsyncDataStream.OutputMode outputMode) {
+		this.asyncFunction = asyncFunction;
+		this.timeout = timeout;
+		this.capacity = capacity;
+		this.outputMode = outputMode;
+	}
+
+	@Override
+	public void setMailboxExecutor(MailboxExecutor mailboxExecutor) {
+		this.mailboxExecutor = mailboxExecutor;
+	}
+
+	@Override
+	public StreamOperator createStreamOperator(StreamTask containingTask, StreamConfig config, Output output) {
+		AsyncWaitOperator asyncWaitOperator = new AsyncWaitOperator(
+				asyncFunction,
+				timeout,
+				capacity,
+				outputMode,
+				mailboxExecutor);
+		asyncWaitOperator.setup(containingTask, config, output);
+		return asyncWaitOperator;
+	}
+
+	@Override
+	public void setChainingStrategy(ChainingStrategy strategy) {
+		this.strategy = strategy;
+	}
+
+	@Override
+	public ChainingStrategy getChainingStrategy() {
+		return strategy;
+	}
+
+	@Override
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return AsyncWaitOperator.class;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/Emitter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/Emitter.java
@@ -26,10 +26,13 @@ import org.apache.flink.streaming.api.operators.async.queue.AsyncResult;
 import org.apache.flink.streaming.api.operators.async.queue.AsyncWatermarkResult;
 import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueue;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutor;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
 
 import java.util.Collection;
 
@@ -50,6 +53,9 @@ public class Emitter<OUT> implements Runnable {
 	/** Output for the watermark elements. */
 	private final Output<StreamRecord<OUT>> output;
 
+	/** Executor for mailbox. */
+	private final MailboxExecutor executor;
+
 	/** Queue to consume the async results from. */
 	private final StreamElementQueue streamElementQueue;
 
@@ -62,11 +68,13 @@ public class Emitter<OUT> implements Runnable {
 
 	public Emitter(
 			final Object checkpointLock,
-			final Output<StreamRecord<OUT>> output,
-			final StreamElementQueue streamElementQueue,
-			final OperatorActions operatorActions) {
+			final @Nonnull MailboxExecutor executor,
+			final @Nonnull Output<StreamRecord<OUT>> output,
+			final @Nonnull StreamElementQueue streamElementQueue,
+			final @Nonnull OperatorActions operatorActions) {
 
 		this.checkpointLock = Preconditions.checkNotNull(checkpointLock, "checkpointLock");
+		this.executor = Preconditions.checkNotNull(executor, "executor");
 		this.output = Preconditions.checkNotNull(output, "output");
 		this.streamElementQueue = Preconditions.checkNotNull(streamElementQueue, "streamElementQueue");
 		this.operatorActions = Preconditions.checkNotNull(operatorActions, "operatorActions");
@@ -80,9 +88,14 @@ public class Emitter<OUT> implements Runnable {
 		try {
 			while (running) {
 				LOG.debug("Wait for next completed async stream element result.");
-				AsyncResult streamElementEntry = streamElementQueue.peekBlockingly();
-
-				output(streamElementEntry);
+				AsyncResult asyncResult = streamElementQueue.peekBlockingly();
+				executor.submit(() -> {
+					try {
+						output(asyncResult);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}).get();
 			}
 		} catch (InterruptedException e) {
 			if (running) {
@@ -97,21 +110,22 @@ public class Emitter<OUT> implements Runnable {
 		}
 	}
 
+	/**
+	 * Executed as a mail in the mailbox thread. Output needs to be guarded with checkpoint lock (for the time being).
+	 *
+	 * @param asyncResult the result to output.
+	 */
 	private void output(AsyncResult asyncResult) throws InterruptedException {
 		if (asyncResult.isWatermark()) {
+			AsyncWatermarkResult asyncWatermarkResult = asyncResult.asWatermark();
+
+			LOG.debug("Output async watermark.");
+
 			synchronized (checkpointLock) {
-				AsyncWatermarkResult asyncWatermarkResult = asyncResult.asWatermark();
-
-				LOG.debug("Output async watermark.");
 				output.emitWatermark(asyncWatermarkResult.getWatermark());
-
 				// remove the peeked element from the async collector buffer so that it is no longer
 				// checkpointed
 				streamElementQueue.poll();
-
-				// notify the main thread that there is again space left in the async collector
-				// buffer
-				checkpointLock.notifyAll();
 			}
 		} else {
 			AsyncCollectionResult<OUT> streamRecordResult = asyncResult.asResultCollection();
@@ -122,9 +136,9 @@ public class Emitter<OUT> implements Runnable {
 				timestampedCollector.eraseTimestamp();
 			}
 
-			synchronized (checkpointLock) {
-				LOG.debug("Output async stream element collection result.");
+			LOG.debug("Output async stream element collection result.");
 
+			synchronized (checkpointLock) {
 				try {
 					Collection<OUT> resultCollection = streamRecordResult.get();
 
@@ -142,10 +156,6 @@ public class Emitter<OUT> implements Runnable {
 				// remove the peeked element from the async collector buffer so that it is no longer
 				// checkpointed
 				streamElementQueue.poll();
-
-				// notify the main thread that there is again space left in the async collector
-				// buffer
-				checkpointLock.notifyAll();
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -30,6 +30,7 @@ import org.apache.flink.util.FlinkException;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 /**
  * {@link StreamTask} for executing a {@link StreamSource}.
@@ -85,7 +86,8 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 					final CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, timestamp);
 
 					try {
-						SourceStreamTask.super.triggerCheckpoint(checkpointMetaData, checkpointOptions, false);
+						SourceStreamTask.super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, false)
+							.get();
 					}
 					catch (RuntimeException e) {
 						throw e;
@@ -151,14 +153,14 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 	// ------------------------------------------------------------------------
 
 	@Override
-	public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) throws Exception {
+	public Future<Boolean> triggerCheckpointAsync(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
 		if (!externallyInducedCheckpoints) {
-			return super.triggerCheckpoint(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
+			return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
 		}
 		else {
 			// we do not trigger checkpoints here, we simply state whether we can trigger them
 			synchronized (getCheckpointLock()) {
-				return isRunning();
+				return CompletableFuture.completedFuture(isRunning());
 			}
 		}
 	}
@@ -167,6 +169,14 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 	protected void declineCheckpoint(long checkpointId) {
 		if (!externallyInducedCheckpoints) {
 			super.declineCheckpoint(checkpointId);
+		}
+	}
+
+	@Override
+	protected void handleCheckpointException(Exception exception) {
+		// For externally induced checkpoints, the exception would be passed via triggerCheckpointAsync future.
+		if (!externallyInducedCheckpoints) {
+			super.handleCheckpointException(exception);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -87,7 +87,7 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 					try {
 						SourceStreamTask.super.triggerCheckpoint(checkpointMetaData, checkpointOptions, false);
 					}
-					catch (RuntimeException | FlinkException e) {
+					catch (RuntimeException e) {
 						throw e;
 					}
 					catch (Exception e) {
@@ -160,6 +160,13 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 			synchronized (getCheckpointLock()) {
 				return isRunning();
 			}
+		}
+	}
+
+	@Override
+	protected void declineCheckpoint(long checkpointId) {
+		if (!externallyInducedCheckpoints) {
+			super.declineCheckpoint(checkpointId);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -379,9 +379,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// -------- Invoke --------
 			LOG.debug("Invoking {}", getName());
 
-			// open mailbox
-			mailboxProcessor.open();
-
 			// we need to make sure that any triggers scheduled in open() cannot be
 			// executed before all operators are opened
 			synchronized (lock) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -360,7 +360,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				ThreadFactory timerThreadFactory = new DispatcherThreadFactory(TRIGGER_THREAD_GROUP,
 					"Time Trigger for " + getName(), getUserCodeClassLoader());
 
-				timerService = new SystemProcessingTimeService(this, getCheckpointLock(), timerThreadFactory);
+				timerService = new SystemProcessingTimeService(new TimerInvocationContext(), timerThreadFactory);
 			}
 
 			operatorChain = new OperatorChain<>(this, recordWriters);
@@ -1366,5 +1366,18 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			.build(bufferWriter);
 		output.setMetricGroup(environment.getMetricGroup().getIOMetricGroup());
 		return output;
+	}
+
+	private class TimerInvocationContext implements SystemProcessingTimeService.ScheduledCallbackExecutionContext {
+		@Override
+		public void invoke(ProcessingTimeCallback callback, long timestamp) {
+			synchronized (getCheckpointLock()) {
+				try {
+					callback.onProcessingTime(timestamp);
+				} catch (Throwable t) {
+					handleAsyncException("Caught exception while processing timer.", new TimerException(t));
+				}
+			}
+		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -63,6 +63,7 @@ import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.mailbox.execution.DefaultActionContext;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutorFactory;
 import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.execution.SuspendedMailboxDefaultAction;
@@ -426,6 +427,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				// only set the StreamTask to not running after all operators have been closed!
 				// See FLINK-7430
 				isRunning = false;
+			}
+			MailboxExecutor mainMailboxExecutor = mailboxProcessor.getMainMailboxExecutor();
+			while (mainMailboxExecutor.tryYield()) {
+				// Run until we have processed all remaining letters.
 			}
 
 			// make sure all timers finish

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
@@ -72,6 +72,13 @@ public interface TaskMailbox {
 	State getState();
 
 	/**
+	 * Returns a mailbox view bound to all mails.
+	 *
+	 * @return the mailbox
+	 */
+	Mailbox getMainMailbox();
+
+	/**
 	 * Returns a mailbox view bound to the given priority.
 	 *
 	 * <p>Enqueuing letters (e.g., {@link Mailbox#putMail(Runnable)} and {@link Mailbox#putFirst(Runnable)}) will mark these letters

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
@@ -24,8 +24,9 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * A task mailbox wraps the basic {@link Mailbox} interface with a lifecycle of closed -> open -> (quiesced) ->
- * closed.
+ * A task mailbox wraps the basic {@link Mailbox} interface with a lifecycle of open -> (quiesced) -> closed.
+ * In the open state, the mailbox supports put and take operations.
+ * In the quiesced state, the mailbox supports only take operations.
  *
  * <p>Additionally, letters have a priority that can be used to retrieve only relevant letters.
  */
@@ -46,11 +47,6 @@ public interface TaskMailbox {
 	enum State {
 		OPEN, QUIESCED, CLOSED
 	}
-
-	/**
-	 * Open the mailbox. In this state, the mailbox supports put and take operations.
-	 */
-	void open();
 
 	/**
 	 * Quiesce the mailbox. In this state, the mailbox supports only take operations and all pending and future put

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
@@ -247,6 +247,11 @@ public class TaskMailboxImpl implements TaskMailbox {
 	}
 
 	@Override
+	public Mailbox getMainMailbox() {
+		return new DownstreamMailbox(TaskMailbox.MIN_PRIORITY);
+	}
+
+	@Override
 	public Mailbox getDownstreamMailbox(int priority) {
 		Preconditions.checkArgument(priority >= 0, "The priority of a downstream mailbox should be non-negative");
 		return new DownstreamMailbox(priority);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
@@ -72,7 +72,7 @@ public class TaskMailboxImpl implements TaskMailbox {
 	public TaskMailboxImpl() {
 		this.lock = new ReentrantLock();
 		this.notEmpty = lock.newCondition();
-		this.state = State.CLOSED;
+		this.state = State.OPEN;
 		this.queue = new LinkedList<>();
 		this.count = 0;
 	}
@@ -206,18 +206,6 @@ public class TaskMailboxImpl implements TaskMailbox {
 		if (!isTakeAbleState()) {
 			throw new MailboxStateException("Mailbox is in state " + state + ", but is required to be in state " +
 				State.OPEN + " or " + State.QUIESCED + " for take operations.");
-		}
-	}
-
-	@Override
-	public void open() {
-		lock.lock();
-		try {
-			if (state == State.CLOSED) {
-				state = State.OPEN;
-			}
-		} finally {
-			lock.unlock();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/MailboxExecutor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/MailboxExecutor.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.Mailbox;
 
 import javax.annotation.Nonnull;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -53,7 +54,11 @@ public interface MailboxExecutor extends Executor {
 	 * quiesced or closed.
 	 */
 	default @Nonnull Future<?> submit(@Nonnull Runnable command) {
-		FutureTask<?> future = new FutureTask<>(Executors.callable(command, null));
+		return submit(Executors.callable(command, null));
+	}
+
+	default @Nonnull <T> Future<T> submit(@Nonnull Callable<T> task) {
+		FutureTask<T> future = new FutureTask<>(task);
 		execute(future);
 		return future;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/MailboxProcessor.java
@@ -99,13 +99,6 @@ public class MailboxProcessor {
 	}
 
 	/**
-	 * Lifecycle method to open the mailbox for action submission.
-	 */
-	public void open() {
-		mailbox.open();
-	}
-
-	/**
 	 * Lifecycle method to close the mailbox for action submission.
 	 */
 	public void prepareClose() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/MailboxProcessor.java
@@ -68,6 +68,9 @@ public class MailboxProcessor {
 	/** The thread that executes the mailbox letters. */
 	private final Thread mailboxThread;
 
+	/** A pre-created instance of mailbox executor that executes all letters. */
+	private final MailboxExecutor mainMailboxExecutor;
+
 	/** Control flag to terminate the mailbox loop. Must only be accessed from mailbox thread. */
 	private boolean mailboxLoopRunning;
 
@@ -85,9 +88,17 @@ public class MailboxProcessor {
 		this.mailboxDefaultAction = Preconditions.checkNotNull(mailboxDefaultAction);
 		this.mailbox = new TaskMailboxImpl();
 		this.mailboxThread = Thread.currentThread();
+		this.mainMailboxExecutor = new MailboxExecutorImpl(mailbox.getMainMailbox(), mailboxThread);
 		this.mailboxPoisonLetter = () -> mailboxLoopRunning = false;
 		this.mailboxLoopRunning = true;
 		this.suspendedDefaultAction = null;
+	}
+
+	/**
+	 * Returns a pre-created executor service that executes all mails.
+	 */
+	public MailboxExecutor getMainMailboxExecutor() {
+		return mainMailboxExecutor;
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -250,10 +250,10 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 					public void run() {
 						try {
 							runStarted.await();
-							if (getContainingTask().isCanceled() || getContainingTask().triggerCheckpoint(
+							if (getContainingTask().isCanceled() || getContainingTask().triggerCheckpointAsync(
 									new CheckpointMetaData(0, System.currentTimeMillis()),
 									CheckpointOptions.forCheckpointWithDefaultLocation(),
-									false)) {
+									false).get()) {
 								LifecycleTrackingStreamSource.runFinish.trigger();
 							}
 						} catch (Exception e) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -37,8 +37,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
-import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
-import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.streaming.api.datastream.AsyncDataStream;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -66,8 +64,6 @@ import org.apache.flink.util.TestLogger;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
-
-import javax.annotation.Nonnull;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -700,11 +696,11 @@ public class AsyncWaitOperatorTest extends TestLogger {
 			2,
 			AsyncDataStream.OutputMode.ORDERED);
 
-		final MockEnvironment mockEnvironment = createMockEnvironment();
-		mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
-
 		final OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
-			new OneInputStreamOperatorTestHarness<>(operator, IntSerializer.INSTANCE, mockEnvironment);
+			new OneInputStreamOperatorTestHarness<>(operator, IntSerializer.INSTANCE);
+
+		final MockEnvironment mockEnvironment = testHarness.getEnvironment();
+		mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
 
 		final long initialTime = 0L;
 		final ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
@@ -740,16 +736,6 @@ public class AsyncWaitOperatorTest extends TestLogger {
 				mockEnvironment.getActualExternalFailureCause().get(),
 				expectedException.get()).isPresent());
 		}
-	}
-
-	@Nonnull
-	private MockEnvironment createMockEnvironment() {
-		return new MockEnvironmentBuilder()
-			.setTaskName("foobarTask")
-			.setMemorySize(1024 * 1024L)
-			.setInputSplitProvider(new MockInputSplitProvider())
-			.setBufferSize(4 * 1024)
-			.build();
 	}
 
 	/**
@@ -861,13 +847,11 @@ public class AsyncWaitOperatorTest extends TestLogger {
 			2,
 			outputMode);
 
-		final MockEnvironment mockEnvironment = createMockEnvironment();
-		mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
-
 		OneInputStreamOperatorTestHarness<Integer, Integer> harness = new OneInputStreamOperatorTestHarness<>(
 			asyncWaitOperator,
-			IntSerializer.INSTANCE,
-			mockEnvironment);
+			IntSerializer.INSTANCE);
+
+		harness.getEnvironment().setExpectedExternalFailureCause(Throwable.class);
 
 		harness.open();
 
@@ -927,13 +911,11 @@ public class AsyncWaitOperatorTest extends TestLogger {
 			2,
 			outputMode);
 
-		final MockEnvironment mockEnvironment = createMockEnvironment();
-		mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
-
 		OneInputStreamOperatorTestHarness<Integer, Integer> harness = new OneInputStreamOperatorTestHarness<>(
 			asyncWaitOperator,
-			IntSerializer.INSTANCE,
-			mockEnvironment);
+			IntSerializer.INSTANCE);
+
+		harness.getEnvironment().setExpectedExternalFailureCause(Throwable.class);
 
 		harness.open();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -252,7 +252,8 @@ public class AsyncWaitOperatorTest extends TestLogger {
 			EmitterBlockingFunction.lock = lock;
 		}
 
-		@Override public void asyncInvoke(Integer input, ResultFuture<Integer> resultFuture) throws Exception {
+		@Override
+		public void asyncInvoke(Integer input, ResultFuture<Integer> resultFuture) throws Exception {
 			assertTrue(Thread.currentThread().holdsLock(lock));
 
 			outputLatch.trigger();
@@ -484,8 +485,10 @@ public class AsyncWaitOperatorTest extends TestLogger {
 				new StreamRecordComparator());
 	}
 
-	private JobVertex createChainedVertex(AsyncFunction<Integer, Integer> firstFunction,
+	private JobVertex createChainedVertex(
+			AsyncFunction<Integer, Integer> firstFunction,
 			AsyncFunction<Integer, Integer> secondFunction) {
+
 		StreamExecutionEnvironment chainEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		// set parallelism to 2 to avoid chaining with source in case when available processors is 1.
@@ -677,7 +680,8 @@ public class AsyncWaitOperatorTest extends TestLogger {
 			new StreamRecord<>(2, 5L));
 	}
 
-	private void testAsyncTimeout(LazyAsyncFunction lazyAsyncFunction,
+	private void testAsyncTimeout(
+			LazyAsyncFunction lazyAsyncFunction,
 			Optional<Class<? extends Throwable>> expectedException,
 			StreamRecord<Integer>... expectedRecords) throws Exception {
 		final long timeout = 10L;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -737,6 +737,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 	 * <p>Note that this test does not enforce the exact strict ordering because with the fix it is no
 	 * longer possible. However, it provokes the described situation without the fix.
 	 */
+	@Ignore("TODO: fix me when AsyncWaitOperator integrates with mailbox")
 	@Test(timeout = 10000L)
 	public void testClosingWithBlockedEmitter() throws Exception {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
@@ -1324,7 +1324,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 		public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		public void notifyCheckpointComplete(long checkpointId) {
 			throw new UnsupportedOperationException("should never be called");
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1297,10 +1298,10 @@ public abstract class CheckpointBarrierAlignerTestBase {
 		}
 
 		@Override
-		public boolean triggerCheckpoint(
+		public Future<Boolean> triggerCheckpointAsync(
 				CheckpointMetaData checkpointMetaData,
 				CheckpointOptions checkpointOptions,
-				boolean advanceToEndOfEventTime) throws Exception {
+				boolean advanceToEndOfEventTime) {
 			throw new UnsupportedOperationException("should never be called");
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
@@ -1325,7 +1325,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 		public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) {
+		public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
 			throw new UnsupportedOperationException("should never be called");
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointSequenceValidator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointSequenceValidator.java
@@ -86,7 +86,7 @@ class CheckpointSequenceValidator extends AbstractInvokable {
 	}
 
 	@Override
-	public void notifyCheckpointComplete(long checkpointId) {
+	public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
 		throw new UnsupportedOperationException("should never be called");
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointSequenceValidator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointSequenceValidator.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 
+import java.util.concurrent.Future;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -48,7 +50,7 @@ class CheckpointSequenceValidator extends AbstractInvokable {
 	}
 
 	@Override
-	public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) throws Exception {
+	public Future<Boolean> triggerCheckpointAsync(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
 		throw new UnsupportedOperationException("should never be called");
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointSequenceValidator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointSequenceValidator.java
@@ -84,7 +84,7 @@ class CheckpointSequenceValidator extends AbstractInvokable {
 	}
 
 	@Override
-	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+	public void notifyCheckpointComplete(long checkpointId) {
 		throw new UnsupportedOperationException("should never be called");
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.operators;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
-import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
@@ -28,8 +27,14 @@ import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskTestHarness;
+import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+
+import javax.annotation.Nullable;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -40,69 +45,36 @@ import static org.junit.Assert.fail;
  * Tests for the timer service of {@link org.apache.flink.streaming.runtime.tasks.StreamTask}.
  */
 @SuppressWarnings("serial")
-public class StreamTaskTimerTest {
+public class StreamTaskTimerTest extends TestLogger {
+
+	private StreamTaskTestHarness<?> testHarness;
+	private ProcessingTimeService timeService;
+
+	@Before
+	public void setup() throws Exception {
+		testHarness = startTestHarness();
+		timeService = testHarness.getProcessingTimeService();
+	}
+
+	@After
+	public void teardown() throws Exception {
+		stopTestHarness(testHarness, 4000L);
+	}
 
 	@Test
-	public void testOpenCloseAndTimestamps() throws Exception {
-
-		final OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(
-				OneInputStreamTask::new,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO);
-
-		testHarness.setupOutputForSingletonOperatorChain();
-
-		StreamConfig streamConfig = testHarness.getStreamConfig();
-
-		StreamMap<String, String> mapOperator = new StreamMap<>(new DummyMapFunction<String>());
-		streamConfig.setStreamOperator(mapOperator);
-		streamConfig.setOperatorID(new OperatorID());
-
-		testHarness.invoke();
-		testHarness.waitForTaskRunning();
-
-		final OneInputStreamTask<String, String> mapTask = testHarness.getTask();
-
+	public void testOpenCloseAndTimestamps() {
 		// first one spawns thread
-		mapTask.getProcessingTimeService().registerTimer(System.currentTimeMillis(), new ProcessingTimeCallback() {
+		timeService.registerTimer(System.currentTimeMillis(), new ProcessingTimeCallback() {
 			@Override
 			public void onProcessingTime(long timestamp) {
 			}
 		});
 
 		assertEquals(1, StreamTask.TRIGGER_THREAD_GROUP.activeCount());
-
-		testHarness.endInput();
-		testHarness.waitForTaskCompletion();
-
-		// thread needs to die in time
-		long deadline = System.currentTimeMillis() + 4000;
-		while (StreamTask.TRIGGER_THREAD_GROUP.activeCount() > 0 && System.currentTimeMillis() < deadline) {
-			Thread.sleep(10);
-		}
-
-		assertEquals("Trigger timer thread did not properly shut down",
-				0, StreamTask.TRIGGER_THREAD_GROUP.activeCount());
 	}
 
 	@Test
-	public void checkScheduledTimestampe() throws Exception {
-		final OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(
-				OneInputStreamTask::new,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO);
-
-		testHarness.setupOutputForSingletonOperatorChain();
-
-		StreamConfig streamConfig = testHarness.getStreamConfig();
-		StreamMap<String, String> mapOperator = new StreamMap<>(new DummyMapFunction<String>());
-		streamConfig.setStreamOperator(mapOperator);
-
-		testHarness.invoke();
-		testHarness.waitForTaskRunning();
-
-		final OneInputStreamTask<String, String> mapTask = testHarness.getTask();
-
+	public void checkScheduledTimestamps() throws Exception {
 		final AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
 		final long t1 = System.currentTimeMillis();
@@ -110,7 +82,6 @@ public class StreamTaskTimerTest {
 		final long t3 = System.currentTimeMillis() + 100;
 		final long t4 = System.currentTimeMillis() + 200;
 
-		ProcessingTimeService timeService = mapTask.getProcessingTimeService();
 		timeService.registerTimer(t1, new ValidatingProcessingTimeCallback(errorRef, t1, 0));
 		timeService.registerTimer(t2, new ValidatingProcessingTimeCallback(errorRef, t2, 1));
 		timeService.registerTimer(t3, new ValidatingProcessingTimeCallback(errorRef, t3, 2));
@@ -123,25 +94,8 @@ public class StreamTaskTimerTest {
 			Thread.sleep(100);
 		}
 
-		// handle errors
-		if (errorRef.get() != null) {
-			errorRef.get().printStackTrace();
-			fail(errorRef.get().getMessage());
-		}
-
+		verifyNoException(errorRef.get());
 		assertEquals(4, ValidatingProcessingTimeCallback.numInSequence);
-
-		testHarness.endInput();
-		testHarness.waitForTaskCompletion();
-
-		// wait until the trigger thread is shut down. otherwise, the other tests may become unstable
-		deadline = System.currentTimeMillis() + 4000;
-		while (StreamTask.TRIGGER_THREAD_GROUP.activeCount() > 0 && System.currentTimeMillis() < deadline) {
-			Thread.sleep(10);
-		}
-
-		assertEquals("Trigger timer thread did not properly shut down",
-				0, StreamTask.TRIGGER_THREAD_GROUP.activeCount());
 	}
 
 	private static class ValidatingProcessingTimeCallback implements ProcessingTimeCallback {
@@ -172,6 +126,13 @@ public class StreamTaskTimerTest {
 		}
 	}
 
+	private static void verifyNoException(@Nullable Throwable exception) {
+		if (exception != null) {
+			exception.printStackTrace();
+			fail(exception.getMessage());
+		}
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -182,5 +143,36 @@ public class StreamTaskTimerTest {
 		public T map(T value) {
 			return value;
 		}
+	}
+
+	private StreamTaskTestHarness<?> startTestHarness() throws Exception {
+		final OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(
+				OneInputStreamTask::new,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness.setupOutputForSingletonOperatorChain();
+
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setStreamOperator(new StreamMap<String, String>(new DummyMapFunction<>()));
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		return testHarness;
+	}
+
+	private void stopTestHarness(StreamTaskTestHarness<?> testHarness, long timeout) throws Exception {
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+
+		// thread needs to die in time
+		long deadline = System.currentTimeMillis() + timeout;
+		while (StreamTask.TRIGGER_THREAD_GROUP.activeCount() > 0 && System.currentTimeMillis() < deadline) {
+			Thread.sleep(10);
+		}
+
+		assertEquals("Trigger timer thread did not properly shut down",
+				0, StreamTask.TRIGGER_THREAD_GROUP.activeCount());
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
@@ -22,15 +22,12 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamMap;
-import org.apache.flink.streaming.runtime.tasks.AsyncExceptionHandler;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
 import org.junit.Test;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 
@@ -93,24 +90,5 @@ public class TestProcessingTimeServiceTest {
 		assertEquals(0, tp.getNumActiveTimers());
 
 		tp.shutdownService();
-	}
-
-	// ------------------------------------------------------------------------
-
-	/**
-	 * An {@link AsyncExceptionHandler} storing the handled exception.
-	 */
-	public static class ReferenceSettingExceptionHandler implements AsyncExceptionHandler {
-
-		private final AtomicReference<Throwable> errorReference;
-
-		public ReferenceSettingExceptionHandler(AtomicReference<Throwable> errorReference) {
-			this.errorReference = errorReference;
-		}
-
-		@Override
-		public void handleAsyncException(String message, Throwable exception) {
-			errorReference.compareAndSet(null, exception);
-		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -527,7 +527,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 
 		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, checkpointTimestamp);
 
-		while (!streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false)) {}
+		streamTask.triggerCheckpointAsync(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false).get();
 
 		// since no state was set, there shouldn't be restore calls
 		assertEquals(0, TestingStreamOperator.numberRestoreCalls);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
@@ -268,7 +268,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 
 		testHarness.taskStateManager.setWaitForReportLatch(new OneShotLatch());
 
-		while (!streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false)) {}
+		streamTask.triggerCheckpointAsync(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false);
 
 		testHarness.taskStateManager.getWaitForReportLatch().await();
 		long reportedCheckpointId = testHarness.taskStateManager.getReportedCheckpointId();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceExternalCheckpointTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceExternalCheckpointTriggerTest.java
@@ -85,7 +85,7 @@ public class SourceExternalCheckpointTriggerTest {
 		ready.await();
 
 		// now send an external trigger that should be ignored
-		assertTrue(sourceTask.triggerCheckpoint(new CheckpointMetaData(32, 829), CheckpointOptions.forCheckpointWithDefaultLocation(), false));
+		assertTrue(sourceTask.triggerCheckpointAsync(new CheckpointMetaData(32, 829), CheckpointOptions.forCheckpointWithDefaultLocation(), false).get());
 
 		// step by step let the source thread emit elements
 		sync.trigger();
@@ -101,7 +101,7 @@ public class SourceExternalCheckpointTriggerTest {
 		verifyNextElement(testHarness.getOutput(), 4L);
 
 		// now send an regular trigger command that should be ignored
-		assertTrue(sourceTask.triggerCheckpoint(new CheckpointMetaData(34, 900), CheckpointOptions.forCheckpointWithDefaultLocation(), false));
+		assertTrue(sourceTask.triggerCheckpointAsync(new CheckpointMetaData(34, 900), CheckpointOptions.forCheckpointWithDefaultLocation(), false).get());
 
 		sync.trigger();
 		verifyNextElement(testHarness.getOutput(), 5L);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
@@ -89,10 +89,11 @@ public class SourceTaskTerminationTest extends TestLogger {
 		emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 1L);
 		emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 2L);
 
-		srcTask.triggerCheckpoint(
+		srcTask.triggerCheckpointAsync(
 				new CheckpointMetaData(31L, 900),
 				CheckpointOptions.forCheckpointWithDefaultLocation(),
-				false);
+				false)
+				.get();
 
 		assertFalse(syncSavepointLatch.isSet());
 		assertFalse(syncSavepointLatch.isCompleted());
@@ -102,10 +103,11 @@ public class SourceTaskTerminationTest extends TestLogger {
 
 		emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 3L);
 
-		srcTask.triggerCheckpoint(
+		srcTask.triggerCheckpointAsync(
 				new CheckpointMetaData(syncSavepointId, 900),
 				new CheckpointOptions(CheckpointType.SYNC_SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
-				withMaxWatermark);
+				withMaxWatermark)
+				.get();
 
 		assertTrue(syncSavepointLatch.isSet());
 		assertFalse(syncSavepointLatch.isCompleted());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -53,12 +53,15 @@ import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -102,7 +105,8 @@ public class StreamMockEnvironment implements Environment {
 
 	private final GlobalAggregateManager aggregateManager;
 
-	private volatile boolean wasFailedExternally = false;
+	@Nullable
+	private Consumer<Throwable> externalExceptionHandler;
 
 	private TaskEventDispatcher taskEventDispatcher = mock(TaskEventDispatcher.class);
 
@@ -193,6 +197,10 @@ public class StreamMockEnvironment implements Environment {
 			t.printStackTrace();
 			fail(t.getMessage());
 		}
+	}
+
+	public void setExternalExceptionHandler(Consumer<Throwable> externalExceptionHandler) {
+		this.externalExceptionHandler = externalExceptionHandler;
 	}
 
 	@Override
@@ -325,11 +333,9 @@ public class StreamMockEnvironment implements Environment {
 
 	@Override
 	public void failExternally(Throwable cause) {
-		this.wasFailedExternally = true;
-	}
-
-	public boolean wasFailedExternally() {
-		return wasFailedExternally;
+		if (externalExceptionHandler != null) {
+			externalExceptionHandler.accept(cause);
+		}
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -85,7 +85,9 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import javax.annotation.Nonnull;
 
@@ -96,6 +98,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -108,9 +111,12 @@ import static org.mockito.Mockito.when;
  */
 public class StreamTaskTerminationTest extends TestLogger {
 
-	public static final OneShotLatch RUN_LATCH = new OneShotLatch();
-	public static final OneShotLatch CHECKPOINTING_LATCH = new OneShotLatch();
+	private static final OneShotLatch RUN_LATCH = new OneShotLatch();
+	private static final AtomicBoolean SNAPSHOT_HAS_STARTED = new AtomicBoolean();
 	private static final OneShotLatch CLEANUP_LATCH = new OneShotLatch();
+
+	@Rule
+	public final Timeout timeoutPerTest = Timeout.seconds(10);
 
 	/**
 	 * FLINK-6833
@@ -217,6 +223,8 @@ public class StreamTaskTerminationTest extends TestLogger {
 	 */
 	public static class BlockingStreamTask<T, OP extends StreamOperator<T>> extends StreamTask<T, OP> {
 
+		private boolean isRunning;
+
 		public BlockingStreamTask(Environment env) {
 			super(env);
 		}
@@ -227,10 +235,14 @@ public class StreamTaskTerminationTest extends TestLogger {
 
 		@Override
 		protected void processInput(DefaultActionContext context) throws Exception {
-			RUN_LATCH.trigger();
+			if (!isRunning) {
+				isRunning = true;
+				RUN_LATCH.trigger();
+			}
 			// wait until we have started an asynchronous checkpoint
-			CHECKPOINTING_LATCH.await();
-			context.allActionsCompleted();
+			if (isCanceled() || SNAPSHOT_HAS_STARTED.get()) {
+				context.allActionsCompleted();
+			}
 		}
 
 		@Override
@@ -297,7 +309,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 		@Override
 		public SnapshotResult<OperatorStateHandle> call() throws Exception {
 			// notify that we have started the asynchronous checkpointed operation
-			CHECKPOINTING_LATCH.trigger();
+			SNAPSHOT_HAS_STARTED.set(true);
 			// wait until we have reached the StreamTask#cleanup --> This will already cancel this FutureTask
 			CLEANUP_LATCH.await();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -368,10 +368,11 @@ public class StreamTaskTest extends TestLogger {
 
 		waitTaskIsRunning(streamTask, task.invocationFuture);
 
-		streamTask.triggerCheckpoint(
+		streamTask.triggerCheckpointAsync(
 			new CheckpointMetaData(42L, 1L),
 			CheckpointOptions.forCheckpointWithDefaultLocation(),
-			false);
+			false)
+			.get();
 
 		assertEquals(testException, declineDummyEnvironment.getLastDeclinedCheckpointCause());
 
@@ -408,7 +409,7 @@ public class StreamTaskTest extends TestLogger {
 
 		waitTaskIsRunning(streamTask, task.invocationFuture);
 
-		streamTask.triggerCheckpoint(
+		streamTask.triggerCheckpointAsync(
 			new CheckpointMetaData(42L, 1L),
 			CheckpointOptions.forCheckpointWithDefaultLocation(),
 			false);
@@ -450,10 +451,11 @@ public class StreamTaskTest extends TestLogger {
 			waitTaskIsRunning(streamTask, task.invocationFuture);
 
 			mockEnvironment.setExpectedExternalFailureCause(Throwable.class);
-			streamTask.triggerCheckpoint(
+			streamTask.triggerCheckpointAsync(
 				new CheckpointMetaData(42L, 1L),
 				CheckpointOptions.forCheckpointWithDefaultLocation(),
-				false);
+				false)
+				.get();
 
 			// wait for the completion of the async task
 			ExecutorService executor = streamTask.getAsyncOperationsThreadPool();
@@ -549,7 +551,7 @@ public class StreamTaskTest extends TestLogger {
 			waitTaskIsRunning(streamTask, task.invocationFuture);
 
 			final long checkpointId = 42L;
-			streamTask.triggerCheckpoint(
+			streamTask.triggerCheckpointAsync(
 				new CheckpointMetaData(checkpointId, 1L),
 				CheckpointOptions.forCheckpointWithDefaultLocation(),
 				false);
@@ -630,7 +632,7 @@ public class StreamTaskTest extends TestLogger {
 		waitTaskIsRunning(task.streamTask, task.invocationFuture);
 
 		final long checkpointId = 42L;
-		task.streamTask.triggerCheckpoint(
+		task.streamTask.triggerCheckpointAsync(
 			new CheckpointMetaData(checkpointId, 1L),
 			CheckpointOptions.forCheckpointWithDefaultLocation(),
 			false);
@@ -708,7 +710,7 @@ public class StreamTaskTest extends TestLogger {
 
 			waitTaskIsRunning(task.streamTask, task.invocationFuture);
 
-			task.streamTask.triggerCheckpoint(
+			task.streamTask.triggerCheckpointAsync(
 				new CheckpointMetaData(42L, 1L),
 				CheckpointOptions.forCheckpointWithDefaultLocation(),
 				false);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -143,6 +143,10 @@ public class StreamTaskTestHarness<OUT> {
 		this.taskStateManager = new TestTaskStateManager(localRecoveryConfig);
 	}
 
+	public StreamMockEnvironment getEnvironment() {
+		return mockEnv;
+	}
+
 	public ProcessingTimeService getProcessingTimeService() {
 		return taskThread.task.getProcessingTimeService();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -70,6 +70,7 @@ import org.junit.rules.Timeout;
 
 import java.util.Collections;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.hamcrest.Matchers.is;
@@ -151,11 +152,16 @@ public class SynchronousCheckpointITCase {
 		}
 
 		@Override
-		public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) throws Exception {
-			eventQueue.put(Event.PRE_TRIGGER_CHECKPOINT);
-			boolean result = super.triggerCheckpoint(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
-			eventQueue.put(Event.POST_TRIGGER_CHECKPOINT);
-			return result;
+		public Future<Boolean> triggerCheckpointAsync(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
+			try {
+				eventQueue.put(Event.PRE_TRIGGER_CHECKPOINT);
+				Future<Boolean> result = super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
+				eventQueue.put(Event.POST_TRIGGER_CHECKPOINT);
+				return result;
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new RuntimeException(e);
+			}
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -159,10 +159,15 @@ public class SynchronousCheckpointITCase {
 		}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) throws Exception {
-			eventQueue.put(Event.PRE_NOTIFY_CHECKPOINT_COMPLETE);
-			super.notifyCheckpointComplete(checkpointId);
-			eventQueue.put(Event.POST_NOTIFY_CHECKPOINT_COMPLETE);
+		public void notifyCheckpointComplete(long checkpointId) {
+			try {
+				eventQueue.put(Event.PRE_NOTIFY_CHECKPOINT_COMPLETE);
+				super.notifyCheckpointComplete(checkpointId);
+				eventQueue.put(Event.POST_NOTIFY_CHECKPOINT_COMPLETE);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new RuntimeException(e);
+			}
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -165,11 +165,12 @@ public class SynchronousCheckpointITCase {
 		}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) {
+		public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
 			try {
 				eventQueue.put(Event.PRE_NOTIFY_CHECKPOINT_COMPLETE);
-				super.notifyCheckpointComplete(checkpointId);
+				Future<Void> result = super.notifyCheckpointCompleteAsync(checkpointId);
 				eventQueue.put(Event.POST_NOTIFY_CHECKPOINT_COMPLETE);
+				return result;
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 				throw new RuntimeException(e);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
@@ -32,10 +31,16 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.execution.DefaultActionC
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -44,33 +49,35 @@ import static org.junit.Assert.fail;
  */
 public class SynchronousCheckpointTest {
 
-	private OneShotLatch execLatch;
+	private enum Event {
+		TASK_INITIALIZED,
+	}
 
-	private AtomicReference<Throwable> error;
-
-	private StreamTask streamTaskUnderTest;
-	private Thread mainThreadExecutingTaskUnderTest;
-	private Thread checkpointingThread;
+	private StreamTaskUnderTest streamTaskUnderTest;
+	private CompletableFuture<Void> taskInvocation;
+	private LinkedBlockingQueue<Event> eventQueue = new LinkedBlockingQueue<>();
 
 	@Before
 	public void setupTestEnvironment() throws InterruptedException {
-		final OneShotLatch runningLatch = new OneShotLatch();
 
-		execLatch = new OneShotLatch();
-		error = new AtomicReference<>();
+		taskInvocation = CompletableFuture.runAsync(
+			() -> {
+				streamTaskUnderTest = createTask(eventQueue);
+				try {
+					streamTaskUnderTest.invoke();
+				} catch (RuntimeException e) {
+					throw e;
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+			},
+			Executors.newSingleThreadExecutor());
 
-		mainThreadExecutingTaskUnderTest = launchOnSeparateThread(() -> {
-			streamTaskUnderTest = createTask(runningLatch, execLatch);
-			try {
-				streamTaskUnderTest.invoke();
-			} catch (Exception e) {
-				error.set(e);
-			}
-		});
-		runningLatch.await();
+		// Wait until task has been initialized.
+		assertThat(eventQueue.take(), is(Event.TASK_INITIALIZED));
 	}
 
-	@Test(timeout = 1000)
+	@Test(timeout = 20_000)
 	public void synchronousCheckpointBlocksUntilNotificationForCorrectCheckpointComes() throws Exception {
 		final SynchronousSavepointLatch syncSavepointLatch = launchSynchronousSavepointAndGetTheLatch();
 		assertFalse(syncSavepointLatch.isCompleted());
@@ -81,55 +88,42 @@ public class SynchronousCheckpointTest {
 		streamTaskUnderTest.notifyCheckpointComplete(42);
 		assertTrue(syncSavepointLatch.isCompleted());
 
-		waitUntilCheckpointingThreadIsFinished();
-		allowTaskToExitTheRunLoop();
+		streamTaskUnderTest.stopTask();
 		waitUntilMainExecutionThreadIsFinished();
 
 		assertFalse(streamTaskUnderTest.isCanceled());
 	}
 
-	@Test(timeout = 1000)
+	@Test(timeout = 10_000)
 	public void cancelShouldAlsoCancelPendingSynchronousCheckpoint() throws Throwable {
 		final SynchronousSavepointLatch syncSavepointLatch = launchSynchronousSavepointAndGetTheLatch();
 		assertFalse(syncSavepointLatch.isCompleted());
 
-		allowTaskToExitTheRunLoop();
+		streamTaskUnderTest.cancel();
 
 		assertFalse(syncSavepointLatch.isCompleted());
 		streamTaskUnderTest.cancel();
 		assertTrue(syncSavepointLatch.isCanceled());
 
-		waitUntilCheckpointingThreadIsFinished();
 		waitUntilMainExecutionThreadIsFinished();
 
 		assertTrue(streamTaskUnderTest.isCanceled());
 	}
 
 	private SynchronousSavepointLatch launchSynchronousSavepointAndGetTheLatch() throws InterruptedException {
-		checkpointingThread = launchOnSeparateThread(() -> {
-			try {
-				streamTaskUnderTest.triggerCheckpoint(
-						new CheckpointMetaData(42, System.currentTimeMillis()),
-						new CheckpointOptions(CheckpointType.SYNC_SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
-						false
-				);
-			} catch (Exception e) {
-				error.set(e);
-			}
-		});
+		streamTaskUnderTest.triggerCheckpointAsync(
+			new CheckpointMetaData(42, System.currentTimeMillis()),
+			new CheckpointOptions(CheckpointType.SYNC_SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
+			false);
 		return waitForSyncSavepointLatchToBeSet(streamTaskUnderTest);
 	}
 
-	private void waitUntilMainExecutionThreadIsFinished() throws InterruptedException {
-		mainThreadExecutingTaskUnderTest.join();
-	}
-
-	private void waitUntilCheckpointingThreadIsFinished() throws InterruptedException {
-		checkpointingThread.join();
-	}
-
-	private void allowTaskToExitTheRunLoop() {
-		execLatch.trigger();
+	private void waitUntilMainExecutionThreadIsFinished() {
+		try {
+			taskInvocation.get();
+		} catch (Exception e) {
+			assertThat(e.getCause(), is(instanceOf(CancelTaskException.class)));
+		}
 	}
 
 	private SynchronousSavepointLatch waitForSyncSavepointLatchToBeSet(final StreamTask streamTaskUnderTest) throws InterruptedException {
@@ -138,44 +132,44 @@ public class SynchronousCheckpointTest {
 		while (!syncSavepointFuture.isSet()) {
 			Thread.sleep(10L);
 
-			if (error.get() != null && !(error.get() instanceof CancelTaskException)) {
-				fail();
+			if (taskInvocation.isDone()) {
+				fail("Task has been terminated too early");
 			}
 		}
 		return syncSavepointFuture;
 	}
 
-	private Thread launchOnSeparateThread(final Runnable runnable) {
-		final Thread thread = new Thread(runnable);
-		thread.start();
-		return thread;
-	}
-
-	private StreamTask createTask(final OneShotLatch runningLatch, final OneShotLatch execLatch) {
-		final DummyEnvironment environment =
-				new DummyEnvironment("test", 1, 0);
-		return new StreamTaskUnderTest(environment, runningLatch, execLatch);
+	private static StreamTaskUnderTest createTask(Queue<Event> eventQueue) {
+		final DummyEnvironment environment = new DummyEnvironment("test", 1, 0);
+		return new StreamTaskUnderTest(environment, eventQueue);
 	}
 
 	private static class StreamTaskUnderTest extends NoOpStreamTask {
 
-		private final OneShotLatch runningLatch;
-		private final OneShotLatch execLatch;
+		private Queue<Event> eventQueue;
+		private volatile boolean stopped;
 
 		StreamTaskUnderTest(
 				final Environment env,
-				final OneShotLatch runningLatch,
-				final OneShotLatch execLatch) {
+				Queue<Event> eventQueue) {
 			super(env);
-			this.runningLatch = checkNotNull(runningLatch);
-			this.execLatch = checkNotNull(execLatch);
+			this.eventQueue = checkNotNull(eventQueue);
+		}
+
+		@Override
+		protected void init() {
+			eventQueue.add(Event.TASK_INITIALIZED);
 		}
 
 		@Override
 		protected void processInput(DefaultActionContext context) throws Exception {
-			runningLatch.trigger();
-			execLatch.await();
-			super.processInput(context);
+			if (stopped || isCanceled()) {
+				context.allActionsCompleted();
+			}
+		}
+
+		void stopTask() {
+			stopped = true;
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImplTest.java
@@ -111,7 +111,7 @@ public class TaskMailboxImplTest {
 	@Test
 	public void testConcurrentPutTakeNonBlockingAndWait() throws Exception {
 		testPutTake((mailbox -> {
-					Optional<Runnable> optionalLetter = mailbox.tryTakeMail();
+				Optional<Runnable> optionalLetter = mailbox.tryTakeMail();
 				while (!optionalLetter.isPresent()) {
 					optionalLetter = mailbox.tryTakeMail();
 				}
@@ -187,7 +187,7 @@ public class TaskMailboxImplTest {
 	}
 
 	private void testUnblocksInternal(
-		RunnableWithException testMethod,
+			RunnableWithException testMethod,
 			Consumer<TaskMailbox> unblockMethod) throws InterruptedException {
 		final Thread[] blockedThreads = new Thread[8];
 		final Exception[] exceptions = new Exception[blockedThreads.length];

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImplTest.java
@@ -50,7 +50,6 @@ public class TaskMailboxImplTest {
 	@Before
 	public void setUp() {
 		taskMailbox = new TaskMailboxImpl();
-		taskMailbox.open();
 	}
 
 	@After
@@ -279,7 +278,6 @@ public class TaskMailboxImplTest {
 		@Before
 		public void setUp() {
 			taskMailbox = new TaskMailboxImpl();
-			taskMailbox.open();
 		}
 
 		@After

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/MailboxExecutorImplTest.java
@@ -48,7 +48,6 @@ public class MailboxExecutorImplTest {
 	@Before
 	public void setUp() throws Exception {
 		this.mailbox = new TaskMailboxImpl();
-		this.mailbox.open();
 		this.mailboxExecutor = new MailboxExecutorImpl(mailbox.getDownstreamMailbox(DEFAULT_PRIORITY));
 		this.otherThreadExecutor = Executors.newSingleThreadScheduledExecutor();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/TaskMailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/TaskMailboxProcessorTest.java
@@ -39,6 +39,7 @@ public class TaskMailboxProcessorTest {
 	@Test
 	public void testRejectIfNotOpen() {
 		MailboxProcessor mailboxProcessor = new MailboxProcessor((ctx) -> {});
+		mailboxProcessor.prepareClose();
 		try {
 			mailboxProcessor.getMailboxExecutor(DEFAULT_PRIORITY).execute(() -> {});
 			Assert.fail("Should not be able to accept runnables if not opened.");
@@ -50,7 +51,6 @@ public class TaskMailboxProcessorTest {
 	public void testShutdown() {
 		MailboxProcessor mailboxProcessor = new MailboxProcessor((ctx) -> {});
 		FutureTask<Void> testRunnableFuture = new FutureTask<>(() -> {}, null);
-		mailboxProcessor.open();
 		mailboxProcessor.getMailboxExecutor(DEFAULT_PRIORITY).execute(testRunnableFuture);
 		mailboxProcessor.prepareClose();
 
@@ -164,7 +164,6 @@ public class TaskMailboxProcessorTest {
 
 		mailboxThread.start();
 		final MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();
-		mailboxProcessor.open();
 
 		final Thread asyncUnblocker = new Thread(() -> {
 			int count = 0;
@@ -206,7 +205,6 @@ public class TaskMailboxProcessorTest {
 	private static MailboxProcessor start(MailboxThread mailboxThread) {
 		mailboxThread.start();
 		final MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();
-		mailboxProcessor.open();
 		mailboxThread.signalStart();
 		return mailboxProcessor;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -82,7 +82,6 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 
 	@Override
 	public void init() {
-		this.mailboxProcessor.open();
 	}
 
 	@Override

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.scala.AsyncDataStreamITCase._
 import org.apache.flink.streaming.api.scala.async.{ResultFuture, RichAsyncFunction}
 import org.apache.flink.test.util.AbstractTestBase
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Ignore, Test}
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,11 +37,13 @@ object AsyncDataStreamITCase {
 
 class AsyncDataStreamITCase extends AbstractTestBase {
 
+  @Ignore("TODO: fix me when AsyncWaitOperator integrates with mailbox")
   @Test
   def testOrderedWait(): Unit = {
     testAsyncWait(true)
   }
 
+  @Ignore("TODO: fix me when AsyncWaitOperator integrates with mailbox")
   @Test
   def testUnorderedWait(): Unit = {
     testAsyncWait(false)

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.scala.AsyncDataStreamITCase._
 import org.apache.flink.streaming.api.scala.async.{ResultFuture, RichAsyncFunction}
 import org.apache.flink.test.util.AbstractTestBase
 import org.junit.Assert._
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,13 +37,11 @@ object AsyncDataStreamITCase {
 
 class AsyncDataStreamITCase extends AbstractTestBase {
 
-  @Ignore("TODO: fix me when AsyncWaitOperator integrates with mailbox")
   @Test
   def testOrderedWait(): Unit = {
     testAsyncWait(true)
   }
 
-  @Ignore("TODO: fix me when AsyncWaitOperator integrates with mailbox")
   @Test
   def testUnorderedWait(): Unit = {
     testAsyncWait(false)

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.api.datastream.AsyncDataStream;
 import org.apache.flink.streaming.api.functions.async.AsyncFunction;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.streaming.api.functions.async.RichAsyncFunction;
-import org.apache.flink.streaming.api.operators.async.AsyncWaitOperator;
+import org.apache.flink.streaming.api.operators.async.AsyncWaitOperatorFactory;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryString;
@@ -238,14 +238,12 @@ public class AsyncLookupJoinHarnessTest {
 				ASYNC_BUFFER_CAPACITY);
 		}
 
-		AsyncWaitOperator<BaseRow, BaseRow> operator = new AsyncWaitOperator<>(
-			joinRunner,
-			ASYNC_TIMEOUT_MS,
-			ASYNC_BUFFER_CAPACITY,
-			AsyncDataStream.OutputMode.ORDERED);
-
 		return new OneInputStreamOperatorTestHarness<>(
-			operator,
+			new AsyncWaitOperatorFactory<>(
+				joinRunner,
+				ASYNC_TIMEOUT_MS,
+				ASYNC_BUFFER_CAPACITY,
+				AsyncDataStream.OutputMode.ORDERED),
 			inSerializer);
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -321,7 +321,7 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		public void notifyCheckpointComplete(long checkpointId) {
 			final long taskIndex = getEnvironment().getTaskInfo().getIndexOfThisSubtask();
 			if (checkpointId == synchronousSavepointId && taskIndex == 0) {
 				throw new RuntimeException("Expected Exception");

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -322,13 +322,13 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		public void notifyCheckpointComplete(long checkpointId) {
+		public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
 			final long taskIndex = getEnvironment().getTaskInfo().getIndexOfThisSubtask();
 			if (checkpointId == synchronousSavepointId && taskIndex == 0) {
 				throw new RuntimeException("Expected Exception");
 			}
 
-			super.notifyCheckpointComplete(checkpointId);
+			return super.notifyCheckpointCompleteAsync(checkpointId);
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -304,7 +305,7 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) throws Exception {
+		public Future<Boolean> triggerCheckpointAsync(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, boolean advanceToEndOfEventTime) {
 			final long checkpointId = checkpointMetaData.getCheckpointId();
 			final CheckpointType checkpointType = checkpointOptions.getCheckpointType();
 
@@ -317,7 +318,7 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 			if (taskIndex == 0) {
 				checkpointsToWaitFor.countDown();
 			}
-			return super.triggerCheckpoint(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
+			return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, advanceToEndOfEventTime);
 		}
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -246,7 +246,8 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
 		}
 
 		@Override
-		public void notifyCheckpointComplete(final long checkpointId) {
+		public Future<Void> notifyCheckpointCompleteAsync(final long checkpointId) {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -49,8 +49,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -227,7 +229,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
 		}
 
 		@Override
-		public boolean triggerCheckpoint(final CheckpointMetaData checkpointMetaData, final CheckpointOptions checkpointOptions, final boolean advanceToEndOfEventTime) {
+		public Future<Boolean> triggerCheckpointAsync(final CheckpointMetaData checkpointMetaData, final CheckpointOptions checkpointOptions, final boolean advanceToEndOfEventTime) {
 			final TaskStateSnapshot checkpointStateHandles = new TaskStateSnapshot();
 			checkpointStateHandles.putSubtaskStateByOperatorID(
 				OperatorID.fromJobVertexID(getEnvironment().getJobVertexId()),
@@ -240,7 +242,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
 
 			triggerCheckpointLatch.countDown();
 
-			return true;
+			return CompletableFuture.completedFuture(true);
 		}
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
@@ -176,7 +176,7 @@ public class StatefulOperatorChainedTaskTest {
 
 		testHarness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
 
-		while (!streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false)) {}
+		while (!streamTask.triggerCheckpointAsync(checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation(), false).get()) {}
 
 		testHarness.getTaskStateManager().getWaitForReportLatch().await();
 		long reportedCheckpointId = testHarness.getTaskStateManager().getReportedCheckpointId();


### PR DESCRIPTION
## What is the purpose of the change

This PR contains changes for
 * FLINK-12481: to migrate timer triggers to mailbox execution model;
 * FLINK-12482: to migrate checkpoint triggers to mailbox execution model;
 * FLINK-12958: modifies `AsyncWaitOperator` to be compatible with mailbox execution model.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
