### PR TITLE
[FLINK-13864][streaming]: Modify the StreamingFileSink Builder interface to allow for easier subclassing of StreamingFileSink 

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -110,7 +110,7 @@ public class StreamingFileSink<IN>
 
 	private final long bucketCheckInterval;
 
-	private final StreamingFileSink.BucketsBuilder<IN, ?> bucketsBuilder;
+	private final StreamingFileSink.BucketsBuilder<IN, ?, ? extends BucketsBuilder<IN, ?, ?>> bucketsBuilder;
 
 	// --------------------------- runtime fields -----------------------------
 
@@ -125,11 +125,24 @@ public class StreamingFileSink<IN>
 	private transient ListState<Long> maxPartCountersState;
 
 	/**
-	 * Creates a new {@code StreamingFileSink} that writes files to the given base directory.
+	 * Creates a new {@code StreamingFileSink} that writes files in row-based format to the given base directory.
 	 */
 	protected StreamingFileSink(
-			final StreamingFileSink.BucketsBuilder<IN, ?> bucketsBuilder,
-			final long bucketCheckInterval) {
+		final RowFormatBuilder<IN, ?, ? extends BucketsBuilder<IN, ?, ?>> bucketsBuilder,
+		final long bucketCheckInterval) {
+
+		Preconditions.checkArgument(bucketCheckInterval > 0L);
+
+		this.bucketsBuilder = Preconditions.checkNotNull(bucketsBuilder);
+		this.bucketCheckInterval = bucketCheckInterval;
+	}
+
+	/**
+	 * Creates a new {@code StreamingFileSink} that writes files in bulk-encoded format to the given base directory.
+	 */
+	protected StreamingFileSink(
+		final BulkFormatBuilder<IN, ?, ? extends BucketsBuilder<IN, ?, ?>> bucketsBuilder,
+		final long bucketCheckInterval) {
 
 		Preconditions.checkArgument(bucketCheckInterval > 0L);
 
@@ -149,7 +162,7 @@ public class StreamingFileSink<IN>
 	 * @return The builder where the remaining of the configuration parameters for the sink can be configured.
 	 * In order to instantiate the sink, call {@link RowFormatBuilder#build()} after specifying the desired parameters.
 	 */
-	public static <IN> StreamingFileSink.RowFormatBuilder<IN, String> forRowFormat(
+	public static <IN> StreamingFileSink.RowFormatBuilder<IN, String, ? extends RowFormatBuilder<IN, String, ?>> forRowFormat(
 			final Path basePath, final Encoder<IN> encoder) {
 		return new StreamingFileSink.RowFormatBuilder<>(basePath, encoder, new DateTimeBucketAssigner<>());
 	}
@@ -162,7 +175,7 @@ public class StreamingFileSink<IN>
 	 * @return The builder where the remaining of the configuration parameters for the sink can be configured.
 	 * In order to instantiate the sink, call {@link RowFormatBuilder#build()} after specifying the desired parameters.
 	 */
-	public static <IN> StreamingFileSink.BulkFormatBuilder<IN, String> forBulkFormat(
+	public static <IN> StreamingFileSink.BulkFormatBuilder<IN, String, ? extends BulkFormatBuilder<IN, String, ?>> forBulkFormat(
 			final Path basePath, final BulkWriter.Factory<IN> writerFactory) {
 		return new StreamingFileSink.BulkFormatBuilder<>(basePath, writerFactory, new DateTimeBucketAssigner<>());
 	}
@@ -170,9 +183,17 @@ public class StreamingFileSink<IN>
 	/**
 	 * The base abstract class for the {@link RowFormatBuilder} and {@link BulkFormatBuilder}.
 	 */
-	protected abstract static class BucketsBuilder<IN, BucketID> implements Serializable {
+	private abstract static class BucketsBuilder<IN, BucketID, T extends BucketsBuilder<IN, BucketID, T>> implements
+		Serializable {
 
 		private static final long serialVersionUID = 1L;
+
+		protected static final long DEFAULT_BUCKET_CHECK_INTERVAL = 60L * 1000L;
+
+		@SuppressWarnings("unchecked")
+		protected T self() {
+			return (T) this;
+		}
 
 		abstract Buckets<IN, BucketID> createBuckets(final int subtaskIndex) throws IOException;
 	}
@@ -181,31 +202,31 @@ public class StreamingFileSink<IN>
 	 * A builder for configuring the sink for row-wise encoding formats.
 	 */
 	@PublicEvolving
-	public static class RowFormatBuilder<IN, BucketID> extends StreamingFileSink.BucketsBuilder<IN, BucketID> {
+	public static class RowFormatBuilder<IN, BucketID, T extends RowFormatBuilder<IN, BucketID, T>> extends StreamingFileSink.BucketsBuilder<IN, BucketID, T> {
 
 		private static final long serialVersionUID = 1L;
 
-		private final long bucketCheckInterval;
+		private long bucketCheckInterval;
 
 		private final Path basePath;
 
-		private final Encoder<IN> encoder;
+		private Encoder<IN> encoder;
 
-		private final BucketAssigner<IN, BucketID> bucketAssigner;
+		private BucketAssigner<IN, BucketID> bucketAssigner;
 
-		private final RollingPolicy<IN, BucketID> rollingPolicy;
+		private RollingPolicy<IN, BucketID> rollingPolicy;
 
-		private final BucketFactory<IN, BucketID> bucketFactory;
+		private BucketFactory<IN, BucketID> bucketFactory;
 
-		private final String partFilePrefix;
+		private String partFilePrefix;
 
-		private final String partFileSuffix;
+		private String partFileSuffix;
 
-		RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
-			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.builder().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>(), PartFileConfig.DEFAULT_PART_PREFIX, PartFileConfig.DEFAULT_PART_SUFFIX);
+		protected RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
+			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.builder().build(), DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>(), PartFileConfig.DEFAULT_PART_PREFIX, PartFileConfig.DEFAULT_PART_SUFFIX);
 		}
 
-		private RowFormatBuilder(
+		protected RowFormatBuilder(
 				Path basePath,
 				Encoder<IN> encoder,
 				BucketAssigner<IN, BucketID> assigner,
@@ -224,49 +245,55 @@ public class StreamingFileSink<IN>
 			this.partFileSuffix = Preconditions.checkNotNull(partFileSuffix);
 		}
 
-		/**
-		 * Creates a new builder instance with the specified bucket check interval. The interval specifies how often
-		 * time based {@link RollingPolicy}s will be checked/executed for the open buckets.
-		 * @param interval Time interval in milliseconds
-		 * @return A new builder with the check interval set.
-		 */
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketCheckInterval(final long interval) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, interval, bucketFactory, partFilePrefix, partFileSuffix);
+		public long getBucketCheckInterval() {
+			return bucketCheckInterval;
 		}
 
-		/**
-		 * Creates a new builder instance with the specified {@link BucketAssigner}.
-		 * @param assigner @{@link BucketAssigner} to be used.
-		 * @return A new builder with the assigner set.
-		 */
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketAssigner(final BucketAssigner<IN, BucketID> assigner) {
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), rollingPolicy, bucketCheckInterval, bucketFactory, partFilePrefix, partFileSuffix);
+		public T withBucketCheckInterval(final long interval) {
+			this.bucketCheckInterval = interval;
+			return self();
 		}
 
-		/**
-		 * Creates a new builder instance with the specified {@link RollingPolicy} set for the bucketing logic.
-		 * @param policy {@link RollingPolicy} to be applied
-		 * @return A new builder with the check interval set.
-		 */
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withRollingPolicy(final RollingPolicy<IN, BucketID> policy) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, Preconditions.checkNotNull(policy), bucketCheckInterval, bucketFactory, partFilePrefix, partFileSuffix);
+		public T withBucketAssigner(final BucketAssigner<IN, BucketID> assigner) {
+			this.bucketAssigner = Preconditions.checkNotNull(assigner);
+			return self();
 		}
 
-		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID> withBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
+		public T withRollingPolicy(final RollingPolicy<IN, BucketID> policy) {
+			this.rollingPolicy = Preconditions.checkNotNull(policy);
+			return self();
+		}
+
+		public T withBucketAssignerAndPolicy(final BucketAssigner<IN, BucketID> assigner, final RollingPolicy<IN, BucketID> policy) {
+			this.bucketAssigner = Preconditions.checkNotNull(assigner);
+			this.rollingPolicy = Preconditions.checkNotNull(policy);
+			return self();
+		}
+
+		public T withPartFilePrefix(final String partPrefix) {
+			this.partFilePrefix = partPrefix;
+			return self();
+		}
+
+		public T withPartFileSuffix(final String partSuffix) {
+			this.partFileSuffix = partSuffix;
+			return self();
+		}
+
+		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID, ? extends RowFormatBuilder<IN, ID, ?>> newBuilderWithBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
+			Preconditions.checkState(bucketFactory.getClass() == DefaultBucketFactoryImpl.class, "newBuilderWithBucketAssignerAndPolicy() cannot be called after specifying a customized bucket factory");
 			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFilePrefix, partFileSuffix);
-		}
-
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withPartFilePrefix(final String partPrefix) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, bucketFactory, partPrefix, partFileSuffix);
-		}
-
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withPartFileSuffix(final String partSuffix) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, bucketFactory, partFilePrefix, partSuffix);
 		}
 
 		/** Creates the actual sink. */
 		public StreamingFileSink<IN> build() {
 			return new StreamingFileSink<>(this, bucketCheckInterval);
+		}
+
+		@VisibleForTesting
+		T withBucketFactory(final BucketFactory<IN, BucketID> factory) {
+			this.bucketFactory = Preconditions.checkNotNull(factory);
+			return self();
 		}
 
 		@Override
