### PR TITLE
[FLINK-13978] Add azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+trigger:
+  branches:
+    include:
+    - '*' 
+
+resources:
+  containers:
+  # Container with Maven 3.2.5 to have the same environment everywhere.
+  - container: flink-build-container
+    image: rmetzger/flink-ci:3
+  repositories:
+    - repository: templates
+      type: github
+      name: flink-ci/flink-azure-builds
+      endpoint: flink-ci
+
+jobs:
+- template: flink-build-jobs.yml@templates
+


### PR DESCRIPTION
## What is the purpose of the change

* Introduce an `azure-pipelines.yml` file, so that we can trigger [Azure Pipelines](https://dev.azure.com/rmetzger/Flink/_build?definitionId=4&_a=summary&view=branches) builds from `flink-ci/flink`.

