### PR TITLE
[FLINK-13926][window]`ProcessingTimeSessionWindows` and `EventTimeSessionWindows` should be generic

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/EventTimeSessionWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/EventTimeSessionWindows.java
@@ -42,7 +42,7 @@ import java.util.Collections;
  *   keyed.window(EventTimeSessionWindows.withGap(Time.minutes(1)));
  * } </pre>
  */
-public class EventTimeSessionWindows extends MergingWindowAssigner<Object, TimeWindow> {
+public class EventTimeSessionWindows<T> extends MergingWindowAssigner<T, TimeWindow> {
 	private static final long serialVersionUID = 1L;
 
 	protected long sessionTimeout;
@@ -56,12 +56,12 @@ public class EventTimeSessionWindows extends MergingWindowAssigner<Object, TimeW
 	}
 
 	@Override
-	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
+	public Collection<TimeWindow> assignWindows(T element, long timestamp, WindowAssignerContext context) {
 		return Collections.singletonList(new TimeWindow(timestamp, timestamp + sessionTimeout));
 	}
 
 	@Override
-	public Trigger<Object, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
+	public Trigger<T, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
 		return EventTimeTrigger.create();
 	}
 
@@ -77,8 +77,8 @@ public class EventTimeSessionWindows extends MergingWindowAssigner<Object, TimeW
 	 * @param size The session timeout, i.e. the time gap between sessions
 	 * @return The policy.
 	 */