@@ -280,40 +307,35 @@ public class StreamingFileSink<IN>
 					subtaskIndex,
 					new PartFileConfig(partFilePrefix, partFileSuffix));
 		}
-
-		@VisibleForTesting
-		StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, Preconditions.checkNotNull(factory), partFilePrefix, partFileSuffix);
-		}
 	}
 
 	/**
 	 * A builder for configuring the sink for bulk-encoding formats, e.g. Parquet/ORC.
 	 */
 	@PublicEvolving
-	public static class BulkFormatBuilder<IN, BucketID> extends StreamingFileSink.BucketsBuilder<IN, BucketID> {
+	public static class BulkFormatBuilder<IN, BucketID, T extends BulkFormatBuilder<IN, BucketID, T>> extends StreamingFileSink.BucketsBuilder<IN, BucketID, T> {
 
 		private static final long serialVersionUID = 1L;
 
-		private final long bucketCheckInterval;
+		private long bucketCheckInterval;
 
 		private final Path basePath;
 
-		private final BulkWriter.Factory<IN> writerFactory;
+		private BulkWriter.Factory<IN> writerFactory;
 
-		private final BucketAssigner<IN, BucketID> bucketAssigner;
+		private BucketAssigner<IN, BucketID> bucketAssigner;
 
-		private final BucketFactory<IN, BucketID> bucketFactory;
+		private BucketFactory<IN, BucketID> bucketFactory;
 
-		private final String partFilePrefix;
+		private String partFilePrefix;
 
-		private final String partFileSuffix;
+		private String partFileSuffix;
 
-		BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, BucketID> assigner) {
-			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>(), PartFileConfig.DEFAULT_PART_PREFIX, PartFileConfig.DEFAULT_PART_SUFFIX);
+		protected BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, BucketID> assigner) {
+			this(basePath, writerFactory, assigner, DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>(), PartFileConfig.DEFAULT_PART_PREFIX, PartFileConfig.DEFAULT_PART_SUFFIX);
 		}
 
