### PR TITLE
 [FLINK-14004][runtime] Define SourceReaderOperator to verify the integration with StreamOneInputProcessor

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceReaderOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
+
+/**
+ * Base source operator only used for integrating the source reader which is proposed by FLIP-27. It implements
+ * the interface of {@link PushingAsyncDataInput} for naturally compatible with one input processing in runtime
+ * stack.
+ *
+ * <p>Note: We are expecting this to be changed to the concrete class once SourceReader interface is introduced.
+ *
+ * @param <OUT> The output type of the operator
+ */
+@Internal
+public abstract class SourceReaderOperator<OUT> extends AbstractStreamOperator<OUT> implements PushingAsyncDataInput<OUT> {
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractDataOutput.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Base class for all data outputs. It implements the unified way of emitting stream status
+ * for both network and source outputs.
+ *
+ * @param <T> The output type
+ */
+@Internal
+public abstract class AbstractDataOutput<T> implements PushingAsyncDataInput.DataOutput<T> {
+
+	/** The maintainer toggles the current stream status. */
+	protected final StreamStatusMaintainer streamStatusMaintainer;
+
+	protected final Object lock;
+
+	public AbstractDataOutput(StreamStatusMaintainer streamStatusMaintainer, Object lock) {
+		this.streamStatusMaintainer = checkNotNull(streamStatusMaintainer);
+		this.lock = checkNotNull(lock);
+	}
+
+	@Override
+	public void emitStreamStatus(StreamStatus streamStatus) {
+		synchronized (lock) {
+			streamStatusMaintainer.toggleStreamStatus(streamStatus);
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.SourceReaderOperator;
+import org.apache.flink.util.IOUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Implementation of {@link StreamTaskInput} that reads data from the {@link SourceReaderOperator}
+ * and returns the {@link InputStatus} to indicate whether the source state is available,
+ * unavailable or finished.
+ */
+@Internal
+public final class StreamTaskSourceInput<T> implements StreamTaskInput<T> {
+
+	private final SourceReaderOperator<T> operator;
+
+	public StreamTaskSourceInput(SourceReaderOperator<T> operator) {
+		this.operator = checkNotNull(operator);
+	}
+
+	@Override
+	public InputStatus emitNext(DataOutput<T> output) throws Exception {
+		return operator.emitNext(output);
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return operator.isAvailable();
+	}
+
+	/**
+	 * This method is invalid and never called by the one/source input processor.
+	 */
+	@Override
+	public int getInputIndex() {
+		return -1;
+	}
+
+	@Override
+	public void close() {
+		IOUtils.closeQuietly(operator::close);
+	}
+}
+

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -332,17 +332,12 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 	 * The network data output implementation used for processing stream elements
 	 * from {@link StreamTaskNetworkInput} in two input selective processor.
 	 */
-	private class StreamTaskNetworkOutput<T> implements DataOutput<T> {
+	private class StreamTaskNetworkOutput<T> extends AbstractDataOutput<T> {
 
 		private final TwoInputStreamOperator<IN1, IN2, ?> operator;
 
 		/** The function way is only used for frequent record processing as for JIT optimization. */
 		private final ThrowingConsumer<StreamRecord<T>, Exception> recordConsumer;
-
-		private final Object lock;
-
-		/** The maintainer toggles the current stream status as well as retrieves it. */
-		private final StreamStatusMaintainer streamStatusMaintainer;
 
 		private final WatermarkGauge inputWatermarkGauge;
 
@@ -356,11 +351,10 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 				StreamStatusMaintainer streamStatusMaintainer,
 				WatermarkGauge inputWatermarkGauge,
 				int inputIndex) {
+			super(streamStatusMaintainer, lock);
 
 			this.operator = checkNotNull(operator);
 			this.recordConsumer = checkNotNull(recordConsumer);
-			this.lock = checkNotNull(lock);
-			this.streamStatusMaintainer = checkNotNull(streamStatusMaintainer);
 			this.inputWatermarkGauge = checkNotNull(inputWatermarkGauge);
 			this.inputIndex = inputIndex;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTask.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.SourceReaderOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.AbstractDataOutput;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
+import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A subclass of {@link StreamTask} for executing the {@link SourceReaderOperator}.
+ */
+@Internal
+public class SourceReaderStreamTask<T> extends StreamTask<T, SourceReaderOperator<T>> {
+
+	public SourceReaderStreamTask(Environment env) {
+		super(env);
+	}
+
+	@Override
+	public void init() {
+		StreamTaskInput<T> input = new StreamTaskSourceInput<>(headOperator);
+		DataOutput<T> output = new StreamTaskSourceOutput<>(
+			operatorChain.getChainEntryPoint(),
+			getStreamStatusMaintainer(),
+			getCheckpointLock());
+
+		inputProcessor = new StreamOneInputProcessor<>(
+			input,
+			output,
+			getCheckpointLock(),
+			operatorChain);
+	}
+
+	/**
+	 * Implementation of {@link DataOutput} that wraps a specific {@link Output} to emit
+	 * stream elements for {@link SourceReaderOperator}.
+	 */
+	private static class StreamTaskSourceOutput<T> extends AbstractDataOutput<T> {
+
+		private final Output<StreamRecord<T>> output;
+
+		StreamTaskSourceOutput(
+				Output<StreamRecord<T>> output,
+				StreamStatusMaintainer streamStatusMaintainer,
+				Object lock) {
+			super(streamStatusMaintainer, lock);
+
+			this.output = checkNotNull(output);
+		}
+
+		@Override
+		public void emitRecord(StreamRecord<T> streamRecord) {
+			synchronized (lock) {
+				output.collect(streamRecord);
+			}
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) {
+			synchronized (lock) {
+				output.emitLatencyMarker(latencyMarker);
+			}
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) {
+			synchronized (lock) {
+				output.emitWatermark(watermark);
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTaskTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.SourceReaderOperator;
+import org.apache.flink.streaming.runtime.io.InputStatus;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Tests for verifying that the {@link SourceReaderOperator} as a task input can be integrated
+ * well with {@link org.apache.flink.streaming.runtime.io.StreamOneInputProcessor}.
+ */
+public class SourceReaderStreamTaskTest {
+
+	@Test
+	public void testSourceOutputCorrectness() throws Exception {
+		final int numRecords = 10;
+		final StreamTaskTestHarness<Integer> testHarness = new StreamTaskTestHarness<>(
+			SourceReaderStreamTask::new,
+			BasicTypeInfo.INT_TYPE_INFO);
+		final StreamConfig streamConfig = testHarness.getStreamConfig();
+
+		testHarness.setupOutputForSingletonOperatorChain();
+		streamConfig.setStreamOperator(new TestingFiniteSourceReaderOperator(numRecords));
+		streamConfig.setOperatorID(new OperatorID());
+
+		testHarness.invoke();
+		testHarness.waitForTaskCompletion();
+
+		final LinkedBlockingQueue<Object> expectedOutput = new LinkedBlockingQueue<>();
+		for (int i = 1; i <= numRecords; i++) {
+			expectedOutput.add(new StreamRecord<>(i));
+		}
+
+		TestHarnessUtil.assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+	}
+
+	/**
+	 * A simple {@link SourceReaderOperator} implementation for emitting limited int type records.
+	 */
+	private static class TestingFiniteSourceReaderOperator extends SourceReaderOperator<Integer> {
+		private static final long serialVersionUID = 1L;
+
+		private final int numRecords;
+		private int counter;
+
+		TestingFiniteSourceReaderOperator(int numRecords) {
+			this.numRecords = numRecords;
+		}
+
+		@Override
+		public InputStatus emitNext(DataOutput<Integer> output) throws Exception {
+			output.emitRecord(new StreamRecord<>(++counter));
+
+			return counter < numRecords ? InputStatus.MORE_AVAILABLE : InputStatus.END_OF_INPUT;
+		}
+
+		@Override
+		public CompletableFuture<?> isAvailable() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

We already refactored the task input and output in runtime stack for considering the requirements of FLIP-27. In order to further verify that the new source could work well with the unified `StreamOneInputProcessor` in mailbox model, we define the `SourceReaderOperator` as task input and implement a unit test for passing through the whole process.

## Brief change log

- Define `AbstractDataOutput` as the base class for both source output and network output.
- Refactor the previous processes based on `AbstractDataOutput`.
- Define `SourceReaderOperator` base class.
- Define `SourceReaderStreamTask` to generate the source input and output for `StreamOneInputProcessor`.

## Verifying this change

  - Added unit test in `SourceReaderStreamTaskTest` for verifying that the source reader operator could be integrated well with `StreamOneInputProcessor`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)