### PR TITLE
[FLINK-12501] Use SpecificRecord.getSchema in AvroFactory

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroFactory.java
@@ -37,6 +37,8 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -49,6 +51,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 final class AvroFactory<T> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(AvroFactory.class);
 
 	private final DataOutputEncoder encoder = new DataOutputEncoder();
 	private final DataInputDecoder decoder = new DataInputDecoder();
@@ -94,8 +98,7 @@ final class AvroFactory<T> {
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	private static <T> AvroFactory<T> fromSpecific(Class<T> type, ClassLoader cl, Optional<Schema> previousSchema) {
 		SpecificData specificData = new SpecificData(cl);
-		Optional<Schema> newSchemaOptional = tryExtractAvroSchema(type);
-		Schema newSchema = newSchemaOptional.orElseGet(() -> specificData.getSchema(type));
+		Schema newSchema = extractAvroSpecificSchema(type, specificData);
 
 		return new AvroFactory<>(
 			specificData,
@@ -132,15 +135,31 @@ final class AvroFactory<T> {
 	}
 
 	/**
+	 * Extracts an Avro {@link Schema} from a {@link SpecificRecord}. We do this either via {@link
+	 * SpecificData} or by instantiating a record and extracting the schema from the instance.
+	 */
+	static <T> Schema extractAvroSpecificSchema(
+			Class<T> type,
+			SpecificData specificData) {
+		Optional<Schema> newSchemaOptional = tryExtractAvroSchemaViaInstance(type);
+		return newSchemaOptional.orElseGet(() -> specificData.getSchema(type));
+	}
+
+	/**
 	 * Extracts an Avro {@link Schema} from a {@link SpecificRecord}. We do this by creating an
 	 * instance of the class using the zero-argument constructor and calling {@link
 	 * SpecificRecord#getSchema()} on it.
 	 */
-	private static Optional<Schema> tryExtractAvroSchema(Class<?> type) {
+	@SuppressWarnings("unchecked")
+	private static Optional<Schema> tryExtractAvroSchemaViaInstance(Class<?> type) {
 		try {
 			SpecificRecord instance = (SpecificRecord) type.newInstance();
-			return Optional.of(instance.getSchema());
+			return Optional.ofNullable(instance.getSchema());
 		} catch (InstantiationException | IllegalAccessException e) {
+			LOG.warn(
+					"Could not extract schema from Avro-generated SpecificRecord class {}: {}.",
+					type,
+					e);
 			return Optional.empty();
 		}
 	}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshot.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshot.java
@@ -186,7 +186,7 @@ public class AvroSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
 		}
 		if (isSpecificRecord(runtimeType)) {
 			SpecificData d = new SpecificData(cl);
-			return d.getSchema(runtimeType);
+			return AvroFactory.extractAvroSpecificSchema(runtimeType, d);
 		}
 		ReflectData d = new ReflectData(cl);
 		return d.getSchema(runtimeType);


### PR DESCRIPTION
## What is the purpose of the change

Before, we were using SpecificData.getSchema(type) which was not working
for types that were generated using Avrohugger (for Scala) because
the SCHEMA was generated in the companion object. Now we use a method
that must be available on all SpecificRecord(s).

We still use the old method as a fallback if we cannot instantiate or
call getSchema() on the instance.

## Brief change log

  - We create an instance of the `SpecificRecord` using `Class.newInstance` and then call `SpecificRecord.getSchema()`. We use the old method as a fallback

## Verifying this change

This is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - The serializers: yes, the avro serializer

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
