### PR TITLE
[FLINK-13946] Remove job session related code from ExecutionEnvironment

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -182,6 +182,17 @@ public class LocalExecutor extends PlanExecutor {
 			throw new IllegalArgumentException("The plan may not be null.");
 		}
 
+		stop();
+
+		// configure the number of local slots equal to the parallelism of the local plan
+		if (this.taskManagerNumSlots == DEFAULT_TASK_MANAGER_NUM_SLOTS) {
+			int maxParallelism = plan.getMaximumParallelism();
+			if (maxParallelism > 0) {
+				this.taskManagerNumSlots = maxParallelism;
+			}
+		}
+		start();
+
 		synchronized (this.lock) {
 
 			// check if we start a session dedicated for this execution
@@ -189,14 +200,6 @@ public class LocalExecutor extends PlanExecutor {
 
 			if (jobExecutorService == null) {
 				shutDownAtEnd = true;
-
-				// configure the number of local slots equal to the parallelism of the local plan
-				if (this.taskManagerNumSlots == DEFAULT_TASK_MANAGER_NUM_SLOTS) {
-					int maxParallelism = plan.getMaximumParallelism();
-					if (maxParallelism > 0) {
-						this.taskManagerNumSlots = maxParallelism;
-					}
-				}
 
 				// start the cluster for us
 				start();

--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -42,7 +42,6 @@ import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A PlanExecutor that runs Flink programs on a local embedded Flink runtime instance.
@@ -59,17 +58,8 @@ public class LocalExecutor extends PlanExecutor {
 
 	private static final int DEFAULT_TASK_MANAGER_NUM_SLOTS = -1;
 
-	/** we lock to ensure singleton execution. */
-	private final Object lock = new Object();
-
 	/** Custom user configuration for the execution. */
 	private final Configuration baseConfiguration;
-
-	/** Service for executing Flink jobs. */
-	private JobExecutorService jobExecutorService;
-
-	/** Current job executor service configuration. */
-	private Configuration jobExecutorServiceConfiguration;
 
 	/** Config value for how many slots to provide in the local cluster. */
 	private int taskManagerNumSlots = DEFAULT_TASK_MANAGER_NUM_SLOTS;
@@ -109,13 +99,9 @@ public class LocalExecutor extends PlanExecutor {
 
 	// --------------------------------------------------------------------------------------------
 
-	private void start() throws Exception {
-		Thread.holdsLock(lock);
-		checkState(jobExecutorService == null);
-
-		// start the embedded runtime
-		jobExecutorServiceConfiguration = createConfiguration();
-		jobExecutorService = createJobExecutorService(jobExecutorServiceConfiguration);
+	private JobExecutorService startExecutorService(final Configuration executorServiceConfig) throws Exception {
+		checkNotNull(executorServiceConfig);
+		return createJobExecutorService(executorServiceConfig);
 	}
 
 	private JobExecutorService createJobExecutorService(Configuration configuration) throws Exception {
@@ -143,12 +129,9 @@ public class LocalExecutor extends PlanExecutor {
 		return miniCluster;
 	}
 
-	private void stop() throws Exception {
-		Thread.holdsLock(lock);
-		if (jobExecutorService != null) {
-			jobExecutorService.close();
-			jobExecutorService = null;
-		}
+	private void stopExecutorService(final JobExecutorService executorService) throws Exception {
+		checkNotNull(executorService);
+		executorService.close();
 	}
 
 	/**
@@ -168,36 +151,59 @@ public class LocalExecutor extends PlanExecutor {
 	public JobExecutionResult executePlan(Plan plan) throws Exception {
 		checkNotNull(plan);
 
-		synchronized (this.lock) {
-			try {
-				configureNoOfLocalSlots(plan);
-				start();
+		JobExecutorService executorService = null;
+		try {
+			final Configuration jobExecutorServiceConfiguration = configureExecution(plan);
 
-				// TODO: Set job's default parallelism to max number of slots
-				final int slotsPerTaskManager = jobExecutorServiceConfiguration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, taskManagerNumSlots);
-				final int numTaskManagers = jobExecutorServiceConfiguration.getInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
-				plan.setDefaultParallelism(slotsPerTaskManager * numTaskManagers);
+			executorService = startExecutorService(jobExecutorServiceConfiguration);
 
-				Optimizer pc = new Optimizer(new DataStatistics(), jobExecutorServiceConfiguration);
-				OptimizedPlan op = pc.compile(plan);
+			Optimizer pc = new Optimizer(new DataStatistics(), jobExecutorServiceConfiguration);
+			OptimizedPlan op = pc.compile(plan);
 
-				JobGraphGenerator jgg = new JobGraphGenerator(jobExecutorServiceConfiguration);
-				JobGraph jobGraph = jgg.compileJobGraph(op, plan.getJobId());
+			JobGraphGenerator jgg = new JobGraphGenerator(jobExecutorServiceConfiguration);
+			JobGraph jobGraph = jgg.compileJobGraph(op, plan.getJobId());
 
-				return jobExecutorService.executeJobBlocking(jobGraph);
-			} finally {
-				stop();
+			return executorService.executeJobBlocking(jobGraph);
+		} finally {
+			if (executorService != null) {
+				stopExecutorService(executorService);
 			}
 		}
 	}
 
-	private void configureNoOfLocalSlots(final Plan plan) {
+	private Configuration configureExecution(final Plan executable) {
+		setNumberOfTaskSlots(executable);
+		final Configuration executorConfiguration = createExecutorServiceConfig();
+		setPlanParallelism(executable, executorConfiguration);
+		return executorConfiguration;
+	}
+
+	private void setNumberOfTaskSlots(final Plan plan) {
 		if (this.taskManagerNumSlots == DEFAULT_TASK_MANAGER_NUM_SLOTS) {
 			int maxParallelism = plan.getMaximumParallelism();
 			if (maxParallelism > 0) {
 				this.taskManagerNumSlots = maxParallelism;
 			}
 		}
+	}
+
+	private Configuration createExecutorServiceConfig() {
+		final Configuration newConfiguration = new Configuration();
+		newConfiguration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, taskManagerNumSlots);
+		newConfiguration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, defaultOverwriteFiles);
+
+		newConfiguration.addAll(baseConfiguration);
+
+		return newConfiguration;
+	}
+
+	private void setPlanParallelism(final Plan plan, final Configuration executorServiceConfig) {
+		// TODO: Set job's default parallelism to max number of slots
+		final int slotsPerTaskManager = executorServiceConfig.getInteger(
+				TaskManagerOptions.NUM_TASK_SLOTS, taskManagerNumSlots);
+		final int numTaskManagers = executorServiceConfig.getInteger(
+				ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
+		plan.setDefaultParallelism(slotsPerTaskManager * numTaskManagers);
 	}
 
 	/**
@@ -215,16 +221,6 @@ public class LocalExecutor extends PlanExecutor {
 		OptimizedPlan op = pc.compile(plan);
 
 		return new PlanJSONDumpGenerator().getOptimizerPlanAsJSON(op);
-	}
-
-	private Configuration createConfiguration() {
-		Configuration newConfiguration = new Configuration();
-		newConfiguration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, getTaskManagerNumSlots());
-		newConfiguration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, isDefaultOverwriteFiles());
-
-		newConfiguration.addAll(baseConfiguration);
-
-		return newConfiguration;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.optimizer.DataStatistics;
@@ -54,15 +53,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class LocalExecutor extends PlanExecutor {
 
-	private static final boolean DEFAULT_OVERWRITE = false;
-
 	/** Custom user configuration for the execution. */
 	private final Configuration baseConfiguration;
-
-	/** Config flag whether to overwrite existing files by default. */
-	private boolean defaultOverwriteFiles = DEFAULT_OVERWRITE;
-
-	// ------------------------------------------------------------------------
 
 	public LocalExecutor() {
 		this(new Configuration());
@@ -71,20 +63,6 @@ public class LocalExecutor extends PlanExecutor {
 	public LocalExecutor(Configuration conf) {
 		this.baseConfiguration = checkNotNull(conf);
 	}
-
-	// ------------------------------------------------------------------------
-	//  Configuration
-	// ------------------------------------------------------------------------
-
-	public boolean isDefaultOverwriteFiles() {
-		return defaultOverwriteFiles;
-	}
-
-	public void setDefaultOverwriteFiles(boolean defaultOverwriteFiles) {
-		this.defaultOverwriteFiles = defaultOverwriteFiles;
-	}
-
-	// --------------------------------------------------------------------------------------------
 
 	private JobExecutorService createJobExecutorService(Configuration configuration) throws Exception {
 		if (!configuration.contains(RestOptions.BIND_PORT)) {
@@ -151,10 +129,7 @@ public class LocalExecutor extends PlanExecutor {
 	private Configuration createExecutorServiceConfig(final Plan plan) {
 		final Configuration newConfiguration = new Configuration();
 		newConfiguration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, plan.getMaximumParallelism());
-		newConfiguration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, defaultOverwriteFiles);
-
 		newConfiguration.addAll(baseConfiguration);
-
 		return newConfiguration;
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -171,10 +171,10 @@ public class LocalExecutor extends PlanExecutor {
 		}
 	}
 
-	private Configuration configureExecution(final Plan executable) {
-		setNumberOfTaskSlots(executable);
+	private Configuration configureExecution(final Plan plan) {
+		setNumberOfTaskSlots(plan);
 		final Configuration executorConfiguration = createExecutorServiceConfig();
-		setPlanParallelism(executable, executorConfiguration);
+		setPlanParallelism(plan, executorConfiguration);
 		return executorConfiguration;
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -107,7 +107,7 @@ public class RemoteExecutor extends PlanExecutor {
 	public int getDefaultParallelism() {
 		return defaultParallelism;
 	}
-	
+
 	// ------------------------------------------------------------------------
 	//  Executing programs
 	// ------------------------------------------------------------------------
@@ -123,14 +123,8 @@ public class RemoteExecutor extends PlanExecutor {
 	private JobExecutionResult executePlanWithJars(JobWithJars program) throws Exception {
 		checkNotNull(program);
 
-		ClusterClient<?>  client = null;
-		try {
-			client = new RestClusterClient<>(clientConfiguration, "RemoteExecutor");
+		try (ClusterClient<?>  client = new RestClusterClient<>(clientConfiguration, "RemoteExecutor")) {
 			return client.run(program, defaultParallelism).getJobExecutionResult();
-		} finally {
-			if (client != null) {
-				client.shutdown();
-			}
 		}
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -32,7 +32,6 @@ import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
-import org.apache.flink.util.NetUtils;
 
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -64,36 +63,6 @@ public class RemoteExecutor extends PlanExecutor {
 	public RemoteExecutor(String hostname, int port) {
 		this(hostname, port, new Configuration(), Collections.<URL>emptyList(),
 				Collections.<URL>emptyList());
-	}
-
-	public RemoteExecutor(String hostname, int port, URL jarFile) {
-		this(hostname, port, new Configuration(), Collections.singletonList(jarFile),
-				Collections.<URL>emptyList());
-	}
-
-	public RemoteExecutor(String hostport, URL jarFile) {
-		this(NetUtils.parseHostPortAddress(hostport), new Configuration(), Collections.singletonList(jarFile),
-				Collections.<URL>emptyList());
-	}
-
-	public RemoteExecutor(String hostname, int port, List<URL> jarFiles) {
-		this(new InetSocketAddress(hostname, port), new Configuration(), jarFiles,
-				Collections.<URL>emptyList());
-	}
-
-	public RemoteExecutor(String hostname, int port, Configuration clientConfiguration) {
-		this(hostname, port, clientConfiguration, Collections.<URL>emptyList(),
-				Collections.<URL>emptyList());
-	}
-
-	public RemoteExecutor(String hostname, int port, Configuration clientConfiguration, URL jarFile) {
-		this(hostname, port, clientConfiguration, Collections.singletonList(jarFile),
-				Collections.<URL>emptyList());
-	}
-
-	public RemoteExecutor(String hostport, Configuration clientConfiguration, URL jarFile) {
-		this(NetUtils.parseHostPortAddress(hostport), clientConfiguration,
-				Collections.singletonList(jarFile), Collections.<URL>emptyList());
 	}
 
 	public RemoteExecutor(String hostname, int port, Configuration clientConfiguration,

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -107,20 +107,7 @@ public class RemoteExecutor extends PlanExecutor {
 	public int getDefaultParallelism() {
 		return defaultParallelism;
 	}
-
-	// ------------------------------------------------------------------------
-	//  Startup & Shutdown
-	// ------------------------------------------------------------------------
-
-	private ClusterClient<?> startClusterClient() throws Exception {
-		return new RestClusterClient<>(clientConfiguration, "RemoteExecutor");
-	}
-
-	private void stopClusterClient(final ClusterClient<?> client) throws Exception {
-		checkNotNull(client);
-		client.shutdown();
-	}
-
+	
 	// ------------------------------------------------------------------------
 	//  Executing programs
 	// ------------------------------------------------------------------------
@@ -138,11 +125,11 @@ public class RemoteExecutor extends PlanExecutor {
 
 		ClusterClient<?>  client = null;
 		try {
-			client = startClusterClient();
+			client = new RestClusterClient<>(clientConfiguration, "RemoteExecutor");
 			return client.run(program, defaultParallelism).getJobExecutionResult();
 		} finally {
 			if (client != null) {
-				stopClusterClient(client);
+				client.shutdown();
 			}
 		}
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -235,7 +235,7 @@ public class CliFrontend {
 				logAndSysout("Job has been submitted with JobID " + jobGraph.getJobID());
 
 				try {
-					client.shutdown();
+					client.close();
 				} catch (Exception e) {
 					LOG.info("Could not properly shut down the client.", e);
 				}
@@ -284,7 +284,7 @@ public class CliFrontend {
 						}
 					}
 					try {
-						client.shutdown();
+						client.close();
 					} catch (Exception e) {
 						LOG.info("Could not properly shut down the client.", e);
 					}
@@ -944,7 +944,7 @@ public class CliFrontend {
 					clusterAction.runAction(clusterClient);
 				} finally {
 					try {
-						clusterClient.shutdown();
+						clusterClient.close();
 					} catch (Exception e) {
 						LOG.info("Could not properly shut down the cluster client.", e);
 					}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -101,6 +101,11 @@ public abstract class ClusterClient<T> implements AutoCloseable {
 		this.timeout = AkkaUtils.getClientTimeout(flinkConfig);
 	}
 
+	@Override
+	public void close() throws Exception {
+
+	}
+
 	// ------------------------------------------------------------------------
 	//  Access to the Program's Plan
 	// ------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -62,7 +62,7 @@ import scala.concurrent.duration.FiniteDuration;
  *
  * @param <T> type of the cluster id
  */
-public abstract class ClusterClient<T> {
+public abstract class ClusterClient<T> implements AutoCloseable {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -99,17 +99,6 @@ public abstract class ClusterClient<T> {
 		this.flinkConfig = Preconditions.checkNotNull(flinkConfig);
 		this.compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), flinkConfig);
 		this.timeout = AkkaUtils.getClientTimeout(flinkConfig);
-	}
-
-	// ------------------------------------------------------------------------
-	//  Startup & Shutdown
-	// ------------------------------------------------------------------------
-
-	/**
-	 * User overridable hook to close the client, possibly closes internal services.
-	 */
-	public void shutdown() throws Exception {
-
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -20,7 +20,6 @@ package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
@@ -73,14 +72,8 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public void startNewSession() throws Exception {
-		jobID = JobID.generate();
-	}
-
-	@Override
 	public String toString() {
-		return "Context Environment (parallelism = " + (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? "default" : getParallelism())
-				+ ") : " + getIdString();
+		return "Context Environment (parallelism = " + (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? "default" : getParallelism()) + ").";
 	}
 
 	public ClusterClient<?> getClient() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -73,7 +73,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String toString() {
-		return "Context Environment (parallelism = " + (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? "default" : getParallelism()) + ").";
+		return "Context Environment (parallelism = " + (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? "default" : getParallelism()) + ")";
 	}
 
 	public ClusterClient<?> getClient() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -56,11 +56,6 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	}
 
 	@Override
-	public void close() throws Exception {
-
-	}
-
-	@Override
 	public JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
 		final CompletableFuture<JobSubmissionResult> jobSubmissionResultFuture = submitJob(jobGraph);
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -56,6 +56,11 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	}
 
 	@Override
+	public void close() throws Exception {
+
+	}
+
+	@Override
 	public JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
 		final CompletableFuture<JobSubmissionResult> jobSubmissionResultFuture = submitJob(jobGraph);
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -63,11 +63,6 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 		throw new ProgramAbortException();
 	}
 
-	@Override
-	public void startNewSession() {
-		// do nothing
-	}
-
 	public FlinkPlan getOptimizedPlan(PackagedProgram prog) throws ProgramInvocationException {
 
 		// temporarily write syserr and sysout to a byte array.

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
@@ -56,10 +56,6 @@ public final class PreviewPlanEnvironment extends ExecutionEnvironment {
 		throw new OptimizerPlanEnvironment.ProgramAbortException();
 	}
 
-	@Override
-	public void startNewSession() {
-	}
-
 	public void setAsContext() {
 		ExecutionEnvironmentFactory factory = new ExecutionEnvironmentFactory() {
 			@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -186,7 +186,7 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 	}
 
 	@Override
-	public void shutdown() {
+	public void close() {
 		ExecutorUtils.gracefulShutdown(restClusterClientConfiguration.getRetryDelay(), TimeUnit.MILLISECONDS, retryExecutorService);
 
 		this.restClient.shutdown(Time.seconds(5));

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -203,6 +203,12 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 		} catch (Exception e) {
 			log.error("An error occurred during stopping the ClientHighAvailabilityServices", e);
 		}
+
+		try {
+			super.close();
+		} catch (Exception e) {
+			log.error("Error while closing the Cluster Client", e);
+		}
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -94,7 +94,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			assertTrue(buffer.toString().contains(savepointPath));
 		}
 		finally {
-			clusterClient.shutdown();
+			clusterClient.close();
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -124,7 +124,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			}
 		}
 		finally {
-			clusterClient.shutdown();
+			clusterClient.close();
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -175,7 +175,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			assertTrue(buffer.toString().contains(savepointDirectory));
 		}
 		finally {
-			clusterClient.shutdown();
+			clusterClient.close();
 
 			restoreStdOutAndStdErr();
 		}
@@ -206,7 +206,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			assertTrue(outMsg.contains("disposed"));
 		}
 		finally {
-			clusterClient.shutdown();
+			clusterClient.close();
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -243,7 +243,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 
 			assertEquals(disposePath, actualSavepointPath);
 		} finally {
-			clusterClient.shutdown();
+			clusterClient.close();
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -272,7 +272,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			}
 		}
 		finally {
-			clusterClient.shutdown();
+			clusterClient.close();
 			restoreStdOutAndStdErr();
 		}
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -238,7 +238,7 @@ public class RestClusterClientTest extends TestLogger {
 				restClusterClient.cancel(jobId);
 				Assert.assertTrue(terminationHandler.jobCanceled);
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 	}
@@ -264,7 +264,7 @@ public class RestClusterClientTest extends TestLogger {
 				assertThat(jobSubmissionResult, is(not(instanceOf(JobExecutionResult.class))));
 				assertThat(jobSubmissionResult.getJobID(), is(jobId));
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 
@@ -383,7 +383,7 @@ public class RestClusterClientTest extends TestLogger {
 					assertThat(cause.get().getMessage(), equalTo("expected"));
 				}
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 	}
@@ -432,7 +432,7 @@ public class RestClusterClientTest extends TestLogger {
 					}
 				}
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 	}
@@ -504,7 +504,7 @@ public class RestClusterClientTest extends TestLogger {
 				JobStatusMessage job2 = jobDetailsIterator.next();
 				Assert.assertNotEquals("The job status should not be equal.", job1.getJobState(), job2.getJobState());
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 	}
@@ -528,7 +528,7 @@ public class RestClusterClientTest extends TestLogger {
 					assertEquals("testValue", accumulators.get("testKey").get().toString());
 				}
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 	}
@@ -583,7 +583,7 @@ public class RestClusterClientTest extends TestLogger {
 
 				restClusterClient.sendRequest(PingRestHandlerHeaders.INSTANCE).get();
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 	}
@@ -598,7 +598,7 @@ public class RestClusterClientTest extends TestLogger {
 			} catch (final ProgramInvocationException expected) {
 				// expected
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 	}
@@ -635,7 +635,7 @@ public class RestClusterClientTest extends TestLogger {
 			}  catch (Exception e) {
 				assertThat(ExceptionUtils.findThrowableWithMessage(e, exceptionMessage).isPresent(), is(true));
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -45,35 +45,6 @@ public abstract class PlanExecutor {
 	private static final String REMOTE_EXECUTOR_CLASS = "org.apache.flink.client.RemoteExecutor";
 
 	// ------------------------------------------------------------------------
-	//  Startup & Shutdown
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Starts the program executor. After the executor has been started, it will keep
-	 * running until {@link #stop()} is called. 
-	 * 
-	 * @throws Exception Thrown, if the executor startup failed.
-	 */
-	public abstract void start() throws Exception;
-
-	/**
-	 * Shuts down the plan executor and releases all local resources.
-	 *
-	 * <p>This method also ends all sessions created by this executor. Remote job executions
-	 * may complete, but the session is not kept alive after that.</p>
-	 *
-	 * @throws Exception Thrown, if the proper shutdown failed. 
-	 */
-	public abstract void stop() throws Exception;
-
-	/**
-	 * Checks if this executor is currently running.
-	 * 
-	 * @return True is the executor is running, false otherwise.
-	 */
-	public abstract boolean isRunning();
-	
-	// ------------------------------------------------------------------------
 	//  Program Execution
 	// ------------------------------------------------------------------------
 	
@@ -154,12 +125,11 @@ public abstract class PlanExecutor {
 				Collections.<URL>emptyList() : globalClasspaths;
 
 		try {
-			PlanExecutor executor = (clientConfiguration == null) ?
+			return (clientConfiguration == null) ?
 					reClass.getConstructor(String.class, int.class, List.class)
 						.newInstance(hostname, port, files) :
 					reClass.getConstructor(String.class, int.class, Configuration.class, List.class, List.class)
 						.newInstance(hostname, port, clientConfiguration, files, paths);
-			return executor;
 		}
 		catch (Throwable t) {
 			throw new RuntimeException("An error occurred while loading the remote executor ("

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -48,8 +48,4 @@ public class CollectionEnvironment extends ExecutionEnvironment {
 	public String getExecutionPlan() throws Exception {
 		throw new UnsupportedOperationException("Execution plans are not used for collection-based execution.");
 	}
-
-	@Override
-	public void startNewSession() throws Exception {
-	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -24,7 +24,6 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.io.FileInputFormat;
@@ -120,13 +119,6 @@ public abstract class ExecutionEnvironment {
 	/** Result from the latest execution, to make it retrievable when using eager execution methods. */
 	protected JobExecutionResult lastJobExecutionResult;
 
-	/** The ID of the session, defined by this execution environment. Sessions and Jobs are same in
-	 *  Flink, as Jobs can consist of multiple parts that are attached to the growing dataflow graph. */
-	protected JobID jobID;
-
-	/** The session timeout in seconds. */
-	protected long sessionTimeout;
-
 	/** Flag to indicate whether sinks have been cleared in previous executions. */
 	private boolean wasExecuted = false;
 
@@ -134,7 +126,7 @@ public abstract class ExecutionEnvironment {
 	 * Creates a new Execution Environment.
 	 */
 	protected ExecutionEnvironment() {
-		jobID = JobID.generate();
+
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -244,68 +236,6 @@ public abstract class ExecutionEnvironment {
 	public JobExecutionResult getLastJobExecutionResult(){
 		return this.lastJobExecutionResult;
 	}
-
-	// --------------------------------------------------------------------------------------------
-	//  Session Management
-	// --------------------------------------------------------------------------------------------
-
-	/**
-	 * Gets the JobID by which this environment is identified. The JobID sets the execution context
-	 * in the cluster or local environment.
-	 *
-	 * @return The JobID of this environment.
-	 * @see #getIdString()
-	 */
-	@PublicEvolving
-	public JobID getId() {
-		return this.jobID;
-	}
-
-	/**
-	 * Gets the JobID by which this environment is identified, as a string.
-	 *
-	 * @return The JobID as a string.
-	 * @see #getId()
-	 */
-	@PublicEvolving
-	public String getIdString() {
-		return this.jobID.toString();
-	}
-
-	/**
-	 * Sets the session timeout to hold the intermediate results of a job. This only
-	 * applies the updated timeout in future executions.
-	 *
-	 * @param timeout The timeout, in seconds.
-	 */
-	@PublicEvolving
-	public void setSessionTimeout(long timeout) {
-		throw new IllegalStateException("Support for sessions is currently disabled. " +
-				"It will be enabled in future Flink versions.");
-		// Session management is disabled, revert this commit to enable
-		//if (timeout < 0) {
-		//	throw new IllegalArgumentException("The session timeout must not be less than zero.");
-		//}
-		//this.sessionTimeout = timeout;
-	}
-
-	/**
-	 * Gets the session timeout for this environment. The session timeout defines for how long
-	 * after an execution, the job and its intermediate results will be kept for future
-	 * interactions.
-	 *
-	 * @return The session timeout, in seconds.
-	 */
-	@PublicEvolving
-	public long getSessionTimeout() {
-		return sessionTimeout;
-	}
-
-	/**
-	 * Starts a new session, discarding the previous data flow and all of its intermediate results.
-	 */
-	@PublicEvolving
-	public abstract void startNewSession() throws Exception;
 
 	// --------------------------------------------------------------------------------------------
 	//  Registry for types and serializers

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -77,16 +77,8 @@ public class LocalEnvironment extends ExecutionEnvironment {
 		final Plan p = createProgramPlan(jobName);
 
 		// TODO: 31.08.19 make the executor autocloseable
-		PlanExecutor executor = null;
-		try {
-			executor = PlanExecutor.createLocalExecutor(configuration);
-			executor.start();
-			lastJobExecutionResult = executor.executePlan(p);
-		} finally {
-			if (executor != null) {
-				executor.stop();
-			}
-		}
+		final PlanExecutor executor = PlanExecutor.createLocalExecutor(configuration);
+		lastJobExecutionResult = executor.executePlan(p);
 		return lastJobExecutionResult;
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -19,14 +19,14 @@
 package org.apache.flink.api.java;
 
 import org.apache.flink.annotation.Public;
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.configuration.Configuration;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * An {@link ExecutionEnvironment} that runs the program locally, multi-threaded, in the JVM where the
@@ -44,14 +44,6 @@ public class LocalEnvironment extends ExecutionEnvironment {
 
 	/** The user-defined configuration for the local execution. */
 	private final Configuration configuration;
-
-	/** Create lazily upon first use. */
-	private PlanExecutor executor;
-
-	/** In case we keep the executor alive for sessions, this reaper shuts it down eventually.
-	 * The reaper's finalize method triggers the executor shutdown. */
-	@SuppressWarnings("all")
-	private ExecutorReaper executorReaper;
 
 	/**
 	 * Creates a new local environment.
@@ -71,150 +63,42 @@ public class LocalEnvironment extends ExecutionEnvironment {
 					"The LocalEnvironment cannot be instantiated when running in a pre-defined context " +
 							"(such as Command Line Client, Scala Shell, or TestEnvironment)");
 		}
-		this.configuration = config == null ? new Configuration() : config;
+		this.configuration = checkNotNull(config);
 	}
 
 	// --------------------------------------------------------------------------------------------
 
+	// TODO: 31.08.19 make sure that start and stop are called in the execute.
+	// the other place would be here, but this can complicate code, as the
+	// lifecycle management would be outside the executor itself.
+
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
-		if (executor == null) {
-			startNewSession();
+		final Plan p = createProgramPlan(jobName);
+
+		// TODO: 31.08.19 make the executor autocloseable
+		PlanExecutor executor = null;
+		try {
+			executor = PlanExecutor.createLocalExecutor(configuration);
+			executor.start();
+			lastJobExecutionResult = executor.executePlan(p);
+		} finally {
+			if (executor != null) {
+				executor.stop();
+			}
 		}
-
-		Plan p = createProgramPlan(jobName);
-
-		// Session management is disabled, revert this commit to enable
-		//p.setJobId(jobID);
-		//p.setSessionTimeout(sessionTimeout);
-
-		JobExecutionResult result = executor.executePlan(p);
-
-		this.lastJobExecutionResult = result;
-		return result;
+		return lastJobExecutionResult;
 	}
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan(null, false);
-
-		// make sure that we do not start an executor in any case here.
-		// if one runs, fine, of not, we only create the class but disregard immediately afterwards
-		if (executor != null) {
-			return executor.getOptimizerPlanAsJSON(p);
-		}
-		else {
-			PlanExecutor tempExecutor = PlanExecutor.createLocalExecutor(configuration);
-			return tempExecutor.getOptimizerPlanAsJSON(p);
-		}
+		final Plan p = createProgramPlan("plan", false);
+		final PlanExecutor tempExecutor = PlanExecutor.createLocalExecutor(configuration);
+		return tempExecutor.getOptimizerPlanAsJSON(p);
 	}
-
-	@Override
-	@PublicEvolving
-	public void startNewSession() throws Exception {
-		if (executor != null) {
-			// we need to end the previous session
-			executor.stop();
-			// create also a new JobID
-			jobID = JobID.generate();
-		}
-
-		// create a new local executor
-		executor = PlanExecutor.createLocalExecutor(configuration);
-
-		// if we have a session, start the mini cluster eagerly to have it available across sessions
-		if (getSessionTimeout() > 0) {
-			executor.start();
-
-			// also install the reaper that will shut it down eventually
-			executorReaper = new ExecutorReaper(executor);
-		}
-	}
-
-	// ------------------------------------------------------------------------
-	//  Utilities
-	// ------------------------------------------------------------------------
 
 	@Override
 	public String toString() {
-		return "Local Environment (parallelism = " + (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? "default" : getParallelism())
-				+ ") : " + getIdString();
-	}
-
-	// ------------------------------------------------------------------------
-	//  Reaping the local executor when in session mode
-	// ------------------------------------------------------------------------
-
-	/**
-	 * This thread shuts down the local executor.
-	 *
-	 * <p><b>IMPORTANT:</b> This must be a static inner class to hold no reference to the outer class.
-	 * Otherwise, the outer class could never become garbage collectible while this thread runs.
-	 */
-	private static class ShutdownThread extends Thread {
-
-		private final Object monitor = new Object();
-
-		private final PlanExecutor executor;
-
-		private volatile boolean triggered = false;
-
-		ShutdownThread(PlanExecutor executor) {
-			super("Local cluster reaper");
-			setDaemon(true);
-			setPriority(Thread.MIN_PRIORITY);
-
-			this.executor = executor;
-		}
-
-		@Override
-		public void run() {
-			synchronized (monitor) {
-				while (!triggered) {
-					try {
-						monitor.wait();
-					}
-					catch (InterruptedException e) {
-						// should never happen
-					}
-				}
-			}
-
-			try {
-				executor.stop();
-			}
-			catch (Throwable t) {
-				System.err.println("Cluster reaper caught exception during shutdown");
-				t.printStackTrace();
-			}
-		}
-
-		void trigger() {
-			triggered = true;
-			synchronized (monitor) {
-				monitor.notifyAll();
-			}
-		}
-
-	}
-
-	/**
-	 * A class that, upon finalization, shuts down the local mini cluster by triggering the reaper
-	 * thread.
-	 */
-	private static class ExecutorReaper {
-
-		private final ShutdownThread shutdownThread;
-
-		ExecutorReaper(PlanExecutor executor) {
-			this.shutdownThread = new ShutdownThread(executor);
-			this.shutdownThread.start();
-		}
-
-		@Override
-		protected void finalize() throws Throwable {
-			super.finalize();
-			shutdownThread.trigger();
-		}
+		return "Local Environment (parallelism = " + (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? "default" : getParallelism()) + ").";
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -68,15 +68,10 @@ public class LocalEnvironment extends ExecutionEnvironment {
 
 	// --------------------------------------------------------------------------------------------
 
-	// TODO: 31.08.19 make sure that start and stop are called in the execute.
-	// the other place would be here, but this can complicate code, as the
-	// lifecycle management would be outside the executor itself.
-
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		final Plan p = createProgramPlan(jobName);
 
-		// TODO: 31.08.19 make the executor autocloseable
 		final PlanExecutor executor = PlanExecutor.createLocalExecutor(configuration);
 		lastJobExecutionResult = executor.executePlan(p);
 		return lastJobExecutionResult;

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -19,14 +19,11 @@
 package org.apache.flink.api.java;
 
 import org.apache.flink.annotation.Public;
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.ShutdownHookUtil;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -60,12 +57,6 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 
 	/** The configuration used by the client that connects to the cluster. */
 	protected Configuration clientConfiguration;
-
-	/** The remote executor lazily created upon first use. */
-	protected PlanExecutor executor;
-
-	/** Optional shutdown hook, used in session mode to eagerly terminate the last session. */
-	private Thread shutdownHook;
 
 	/** The classpaths that need to be attached to each job. */
 	protected final List<URL> globalClasspaths;
@@ -162,95 +153,31 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
-		PlanExecutor executor = getExecutor();
+		final Plan p = createProgramPlan(jobName);
 
-		Plan p = createProgramPlan(jobName);
-
-		// Session management is disabled, revert this commit to enable
-		//p.setJobId(jobID);
-		//p.setSessionTimeout(sessionTimeout);
-
-		JobExecutionResult result = executor.executePlan(p);
-
-		this.lastJobExecutionResult = result;
-		return result;
-	}
-
-	@Override
-	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan("plan", false);
-
-		// make sure that we do not start an new executor here
-		// if one runs, fine, of not, we create a local executor (lightweight) and let it
-		// generate the plan
-		if (executor != null) {
-			return executor.getOptimizerPlanAsJSON(p);
-		}
-		else {
-			PlanExecutor le = PlanExecutor.createLocalExecutor(null);
-			String plan = le.getOptimizerPlanAsJSON(p);
-
-			le.stop();
-
-			return plan;
-		}
-	}
-
-	@Override
-	@PublicEvolving
-	public void startNewSession() throws Exception {
-		dispose();
-		jobID = JobID.generate();
-		installShutdownHook();
-	}
-
-	protected PlanExecutor getExecutor() throws Exception {
-		if (executor == null) {
-			executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration,
-				jarFiles, globalClasspaths);
-		}
-
-		// if we are using sessions, we keep the executor running
-		if (getSessionTimeout() > 0 && !executor.isRunning()) {
-			executor.start();
-			installShutdownHook();
-		}
-
-		return executor;
-	}
-
-	// ------------------------------------------------------------------------
-	//  Dispose
-	// ------------------------------------------------------------------------
-
-	protected void dispose() {
-		// Remove shutdown hook to prevent resource leaks
-		ShutdownHookUtil.removeShutdownHook(shutdownHook, getClass().getSimpleName(), LOG);
-
+		PlanExecutor executor = null;
 		try {
-			PlanExecutor executor = this.executor;
+			executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration, jarFiles, globalClasspaths);
+			executor.start();
+			lastJobExecutionResult = executor.executePlan(p);
+		} finally {
 			if (executor != null) {
 				executor.stop();
 			}
 		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to dispose the session shutdown hook.");
-		}
+		return lastJobExecutionResult;
+	}
+
+	@Override
+	public String getExecutionPlan() throws Exception {
+		final Plan p = createProgramPlan("plan", false);
+		final PlanExecutor tempExecutor = PlanExecutor.createLocalExecutor(new Configuration());
+		return tempExecutor.getOptimizerPlanAsJSON(p);
 	}
 
 	@Override
 	public String toString() {
 		return "Remote Environment (" + this.host + ":" + this.port + " - parallelism = " +
-				(getParallelism() == -1 ? "default" : getParallelism()) + ") : " + getIdString();
-	}
-
-	// ------------------------------------------------------------------------
-	//  Shutdown hooks and reapers
-	// ------------------------------------------------------------------------
-
-	private void installShutdownHook() {
-		if (shutdownHook == null) {
-			this.shutdownHook = ShutdownHookUtil.addShutdownHook(this::dispose, getClass().getSimpleName(), LOG);
-		}
+				(getParallelism() == -1 ? "default" : getParallelism()) + ").";
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -155,16 +155,8 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		final Plan p = createProgramPlan(jobName);
 
-		PlanExecutor executor = null;
-		try {
-			executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration, jarFiles, globalClasspaths);
-			executor.start();
-			lastJobExecutionResult = executor.executePlan(p);
-		} finally {
-			if (executor != null) {
-				executor.stop();
-			}
-		}
+		final PlanExecutor executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration, jarFiles, globalClasspaths);
+		lastJobExecutionResult = executor.executePlan(p);
 		return lastJobExecutionResult;
 	}
 

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
@@ -19,10 +19,13 @@ package org.apache.flink.api.java;
  * limitations under the License.
  */
 
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.api.scala.FlinkILoop;
 import org.apache.flink.configuration.Configuration;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,28 +58,29 @@ public class ScalaShellRemoteEnvironment extends RemoteEnvironment {
 	}
 
 	@Override
-	protected PlanExecutor getExecutor() throws Exception {
-		// check if we had already started a PlanExecutor. If true, then stop it, because there will
-		// be a new jar file available for the user code classes
-		if (this.executor != null) {
-			this.executor.stop();
-		}
+	public JobExecutionResult execute(String jobName) throws Exception {
+		final Plan p = createProgramPlan(jobName);
+		final List<URL> allJarFiles = getUpdatedJarFiles();
 
+		PlanExecutor executor = null;
+		try {
+			executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration, allJarFiles, globalClasspaths);
+			executor.start();
+			lastJobExecutionResult = executor.executePlan(p);
+		} finally {
+			if (executor != null) {
+				executor.stop();
+			}
+		}
+		return lastJobExecutionResult;
+	}
+
+	private List<URL> getUpdatedJarFiles() throws MalformedURLException {
 		// write generated classes to disk so that they can be shipped to the cluster
 		URL jarUrl = flinkILoop.writeFilesToDisk().getAbsoluteFile().toURI().toURL();
-
 		List<URL> allJarFiles = new ArrayList<>(jarFiles);
 		allJarFiles.add(jarUrl);
-
-		this.executor = PlanExecutor.createRemoteExecutor(
-			host,
-			port,
-			clientConfiguration,
-			allJarFiles,
-			globalClasspaths
-		);
-
-		return executor;
+		return allJarFiles;
 	}
 
 	public static void disableAllContextAndOtherEnvironments() {

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
@@ -62,16 +62,8 @@ public class ScalaShellRemoteEnvironment extends RemoteEnvironment {
 		final Plan p = createProgramPlan(jobName);
 		final List<URL> allJarFiles = getUpdatedJarFiles();
 
-		PlanExecutor executor = null;
-		try {
-			executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration, allJarFiles, globalClasspaths);
-			executor.start();
-			lastJobExecutionResult = executor.executePlan(p);
-		} finally {
-			if (executor != null) {
-				executor.stop();
-			}
-		}
+		final PlanExecutor executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration, allJarFiles, globalClasspaths);
+		lastJobExecutionResult = executor.executePlan(p);
 		return lastJobExecutionResult;
 	}
 

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -230,7 +230,7 @@ object FlinkShell {
         case Some(Left(miniCluster)) => miniCluster.close()
         case Some(Right(yarnCluster)) =>
           yarnCluster.shutDownCluster()
-          yarnCluster.shutdown()
+          yarnCluster.close()
         case _ =>
       }
     }

--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -128,21 +128,6 @@ public class FlinkILoopTest extends TestLogger {
 		private List<String> globalClasspaths;
 
 		@Override
-		public void start() throws Exception {
-
-		}
-
-		@Override
-		public void stop() throws Exception {
-
-		}
-
-		@Override
-		public boolean isRunning() {
-			return false;
-		}
-
-		@Override
 		public JobExecutionResult executePlan(Plan plan) throws Exception {
 			return null;
 		}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult, JobID}
+import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult}
 import org.apache.flink.api.java.io._
 import org.apache.flink.api.java.operators.DataSource
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -135,57 +135,9 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   def getNumberOfExecutionRetries = javaEnv.getNumberOfExecutionRetries
 
   /**
-   * Gets the UUID by which this environment is identified. The UUID sets the execution context
-   * in the cluster or local environment.
-   */
-  @PublicEvolving
-  def getId: JobID = {
-    javaEnv.getId
-  }
-
-  /**
    * Gets the JobExecutionResult of the last executed job.
    */
   def getLastJobExecutionResult = javaEnv.getLastJobExecutionResult
-
-  /**
-   * Gets the UUID by which this environment is identified, as a string.
-   */
-  @PublicEvolving
-  def getIdString: String = {
-    javaEnv.getIdString
-  }
-
-  /**
-   * Starts a new session, discarding all intermediate results.
-   */
-  @PublicEvolving
-  def startNewSession() {
-    javaEnv.startNewSession()
-  }
-
-  /**
-   * Sets the session timeout to hold the intermediate results of a job. This only
-   * applies the updated timeout in future executions.
- *
-   * @param timeout The timeout in seconds.
-   */
-  @PublicEvolving
-  def setSessionTimeout(timeout: Long) {
-    javaEnv.setSessionTimeout(timeout)
-  }
-
-  /**
-   * Gets the session timeout for this environment. The session timeout defines for how long
-   * after an execution, the job and its intermediate results will be kept for future
-   * interactions.
-   *
-   * @return The session timeout, in seconds.
-   */
-  @PublicEvolving
-  def getSessionTimeout: Long = {
-    javaEnv.getSessionTimeout
-  }
 
   /**
    * Registers the given type with the serializer at the [[KryoSerializer]].

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -292,7 +292,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		}
 		finally {
 			try {
-				client.shutdown();
+				client.close();
 			} catch (Exception e) {
 				LOG.warn("Could not properly shut down the cluster client.", e);
 			}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -431,7 +431,7 @@ public class LocalExecutor implements Executor {
 			} finally {
 				try {
 					if (clusterClient != null) {
-						clusterClient.shutdown();
+						clusterClient.close();
 					}
 				} catch (Exception e) {
 					// ignore

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
@@ -131,7 +131,7 @@ public class ProgramDeployer<C> implements Runnable {
 		} finally {
 			try {
 				if (clusterClient != null) {
-					clusterClient.shutdown();
+					clusterClient.close();
 				}
 			} catch (Exception e) {
 				// ignore
@@ -172,7 +172,7 @@ public class ProgramDeployer<C> implements Runnable {
 		} finally {
 			try {
 				if (clusterClient != null) {
-					clusterClient.shutdown();
+					clusterClient.close();
 				}
 			} catch (Exception e) {
 				// ignore

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterWithClientResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterWithClientResource.java
@@ -66,7 +66,7 @@ public class MiniClusterWithClientResource extends MiniClusterResource {
 
 		if (clusterClient != null) {
 			try {
-				clusterClient.shutdown();
+				clusterClient.close();
 			} catch (Exception e) {
 				exception = e;
 			}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -97,10 +97,6 @@ public class TestEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public void startNewSession() throws Exception {
-	}
-
-	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		OptimizedPlan op = compileProgram(jobName);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -77,7 +77,7 @@ public class JobRetrievalITCase extends TestLogger {
 	@After
 	public void tearDown() {
 		if (client != null) {
-			client.shutdown();
+			client.close();
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
@@ -55,7 +55,6 @@ public class LocalExecutorITCase extends TestLogger {
 
 			LocalExecutor executor = new LocalExecutor();
 			executor.setDefaultOverwriteFiles(true);
-			executor.setTaskManagerNumSlots(parallelism);
 
 			Plan wcPlan = getWordCountPlan(inFile, outFile, parallelism);
 			wcPlan.setExecutionConfig(new ExecutionConfig());

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.LocalExecutor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.testfunctions.Tokenizer;
 import org.apache.flink.util.TestLogger;
@@ -53,8 +55,10 @@ public class LocalExecutorITCase extends TestLogger {
 				fw.write(WordCountData.TEXT);
 			}
 
-			LocalExecutor executor = new LocalExecutor();
-			executor.setDefaultOverwriteFiles(true);
+			final Configuration config = new Configuration();
+			config.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+
+			final LocalExecutor executor = new LocalExecutor(config);
 
 			Plan wcPlan = getWordCountPlan(inFile, outFile, parallelism);
 			wcPlan.setExecutionConfig(new ExecutionConfig());

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
@@ -56,11 +56,10 @@ public class LocalExecutorITCase extends TestLogger {
 			LocalExecutor executor = new LocalExecutor();
 			executor.setDefaultOverwriteFiles(true);
 			executor.setTaskManagerNumSlots(parallelism);
-			executor.start();
+
 			Plan wcPlan = getWordCountPlan(inFile, outFile, parallelism);
 			wcPlan.setExecutionConfig(new ExecutionConfig());
 			executor.executePlan(wcPlan);
-			executor.stop();
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail(e.getMessage());

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -334,10 +334,6 @@ public class JsonJobGraphGenerationTest {
 		}
 
 		@Override
-		public void startNewSession() throws Exception {
-		}
-
-		@Override
 		public JobExecutionResult execute(String jobName) throws Exception {
 			Plan plan = createProgramPlan(jobName);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -242,7 +242,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 				taskManagerProcess.destroy();
 			}
 			if (clusterClient != null) {
-				clusterClient.shutdown();
+				clusterClient.close();
 			}
 			if (dispatcherResourceManagerComponent != null) {
 				dispatcherResourceManagerComponent.deregisterApplicationAndClose(ApplicationStatus.SUCCEEDED, null);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
@@ -103,7 +103,7 @@ public class BigUserProgramJobSubmitITCase extends TestLogger {
 
 			assertEquals(expected, result);
 		} finally {
-			restClusterClient.shutdown();
+			restClusterClient.close();
 		}
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -176,7 +176,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 
 				killApplicationAndWait(id);
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		});
 	}
@@ -199,7 +199,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 
 				killApplicationAndWait(restClusterClient.getClusterId());
 			} finally {
-				restClusterClient.shutdown();
+				restClusterClient.close();
 			}
 		});
 	}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -125,7 +125,7 @@ public class YARNITCase extends YarnTestBase {
 					waitApplicationFinishedElseKillIt(applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor);
 				} finally {
 					if (clusterClient != null) {
-						clusterClient.shutdown();
+						clusterClient.close();
 					}
 				}
 			}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -196,7 +196,7 @@ public class YarnConfigurationITCase extends YarnTestBase {
 					assertThat((int) (taskManagerInfo.getHardwareDescription().getSizeOfManagedMemory() >> 20), is(expectedManagedMemoryMB));
 				} finally {
 					restClient.shutdown(TIMEOUT);
-					clusterClient.shutdown();
+					clusterClient.close();
 				}
 
 				clusterDescriptor.killCluster(clusterId);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
@@ -93,4 +93,9 @@ public class FakeClusterClient extends ClusterClient<ApplicationId> {
 	public Map<String, OptionalFailure<Object>> getAccumulators(JobID jobID, ClassLoader loader) {
 		return Collections.emptyMap();
 	}
+
+	@Override
+	public void close() throws Exception {
+
+	}
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
@@ -93,9 +93,4 @@ public class FakeClusterClient extends ClusterClient<ApplicationId> {
 	public Map<String, OptionalFailure<Object>> getAccumulators(JobID jobID, ClassLoader loader) {
 		return Collections.emptyMap();
 	}
-
-	@Override
-	public void close() throws Exception {
-
-	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -626,7 +626,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 							yarnClusterDescriptor.getDynamicPropertiesEncoded());
 					} catch (Exception e) {
 						try {
-							clusterClient.shutdown();
+							clusterClient.close();
 						} catch (Exception ex) {
 							LOG.info("Could not properly shutdown cluster client.", ex);
 						}
@@ -705,7 +705,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		clusterClient.shutDownCluster();
 
 		try {
-			clusterClient.shutdown();
+			clusterClient.close();
 		} catch (Exception e) {
 			LOG.info("Could not properly shutdown cluster client.", e);
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR removes code related to JobSessions from the `ExecutionEnvironment` and the `PlanExecutor`s. This code was added in the context of [FLINK-2097](https://issues.apache.org/jira/browse/FLINK-2097) but it was never activated, as illustrated by the comment at [ExecutionEnvironment.java#L285 ](https://github.com/apache/flink/blob/master/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java#L285). The work in this PR is part of the preparation for the upcoming re-design of the whole Client/Executor API.

## Brief change log

The changes in the subclasses of the `ExecutionEnvironment` remove methods that were setting session-related parameters and reflect the simplification of the `PlanExecutor` _lifecycle_ explained below (for `Local` and `RemoteEnvironment`).

The changes to the `PlanExecutors` have to do with the executor's lifecycle. Now the executor itself controls its lifecycle (`start()` and `stop()` are `private`) and we instantiate an executor for each call to `executePlan()`. This allows to get rid of the reapers from the `Local` and `RemoteEnvironments` and the `lock` that protected concurrent access to the executor's state.

The lifecycle is more explicit now and aligned with the current use of the `ExecutionEnvironment`. If in the future we choose to change this and decide to re-use execution environments, then we can add this functionality back, potentially under a different design/architecture.

## Verifying this change

This change is a code cleanup so it is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

Please have a look at this one @aljoscha and @tillrohrmann.