### PR TITLE
[FLINK-13927] Add note about hadoop dependencies for local debug

### DIFF
--- a/docs/ops/deployment/hadoop.md
+++ b/docs/ops/deployment/hadoop.md
@@ -46,4 +46,26 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 
 in the shell. Note that `hadoop` is the hadoop binary and that `classpath` is an argument that will make it print the configured Hadoop classpath.
 
+## Running a job locally
+
+To run a job locally as one JVM process using the mini cluster, the required hadoop dependencies have to be explicitly
+added to the classpath of the started JVM process.
+
+To run an application using maven (also from IDE as a maven project), the required hadoop dependencies can be added
+as provided to the pom.xml, e.g.:
+
+```xml
+<dependency>
+    <groupId>org.apache.hadoop</groupId>
+    <artifactId>hadoop-client</artifactId>
+    <version>2.8.3</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+This way it should work both in local and cluster run where the provided dependencies are added elsewhere as described before.
+
+To run or debug an application in IntelliJ Idea the provided dependencies can be included to the class path
+in the "Run|Edit Configurations" window.
+
 {% top %}

--- a/docs/ops/deployment/hadoop.zh.md
+++ b/docs/ops/deployment/hadoop.zh.md
@@ -46,4 +46,26 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 
 in the shell. Note that `hadoop` is the hadoop binary and that `classpath` is an argument that will make it print the configured Hadoop classpath.
 
+## Running a job locally
+
+To run a job locally as one JVM process using the mini cluster, the required hadoop dependencies have to be explicitly
+added to the classpath of the started JVM process.
+
+To run an application using maven (also from IDE as a maven project), the required hadoop dependencies can be added
+as provided to the pom.xml, e.g.:
+
+```xml
+<dependency>
+    <groupId>org.apache.hadoop</groupId>
+    <artifactId>hadoop-client</artifactId>
+    <version>2.8.3</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+This way it should work both in local and cluster run where the provided dependencies are added elsewhere as described before.
+
+To run or debug an application in IntelliJ Idea the provided dependencies can be included to the class path
+in the "Run|Edit Configurations" window.
+
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

Currently if user tries to run the job locally (e.g. from IDE) and uses Hadoop fs, it will not work if hadoop dependencies are not on the class path which is the case for the example from the quick start.

## Brief change log

We can add a hint about adding provided hadoop dependencies in this case (+ Idea hint about provided included checkbox in run/debug app setup) to `docs/ops/deployment/hadoop.md`.

## Verifying this change

Run `./docs/build_docs.sh` -i and [open](http://localhost:4000/ops/deployment/hadoop.html) in browser to check the doc changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