-	public static EventTimeSessionWindows withGap(Time size) {
-		return new EventTimeSessionWindows(size.toMilliseconds());
+	public static <T> EventTimeSessionWindows<T> withGap(Time size) {
+		return new EventTimeSessionWindows<>(size.toMilliseconds());
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/ProcessingTimeSessionWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/ProcessingTimeSessionWindows.java
@@ -42,7 +42,7 @@ import java.util.Collections;
  *   keyed.window(ProcessingTimeSessionWindows.withGap(Time.minutes(1)));
  * } </pre>
  */
-public class ProcessingTimeSessionWindows extends MergingWindowAssigner<Object, TimeWindow> {
+public class ProcessingTimeSessionWindows<T> extends MergingWindowAssigner<T, TimeWindow> {
 	private static final long serialVersionUID = 1L;
 
 	protected long sessionTimeout;
@@ -56,13 +56,13 @@ public class ProcessingTimeSessionWindows extends MergingWindowAssigner<Object, 
 	}
 
 	@Override
-	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
+	public Collection<TimeWindow> assignWindows(T element, long timestamp, WindowAssignerContext context) {
 		long currentProcessingTime = context.getCurrentProcessingTime();
 		return Collections.singletonList(new TimeWindow(currentProcessingTime, currentProcessingTime + sessionTimeout));
 	}
 
 	@Override
-	public Trigger<Object, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
+	public Trigger<T, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
 		return ProcessingTimeTrigger.create();
 	}
 
@@ -78,8 +78,8 @@ public class ProcessingTimeSessionWindows extends MergingWindowAssigner<Object, 
 	 * @param size The session timeout, i.e. the time gap between sessions
 	 * @return The policy.
 	 */
-	public static ProcessingTimeSessionWindows withGap(Time size) {
-		return new ProcessingTimeSessionWindows(size.toMilliseconds());
+	public static <T> ProcessingTimeSessionWindows<T> withGap(Time size) {
+		return new ProcessingTimeSessionWindows<>(size.toMilliseconds());
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
@@ -28,13 +28,13 @@ import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
  * @see org.apache.flink.streaming.api.watermark.Watermark
  */
 @PublicEvolving
-public class EventTimeTrigger extends Trigger<Object, TimeWindow> {
+public class EventTimeTrigger<T> extends Trigger<T, TimeWindow> {
 	private static final long serialVersionUID = 1L;
 
 	private EventTimeTrigger() {}
 
 	@Override
-	public TriggerResult onElement(Object element, long timestamp, TimeWindow window, TriggerContext ctx) throws Exception {
+	public TriggerResult onElement(T element, long timestamp, TimeWindow window, TriggerContext ctx) throws Exception {
 		if (window.maxTimestamp() <= ctx.getCurrentWatermark()) {
 			// if the watermark is already past the window fire immediately
 			return TriggerResult.FIRE;
@@ -89,7 +89,7 @@ public class EventTimeTrigger extends Trigger<Object, TimeWindow> {
 	 * <p>Once the trigger fires all elements are discarded. Elements that arrive late immediately
 	 * trigger window evaluation with just this one element.
 	 */
-	public static EventTimeTrigger create() {
-		return new EventTimeTrigger();
+	public static <T> EventTimeTrigger<T> create() {
+		return new EventTimeTrigger<>();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
@@ -26,13 +26,13 @@ import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
  * to which a pane belongs.
  */
 @PublicEvolving
-public class ProcessingTimeTrigger extends Trigger<Object, TimeWindow> {
+public class ProcessingTimeTrigger<T> extends Trigger<T, TimeWindow> {
 	private static final long serialVersionUID = 1L;
 
 	private ProcessingTimeTrigger() {}
 
 	@Override
-	public TriggerResult onElement(Object element, long timestamp, TimeWindow window, TriggerContext ctx) {
+	public TriggerResult onElement(T element, long timestamp, TimeWindow window, TriggerContext ctx) {
 		ctx.registerProcessingTimeTimer(window.maxTimestamp());
 		return TriggerResult.CONTINUE;
 	}
@@ -77,8 +77,8 @@ public class ProcessingTimeTrigger extends Trigger<Object, TimeWindow> {
 	/**
 	 * Creates a new trigger that fires once system time passes the end of the window.
 	 */
-	public static ProcessingTimeTrigger create() {
-		return new ProcessingTimeTrigger();
+	public static <T> ProcessingTimeTrigger<T> create() {
+		return new ProcessingTimeTrigger<>();
 	}
 
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EventTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EventTimeSessionWindowsTest.java
@@ -67,7 +67,7 @@ public class EventTimeSessionWindowsTest extends TestLogger {
 		WindowAssigner.WindowAssignerContext mockContext =
 				mock(WindowAssigner.WindowAssignerContext.class);
 
-		EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.milliseconds(sessionGap));
+		EventTimeSessionWindows<String> assigner = EventTimeSessionWindows.withGap(Time.milliseconds(sessionGap));
 
 		assertThat(assigner.assignWindows("String", 0L, mockContext), contains(timeWindow(0, 0 + sessionGap)));
 		assertThat(assigner.assignWindows("String", 4999L, mockContext), contains(timeWindow(4999, 4999 + sessionGap)));
@@ -78,7 +78,7 @@ public class EventTimeSessionWindowsTest extends TestLogger {
 	public void testMergeSinglePointWindow() {
 		MergingWindowAssigner.MergeCallback callback = mock(MergingWindowAssigner.MergeCallback.class);
 
-		EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
+		EventTimeSessionWindows<String> assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
 
 		assigner.mergeWindows(Lists.newArrayList(new TimeWindow(0, 0)), callback);
 
@@ -89,7 +89,7 @@ public class EventTimeSessionWindowsTest extends TestLogger {
 	public void testMergeSingleWindow() {
 		MergingWindowAssigner.MergeCallback callback = mock(MergingWindowAssigner.MergeCallback.class);
 
-		EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
+		EventTimeSessionWindows<String> assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
 
 		assigner.mergeWindows(Lists.newArrayList(new TimeWindow(0, 1)), callback);
 
@@ -100,7 +100,7 @@ public class EventTimeSessionWindowsTest extends TestLogger {
 	public void testMergeConsecutiveWindows() {
 		MergingWindowAssigner.MergeCallback callback = mock(MergingWindowAssigner.MergeCallback.class);
 
-		EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
+		EventTimeSessionWindows<String> assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
 
 		assigner.mergeWindows(
 				Lists.newArrayList(
@@ -156,7 +156,7 @@ public class EventTimeSessionWindowsTest extends TestLogger {
 		WindowAssigner.WindowAssignerContext mockContext =
 				mock(WindowAssigner.WindowAssignerContext.class);
 
-		EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.seconds(sessionGap / 1000));
+		EventTimeSessionWindows<String> assigner = EventTimeSessionWindows.withGap(Time.seconds(sessionGap / 1000));
 
 		assertThat(assigner.assignWindows("String", 0L, mockContext), contains(timeWindow(0, 0 + sessionGap)));
 		assertThat(assigner.assignWindows("String", 4999L, mockContext), contains(timeWindow(4999, 4999 + sessionGap)));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ProcessingTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ProcessingTimeSessionWindowsTest.java
@@ -66,7 +66,7 @@ public class ProcessingTimeSessionWindowsTest extends TestLogger {
 		WindowAssigner.WindowAssignerContext mockContext =
 				mock(WindowAssigner.WindowAssignerContext.class);
 
-		ProcessingTimeSessionWindows assigner = ProcessingTimeSessionWindows.withGap(Time.milliseconds(5000));
+		ProcessingTimeSessionWindows<String> assigner = ProcessingTimeSessionWindows.withGap(Time.milliseconds(5000));
 
 		when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
 		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(0, 5000)));
@@ -158,7 +158,7 @@ public class ProcessingTimeSessionWindowsTest extends TestLogger {
 		WindowAssigner.WindowAssignerContext mockContext =
 				mock(WindowAssigner.WindowAssignerContext.class);
 
-		ProcessingTimeSessionWindows assigner = ProcessingTimeSessionWindows.withGap(Time.seconds(5));
+		ProcessingTimeSessionWindows<String> assigner = ProcessingTimeSessionWindows.withGap(Time.seconds(5));
 
 		when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
 		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(0, 5000)));

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AllWindowTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AllWindowTranslationTest.scala
@@ -197,8 +197,8 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
-    assertTrue(winOperator.getWindowAssigner.isInstanceOf[EventTimeSessionWindows])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
+    assertTrue(winOperator.getWindowAssigner.isInstanceOf[EventTimeSessionWindows[(String, Int)]])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
     processElementAndEnsureOutput[String, (String, Int), (String, Int)](
@@ -235,7 +235,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -268,7 +268,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -301,7 +301,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -341,7 +341,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -380,7 +380,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -420,7 +420,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -459,7 +459,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -498,7 +498,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -536,7 +536,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -573,7 +573,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -606,7 +606,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -639,7 +639,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -672,7 +672,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -705,7 +705,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -738,7 +738,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -775,7 +775,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -812,7 +812,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -845,7 +845,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -878,7 +878,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -920,7 +920,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -961,7 +961,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1002,7 +1002,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1043,7 +1043,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1085,7 +1085,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1123,7 +1123,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1166,7 +1166,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1205,7 +1205,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1244,7 +1244,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1283,7 +1283,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1318,7 +1318,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1502,7 +1502,7 @@ class AllWindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1538,7 +1538,7 @@ class AllWindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1583,7 +1583,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1624,7 +1624,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/TimeWindowTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/TimeWindowTranslationTest.scala
@@ -106,7 +106,7 @@ class TimeWindowTranslationTest extends AbstractTestBase {
 
     val winOperator1 = operator1.asInstanceOf[WindowOperator[_, _, _, _, _]]
 
-    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator1.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator1.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
   }
@@ -132,7 +132,7 @@ class TimeWindowTranslationTest extends AbstractTestBase {
 
     val winOperator1 = operator1.asInstanceOf[WindowOperator[_, _, _, _, _]]
 
-    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator1.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator1.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
   }
@@ -164,7 +164,7 @@ class TimeWindowTranslationTest extends AbstractTestBase {
 
     val winOperator1 = operator1.asInstanceOf[WindowOperator[_, _, _, _, _]]
 
-    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator1.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator1.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
   }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowTranslationTest.scala
@@ -202,8 +202,8 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
-    assertTrue(winOperator.getWindowAssigner.isInstanceOf[EventTimeSessionWindows])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
+    assertTrue(winOperator.getWindowAssigner.isInstanceOf[EventTimeSessionWindows[(String, Int)]])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
     processElementAndEnsureOutput[String, (String, Int), (String, Int)](
@@ -240,7 +240,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -274,7 +274,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -308,7 +308,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -349,7 +349,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -390,7 +390,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -432,7 +432,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -474,7 +474,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -515,7 +515,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -558,7 +558,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -598,7 +598,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -636,7 +636,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -670,7 +670,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -704,7 +704,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -738,7 +738,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -772,7 +772,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -806,7 +806,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -844,7 +844,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -882,7 +882,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -916,7 +916,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -950,7 +950,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -994,7 +994,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1037,7 +1037,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1080,7 +1080,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1123,7 +1123,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1167,7 +1167,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1212,7 +1212,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1255,7 +1255,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1300,7 +1300,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1341,7 +1341,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1382,7 +1382,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1423,7 +1423,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1459,7 +1459,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1651,7 +1651,7 @@ class WindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1688,7 +1688,7 @@ class WindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1724,7 +1724,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1759,7 +1759,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1795,7 +1795,7 @@ class WindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1836,7 +1836,7 @@ class WindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1884,7 +1884,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1927,7 +1927,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[(String, Int)]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])


### PR DESCRIPTION




## What is the purpose of the change

`ProcessingTimeSessionWindows` and `EventTimeSessionWindows` should be generic just like `DynamicEventTimeSessionWindows` and `DynamicProcessingTimeSessionWindows`.

now:
 
```java
public class ProcessingTimeSessionWindows extends MergingWindowAssigner<Object, TimeWindow> {}
```

proposal:
 
```java
public class ProcessingTimeSessionWindows<T> extends MergingWindowAssigner<T, TimeWindow> {}
```

## Brief change log


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
