### PR TITLE
[FLINK-13967][licensing] Fully generate binary licensing

### DIFF
--- a/tools/releasing/LICENSE.slf4j
+++ b/tools/releasing/LICENSE.slf4j
@@ -1,0 +1,21 @@
+Copyright (c) 2004-2017 QOS.ch
+ All rights reserved.
+
+ Permission is hereby granted, free  of charge, to any person obtaining
+ a  copy  of this  software  and  associated  documentation files  (the
+ "Software"), to  deal in  the Software without  restriction, including
+ without limitation  the rights to  use, copy, modify,  merge, publish,
+ distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ permit persons to whom the Software  is furnished to do so, subject to
+ the following conditions:
+
+ The  above  copyright  notice  and  this permission  notice  shall  be
+ included in all copies or substantial portions of the Software.
+
+ THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------
+// NOTICE file corresponding to the section 4d of The Apache License,
+// Version 2.0, in this case for Apache Flink
+// ------------------------------------------------------------------
+
+Apache Flink
+Copyright 2014-2019 The Apache Software Foundation
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- log4j:log4j:1.2.17
+
+This project bundles the following dependencies under the MIT/X11 license.
+See bundled license files for details.
+
+- org.slf4j:slf4j-log4j12:1.7.15
+

--- a/tools/releasing/collect_license_files.sh
+++ b/tools/releasing/collect_license_files.sh
@@ -30,6 +30,9 @@ SRC=${1:-.}
 DST=${2:-licenses-output}
 PWD=$(pwd)
 TMP="${DST}/tmp"
+DIR=$(dirname "$0")
+NOTICE_BINARY_PREAMBLE="${DIR}/NOTICE-binary_PREAMBLE.txt"
+SLF4J_LICENSE="${DIR}/LICENSE.slf4j"
 
 USAGE="collect_license_files <SOURCE_DIRECTORY:-.> <OUTPUT_DIRECTORY:-licenses-output>"
 
@@ -46,12 +49,15 @@ do
 	(cd "${DIR}" && jar xf ${JAR} META-INF/NOTICE META-INF/licenses)
 done
 
-NOTICE="${DST}/NOTICE"
+NOTICE="${DST}/NOTICE-binary"
 [ -f "${NOTICE}" ] && rm "${NOTICE}"
+cp "${NOTICE_BINARY_PREAMBLE}" "${NOTICE}"
 (export LC_ALL=C; find "${TMP}" -name "NOTICE" | sort | xargs cat >> "${NOTICE}")
 
-LICENSES="${DST}/licenses"
-[ -f "${LICENSES}" ] && rm -r ""
+LICENSES="${DST}/licenses-binary"
+[ -f "${LICENSES}" ] && rm -r "${LICENSES}"
 find "${TMP}" -name "licenses" -type d -exec cp -r -- "{}" "${DST}" \;
+mv "${DST}/licenses" "${LICENSES}"
+cp "${SLF4J_LICENSE}" "${LICENSES}"
 
 rm -r "${TMP}"


### PR DESCRIPTION
Based on #9623 so that the correctness of the generator can be verified.

With this PR `collect_license_files.sh` generates the full binary licensing, including `NOTICE-binary` and `licenses-binary`.

Henceforth, no additional manual steps are required for assembling said licensing (apart from running the script and copying said files)