### PR TITLE
[FLINK-13906] Implement hashCode() method in class `GlobalJobParameters`.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -1075,6 +1075,11 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 			return true;
 		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash();
+		}
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
@@ -159,4 +159,13 @@ public class ExecutionConfigTest extends TestLogger {
 
 		assertNotNull(config.getGlobalJobParameters());
 	}
+
+	@Test
+	public void testGlobalParametersHashCode() {
+		ExecutionConfig config = new ExecutionConfig();
+		ExecutionConfig anotherConfig = new ExecutionConfig();
+
+		assertEquals(config.getGlobalJobParameters().hashCode(),
+			anotherConfig.getGlobalJobParameters().hashCode());
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request implements the hashCode() method in class `GlobalJobParameters` to fix the test failure of python test `ExecutionConfigTests.test_equals_and_hash`.*


## Brief change log

  - *implements hashCode() method in class `GlobalJobParameters`.*


## Verifying this change

This change is already covered by existing python test `ExecutionConfigTests.test_equals_and_hash`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
