### PR TITLE
[FLINK-13921] Simplify cluster level RestartStrategy configuration

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -104,17 +104,25 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 
 		private static final long serialVersionUID = 6642934067762271950L;
 
-		private final int maxAttempts;
-		private final long delay;
+		private final int maxNumberRestartAttempts;
+		private final long delayBetweenRestartAttempts;
 
-		public FixedDelayRestartStrategyFactory(int maxAttempts, long delay) {
-			this.maxAttempts = maxAttempts;
-			this.delay = delay;
+		public FixedDelayRestartStrategyFactory(int maxNumberRestartAttempts, long delayBetweenRestartAttempts) {
+			this.maxNumberRestartAttempts = maxNumberRestartAttempts;
+			this.delayBetweenRestartAttempts = delayBetweenRestartAttempts;
 		}
 
 		@Override
 		public RestartStrategy createRestartStrategy() {
-			return new FixedDelayRestartStrategy(maxAttempts, delay);
+			return new FixedDelayRestartStrategy(maxNumberRestartAttempts, delayBetweenRestartAttempts);
+		}
+
+		int getMaxNumberRestartAttempts() {
+			return maxNumberRestartAttempts;
+		}
+
+		long getDelayBetweenRestartAttempts() {
+			return delayBetweenRestartAttempts;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.executiongraph.restart;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 
@@ -29,8 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
-import scala.concurrent.duration.Duration;
 
 /**
  * Factory for {@link RestartStrategy}.
@@ -90,34 +87,7 @@ public abstract class RestartStrategyFactory implements Serializable {
 		String restartStrategyName = configuration.getString(ConfigConstants.RESTART_STRATEGY, null);
 
 		if (restartStrategyName == null) {
-			// support deprecated ConfigConstants values
-			final int numberExecutionRetries = configuration.getInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS,
-				ConfigConstants.DEFAULT_EXECUTION_RETRIES);
-			String pauseString = configuration.getString(AkkaOptions.WATCH_HEARTBEAT_PAUSE);
-			String delayString = configuration.getString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
-				pauseString);
-
-			long delay;
-
-			try {
-				delay = Duration.apply(delayString).toMillis();
-			} catch (NumberFormatException nfe) {
-				if (delayString.equals(pauseString)) {
-					throw new Exception("Invalid config value for " +
-						AkkaOptions.WATCH_HEARTBEAT_PAUSE.key() + ": " + pauseString +
-						". Value must be a valid duration (such as '10 s' or '1 min')");
-				} else {
-					throw new Exception("Invalid config value for " +
-						ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY + ": " + delayString +
-						". Value must be a valid duration (such as '100 milli' or '10 s')");
-				}
-			}
-
-			if (numberExecutionRetries > 0 && delay >= 0) {
-				return new FixedDelayRestartStrategy.FixedDelayRestartStrategyFactory(numberExecutionRetries, delay);
-			} else {
-				return new NoOrFixedIfCheckpointingEnabledRestartStrategyFactory();
-			}
+			return new NoOrFixedIfCheckpointingEnabledRestartStrategyFactory();
 		}
 
 		switch (restartStrategyName.toLowerCase()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.restart;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for the {@link RestartStrategyFactory}.
+ */
+public class RestartStrategyFactoryTest extends TestLogger {
+
+	@Test
+	public void createRestartStrategyFactory_noRestartStrategyConfigured_returnsNoOrFixedIfCheckpointingEnabledRestartStrategyFactory() throws Exception {
+		final Configuration configuration = new Configuration();
+
+		final RestartStrategyFactory restartStrategyFactory = RestartStrategyFactory.createRestartStrategyFactory(configuration);
+
+		assertThat(restartStrategyFactory, instanceOf(NoOrFixedIfCheckpointingEnabledRestartStrategyFactory.class));
+	}
+
+	@Test
+	public void createRestartStrategyFactory_noRestartStrategyButAttemptsConfigured_returnsNoOrFixedIfCheckpointingEnabledRestartStrategyFactory() throws Exception {
+		final Configuration configuration = new Configuration();
+		configuration.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+
+		final RestartStrategyFactory restartStrategyFactory = RestartStrategyFactory.createRestartStrategyFactory(configuration);
+
+		assertThat(restartStrategyFactory, instanceOf(NoOrFixedIfCheckpointingEnabledRestartStrategyFactory.class));
+	}
+
+	@Test
+	public void createRestartStrategyFactory_fixedDelayRestartStrategyConfigured_returnsConfiguredFixedDelayRestartStrategy() throws Exception {
+		final int attempts = 42;
+		final Duration delayBetweenRestartAttempts = Duration.ofSeconds(1337L);
+		final Configuration configuration = new Configuration();
+		configuration.setString(ConfigConstants.RESTART_STRATEGY, "fixed-delay");
+		configuration.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, attempts);
+		configuration.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, delayBetweenRestartAttempts.getSeconds() + "s");
+
+		final RestartStrategyFactory restartStrategyFactory = RestartStrategyFactory.createRestartStrategyFactory(configuration);
+
+		assertThat(restartStrategyFactory, instanceOf(FixedDelayRestartStrategy.FixedDelayRestartStrategyFactory.class));
+		final FixedDelayRestartStrategy.FixedDelayRestartStrategyFactory fixedDelayRestartStrategyFactory = (FixedDelayRestartStrategy.FixedDelayRestartStrategyFactory) restartStrategyFactory;
+
+		assertThat(fixedDelayRestartStrategyFactory.getMaxNumberRestartAttempts(), is(attempts));
+		assertThat(fixedDelayRestartStrategyFactory.getDelayBetweenRestartAttempts(), is(delayBetweenRestartAttempts.toMillis()));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR simplifies the cluster `RestartStrategy` configuration. The configuration works now the following way:

* If the config option `restart-strategy` is configured, then Flink uses this `RestartStrategy`
* If the config option `restart-strategy` is not configured, then
** If checkpointing is disabled, then choose `NoRestartStrategy`
** If checkpointing is enabled, then choose `FixedDelayRestartStrategy(Integer.MAX_VALUE, "0 s")`

## Verifying this change

- Added `RestartStrategyFactoryTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
