### PR TITLE
[FLINK-13912][client] Remove ClusterClient#getClusterConnectionInfo

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -41,10 +41,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.util.LeaderConnectionInfo;
-import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.Preconditions;
@@ -154,22 +151,6 @@ public abstract class ClusterClient<T> {
 				highAvailabilityServices.close();
 			}
 		}
-	}
-
-	// ------------------------------------------------------------------------
-	//  Configuration
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Gets the current cluster connection info (may change in case of a HA setup).
-	 *
-	 * @return The the connection info to the leader component of the cluster
-	 * @throws LeaderRetrievalException if the leader could not be retrieved
-	 */
-	public LeaderConnectionInfo getClusterConnectionInfo() throws LeaderRetrievalException {
-		return LeaderRetrievalUtils.retrieveLeaderConnectionInfo(
-			highAvailabilityServices.getDispatcherLeaderRetriever(),
-			timeout);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -23,13 +23,15 @@ import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.runtime.util.LeaderConnectionInfo;
+import org.apache.flink.configuration.RestOptions;
 
 import org.apache.commons.cli.CommandLine;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.net.URL;
 
 import static org.junit.Assert.assertThat;
 
@@ -52,8 +54,8 @@ public class DefaultCLITest extends CliFrontendTestBase {
 		final String localhost = "localhost";
 		final int port = 1234;
 
-		configuration.setString(JobManagerOptions.ADDRESS, localhost);
-		configuration.setInteger(JobManagerOptions.PORT, port);
+		configuration.setString(RestOptions.ADDRESS, localhost);
+		configuration.setInteger(RestOptions.PORT, port);
 
 		@SuppressWarnings("unchecked")
 		final AbstractCustomCommandLine<StandaloneClusterId> defaultCLI =
@@ -68,10 +70,10 @@ public class DefaultCLITest extends CliFrontendTestBase {
 
 		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
-		final LeaderConnectionInfo clusterConnectionInfo = clusterClient.getClusterConnectionInfo();
+		final URL webInterfaceUrl = new URL(clusterClient.getWebInterfaceURL());
 
-		assertThat(clusterConnectionInfo.getHostname(), Matchers.equalTo(localhost));
-		assertThat(clusterConnectionInfo.getPort(), Matchers.equalTo(port));
+		assertThat(webInterfaceUrl.getHost(), Matchers.equalTo(localhost));
+		assertThat(webInterfaceUrl.getPort(), Matchers.equalTo(port));
 	}
 
 	/**
@@ -101,10 +103,10 @@ public class DefaultCLITest extends CliFrontendTestBase {
 
 		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
-		final LeaderConnectionInfo clusterConnectionInfo = clusterClient.getClusterConnectionInfo();
+		final URL webInterfaceUrl = new URL(clusterClient.getWebInterfaceURL());
 
-		assertThat(clusterConnectionInfo.getHostname(), Matchers.equalTo(manualHostname));
-		assertThat(clusterConnectionInfo.getPort(), Matchers.equalTo(manualPort));
+		assertThat(webInterfaceUrl.getHost(), Matchers.equalTo(manualHostname));
+		assertThat(webInterfaceUrl.getPort(), Matchers.equalTo(manualPort));
 	}
 
 }

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -19,12 +19,12 @@
 package org.apache.flink.api.scala
 
 import java.io._
+import java.net.{InetSocketAddress, URL}
 
 import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
 import org.apache.flink.client.deployment.ClusterDescriptor
 import org.apache.flink.client.program.ClusterClient
 import org.apache.flink.configuration.{Configuration, GlobalConfiguration, JobManagerOptions}
-import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration}
 
 import scala.collection.mutable.ArrayBuffer
@@ -277,8 +277,9 @@ object FlinkShell {
 
     val cluster = clusterDescriptor.deploySessionCluster(clusterSpecification)
 
-    val inetSocketAddress = AkkaUtils.getInetSocketAddressFromAkkaURL(
-      cluster.getClusterConnectionInfo.getAddress)
+    val webMonitorUrl = new URL(cluster.getWebInterfaceURL)
+
+    val inetSocketAddress = new InetSocketAddress(webMonitorUrl.getHost, webMonitorUrl.getPort)
 
     val address = inetSocketAddress.getAddress.getHostAddress
     val port = inetSocketAddress.getPort
@@ -317,10 +318,9 @@ object FlinkShell {
       throw new RuntimeException("Yarn Cluster could not be retrieved.")
     }
 
-    val jobManager = AkkaUtils.getInetSocketAddressFromAkkaURL(
-      cluster.getClusterConnectionInfo.getAddress)
+    val webMonitorUrl = new URL(cluster.getWebInterfaceURL)
 
-    (jobManager.getHostString, jobManager.getPort, None)
+    (webMonitorUrl.getHost, webMonitorUrl.getPort, None)
   }
 
   def ensureYarnConfig(config: Config) = config.yarnConfig match {

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -279,12 +279,7 @@ object FlinkShell {
 
     val webMonitorUrl = new URL(cluster.getWebInterfaceURL)
 
-    val inetSocketAddress = new InetSocketAddress(webMonitorUrl.getHost, webMonitorUrl.getPort)
-
-    val address = inetSocketAddress.getAddress.getHostAddress
-    val port = inetSocketAddress.getPort
-
-    (address, port, Some(Right(cluster)))
+    (webMonitorUrl.getHost, webMonitorUrl.getPort, Some(Right(cluster)))
   }
 
   def fetchDeployedYarnClusterInfo(

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.api.scala
 
 import java.io._
-import java.net.{InetSocketAddress, URL}
+import java.net.URL
 
 import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
 import org.apache.flink.client.deployment.ClusterDescriptor

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -153,7 +153,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-t", flinkShadedHadoopDir.getAbsolutePath(),
 				"-jm", "768m",
 				"-tm", "1024m", "-qu", "qa-team"},
-			"Flink JobManager is now running on ", null, RunTypes.YARN_SESSION, 0));
+			"JobManager Web Interface:", null, RunTypes.YARN_SESSION, 0));
 	}
 
 	/**
@@ -264,7 +264,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 					"-Dfancy-configuration-value=veryFancy",
 					"-Dyarn.maximum-failed-containers=3",
 					"-D" + YarnConfigOptions.VCORES.key() + "=2"},
-				"Flink JobManager is now running on ",
+				"JobManager Web Interface:",
 				RunTypes.YARN_SESSION);
 
 			try {
@@ -272,7 +272,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				final HostAndPort hostAndPort = parseJobManagerHostname(logs);
 				final String host = hostAndPort.getHostText();
 				final int port = hostAndPort.getPort();
-				LOG.info("Extracted hostname:port: {}", host, port);
+				LOG.info("Extracted hostname:port: {}:{}", host, port);
 
 				submitJob("WindowJoin.jar");
 
@@ -313,7 +313,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	}
 
 	private static HostAndPort parseJobManagerHostname(final String logs) {
-		final Pattern p = Pattern.compile("Flink JobManager is now running on ([a-zA-Z0-9.-]+):([0-9]+)");
+		final Pattern p = Pattern.compile("JobManager Web Interface: http://([a-zA-Z0-9.-]+):([0-9]+)");
 		final Matcher matches = p.matcher(logs);
 		String hostname = null;
 		String port = null;

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -132,7 +132,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 			Runner clusterRunner =
 				startWithArgs(
 					args.toArray(new String[args.size()]),
-					"Flink JobManager is now running on", RunTypes.YARN_SESSION);
+					"JobManager Web Interface:", RunTypes.YARN_SESSION);
 
 			// before checking any strings outputted by the CLI, first give it time to return
 			clusterRunner.join();

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnPrioritySchedulingITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnPrioritySchedulingITCase.java
@@ -56,7 +56,7 @@ public class YarnPrioritySchedulingITCase extends YarnTestBase {
 					"-jm", "768m",
 					"-tm", "1024m",
 					"-Dyarn.application.priority=" + priority},
-				"Flink JobManager is now running on ",
+				"JobManager Web Interface:",
 				RunTypes.YARN_SESSION);
 
 			try {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -29,7 +29,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -29,6 +29,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
@@ -348,12 +349,15 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			}
 
 			final String host = report.getHost();
-			final int rpcPort = report.getRpcPort();
+			final int port = report.getRpcPort();
 
-			LOG.info("Found Web Interface {}:{} of application '{}'.", host, rpcPort, applicationId);
+			LOG.info("Found Web Interface {}:{} of application '{}'.", host, port, applicationId);
+
+			flinkConfiguration.setString(JobManagerOptions.ADDRESS, host);
+			flinkConfiguration.setInteger(JobManagerOptions.PORT, port);
 
 			flinkConfiguration.setString(RestOptions.ADDRESS, host);
-			flinkConfiguration.setInteger(RestOptions.PORT, rpcPort);
+			flinkConfiguration.setInteger(RestOptions.PORT, port);
 
 			return createYarnClusterClient(
 				this,
@@ -510,6 +514,9 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		final String host = report.getHost();
 		final int port = report.getRpcPort();
+
+		flinkConfiguration.setString(JobManagerOptions.ADDRESS, host);
+		flinkConfiguration.setInteger(JobManagerOptions.PORT, port);
 
 		flinkConfiguration.setString(RestOptions.ADDRESS, host);
 		flinkConfiguration.setInteger(RestOptions.PORT, port);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -339,23 +339,19 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 					"configuration for accessing YARN.");
 			}
 
-			final ApplicationReport appReport = yarnClient.getApplicationReport(applicationId);
+			final ApplicationReport report = yarnClient.getApplicationReport(applicationId);
 
-			if (appReport.getFinalApplicationStatus() != FinalApplicationStatus.UNDEFINED) {
+			if (report.getFinalApplicationStatus() != FinalApplicationStatus.UNDEFINED) {
 				// Flink cluster is not running anymore
 				LOG.error("The application {} doesn't run anymore. It has previously completed with final status: {}",
-					applicationId, appReport.getFinalApplicationStatus());
+					applicationId, report.getFinalApplicationStatus());
 				throw new RuntimeException("The Yarn application " + applicationId + " doesn't run anymore.");
 			}
 
-			final String host = appReport.getHost();
-			final int rpcPort = appReport.getRpcPort();
+			final String host = report.getHost();
+			final int rpcPort = report.getRpcPort();
 
-			LOG.info("Found application JobManager host name '{}' and port '{}' from supplied application id '{}'",
-				host, rpcPort, applicationId);
-
-			flinkConfiguration.setString(JobManagerOptions.ADDRESS, host);
-			flinkConfiguration.setInteger(JobManagerOptions.PORT, rpcPort);
+			LOG.info("Found Web Interface {}:{} of application '{}'.", host, rpcPort, applicationId);
 
 			flinkConfiguration.setString(RestOptions.ADDRESS, host);
 			flinkConfiguration.setInteger(RestOptions.PORT, rpcPort);
@@ -364,7 +360,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 				this,
 				-1, // we don't know the number of task managers of a started Flink cluster
 				-1, // we don't know how many slots each task manager has for a started Flink cluster
-				appReport,
+				report,
 				flinkConfiguration,
 				false);
 		} catch (Exception e) {
@@ -513,12 +509,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			yarnApplication,
 			validClusterSpecification);
 
-		String host = report.getHost();
-		int port = report.getRpcPort();
-
-		// Correctly initialize the Flink config
-		flinkConfiguration.setString(JobManagerOptions.ADDRESS, host);
-		flinkConfiguration.setInteger(JobManagerOptions.PORT, port);
+		final String host = report.getHost();
+		final int port = report.getRpcPort();
 
 		flinkConfiguration.setString(RestOptions.ADDRESS, host);
 		flinkConfiguration.setInteger(RestOptions.PORT, port);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
-import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
@@ -619,10 +618,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 					yarnApplicationId = clusterClient.getClusterId();
 
 					try {
-						final LeaderConnectionInfo connectionInfo = clusterClient.getClusterConnectionInfo();
-
-						System.out.println("Flink JobManager is now running on " + connectionInfo.getHostname() +
-							':' + connectionInfo.getPort() + " with leader id " + connectionInfo.getLeaderSessionID() + '.');
 						System.out.println("JobManager Web Interface: " + clusterClient.getWebInterfaceURL());
 
 						writeYarnPropertiesFile(


### PR DESCRIPTION
## What is the purpose of the change

As discussed in [FLINK-13750](https://issues.apache.org/jira/browse/FLINK-13750), we actually doesn't need this method any more. All configuration needed is `WebMonitor` address and port in standalone HA mode. We can safely remove this method and replace its usages with `ClusterClient#getWebInterfaceURL`


## Brief change log

- Remove `ClusterClient#getClusterConnectionInfo`
- Replace its usages with `ClusterClient#getWebInterfaceURL`
- Adjust logs and tests


## Verifying this change

This change remove an existing method so that existing tests should guard nothing breaks.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann 