-		private BulkFormatBuilder(
+		protected BulkFormatBuilder(
 				Path basePath,
 				BulkWriter.Factory<IN> writerFactory,
 				BucketAssigner<IN, BucketID> assigner,
@@ -330,34 +352,39 @@ public class StreamingFileSink<IN>
 			this.partFileSuffix = Preconditions.checkNotNull(partFileSuffix);
 		}
 
-		/**
-		 * Currently bulk formats always use the {@link OnCheckpointRollingPolicy} therefore this settings does
-		 * not have any effect.
-		 */
-		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketCheckInterval(long interval) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, interval, bucketFactory, partFilePrefix, partFileSuffix);
+		public long getBucketCheckInterval() {
+			return bucketCheckInterval;
 		}
 
-		/**
-		 * Creates a new builder instance with the specified {@link BucketAssigner}.
-		 * @param assigner @{@link BucketAssigner} to be used.
-		 * @return A new builder with the assigner set.
-		 */
-		public <ID> StreamingFileSink.BulkFormatBuilder<IN, ID> withBucketAssigner(BucketAssigner<IN, ID> assigner) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFilePrefix, partFileSuffix);
+		public T withBucketCheckInterval(long interval) {
+			this.bucketCheckInterval = interval;
+			return self();
+		}
+
+		public T withBucketAssigner(BucketAssigner<IN, BucketID> assigner) {
+			this.bucketAssigner = Preconditions.checkNotNull(assigner);
+			return self();
 		}
 
 		@VisibleForTesting
