### PR TITLE
[hotfix][configuration] Remove usages of deprecated options TASK_MANAGER_HEAP_MEMORY_MB and JOB_MANAGER_HEAP_MEMORY_MB

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -38,41 +38,23 @@ public class ConfigurationUtils {
 	private static final String[] EMPTY = new String[0];
 
 	/**
-	 * Get job manager's heap memory. This method will check the new key
-	 * {@link JobManagerOptions#JOB_MANAGER_HEAP_MEMORY} and
-	 * the old key {@link JobManagerOptions#JOB_MANAGER_HEAP_MEMORY_MB} for backwards compatibility.
+	 * Get job manager's heap memory.
 	 *
 	 * @param configuration the configuration object
 	 * @return the memory size of job manager's heap memory.
 	 */
 	public static MemorySize getJobManagerHeapMemory(Configuration configuration) {
-		if (configuration.containsKey(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY.key())) {
-			return MemorySize.parse(configuration.getString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY));
-		} else if (configuration.containsKey(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB.key())) {
-			return MemorySize.parse(configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB) + "m");
-		} else {
-			//use default value
-			return MemorySize.parse(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY.defaultValue());
-		}
+		return MemorySize.parse(configuration.getString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY));
 	}
 
 	/**
-	 * Get task manager's heap memory. This method will check the new key
-	 * {@link TaskManagerOptions#TASK_MANAGER_HEAP_MEMORY} and
-	 * the old key {@link TaskManagerOptions#TASK_MANAGER_HEAP_MEMORY_MB} for backwards compatibility.
+	 * Get task manager's heap memory.
 	 *
 	 * @param configuration the configuration object
 	 * @return the memory size of task manager's heap memory.
 	 */
 	public static MemorySize getTaskManagerHeapMemory(Configuration configuration) {
-		if (configuration.containsKey(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY.key())) {
-			return MemorySize.parse(configuration.getString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY));
-		} else if (configuration.containsKey(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB.key())) {
-			return MemorySize.parse(configuration.getInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB) + "m");
-		} else {
-			//use default value
-			return MemorySize.parse(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY.defaultValue());
-		}
+		return MemorySize.parse(configuration.getString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY));
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -77,23 +77,24 @@ public class JobManagerOptions {
 			" leader from potentially multiple standby JobManagers.");
 
 	/**
-	 * JVM heap size for the JobManager with memory size.
-	 */
-	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
-	public static final ConfigOption<String> JOB_MANAGER_HEAP_MEMORY =
-		key("jobmanager.heap.size")
-		.defaultValue("1024m")
-		.withDescription("JVM heap size for the JobManager.");
-
-	/**
 	 * JVM heap size (in megabytes) for the JobManager.
 	 * @deprecated use {@link #JOB_MANAGER_HEAP_MEMORY}
 	 */
 	@Deprecated
 	public static final ConfigOption<Integer> JOB_MANAGER_HEAP_MEMORY_MB =
 		key("jobmanager.heap.mb")
-		.defaultValue(1024)
-		.withDescription("JVM heap size (in megabytes) for the JobManager.");
+			.defaultValue(1024)
+			.withDescription("JVM heap size (in megabytes) for the JobManager.");
+
+	/**
+	 * JVM heap size for the JobManager with memory size.
+	 */
+	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
+	public static final ConfigOption<String> JOB_MANAGER_HEAP_MEMORY =
+		key("jobmanager.heap.size")
+		.defaultValue("1024m")
+		.withDeprecatedKeys(JOB_MANAGER_HEAP_MEMORY_MB.key())
+		.withDescription("JVM heap size for the JobManager.");
 
 	/**
 	 * The maximum number of prior execution attempts kept in history.

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -42,28 +42,29 @@ public class TaskManagerOptions {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * JVM heap size for the TaskManagers with memory size.
-	 */
-	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
-	public static final ConfigOption<String> TASK_MANAGER_HEAP_MEMORY =
-			key("taskmanager.heap.size")
-			.defaultValue("1024m")
-			.withDescription("JVM heap size for the TaskManagers, which are the parallel workers of" +
-					" the system. On YARN setups, this value is automatically configured to the size of the TaskManager's" +
-					" YARN container, minus a certain tolerance value.");
-
-	/**
 	 * JVM heap size (in megabytes) for the TaskManagers.
 	 *
 	 * @deprecated use {@link #TASK_MANAGER_HEAP_MEMORY}
 	 */
 	@Deprecated
 	public static final ConfigOption<Integer> TASK_MANAGER_HEAP_MEMORY_MB =
-			key("taskmanager.heap.mb")
+		key("taskmanager.heap.mb")
 			.defaultValue(1024)
 			.withDescription("JVM heap size (in megabytes) for the TaskManagers, which are the parallel workers of" +
 				" the system. On YARN setups, this value is automatically configured to the size of the TaskManager's" +
 				" YARN container, minus a certain tolerance value.");
+
+	/**
+	 * JVM heap size for the TaskManagers with memory size.
+	 */
+	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
+	public static final ConfigOption<String> TASK_MANAGER_HEAP_MEMORY =
+			key("taskmanager.heap.size")
+			.defaultValue("1024m")
+			.withDeprecatedKeys(TASK_MANAGER_HEAP_MEMORY_MB.key())
+			.withDescription("JVM heap size for the TaskManagers, which are the parallel workers of" +
+					" the system. On YARN setups, this value is automatically configured to the size of the TaskManager's" +
+					" YARN container, minus a certain tolerance value.");
 
 	/**
 	 * Whether to kill the TaskManager when the task thread throws an OutOfMemoryError.

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -414,8 +414,8 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	@Test
 	public void testHeapMemoryPropertyWithOldConfigKey() throws Exception {
 		Configuration configuration = new Configuration();
-		configuration.setInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB, 2048);
-		configuration.setInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB, 4096);
+		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, "2048m");
+		configuration.setString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, "4096m");
 
 		final FlinkYarnSessionCli flinkYarnSessionCli = new FlinkYarnSessionCli(
 			configuration,


### PR DESCRIPTION
## What is the purpose of the change

Logic about deprecated key should be carefully handled by `ConfigOption`. We should never use deprecated key anywhere outside.

## Verifying this change

This change is a trivial code cleanup without any new test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, add deprecated key instead of handle deprecation logic inline)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @twalthr @dawidwys 
