### PR TITLE
[FLINK-13776][table] Introduce new interfaces to BuiltInFunctionDefinition

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
@@ -48,6 +48,11 @@ public interface ResolverRule {
 	interface ResolutionContext {
 
 		/**
+		 * If this a aggregation query with grouping.
+		 */
+		boolean hasGrouping();
+
+		/**
 		 * Access to available {@link org.apache.flink.table.expressions.FieldReferenceExpression} in inputs.
 		 */
 		FieldReferenceLookup referenceLookup();

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
@@ -217,7 +217,7 @@ public final class OperationTreeBuilder {
 		ExpressionResolver resolver = getResolver(child);
 
 		List<ResolvedExpression> resolvedGroupings = resolver.resolve(groupingExpressions);
-		List<ResolvedExpression> resolvedAggregates = resolver.resolve(aggregates);
+		List<ResolvedExpression> resolvedAggregates = resolver.resolveAggregates(!groupingExpressions.isEmpty(), aggregates);
 
 		return aggregateOperationFactory.createAggregate(resolvedGroupings, resolvedAggregates, child);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinition.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.InputTypeValidator;
 import org.apache.flink.table.types.inference.TypeInference;
@@ -78,6 +79,17 @@ public final class BuiltInFunctionDefinition implements FunctionDefinition {
 	 */
 	public Optional<String> getStandardSql() {
 		return Optional.ofNullable(standardSql);
+	}
+
+	/**
+	 * Returns whether a function is monotonic.
+	 *
+	 * <p>Default implementation returns {@link FunctionMonotonicity#NOT_MONOTONIC}.
+	 *
+	 * @param context provides details about the function call.
+	 */
+	public FunctionMonotonicity getMonotonicity(CallContext context) {
+		return FunctionMonotonicity.NOT_MONOTONIC;
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinition.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.types.inference.TypeStrategy;
 import org.apache.flink.util.Preconditions;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Definition of a built-in function. It enables unique identification across different
@@ -41,15 +42,19 @@ public final class BuiltInFunctionDefinition implements FunctionDefinition {
 
 	private final String name;
 
+	private final String standardSql;
+
 	private final FunctionKind kind;
 
 	private final TypeInference typeInference;
 
 	private BuiltInFunctionDefinition(
 			String name,
+			String standardSql,
 			FunctionKind kind,
 			TypeInference typeInference) {
 		this.name = Preconditions.checkNotNull(name, "Name must not be null.");
+		this.standardSql = standardSql;
 		this.kind = Preconditions.checkNotNull(kind, "Kind must not be null.");
 		this.typeInference = Preconditions.checkNotNull(typeInference, "Type inference must not be null.");
 	}
@@ -64,6 +69,14 @@ public final class BuiltInFunctionDefinition implements FunctionDefinition {
 	 */
 	public TypeInference getTypeInference() {
 		return typeInference;
+	}
+
+	/**
+	 * The standard sql function name of this function definition, only standard function should
+	 * have this field. It help mapping flink function definition to calcite SqlFunction.
+	 */
+	public Optional<String> getStandardSql() {
+		return Optional.ofNullable(standardSql);
 	}
 
 	@Override
@@ -85,6 +98,8 @@ public final class BuiltInFunctionDefinition implements FunctionDefinition {
 
 		private String name;
 
+		private String standardSql;
+
 		private FunctionKind kind;
 
 		private TypeInference.Builder typeInferenceBuilder = new TypeInference.Builder();
@@ -95,6 +110,11 @@ public final class BuiltInFunctionDefinition implements FunctionDefinition {
 
 		public Builder name(String name) {
 			this.name = name;
+			return this;
+		}
+
+		public Builder standardSql(String standardSql) {
+			this.standardSql = standardSql;
 			return this;
 		}
 
@@ -129,7 +149,7 @@ public final class BuiltInFunctionDefinition implements FunctionDefinition {
 		}
 
 		public BuiltInFunctionDefinition build() {
-			return new BuiltInFunctionDefinition(name, kind, typeInferenceBuilder.build());
+			return new BuiltInFunctionDefinition(name, standardSql, kind, typeInferenceBuilder.build());
 		}
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinition.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.InputTypeValidator;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategy;
@@ -135,6 +136,11 @@ public final class BuiltInFunctionDefinition implements FunctionDefinition {
 
 		public Builder outputTypeStrategy(TypeStrategy outputTypeStrategy) {
 			this.typeInferenceBuilder.outputTypeStrategy(outputTypeStrategy);
+			return this;
+		}
+
+		public Builder inputTypeStrategy(InputTypeStrategy inputTypeStrategy) {
+			this.typeInferenceBuilder.inputTypeStrategy(inputTypeStrategy);
 			return this;
 		}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -19,8 +19,12 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.InputTypeValidators;
 import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.inference.TypeTransformations;
 import org.apache.flink.util.Preconditions;
 
 import java.lang.reflect.Field;
@@ -33,6 +37,7 @@ import java.util.Set;
 import static org.apache.flink.table.functions.FunctionKind.AGGREGATE;
 import static org.apache.flink.table.functions.FunctionKind.OTHER;
 import static org.apache.flink.table.functions.FunctionKind.SCALAR;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BOOLEAN;
 
 /**
  * Dictionary of function definitions for all built-in functions.
@@ -44,8 +49,13 @@ public final class BuiltInFunctionDefinitions {
 	public static final BuiltInFunctionDefinition AND =
 		new BuiltInFunctionDefinition.Builder()
 			.name("and")
+			.standardSql("AND")
 			.kind(SCALAR)
-			.outputTypeStrategy(TypeStrategies.MISSING)
+			.outputTypeStrategy(TypeStrategies.cascade(
+				TypeStrategies.explicit(DataTypes.BOOLEAN().notNull()),
+				TypeTransformations.TO_NULLABLE))
+			.inputTypeValidator(InputTypeValidators.typeRoot(BOOLEAN, BOOLEAN))
+			.inputTypeStrategy(InputTypeStrategies.explicit(DataTypes.BOOLEAN()))
 			.build();
 	public static final BuiltInFunctionDefinition OR =
 		new BuiltInFunctionDefinition.Builder()

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionMonotonicity.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionMonotonicity.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+/**
+ * Enumeration of types of monotonicity.
+ */
+public enum FunctionMonotonicity {
+
+	INCREASING,
+
+	DECREASING,
+
+	NOT_MONOTONIC
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/ArgumentCount.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/ArgumentCount.java
@@ -49,4 +49,94 @@ public interface ArgumentCount {
 	 * <p>{@link Optional#empty()} if such an upper bound is not defined.
 	 */
 	Optional<Integer> getMaxCount();
+
+	/**
+	 * The argument count should to be exactly the same as count.
+	 */
+	static ArgumentCount exact(int count) {
+		return new ArgumentCount() {
+
+			@Override
+			public boolean isValidCount(int validCount) {
+				return count == validCount;
+			}
+
+			@Override
+			public Optional<Integer> getMinCount() {
+				return Optional.of(count);
+			}
+
+			@Override
+			public Optional<Integer> getMaxCount() {
+				return Optional.of(count);
+			}
+		};
+	}
+
+	/**
+	 * The argument count should to be in the range of min and max.
+	 */
+	static ArgumentCount range(int min, int max) {
+		return new ArgumentCount() {
+			@Override
+			public boolean isValidCount(int count) {
+				return min <= count && count <= max;
+			}
+
+			@Override
+			public Optional<Integer> getMinCount() {
+				return Optional.of(min);
+			}
+
+			@Override
+			public Optional<Integer> getMaxCount() {
+				return Optional.of(max);
+			}
+		};
+	}
+
+	/**
+	 * The argument count should bigger than min.
+	 */
+	static ArgumentCount atLeast(int min) {
+		return new ArgumentCount() {
+			@Override
+			public boolean isValidCount(int count) {
+				return min <= count;
+			}
+
+			@Override
+			public Optional<Integer> getMinCount() {
+				return Optional.of(min);
+			}
+
+			@Override
+			public Optional<Integer> getMaxCount() {
+				return Optional.empty();
+			}
+		};
+	}
+
+	/**
+	 * Always pass on {@link ArgumentCount}.
+	 */
+	static ArgumentCount passing() {
+		return new ArgumentCount() {
+
+			@Override
+			public boolean isValidCount(int count) {
+				return true;
+			}
+
+			@Override
+			public Optional<Integer> getMinCount() {
+				return Optional.empty();
+			}
+
+			@Override
+			public Optional<Integer> getMaxCount() {
+				return Optional.empty();
+			}
+		};
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/CallContextBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/CallContextBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.functions.FunctionDefinition;
 
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Provides details about the function call for which type inference is performed.
@@ -54,6 +55,11 @@ public interface CallContextBase {
 	 * <p>Use {@link #isArgumentLiteral(int)} before to check if the argument is actually a literal.
 	 */
 	<T> Optional<T> getArgumentValue(int pos, Class<T> clazz);
+
+	/**
+	 * Returns the set of usages in this context.
+	 */
+	Set<ContextUsage> getUsages();
 
 	/**
 	 * Returns the function's name usually referencing the function in a catalog.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/ContextUsage.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/ContextUsage.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference;
+
+/**
+ * Characteristics that a {@link CallContextBase} use.
+ */
+public enum ContextUsage {
+
+	/**
+	 * Using grouping columns for aggregation, indicate the grouping size is greater than zero.
+	 */
+	GROUPING_AGGREGATION,
+
+	/**
+	 * Indicate the function is an aggregate function with a filter.
+	 */
+	FILTERING_AGGREGATION
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+
+import java.util.Arrays;
+
+/**
+ * Strategies for inferring unknown types of the inputs of a function definition.
+ *
+ * @see InputTypeStrategy
+ */
+@Internal
+public class InputTypeStrategies {
+
+	/**
+	 * Creates a input type strategy that set all input types to an explicitly given type.
+	 */
+	public static InputTypeStrategy explicit(DataType type) {
+		return (callContext, outputType, inputTypes) -> Arrays.fill(inputTypes, type);
+	}
+
+	/**
+	 * Input type-inference strategy where an unknown operand type is derived from the call's
+	 * output type.
+	 */
+	public static final InputTypeStrategy OUTPUT_TYPE = (callContext, outputType, inputTypes) ->
+		Arrays.fill(inputTypes, outputType);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference;
+
+import org.apache.flink.table.types.DataType;
+
+/**
+ * Strategy to infer unknown types of the inputs of a function definition.
+ */
+public interface InputTypeStrategy {
+
+	/**
+	 * Infers any unknown operand types.
+	 *
+	 * @param callContext description of the call being analyzed
+	 * @param outputType  the type known or inferred for the result of the call
+	 * @param inputTypes  receives the inferred types for all operands
+	 */
+	void inferTypes(CallContext callContext, DataType outputType, DataType[] inputTypes);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeValidators.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeValidators.java
@@ -20,6 +20,12 @@ package org.apache.flink.table.types.inference;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.types.inference.validators.PassingTypeValidator;
+import org.apache.flink.table.types.inference.validators.TypeFamilyTypeValidator;
+import org.apache.flink.table.types.inference.validators.TypeRootTypeValidator;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import java.util.Arrays;
 
 /**
  * Validators for checking the input data types of a function call.
@@ -28,6 +34,28 @@ import org.apache.flink.table.types.inference.validators.PassingTypeValidator;
  */
 @Internal
 public final class InputTypeValidators {
+
+	// --------------------------------------------------------------------------------------------
+	// factory methods for type strategies
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Validator which checks if operands are of given type roots.
+	 */
+	public static InputTypeValidator typeRoot(LogicalTypeRoot... types) {
+		return new TypeRootTypeValidator(Arrays.asList(types));
+	}
+
+	/**
+	 * Validator which checks if operands are of given type families.
+	 */
+	public static InputTypeValidator family(LogicalTypeFamily... types) {
+		return new TypeFamilyTypeValidator(Arrays.asList(types));
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// concrete, reusable type strategies
+	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Validator that does not perform any validation and always passes.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInference.java
@@ -44,6 +44,8 @@ public final class TypeInference {
 
 	private final InputTypeValidator inputTypeValidator;
 
+	private final @Nullable InputTypeStrategy inputTypeStrategy;
+
 	private final @Nullable TypeStrategy accumulatorTypeStrategy;
 
 	private final TypeStrategy outputTypeStrategy;
@@ -54,11 +56,13 @@ public final class TypeInference {
 
 	private TypeInference(
 			InputTypeValidator inputTypeValidator,
+			@Nullable InputTypeStrategy inputTypeStrategy,
 			@Nullable TypeStrategy accumulatorTypeStrategy,
 			TypeStrategy outputTypeStrategy,
 			@Nullable List<String> argumentNames,
 			@Nullable List<DataType> argumentTypes) {
 		this.inputTypeValidator = inputTypeValidator;
+		this.inputTypeStrategy = inputTypeStrategy;
 		this.accumulatorTypeStrategy = accumulatorTypeStrategy;
 		this.outputTypeStrategy = outputTypeStrategy;
 		if (argumentNames != null && argumentTypes != null && argumentNames.size() != argumentTypes.size()) {
@@ -74,6 +78,10 @@ public final class TypeInference {
 
 	public InputTypeValidator getInputTypeValidator() {
 		return inputTypeValidator;
+	}
+
+	public InputTypeStrategy getInputTypeStrategy() {
+		return inputTypeStrategy;
 	}
 
 	public Optional<TypeStrategy> getAccumulatorTypeStrategy() {
@@ -104,6 +112,8 @@ public final class TypeInference {
 		private @Nullable TypeStrategy accumulatorTypeStrategy;
 
 		private @Nullable TypeStrategy outputTypeStrategy;
+
+		private @Nullable InputTypeStrategy inputTypeStrategy;
 
 		private @Nullable List<String> argumentNames;
 
@@ -145,6 +155,17 @@ public final class TypeInference {
 		}
 
 		/**
+		 * Sets the strategy for inferring unknown types of the inputs of a function definition.
+		 *
+		 * <p>Required.
+		 */
+		public Builder inputTypeStrategy(InputTypeStrategy inputTypeStrategy) {
+			this.inputTypeStrategy =
+					Preconditions.checkNotNull(inputTypeStrategy, "Input type strategy must not be null.");
+			return this;
+		}
+
+		/**
 		 * Sets the list of argument names for specifying static input explicitly.
 		 *
 		 * <p>This information is useful for SQL's concept of named arguments using the assignment
@@ -170,6 +191,7 @@ public final class TypeInference {
 		public TypeInference build() {
 			return new TypeInference(
 				inputTypeValidator,
+				inputTypeStrategy,
 				accumulatorTypeStrategy,
 				Preconditions.checkNotNull(outputTypeStrategy, "Output type strategy must not be null."),
 				argumentNames,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -305,6 +306,11 @@ public final class TypeInferenceUtil {
 				return Optional.empty();
 			}
 			return originalContext.getArgumentValue(pos, clazz);
+		}
+
+		@Override
+		public Set<ContextUsage> getUsages() {
+			return originalContext.getUsages();
 		}
 
 		@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -159,14 +159,18 @@ public final class TypeInferenceUtil {
 			InputTypeValidator validator,
 			CallContext callContext) {
 
-		final String expectedSignatures = validator.getExpectedSignatures(callContext.getFunctionDefinition())
-			.stream()
-			.map(s -> formatSignature(callContext.getName(), s))
-			.collect(Collectors.joining("\n"));
+		final String expectedSignatures = formatSignatures(callContext.getName(),
+				validator.getExpectedSignatures(callContext.getFunctionDefinition()));
 		return new ValidationException(
 			String.format(
 				"Invalid input arguments. Expected signatures are:\n%s",
 				expectedSignatures));
+	}
+
+	public static String formatSignatures(String name, List<Signature> signatures) {
+		return signatures.stream()
+				.map(s -> formatSignature(name, s))
+				.collect(Collectors.joining("\n"));
 	}
 
 	private static String formatSignature(String name, Signature s) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategies.java
@@ -19,7 +19,12 @@
 package org.apache.flink.table.types.inference;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.strategies.CascadeTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.ExplicitTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.MissingTypeStrategy;
+
+import java.util.Arrays;
 
 /**
  * Strategies for inferring an output or accumulator data type of a function call.
@@ -28,6 +33,28 @@ import org.apache.flink.table.types.inference.strategies.MissingTypeStrategy;
  */
 @Internal
 public final class TypeStrategies {
+
+	// --------------------------------------------------------------------------------------------
+	// factory methods for type strategies
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Creates a type strategy that return an explicitly given type.
+	 */
+	public static TypeStrategy explicit(DataType dataType) {
+		return new ExplicitTypeStrategy(dataType);
+	}
+
+	/**
+	 * Creates a type strategy that applies a strategy and then a sequence of transforms to its result.
+	 */
+	public static TypeStrategy cascade(TypeStrategy strategy, TypeTransformation... transformations) {
+		return new CascadeTypeStrategy(strategy, Arrays.asList(transformations));
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// concrete, reusable type strategies
+	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Placeholder for a missing type strategy.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeTransformations.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeTransformations.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.inference.transformations.ToNullableTransformation;
+
+/**
+ * Transformations that can be used in {@link TypeStrategy}s with e.g.
+ * {@link TypeStrategies#cascade(TypeStrategy, TypeTransformation...)}.
+ */
+@Internal
+public class TypeTransformations {
+
+	/**
+	 * Type transformation where a result type is transformed into the same type
+	 * but nullable if any of the calls operands is nullable.
+	 */
+	public static final TypeTransformation TO_NULLABLE = new ToNullableTransformation();
+
+	private TypeTransformations() {
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CascadeTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CascadeTypeStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+import org.apache.flink.table.types.inference.TypeTransformation;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Strategy to infer the data type of a function call from the type of the operands
+ * by using one {@link TypeStrategy} rule and a combination of
+ * {@link TypeTransformation}s applied onto its result.
+ */
+@Internal
+public class CascadeTypeStrategy implements TypeStrategy {
+
+	private final TypeStrategy typeStrategy;
+	private final List<TypeTransformation> typeTransformations;
+
+	public CascadeTypeStrategy(
+			TypeStrategy typeStrategy,
+			List<TypeTransformation> typeTransformations) {
+		this.typeStrategy = typeStrategy;
+		this.typeTransformations = typeTransformations;
+	}
+
+	@Override
+	public Optional<DataType> inferType(CallContext callContext) {
+		return typeStrategy.inferType(callContext).map(
+			type -> {
+				DataType transformedType = type;
+				for (TypeTransformation transformation : typeTransformations) {
+					transformedType = transformation.transform(callContext, transformedType);
+				}
+
+				return transformedType;
+			}
+		);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ExplicitTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ExplicitTypeStrategy.java
@@ -16,37 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.types.inference.validators;
+package org.apache.flink.table.types.inference.strategies;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.functions.FunctionDefinition;
-import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.CallContext;
-import org.apache.flink.table.types.inference.InputTypeValidator;
-import org.apache.flink.table.types.inference.Signature;
-import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.inference.TypeStrategy;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Optional;
 
 /**
- * Validator that does not perform any validation and always passes.
+ * A type strategy that returns an explicitly specified {@link DataType}.
  */
 @Internal
-public class PassingTypeValidator implements InputTypeValidator {
+public class ExplicitTypeStrategy implements TypeStrategy {
 
-	@Override
-	public ArgumentCount getArgumentCount() {
-		return ArgumentCount.passing();
+	private final DataType dataType;
+
+	public ExplicitTypeStrategy(DataType dataType) {
+		this.dataType = dataType;
 	}
 
 	@Override
-	public boolean validate(CallContext callContext, boolean throwOnFailure) {
-		return true;
-	}
-
-	@Override
-	public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
-		return Collections.singletonList(Signature.of(Argument.of("*")));
+	public Optional<DataType> inferType(CallContext callContext) {
+		return Optional.of(dataType);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -43,7 +43,6 @@ public class DirectConvertRule implements CallExpressionConvertRule {
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.SHA1, FlinkSqlOperatorTable.SHA1);
 
 		// logic functions
-		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.AND, FlinkSqlOperatorTable.AND);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.OR, FlinkSqlOperatorTable.OR);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.NOT, FlinkSqlOperatorTable.NOT);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.IF, FlinkSqlOperatorTable.CASE);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -73,7 +73,8 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 		new ScalarFunctionConvertRule(),
 		new OverConvertRule(),
 		new DirectConvertRule(),
-		new CustomizedConvertRule()
+		new CustomizedConvertRule(),
+		new StandardSqlConvertRule()
 	);
 
 	private final RelBuilder relBuilder;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/StandardSqlConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/StandardSqlConvertRule.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions.converter;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.apache.flink.table.planner.expressions.converter.ExpressionConverter.toRexNodes;
+
+/**
+ * Use standard sql to convert function to RexNode.
+ */
+public class StandardSqlConvertRule implements CallExpressionConvertRule {
+
+	@Override
+	public Optional<RexNode> convert(CallExpression call, ConvertContext context) {
+		FunctionDefinition def = call.getFunctionDefinition();
+		Optional<String> standardSql = def instanceof BuiltInFunctionDefinition ?
+				((BuiltInFunctionDefinition) def).getStandardSql() :
+				Optional.empty();
+		return standardSql.map(s -> {
+			try {
+				Field field = SqlStdOperatorTable.class.getField(s);
+				RexNode rexNode = context.getRelBuilder().call(
+						(SqlOperator) field.get(SqlStdOperatorTable.class),
+						toRexNodes(context, call.getChildren()));
+				LogicalType flinkType = call.getOutputDataType().getLogicalType();
+				LogicalType calciteType = FlinkTypeFactory.toLogicalType(rexNode.getType());
+				if (!flinkType.equals(calciteType)) {
+					throw new TableException(String.format(
+							"Function definition output type(%s) should be the same as calcite output type(%s)",
+							flinkType,
+							calciteType));
+				}
+				return rexNode;
+			} catch (NoSuchFieldException | IllegalAccessException e) {
+				throw new TableException("Wrong standardSql: " + s, e);
+			}
+		});
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/StandardSqlConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/StandardSqlConvertRule.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import static org.apache.flink.table.planner.expressions.converter.ExpressionConverter.toRexNodes;
 
 /**
- * Use standard sql to convert function to RexNode.
+ * Use standard sql to convert {@link CallExpression} to RexNode.
  */
 public class StandardSqlConvertRule implements CallExpressionConvertRule {
 


### PR DESCRIPTION
## What is the purpose of the change

Introduce new interfaces to BuiltInFunctionDefinition from https://cwiki.apache.org/confluence/display/FLINK/FLIP-51%3A+Rework+of+the+Expression+Design

1.Introduce ContextUsage to CallContextBase
2.Pass hasGrouping to CallContext from TableApi
3.Add standardSql to BuiltInFunctionDefinition
4.Add InputTypeStrategy to BuiltInFunctionDefinition
5.Add FunctionMonotonicity to BuiltInFunctionDefinition
6.Add StandardSqlConvertRule to convert CallExpression to RexNode.
7.Implement type inference for AND function

## Verifying this change

This change is already covered by existing tests, expression tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (docs)
https://cwiki.apache.org/confluence/display/FLINK/FLIP-51%3A+Rework+of+the+Expression+Design
