### PR TITLE
[FLINK-13591][web]: fix job list display when job name is too long

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/share/customize/job-list/job-list.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/job-list/job-list.component.html
@@ -24,7 +24,7 @@
     [nzShowPagination]="false">
     <thead (nzSortChange)="sort($event)" nzSingleSort>
       <tr>
-        <th>Job Name</th>
+        <th nzWidth="40%">Job Name</th>
         <th nzShowSort nzSortKey="start-time">Start Time</th>
         <th nzShowSort nzSortKey="duration">Duration</th>
         <th nzShowSort nzSortKey="end-time">End Time</th>


### PR DESCRIPTION
## What is the purpose of the change

fix Job List in Flink web doesn't display right when the job name is very long

## Brief change log

add max-width to the td of job name column table to 40%

## Verifying this change

  - *Submit a job with long name (more than 200 char)*
  - *Visit the overview page*

The job name column is not more than 40% width of table

before
![FireShot Capture 361 - Apache Flink Web Dashboard - localhost](https://user-images.githubusercontent.com/1506722/64306606-f8221180-cfc5-11e9-8971-36b2ffe63554.png)

after fix
![FireShot Capture 362 - Apache Flink Web Dashboard - localhost](https://user-images.githubusercontent.com/1506722/64306634-0ec86880-cfc6-11e9-81fb-d2b5e04c19ac.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
