### PR TITLE
[FLINK-13056][runtime] Introduce FastRestartPipelinedRegionStrategy

### DIFF
--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -20,7 +20,7 @@
         <tr>
             <td><h5>jobmanager.execution.failover-strategy</h5></td>
             <td style="word-wrap: break-word;">"full"</td>
-            <td>This option specifies how the job computation recovers from task failures. Accepted values are:<ul><li>'full': Restarts all tasks to recover the job.</li><li>'region': Restarts all tasks that could be affected by the task failure. More details can be found <a href="../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy">here</a>.</li></ul></td>
+            <td>This option specifies how the job computation recovers from task failures. Accepted values are:<ul><li>'full': Restarts all tasks to recover the job.</li><li>'region': Restarts all tasks that could be affected by the task failure. More details can be found <a href="../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy">here</a>.</li><li>'region-fast': It behaves the same as 'region' but has better performance to determine tasks to restart. This improvement would help if the job scale is large. The side effect is longer region building time and more memory for cache.</li></ul></td>
         </tr>
         <tr>
             <td><h5>jobmanager.heap.size</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -124,7 +124,10 @@ public class JobManagerOptions {
 						"More details can be found %s.",
 						link(
 							"../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy",
-							"here"))
+							"here")),
+					text("'region-fast': It behaves the same as 'region' but has better performance to " +
+						"determine tasks to restart. This improvement would help if the job scale is large. " +
+						"The side effect is longer region building time and more memory for cache.")
 				).build());
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyLoader.java
@@ -41,6 +41,9 @@ public class FailoverStrategyLoader {
 	/** Config name for the {@link AdaptedRestartPipelinedRegionStrategyNG}. */
 	public static final String PIPELINED_REGION_RESTART_STRATEGY_NAME = "region";
 
+	/** Config name for the {@link AdaptedRestartPipelinedRegionStrategyNG} but use it in fast mode. */
+	public static final String FAST_PIPELINED_REGION_RESTART_STRATEGY_NAME = "region-fast";
+
 	/** Config name for the {@link NoOpFailoverStrategy}. */
 	public static final String NO_OP_FAILOVER_STRATEGY = "noop";
 
@@ -70,7 +73,10 @@ public class FailoverStrategyLoader {
 					return new RestartAllStrategy.Factory();
 
 				case PIPELINED_REGION_RESTART_STRATEGY_NAME:
-					return new AdaptedRestartPipelinedRegionStrategyNG.Factory();
+					return new AdaptedRestartPipelinedRegionStrategyNG.Factory(false);
+
+				case FAST_PIPELINED_REGION_RESTART_STRATEGY_NAME:
+					return new AdaptedRestartPipelinedRegionStrategyNG.Factory(true);
 
 				case INDIVIDUAL_RESTART_STRATEGY_NAME:
 					return new RestartIndividualStrategy.Factory();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FastRestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FastRestartPipelinedRegionStrategy.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * This failover strategy makes the same restart decision as {@link RestartPipelinedRegionStrategy}.
+ * It has better failover handling performance at the cost of slower region building and more memory
+ * used for region boundary cache.
+ */
+public class FastRestartPipelinedRegionStrategy extends RestartPipelinedRegionStrategy {
+
+	/** Maps a failover region to its input result partitions. */
+	private final IdentityHashMap<FailoverRegion, Collection<IntermediateResultPartitionID>> regionInputs;
+
+	/** Maps a failover region to its consumer regions. */
+	private final IdentityHashMap<FailoverRegion, Collection<FailoverRegion>> regionConsumers;
+
+	/** Maps result partition id to its producer failover region. Only for inter-region consumed result partitions. */
+	private final Map<IntermediateResultPartitionID, FailoverRegion> resultPartitionProducerRegion;
+
+	/**
+	 * Creates a new failover strategy to restart pipelined regions that works on the given topology.
+	 *
+	 * @param topology containing info about all the vertices and edges
+	 * @param resultPartitionAvailabilityChecker helps to query result partition availability
+	 */
+	public FastRestartPipelinedRegionStrategy(
+			final FailoverTopology<?, ?> topology,
+			final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+
+		super(topology, resultPartitionAvailabilityChecker);
+
+		this.regionInputs = new IdentityHashMap<>();
+		this.regionConsumers = new IdentityHashMap<>();
+		this.resultPartitionProducerRegion = new HashMap<>();
+		buildRegionInputsAndOutputs();
+	}
+
+	private void buildRegionInputsAndOutputs() {
+		for (FailoverRegion region : regions) {
+			final Set<IntermediateResultPartitionID> consumedExternalResultPartitions = new HashSet<>();
+			final Set<ExecutionVertexID> externalConsumerVertices = new HashSet<>();
+
+			final Set<? extends FailoverVertex<?, ?>> regionVertices = region.getAllExecutionVertices();
+			for (FailoverVertex<?, ?> vertex : regionVertices) {
+				for (FailoverResultPartition<?, ?> consumedResultPartition : vertex.getConsumedResults()) {
+					if (!regionVertices.contains(consumedResultPartition.getProducer())) {
+						consumedExternalResultPartitions.add(consumedResultPartition.getId());
+					}
+				}
+				for (FailoverResultPartition<?, ?> producedResult : vertex.getProducedResults()) {
+					for (FailoverVertex<?, ?> consumerVertex : producedResult.getConsumers()) {
+						if (!regionVertices.contains(consumerVertex)) {
+							externalConsumerVertices.add(consumerVertex.getId());
+
+							this.resultPartitionProducerRegion.put(producedResult.getId(), region);
+						}
+					}
+				}
+			}
+
+			final Set<FailoverRegion> consumerRegions = Collections.newSetFromMap(new IdentityHashMap<>());
+			externalConsumerVertices.forEach(id -> consumerRegions.add(getFailoverRegion(id)));
+
+			this.regionInputs.put(region, new ArrayList<>(consumedExternalResultPartitions));
+			this.regionConsumers.put(region, new ArrayList<>(consumerRegions));
+		}
+	}
+
+	@Override
+	protected void determineProducerRegionsToVisit(
+			final FailoverRegion currentRegion,
+			final Queue<FailoverRegion> regionsToVisit,
+			final Set<FailoverRegion> visitedRegions) {
+
+		for (IntermediateResultPartitionID resultPartitionID : regionInputs.get(currentRegion)) {
+			if (!isResultPartitionAvailable(resultPartitionID)) {
+				final FailoverRegion producerRegion = resultPartitionProducerRegion.get(resultPartitionID);
+				if (!visitedRegions.contains(producerRegion)) {
+					visitedRegions.add(producerRegion);
+					regionsToVisit.add(producerRegion);
+				}
+			}
+		}
+	}
+
+	@Override
+	protected void determineConsumerRegionsToVisit(
+			final FailoverRegion currentRegion,
+			final Queue<FailoverRegion> regionsToVisit,
+			final Set<FailoverRegion> visitedRegions) {
+
+		for (FailoverRegion consumerRegion : regionConsumers.get(currentRegion)) {
+			if (!visitedRegions.contains(consumerRegion)) {
+				visitedRegions.add(consumerRegion);
+				regionsToVisit.add(consumerRegion);
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FastRestartPipelinedRegionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FastRestartPipelinedRegionStrategyTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+/**
+ * Tests the failure handling logic of {@link FastRestartPipelinedRegionStrategy}.
+ */
+public class FastRestartPipelinedRegionStrategyTest extends RestartPipelinedRegionStrategyTest {
+
+	@Override
+	protected FastRestartPipelinedRegionStrategy createFailoverStrategy(FailoverTopology topology) {
+		return new FastRestartPipelinedRegionStrategy(topology, resultPartitionID -> true);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyBuildingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyBuildingTest.java
@@ -44,7 +44,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testIndividualVertices() throws Exception {
+	public void testIndividualVertices() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -74,7 +74,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testEmbarrassinglyParallelCase() throws Exception {
+	public void testEmbarrassinglyParallelCase() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex va1 = topologyBuilder.newVertex();
@@ -118,7 +118,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testOneComponentViaTwoExchanges() throws Exception {
+	public void testOneComponentViaTwoExchanges() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex va1 = topologyBuilder.newVertex();
@@ -167,7 +167,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testOneComponentViaCascadeOfJoins() throws Exception {
+	public void testOneComponentViaCascadeOfJoins() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -216,7 +216,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testOneComponentInstanceFromOneSource() throws Exception {
+	public void testOneComponentInstanceFromOneSource() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -263,7 +263,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testTwoComponentsViaBlockingExchange() throws Exception {
+	public void testTwoComponentsViaBlockingExchange() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex va1 = topologyBuilder.newVertex();
@@ -310,7 +310,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testTwoComponentsViaBlockingExchange2() throws Exception {
+	public void testTwoComponentsViaBlockingExchange2() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex va1 = topologyBuilder.newVertex();
@@ -365,7 +365,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * <p>Component 1: 1, 2, 5; component 2: 3,4,6; component 3: 7
 	 */
 	@Test
-	public void testMultipleComponentsViaCascadeOfJoins() throws Exception {
+	public void testMultipleComponentsViaCascadeOfJoins() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -416,7 +416,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testDiamondWithMixedPipelinedAndBlockingExchanges() throws Exception {
+	public void testDiamondWithMixedPipelinedAndBlockingExchanges() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -457,7 +457,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testBlockingAllToAllTopologyWithCoLocation() throws Exception {
+	public void testBlockingAllToAllTopologyWithCoLocation() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex va1 = topologyBuilder.newVertex();
@@ -495,7 +495,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 	 * </pre>
 	 */
 	@Test
-	public void testPipelinedOneToOneTopologyWithCoLocation() throws Exception {
+	public void testPipelinedOneToOneTopologyWithCoLocation() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex va1 = topologyBuilder.newVertex();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyTest.java
@@ -58,7 +58,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	 * Each vertex is in an individual region.
 	 */
 	@Test
-	public void testRegionFailoverForRegionInternalErrors() throws Exception {
+	public void testRegionFailoverForRegionInternalErrors() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -138,7 +138,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	 * Each vertex is in an individual region.
 	 */
 	@Test
-	public void testRegionFailoverForDataConsumptionErrors() throws Exception {
+	public void testRegionFailoverForDataConsumptionErrors() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -239,7 +239,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	 * rp1, rp2 are result partitions.
 	 */
 	@Test
-	public void testRegionFailoverForVariousResultPartitionAvailabilityCombinations() throws Exception {
+	public void testRegionFailoverForVariousResultPartitionAvailabilityCombinations() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -354,7 +354,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	 * Component 1: 1,2; component 2: 3,4; component 3: 5,6
 	 */
 	@Test
-	public void testRegionFailoverForMultipleVerticesRegions() throws Exception {
+	public void testRegionFailoverForMultipleVerticesRegions() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyTest.java
@@ -76,7 +76,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionStrategy strategy = createFailoverStrategy(topology);
 
 		// when v1 fails, {v1,v4,v5} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();
@@ -156,7 +156,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionStrategy strategy = createFailoverStrategy(topology);
 
 		// when v4 fails to consume data from v1, {v1,v4,v5} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();
@@ -372,7 +372,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionStrategy strategy = createFailoverStrategy(topology);
 
 		// when v3 fails due to internal error, {v3,v4,v5,v6} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();
@@ -403,6 +403,10 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	// ------------------------------------------------------------------------
 	//  utilities
 	// ------------------------------------------------------------------------
+
+	protected RestartPipelinedRegionStrategy createFailoverStrategy(FailoverTopology topology) {
+		return new RestartPipelinedRegionStrategy(topology);
+	}
 
 	private static class TestResultPartitionAvailabilityChecker implements ResultPartitionAvailabilityChecker {
 


### PR DESCRIPTION
## What is the purpose of the change

*Currently some region boundary structures are calculated each time of a region failover. This calculation can be heavy as its complexity goes up with execution edge count.*
*This PR is to introduce FastRestartPipelinedRegionStrategy which has better failover handling performance at the cost of slower region building and more memory used.*

*More details and testing results can be found at [FLINK-13056](https://issues.apache.org/jira/browse/FLINK-13056).*


## Brief change log

  - *Added FastRestartPipelinedRestartStrategy*

## Verifying this change

  - *Unit test added*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
