### PR TITLE
[FLINK-13516][test] Bump MiniKdc to 3.2.0 to fix the failure of YARNSessionFIFOSecuredITCase on Java 11

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.modules.HadoopModule;
 import org.apache.flink.test.util.SecureTestEnvironment;
 import org.apache.flink.test.util.TestingSecurityContext;
-import org.apache.flink.testutils.junit.FailsOnJava11;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
@@ -38,7 +37,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +106,6 @@ public class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
 
 	@Test(timeout = 60000) // timeout after a minute.
 	@Override
-	@Category(FailsOnJava11.class)
 	public void testDetachedMode() throws Exception {
 		runTest(() -> {
 			runDetachedModeTest();

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@ under the License.
 			Starting Hadoop 3, org.apache.kerby will be used instead of MiniKDC. We may have
 			to revisit the impact at that time.
 		-->
-		<minikdc.version>2.7.2</minikdc.version>
+		<minikdc.version>3.2.0</minikdc.version>
 		<generated.docs.dir>./docs/_includes/generated</generated.docs.dir>
 		<hive.version>2.3.4</hive.version>
 		<!--


### PR DESCRIPTION
## What is the purpose of the change

This pull request bumps `MiniKdc` to 3.2.0 to fix the failure of `YARNSessionFIFOSecuredITCase` on Java 11. 

The failure of `YARNSessionFIFOSecuredITCase` is due to the failure of authentication when the yarn client requests access authorization of resource manager, and subsequent retries lead to test timeout. New encryption types of `es128-cts-hmac-sha256-128` and `aes256-cts-hmac-sha384-192` (for Kerberos 5) enabled by default were added in Java 11, while the current version of `MiniKdc` used by Flink does not support these encryption types and does not work well when these encryption types are enabled, which results in the authentication failure.

## Brief change log

  - Bumps MiniKdc to 3.2.0 


## Verifying this change

This change is already covered by existing tests, such as `YARNSessionFIFOSecuredITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
