### PR TITLE
[FLINK-13633][coordination] Move submittedJobGraph and completedCheckpoint to cluster-id subdirectory of high-availability storage

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -52,9 +52,12 @@ public class FileSystemBlobStore implements BlobStoreService {
 	/** The base path of the blob store. */
 	private final String basePath;
 
+	/** The name of the blob path. */
+	public static final String BLOB_PATH_NAME = "blob";
+
 	public FileSystemBlobStore(FileSystem fileSystem, String storagePath) throws IOException {
 		this.fileSystem = checkNotNull(fileSystem);
-		this.basePath = checkNotNull(storagePath) + "/blob";
+		this.basePath = checkNotNull(storagePath) + "/" + BLOB_PATH_NAME;
 
 		LOG.info("Creating highly available BLOB storage directory at {}", basePath);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -23,11 +23,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCompletedCheckpointStore;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.jobmanager.ZooKeeperJobGraphStore;
@@ -362,24 +362,7 @@ public class ZooKeeperUtils {
 			Configuration configuration,
 			String prefix) throws IOException {
 
-		return new FileSystemStateStorageHelper<T>(getClusterHighAvailabilityStoragePath(configuration), prefix);
-	}
-
-	/**
-	 * Get high availability storage path of current flink cluster.
-	 * @param configuration {@link Configuration} object
-	 * @return high availability storage path of current flink cluster
-	 */
-	private static String getClusterHighAvailabilityStoragePath(Configuration configuration) {
-		String rootPath = configuration.getValue(HighAvailabilityOptions.HA_STORAGE_PATH);
-
-		if (rootPath == null || StringUtils.isBlank(rootPath)) {
-			throw new IllegalConfigurationException("Missing high-availability storage path for metadata." +
-					" Specify via configuration key '" + HighAvailabilityOptions.HA_STORAGE_PATH + "'.");
-		} else {
-			final String clusterId = configuration.getValue(HighAvailabilityOptions.HA_CLUSTER_ID);
-			return new Path(rootPath, clusterId).toString();
-		}
+		return new FileSystemStateStorageHelper<>(HighAvailabilityServicesUtils.getClusterHighAvailableStoragePath(configuration), prefix);
 	}
 
 	public static String generateZookeeperPath(String root, String namespace) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/filesystem/FileSystemStateStorageHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/filesystem/FileSystemStateStorageHelper.java
@@ -44,10 +44,6 @@ public class FileSystemStateStorageHelper<T extends Serializable> implements Ret
 
 	private final FileSystem fs;
 
-	public FileSystemStateStorageHelper(String rootPath, String prefix) throws IOException {
-		this(new Path(rootPath), prefix);
-	}
-
 	public FileSystemStateStorageHelper(Path rootPath, String prefix) throws IOException {
 		this.rootPath = Preconditions.checkNotNull(rootPath, "Root path");
 		this.prefix = Preconditions.checkNotNull(prefix, "Prefix");


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request moves submittedJobGraph and completedCheckpoint to cluster-id subdirectory of high-availability storage. If the flink cluster terminates exceptionally, some external tools could be used to clean up these residual files.


## Brief change log

Use cluster-id sub directory instead of ha storage in `ZookeeperUtils#createCompletedCheckpoints()` and `ZookeeperUtils#createJobGraphs()`.


## Verifying this change

This change added tests and can be verified as follows:
  - Added integration tests `ZooKeeperHaStorageITCase` to check the high availability storage directory structure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
