### PR TITLE
[FLINK-13968][travis] Check correctness of binary licensing

### DIFF
--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -127,6 +127,26 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
     fi
 
     if [ $EXIT_CODE == 0 ]; then
+        ./tools/releasing/collect_license_files.sh ./build-target
+        diff "NOTICE-binary" "licenses-output/NOTICE-binary"
+        EXIT_CODE=$(($EXIT_CODE+$?))
+        diff -r "licenses-binary" "licenses-output/licenses-binary"
+        EXIT_CODE=$(($EXIT_CODE+$?))
+
+        if [ $EXIT_CODE != 0 ]; then
+          echo "=============================================================================="
+          echo "ERROR: binary licensing is out-of-date."
+          echo "Please update NOTICE-binary and licenses-binary using"
+          echo "'tools/releasing/collect_license_files.sh'."
+          echo "=============================================================================="
+        fi
+    else
+        echo "=============================================================================="
+        echo "Previous build failure detected, skipping licensing check."
+        echo "=============================================================================="
+    fi
+
+    if [ $EXIT_CODE == 0 ]; then
         echo "Creating cache build directory $CACHE_FLINK_DIR"
         mkdir -p "$CACHE_FLINK_DIR"
     


### PR DESCRIPTION
Based on #9624 for the check to actually succeed.

Adds a check to Travis for verifying the correctness of the binary licensing (NOTICE-binary, licenses-binary).

The check simple generates the license files and runs a `diff` against the current licensing.