### PR TITLE
[FLINK-13963] Consolidate Hadoop file systems usage and Hadoop integration docs

### DIFF
--- a/docs/dev/batch/connectors.md
+++ b/docs/dev/batch/connectors.md
@@ -30,40 +30,6 @@ under the License.
 The Apache Flink project supports multiple [file systems]({{ site.baseurl }}/ops/filesystems/index.html) that can be used as backing stores
 for input and output connectors. 
 
-### Using Hadoop file system implementations
-
-Apache Flink allows users to use any file system implementing the `org.apache.hadoop.fs.FileSystem`
-interface. There are Hadoop `FileSystem` implementations for
-
-- [S3](https://aws.amazon.com/s3/) (tested)
-- [Google Cloud Storage Connector for Hadoop](https://cloud.google.com/hadoop/google-cloud-storage-connector) (tested)
-- [Alluxio](http://alluxio.org/) (tested)
-- [XtreemFS](http://www.xtreemfs.org/) (tested)
-- FTP via [Hftp](http://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
-- and many more.
-
-In order to use a Hadoop file system with Flink, make sure that
-
-- the `flink-conf.yaml` has set the `fs.hdfs.hadoopconf` property to the Hadoop configuration directory. For automated testing or running from an IDE the directory containing `flink-conf.yaml` can be set by defining the `FLINK_CONF_DIR` environment variable.
-- the Hadoop configuration (in that directory) has an entry for the required file system in a file `core-site.xml`. Examples for S3 and Alluxio are linked/shown below.
-- the required classes for using the file system are available in the `lib/` folder of the Flink installation (on all machines running Flink). If putting the files into the directory is not possible, Flink also respects the `HADOOP_CLASSPATH` environment variable to add Hadoop jar files to the classpath.
-
-#### Amazon S3
-
-See [Deployment & Operations - Deployment - AWS - S3: Simple Storage Service]({{ site.baseurl }}/ops/deployment/aws.html) for available S3 file system implementations, their configuration and required libraries.
-
-#### Alluxio
-
-For Alluxio support add the following entry into the `core-site.xml` file:
-
-{% highlight xml %}
-<property>
-  <name>fs.alluxio.impl</name>
-  <value>alluxio.hadoop.FileSystem</value>
-</property>
-{% endhighlight %}
-
-
 ## Connecting to other systems using Input/OutputFormat wrappers for Hadoop
 
 Apache Flink allows users to access many different systems as data sources or sinks.

--- a/docs/dev/batch/connectors.zh.md
+++ b/docs/dev/batch/connectors.zh.md
@@ -30,40 +30,6 @@ under the License.
 The Apache Flink project supports multiple [file systems]({{ site.baseurl }}/ops/filesystems/index.html) that can be used as backing stores
 for input and output connectors. 
 
-### Using Hadoop file system implementations
-
-Apache Flink allows users to use any file system implementing the `org.apache.hadoop.fs.FileSystem`
-interface. There are Hadoop `FileSystem` implementations for
-
-- [S3](https://aws.amazon.com/s3/) (tested)
-- [Google Cloud Storage Connector for Hadoop](https://cloud.google.com/hadoop/google-cloud-storage-connector) (tested)
-- [Alluxio](http://alluxio.org/) (tested)
-- [XtreemFS](http://www.xtreemfs.org/) (tested)
-- FTP via [Hftp](http://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
-- and many more.
-
-In order to use a Hadoop file system with Flink, make sure that
-
-- the `flink-conf.yaml` has set the `fs.hdfs.hadoopconf` property to the Hadoop configuration directory. For automated testing or running from an IDE the directory containing `flink-conf.yaml` can be set by defining the `FLINK_CONF_DIR` environment variable.
-- the Hadoop configuration (in that directory) has an entry for the required file system in a file `core-site.xml`. Examples for S3 and Alluxio are linked/shown below.
-- the required classes for using the file system are available in the `lib/` folder of the Flink installation (on all machines running Flink). If putting the files into the directory is not possible, Flink also respects the `HADOOP_CLASSPATH` environment variable to add Hadoop jar files to the classpath.
-
-#### Amazon S3
-
-See [Deployment & Operations - Deployment - AWS - S3: Simple Storage Service]({{ site.baseurl }}/ops/deployment/aws.html) for available S3 file system implementations, their configuration and required libraries.
-
-#### Alluxio
-
-For Alluxio support add the following entry into the `core-site.xml` file:
-
-{% highlight xml %}
-<property>
-  <name>fs.alluxio.impl</name>
-  <value>alluxio.hadoop.FileSystem</value>
-</property>
-{% endhighlight %}
-
-
 ## Connecting to other systems using Input/OutputFormat wrappers for Hadoop
 
 Apache Flink allows users to access many different systems as data sources or sinks.

--- a/docs/dev/batch/hadoop_compatibility.md
+++ b/docs/dev/batch/hadoop_compatibility.md
@@ -35,7 +35,7 @@ You can:
 - use a Hadoop `Reducer` as [GroupReduceFunction](dataset_transformations.html#groupreduce-on-grouped-dataset).
 
 This document shows how to use existing Hadoop MapReduce code with Flink. Please refer to the
-[Connecting to other systems]({{ site.baseurl }}/dev/batch/connectors.html) guide for reading from Hadoop supported file systems.
+[Connecting to other systems]({{ site.baseurl }}/ops/filesystems/index.html#hadoop-file-system-hdfs-and-its-other-implementations) guide for reading from Hadoop supported file systems.
 
 * This will be replaced by the TOC
 {:toc}
@@ -64,12 +64,7 @@ and Reducers.
 </dependency>
 {% endhighlight %}
 
-### Using Hadoop Data Types
-
-Flink supports all Hadoop `Writable` and `WritableComparable` data types
-out-of-the-box. You do not need to include the Hadoop Compatibility dependency,
-if you only want to use your Hadoop data types. See the
-[Programming Guide](index.html) for more details.
+See also **[how to configure hadoop dependencies]({{ site.baseurl }}/ops/deployment/hadoop.html#add-hadoop-classpaths)**.
 
 ### Using Hadoop InputFormats
 

--- a/docs/dev/batch/hadoop_compatibility.zh.md
+++ b/docs/dev/batch/hadoop_compatibility.zh.md
@@ -35,7 +35,7 @@ You can:
 - use a Hadoop `Reducer` as [GroupReduceFunction](dataset_transformations.html#groupreduce-on-grouped-dataset).
 
 This document shows how to use existing Hadoop MapReduce code with Flink. Please refer to the
-[Connecting to other systems]({{ site.baseurl }}/dev/batch/connectors.html) guide for reading from Hadoop supported file systems.
+[Connecting to other systems]({{ site.baseurl }}/ops/filesystems/index.html#hadoop-file-system-hdfs-and-its-other-implementations) guide for reading from Hadoop supported file systems.
 
 * This will be replaced by the TOC
 {:toc}
@@ -64,12 +64,7 @@ and Reducers.
 </dependency>
 {% endhighlight %}
 
-### Using Hadoop Data Types
-
-Flink supports all Hadoop `Writable` and `WritableComparable` data types
-out-of-the-box. You do not need to include the Hadoop Compatibility dependency,
-if you only want to use your Hadoop data types. See the
-[Programming Guide](index.html) for more details.
+See also **[how to configure hadoop dependencies]({{ site.baseurl }}/ops/deployment/hadoop.html#add-hadoop-classpaths)**.
 
 ### Using Hadoop InputFormats
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -50,6 +50,8 @@ The configuration files for the TaskManagers can be different, Flink does not as
   <strong>Note:</strong> These keys are deprecated and it is recommended to configure the Hadoop path with the environment variable <code>HADOOP_CONF_DIR</code> instead.
 </div>
 
+See also [how to configure Hadoop]({{ site.baseurl }}/ops/deployment/hadoop.html#configure-hadoop).
+
 These parameters configure the default HDFS used by Flink. Setups that do not specify a HDFS configuration have to specify the full path to HDFS files (`hdfs://address:port/path/to/files`) Files will also be written with default HDFS parameters (block size, replication factor).
 
 - `fs.hdfs.hadoopconf`: The absolute path to the Hadoop File System's (HDFS) configuration **directory** (OPTIONAL VALUE). Specifying this value allows programs to reference HDFS files using short URIs (`hdfs:///path/to/files`, without including the address and port of the NameNode in the file URI). Without this option, HDFS files can be accessed, but require fully qualified URIs like `hdfs://address:port/path/to/files`. This option also causes file writers to pick up the HDFS's default values for block sizes and replication factors. Flink will look for the "core-site.xml" and "hdfs-site.xml" files in the specified directory.

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -50,6 +50,8 @@ The configuration files for the TaskManagers can be different, Flink does not as
   <strong>Note:</strong> These keys are deprecated and it is recommended to configure the Hadoop path with the environment variable <code>HADOOP_CONF_DIR</code> instead.
 </div>
 
+See also [how to configure Hadoop]({{ site.baseurl }}/ops/deployment/hadoop.html#configure-hadoop).
+
 These parameters configure the default HDFS used by Flink. Setups that do not specify a HDFS configuration have to specify the full path to HDFS files (`hdfs://address:port/path/to/files`) Files will also be written with default HDFS parameters (block size, replication factor).
 
 - `fs.hdfs.hadoopconf`: The absolute path to the Hadoop File System's (HDFS) configuration **directory** (OPTIONAL VALUE). Specifying this value allows programs to reference HDFS files using short URIs (`hdfs:///path/to/files`, without including the address and port of the NameNode in the file URI). Without this option, HDFS files can be accessed, but require fully qualified URIs like `hdfs://address:port/path/to/files`. This option also causes file writers to pick up the HDFS's default values for block sizes and replication factors. Flink will look for the "core-site.xml" and "hdfs-site.xml" files in the specified directory.

--- a/docs/ops/deployment/hadoop.md
+++ b/docs/ops/deployment/hadoop.md
@@ -26,7 +26,25 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-## Configuring Flink with Hadoop Classpaths
+## Referencing a Hadoop configuration
+
+You can reference a Hadoop configuration by setting the environment variable `HADOOP_CONF_DIR`.
+
+```sh
+HADOOP_CONF_DIR=/path/to/etc/hadoop
+```
+
+Referencing the HDFS configuration in the [Flink configuration]({{ site.baseurl }}/ops/config.html#hdfs) is deprecated.
+
+Another way to provide the Hadoop configuration is to have it on the class path of the Flink process, see more details below.
+
+## Adding Hadoop Classpaths
+
+The required classes to use Hadoop should be available in the `lib/` folder of the Flink installation
+(on all machines running Flink) unless Flink is built with [Hadoop shaded dependencies]({{ site.baseurl }}/flinkDev/building.html#pre-bundled-versions).
+
+If putting the files into the directory is not possible, Flink also respects
+the `HADOOP_CLASSPATH` environment variable to add Hadoop jar files to the classpath.
 
 Flink will use the environment variable `HADOOP_CLASSPATH` to augment the
 classpath that is used when starting Flink components such as the Client,
@@ -45,6 +63,8 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 {% endhighlight %}
 
 in the shell. Note that `hadoop` is the hadoop binary and that `classpath` is an argument that will make it print the configured Hadoop classpath.
+
+Putting the Hadoop configuration in the same class path as the Hadoop libraries makes Flink pick up that configuration.
 
 ## Running a job locally
 

--- a/docs/ops/deployment/hadoop.zh.md
+++ b/docs/ops/deployment/hadoop.zh.md
@@ -26,7 +26,25 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-## Configuring Flink with Hadoop Classpaths
+## Referencing a Hadoop configuration
+
+You can reference a Hadoop configuration by setting the environment variable `HADOOP_CONF_DIR`.
+
+```sh
+HADOOP_CONF_DIR=/path/to/etc/hadoop
+```
+
+Referencing the HDFS configuration in the [Flink configuration]({{ site.baseurl }}/ops/config.html#hdfs) is deprecated.
+
+Another way to provide the Hadoop configuration is to have it on the class path of the Flink process, see more details below.
+
+## Adding Hadoop Classpaths
+
+The required classes to use Hadoop should be available in the `lib/` folder of the Flink installation
+(on all machines running Flink) unless Flink is built with [Hadoop shaded dependencies]({{ site.baseurl }}/flinkDev/building.html#pre-bundled-versions).
+
+If putting the files into the directory is not possible, Flink also respects
+the `HADOOP_CLASSPATH` environment variable to add Hadoop jar files to the classpath.
 
 Flink will use the environment variable `HADOOP_CLASSPATH` to augment the
 classpath that is used when starting Flink components such as the Client,
@@ -45,6 +63,8 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 {% endhighlight %}
 
 in the shell. Note that `hadoop` is the hadoop binary and that `classpath` is an argument that will make it print the configured Hadoop classpath.
+
+Putting the Hadoop configuration in the same class path as the Hadoop libraries makes Flink pick up that configuration.
 
 ## Running a job locally
 

--- a/docs/ops/filesystems/index.md
+++ b/docs/ops/filesystems/index.md
@@ -78,33 +78,6 @@ JAR file into `lib` directory.
 It's encouraged to use the plugin-based loading mechanism for file systems that support it. Loading file systems components from the `lib`
 directory may be not supported in future Flink versions.
 
-## HDFS and Hadoop File System support
-
-For all schemes where Flink cannot find a directly supported file system, it falls back to Hadoop.
-All Hadoop file systems are automatically available when `flink-runtime` and the Hadoop libraries are on the classpath.
-
-This way, Flink seamlessly supports all of Hadoop file systems, and all Hadoop-compatible file systems (HCFS).
-
-  - **hdfs**
-  - **ftp**
-  - **s3n** and **s3a**
-  - **har**
-  - ...
-
-### Hadoop Configuration
-
-We recommend using Flink's built-in file systems unless required otherwise. Using a Hadoop File System directly may be required, for example, when using that file system for YARN's resource storage, via the `fs.defaultFS` configuration property in Hadoop's `core-site.xml`.
-
-Putting the Hadoop configuration in the same class path as the Hadoop libraries makes the Hadoop File Systems pick up that configuration.
-You can reference another Hadoop configuration by setting the environment variable `HADOOP_CONF_DIR`, or by referencing it via the [Flink configuration](../config.html#hdfs).
-
-{% highlight yaml %}
-fs.hdfs.hadoopconf: /path/to/etc/hadoop
-{% endhighlight %}
-
-This registers `/path/to/etc/hadoop` as Hadoop's configuration directory and is where Flink will look for the `core-site.xml` and `hdfs-site.xml` files.
-
-
 ## Adding a new pluggable File System implementation
 
 File systems are represented via the `org.apache.flink.core.fs.FileSystem` class, which captures the ways to access and modify files and objects in that file system.
@@ -121,5 +94,39 @@ The same class loader should be used during file system instantiation and the fi
 
 <span class="label label-warning">Warning</span> In practice, it means you should avoid using `Thread.currentThread().getContextClassLoader()` class loader
 in your implementation. 
+
+## Hadoop File System (HDFS) and its other implementations
+
+For all schemes where Flink cannot find a directly supported file system, it falls back to Hadoop.
+All Hadoop file systems are automatically available when `flink-runtime` and the Hadoop libraries are on the classpath.
+See also **[Hadoop Integration]({{ site.baseurl }}/ops/deployment/hadoop.html)**.
+
+This way, Flink seamlessly supports all of Hadoop file systems implementing the `org.apache.hadoop.fs.FileSystem` interface,
+and all Hadoop-compatible file systems (HCFS).
+
+  - HDFS (tested)
+  - [Google Cloud Storage Connector for Hadoop](https://cloud.google.com/hadoop/google-cloud-storage-connector) (tested)
+  - [Alluxio](http://alluxio.org/) (tested, see configuration specifics below)
+  - [XtreemFS](http://www.xtreemfs.org/) (tested)
+  - FTP via [Hftp](http://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
+  - HAR (not tested)
+  - ...
+
+The Hadoop configuration has to have an entry for the required file system implementation in the `core-site.xml` file.
+See example for **[Alluxio]({{ site.baseurl }}/ops/filesystems/#alluxio)**.
+
+We recommend using Flink's built-in file systems unless required otherwise. Using a Hadoop File System directly may be required,
+for example, when using that file system for YARN's resource storage, via the `fs.defaultFS` configuration property in Hadoop's `core-site.xml`.
+
+### Alluxio
+
+For Alluxio support add the following entry into the `core-site.xml` file:
+
+{% highlight xml %}
+<property>
+  <name>fs.alluxio.impl</name>
+  <value>alluxio.hadoop.FileSystem</value>
+</property>
+{% endhighlight %}
 
 {% top %}

--- a/docs/ops/filesystems/index.zh.md
+++ b/docs/ops/filesystems/index.zh.md
@@ -78,33 +78,6 @@ JAR file into `lib` directory.
 It's encouraged to use the plugin-based loading mechanism for file systems that support it. Loading file systems components from the `lib`
 directory may be not supported in future Flink versions.
 
-## HDFS and Hadoop File System support
-
-For all schemes where Flink cannot find a directly supported file system, it falls back to Hadoop.
-All Hadoop file systems are automatically available when `flink-runtime` and the Hadoop libraries are on the classpath.
-
-This way, Flink seamlessly supports all of Hadoop file systems, and all Hadoop-compatible file systems (HCFS).
-
-  - **hdfs**
-  - **ftp**
-  - **s3n** and **s3a**
-  - **har**
-  - ...
-
-### Hadoop Configuration
-
-We recommend using Flink's built-in file systems unless required otherwise. Using a Hadoop File System directly may be required, for example, when using that file system for YARN's resource storage, via the `fs.defaultFS` configuration property in Hadoop's `core-site.xml`.
-
-Putting the Hadoop configuration in the same class path as the Hadoop libraries makes the Hadoop File Systems pick up that configuration.
-You can reference another Hadoop configuration by setting the environment variable `HADOOP_CONF_DIR`, or by referencing it via the [Flink configuration](../config.html#hdfs).
-
-{% highlight yaml %}
-fs.hdfs.hadoopconf: /path/to/etc/hadoop
-{% endhighlight %}
-
-This registers `/path/to/etc/hadoop` as Hadoop's configuration directory and is where Flink will look for the `core-site.xml` and `hdfs-site.xml` files.
-
-
 ## Adding a new pluggable File System implementation
 
 File systems are represented via the `org.apache.flink.core.fs.FileSystem` class, which captures the ways to access and modify files and objects in that file system.
@@ -120,6 +93,40 @@ During plugins discovery, the file system factory class will be loaded by a dedi
 The same class loader should be used during file system instantiation and the file system operation calls.
 
 <span class="label label-warning">Warning</span> In practice, it means you should avoid using `Thread.currentThread().getContextClassLoader()` class loader
-in your implementation. 
+in your implementation.
+
+## Hadoop File System (HDFS) and its other implementations
+
+For all schemes where Flink cannot find a directly supported file system, it falls back to Hadoop.
+All Hadoop file systems are automatically available when `flink-runtime` and the Hadoop libraries are on the classpath.
+See also **[Hadoop Integration]({{ site.baseurl }}/ops/deployment/hadoop.html)**.
+
+This way, Flink seamlessly supports all of Hadoop file systems implementing the `org.apache.hadoop.fs.FileSystem` interface,
+and all Hadoop-compatible file systems (HCFS).
+
+  - HDFS (tested)
+  - [Google Cloud Storage Connector for Hadoop](https://cloud.google.com/hadoop/google-cloud-storage-connector) (tested)
+  - [Alluxio](http://alluxio.org/) (tested, see configuration specifics below)
+  - [XtreemFS](http://www.xtreemfs.org/) (tested)
+  - FTP via [Hftp](http://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
+  - HAR (not tested)
+  - ...
+
+The Hadoop configuration has to have an entry for the required file system implementation in the `core-site.xml` file.
+See example for **[Alluxio]({{ site.baseurl }}/ops/filesystems/#alluxio)**.
+
+We recommend using Flink's built-in file systems unless required otherwise. Using a Hadoop File System directly may be required,
+for example, when using that file system for YARN's resource storage, via the `fs.defaultFS` configuration property in Hadoop's `core-site.xml`.
+
+### Alluxio
+
+For Alluxio support add the following entry into the `core-site.xml` file:
+
+{% highlight xml %}
+<property>
+  <name>fs.alluxio.impl</name>
+  <value>alluxio.hadoop.FileSystem</value>
+</property>
+{% endhighlight %}
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

We have hadoop related docs in several places at the moment:

- **dev/batch/connectors.md** (Hadoop FS implementations and setup)
- **dev/batch/hadoop_compatibility.md** (not valid any more that Flink always has Hadoop types out of the box as we do not build and provide Flink with Hadoop by default)
- **ops/filesystems/index.md** (plugins, Hadoop FS implementations and setup revisited)
- **ops/deployment/hadoop.md** (Hadoop classpath)
- **ops/config.md** (deprecated way to provide Hadoop configuration in Flink conf)

We could consolidate all these pieces of docs into a consistent structure to help users to navigate through the docs to well-defined spots depending on which feature they are trying to use.

The places in docs which should contain the information about Hadoop:

- **dev/batch/hadoop_compatibility.md** (only Dataset API specific stuff about integration with Hadoop)
- **ops/filesystems/index.md** (Flink FS plugins and Hadoop FS implementations)
- **ops/deployment/hadoop.md** (Hadoop configuration and classpath)

How to setup Hadoop itself should be only in ops/deployment/hadoop.md. All other places dealing with Hadoop/HDFS should contain only their related things and just reference it 'how to configure Hadoop'. Like all chapters about writing to file systems (batch connectors and streaming file sinks) should just reference file systems.

You can firstly review the first commit. The second one just duplicates the change into the Chinese translation and will be squashed after merge.

## Brief change log

See previous section.

## Verifying this change

Run ./docs/build_docs.sh -i and open http://localhost:4000 in browser to check the doc changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
