### PR TITLE
[Flink-12164][tests] Harden JobMasterTest#testJobFailureWhenTaskExecutorHeartbeatTimeout

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -28,9 +28,6 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Heartbeat manager implementation. The heartbeat manager maintains a map of heartbeat monitors
@@ -60,7 +57,9 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 	protected final Logger log;
 
 	/** Map containing the heartbeat monitors associated with the respective resource ID. */
-	private final ConcurrentHashMap<ResourceID, HeartbeatManagerImpl.HeartbeatMonitor<O>> heartbeatTargets;
+	private final ConcurrentHashMap<ResourceID, HeartbeatMonitor<O>> heartbeatTargets;
+
+	private final HeartbeatMonitor.Factory heartbeatMonitorFactory;
 
 	/** Running state of the heartbeat manager. */
 	protected volatile boolean stopped;
@@ -71,6 +70,23 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 			HeartbeatListener<I, O> heartbeatListener,
 			ScheduledExecutor mainThreadExecutor,
 			Logger log) {
+		this(
+			heartbeatTimeoutIntervalMs,
+			ownResourceID,
+			heartbeatListener,
+			mainThreadExecutor,
+			log,
+			new HeartbeatMonitorImpl.Factory());
+	}
+
+	public HeartbeatManagerImpl(
+			long heartbeatTimeoutIntervalMs,
+			ResourceID ownResourceID,
+			HeartbeatListener<I, O> heartbeatListener,
+			ScheduledExecutor mainThreadExecutor,
+			Logger log,
+			HeartbeatMonitor.Factory heartbeatMonitorFactory) {
+
 		Preconditions.checkArgument(heartbeatTimeoutIntervalMs > 0L, "The heartbeat timeout has to be larger than 0.");
 
 		this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
@@ -78,6 +94,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		this.heartbeatListener = Preconditions.checkNotNull(heartbeatListener, "heartbeatListener");
 		this.mainThreadExecutor = Preconditions.checkNotNull(mainThreadExecutor);
 		this.log = Preconditions.checkNotNull(log);
+		this.heartbeatMonitorFactory = heartbeatMonitorFactory;
 		this.heartbeatTargets = new ConcurrentHashMap<>(16);
 
 		stopped = false;
@@ -109,12 +126,13 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 			if (heartbeatTargets.containsKey(resourceID)) {
 				log.debug("The target with resource ID {} is already been monitored.", resourceID);
 			} else {
-				HeartbeatManagerImpl.HeartbeatMonitor<O> heartbeatMonitor = new HeartbeatManagerImpl.HeartbeatMonitor<>(
-					resourceID,
-					heartbeatTarget,
-					mainThreadExecutor,
-					heartbeatListener,
-					heartbeatTimeoutIntervalMs);
+				HeartbeatMonitor<O> heartbeatMonitor =
+					heartbeatMonitorFactory.createHeartbeatMonitor(
+						resourceID,
+						heartbeatTarget,
+						mainThreadExecutor,
+						heartbeatListener,
+						heartbeatTimeoutIntervalMs);
 
 				heartbeatTargets.put(
 					resourceID,
@@ -133,7 +151,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 	@Override
 	public void unmonitorTarget(ResourceID resourceID) {
 		if (!stopped) {
-			HeartbeatManagerImpl.HeartbeatMonitor<O> heartbeatMonitor = heartbeatTargets.remove(resourceID);
+			HeartbeatMonitor<O> heartbeatMonitor = heartbeatTargets.remove(resourceID);
 
 			if (heartbeatMonitor != null) {
 				heartbeatMonitor.cancel();
@@ -145,7 +163,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 	public void stop() {
 		stopped = true;
 
-		for (HeartbeatManagerImpl.HeartbeatMonitor<O> heartbeatMonitor : heartbeatTargets.values()) {
+		for (HeartbeatMonitor<O> heartbeatMonitor : heartbeatTargets.values()) {
 			heartbeatMonitor.cancel();
 		}
 
@@ -202,127 +220,12 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 
 	HeartbeatTarget<O> reportHeartbeat(ResourceID resourceID) {
 		if (heartbeatTargets.containsKey(resourceID)) {
-			HeartbeatManagerImpl.HeartbeatMonitor<O> heartbeatMonitor = heartbeatTargets.get(resourceID);
+			HeartbeatMonitor<O> heartbeatMonitor = heartbeatTargets.get(resourceID);
 			heartbeatMonitor.reportHeartbeat();
 
 			return heartbeatMonitor.getHeartbeatTarget();
 		} else {
 			return null;
-		}
-	}
-
-	//----------------------------------------------------------------------------------------------
-	// Utility classes
-	//----------------------------------------------------------------------------------------------
-
-	/**
-	 * Heartbeat monitor which manages the heartbeat state of the associated heartbeat target. The
-	 * monitor notifies the {@link HeartbeatListener} whenever it has not seen a heartbeat signal
-	 * in the specified heartbeat timeout interval. Each heartbeat signal resets this timer.
-	 *
-	 * @param <O> Type of the payload being sent to the associated heartbeat target
-	 */
-	static class HeartbeatMonitor<O> implements Runnable {
-
-		/** Resource ID of the monitored heartbeat target. */
-		private final ResourceID resourceID;
-
-		/** Associated heartbeat target. */
-		private final HeartbeatTarget<O> heartbeatTarget;
-
-		private final ScheduledExecutor scheduledExecutor;
-
-		/** Listener which is notified about heartbeat timeouts. */
-		private final HeartbeatListener<?, ?> heartbeatListener;
-
-		/** Maximum heartbeat timeout interval. */
-		private final long heartbeatTimeoutIntervalMs;
-
-		private volatile ScheduledFuture<?> futureTimeout;
-
-		private final AtomicReference<State> state = new AtomicReference<>(State.RUNNING);
-
-		private volatile long lastHeartbeat;
-
-		HeartbeatMonitor(
-			ResourceID resourceID,
-			HeartbeatTarget<O> heartbeatTarget,
-			ScheduledExecutor scheduledExecutor,
-			HeartbeatListener<?, O> heartbeatListener,
-			long heartbeatTimeoutIntervalMs) {
-
-			this.resourceID = Preconditions.checkNotNull(resourceID);
-			this.heartbeatTarget = Preconditions.checkNotNull(heartbeatTarget);
-			this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor);
-			this.heartbeatListener = Preconditions.checkNotNull(heartbeatListener);
-
-			Preconditions.checkArgument(heartbeatTimeoutIntervalMs > 0L, "The heartbeat timeout interval has to be larger than 0.");
-			this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
-
-			lastHeartbeat = 0L;
-
-			resetHeartbeatTimeout(heartbeatTimeoutIntervalMs);
-		}
-
-		HeartbeatTarget<O> getHeartbeatTarget() {
-			return heartbeatTarget;
-		}
-
-		ResourceID getHeartbeatTargetId() {
-			return resourceID;
-		}
-
-		public long getLastHeartbeat() {
-			return lastHeartbeat;
-		}
-
-		void reportHeartbeat() {
-			lastHeartbeat = System.currentTimeMillis();
-			resetHeartbeatTimeout(heartbeatTimeoutIntervalMs);
-		}
-
-		void resetHeartbeatTimeout(long heartbeatTimeout) {
-			if (state.get() == State.RUNNING) {
-				cancelTimeout();
-
-				futureTimeout = scheduledExecutor.schedule(this, heartbeatTimeout, TimeUnit.MILLISECONDS);
-
-				// Double check for concurrent accesses (e.g. a firing of the scheduled future)
-				if (state.get() != State.RUNNING) {
-					cancelTimeout();
-				}
-			}
-		}
-
-		void cancel() {
-			// we can only cancel if we are in state running
-			if (state.compareAndSet(State.RUNNING, State.CANCELED)) {
-				cancelTimeout();
-			}
-		}
-
-		private void cancelTimeout() {
-			if (futureTimeout != null) {
-				futureTimeout.cancel(true);
-			}
-		}
-
-		public boolean isCanceled() {
-			return state.get() == State.CANCELED;
-		}
-
-		@Override
-		public void run() {
-			// The heartbeat has timed out if we're in state running
-			if (state.compareAndSet(State.RUNNING, State.TIMEOUT)) {
-				heartbeatListener.notifyHeartbeatTimeout(resourceID);
-			}
-		}
-
-		private enum State {
-			RUNNING,
-			TIMEOUT,
-			CANCELED
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -114,6 +115,10 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 
 	Collection<HeartbeatMonitor<O>> getHeartbeatTargets() {
 		return heartbeatTargets.values();
+	}
+
+	Optional<HeartbeatMonitor<O>> getHeartbeatTarget(ResourceID resourceId) {
+		return Optional.ofNullable(heartbeatTargets.get(resourceId));
 	}
 
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -43,12 +43,31 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
 			HeartbeatListener<I, O> heartbeatListener,
 			ScheduledExecutor mainThreadExecutor,
 			Logger log) {
+		this(
+			heartbeatPeriod,
+			heartbeatTimeout,
+			ownResourceID,
+			heartbeatListener,
+			mainThreadExecutor,
+			log,
+			new HeartbeatMonitorImpl.Factory());
+	}
+
+	HeartbeatManagerSenderImpl(
+			long heartbeatPeriod,
+			long heartbeatTimeout,
+			ResourceID ownResourceID,
+			HeartbeatListener<I, O> heartbeatListener,
+			ScheduledExecutor mainThreadExecutor,
+			Logger log,
+			HeartbeatMonitor.Factory heartbeatMonitorFactory) {
 		super(
 			heartbeatTimeout,
 			ownResourceID,
 			heartbeatListener,
 			mainThreadExecutor,
-			log);
+			log,
+			heartbeatMonitorFactory);
 
 		this.heartbeatPeriod = heartbeatPeriod;
 		mainThreadExecutor.schedule(this, 0L, TimeUnit.MILLISECONDS);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitor.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.heartbeat;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+
+/**
+ * Heartbeat monitor which manages the heartbeat state of the associated heartbeat target. The
+ * monitor notifies the {@link HeartbeatListener} whenever it has not seen a heartbeat signal
+ * in the specified heartbeat timeout interval. Each heartbeat signal resets this timer.
+ *
+ * @param <O> Type of the payload being sent to the associated heartbeat target
+ */
+public interface HeartbeatMonitor<O> {
+
+	/**
+	 * Gets heartbeat target.
+	 *
+	 * @return the heartbeat target
+	 */
+	HeartbeatTarget<O> getHeartbeatTarget();
+
+	/**
+	 * Gets heartbeat target id.
+	 *
+	 * @return the heartbeat target id
+	 */
+	ResourceID getHeartbeatTargetId();
+
+	/**
+	 * Report heartbeat from the monitored target.
+	 */
+	void reportHeartbeat();
+
+	/**
+	 * Cancel this monitor.
+	 */
+	void cancel();
+
+	/**
+	 * Gets the last heartbeat.
+	 *
+	 * @return the last heartbeat
+	 */
+	long getLastHeartbeat();
+
+	/**
+	 * This factory provides an indirection way to create {@link HeartbeatMonitor}.
+	 */
+	interface Factory {
+		/**
+		 * Create heartbeat monitor heartbeat monitor.
+		 *
+		 * @param <O>                        the type of payload
+		 * @param resourceID                 the resource id
+		 * @param heartbeatTarget            the heartbeat target
+		 * @param mainThreadExecutor         the main thread executor
+		 * @param heartbeatListener          the heartbeat listener
+		 * @param heartbeatTimeoutIntervalMs the heartbeat timeout interval ms
+		 * @return the heartbeat monitor
+		 */
+		<O> HeartbeatMonitor<O> createHeartbeatMonitor(
+			ResourceID resourceID,
+			HeartbeatTarget<O> heartbeatTarget,
+			ScheduledExecutor mainThreadExecutor,
+			HeartbeatListener<?, O> heartbeatListener,
+			long heartbeatTimeoutIntervalMs);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitorImpl.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.heartbeat;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The default implementation of {@link HeartbeatMonitor}.
+ *
+ * @param <O> Type of the payload being sent to the associated heartbeat target
+ */
+public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
+
+	/** Resource ID of the monitored heartbeat target. */
+	private final ResourceID resourceID;
+
+	/** Associated heartbeat target. */
+	private final HeartbeatTarget<O> heartbeatTarget;
+
+	private final ScheduledExecutor scheduledExecutor;
+
+	/** Listener which is notified about heartbeat timeouts. */
+	private final HeartbeatListener<?, ?> heartbeatListener;
+
+	/** Maximum heartbeat timeout interval. */
+	private final long heartbeatTimeoutIntervalMs;
+
+	private volatile ScheduledFuture<?> futureTimeout;
+
+	private final AtomicReference<State> state = new AtomicReference<>(State.RUNNING);
+
+	private volatile long lastHeartbeat;
+
+	HeartbeatMonitorImpl(
+		ResourceID resourceID,
+		HeartbeatTarget<O> heartbeatTarget,
+		ScheduledExecutor scheduledExecutor,
+		HeartbeatListener<?, O> heartbeatListener,
+		long heartbeatTimeoutIntervalMs) {
+
+		this.resourceID = Preconditions.checkNotNull(resourceID);
+		this.heartbeatTarget = Preconditions.checkNotNull(heartbeatTarget);
+		this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor);
+		this.heartbeatListener = Preconditions.checkNotNull(heartbeatListener);
+
+		Preconditions.checkArgument(heartbeatTimeoutIntervalMs > 0L, "The heartbeat timeout interval has to be larger than 0.");
+		this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
+
+		lastHeartbeat = 0L;
+
+		resetHeartbeatTimeout(heartbeatTimeoutIntervalMs);
+	}
+
+	@Override
+	public HeartbeatTarget<O> getHeartbeatTarget() {
+		return heartbeatTarget;
+	}
+
+	@Override
+	public ResourceID getHeartbeatTargetId() {
+		return resourceID;
+	}
+
+	@Override
+	public long getLastHeartbeat() {
+		return lastHeartbeat;
+	}
+
+	@Override
+	public void reportHeartbeat() {
+		lastHeartbeat = System.currentTimeMillis();
+		resetHeartbeatTimeout(heartbeatTimeoutIntervalMs);
+	}
+
+	@Override
+	public void cancel() {
+		// we can only cancel if we are in state running
+		if (state.compareAndSet(State.RUNNING, State.CANCELED)) {
+			cancelTimeout();
+		}
+	}
+
+	@Override
+	public void run() {
+		// The heartbeat has timed out if we're in state running
+		if (state.compareAndSet(State.RUNNING, State.TIMEOUT)) {
+			heartbeatListener.notifyHeartbeatTimeout(resourceID);
+		}
+	}
+
+	public boolean isCanceled() {
+		return state.get() == State.CANCELED;
+	}
+
+	void resetHeartbeatTimeout(long heartbeatTimeout) {
+		if (state.get() == State.RUNNING) {
+			cancelTimeout();
+
+			futureTimeout = scheduledExecutor.schedule(this, heartbeatTimeout, TimeUnit.MILLISECONDS);
+
+			// Double check for concurrent accesses (e.g. a firing of the scheduled future)
+			if (state.get() != State.RUNNING) {
+				cancelTimeout();
+			}
+		}
+	}
+
+	private void cancelTimeout() {
+		if (futureTimeout != null) {
+			futureTimeout.cancel(true);
+		}
+	}
+
+	private enum State {
+		RUNNING,
+		TIMEOUT,
+		CANCELED
+	}
+
+	/**
+	 * The factory that instantiates {@link HeartbeatMonitorImpl}.
+	 */
+	static class Factory implements HeartbeatMonitor.Factory {
+
+		@Override
+		public <O> HeartbeatMonitor<O> createHeartbeatMonitor(
+			ResourceID resourceID,
+			HeartbeatTarget<O> heartbeatTarget,
+			ScheduledExecutor mainThreadExecutor,
+			HeartbeatListener<?, O> heartbeatListener,
+			long heartbeatTimeoutIntervalMs) {
+
+			return new HeartbeatMonitorImpl<>(resourceID, heartbeatTarget, mainThreadExecutor, heartbeatListener, heartbeatTimeoutIntervalMs);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1779,7 +1779,7 @@ public class JobMasterTest extends TestLogger {
 	}
 
 	/**
-	 * Tests the updateGlobalAggregate functionality
+	 * Tests the updateGlobalAggregate functionality.
 	 */
 	@Test
 	public void testJobMasterAggregatesValuesCorrectly() throws Exception {
@@ -1837,9 +1837,7 @@ public class JobMasterTest extends TestLogger {
 
 			@Override
 			public Integer add(Integer value, Integer accumulator) {
-				Integer _acc = (Integer) accumulator;
-				Integer _value = (Integer) value;
-				return _acc + _value;
+				return accumulator + value;
 			}
 
 			@Override


### PR DESCRIPTION
## What is the purpose of the change

* Harden unstable case `JobMasterTest#testJobFailureWhenTaskExecutorHeartbeatTimeout`

## Brief change log

* Introduce factory pattern for `HeartbeatMonitor`. So that we could inject codes for testing.
* Enrich `TestingHeartbeatServices` by supporting manually triggering timeout
* Use `TestingHeartbeatServices` to trigger timeout manually for `JobMasterTest#testJobFailureWhenTaskExecutorHeartbeatTimeout` instead of the heartbeat service with a short heartbeat timeout threshold

## Verifying this change

* This change is about testing
* Verify the change by re-running the relevant cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable