### PR TITLE
[FLINK-13966][licensing] Pin locale for deterministic sort order

### DIFF
--- a/tools/releasing/collect_license_files.sh
+++ b/tools/releasing/collect_license_files.sh
@@ -48,7 +48,7 @@ done
 
 NOTICE="${DST}/NOTICE"
 [ -f "${NOTICE}" ] && rm "${NOTICE}"
-find "${TMP}" -name "NOTICE" | sort | xargs cat >> "${NOTICE}"
+(export LC_ALL=C; find "${TMP}" -name "NOTICE" | sort | xargs cat >> "${NOTICE}")
 
 LICENSES="${DST}/licenses"
 [ -f "${LICENSES}" ] && rm -r ""


### PR DESCRIPTION
Pins the locale during the sort operation in `collect_license_files.sh` to `C`, which appears to be the one we've been using so far.