### PR TITLE
[FLINK-13887] [core] Ensure defaultInputDependencyConstraint to be non-null when setting it in ExecutionConfig

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -546,7 +546,13 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 */
 	@PublicEvolving
 	public void setDefaultInputDependencyConstraint(InputDependencyConstraint inputDependencyConstraint) {
-		this.defaultInputDependencyConstraint = inputDependencyConstraint;
+		if (inputDependencyConstraint != null) {
+			this.defaultInputDependencyConstraint = inputDependencyConstraint;
+		} else {
+			// defaultInputDependencyConstraint is not allowed to be null
+			// setting it to ANY to not break existing jobs
+			this.defaultInputDependencyConstraint = InputDependencyConstraint.ANY;
+		}
 	}
 
 	/**


### PR DESCRIPTION

## What is the purpose of the change

*If a user invokes ExecutionConfig#setDefaultInputDependencyConstraint(null) to set the defaultInputDependencyConstraint to be null, the scheduling topology building will throw NPE in ExecutionGraph creating stage, causing a master node fatal error.*


## Brief change log

*Setting defaultInputDependencyConstraint to ANY in ExecutionConfig if ExecutionConfig#setDefaultInputDependencyConstraint is invoked with a `null` param.*


## Verifying this change

This change is trivial so no test case is added to reduce code redundancy.
*Manually verified the change by invoking ExecutionConfig#setDefaultInputDependencyConstraint in BatchFineGrainedRecoveryITCase. Without this change there will be job submission error and the case will fail. With this change, the case can pass.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