-		StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, Preconditions.checkNotNull(factory), partFilePrefix, partFileSuffix);
+		T withBucketFactory(final BucketFactory<IN, BucketID> factory) {
+			this.bucketFactory = Preconditions.checkNotNull(factory);
+			return self();
 	}
 
-		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withPartFilePrefix(final String partPrefix) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, bucketFactory, partPrefix, partFileSuffix);
+		public T withPartFilePrefix(final String partPrefix) {
+			this.partFilePrefix = partPrefix;
+			return self();
 		}
 
-		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withPartFileSuffix(final String partSuffix) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, bucketFactory, partFilePrefix, partSuffix);
+		public T withPartFileSuffix(final String partSuffix) {
+			this.partFileSuffix = partSuffix;
+			return self();
+		}
+
+		public <ID> StreamingFileSink.BulkFormatBuilder<IN, ID, ? extends BulkFormatBuilder<IN, ID, ?>> newBuilderWithBucketAssigner(BucketAssigner<IN, ID> assigner) {
+			Preconditions.checkState(bucketFactory.getClass() == DefaultBucketFactoryImpl.class, "newBuilderWithBucketAssigner() cannot be called after specifying a customized bucket factory");
+			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFilePrefix, partFileSuffix);
 		}
 
 		/** Creates the actual sink. */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
@@ -61,7 +61,28 @@ public class BulkWriterTest extends TestLogger {
 								new TestBulkWriterFactory(),
 								new DefaultBucketFactoryImpl<>())
 		) {
-			testPartFiles(testHarness, outDir, ".part-0-0.inprogress", ".part-0-1.inprogress");
+			testPartFilesWithStringBucketer(testHarness, outDir, ".part-0-0.inprogress", ".part-0-1.inprogress");
+		}
+	}
+
+	@Test
+	public void testCustomBulkWriterWithBucketAssigner() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+
+		// we set the max bucket size to small so that we can know when it rolls
+		try (
+				OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
+						TestUtils.createTestSinkWithCustomizedBulkEncoder(
+								outDir,
+								1,
+								0,
+								10L,
+								// use a customized bucketer with Integer bucket ID
+								new TestUtils.TupleToIntegerBucketer(),
+								new TestBulkWriterFactory(),
+								new DefaultBucketFactoryImpl<>())
+		) {
+			testPartFilesWithIntegerBucketer(testHarness, outDir, ".part-0-0.inprogress", ".part-0-1.inprogress", ".part-0-2.inprogress");
 		}
 	}
 
@@ -83,11 +104,11 @@ public class BulkWriterTest extends TestLogger {
 							"prefix",
 							".ext")
 		) {
-			testPartFiles(testHarness, outDir, ".prefix-0-0.ext.inprogress", ".prefix-0-1.ext.inprogress");
+			testPartFilesWithStringBucketer(testHarness, outDir, ".prefix-0-0.ext.inprogress", ".prefix-0-1.ext.inprogress");
 		}
 	}
 
