### PR TITLE
[FLINK-14043] Speed up SavepointMigrationTestBase sub classes

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -25,6 +25,7 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointSerializers;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -118,6 +119,7 @@ public abstract class SavepointMigrationTestBase extends TestBaseUtils {
 		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
 		config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 0);
 		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+		config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 300L);
 
 		return config;
 	}


### PR DESCRIPTION
## What is the purpose of the change

Since all SavepointMigrationTestBase sub classes rely on the
MigrationTestUtils.AccumulatorCountingSink which uses user code accumulators
in order to communicate with the test driver, we set the heartbeat interval
to 300ms in order to speed the test execution up. The reason this works is
that Flink transports user code accumulators from the TM to the JM via
the heartbeats. Hence, the heartbeat interval represents the lower boundary
for the test completion.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
