### PR TITLE
[FLINK-13677][docs-zh] Translate "Monitoring Back Pressure" page into Chinese

### DIFF
--- a/docs/monitoring/back_pressure.zh.md
+++ b/docs/monitoring/back_pressure.zh.md
@@ -22,59 +22,62 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Flink's web interface provides a tab to monitor the back pressure behaviour of running jobs.
+Flink Web 界面提供了一个选项卡来监控正在运行 Job 的反压行为。
 
 * ToC
 {:toc}
 
-## Back Pressure
+## 反压
 
-If you see a **back pressure warning** (e.g. `High`) for a task, this means that it is producing data faster than the downstream operators can consume. Records in your job flow downstream (e.g. from sources to sinks) and back pressure is propagated in the opposite direction, up the stream.
+如果你看到一个 Task 发生 **反压警告**（例如： `High`），意味着它生产数据的速率比下游 Task 消费数据的速率要快。
+在工作流中数据记录是从上游向下游流动的（例如：从 Sources 到 Sinks）。反压沿着相反的方向传播，沿着数据流向上游传播。
 
-Take a simple `Source -> Sink` job as an example. If you see a warning for `Source`, this means that `Sink` is consuming data slower than `Source` is producing. `Sink` is back pressuring the upstream operator `Source`.
+以一个简单的 `Source -> Sink` Job 为例。如果看到 `Source` 发生了警告，意味着 `Sink` 消费数据的速率比 `Source` 生产数据的速率要慢。
+`Sink` 正在向上游的 `Source` 算子产生反压。
 
 
-## Sampling Threads
+## 采样线程
 
-Back pressure monitoring works by repeatedly taking stack trace samples of your running tasks. The JobManager triggers repeated calls to `Thread.getStackTrace()` for the tasks of your job.
+通过不断对每个 Task 的 stack trace 采样来进行反压监控。JobManager 会触发对 Task `Thread.getStackTrace()` 的重复调用。
 
 <img src="{{ site.baseurl }}/fig/back_pressure_sampling.png" class="img-responsive">
 <!-- https://docs.google.com/drawings/d/1_YDYGdUwGUck5zeLxJ5Z5jqhpMzqRz70JxKnrrJUltA/edit?usp=sharing -->
 
-If the samples show that a task Thread is stuck in a certain internal method call (requesting buffers from the network stack), this indicates that there is back pressure for the task.
+如果样本显示 Task 线程卡在某个内部方法调用中（例如：从网络堆栈请求缓冲区），则表示这个 Task 存在反压。
 
-By default, the job manager triggers 100 stack traces every 50ms for each task in order to determine back pressure. The ratio you see in the web interface tells you how many of these stack traces were stuck in the internal method call, e.g. `0.01` indicates that only 1 in 100 was stuck in that method.
+默认情况下，JobManager 会触发 100 次 stack trace 采样，每次间隔 50ms 来确定反压。
+你在 Web 界面看到的比率表示在内部方法调用中有多少 stack trace 被卡住，例如: `0.01` 表示在该方法中 100 个只有 1 个被卡住了。
 
-- **OK**: 0 <= Ratio <= 0.10
-- **LOW**: 0.10 < Ratio <= 0.5
-- **HIGH**: 0.5 < Ratio <= 1
+- **OK**: 0 <= 比例 <= 0.10
+- **LOW**: 0.10 < 比例 <= 0.5
+- **HIGH**: 0.5 < 比例 <= 1
 
-In order to not overload the task managers with stack trace samples, the web interface refreshes samples only after 60 seconds.
+为了不因为 stack trace 导致 TaskManager 产生负载，Web 界面仅在 60 秒后重新采样。
 
-## Configuration
+## 配置参数
 
-You can configure the number of samples for the job manager with the following configuration keys:
+你可以使用以下键来配置 JobManager 的样本数：
 
-- `web.backpressure.refresh-interval`: Time after which available stats are deprecated and need to be refreshed (DEFAULT: 60000, 1 min).
-- `web.backpressure.num-samples`: Number of stack trace samples to take to determine back pressure (DEFAULT: 100).
-- `web.backpressure.delay-between-samples`: Delay between stack trace samples to determine back pressure (DEFAULT: 50, 50 ms).
+- `web.backpressure.refresh-interval`: 有效统计被废弃并重新进行采样的时间 (默认: 60000, 1 min)。
+- `web.backpressure.num-samples`: 用于确定反压的 stack trace 样本数 (默认: 100)。
+- `web.backpressure.delay-between-samples`: 用于确定反压的 stack trace 采样间隔时间 (默认: 50, 50 ms)。
 
 
-## Example
+## 案例
 
-You can find the *Back Pressure* tab next to the job overview.
+你可以在 Job 的 Overview 选项卡后面找到 *Back Pressure* 。
 
-### Sampling In Progress
+### 采样进行中
 
-This means that the JobManager triggered a stack trace sample of the running tasks. With the default configuration, this takes about 5 seconds to complete.
+这意味着 JobManager 对正在运行的 Task 触发了 stack trace 采样。默认情况下，大约需要 5 秒完成采样。
 
-Note that clicking the row, you trigger the sample for all subtasks of this operator.
+注意，点击该行，可触发该算子所有 SubTask 的采样。
 
 <img src="{{ site.baseurl }}/fig/back_pressure_sampling_in_progress.png" class="img-responsive">
 
-### Back Pressure Status
+### 反压状态
 
-If you see status **OK** for the tasks, there is no indication of back pressure. **HIGH** on the other hand means that the tasks are back pressured.
+如果你看到 Task 的状态为 **OK** 表示没有反压。**HIGH** 表示这个 Task 被反压。
 
 <img src="{{ site.baseurl }}/fig/back_pressure_sampling_ok.png" class="img-responsive">
 

--- a/docs/monitoring/back_pressure.zh.md
+++ b/docs/monitoring/back_pressure.zh.md
@@ -30,7 +30,7 @@ Flink Web 界面提供了一个选项卡来监控正在运行 Job 的反压行�
 ## 反压
 
 如果你看到一个 Task 发生 **反压警告**（例如： `High`），意味着它生产数据的速率比下游 Task 消费数据的速率要快。
-在工作流中数据记录是从上游向下游流动的（例如：从 Sources 到 Sinks）。反压沿着相反的方向传播，沿着数据流向上游传播。
+在工作流中数据记录是从上游向下游流动的（例如：从 Source 到 Sink）。反压沿着相反的方向传播，沿着数据流向上游传播。
 
 以一个简单的 `Source -> Sink` Job 为例。如果看到 `Source` 发生了警告，意味着 `Sink` 消费数据的速率比 `Source` 生产数据的速率要慢。
 `Sink` 正在向上游的 `Source` 算子产生反压。
@@ -63,7 +63,7 @@ Flink Web 界面提供了一个选项卡来监控正在运行 Job 的反压行�
 - `web.backpressure.delay-between-samples`: 用于确定反压的 stack trace 采样间隔时间 (默认: 50, 50 ms)。
 
 
-## 案例
+## 示例
 
 你可以在 Job 的 Overview 选项卡后面找到 *Back Pressure* 。
 


### PR DESCRIPTION
## What is the purpose of the change

Translate "Monitoring Back Pressure" page into Chinese

## Brief change log

Translate "Monitoring Back Pressure" page into Chinese

## Verifying this change

This change is to add a new translated document.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no