-	private void testPartFiles(
+	private void testPartFilesWithStringBucketer(
 			OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness,
 			File outDir,
 			String partFileName1,
@@ -122,6 +143,8 @@ public class BulkWriterTest extends TestLogger {
 				fileCounter++;
 				Assert.assertEquals("test1@2\ntest1@3\n", fileContents.getValue());
 			}
+			// check bucket name
+			Assert.assertEquals("test1", fileContents.getKey().getParentFile().getName());
 		}
 		Assert.assertEquals(2L, fileCounter);
 
@@ -129,6 +152,57 @@ public class BulkWriterTest extends TestLogger {
 		testHarness.notifyOfCompletedCheckpoint(2L);
 
 		TestUtils.checkLocalFs(outDir, 0, 2);
+	}
+
+	private void testPartFilesWithIntegerBucketer(
+			OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness,
+			File outDir,
+			String partFileName1,
+			String partFileName2,
+			String partFileName3) throws Exception {
+
+		testHarness.setup();
+		testHarness.open();
+
+		// this creates a new bucket "test1" and part-0-0
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
+		TestUtils.checkLocalFs(outDir, 1, 0);
+
+		// we take a checkpoint so we roll.
+		testHarness.snapshot(1L, 1L);
+
+		// these will close part-0-0 and open part-0-1 and part-0-2
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
+
+		// we take a checkpoint so we roll again.
+		testHarness.snapshot(2L, 2L);
+
+		TestUtils.checkLocalFs(outDir, 3, 0);
+
+		Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
+		int fileCounter = 0;
+		for (Map.Entry<File, String> fileContents : contents.entrySet()) {
+			if (fileContents.getKey().getName().contains(partFileName1)) {
+				fileCounter++;
+				Assert.assertEquals("test1@1\n", fileContents.getValue());
+				Assert.assertEquals("1", fileContents.getKey().getParentFile().getName());
+			} else if (fileContents.getKey().getName().contains(partFileName2)) {
+				fileCounter++;
+				Assert.assertEquals("test1@2\n", fileContents.getValue());
+				Assert.assertEquals("2", fileContents.getKey().getParentFile().getName());
+			} else if (fileContents.getKey().getName().contains(partFileName3)) {
+				fileCounter++;
+				Assert.assertEquals("test1@3\n", fileContents.getValue());
+				Assert.assertEquals("3", fileContents.getKey().getParentFile().getName());
+			}
+		}
+		Assert.assertEquals(3L, fileCounter);
+
+		// we acknowledge the latest checkpoint, so everything should be published.
+		testHarness.notifyOfCompletedCheckpoint(2L);
+
+		TestUtils.checkLocalFs(outDir, 0, 3);
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -38,6 +38,9 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -68,25 +71,18 @@ public class TestUtils {
 						.withInactivityInterval(inactivityInterval)
 						.build();
 
-		final BucketAssigner<Tuple2<String, Integer>, String> bucketer = new TupleToStringBucketer();
-
-		final Encoder<Tuple2<String, Integer>> encoder = (element, stream) -> {
-			stream.write((element.f0 + '@' + element.f1).getBytes(StandardCharsets.UTF_8));
-			stream.write('\n');
-		};
-
-		return createCustomRescalingTestSink(
+		return createRescalingTestSink(
 				outDir,
 				totalParallelism,
 				taskIdx,
 				10L,
-				bucketer,
-				encoder,
+				new TupleToStringBucketer(),
+				new Tuple2Encoder(),
 				rollingPolicy,
 				new DefaultBucketFactoryImpl<>());
 	}
 
-	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createCustomRescalingTestSink(
+	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createRescalingTestSink(
 			final File outDir,
 			final int totalParallelism,
 			final int taskIdx,
@@ -100,6 +96,26 @@ public class TestUtils {
 				.forRowFormat(new Path(outDir.toURI()), writer)
 				.withBucketAssigner(bucketer)
 				.withRollingPolicy(rollingPolicy)
+				.withBucketCheckInterval(bucketCheckInterval)
+				.withBucketFactory(bucketFactory)
+				.build();
+
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
+	}
+
+	static <ID> OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createCustomizedRescalingTestSink(
+			final File outDir,
+			final int totalParallelism,
+			final int taskIdx,
+			final long bucketCheckInterval,
+			final BucketAssigner<Tuple2<String, Integer>, ID> bucketer,
+			final Encoder<Tuple2<String, Integer>> writer,
+			final RollingPolicy<Tuple2<String, Integer>, ID> rollingPolicy,
+			final BucketFactory<Tuple2<String, Integer>, ID> bucketFactory) throws Exception {
+
+		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
+				.forRowFormat(new Path(outDir.toURI()), writer)
+				.newBuilderWithBucketAssignerAndPolicy(bucketer, rollingPolicy)
 				.withBucketCheckInterval(bucketCheckInterval)
 				.withBucketFactory(bucketFactory)
 				.build();
@@ -151,6 +167,50 @@ public class TestUtils {
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
 	}
 
+	static <ID> OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithCustomizedBulkEncoder(
+			final File outDir,
+			final int totalParallelism,
+			final int taskIdx,
+			final long bucketCheckInterval,
+			final BucketAssigner<Tuple2<String, Integer>, ID> bucketer,
+			final BulkWriter.Factory<Tuple2<String, Integer>> writer,
+			final BucketFactory<Tuple2<String, Integer>, ID> bucketFactory) throws Exception {
+
+		return createTestSinkWithCustomizedBulkEncoder(
+				outDir,
+				totalParallelism,
+				taskIdx,
+				bucketCheckInterval,
+				bucketer,
+				writer,
+				bucketFactory,
+				PartFileConfig.DEFAULT_PART_PREFIX,
+				PartFileConfig.DEFAULT_PART_SUFFIX);
+	}
+
+	static <ID> OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithCustomizedBulkEncoder(
+			final File outDir,
+			final int totalParallelism,
+			final int taskIdx,
+			final long bucketCheckInterval,
+			final BucketAssigner<Tuple2<String, Integer>, ID> bucketer,
+			final BulkWriter.Factory<Tuple2<String, Integer>> writer,
+			final BucketFactory<Tuple2<String, Integer>, ID> bucketFactory,
+			final String partFilePrefix,
+			final String partFileSuffix) throws Exception {
+
+		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
+				.forBulkFormat(new Path(outDir.toURI()), writer)
+				.newBuilderWithBucketAssigner(bucketer)
+				.withBucketCheckInterval(bucketCheckInterval)
+				.withBucketFactory(bucketFactory)
+				.withPartFilePrefix(partFilePrefix)
+				.withPartFileSuffix(partFileSuffix)
+				.build();
+
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
+	}
+
 	static void checkLocalFs(File outDir, int expectedInProgress, int expectedCompleted) {
 		int inProgress = 0;
 		int finished = 0;
@@ -181,6 +241,21 @@ public class TestUtils {
 		return contents;
 	}
 
+	/**
+	 * A simple {@link Encoder} that encodes {@code Tuple2} object.
+	 */
+	static class Tuple2Encoder implements Encoder<Tuple2<String, Integer>> {
+		@Override
+		public void encode(Tuple2<String, Integer> element, OutputStream stream) throws IOException {
+			stream.write((element.f0 + '@' + element.f1).getBytes(StandardCharsets.UTF_8));
+			stream.write('\n');
+		}
+	}
+
+	/**
+	 * A simple {@link BucketAssigner} that returns the first (String) element of a {@code Tuple2}
+	 * object as the bucket id.
+	 */
 	static class TupleToStringBucketer implements BucketAssigner<Tuple2<String, Integer>, String> {
 
 		private static final long serialVersionUID = 1L;
@@ -193,6 +268,48 @@ public class TestUtils {
 		@Override
 		public SimpleVersionedSerializer<String> getSerializer() {
 			return SimpleVersionedStringSerializer.INSTANCE;
+		}
+	}
+
+	/**
+	 * A simple {@link BucketAssigner} that returns the second (Integer) element of a {@code Tuple2}
+	 * object as the bucket id.
+	 */
+	static class TupleToIntegerBucketer implements BucketAssigner<Tuple2<String, Integer>, Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer getBucketId(Tuple2<String, Integer> element, Context context) {
+			return element.f1;
+		}
+
+		@Override
+		public SimpleVersionedSerializer<Integer> getSerializer() {
+			return new SimpleVersionedIntegerSerializer();
+		}
+	}
+
+	private static final class SimpleVersionedIntegerSerializer implements SimpleVersionedSerializer<Integer> {
+		static final int VERSION = 1;
+
+		private SimpleVersionedIntegerSerializer() {
+		}
+
+		public int getVersion() {
+			return 1;
+		}
+
+		public byte[] serialize(Integer value) {
+			byte[] bytes = new byte[4];
+			ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).putInt(value);
+			return bytes;
+		}
+
+		public Integer deserialize(int version, byte[] serialized) throws IOException {
+			Assert.assertEquals(1L, (long) version);
+			Assert.assertEquals(4L, serialized.length);
+			return ByteBuffer.wrap(serialized).order(ByteOrder.LITTLE_ENDIAN).getInt();
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This patch makes it easier to extend `StreamingFileSink`, which adopts the builder pattern as a way to construct a new `StreamingFileSink` object. It follows the technique of "recurring generic pattern" which is documented in [[1](https://community.oracle.com/blogs/emcmanus/2010/10/24/using-builder-pattern-subclasses)] and [[2](https://stackoverflow.com/questions/17164375/subclassing-a-java-builder-class)].  

## Brief change log

**StreamingFileSink**
  - Added the builder type as the class signature for `BucketsBuilder`, `RowFormatBuilder` and `BulkFormatBuilder`. 
  - Added a `self()` method inside `BucketsBuilder` to return the proper builder type for base classes and subclasses in the path of inheritance. 
  - Change the construction methods to return the builder object (`self()`), instead of a new instance of the builder.  
  - Removed `final` for a few variables as they are now set by the construction methods. 

## Verifying this change

This change is merely an interface change and is already covered by existing tests, such as *LocalStreamingFileSinkTest* and *BulkWriterTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (yes) it affects *StreamingFileSink* but merely an interface change.

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
