### PR TITLE
[FLINK-13941][fs-connector] Do not delete partial part files from S3.

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableWriter.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableWriter.java
@@ -103,7 +103,7 @@ public class S3RecoverableWriter implements RecoverableWriter {
 
 	@Override
 	public boolean requiresCleanupOfRecoverableState() {
-		return false;
+		return true;
 	}
 
 	@Override

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableWriter.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableWriter.java
@@ -103,7 +103,7 @@ public class S3RecoverableWriter implements RecoverableWriter {
 
 	@Override
 	public boolean requiresCleanupOfRecoverableState() {
-		return true;
+		return false;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -150,10 +150,6 @@ public class Bucket<IN, BucketID> {
 
 			fsWriter.recoverForCommit(resumable).commitAfterRecovery();
 		}
-
-		if (fsWriter.requiresCleanupOfRecoverableState()) {
-			fsWriter.cleanupRecoverableState(resumable);
-		}
 	}
 
 	private void commitRecoveredPendingFiles(final BucketState<BucketID> state) throws IOException {
@@ -316,12 +312,19 @@ public class Bucket<IN, BucketID> {
 
 		while (it.hasNext()) {
 			final ResumeRecoverable recoverable = it.next().getValue();
-			final boolean successfullyDeleted = fsWriter.cleanupRecoverableState(recoverable);
-			it.remove();
 
-			if (LOG.isDebugEnabled() && successfullyDeleted) {
-				LOG.debug("Subtask {} successfully deleted incomplete part for bucket id={}.", subtaskIndex, bucketId);
+			// this check is redundant, as we only put entries in the resumablesPerCheckpoint map
+			// list when the requiresCleanupOfRecoverableState() returns true, but having it makes
+			// the code more readable.
+
+			if (fsWriter.requiresCleanupOfRecoverableState()) {
+				final boolean successfullyDeleted = fsWriter.cleanupRecoverableState(recoverable);
+
+				if (LOG.isDebugEnabled() && successfullyDeleted) {
+					LOG.debug("Subtask {} successfully deleted incomplete part for bucket id={}.", subtaskIndex, bucketId);
+				}
 			}
+			it.remove();
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
@@ -99,28 +99,6 @@ public class BucketTest {
 	}
 
 	@Test
-	public void shouldCleanupResumableAfterRestoring() throws Exception {
-		final File outDir = TEMP_FOLDER.newFolder();
-		final Path path = new Path(outDir.toURI());
-
-		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
-		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0, new PartFileConfig());
-
-		bucketUnderTest.write("test-element", 0L);
-
-		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
-		assertThat(state, hasActiveInProgressFile());
-
-		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
-
-		final TestRecoverableWriter newRecoverableWriter = getRecoverableWriter(path);
-		restoreBucket(newRecoverableWriter, 0, 1, state, new PartFileConfig());
-
-		assertThat(newRecoverableWriter, hasCalledDiscard(1)); // that is for checkpoints 0 and 1
-	}
-
-	@Test
 	public void shouldNotCallCleanupWithoutInProgressPartFiles() throws Exception {
 		final File outDir = TEMP_FOLDER.newFolder();
 		final Path path = new Path(outDir.toURI());


### PR DESCRIPTION
## What is the purpose of the change

Fixes potential data-loss in the `StreamingFileSink` that can happen after restoring from a failure. For a scenario that can trigger this data-loss, check https://issues.apache.org/jira/browse/FLINK-13940. 

## Brief change log

The `S3RecoverableWriter.requiresCleanupOfRecoverableState()` returns `false` so that no clean-up is performed and, in any case, no clean-up is performed in the `initializeState`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)