### PR TITLE
[hotfix][docs] wrong link to class in SavepointSerializer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointSerializer.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.checkpoint.savepoint;
 
+import org.apache.flink.runtime.checkpoint.Checkpoints;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -25,7 +27,7 @@ import java.io.IOException;
 /**
  * Serializer for {@link Savepoint} instances.
  *
- * <p>This serializer is used to read/write a savepoint via {@link SavepointStore}.
+ * <p>This serializer is used to read/write a savepoint via {@link Checkpoints}.
  *
  * <p>Version-specific serializers are accessed via the {@link SavepointSerializers} helper.
  *


### PR DESCRIPTION
## Verifying this change
This change is a trivial typo fix.
