### PR TITLE
[FLINK-13960] Add throwing HighAvailabilityServices#getWebMonitorLeaderRetriever default impl

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -107,7 +107,13 @@ public interface HighAvailabilityServices extends AutoCloseable {
 	 * @deprecated just use {@link ClientHighAvailabilityServices} instead of this services.
 	 */
 	@Deprecated
-	LeaderRetrievalService getWebMonitorLeaderRetriever();
+	default LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		throw new UnsupportedOperationException(
+			String.format(
+				"getWebMonitorLeaderRetriever should no longer be used. Instead use %s to " +
+					"instantiate the cluster rest endpoint leader retriever.",
+				ClientHighAvailabilityServices.class.getName()));
+	}
 
 	/**
 	 * Gets the leader election service for the cluster's resource manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -79,7 +79,7 @@ public interface HighAvailabilityServices extends AutoCloseable {
 	LeaderRetrievalService getDispatcherLeaderRetriever();
 
 	/**
-	 * Gets the leader retriever for the job JobMaster which is responsible for the given job
+	 * Gets the leader retriever for the job JobMaster which is responsible for the given job.
 	 *
 	 * @param jobID The identifier of the job.
 	 * @return Leader retrieval service to retrieve the job manager for the given job
@@ -89,7 +89,7 @@ public interface HighAvailabilityServices extends AutoCloseable {
 	LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID);
 
 	/**
-	 * Gets the leader retriever for the job JobMaster which is responsible for the given job
+	 * Gets the leader retriever for the job JobMaster which is responsible for the given job.
 	 *
 	 * @param jobID The identifier of the job.
 	 * @param defaultJobManagerAddress JobManager address which will be returned by
@@ -134,14 +134,14 @@ public interface HighAvailabilityServices extends AutoCloseable {
 	LeaderElectionService getWebMonitorLeaderElectionService();
 
 	/**
-	 * Gets the checkpoint recovery factory for the job manager
+	 * Gets the checkpoint recovery factory for the job manager.
 	 *
 	 * @return Checkpoint recovery factory
 	 */
 	CheckpointRecoveryFactory getCheckpointRecoveryFactory();
 
 	/**
-	 * Gets the submitted job graph store for the job manager
+	 * Gets the submitted job graph store for the job manager.
 	 *
 	 * @return Submitted job graph store
 	 * @throws Exception if the submitted job graph store could not be created


### PR DESCRIPTION
## What is the purpose of the change

Default impl `HighAvailabilitySerivces.getWebMonitorLeaderRetriever` throws exception referring to implement the ClientHighAvailabilityServices instead.

cc @TisonKun 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
