### PR TITLE
[FLINK-13894][web]Web Ui add log url for subtask of vertex

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-subtask.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-subtask.ts
@@ -34,5 +34,5 @@ export interface JobSubTaskInterface {
     'write-records': number;
     'write-records-complete': boolean;
   };
-  'resource-id': string;
+  'taskmanager-id': string;
 }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-subtask.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-subtask.ts
@@ -34,4 +34,5 @@ export interface JobSubTaskInterface {
     'write-records': number;
     'write-records-complete': boolean;
   };
+  'resource-id': string;
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -26,8 +26,7 @@
   [nzShowPagination]="false">
   <thead (nzSortChange)="sort($event)" nzSingleSort>
     <tr>
-      <th nzWidth="35px" nzLeft="0px">ID</th>
-      <th nzWidth="95px" nzLeft="35px">TaskManager</th>
+      <th nzWidth="80px" nzLeft="0px">ID</th>
       <th nzSortKey="metrics.read-bytes" nzShowSort nzWidth="140px">Bytes Received</th>
       <th nzSortKey="metrics.read-records" nzShowSort nzWidth="150px">Records Received</th>
       <th nzSortKey="metrics.write-bytes" nzShowSort nzWidth="120px">Bytes Sent</th>
@@ -37,19 +36,14 @@
       <th nzSortKey="start_time" nzShowSort nzWidth="150px">Start Time</th>
       <th nzSortKey="duration" nzShowSort nzWidth="100px">Duration</th>
       <th nzSortKey="end-time" nzShowSort nzWidth="150px">End Time</th>
-      <th nzSortKey="status" nzShowSort nzWidth="120px" nzRight="0px">Status</th>
+      <th nzSortKey="status" nzShowSort nzWidth="120px" nzRight="50px">Status</th>
+      <th nzWidth="50px" nzRight="0px">More</th>
     </tr>
   </thead>
   <tbody>
     <tr *ngFor="let task of listOfTask; trackBy:trackTaskBy;">
       <td nzLeft="0">
         {{ task.subtask }}
-      </td>
-      <td nzLeft="35px">
-        <span *ngIf="!task['taskmanager-id'] || task['taskmanager-id'] === '(unassigned)'; else hrefTpl">-</span>
-        <ng-template #hrefTpl>
-          <a [routerLink]="['/task-manager',task['taskmanager-id'],'metrics']" target="_blank">TaskManager</a>
-        </ng-template>
       </td>
       <td>
         <span *ngIf="task.metrics['read-bytes-complete'];else loadingTemplate">
@@ -76,8 +70,21 @@
       <td>{{ task["start_time"] | humanizeDate: 'yyyy-MM-dd HH:mm:ss' }}</td>
       <td>{{ task.duration | humanizeDuration }}</td>
       <td>{{ task["end-time"] | humanizeDate: 'yyyy-MM-dd HH:mm:ss' }}</td>
-      <td nzRight="0px">
+      <td nzRight="50px">
         <flink-job-badge [state]="task.status"></flink-job-badge>
+      </td>
+      <td nzRight="0px">
+        <nz-dropdown [nzPlacement]="'bottomRight'">
+          <span nz-dropdown><i nz-icon nzType="ellipsis" nzTheme="outline"></i></span>
+              <ul nz-menu nzSelectable>
+                <li nz-menu-item>
+              <span *ngIf="!task['taskmanager-id'] || task['taskmanager-id'] === '(unassigned)'; else hrefTpl">-</span>
+              <ng-template #hrefTpl>
+                <a [routerLink]="['/task-manager',task['taskmanager-id'],'logs']" target="_blank">Taskamanger Log</a>
+              </ng-template>
+            </li>
+          </ul>
+        </nz-dropdown>
       </td>
     </tr>
   </tbody>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -78,7 +78,7 @@
         <ng-template #hrefTpl>
           <nz-dropdown [nzPlacement]="'bottomRight'">
             <span nz-dropdown><i nz-icon nzType="ellipsis" nzTheme="outline"></i></span>
