### PR TITLE
[FLINK-13903][hive] Support Hive version 2.3.6

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimLoader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimLoader.java
@@ -43,6 +43,7 @@ public class HiveShimLoader {
 	public static final String HIVE_VERSION_V2_3_3 = "2.3.3";
 	public static final String HIVE_VERSION_V2_3_4 = "2.3.4";
 	public static final String HIVE_VERSION_V2_3_5 = "2.3.5";
+	public static final String HIVE_VERSION_V2_3_6 = "2.3.6";
 
 	private static final Map<String, HiveShim> hiveShims = new ConcurrentHashMap<>(2);
 
@@ -85,6 +86,9 @@ public class HiveShimLoader {
 			}
 			if (v.startsWith(HIVE_VERSION_V2_3_5)) {
 				return new HiveShimV235();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_3_6)) {
+				return new HiveShimV236();
 			}
 			throw new CatalogException("Unsupported Hive version " + v);
 		});

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV236.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV236.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 2.3.6.
+ */
+public class HiveShimV236 extends HiveShimV235 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerShimLoader.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerShimLoader.java
@@ -49,6 +49,7 @@ public class HiveRunnerShimLoader {
 				case HiveShimLoader.HIVE_VERSION_V2_3_3:
 				case HiveShimLoader.HIVE_VERSION_V2_3_4:
 				case HiveShimLoader.HIVE_VERSION_V2_3_5:
+				case HiveShimLoader.HIVE_VERSION_V2_3_6:
 					return new HiveRunnerShimV4();
 				default:
 					throw new RuntimeException("Unsupported Hive version " + v);


### PR DESCRIPTION
## What is the purpose of the change

Support Hive 2.3.6, which was released a few days ago.

## Brief change log

  - Added  a new shim for this version

## Verifying this change


This change is already covered by existing tests, and manually ran the tests for the version.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
