### PR TITLE
[hotfix][docs] Fix few typos in the java docs

### DIFF
--- a/docs/_includes/generated/file_system_configuration.html
+++ b/docs/_includes/generated/file_system_configuration.html
@@ -10,7 +10,7 @@
         <tr>
             <td><h5>fs.default-scheme</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>The default filesystem scheme, used for paths that do not declare a scheme explicitly. May contain an authority, e.g. host:port in case of a HDFS NameNode.</td>
+            <td>The default filesystem scheme, used for paths that do not declare a scheme explicitly. May contain an authority, e.g. host:port in case of an HDFS NameNode.</td>
         </tr>
         <tr>
             <td><h5>fs.output.always-create-directory</h5></td>

--- a/docs/dev/batch/index.md
+++ b/docs/dev/batch/index.md
@@ -858,7 +858,7 @@ ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 // read text file from local files system
 DataSet<String> localLines = env.readTextFile("file:///path/to/my/textfile");
 
-// read text file from a HDFS running at nnHost:nnPort
+// read text file from an HDFS running at nnHost:nnPort
 DataSet<String> hdfsLines = env.readTextFile("hdfs://nnHost:nnPort/path/to/my/textfile");
 
 // read a CSV file with three fields
@@ -999,7 +999,7 @@ val env  = ExecutionEnvironment.getExecutionEnvironment
 // read text file from local files system
 val localLines = env.readTextFile("file:///path/to/my/textfile")
 
-// read text file from a HDFS running at nnHost:nnPort
+// read text file from an HDFS running at nnHost:nnPort
 val hdfsLines = env.readTextFile("hdfs://nnHost:nnPort/path/to/my/textfile")
 
 // read a CSV file with three fields
@@ -1159,7 +1159,7 @@ DataSet<String> textData = // [...]
 // write DataSet to a file on the local file system
 textData.writeAsText("file:///my/result/on/localFS");
 
-// write DataSet to a file on a HDFS with a namenode running at nnHost:nnPort
+// write DataSet to a file on an HDFS with a namenode running at nnHost:nnPort
 textData.writeAsText("hdfs://nnHost:nnPort/my/result/on/localFS");
 
 // write DataSet to a file and overwrite the file if it exists
@@ -1261,7 +1261,7 @@ val textData: DataSet[String] = // [...]
 // write DataSet to a file on the local file system
 textData.writeAsText("file:///my/result/on/localFS")
 
-// write DataSet to a file on a HDFS with a namenode running at nnHost:nnPort
+// write DataSet to a file on an HDFS with a namenode running at nnHost:nnPort
 textData.writeAsText("hdfs://nnHost:nnPort/my/result/on/localFS")
 
 // write DataSet to a file and overwrite the file if it exists

--- a/docs/dev/batch/index.zh.md
+++ b/docs/dev/batch/index.zh.md
@@ -858,7 +858,7 @@ ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 // read text file from local files system
 DataSet<String> localLines = env.readTextFile("file:///path/to/my/textfile");
 
-// read text file from a HDFS running at nnHost:nnPort
+// read text file from an HDFS running at nnHost:nnPort
 DataSet<String> hdfsLines = env.readTextFile("hdfs://nnHost:nnPort/path/to/my/textfile");
 
 // read a CSV file with three fields
@@ -999,7 +999,7 @@ val env  = ExecutionEnvironment.getExecutionEnvironment
 // read text file from local files system
 val localLines = env.readTextFile("file:///path/to/my/textfile")
 
-// read text file from a HDFS running at nnHost:nnPort
+// read text file from an HDFS running at nnHost:nnPort
 val hdfsLines = env.readTextFile("hdfs://nnHost:nnPort/path/to/my/textfile")
 
 // read a CSV file with three fields
@@ -1159,7 +1159,7 @@ DataSet<String> textData = // [...]
 // write DataSet to a file on the local file system
 textData.writeAsText("file:///my/result/on/localFS");
 
-// write DataSet to a file on a HDFS with a namenode running at nnHost:nnPort
+// write DataSet to a file on an HDFS with a namenode running at nnHost:nnPort
 textData.writeAsText("hdfs://nnHost:nnPort/my/result/on/localFS");
 
 // write DataSet to a file and overwrite the file if it exists
@@ -1261,7 +1261,7 @@ val textData: DataSet[String] = // [...]
 // write DataSet to a file on the local file system
 textData.writeAsText("file:///my/result/on/localFS")
 