-            <ul nz-menu nzSelectable>
+            <ul nz-menu>
               <li nz-menu-item>
                 <a [routerLink]="['/task-manager',task['taskmanager-id'],'logs']" target="_blank">View taskmanager log</a>
               </li>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -27,7 +27,7 @@
   <thead (nzSortChange)="sort($event)" nzSingleSort>
     <tr>
       <th nzWidth="40px" nzLeft="0px">ID</th>
-      <th nzWidth="50px" nzLeft="40px">LOG</th>
+      <th nzWidth="50px" nzLeft="40px">Logs</th>
       <th nzSortKey="metrics.read-bytes" nzShowSort nzWidth="140px">Bytes Received</th>
       <th nzSortKey="metrics.read-records" nzShowSort nzWidth="150px">Records Received</th>
       <th nzSortKey="metrics.write-bytes" nzShowSort nzWidth="120px">Bytes Sent</th>
@@ -42,13 +42,13 @@
   </thead>
   <tbody>
     <tr *ngFor="let task of listOfTask; trackBy:trackTaskBy;">
-      <td nzLeft="0" nzWidth="40px">
+      <td nzLeft="0">
         {{ task.subtask }}
       </td>
       <td nzLeft="40px">
         <span *ngIf="!task['taskmanager-id'] || task['taskmanager-id'] === '(unassigned)'; else hrefTpl">-</span>
         <ng-template #hrefTpl>
-          <a [routerLink]="['/task-manager',task['taskmanager-id'],'logs']" target="_blank">LOG</a>
+          <a [routerLink]="['/task-manager',task['taskmanager-id'],'logs']" target="_blank">log</a>
         </ng-template>
       </td>
       <td>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -46,9 +46,9 @@
         {{ task.subtask }}
       </td>
       <td nzLeft="40px">
-        <span *ngIf="!task['resource-id'] || task['resource-id'] === '(unassigned)'; else hrefTpl">-</span>
+        <span *ngIf="!task['taskmanager-id'] || task['taskmanager-id'] === '(unassigned)'; else hrefTpl">-</span>
         <ng-template #hrefTpl>
-          <a [routerLink]="['/task-manager',task['resource-id'],'logs']" target="_blank">LOG {{ task.subtask }}</a>
+          <a [routerLink]="['/task-manager',task['taskmanager-id'],'logs']" target="_blank">LOG</a>
         </ng-template>
       </td>
       <td>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -21,13 +21,13 @@
   [nzSize]="'small'"
   [nzLoading]="isLoading"
   [nzData]="listOfTask"
-  [nzScroll]="{x:'1440px',y:'calc( 100% - 35px )'}"
+  [nzScroll]="{x:'1480px',y:'calc( 100% - 35px )'}"
   [nzFrontPagination]="false"
   [nzShowPagination]="false">
   <thead (nzSortChange)="sort($event)" nzSingleSort>
     <tr>
-      <th nzWidth="40px" nzLeft="0px">ID</th>
-      <th nzWidth="50px" nzLeft="40px">Logs</th>
+      <th nzWidth="35px" nzLeft="0px">ID</th>
+      <th nzWidth="95px" nzLeft="35px">TaskManager</th>
       <th nzSortKey="metrics.read-bytes" nzShowSort nzWidth="140px">Bytes Received</th>
       <th nzSortKey="metrics.read-records" nzShowSort nzWidth="150px">Records Received</th>
       <th nzSortKey="metrics.write-bytes" nzShowSort nzWidth="120px">Bytes Sent</th>
@@ -45,10 +45,10 @@
       <td nzLeft="0">
         {{ task.subtask }}
       </td>
-      <td nzLeft="40px">
+      <td nzLeft="35px">
         <span *ngIf="!task['taskmanager-id'] || task['taskmanager-id'] === '(unassigned)'; else hrefTpl">-</span>
         <ng-template #hrefTpl>
