### PR TITLE
[FLINK-13953] [runtime] Facilitate enabling new scheduler in MiniCluster Tests

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -195,7 +195,6 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12.2</version>
 				<configuration>
 					<systemPropertyVariables>
 						<jna.nosys>true</jna.nosys>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
@@ -38,7 +39,7 @@ import static org.apache.flink.runtime.minicluster.RpcServiceSharing.SHARED;
  */
 public class MiniClusterConfiguration {
 
-	static final String SCHEDULER_TYPE_KEY = "schedulerType";
+	static final String SCHEDULER_TYPE_KEY = JobManagerOptions.SCHEDULER.key();
 
 	private final UnmodifiableConfiguration configuration;
 
@@ -66,7 +67,10 @@ public class MiniClusterConfiguration {
 	}
 
 	private UnmodifiableConfiguration generateConfiguration(final Configuration configuration) {
-		final String schedulerType = System.getProperty(SCHEDULER_TYPE_KEY, JobManagerOptions.SCHEDULER.defaultValue());
+		String schedulerType = System.getProperty(SCHEDULER_TYPE_KEY);
+		if (StringUtils.isNullOrWhitespaceOnly(schedulerType)) {
+			schedulerType = JobManagerOptions.SCHEDULER.defaultValue();
+		}
 
 		if (!configuration.contains(JobManagerOptions.SCHEDULER)) {
 			configuration.setString(JobManagerOptions.SCHEDULER, schedulerType);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -38,6 +38,8 @@ import static org.apache.flink.runtime.minicluster.RpcServiceSharing.SHARED;
  */
 public class MiniClusterConfiguration {
 
+	static final String SCHEDULER_TYPE_KEY = "schedulerType";
+
 	private final UnmodifiableConfiguration configuration;
 
 	private final int numTaskManagers;
@@ -57,10 +59,20 @@ public class MiniClusterConfiguration {
 			RpcServiceSharing rpcServiceSharing,
 			@Nullable String commonBindAddress) {
 
-		this.configuration = new UnmodifiableConfiguration(Preconditions.checkNotNull(configuration));
+		this.configuration = generateConfiguration(Preconditions.checkNotNull(configuration));
 		this.numTaskManagers = numTaskManagers;
 		this.rpcServiceSharing = Preconditions.checkNotNull(rpcServiceSharing);
 		this.commonBindAddress = commonBindAddress;
+	}
+
+	private UnmodifiableConfiguration generateConfiguration(final Configuration configuration) {
+		final String schedulerType = System.getProperty(SCHEDULER_TYPE_KEY, JobManagerOptions.SCHEDULER.defaultValue());
+
+		if (!configuration.contains(JobManagerOptions.SCHEDULER)) {
+			configuration.setString(JobManagerOptions.SCHEDULER, schedulerType);
+		}
+
+		return new UnmodifiableConfiguration(configuration);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterConfigurationTest.java
@@ -22,7 +22,9 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -32,9 +34,26 @@ public class MiniClusterConfigurationTest extends TestLogger {
 
 	private static final String TEST_SCHEDULER_NAME = "test-scheduler";
 
+	private static String priorSchedulerType;
+
+	@BeforeClass
+	public static void setUp() {
+		priorSchedulerType = System.getProperty(MiniClusterConfiguration.SCHEDULER_TYPE_KEY);
+		System.setProperty(MiniClusterConfiguration.SCHEDULER_TYPE_KEY, TEST_SCHEDULER_NAME);
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		if (priorSchedulerType != null) {
+			System.setProperty(MiniClusterConfiguration.SCHEDULER_TYPE_KEY, priorSchedulerType);
+			priorSchedulerType = null;
+		} else {
+			System.clearProperty(MiniClusterConfiguration.SCHEDULER_TYPE_KEY);
+		}
+	}
+
 	@Test
 	public void testSchedulerType_setViaSystemProperty() {
-		System.setProperty(MiniClusterConfiguration.SCHEDULER_TYPE_KEY, TEST_SCHEDULER_NAME);
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder().build();
 
 		Assert.assertEquals(
@@ -47,7 +66,6 @@ public class MiniClusterConfigurationTest extends TestLogger {
 		final Configuration config = new Configuration();
 		config.setString(JobManagerOptions.SCHEDULER, JobManagerOptions.SCHEDULER.defaultValue());
 
-		System.setProperty(MiniClusterConfiguration.SCHEDULER_TYPE_KEY, TEST_SCHEDULER_NAME);
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
 			.setConfiguration(config)
 			.build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterConfigurationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.minicluster;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link MiniClusterConfiguration}.
+ */
+public class MiniClusterConfigurationTest extends TestLogger {
+
+	private static final String TEST_SCHEDULER_NAME = "test-scheduler";
+
+	@Test
+	public void testSchedulerType_setViaSystemProperty() {
+		System.setProperty(MiniClusterConfiguration.SCHEDULER_TYPE_KEY, TEST_SCHEDULER_NAME);
+		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder().build();
+
+		Assert.assertEquals(
+			TEST_SCHEDULER_NAME,
+			miniClusterConfiguration.getConfiguration().getString(JobManagerOptions.SCHEDULER));
+	}
+
+	@Test
+	public void testSchedulerType_notOverriddenIfExistingInConfig() {
+		final Configuration config = new Configuration();
+		config.setString(JobManagerOptions.SCHEDULER, JobManagerOptions.SCHEDULER.defaultValue());
+
+		System.setProperty(MiniClusterConfiguration.SCHEDULER_TYPE_KEY, TEST_SCHEDULER_NAME);
+		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
+			.setConfiguration(config)
+			.build();
+
+		Assert.assertEquals(
+			JobManagerOptions.SCHEDULER.defaultValue(),
+			miniClusterConfiguration.getConfiguration().getString(JobManagerOptions.SCHEDULER));
+	}
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/category/AlsoRunWithSchedulerNG.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/category/AlsoRunWithSchedulerNG.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit.category;
+
+/**
+ * Category marker interface to run tests with SchedulerNG.
+ */
+public interface AlsoRunWithSchedulerNG {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,8 @@ under the License.
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
 		<jamicmp.referenceVersion>1.8.0</jamicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
+		<scheduler.type>legacy</scheduler.type>
+		<test.groups></test.groups>
 	</properties>
 
 	<dependencies>
@@ -637,6 +639,18 @@ under the License.
 	</dependencyManagement>
 
 	<profiles>
+		<profile>
+			<id>scheduler-ng</id>
+			<properties>
+				<scheduler.type>ng</scheduler.type>
+				<test.groups>org.apache.flink.testutils.junit.category.AlsoRunWithSchedulerNG</test.groups>
+			</properties>
+			<activation>
+				<property>
+					<name>scheduler-ng</name>
+				</property>
+			</activation>
+		</profile>
 
 		<profile>
 			<id>scala-2.11</id>
@@ -1424,11 +1438,13 @@ under the License.
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.1</version>
 				<configuration>
+					<groups>${test.groups}</groups>
 					<forkCount>${flink.forkCount}</forkCount>
 					<reuseForks>${flink.reuseForks}</reuseForks>
 					<systemPropertyVariables>
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
+						<schedulerType>${scheduler.type}</schedulerType>
 					</systemPropertyVariables>
 					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC</argLine>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@ under the License.
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
 		<jamicmp.referenceVersion>1.8.0</jamicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
-		<scheduler.type>legacy</scheduler.type>
+		<scheduler.type></scheduler.type>
 		<test.groups></test.groups>
 	</properties>
 
@@ -1444,7 +1444,7 @@ under the License.
 					<systemPropertyVariables>
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
-						<schedulerType>${scheduler.type}</schedulerType>
+						<jobmanager.scheduler>${scheduler.type}</jobmanager.scheduler>
 					</systemPropertyVariables>
 					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC</argLine>
 				</configuration>


### PR DESCRIPTION
## What is the purpose of the change

Currently, tests using the `MiniCluster` use the legacy scheduler by default. Once the new scheduler is implemented, we should run tests with the new scheduler enabled. However, it is not expected that all tests will pass immediately. Therefore, it should be possible to enable the new scheduler for a subset of tests. 

In the first step the tests should be able to run manually against new scheduler.

*Acceptance Criteria*
 * A junit test category `AlsoRunWithSchedulerNG` can be used to mark MiniCluster tests.
 * A new maven profile `scheduler-ng` will be enabled to support running `AlsoRunWithSchedulerNG` annotated tests with the new scheduler.

## Brief change log

The change is inspired by the prototype from @tillrohrmann at https://github.com/tillrohrmann/flink/commit/dee9e7d82f65fa1697489de743e84dcf02d76711.
  - *Added a category marker for new scheduler testing*
  - *Enabled setting scheduler type in MiniClusterConfiguration via environment variable*
  - *Added a maven profile to run annotated MiniCluster tests for the new scheduler*
  - *other hotfixes, details see each hotfix commit*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added UTs for MiniClusterConfiguration changes*
  - *Manually verified the change by running command "mvn verify -Dscheduler-ng". Verified that only the tests annotated with `AlsoRunWithSchedulerNG` are executed in this way. Verified that the scheduler type can be specified by setting maven profiles or properties.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