-// write DataSet to a file on a HDFS with a namenode running at nnHost:nnPort
+// write DataSet to a file on an HDFS with a namenode running at nnHost:nnPort
 textData.writeAsText("hdfs://nnHost:nnPort/my/result/on/localFS")
 
 // write DataSet to a file and overwrite the file if it exists

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -52,7 +52,7 @@ The configuration files for the TaskManagers can be different, Flink does not as
 
 See also [how to configure Hadoop]({{ site.baseurl }}/ops/deployment/hadoop.html#configure-hadoop).
 
-These parameters configure the default HDFS used by Flink. Setups that do not specify a HDFS configuration have to specify the full path to HDFS files (`hdfs://address:port/path/to/files`) Files will also be written with default HDFS parameters (block size, replication factor).
+These parameters configure the default HDFS used by Flink. Setups that do not specify an HDFS configuration have to specify the full path to HDFS files (`hdfs://address:port/path/to/files`) Files will also be written with default HDFS parameters (block size, replication factor).
 
 - `fs.hdfs.hadoopconf`: The absolute path to the Hadoop File System's (HDFS) configuration **directory** (OPTIONAL VALUE). Specifying this value allows programs to reference HDFS files using short URIs (`hdfs:///path/to/files`, without including the address and port of the NameNode in the file URI). Without this option, HDFS files can be accessed, but require fully qualified URIs like `hdfs://address:port/path/to/files`. This option also causes file writers to pick up the HDFS's default values for block sizes and replication factors. Flink will look for the "core-site.xml" and "hdfs-site.xml" files in the specified directory.
 

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -52,7 +52,7 @@ The configuration files for the TaskManagers can be different, Flink does not as
 
 See also [how to configure Hadoop]({{ site.baseurl }}/ops/deployment/hadoop.html#configure-hadoop).
 
-These parameters configure the default HDFS used by Flink. Setups that do not specify a HDFS configuration have to specify the full path to HDFS files (`hdfs://address:port/path/to/files`) Files will also be written with default HDFS parameters (block size, replication factor).
+These parameters configure the default HDFS used by Flink. Setups that do not specify an HDFS configuration have to specify the full path to HDFS files (`hdfs://address:port/path/to/files`) Files will also be written with default HDFS parameters (block size, replication factor).
 
 - `fs.hdfs.hadoopconf`: The absolute path to the Hadoop File System's (HDFS) configuration **directory** (OPTIONAL VALUE). Specifying this value allows programs to reference HDFS files using short URIs (`hdfs:///path/to/files`, without including the address and port of the NameNode in the file URI). Without this option, HDFS files can be accessed, but require fully qualified URIs like `hdfs://address:port/path/to/files`. This option also causes file writers to pick up the HDFS's default values for block sizes and replication factors. Flink will look for the "core-site.xml" and "hdfs-site.xml" files in the specified directory.
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -236,7 +236,7 @@ public class CoreOptions {
 			.key("fs.default-scheme")
 			.noDefaultValue()
 			.withDescription("The default filesystem scheme, used for paths that do not declare a scheme explicitly." +
-				" May contain an authority, e.g. host:port in case of a HDFS NameNode.");
+				" May contain an authority, e.g. host:port in case of an HDFS NameNode.");
 
 	/**
 	 * Specifies whether file output writers should overwrite existing files by default.

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileStatus.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileStatus.java
@@ -30,7 +30,7 @@ public final class HadoopFileStatus implements FileStatus {
 	private org.apache.hadoop.fs.FileStatus fileStatus;
 
 	/**
-	 * Creates a new file status from a HDFS file status.
+	 * Creates a new file status from an HDFS file status.
 	 *
 	 * @param fileStatus
 	 *        the HDFS file status

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
@@ -47,7 +47,7 @@ public class HadoopUtils {
 	@SuppressWarnings("deprecation")
 	public static Configuration getHadoopConfiguration(org.apache.flink.configuration.Configuration flinkConfiguration) {
 
-		// Instantiate a HdfsConfiguration to load the hdfs-site.xml and hdfs-default.xml
+		// Instantiate an HdfsConfiguration to load the hdfs-site.xml and hdfs-default.xml
 		// from the classpath
 		Configuration result = new HdfsConfiguration();
 		boolean foundHadoopConfiguration = false;


### PR DESCRIPTION
fix typos(a hdfs), it's better to use "an hdfs"