-          <a [routerLink]="['/task-manager',task['taskmanager-id'],'logs']" target="_blank">log</a>
+          <a [routerLink]="['/task-manager',task['taskmanager-id'],'metrics']" target="_blank">TaskManager</a>
         </ng-template>
       </td>
       <td>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -74,17 +74,17 @@
         <flink-job-badge [state]="task.status"></flink-job-badge>
       </td>
       <td nzRight="0px">
-        <nz-dropdown [nzPlacement]="'bottomRight'">
-          <span nz-dropdown><i nz-icon nzType="ellipsis" nzTheme="outline"></i></span>
-              <ul nz-menu nzSelectable>
-                <li nz-menu-item>
-              <span *ngIf="!task['taskmanager-id'] || task['taskmanager-id'] === '(unassigned)'; else hrefTpl">-</span>
-              <ng-template #hrefTpl>
-                <a [routerLink]="['/task-manager',task['taskmanager-id'],'logs']" target="_blank">Taskamanger Log</a>
-              </ng-template>
-            </li>
-          </ul>
-        </nz-dropdown>
+        <span *ngIf="!task['taskmanager-id'] || task['taskmanager-id'] === '(unassigned)'; else hrefTpl">-</span>
+        <ng-template #hrefTpl>
+          <nz-dropdown [nzPlacement]="'bottomRight'">
+            <span nz-dropdown><i nz-icon nzType="ellipsis" nzTheme="outline"></i></span>
+            <ul nz-menu nzSelectable>
+              <li nz-menu-item>
+                <a [routerLink]="['/task-manager',task['taskmanager-id'],'logs']" target="_blank">View taskmanager log</a>
+              </li>
+            </ul>
+          </nz-dropdown>
+        </ng-template>
       </td>
     </tr>
   </tbody>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -21,12 +21,13 @@
   [nzSize]="'small'"
   [nzLoading]="isLoading"
   [nzData]="listOfTask"
-  [nzScroll]="{x:'1430px',y:'calc( 100% - 35px )'}"
+  [nzScroll]="{x:'1440px',y:'calc( 100% - 35px )'}"
   [nzFrontPagination]="false"
   [nzShowPagination]="false">
   <thead (nzSortChange)="sort($event)" nzSingleSort>
     <tr>
-      <th nzWidth="80px" nzLeft="0px">ID</th>
+      <th nzWidth="40px" nzLeft="0px">ID</th>
+      <th nzWidth="50px" nzLeft="40px">LOG</th>
       <th nzSortKey="metrics.read-bytes" nzShowSort nzWidth="140px">Bytes Received</th>
       <th nzSortKey="metrics.read-records" nzShowSort nzWidth="150px">Records Received</th>
       <th nzSortKey="metrics.write-bytes" nzShowSort nzWidth="120px">Bytes Sent</th>
@@ -41,8 +42,14 @@
   </thead>
   <tbody>
     <tr *ngFor="let task of listOfTask; trackBy:trackTaskBy;">
-      <td nzLeft="0">
+      <td nzLeft="0" nzWidth="40px">
         {{ task.subtask }}
+      </td>
+      <td nzLeft="40px">
+        <span *ngIf="!task['resource-id'] || task['resource-id'] === '(unassigned)'; else hrefTpl">-</span>
+        <ng-template #hrefTpl>
+          <a [routerLink]="['/task-manager',task['resource-id'],'logs']" target="_blank">LOG {{ task.subtask }}</a>
+        </ng-template>
       </td>
       <td>
         <span *ngIf="task.metrics['read-bytes-complete'];else loadingTemplate">


### PR DESCRIPTION
## What is the purpose of the change
This pull request adds log link for subtask in the page of job's vertex. Then it's easy for user seeing log.


## Brief change log
- The JobSubTaskInterface in job-subtask.ts add resource-id .
- job-overview-drawer-subtasks.component.html add log logic.



## Verifying this change
no


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)